### PR TITLE
Turn on device memory planing as default (#20060)

### DIFF
--- a/backends/cuda/runtime/cuda_backend.cpp
+++ b/backends/cuda/runtime/cuda_backend.cpp
@@ -34,7 +34,6 @@
 #include <executorch/backends/aoti/slim/core/storage.h>
 #include <executorch/backends/aoti/slim/factory/empty.h>
 #include <executorch/backends/aoti/slim/factory/from_blob.h>
-#include <executorch/backends/aoti/slim/factory/from_etensor.h>
 #include <executorch/backends/aoti/slim/util/array_ref_util.h>
 
 // Include our shim layer headers
@@ -72,10 +71,7 @@ using executorch::runtime::etensor::Tensor;
 
 // SlimTensor type aliases
 using cuda::CudaGraphPhase;
-using slim::CPU_DEVICE;
-using slim::DEFAULT_CUDA_DEVICE;
 using slim::DeviceTraits;
-using slim::from_etensor;
 using slim::SlimTensor;
 using slim::c10::Device;
 using slim::c10::DeviceType;
@@ -126,32 +122,6 @@ class ET_EXPERIMENTAL CudaBackend final
       pos = comma + 1;
     }
     return false;
-  }
-
-  void set_skip_copy_method(
-      const std::array<char, kMaxOptionValueLength>& raw) {
-    std::lock_guard<std::mutex> guard(skip_copy_method_mutex_);
-    skip_copy_method_ = std::string(raw.data());
-  }
-
-  std::array<char, kMaxOptionValueLength> get_skip_copy_method_as_option()
-      const {
-    std::array<char, kMaxOptionValueLength> out{};
-    std::string value;
-    {
-      std::lock_guard<std::mutex> guard(skip_copy_method_mutex_);
-      value = skip_copy_method_;
-    }
-    std::snprintf(out.data(), out.size(), "%s", value.c_str());
-    return out;
-  }
-
-  bool should_skip_copy_for_method(const std::string& method_name) const {
-    if (method_name.empty()) {
-      return false;
-    }
-    std::lock_guard<std::mutex> guard(skip_copy_method_mutex_);
-    return method_in_csv(method_name, skip_copy_method_);
   }
 
   void set_cuda_graph_method(
@@ -277,16 +247,16 @@ class ET_EXPERIMENTAL CudaBackend final
       override {
     for (const auto& option : backend_options) {
       if (std::strcmp(option.key, kSkipCopyOutputToCpuForMethod) == 0) {
-        if (auto* val = std::get_if<std::array<char, kMaxOptionValueLength>>(
-                &option.value)) {
-          set_skip_copy_method(*val);
-        } else {
-          ET_LOG(
-              Error,
-              "Option %s must be a method name string.",
-              kSkipCopyOutputToCpuForMethod);
-          return Error::InvalidArgument;
-        }
+        // Deprecated, no-op option. CUDA delegate IO is now GPU-resident under
+        // device memory planning, and host<->device transfers are handled by
+        // graph-level et_copy ops. To skip those copies, export the .pte with
+        // ExecutorchBackendConfig.propagate_device_config = PropagateDeviceConfig(
+        // skip_d2h_for_method_outputs=..., skip_h2d_for_method_inputs=...).
+        ET_LOG(
+            Info,
+            "Runtime backend option '%s' is DEPRECATED and no longer has any "
+            "effect; ignoring it.",
+            kSkipCopyOutputToCpuForMethod);
       } else if (std::strcmp(option.key, kUseSharedCudaStream) == 0) {
         if (auto* val = std::get_if<bool>(&option.value)) {
           if (*val) {
@@ -324,12 +294,8 @@ class ET_EXPERIMENTAL CudaBackend final
 
   Error get_option(
       ET_UNUSED BackendOptionContext& context,
-      executorch::runtime::Span<BackendOption>& backend_options) override {
-    for (auto& option : backend_options) {
-      if (std::strcmp(option.key, kSkipCopyOutputToCpuForMethod) == 0) {
-        option.value = get_skip_copy_method_as_option();
-      }
-    }
+      ET_UNUSED executorch::runtime::Span<BackendOption>& backend_options)
+      override {
     return Error::Ok;
   }
 
@@ -499,9 +465,10 @@ class ET_EXPERIMENTAL CudaBackend final
     // is set during serialization by PropagateDevicePass based on the
     // target_device compile spec from CudaPartitioner.
     //
-    // Note: At this stage, the tensor memory is still on CPU. The device_type
-    // is metadata indicating where the tensor *should* reside. The backend
-    // is responsible for copying data to the actual CUDA device.
+    // Under device memory planning, these tensors are GPU-resident: their
+    // storage lives in a planned CUDA arena. The backend wraps them in place
+    // and performs no host<->device copies — graph-level et_copy ops handle
+    // any host<->device transfers outside the delegate.
     for (size_t i = 0; i < n_inputs + n_outputs; i++) {
       auto* tensor = &(args[i]->toTensor());
       auto device_type = tensor->unsafeGetTensorImpl()->device_type();
@@ -512,6 +479,28 @@ class ET_EXPERIMENTAL CudaBackend final
           "Device info may not be properly propagated from CudaPartitioner.",
           i,
           static_cast<int>(device_type));
+
+      // device_type above is only metadata. Also verify the storage actually
+      // lives in CUDA device memory, so a CUDA-typed tensor that is secretly
+      // backed by host memory is caught here instead of corrupting the run.
+      const void* data_ptr = tensor->const_data_ptr();
+      if (data_ptr != nullptr) {
+        cudaPointerAttributes attributes{};
+        const cudaError_t attr_err =
+            cudaPointerGetAttributes(&attributes, data_ptr);
+        ET_CHECK_OR_RETURN_ERROR(
+            attr_err == cudaSuccess &&
+                (attributes.type == cudaMemoryTypeDevice ||
+                 attributes.type == cudaMemoryTypeManaged),
+            InvalidArgument,
+            "Tensor %zu has device_type=CUDA but its data pointer %p is not "
+            "backed by CUDA device memory (cudaPointerGetAttributes err=%d, "
+            "cudaMemoryType=%d).",
+            i,
+            data_ptr,
+            static_cast<int>(attr_err),
+            static_cast<int>(attributes.type));
+      }
     }
 
     // ---------------------------------------------------------------
@@ -522,22 +511,22 @@ class ET_EXPERIMENTAL CudaBackend final
       ET_CHECK_OK_OR_RETURN_ERROR(csr.error());
       cudaStream_t cs = csr.get();
 
-      // Copy new input data into static input buffers
+      // Copy new input data (GPU-resident) into static input buffers (D2D)
       for (size_t i = 0; i < n_inputs; i++) {
-        auto* cpu_tensor = &(args[i]->toTensor());
+        auto* et_input = &(args[i]->toTensor());
         ET_CHECK_OR_RETURN_ERROR(
-            cpu_tensor->nbytes() ==
+            et_input->nbytes() ==
                 handle->cuda_graph_state.static_input_nbytes[i],
             InvalidArgument,
             "CUDA graph replay: input %zu size mismatch (expected %zu, got %zu)",
             i,
             handle->cuda_graph_state.static_input_nbytes[i],
-            cpu_tensor->nbytes());
+            et_input->nbytes());
         ET_CUDA_CHECK_OR_RETURN_ERROR(cudaMemcpyAsync(
             handle->cuda_graph_state.static_input_ptrs[i],
-            cpu_tensor->const_data_ptr(),
+            et_input->const_data_ptr(),
             handle->cuda_graph_state.static_input_nbytes[i],
-            cudaMemcpyHostToDevice,
+            cudaMemcpyDeviceToDevice,
             cs));
       }
 
@@ -550,21 +539,17 @@ class ET_EXPERIMENTAL CudaBackend final
           "cudaGraphLaunch failed: %s",
           cudaGetErrorString(gerr));
 
-      // Copy outputs back to CPU
-      const bool copy_outputs =
-          !should_skip_copy_for_method(handle->method_name);
-      if (copy_outputs) {
-        for (size_t i = 0; i < n_outputs; i++) {
-          auto* cpu_out = &(args[i + n_inputs]->toTensor());
-          ET_CUDA_CHECK_OR_RETURN_ERROR(cudaMemcpyAsync(
-              cpu_out->mutable_data_ptr(),
-              handle->cuda_graph_state.static_output_ptrs[i],
-              handle->cuda_graph_state.static_output_nbytes[i],
-              cudaMemcpyDeviceToHost,
-              cs));
-        }
-        cudaStreamSynchronize(cs);
+      // Copy outputs from static buffers into the planned GPU ET buffers (D2D)
+      for (size_t i = 0; i < n_outputs; i++) {
+        auto* et_output = &(args[i + n_inputs]->toTensor());
+        ET_CUDA_CHECK_OR_RETURN_ERROR(cudaMemcpyAsync(
+            et_output->mutable_data_ptr(),
+            handle->cuda_graph_state.static_output_ptrs[i],
+            handle->cuda_graph_state.static_output_nbytes[i],
+            cudaMemcpyDeviceToDevice,
+            cs));
       }
+      ET_CUDA_CHECK_OR_RETURN_ERROR(cudaStreamSynchronize(cs));
 
       return Error::Ok;
     }
@@ -576,19 +561,18 @@ class ET_EXPERIMENTAL CudaBackend final
         (handle->cuda_graph_state.phase == CudaGraphPhase::Warmup &&
          handle->cuda_graph_state.warmup_remaining == 0);
 
-    // NOTE: ExecuTorch tensors may be on CPU or GPU due to the skip-copy
-    // optimization. We need to create GPU copies for CUDA kernel execution
-    // using SlimTensor.
-    std::vector<SlimTensor*> gpu_inputs(n_inputs);
-    std::vector<SlimTensor*> gpu_outputs(n_outputs);
+    // Wrrap them as SlimTensors for AOTI execution without any host<->device copies.
+    std::vector<SlimTensor*> slim_inputs(n_inputs);
+    std::vector<SlimTensor*> slim_outputs(n_outputs);
 
-    // Process input tensors: convert ETensor (CPU) to SlimTensor (GPU)
+    // Process input tensors: wrap the GPU-resident ETensor buffers directly.
     for (size_t i = 0; i < n_inputs; i++) {
-      auto* cpu_tensor = &(args[i]->toTensor());
+      auto* et_input = &(args[i]->toTensor());
 
-      // CAPTURE step: allocate persistent static GPU buffers
+      // CAPTURE step: allocate persistent static GPU buffers and seed them
+      // from the GPU-resident ET inputs (D2D).
       if (is_capture_step) {
-        size_t nbytes = cpu_tensor->nbytes();
+        size_t nbytes = et_input->nbytes();
 
         void* static_ptr = nullptr;
         cudaError_t merr = cudaMalloc(&static_ptr, nbytes);
@@ -599,73 +583,50 @@ class ET_EXPERIMENTAL CudaBackend final
             i,
             cudaGetErrorString(merr));
 
-        cudaMemcpy(
+        ET_CUDA_CHECK_OR_RETURN_ERROR(cudaMemcpy(
             static_ptr,
-            cpu_tensor->const_data_ptr(),
+            et_input->const_data_ptr(),
             nbytes,
-            cudaMemcpyHostToDevice);
+            cudaMemcpyDeviceToDevice));
 
         handle->cuda_graph_state.static_input_ptrs.push_back(static_ptr);
         handle->cuda_graph_state.static_input_nbytes.push_back(nbytes);
 
-        gpu_inputs[i] = make_slimtensor_from_blob_with_etensor_metadata(
-            static_ptr, cpu_tensor);
+        slim_inputs[i] = make_slimtensor_from_blob_with_etensor_metadata(
+            static_ptr, et_input);
         continue;
       }
 
-      // Check if input data is already on GPU (skip-copy optimization for
-      // inputs) This can happen when the caller has pre-staged data on GPU
-      cudaPointerAttributes attributes{};
-      const void* data_ptr = cpu_tensor->const_data_ptr();
-      if (data_ptr != nullptr) {
-        cudaError_t err = cudaPointerGetAttributes(&attributes, data_ptr);
-        if (err == cudaSuccess && attributes.type == cudaMemoryTypeDevice) {
-          // Data is already on GPU - wrap it directly without copy
-          gpu_inputs[i] = make_slimtensor_from_blob_with_etensor_metadata(
-              const_cast<void*>(data_ptr), cpu_tensor);
-
-          continue;
-        }
-      }
-
-      // Data is on CPU - use from_etensor to copy to GPU
-      gpu_inputs[i] = new SlimTensor(
-          from_etensor(*cpu_tensor, CPU_DEVICE, DEFAULT_CUDA_DEVICE));
+      // Normal path: wrap the GPU buffer in place (zero-copy, non-owning).
+      slim_inputs[i] = make_slimtensor_from_blob_with_etensor_metadata(
+          const_cast<void*>(et_input->const_data_ptr()), et_input);
     }
 
-    // Process output tensors: create GPU SlimTensors for kernel output.
-    // Save pre-run handles to detect orphans after run().
+    // Process output tensors: wrap the GPU-resident ET output buffers as
+    // non-owning SlimTensors so AOTI can write into the planned slot directly
+    // when it does not allocate its own output. Save pre-run handles to detect
+    // when AOTI replaces them with its own allocation.
     std::vector<SlimTensor*> pre_run_outputs(n_outputs, nullptr);
     for (size_t i = 0; i < n_outputs; i++) {
-      auto* cpu_output_tensor = &(args[i + n_inputs]->toTensor());
-      auto sizes = cpu_output_tensor->sizes();
-      auto strides = cpu_output_tensor->strides();
-      auto scalar_type = cpu_output_tensor->scalar_type();
-
-      std::vector<int64_t> sizes_vec(sizes.begin(), sizes.end());
-      std::vector<int64_t> strides_vec(strides.begin(), strides.end());
-
-      gpu_outputs[i] = new SlimTensor(slim::empty_strided(
-          slim::makeArrayRef(sizes_vec),
-          slim::makeArrayRef(strides_vec),
-          static_cast<slim::c10::ScalarType>(scalar_type),
-          DEFAULT_CUDA_DEVICE));
-      pre_run_outputs[i] = gpu_outputs[i];
+      auto* et_output = &(args[i + n_inputs]->toTensor());
+      slim_outputs[i] = make_slimtensor_from_blob_with_etensor_metadata(
+          const_cast<void*>(et_output->const_data_ptr()), et_output);
+      pre_run_outputs[i] = slim_outputs[i];
     }
 
     bool run_called = false;
 
-    // Scope guard: deletes any non-null gpu_outputs on exit. Normal paths
+    // Scope guard: deletes any non-null slim_outputs on exit. Normal paths
     // null entries as they take ownership, so the guard only fires on
     // early-return error paths. Also cleans up inputs if run() was never
     // called (run() steals them via internal RAII).
     executorch::backends::aoti::ScopeGuard cleanup([&]() noexcept {
       if (!run_called) {
-        delete_slimtensor_vector(gpu_inputs);
+        delete_slimtensor_vector(slim_inputs);
       }
-      for (size_t i = 0; i < gpu_outputs.size(); i++) {
-        if (gpu_outputs[i]) {
-          delete gpu_outputs[i];
+      for (size_t i = 0; i < slim_outputs.size(); i++) {
+        if (slim_outputs[i]) {
+          delete slim_outputs[i];
         }
       }
     });
@@ -695,9 +656,9 @@ class ET_EXPERIMENTAL CudaBackend final
 
     AOTIRuntimeError error = handle->run(
         handle->container_handle,
-        reinterpret_cast<Tensor**>(gpu_inputs.data()),
+        reinterpret_cast<Tensor**>(slim_inputs.data()),
         n_inputs,
-        reinterpret_cast<Tensor**>(gpu_outputs.data()),
+        reinterpret_cast<Tensor**>(slim_outputs.data()),
         n_outputs,
         static_cast<void*>(cuda_stream),
         nullptr);
@@ -707,7 +668,7 @@ class ET_EXPERIMENTAL CudaBackend final
     // Must happen before the error check — if run() fails after
     // replacing some outputs, the originals would otherwise leak.
     for (size_t i = 0; i < n_outputs; i++) {
-      if (pre_run_outputs[i] != gpu_outputs[i]) {
+      if (pre_run_outputs[i] != slim_outputs[i]) {
         delete pre_run_outputs[i];
       }
     }
@@ -740,7 +701,7 @@ class ET_EXPERIMENTAL CudaBackend final
 
       // Record static output pointers (stable under graph replay)
       for (size_t i = 0; i < n_outputs; i++) {
-        SlimTensor* out = gpu_outputs[i];
+        SlimTensor* out = slim_outputs[i];
         handle->cuda_graph_state.static_output_ptrs.push_back(out->data_ptr());
         handle->cuda_graph_state.static_output_nbytes.push_back(out->nbytes());
       }
@@ -759,29 +720,19 @@ class ET_EXPERIMENTAL CudaBackend final
           "cudaGraphLaunch (first replay) failed: %s",
           cudaGetErrorString(gerr));
 
-      // Copy capture-step outputs to CPU
-      const bool copy_outputs =
-          !should_skip_copy_for_method(handle->method_name);
-      if (copy_outputs) {
-        for (size_t i = 0; i < n_outputs; i++) {
-          auto* cpu_out = &(args[i + n_inputs]->toTensor());
-          ET_CUDA_CHECK_OR_RETURN_ERROR(cudaMemcpyAsync(
-              cpu_out->mutable_data_ptr(),
-              handle->cuda_graph_state.static_output_ptrs[i],
-              handle->cuda_graph_state.static_output_nbytes[i],
-              cudaMemcpyDeviceToHost,
-              cuda_stream));
-          // Don't delete — static buffers are owned by the handle
-          gpu_outputs[i] = nullptr;
-        }
-        cudaStreamSynchronize(cuda_stream);
-      } else {
-        // Even when skipping copy, null out gpu_outputs to prevent
-        // the ScopeGuard from deleting static output buffers.
-        for (size_t i = 0; i < n_outputs; i++) {
-          gpu_outputs[i] = nullptr;
-        }
+      // Copy capture-step outputs into the planned GPU ET buffers (D2D).
+      for (size_t i = 0; i < n_outputs; i++) {
+        auto* et_output = &(args[i + n_inputs]->toTensor());
+        ET_CUDA_CHECK_OR_RETURN_ERROR(cudaMemcpyAsync(
+            et_output->mutable_data_ptr(),
+            handle->cuda_graph_state.static_output_ptrs[i],
+            handle->cuda_graph_state.static_output_nbytes[i],
+            cudaMemcpyDeviceToDevice,
+            cuda_stream));
+        // Don't delete — static buffers are owned by the AOTI runtime.
+        slim_outputs[i] = nullptr;
       }
+      ET_CUDA_CHECK_OR_RETURN_ERROR(cudaStreamSynchronize(cuda_stream));
 
       return Error::Ok;
     }
@@ -799,39 +750,34 @@ class ET_EXPERIMENTAL CudaBackend final
           handle->method_name.c_str());
     }
 
-    const bool copy_outputs = !should_skip_copy_for_method(handle->method_name);
-
-    if (copy_outputs) {
-      for (size_t i = 0; i < n_outputs; i++) {
-        auto* cpu_output_tensor = &(args[i + n_inputs]->toTensor());
+    // Land each output into its planned GPU ET buffer.
+    //
+    // Before run(), each slim_outputs[i] was a non-owning view over the
+    // planned GPU ET output buffer, and we recorded that pointer in
+    // pre_run_outputs[i]. AOTInductorModelContainerRun may either:
+    //   (a) write directly into the buffer we passed (leaving our handle in
+    //       place), or
+    //   (b) allocate its own output in its caching allocator and overwrite
+    //       slim_outputs[i] with that new handle.
+    // Comparing the post-run handle against the recorded pre-run handle tells
+    // us which happened.
+    for (size_t i = 0; i < n_outputs; i++) {
+      auto* et_output = &(args[i + n_inputs]->toTensor());
+      if (pre_run_outputs[i] == slim_outputs[i]) {
+        // Case (a): AOTI wrote directly into our planned ET buffer. The result
+        // is already in place — nothing to copy, just drop the view wrapper.
+        delete slim_outputs[i];
+      } else {
+        // Case (b): AOTI returned its own buffer. D2D copy the result into the
+        // planned GPU ET buffer, then free AOTI's buffer.
         ET_CHECK_OK_OR_RETURN_ERROR(
-            copy_slimtensor_to_etensor_async(
-                gpu_outputs[i], cpu_output_tensor, cuda_stream),
-            "Failed to copy GPU output %zu back to CPU ETensor",
+            copy_slimtensor_to_device_etensor_async(
+                slim_outputs[i], et_output, cuda_stream),
+            "Failed to D2D copy GPU output %zu into ETensor",
             i);
-        delete gpu_outputs[i];
-        gpu_outputs[i] = nullptr;
+        delete slim_outputs[i];
       }
-    } else {
-      // Skip-copy optimization: point ETensor directly to GPU data.
-      // Lifetime management: cache GPU tensors and delete previous round's.
-      {
-        std::lock_guard<std::mutex> guard(cached_outputs_mutex_);
-        auto& cached_outputs = cached_outputs_[handle];
-
-        delete_slimtensor_vector(cached_outputs);
-
-        for (size_t i = 0; i < n_outputs; i++) {
-          cached_outputs.push_back(gpu_outputs[i]);
-          gpu_outputs[i] = nullptr;
-
-          auto* output_etensor = &(args[i + n_inputs]->toTensor());
-          ET_CHECK_OK_OR_RETURN_ERROR(
-              wrap_slimtensor_to_etensor(cached_outputs.back(), output_etensor),
-              "Failed to wrap GPU output %zu into ETensor",
-              i);
-        }
-      }
+      slim_outputs[i] = nullptr;
     }
 
     return Error::Ok;
@@ -842,16 +788,6 @@ class ET_EXPERIMENTAL CudaBackend final
       return;
     }
     cuda::CudaDelegateHandle* handle = (cuda::CudaDelegateHandle*)handle_;
-
-    // Clean up cached output tensors for this handle
-    {
-      std::lock_guard<std::mutex> guard(cached_outputs_mutex_);
-      auto it = cached_outputs_.find(handle);
-      if (it != cached_outputs_.end()) {
-        delete_slimtensor_vector(it->second);
-        cached_outputs_.erase(it);
-      }
-    }
 
     // The CUDA stream is managed by shared_ptr in the handle.
     // It will be automatically destroyed when the last handle using it
@@ -890,17 +826,14 @@ class ET_EXPERIMENTAL CudaBackend final
   }
 
  private:
-  mutable std::mutex skip_copy_method_mutex_;
-  std::string skip_copy_method_;
-
   mutable std::mutex cuda_graph_method_mutex_;
   std::string cuda_graph_method_;
 
   // Shared CUDA stream for all methods. When set (non-null), all methods use
-  // the same stream to ensure proper ordering (critical for skip-copy
-  // optimization). Created when use_shared_cuda_stream option is set to true.
-  // Managed via shared_ptr so it's automatically cleaned up when last handle
-  // is destroyed.
+  // the same stream to ensure proper ordering across methods that hand off
+  // GPU-resident tensors (e.g. encoder -> decoder -> sampler). Created when
+  // use_shared_cuda_stream option is set to true. Managed via shared_ptr so
+  // it's automatically cleaned up when last handle is destroyed.
   mutable std::mutex cuda_stream_mutex_;
   std::shared_ptr<cudaStream_t> shared_cuda_stream_ = nullptr;
 
@@ -908,15 +841,6 @@ class ET_EXPERIMENTAL CudaBackend final
   // Toggled by the kWeightSharingAcrossMethods runtime backend option. Default
   // OFF — see set_weight_sharing_across_methods() for safety constraints.
   std::atomic<bool> weight_sharing_across_methods_{false};
-
-  // Cached output tensors for skip-copy optimization.
-  // When skip-copy is enabled, output SlimTensors are cached here to keep
-  // the underlying GPU memory alive while the caller processes the results.
-  // Maps each CudaDelegateHandle* to its vector of cached output tensors.
-  mutable std::mutex cached_outputs_mutex_;
-  mutable std::
-      unordered_map<cuda::CudaDelegateHandle*, std::vector<SlimTensor*>>
-          cached_outputs_;
 
   // ---------------------------------------------------------------
   // Per-weight constant cache.
@@ -1122,7 +1046,7 @@ class ET_EXPERIMENTAL CudaBackend final
               static_cast<const uint8_t*>(weights_blob)),
           "update_constants_from_blob failed for method '%s'",
           method_name.c_str());
-      cudaDeviceSynchronize();
+      ET_CUDA_CHECK_OR_RETURN_ERROR(cudaDeviceSynchronize());
       buffer_res->Free();
 
       // Extract all constants from the freshly-loaded container.
@@ -1234,7 +1158,7 @@ class ET_EXPERIMENTAL CudaBackend final
         ET_LOG(Error, "update_constants_from_blob failed");
         return update_err;
       }
-      cudaDeviceSynchronize();
+      ET_CUDA_CHECK_OR_RETURN_ERROR(cudaDeviceSynchronize());
       buffer_res->Free();
     } else {
       ET_LOG(

--- a/backends/cuda/runtime/utils.h
+++ b/backends/cuda/runtime/utils.h
@@ -147,11 +147,13 @@ inline void _strided_copy(
 }
 
 // Copy data from SlimTensor to ETensor, rearranging if strides differ.
-// When stream is non-null, GPU copies use that stream (async fast path).
-// When stream is null, GPU copies are synchronous.
+// dst_device selects the destination memory space (CPU for D2H, a CUDA device
+// for D2D). When stream is non-null, GPU copies use that stream (async fast
+// path). When stream is null, GPU copies are synchronous.
 inline executorch::runtime::Error _copy_slimtensor_to_etensor_impl(
     const executorch::backends::aoti::slim::SlimTensor* slim_tensor,
     executorch::runtime::etensor::Tensor* etensor,
+    const executorch::backends::aoti::slim::c10::Device& dst_device,
     cudaStream_t stream) {
   ET_CHECK_OK_OR_RETURN_ERROR(_check_tensor_metadata(slim_tensor, etensor));
 
@@ -165,7 +167,7 @@ inline executorch::runtime::Error _copy_slimtensor_to_etensor_impl(
 
   if (_strides_match(slim_tensor, etensor)) {
     // Fast path: strides match, raw byte copy
-    if (slim_tensor->is_cpu()) {
+    if (slim_tensor->is_cpu() && dst_device.is_cpu()) {
       std::memcpy(dst_data, src_data, nbytes);
     } else if (stream) {
       executorch::backends::aoti::slim::DeviceTraits<
@@ -174,7 +176,7 @@ inline executorch::runtime::Error _copy_slimtensor_to_etensor_impl(
               dst_data,
               src_data,
               nbytes,
-              executorch::backends::aoti::slim::CPU_DEVICE,
+              dst_device,
               slim_tensor->device(),
               stream);
     } else {
@@ -184,13 +186,14 @@ inline executorch::runtime::Error _copy_slimtensor_to_etensor_impl(
               dst_data,
               src_data,
               nbytes,
-              executorch::backends::aoti::slim::CPU_DEVICE,
+              dst_device,
               slim_tensor->device());
     }
   } else {
     // Slow path: strides differ (e.g., AOTI delegate output layout differs
-    // from .pte's dim_order). Copy to a temp CPU buffer, then rearrange
-    // element-by-element to match the ETensor's expected layout.
+    // from .pte's dim_order). Copy to a temp CPU buffer, rearrange
+    // element-by-element to match the ETensor's expected layout, then move the
+    // result to the destination (CPU stays in place; GPU gets an H2D copy).
     std::vector<char> tmp(nbytes);
     if (slim_tensor->is_cpu()) {
       std::memcpy(tmp.data(), src_data, nbytes);
@@ -218,13 +221,38 @@ inline executorch::runtime::Error _copy_slimtensor_to_etensor_impl(
 
     size_t elem_size = executorch::backends::aoti::slim::c10::elementSize(
         slim_tensor->dtype());
-    _strided_copy(
-        dst_data,
-        tmp.data(),
-        elem_size,
-        sizes_vec,
-        src_strides_vec,
-        dst_strides_vec);
+
+    if (dst_device.is_cpu()) {
+      _strided_copy(
+          dst_data,
+          tmp.data(),
+          elem_size,
+          sizes_vec,
+          src_strides_vec,
+          dst_strides_vec);
+    } else {
+      // Rearrange into a CPU staging buffer, then copy to the GPU destination.
+      std::vector<char> rearranged(nbytes);
+      _strided_copy(
+          rearranged.data(),
+          tmp.data(),
+          elem_size,
+          sizes_vec,
+          src_strides_vec,
+          dst_strides_vec);
+      if (stream) {
+        ET_CUDA_CHECK_OR_RETURN_ERROR(cudaMemcpyAsync(
+            dst_data,
+            rearranged.data(),
+            nbytes,
+            cudaMemcpyHostToDevice,
+            stream));
+        ET_CUDA_CHECK_OR_RETURN_ERROR(cudaStreamSynchronize(stream));
+      } else {
+        ET_CUDA_CHECK_OR_RETURN_ERROR(cudaMemcpy(
+            dst_data, rearranged.data(), nbytes, cudaMemcpyHostToDevice));
+      }
+    }
   }
 
   return executorch::runtime::Error::Ok;
@@ -251,7 +279,39 @@ inline executorch::runtime::Error copy_slimtensor_to_etensor_async(
     const executorch::backends::aoti::slim::SlimTensor* slim_tensor,
     executorch::runtime::etensor::Tensor* etensor,
     cudaStream_t stream) {
-  return _copy_slimtensor_to_etensor_impl(slim_tensor, etensor, stream);
+  return _copy_slimtensor_to_etensor_impl(
+      slim_tensor,
+      etensor,
+      executorch::backends::aoti::slim::CPU_DEVICE,
+      stream);
+}
+
+/**
+ * Copies data from a SlimTensor to a GPU-resident ETensor asynchronously
+ * (device-to-device).
+ *
+ * Used when the destination ETensor's storage lives in a planned GPU arena.
+ * The destination device is taken from the source SlimTensor, so this only
+ * supports same-device D2D copies (source and destination on the same GPU).
+ *
+ * When strides match (common case), performs a fast async D2D copy on the
+ * provided stream. When strides differ, falls back to a staged copy with
+ * element-by-element rearrangement on the host.
+ *
+ * NOTE: In the fast path the copy is asynchronous. The caller must synchronize
+ * the stream before consuming the ETensor data.
+ *
+ * @param slim_tensor Pointer to the source SlimTensor (must not be null).
+ * @param etensor Pointer to the destination GPU ETensor (must not be null).
+ * @param stream The CUDA stream to use for async copy.
+ * @return Error::Ok on success, or an appropriate error code on failure.
+ */
+inline executorch::runtime::Error copy_slimtensor_to_device_etensor_async(
+    const executorch::backends::aoti::slim::SlimTensor* slim_tensor,
+    executorch::runtime::etensor::Tensor* etensor,
+    cudaStream_t stream) {
+  return _copy_slimtensor_to_etensor_impl(
+      slim_tensor, etensor, slim_tensor->device(), stream);
 }
 
 /**
@@ -267,7 +327,11 @@ inline executorch::runtime::Error copy_slimtensor_to_etensor_async(
 inline executorch::runtime::Error copy_slimtensor_to_etensor(
     const executorch::backends::aoti::slim::SlimTensor* slim_tensor,
     executorch::runtime::etensor::Tensor* etensor) {
-  return _copy_slimtensor_to_etensor_impl(slim_tensor, etensor, nullptr);
+  return _copy_slimtensor_to_etensor_impl(
+      slim_tensor,
+      etensor,
+      executorch::backends::aoti::slim::CPU_DEVICE,
+      nullptr);
 }
 
 /**

--- a/backends/cuda/tests/test_cuda_export.py
+++ b/backends/cuda/tests/test_cuda_export.py
@@ -328,18 +328,23 @@ class TestCudaExport(unittest.TestCase):
 
     def test_device_info_propagated_to_cuda_delegate_outputs(self):
         """
-        Test that device info is correctly propagated from export to serialization
-        for CUDA delegate outputs.
+        Verify that, for a CUDA-delegated graph, every memory-planned tensor's
+        actual planned memory location matches its device_type tag.
 
-        This verifies the device propagation flow:
-        1. CudaPartitioner adds target_device="cuda:0" CompileSpec
-        2. PropagateDevicePass sets TensorSpec.device = CUDA for delegate outputs
-        3. Emitter serializes device info into ExtraTensorInfo.device_type
-        4. Serialized tensors have device_type = DeviceType.CUDA
+        With device memory planning (the default), the flow is:
+        1. CudaPartitioner adds target_device="cuda:0" CompileSpec.
+        2. PropagateDevicePass tags delegate IO TensorSpecs as CUDA and inserts
+           et_copy._h2d_copy / _d2h_copy ops at the delegate boundary, so the
+           method inputs/outputs stay on CPU while the delegate IO is CUDA.
+        3. Device-aware memory planning allocates each non-CPU tensor into a CUDA
+           buffer, recorded in ExecutionPlan.non_const_buffer_device.
+        4. The emitter serializes device info into ExtraTensorInfo.device_type.
 
-        Note: At this stage, the tensor memory is still on CPU. The CUDA backend
-        will copy data to GPU device at runtime. Device info tagging is the first
-        step toward full device-aware memory allocation.
+        The core check: for each planned tensor, the device of the buffer it is
+        allocated into (non_const_buffer_device) must agree with the tensor's
+        own device_type. A CUDA-tagged tensor planned into a CPU buffer (or vice
+        versa) means planning and device tagging disagree about where the
+        tensor's real memory lives.
         """
 
         class AddModule(torch.nn.Module):
@@ -354,7 +359,8 @@ class TestCudaExport(unittest.TestCase):
         edge_program_manager = self._export_to_cuda_with_lower(module, inputs)
         self.assertIsNotNone(edge_program_manager, "CUDA export failed")
 
-        # Convert to ExecuTorch and access the serialized program
+        # Convert to ExecuTorch and access the serialized program. The default
+        # config enables device memory planning, so delegate IO is GPU-resident.
         et_prog = edge_program_manager.to_executorch()
         program = et_prog._emitter_output.program
 
@@ -366,32 +372,60 @@ class TestCudaExport(unittest.TestCase):
             "Expected at least one delegate in the execution plan",
         )
 
-        # Count tensors by device type
-        cpu_tensors = []
-        cuda_tensors = []
+        # Build buffer_idx -> device map from the per-buffer device mapping.
+        # Buffers without an entry default to CPU.
+        buffer_device: dict[int, schema.DeviceType] = {}
+        for entry in plan.non_const_buffer_device or []:
+            buffer_device[entry.buffer_idx] = entry.device_type
 
+        def tensor_device(t: schema.Tensor) -> schema.DeviceType:
+            if t.extra_tensor_info is not None:
+                return t.extra_tensor_info.device_type
+            return schema.DeviceType.CPU
+
+        # Walk every memory-planned tensor in the graph and assert its declared
+        # device_type matches the device of the buffer it lives in.
+        cuda_planned = 0
+        cpu_planned = 0
         for value in plan.values:
-            if isinstance(value.val, schema.Tensor):
-                tensor = value.val
-                if (
-                    tensor.extra_tensor_info is not None
-                    and tensor.extra_tensor_info.device_type == schema.DeviceType.CUDA
-                ):
-                    cuda_tensors.append(tensor)
-                else:
-                    # Either no extra_tensor_info or device_type is CPU (default)
-                    cpu_tensors.append(tensor)
+            if not isinstance(value.val, schema.Tensor):
+                continue
+            tensor = value.val
+            # Only memory-planned (non-constant) tensors have allocation_info;
+            # their memory_id indexes into the non_const buffers.
+            if tensor.allocation_info is None:
+                continue
 
-        # Both input and output tensors should be on CUDA device for now.
+            declared = tensor_device(tensor)
+            mem_id = tensor.allocation_info.memory_id
+            planned = buffer_device.get(mem_id, schema.DeviceType.CPU)
+
+            self.assertEqual(
+                planned,
+                declared,
+                f"Tensor planned into buffer {mem_id} has device_type="
+                f"{declared.name} but the buffer is allocated on "
+                f"{planned.name}; planned memory location and device tag "
+                f"must agree.",
+            )
+            if declared == schema.DeviceType.CUDA:
+                cuda_planned += 1
+            else:
+                cpu_planned += 1
+
+        # AddModule has 2 inputs + 1 output. With device memory planning the
+        # delegate IO is CUDA-resident (2 h2d copies + 1 delegate output) and
+        # the host-side method inputs/outputs stay on CPU (2 inputs + 1 d2h
+        # output), giving exactly 3 CUDA- and 3 CPU-resident planned tensors.
         self.assertEqual(
-            len(cpu_tensors),
-            0,
-            f"Expected no CPU tensors: method inputs/outputs should be tagged "
-            f"CUDA, but found {len(cpu_tensors)}",
+            cuda_planned,
+            3,
+            f"Expected exactly 3 CUDA-resident planned tensors (2 h2d copies + "
+            f"1 delegate output), but found {cuda_planned}.",
         )
         self.assertEqual(
-            len(cuda_tensors),
+            cpu_planned,
             3,
-            f"Expected 3 CUDA tensors (2 method inputs + 1 method output), "
-            f"but found {len(cuda_tensors)}",
+            f"Expected exactly 3 CPU-resident planned tensors (2 method inputs "
+            f"+ 1 d2h output), but found {cpu_planned}.",
         )

--- a/examples/models/gemma4_31b/export.py
+++ b/examples/models/gemma4_31b/export.py
@@ -262,7 +262,6 @@ def _export_cuda(model: Gemma4_31B, config: Gemma4_31BConfig, output_dir: str) -
             do_quant_fusion_and_const_prop=True,
             memory_planning_pass=MemoryPlanningPass(
                 alloc_graph_input=False,
-                share_mutable_buffers=True,
             ),
             emit_mutable_buffer_names=True,
         ),

--- a/examples/models/gemma4_31b/main.cpp
+++ b/examples/models/gemma4_31b/main.cpp
@@ -158,8 +158,7 @@ int main(int argc, char** argv) {
       Module::LoadMode::MmapUseMlockIgnoreErrors,
       /*event_tracer=*/nullptr,
       /*memory_allocator=*/nullptr,
-      /*temp_allocator=*/nullptr,
-      /*share_memory_arenas=*/true);
+      /*temp_allocator=*/nullptr);
 
   // Get metadata
   auto metadata_result = llm::get_llm_metadata(tokenizer.get(), module.get());

--- a/examples/models/gemma4_31b/model.md
+++ b/examples/models/gemma4_31b/model.md
@@ -109,11 +109,13 @@ Decoder norms per layer: `input_layernorm`, `post_attention_layernorm`,
 | `decode`  | tokens `(1, 1)` + input_pos `(1,)` + temperature `(1,)`    | `(1, 1)` float   |
 | `prefill` | tokens `(1, T)` + input_pos `(T,)` + temperature `(1,)`, T∈[5, min(max_seq_len-1, 2×sliding_window)] | `(1, 1)` float   |
 
-Both methods share the same KV-cache buffers via
-`MemoryPlanningPass(share_mutable_buffers=True)` and
-`emit_mutable_buffer_names=True`. The exported program performs Gumbel-max
-sampling on-device and returns a single token ID per call so the C++ runner
-only has to feed tokens.
+Both methods share the same KV-cache buffers. On the CUDA/AOTI backend the
+stateful buffers are lifted into the delegate as constants and shared across
+`decode`/`prefill` at runtime via the backend's per-FQN buffer cache, so the
+CUDA export leaves `share_mutable_buffers` off (other backends, e.g. MLX, instead
+share graph-level buffers via `share_mutable_buffers`). The exported program
+performs Gumbel-max sampling on-device and returns a single token ID per call so
+the C++ runner only has to feed tokens.
 
 ### MLX (`--backend mlx`)
 

--- a/examples/models/gemma4_31b/model.py
+++ b/examples/models/gemma4_31b/model.py
@@ -8,8 +8,12 @@
 Gemma 4 31B-IT — export-friendly reference implementation for ExecuTorch.
 
 Model definition designed for torch.export(strict=True) with the CUDA backend.
-All stateful buffers (KV cache, RoPE inv_freq) are registered buffers so they
-are captured by share_mutable_buffers across prefill/decode. The numerically
+All stateful buffers (KV cache, RoPE inv_freq) are registered buffers with
+in-place updates. On the CUDA/AOTI backend they are lifted into the delegate as
+constants and shared across prefill/decode at runtime via the backend's per-FQN
+buffer cache (so the CUDA export leaves share_mutable_buffers off); backends that
+keep these buffers at the graph level (e.g. MLX) instead share them via
+share_mutable_buffers. The numerically
 sensitive primitives — RMSNorm, GELU-tanh MLP, proportional/full RoPE, and
 the BHSD KV cache — are imported from ``examples.models.gemma4.text_decoder``
 so the 31B and E2B/E4B paths share them.

--- a/examples/models/qwen3_5_moe/export.py
+++ b/examples/models/qwen3_5_moe/export.py
@@ -623,8 +623,10 @@ def _materialize_buffers(model, config):
 
     Replaces meta buffers with real tensors on CPU, recomputes RoPE
     inv_freq and causal masks. State buffers (KV cache, conv/recurrent
-    state) are zero-initialized registered buffers that will be shared
-    across methods via share_mutable_buffers.
+    state) are zero-initialized registered buffers. On the CUDA/AOTI backend
+    they are lifted into the delegate as constants and shared across methods at
+    runtime via the backend's per-FQN buffer cache; backends that keep them at
+    the graph level instead share them via share_mutable_buffers.
     """
     # Masks stay bool, inv_freq stays float32.
     for fqn, buf in list(model.named_buffers()):
@@ -922,8 +924,12 @@ def _export_cuda(model, config, args):
         via fused_moe_batched_gemm, with dynamic sequence length.
 
     Both methods share mutable state buffers (KV cache, conv_state,
-    recurrent_state) via share_mutable_buffers=True. The model uses
-    registered buffers with in-place updates — no state in/out args.
+    recurrent_state): the model uses registered buffers with in-place
+    updates (no state in/out args). On the CUDA/AOTI backend these buffers
+    are lifted into the delegate as constants and shared across the
+    decode/prefill methods at runtime via the backend's per-FQN buffer cache
+    (share_mutable_buffers is left off for CUDA); backends that keep them at
+    the graph level instead share them via share_mutable_buffers.
     """
     import torch._inductor.config as inductor_config
 
@@ -1032,8 +1038,7 @@ def _export_cuda(model, config, args):
             extract_delegate_segments=True,
             do_quant_fusion_and_const_prop=True,
             memory_planning_pass=MemoryPlanningPass(
-                alloc_graph_input=False,
-                share_mutable_buffers=True,
+                alloc_graph_input=False
             ),
             emit_mutable_buffer_names=True,
         ),

--- a/examples/models/qwen3_5_moe/main.cpp
+++ b/examples/models/qwen3_5_moe/main.cpp
@@ -144,8 +144,6 @@ int main(int argc, char** argv) {
 
   stats.model_load_start_ms = llm::time_in_ms();
 
-  // Create Module with share_memory_arenas=true so prefill and decode
-  // share mutable buffers (KV cache, conv_state, recurrent_state).
   std::vector<std::string> data_files;
   if (!FLAGS_data_path.empty()) {
     data_files.push_back(FLAGS_data_path);
@@ -156,8 +154,7 @@ int main(int argc, char** argv) {
       Module::LoadMode::File,
       /*event_tracer=*/nullptr,
       /*memory_allocator=*/nullptr,
-      /*temp_allocator=*/nullptr,
-      /*share_memory_arenas=*/true);
+      /*temp_allocator=*/nullptr);
 
   // Get metadata
   auto metadata_result = llm::get_llm_metadata(tokenizer.get(), module.get());

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -128,9 +128,12 @@ class ExecutorchBackendConfig:
 
     # When True, memory planning partitions specs by device and runs the
     # algorithm independently per device, producing separate buffers for CPU
-    # vs. accelerator memory.  Default False preserves the legacy behavior
-    # where all tensors are planned into CPU memory regardless of device.
-    enable_non_cpu_memory_planning: bool = False
+    # vs. accelerator memory.  This is the default: device (e.g. CUDA) delegate
+    # inputs/outputs are planned into real accelerator memory, and
+    # PropagateDevicePass inserts explicit h2d/d2h copies at delegate
+    # boundaries.  Set to False to fall back to the legacy behavior where all
+    # tensors are planned into CPU memory regardless of device.
+    enable_non_cpu_memory_planning: bool = True
 
     # Add ops to the set of re-inplace ops to be used by the reinplace pass.
     # Re-inplace pass checks the eligibility of an op to be re-inplaced and

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -2661,7 +2661,7 @@ class TestEmit(unittest.TestCase):
 
     def test_emit_non_const_buffer_device_none_when_flag_disabled(self) -> None:
         """Even with device tensors, non_const_buffer_device should be None when
-        enable_non_cpu_memory_planning is False (default)."""
+        enable_non_cpu_memory_planning is explicitly disabled."""
         from executorch.exir.backend.test.device_util import DeviceAwarePartitioner
 
         class Model(torch.nn.Module):
@@ -2676,8 +2676,9 @@ class TestEmit(unittest.TestCase):
             compile_config=EdgeCompileConfig(_check_ir_validity=False),
         )
         lowered = edge.to_backend(DeviceAwarePartitioner())
-        # Default: enable_non_cpu_memory_planning=False
-        et_prog = lowered.to_executorch()
+        et_prog = lowered.to_executorch(
+            config=ExecutorchBackendConfig(enable_non_cpu_memory_planning=False),
+        )
         program = et_prog._emitter_output.program
 
         plan = program.execution_plan[0]

--- a/exir/tests/test_propagate_device_pass.py
+++ b/exir/tests/test_propagate_device_pass.py
@@ -381,7 +381,8 @@ class TestPropagateDevicePass(unittest.TestCase):
                 )
 
     def test_copy_nodes_require_non_cpu_memory_planning(self):
-        """Default lowering keeps legacy device tags without runtime copy ops."""
+        """With enable_non_cpu_memory_planning disabled, lowering keeps legacy
+        device tags without inserting runtime copy ops."""
 
         class Model(torch.nn.Module):
             def forward(self, a, b):
@@ -391,7 +392,10 @@ class TestPropagateDevicePass(unittest.TestCase):
         inputs = (torch.randn(2, 2), torch.randn(2, 2))
 
         for pipeline, gm in _lower_model_to_executorch(
-            model, inputs, DeviceAwarePartitioner("cuda:0")
+            model,
+            inputs,
+            DeviceAwarePartitioner("cuda:0"),
+            ExecutorchBackendConfig(enable_non_cpu_memory_planning=False),
         ):
             with self.subTest(pipeline=pipeline):
                 device_copy_nodes = _collect_device_copy_nodes(gm)

--- a/extension/asr/runner/seq2seq_runner.cpp
+++ b/extension/asr/runner/seq2seq_runner.cpp
@@ -113,19 +113,13 @@ Error Seq2SeqRunner::load() {
   // The backend's init() is called during load_method(), which creates CUDA
   // streams. We must configure shared stream mode before any init() calls.
   //
-  // Skip copying outputs to CPU. When a sampler exists, keep both encoder and
-  // decoder outputs on device and pass decoder logits directly into sampler.
-  // The backend will use a shared CUDA stream for all methods when skip-copy
-  // is enabled to ensure proper ordering.
-  executorch::runtime::BackendOptions<2> backend_options;
-  std::string skip_methods = kEncoderMethodName;
-  if (sampler_method_present_) {
-    skip_methods.append(",").append(kDecoderMethodName);
-  }
-  ET_CHECK_OK_OR_RETURN_ERROR(backend_options.set_option(
-      "skip_copy_output_to_cpu_for_method", skip_methods.c_str()));
-  // Enable shared CUDA stream for all methods when skip-copy is used.
-  // This ensures proper ordering between encoder/decoder/sampler outputs.
+  // Keep encoder/decoder outputs on device and pass decoder logits directly
+  // into the sampler. With device memory planning, delegate inputs/outputs are
+  // GPU-resident and graph-level et_copy ops handle host<->device transfers;
+  // the export-time skip_d2h_for_method_outputs / skip_h2d_for_method_inputs
+  // flags elide the unnecessary copies. A shared CUDA stream is still required
+  // to guarantee correct ordering across methods when outputs stay on GPU.
+  executorch::runtime::BackendOptions<1> backend_options;
   ET_CHECK_OK_OR_RETURN_ERROR(
       backend_options.set_option("use_shared_cuda_stream", true));
 


### PR DESCRIPTION
Summary:

This diff turn on the on-device memory planing as default, so that every delegate which enables on device memory planing will be use that./

Also update cuda backend to remove H2D/D2H copies and extra caches

Differential Revision: D107597774


