### PR TITLE
Qualcomm AI Engine Direct - MSVC support without breaking ET_UNWRAP (#20057)

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/runner/attention_sink_rope_runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/attention_sink_rope_runner.cpp
@@ -40,7 +40,7 @@ Error AttentionSinkRopeRunner::load(
   for (const std::string& method_name : method_names) {
     ET_CHECK_OK_OR_RETURN_ERROR(module_->load_method(method_name));
   }
-  ET_UNWRAP(
+  ET_ASSIGN_OR_RETURN(
       eviction_batch_size_evalue__, module_->get("get_eviction_batch_size"));
   eviction_batch_size_ = eviction_batch_size_evalue__.toScalar().to<int64_t>();
   return Error::Ok;

--- a/examples/qualcomm/oss_scripts/llama/runner/lhd_token_generator.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/lhd_token_generator.cpp
@@ -347,7 +347,7 @@ Result<int64_t> LhdTokenGenerator::generate(
       shifted_pos++;
 
       // print the token as string, decode it with the Tokenizer object
-      ET_UNWRAP_TOKENIZER(
+      ET_ASSIGN_OR_RETURN_TOKENIZER(
           decoded_token__, this->tokenizer_->decode(prev_token, cur_token));
       token_callback(decoded_token__);
 

--- a/examples/qualcomm/oss_scripts/llama/runner/multimodal_runner/multimodal_lhd_token_generator.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/multimodal_runner/multimodal_lhd_token_generator.cpp
@@ -332,7 +332,7 @@ Result<int64_t> MultimodalLhdTokenGenerator::generate(
       pos++;
 
       // print the token as string, decode it with the Tokenizer object
-      ET_UNWRAP_TOKENIZER(
+      ET_ASSIGN_OR_RETURN_TOKENIZER(
           decoded_token__, this->tokenizer_->decode(prev_token, cur_token));
       token_callback(decoded_token__);
 

--- a/examples/qualcomm/oss_scripts/llama/runner/multimodal_runner/multimodal_runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/multimodal_runner/multimodal_runner.cpp
@@ -223,7 +223,7 @@ Error QNNMultimodalRunner::load() {
 
   ET_LOG(Info, "Reading metadata from model");
   // retrieve any method meta, can be either prefill or kv
-  ET_UNWRAP(num_layers_evalue__, text_decoder_->get("get_n_layers"));
+  ET_ASSIGN_OR_RETURN(num_layers_evalue__, text_decoder_->get("get_n_layers"));
   int64_t num_layers = num_layers_evalue__.toScalar().to<int64_t>();
 
   ET_CHECK_MSG(num_layers != -1, "Could not retrieve num layers");
@@ -292,7 +292,7 @@ Error QNNMultimodalRunner::load() {
   // attention
   int32_t sliding_window = context_len_;
   if (text_decoder_->method_names()->count("get_sliding_window") > 0) {
-    ET_UNWRAP(
+    ET_ASSIGN_OR_RETURN(
         sliding_window_evalue__, text_decoder_->get("get_sliding_window"));
     sliding_window = sliding_window_evalue__.toInt();
   }
@@ -528,7 +528,7 @@ executorch::runtime::Error QNNMultimodalRunner::generate(
   // print the first token from prefill. No prev_token so use cur_token for
   // it.
   if (token_callback) {
-    ET_UNWRAP_TOKENIZER(
+    ET_ASSIGN_OR_RETURN_TOKENIZER(
         decoded_token__, tokenizer_->decode(cur_token, cur_token));
     token_callback(decoded_token__);
   }
@@ -540,7 +540,7 @@ executorch::runtime::Error QNNMultimodalRunner::generate(
   // start the main loop
   prompt_tokens.push_back(cur_token);
 
-  ET_UNWRAP(
+  ET_ASSIGN_OR_RETURN(
       num_generated_tokens,
       token_generator_->generate(
           prompt_tokens,

--- a/examples/qualcomm/oss_scripts/llama/runner/runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/runner.cpp
@@ -227,7 +227,7 @@ Error Runner::load() {
 
   ET_LOG(Info, "Reading metadata from model");
   // retrieve any method meta, can be either prefill or kv
-  ET_UNWRAP(num_layers_evalue__, module_->get("get_n_layers"));
+  ET_ASSIGN_OR_RETURN(num_layers_evalue__, module_->get("get_n_layers"));
   int64_t num_layers = num_layers_evalue__.toScalar().to<int64_t>();
 
   ET_CHECK_MSG(num_layers != -1, "Could not retrieve num layers");
@@ -270,7 +270,8 @@ Error Runner::load() {
   // attention
   int32_t sliding_window = context_len_;
   if (module_->method_names()->count("get_sliding_window") > 0) {
-    ET_UNWRAP(sliding_window_evalue__, module_->get("get_sliding_window"));
+    ET_ASSIGN_OR_RETURN(
+        sliding_window_evalue__, module_->get("get_sliding_window"));
     sliding_window = sliding_window_evalue__.toInt();
   }
   kv_manager_ = std::make_unique<KVManager>(
@@ -462,7 +463,7 @@ Error Runner::generate_from_prompt_or_file(
   // print the first token from prefill. No prev_token so use cur_token for
   // it.
   if (token_callback) {
-    ET_UNWRAP_TOKENIZER(
+    ET_ASSIGN_OR_RETURN_TOKENIZER(
         decoded_token__, tokenizer_->decode(cur_token, cur_token));
     token_callback(decoded_token__);
   }
@@ -473,7 +474,7 @@ Error Runner::generate_from_prompt_or_file(
 
   // start the main loop
   prompt_tokens.push_back(cur_token);
-  ET_UNWRAP(
+  ET_ASSIGN_OR_RETURN(
       num_generated_tokens,
       token_generator_->generate(
           prompt_tokens,

--- a/examples/qualcomm/oss_scripts/llama/runner/token_generator.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/token_generator.cpp
@@ -337,7 +337,7 @@ Result<int64_t> TokenGenerator::generate(
     pos++;
 
     // print the token as string, decode it with the Tokenizer object
-    ET_UNWRAP_TOKENIZER(
+    ET_ASSIGN_OR_RETURN_TOKENIZER(
         decoded_token__, tokenizer_->decode(prev_token, cur_token));
     token_callback(decoded_token__);
 

--- a/examples/qualcomm/oss_scripts/t5/runner/runner.cpp
+++ b/examples/qualcomm/oss_scripts/t5/runner/runner.cpp
@@ -180,7 +180,7 @@ Error Runner::generate(
     output_token_ids.push_back(cur_token);
 
     if (token_callback) {
-      ET_UNWRAP_TOKENIZER(
+      ET_ASSIGN_OR_RETURN_TOKENIZER(
           decoded_token__, tokenizer_->decode(prev_token, cur_token));
       token_callback(decoded_token__);
     }

--- a/examples/qualcomm/oss_scripts/whisper/runner/runner.cpp
+++ b/examples/qualcomm/oss_scripts/whisper/runner/runner.cpp
@@ -171,7 +171,7 @@ Error Runner::transcribe(
     ++pos;
 
     if (token_callback) {
-      ET_UNWRAP_TOKENIZER(
+      ET_ASSIGN_OR_RETURN_TOKENIZER(
           decoded_token__, tokenizer_->decode(prev_token, cur_token));
       token_callback(decoded_token__);
     }

--- a/extension/llm/runner/util.h
+++ b/extension/llm/runner/util.h
@@ -19,19 +19,33 @@
 #include <sys/resource.h>
 #endif
 
-// The internal result variable is named et_unwrap_result_##var__ rather than
-// a fixed name so that multiple ET_UNWRAP_TOKENIZER calls in the same scope
-// do not collide with each other.
-#define ET_UNWRAP_TOKENIZER(var__, result__)                      \
-  auto et_unwrap_result_##var__ = (result__);                     \
-  if (!et_unwrap_result_##var__.ok()) {                           \
-    ET_LOG(                                                       \
-        Error,                                                    \
-        "Tokenizers error code %d",                               \
-        static_cast<uint32_t>(et_unwrap_result_##var__.error())); \
-    return ::executorch::runtime::Error::InvalidArgument;         \
-  }                                                               \
-  auto var__ = std::move(*et_unwrap_result_##var__);
+#define ET_UNWRAP_TOKENIZER(result__)                       \
+  ({                                                        \
+    auto tk_result__ = (result__);                          \
+    if (!tk_result__.ok()) {                                \
+      ET_LOG(                                               \
+          Error,                                            \
+          "Tokenizers error code %d",                       \
+          static_cast<int>(tk_result__.error()));           \
+      return ::executorch::runtime::Error::InvalidArgument; \
+    }                                                       \
+    std::move(*tk_result__);                                \
+  })
+
+// Portable (MSVC-safe) statement form of ET_UNWRAP_TOKENIZER. Declares var__
+// in the current scope and assigns the unwrapped value to it. The internal
+// result variable is named et_assign_result_##var__ rather than a fixed name
+// so that multiple calls in the same scope do not collide with each other.
+#define ET_ASSIGN_OR_RETURN_TOKENIZER(var__, result__)       \
+  auto et_assign_result_##var__ = (result__);                \
+  if (!et_assign_result_##var__.ok()) {                      \
+    ET_LOG(                                                  \
+        Error,                                               \
+        "Tokenizers error code %d",                          \
+        static_cast<int>(et_assign_result_##var__.error())); \
+    return ::executorch::runtime::Error::InvalidArgument;    \
+  }                                                          \
+  auto var__ = std::move(*et_assign_result_##var__)
 
 #define ET_CHECK_TK_OK_OR_RETURN_ERROR(result__, ...)                        \
   do {                                                                       \

--- a/runtime/core/result.h
+++ b/runtime/core/result.h
@@ -215,11 +215,77 @@ using ::executorch::runtime::Result;
 } // namespace torch
 
 /**
- * Unwrap a Result to obtain its value, declaring var__ in the current
- * scope. If the Result contains an error, propagate the error via trivial
- * function return.
+ * Unwrap a Result to obtain its value. If the Result contains an error,
+ * propagate the error via trivial function return.
  *
  * Note: A function using ET_UNWRAP should itself return a Result or Error.
+ *
+ * This macro expands to a GNU statement expression and is therefore used as an
+ * expression (e.g. `auto value = ET_UNWRAP(expr);`). It is NOT portable to
+ * MSVC, which does not support statement expressions. Code that must compile
+ * under MSVC should use ET_ASSIGN_OR_RETURN below instead.
+ *
+ * @param[in] result__ Expression yielding the result to unwrap.
+ * @param[in] ... Optional format string for the log error message and its
+ * arguments.
+ */
+#define ET_UNWRAP(result__, ...) ET_INTERNAL_UNWRAP(result__, ##__VA_ARGS__)
+
+// Internal only: Use ET_UNWRAP() instead.
+#define ET_INTERNAL_UNWRAP(...)                                         \
+  ET_INTERNAL_UNWRAP_SELECT(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1) \
+  (__VA_ARGS__)
+
+// Internal only: Use ET_UNWRAP() instead.
+#define ET_INTERNAL_UNWRAP_SELECT(                   \
+    _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) \
+  ET_INTERNAL_UNWRAP_##N
+
+// Internal only: Use ET_UNWRAP() instead.
+#define ET_INTERNAL_UNWRAP_1(result__) \
+  ({                                   \
+    auto et_result__ = (result__);     \
+    if (!et_result__.ok()) {           \
+      return et_result__.error();      \
+    }                                  \
+    std::move(*et_result__);           \
+  })
+
+// Internal only: Use ET_UNWRAP() instead.
+#define ET_INTERNAL_UNWRAP_2(result__, message__, ...) \
+  ({                                                   \
+    auto et_result__ = (result__);                     \
+    if (!et_result__.ok()) {                           \
+      ET_LOG(Error, message__, ##__VA_ARGS__);         \
+      return et_result__.error();                      \
+    }                                                  \
+    std::move(*et_result__);                           \
+  })
+
+// Internal only: Use ET_UNWRAP() instead.
+#define ET_INTERNAL_UNWRAP_3 ET_INTERNAL_UNWRAP_2
+#define ET_INTERNAL_UNWRAP_4 ET_INTERNAL_UNWRAP_2
+#define ET_INTERNAL_UNWRAP_5 ET_INTERNAL_UNWRAP_2
+#define ET_INTERNAL_UNWRAP_6 ET_INTERNAL_UNWRAP_2
+#define ET_INTERNAL_UNWRAP_7 ET_INTERNAL_UNWRAP_2
+#define ET_INTERNAL_UNWRAP_8 ET_INTERNAL_UNWRAP_2
+#define ET_INTERNAL_UNWRAP_9 ET_INTERNAL_UNWRAP_2
+#define ET_INTERNAL_UNWRAP_10 ET_INTERNAL_UNWRAP_2
+
+/**
+ * Assign the unwrapped value of a Result to a newly declared variable, or
+ * return the error via trivial function return.
+ *
+ * Unlike ET_UNWRAP (which expands to a GNU statement expression), this macro
+ * expands to plain statements and is therefore portable to MSVC. Prefer it in
+ * code that must build with MSVC.
+ *
+ * Note: A function using ET_ASSIGN_OR_RETURN should itself return a Result or
+ * Error.
+ *
+ * Usage:
+ *   ET_ASSIGN_OR_RETURN(value, expr);
+ *   ET_ASSIGN_OR_RETURN(value, expr, "log message %d", arg);
  *
  * @param[in] var__ Name of the variable to declare and assign the unwrapped
  *   value to.
@@ -227,41 +293,41 @@ using ::executorch::runtime::Result;
  * @param[in] ... Optional format string for the log error message and its
  *   arguments.
  */
-#define ET_UNWRAP(...)                                 \
-  ET_INTERNAL_UNWRAP_EXPAND(ET_INTERNAL_UNWRAP_SELECT( \
+#define ET_ASSIGN_OR_RETURN(...)                                           \
+  ET_INTERNAL_ASSIGN_OR_RETURN_EXPAND(ET_INTERNAL_ASSIGN_OR_RETURN_SELECT( \
       __VA_ARGS__, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)(__VA_ARGS__))
 
-// Internal only: Use ET_UNWRAP() instead.
-#define ET_INTERNAL_UNWRAP_EXPAND(x) x
+// Internal only: Use ET_ASSIGN_OR_RETURN() instead.
+#define ET_INTERNAL_ASSIGN_OR_RETURN_EXPAND(x) x
 
-// Internal only: Use ET_UNWRAP() instead.
-#define ET_INTERNAL_UNWRAP_SELECT(                        \
+// Internal only: Use ET_ASSIGN_OR_RETURN() instead.
+#define ET_INTERNAL_ASSIGN_OR_RETURN_SELECT(              \
     _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, N, ...) \
-  ET_INTERNAL_UNWRAP_##N
+  ET_INTERNAL_ASSIGN_OR_RETURN_##N
 
-// Internal only: Use ET_UNWRAP() instead.
-#define ET_INTERNAL_UNWRAP_2(var__, result__) \
-  auto et_unwrap_result_##var__ = (result__); \
-  if (!et_unwrap_result_##var__.ok()) {       \
-    return et_unwrap_result_##var__.error();  \
-  }                                           \
-  auto var__ = std::move(*et_unwrap_result_##var__)
+// Internal only: Use ET_ASSIGN_OR_RETURN() instead.
+#define ET_INTERNAL_ASSIGN_OR_RETURN_2(var__, result__) \
+  auto et_assign_result_##var__ = (result__);           \
+  if (!et_assign_result_##var__.ok()) {                 \
+    return et_assign_result_##var__.error();            \
+  }                                                     \
+  auto var__ = std::move(*et_assign_result_##var__)
 
-// Internal only: Use ET_UNWRAP() instead.
-#define ET_INTERNAL_UNWRAP_3(var__, result__, message__, ...) \
-  auto et_unwrap_result_##var__ = (result__);                 \
-  if (!et_unwrap_result_##var__.ok()) {                       \
-    ET_LOG(Error, message__, ##__VA_ARGS__);                  \
-    return et_unwrap_result_##var__.error();                  \
-  }                                                           \
-  auto var__ = std::move(*et_unwrap_result_##var__)
+// Internal only: Use ET_ASSIGN_OR_RETURN() instead.
+#define ET_INTERNAL_ASSIGN_OR_RETURN_3(var__, result__, message__, ...) \
+  auto et_assign_result_##var__ = (result__);                           \
+  if (!et_assign_result_##var__.ok()) {                                 \
+    ET_LOG(Error, message__, ##__VA_ARGS__);                            \
+    return et_assign_result_##var__.error();                            \
+  }                                                                     \
+  auto var__ = std::move(*et_assign_result_##var__)
 
-// Internal only: Use ET_UNWRAP() instead.
-#define ET_INTERNAL_UNWRAP_4 ET_INTERNAL_UNWRAP_3
-#define ET_INTERNAL_UNWRAP_5 ET_INTERNAL_UNWRAP_3
-#define ET_INTERNAL_UNWRAP_6 ET_INTERNAL_UNWRAP_3
-#define ET_INTERNAL_UNWRAP_7 ET_INTERNAL_UNWRAP_3
-#define ET_INTERNAL_UNWRAP_8 ET_INTERNAL_UNWRAP_3
-#define ET_INTERNAL_UNWRAP_9 ET_INTERNAL_UNWRAP_3
-#define ET_INTERNAL_UNWRAP_10 ET_INTERNAL_UNWRAP_3
-#define ET_INTERNAL_UNWRAP_11 ET_INTERNAL_UNWRAP_3
+// Internal only: Use ET_ASSIGN_OR_RETURN() instead.
+#define ET_INTERNAL_ASSIGN_OR_RETURN_4 ET_INTERNAL_ASSIGN_OR_RETURN_3
+#define ET_INTERNAL_ASSIGN_OR_RETURN_5 ET_INTERNAL_ASSIGN_OR_RETURN_3
+#define ET_INTERNAL_ASSIGN_OR_RETURN_6 ET_INTERNAL_ASSIGN_OR_RETURN_3
+#define ET_INTERNAL_ASSIGN_OR_RETURN_7 ET_INTERNAL_ASSIGN_OR_RETURN_3
+#define ET_INTERNAL_ASSIGN_OR_RETURN_8 ET_INTERNAL_ASSIGN_OR_RETURN_3
+#define ET_INTERNAL_ASSIGN_OR_RETURN_9 ET_INTERNAL_ASSIGN_OR_RETURN_3
+#define ET_INTERNAL_ASSIGN_OR_RETURN_10 ET_INTERNAL_ASSIGN_OR_RETURN_3
+#define ET_INTERNAL_ASSIGN_OR_RETURN_11 ET_INTERNAL_ASSIGN_OR_RETURN_3


### PR DESCRIPTION
Summary:
Combines the Qualcomm MSVC-compatibility work (originally
pytorch/executorch#19686 by zhaoxul-qti) with a non-breaking treatment of the
ET_UNWRAP / ET_UNWRAP_TOKENIZER macros.

#19686 made the code MSVC-compatible (removing designated initializers, GNU
statement expressions, constexpr-in-lambda, and __attribute__((visibility))),
but it also converted ET_UNWRAP and ET_UNWRAP_TOKENIZER from expression macros
into statement macros that require a variable name as the first argument. Those
two macros are used as expressions in 100+ call sites across fbcode/xplat/arvr,
so that change broke many unrelated targets.

This instead:
- Keeps the MSVC fixes from #19686 (designated initializers, __declspec,
  statement-expression removal in Qualcomm code, etc.).
- Restores ET_UNWRAP (result.h) and ET_UNWRAP_TOKENIZER (extension/llm/runner/
  util.h) to their original expression forms, so existing call sites are
  unchanged.
- Adds portable, MSVC-safe statement macros ET_ASSIGN_OR_RETURN and
  ET_ASSIGN_OR_RETURN_TOKENIZER for code that must build under MSVC.
- Points the Qualcomm oss_scripts runner sites at the new macros.

Co-authored-by: zhaoxul-qti <zhaoxul@qti.qualcomm.com>

Reviewed By: kirklandsign

Differential Revision: D107594919


