### PR TITLE
Arm backend: Complete TOSA dialect shape ops

### DIFF
--- a/backends/arm/test/misc/tosa_dialect/test_tosa_shape_ops.py
+++ b/backends/arm/test/misc/tosa_dialect/test_tosa_shape_ops.py
@@ -9,6 +9,9 @@ import pytest
 import sympy  # type: ignore
 import torch
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
+from executorch.backends.arm.tosa.dialect.ops.shape_ops import (
+    ASSERT_EQUAL_SHAPE as assert_equal_shape_impl,
+)
 from executorch.backends.arm.tosa.specification import (
     TosaLoweringContext,
     TosaSpecification,
@@ -74,6 +77,26 @@ def test_dim_requires_shape_extension():
             exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
 
 
+# Test that DIM rejects unsupported tensor dtypes for the active TOSA profile and extensions.
+def test_dim_rejects_unsupported_dtype() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode() as mode:
+        x = mode.from_tensor(torch.empty((2, 3), dtype=torch.float64))
+        with pytest.raises(TosaValueError, match="Unsupported dtype"):
+            exir_ops.backend.tosa.DIM.default(x, axis=1)
+
+
+# Test that DIM rejects known non-positive dimensions, as required by the TOSA specification.
+def test_dim_rejects_zero_dimension() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode() as mode:
+        x = mode.from_tensor(torch.empty((2, 0, 3), dtype=torch.float32))
+        with pytest.raises(TosaValueError, match=r"shape\[axis\] > 0"):
+            exir_ops.backend.tosa.DIM.default(x, axis=1)
+
+
 # Test that CONST_SHAPE creates a constant shape tensor and returns the expected shape list.
 def test_const_shape():
     with TosaLoweringContext(
@@ -135,16 +158,32 @@ def test_concat_mixed_shape():
     assert _expr(result[2]) == "s0"
 
 
-# Test that CONCAT_SHAPE raises an error when given fewer than 2 shape tensors, as it requires at least 2 to
-# concatenate.
+# Test that CONCAT_SHAPE raises an error when given no shape tensors.
 def test_concat_shape_requires_arguments():
-    with pytest.raises(
-        TosaValueError, match="CONCAT_SHAPE expected 2 or more shape tensors"
-    ):
+    with pytest.raises(TosaValueError, match="requires at least one shape tensor"):
         with TosaLoweringContext(
             TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
         ), FakeTensorMode():
             exir_ops.backend.tosa.CONCAT_SHAPE.default([])
+
+
+# Test that CONCAT_SHAPE allows a single input shape.
+def test_concat_shape_allows_single_argument():
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        result = exir_ops.backend.tosa.CONCAT_SHAPE.default([[2, 3]])
+
+    assert result == [2, 3]
+
+
+# Test that CONCAT_SHAPE rejects empty member shapes.
+def test_concat_shape_rejects_empty_member_shape():
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        with pytest.raises(TosaValueError, match="disallows empty input shapes"):
+            exir_ops.backend.tosa.CONCAT_SHAPE.default([[2], []])
 
 
 # Test ADD_SHAPE with constant values, which should perform elementwise addition and return a constant shape.
@@ -395,3 +434,382 @@ def test_div_floor_mixed_shape():
     assert len(result) == 1
     assert isinstance(result[0], torch.SymInt)
     assert _expr_equals(result[0], sympy.sympify("8//s0"))
+
+
+# Test SLICE_SHAPE with a constant input shape.
+def test_slice_shape_constants() -> None:
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        input_shape = exir_ops.backend.tosa.CONST_SHAPE.default([8, 16, 7])
+        assert exir_ops.backend.tosa.SLICE_SHAPE.default(input_shape, [1], [2]) == [
+            16,
+            7,
+        ]
+
+
+# Test SLICE_SHAPE rejects invalid start and size values.
+def test_slice_shape_rejects_invalid_bounds() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        input_shape = [8, 16, 7]
+        with pytest.raises(TosaValueError, match="start >= 0"):
+            exir_ops.backend.tosa.SLICE_SHAPE.default(input_shape, [-1], [1])
+        with pytest.raises(TosaValueError, match="size > 0"):
+            exir_ops.backend.tosa.SLICE_SHAPE.default(input_shape, [0], [0])
+        with pytest.raises(TosaValueError, match="within input bounds"):
+            exir_ops.backend.tosa.SLICE_SHAPE.default(input_shape, [2], [2])
+
+
+# Test SLICE_SHAPE supports bounded symbolic start values when size is known.
+def test_slice_shape_bounded_symbolic_start() -> None:
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=0, min=0, max=1)
+    d0 = _make_symint(shape_env, "d0", hint=8)
+    d1 = _make_symint(shape_env, "d1", hint=16)
+    d2 = _make_symint(shape_env, "d2", hint=7)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        result = exir_ops.backend.tosa.SLICE_SHAPE.default([d0, d1, d2], [s0], [2])
+
+    assert len(result) == 2
+    assert _expr_equals(
+        result[0],
+        sympy.Piecewise(
+            (sympy.Symbol("d0"), sympy.Eq(sympy.Symbol("s0"), 0)),
+            (sympy.Symbol("d1"), sympy.Eq(sympy.Symbol("s0"), 1)),
+        ),
+    )
+    assert _expr_equals(
+        result[1],
+        sympy.Piecewise(
+            (sympy.Symbol("d1"), sympy.Eq(sympy.Symbol("s0"), 0)),
+            (sympy.Symbol("d2"), sympy.Eq(sympy.Symbol("s0"), 1)),
+        ),
+    )
+
+
+# Test SLICE_SHAPE accepts symbolic sizes that are provably singleton.
+def test_slice_shape_singleton_symbolic_size() -> None:
+    shape_env = ShapeEnv()
+    size = _make_symint(shape_env, "size", hint=2, min=2, max=2)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        result = exir_ops.backend.tosa.SLICE_SHAPE.default([8, 16, 7], [1], [size])
+
+    assert result == [16, 7]
+
+
+# Test SLICE_SHAPE rejects bounded symbolic starts with any out-of-bounds value.
+def test_slice_shape_rejects_out_of_bounds_symbolic_start() -> None:
+    shape_env = ShapeEnv()
+    start = _make_symint(shape_env, "start", hint=1, min=1, max=2)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        with pytest.raises(TosaValueError, match="within input bounds"):
+            exir_ops.backend.tosa.SLICE_SHAPE.default([8, 16, 7], [start], [2])
+
+
+# Test EXP2_SHAPE with constant values.
+def test_exp2_shape_constants() -> None:
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        assert exir_ops.backend.tosa.EXP2_SHAPE.default([0, 3, 4]) == [1, 8, 16]
+
+
+# Test EXP2_SHAPE preserves symbolic expressions.
+def test_exp2_shape_symbolic() -> None:
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=3, min=0, max=6)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        result = exir_ops.backend.tosa.EXP2_SHAPE.default([s0])
+
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(result[0], sympy.Integer(2) ** sympy.Symbol("s0"))
+
+
+# Test that EXP2_SHAPE enforces the TOSA MAX_LOG2_SIZE bound.
+def test_exp2_shape_rejects_max_log2_size() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        with pytest.raises(TosaValueError, match=r"input < 63"):
+            exir_ops.backend.tosa.EXP2_SHAPE.default([63])
+
+
+# Test that EXP2_SHAPE uses the stricter 8k-level MAX_LOG2_SIZE bound.
+def test_exp2_shape_rejects_max_log2_size_at_8k_level() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape+8k")
+    ), FakeTensorMode():
+        with pytest.raises(TosaValueError, match=r"input < 31"):
+            exir_ops.backend.tosa.EXP2_SHAPE.default([31])
+
+
+# Test LOG2_CEIL_SHAPE with constant values.
+def test_log2_ceil_shape_constants() -> None:
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        assert exir_ops.backend.tosa.LOG2_CEIL_SHAPE.default([1, 3, 8]) == [0, 2, 3]
+
+
+# Test LOG2_CEIL_SHAPE rejects non-positive inputs.
+def test_log2_ceil_shape_rejects_zero_input() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        with pytest.raises(TosaValueError, match=r"input > 0"):
+            exir_ops.backend.tosa.LOG2_CEIL_SHAPE.default([0])
+
+
+# Test LOG2_FLOOR_SHAPE with constant values.
+def test_log2_floor_shape_constants() -> None:
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        assert exir_ops.backend.tosa.LOG2_FLOOR_SHAPE.default([1, 3, 8]) == [0, 1, 3]
+
+
+# Test LOG2_FLOOR_SHAPE rejects non-positive inputs.
+def test_log2_floor_shape_rejects_zero_input() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        with pytest.raises(TosaValueError, match=r"input > 0"):
+            exir_ops.backend.tosa.LOG2_FLOOR_SHAPE.default([0])
+
+
+# Test MAX_SHAPE with constant values.
+def test_max_shape_constants() -> None:
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        assert exir_ops.backend.tosa.MAX_SHAPE.default([2, 9], [4, 3]) == [4, 9]
+
+
+# Test MAX_SHAPE with symbolic values.
+def test_max_shape_symbolic() -> None:
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", 4)
+    s1 = _make_symint(shape_env, "s1", 8)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        max_shape = exir_ops.backend.tosa.MAX_SHAPE.default([s0], [s1])
+
+    assert _expr(max_shape[0]) == "Max(s0, s1)"
+
+
+# Test MAX_SHAPE with mixed constant and symbolic values.
+def test_max_shape_mixed() -> None:
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", 4)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        max_shape = exir_ops.backend.tosa.MAX_SHAPE.default([s0], [5])
+
+    assert _expr_equals(max_shape[0], sympy.Max(sympy.Symbol("s0"), sympy.Integer(5)))
+
+
+# Test MIN_SHAPE with constant values.
+def test_min_shape_constants() -> None:
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        assert exir_ops.backend.tosa.MIN_SHAPE.default([2, 9], [4, 3]) == [2, 3]
+
+
+# Test MIN_SHAPE with symbolic values.
+def test_min_shape_symbolic() -> None:
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", 4)
+    s1 = _make_symint(shape_env, "s1", 8)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        min_shape = exir_ops.backend.tosa.MIN_SHAPE.default([s0], [s1])
+
+    assert _expr(min_shape[0]) == "Min(s0, s1)"
+
+
+# Test MIN_SHAPE with mixed constant and symbolic values.
+def test_min_shape_mixed() -> None:
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", 4)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        min_shape = exir_ops.backend.tosa.MIN_SHAPE.default([s0], [5])
+
+    assert _expr_equals(min_shape[0], sympy.Min(sympy.Symbol("s0"), sympy.Integer(5)))
+
+
+# Test DIV_CEIL_SHAPE with constant values.
+def test_div_ceil_shape_constants() -> None:
+    shape_env = ShapeEnv()
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        assert exir_ops.backend.tosa.DIV_CEIL_SHAPE.default([9, 16], [4, 8]) == [3, 2]
+
+
+# Test DIV_CEIL_SHAPE preserves symbolic expressions.
+def test_div_ceil_shape_symbolic() -> None:
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=8)
+    s1 = _make_symint(shape_env, "s1", hint=3)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        s1_tensor = torch.empty(size=(1, 3, s1))
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        dim_s1 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s1_tensor), axis=2)
+        result = exir_ops.backend.tosa.DIV_CEIL_SHAPE.default(dim_s0, dim_s1)
+
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(
+        result[0],
+        sympy.floor(
+            (sympy.Symbol("s0") + sympy.Symbol("s1") - sympy.Integer(1))
+            / sympy.Symbol("s1")
+        ),
+    )
+
+
+# Test DIV_CEIL_SHAPE with mixed constant and symbolic values.
+def test_div_ceil_shape_mixed() -> None:
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=4)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env) as mode:
+        const_shape = exir_ops.backend.tosa.CONST_SHAPE.default([8])
+        s0_tensor = torch.empty(size=(1, 3, s0))
+        dim_s0 = exir_ops.backend.tosa.DIM.default(mode.from_tensor(s0_tensor), axis=2)
+        result = exir_ops.backend.tosa.DIV_CEIL_SHAPE.default(const_shape, dim_s0)
+
+    assert len(result) == 1
+    assert isinstance(result[0], torch.SymInt)
+    assert _expr_equals(
+        result[0],
+        sympy.floor(
+            (sympy.Integer(8) + sympy.Symbol("s0") - sympy.Integer(1))
+            / sympy.Symbol("s0")
+        ),
+    )
+
+
+# Test DIV_CEIL_SHAPE rejects invalid operands.
+def test_div_ceil_shape_rejects_invalid_operands() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        with pytest.raises(TosaValueError, match=r"input1 >= 0"):
+            exir_ops.backend.tosa.DIV_CEIL_SHAPE.default([-1], [4])
+        with pytest.raises(TosaValueError, match=r"input2 > 0"):
+            exir_ops.backend.tosa.DIV_CEIL_SHAPE.default([8], [0])
+
+
+# Test ASSERT_EQUAL_SHAPE accepts same-rank shapes without comparing values.
+def test_assert_equal_shape_allows_same_rank() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        result = assert_equal_shape_impl(
+            [4, 1],
+            [3, 7],
+            allow_broadcast=False,
+        )
+
+    assert result is None
+
+
+# Test ASSERT_EQUAL_SHAPE accepts symbolic same-rank shapes without SymBool checks.
+def test_assert_equal_shape_allows_symbolic_same_rank() -> None:
+    shape_env = ShapeEnv()
+    s0 = _make_symint(shape_env, "s0", hint=2, min=2, max=4)
+    s1 = _make_symint(shape_env, "s1", hint=5, min=5, max=8)
+
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"),
+        shape_env,
+    ), FakeTensorMode(shape_env=shape_env):
+        result = assert_equal_shape_impl(
+            [s0, 1],
+            [s1, 7],
+            allow_broadcast=True,
+        )
+
+    assert result is None
+
+
+# Test ASSERT_EQUAL_SHAPE rejects mismatched ranks.
+def test_assert_equal_shape_rejects_rank_mismatch() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
+    ), FakeTensorMode():
+        with pytest.raises(TosaValueError, match="requires equal lengths"):
+            assert_equal_shape_impl(
+                [4, 1],
+                [4, 1, 7],
+                allow_broadcast=True,
+            )
+
+
+def test_const_shape_allows_non_shape_specs() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.0+FP")
+    ), FakeTensorMode():
+        assert exir_ops.backend.tosa.CONST_SHAPE.default([2, 3]) == [2, 3]
+
+
+def test_slice_shape_requires_shape_extension() -> None:
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.0+FP")
+    ), FakeTensorMode():
+        with pytest.raises(TosaValueError, match="shape extension"):
+            exir_ops.backend.tosa.SLICE_SHAPE.default([2, 3], [0], [1])

--- a/backends/arm/tosa/dialect/ops/shape_ops.py
+++ b/backends/arm/tosa/dialect/ops/shape_ops.py
@@ -20,43 +20,171 @@ from torch.types import IntLikeType
 from torch.utils._sympy.functions import FloorDiv
 
 
-@register_fake_tosa_op(
-    "CONST_SHAPE(int[] shape) -> int[]",  # schema
-    TosaSpecification.all_versions_and_profiles(),
-)
-def CONST_SHAPE(shape: list[int]) -> list[int]:
-    """CONST_SHAPE operator creates a constant shape tensor."""
-
-    return shape
-
-
-@register_fake_tosa_op(
-    "DIM(Tensor input, *, int axis) -> SymInt[]",  # schema
-    TosaSpecification.all_profiles_for_version("1.1"),
-)
-def DIM(x: torch.Tensor, *, axis: int) -> list[torch.SymInt]:
+def _require_shape_extension(op: str) -> None:
     tosa_spec = get_context_spec()
-    """Dim operator extracts a dimension from the input tensor shape."""
-
     if not tosa_spec.support_extension("shape"):
         raise TosaValueError(
-            f"TOSA spec {tosa_spec} doesn't support shape extension", op="DIM"
+            f"TOSA spec {tosa_spec} doesn't support shape extension", op=op
         )
-
-    assert isinstance(
-        x.shape[axis], torch.SymInt
-    ), f"Expected dimension to be SymInt, got {type(x.shape[axis])}"
-    return [x.shape[axis]]  # type: ignore[list-item]
 
 
 def _to_sympy_expr(value: IntLikeType) -> sympy.Expr:
-    """Lift a shape value to a SymPy expression without forcing hints."""
-
     if isinstance(value, torch.SymInt):
-        # `node.expr` flows through ShapeEnv.replace and would plug in hints.
-        # `_expr` is the raw symbolic expression we need to preserve.
         return value.node._expr
     return sympy.Integer(int(value))
+
+
+def _to_lowest_concrete_int(value: IntLikeType, op: str, name: str) -> int:
+    expr = _to_sympy_expr(value)
+    if expr.is_integer is False:
+        raise TosaValueError(f"{op} requires integer {name}", op=op)
+    if expr.is_number:
+        return int(expr)
+
+    value_range = _get_expr_range(expr)
+    if (
+        value_range is not None
+        and value_range.is_int
+        and value_range.is_singleton()
+        and value_range.lower.is_number
+    ):
+        return int(value_range.lower)
+
+    raise TosaValueError(
+        f"{op} requires compile-time constant {name}",
+        op=op,
+    )
+
+
+def _require_known_nonnegative(value: IntLikeType, op: str, name: str) -> None:
+    expr = _to_sympy_expr(value)
+    if expr.is_number and int(expr) < 0:
+        raise TosaValueError(f"{op} requires {name} >= 0", op=op)
+    if expr.is_nonnegative is False:
+        raise TosaValueError(f"{op} requires {name} >= 0", op=op)
+
+
+def _require_known_positive(value: IntLikeType, op: str, name: str) -> None:
+    expr = _to_sympy_expr(value)
+    if expr.is_number and int(expr) < 1:
+        raise TosaValueError(f"{op} requires {name} > 0", op=op)
+    if expr.is_positive is False or expr.is_zero is True:
+        raise TosaValueError(f"{op} requires {name} > 0", op=op)
+
+
+def _require_known_less_than(
+    value: IntLikeType, limit: int, op: str, name: str
+) -> None:
+    expr = _to_sympy_expr(value)
+    if expr.is_number and int(expr) >= limit:
+        raise TosaValueError(f"{op} requires {name} < {limit}", op=op)
+    if sympy.Ge(expr, sympy.Integer(limit)) is sympy.true:
+        raise TosaValueError(f"{op} requires {name} < {limit}", op=op)
+
+
+def _get_expr_range(expr: sympy.Expr):
+    try:
+        shape_env = get_context_shape_env()
+    except RuntimeError:
+        return None
+
+    try:
+        return shape_env.bound_sympy(sympy.simplify(expr))
+    except Exception:
+        return None
+
+
+def _is_definitely_value(expr: sympy.Expr, value: int) -> bool:
+    if sympy.simplify(expr - value) == 0:
+        return True
+
+    value_range = _get_expr_range(expr)
+    if value_range is None or not value_range.is_int or not value_range.is_singleton():
+        return False
+
+    lower = value_range.lower
+    return lower.is_integer and lower.is_number and int(lower) == value
+
+
+def _is_definitely_mismatch(lhs_expr: sympy.Expr, rhs_expr: sympy.Expr) -> bool:
+    if lhs_expr.is_number and rhs_expr.is_number:
+        return int(lhs_expr) != int(rhs_expr)
+
+    if sympy.Ne(lhs_expr, rhs_expr) is sympy.true:
+        return True
+
+    lhs_range = _get_expr_range(lhs_expr)
+    rhs_range = _get_expr_range(rhs_expr)
+    if (
+        lhs_range is None
+        or rhs_range is None
+        or not lhs_range.is_int
+        or not rhs_range.is_int
+    ):
+        return False
+
+    bounds = (
+        lhs_range.lower,
+        lhs_range.upper,
+        rhs_range.lower,
+        rhs_range.upper,
+    )
+    if not all(bound.is_number for bound in bounds):
+        return False
+
+    lhs_lower, lhs_upper, rhs_lower, rhs_upper = (int(bound) for bound in bounds)
+    return lhs_upper < rhs_lower or rhs_upper < lhs_lower
+
+
+def _to_finite_int_values(
+    value: IntLikeType,
+    op: str,
+    name: str,
+    *,
+    max_values: int,
+) -> list[int] | None:
+    expr = _to_sympy_expr(value)
+    if expr.is_integer is False:
+        raise TosaValueError(f"{op} requires integer {name}", op=op)
+    if expr.is_number:
+        return [int(expr)]
+
+    value_range = _get_expr_range(expr)
+    if value_range is None or not value_range.is_int:
+        return None
+
+    lower = value_range.lower
+    upper = value_range.upper
+    if not lower.is_number or not upper.is_number:
+        return None
+
+    lower_i = int(lower)
+    upper_i = int(upper)
+    if upper_i < lower_i:
+        return None
+
+    num_values = upper_i - lower_i + 1
+    if num_values > max_values:
+        return None
+
+    return list(range(lower_i, upper_i + 1))
+
+
+def _supported_dim_dtypes(tosa_spec: TosaSpecification) -> list[torch.dtype]:
+    supported = [torch.bool]
+    if tosa_spec.support_integer():
+        supported.extend([torch.int8, torch.int16, torch.int32])
+    if tosa_spec.support_float():
+        supported.extend([torch.float16, torch.float32])
+    if tosa_spec.support_extension("bf16"):
+        supported.append(torch.bfloat16)
+    if tosa_spec.support_extension("int64"):
+        supported.append(torch.int64)
+    if tosa_spec.support_extension("fp8e4m3"):
+        supported.append(torch.float8_e4m3fn)
+    if tosa_spec.support_extension("fp8e5m2"):
+        supported.append(torch.float8_e5m2)
+    return supported
 
 
 def _combine_shapes(
@@ -64,125 +192,315 @@ def _combine_shapes(
     rhs: list[IntLikeType],
     combine: Callable[[sympy.Expr, sympy.Expr], sympy.Expr | sympy.Integer],
 ) -> list[IntLikeType]:
-    """The fake kernels run during export/meta execution.
-
-    Using Python arithmetic
-    directly on `torch.SymInt` would consult the current ShapeEnv hints and
-    collapse dynamic symbols to concrete ints.  Instead we work with the
-    underlying SymPy expressions and wrap them back into SymInts via the same
-    ShapeEnv, preserving dynamic information for later passes.
-
-    """
-    assert len(lhs) == len(
-        rhs
-    ), f"Expected shapes to be of same length, got {len(lhs)} and {len(rhs)}"
+    if len(lhs) != len(rhs):
+        raise ValueError(
+            f"Expected shapes to be of same length, got {len(lhs)} and {len(rhs)}"
+        )
 
     expr_lhs = [_to_sympy_expr(v) for v in lhs]
     expr_rhs = [_to_sympy_expr(v) for v in rhs]
 
-    shape_env = get_context_shape_env()
     result: list[IntLikeType] = []
     for a, b in zip(expr_lhs, expr_rhs):
         expr = combine(a, b)
-        if isinstance(expr, sympy.Expr):
-            result.append(shape_env.create_symintnode(expr, hint=None))
-        else:
+        if expr.is_number and expr.is_integer:
             result.append(int(expr))
+            continue
+
+        shape_env = get_context_shape_env()
+        result.append(shape_env.create_symintnode(expr, hint=None))
     return result
 
 
 @register_fake_tosa_op(
-    "CONCAT_SHAPE(SymInt[][] shape_list) -> SymInt[]",  # schema (fixed to return SymInt[])
-    TosaSpecification.all_profiles_for_version("1.1"),
-)
-def CONCAT_SHAPE(
-    shape_list: list[list[IntLikeType]],
-) -> list[IntLikeType]:
-    """CONCAT_SHAPE operator concatenates a list of shape lists to create a new
-    list with length the sum of lengths of all lists in input shape_list.
-    """
-
-    if len(shape_list) < 1:
-        raise TosaValueError(
-            f"CONCAT_SHAPE expected 2 or more shape tensors, got {len(shape_list)}",
-            op="CONCAT_SHAPE",
-        )
-
-    concat_shape = list(shape_list[0])
-    for d in shape_list[1:]:
-        concat_shape.extend(d)
-
-    return concat_shape
-
-
-@register_fake_tosa_op(
-    "ADD_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",  # schema
+    "ADD_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",
     TosaSpecification.all_profiles_for_version("1.1"),
 )
 def ADD_SHAPE(
     shape1: list[IntLikeType],
     shape2: list[IntLikeType],
 ) -> list[IntLikeType]:
-    """ADD_SHAPE operator adds each element of the second shape tensor to the
-    first.
-    """
+    _require_shape_extension("ADD_SHAPE")
     return _combine_shapes(shape1, shape2, lambda a, b: a + b)
 
 
 @register_fake_tosa_op(
-    "SUB_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",  # schema
+    "ASSERT_EQUAL_SHAPE(SymInt[] input1, SymInt[] input2, *, bool allow_broadcast) -> SymInt[]",
     TosaSpecification.all_profiles_for_version("1.1"),
 )
-def SUB_SHAPE(
-    shape1: list[IntLikeType],
-    shape2: list[IntLikeType],
-) -> list[IntLikeType]:
-    """SUB_SHAPE operator subtracts each element of the second shape tensor from
-    the first.
-    """
-
-    return _combine_shapes(shape1, shape2, lambda a, b: a - b)
+def ASSERT_EQUAL_SHAPE(
+    input1: list[IntLikeType],
+    input2: list[IntLikeType],
+    *,
+    allow_broadcast: bool,
+) -> None:
+    _require_shape_extension("ASSERT_EQUAL_SHAPE")
+    if len(input1) != len(input2):
+        raise TosaValueError(
+            "ASSERT_EQUAL_SHAPE requires equal lengths, got "
+            f"{len(input1)} and {len(input2)}",
+            op="ASSERT_EQUAL_SHAPE",
+        )
 
 
 @register_fake_tosa_op(
-    "DIV_FLOOR_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",  # schema
+    "CONCAT_SHAPE(SymInt[][] shape_list) -> SymInt[]",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def CONCAT_SHAPE(shape_list: list[list[IntLikeType]]) -> list[IntLikeType]:
+    _require_shape_extension("CONCAT_SHAPE")
+    if not shape_list:
+        raise TosaValueError(
+            "CONCAT_SHAPE requires at least one shape tensor",
+            op="CONCAT_SHAPE",
+        )
+    if any(not shape for shape in shape_list):
+        raise TosaValueError(
+            "CONCAT_SHAPE disallows empty input shapes",
+            op="CONCAT_SHAPE",
+        )
+
+    concat_shape: list[IntLikeType] = []
+    for shape in shape_list:
+        concat_shape.extend(shape)
+
+    return concat_shape
+
+
+@register_fake_tosa_op(
+    "CONST_SHAPE(int[] shape) -> int[]",
+    TosaSpecification.all_versions_and_profiles(),
+)
+def CONST_SHAPE(shape: list[int]) -> list[int]:
+    return shape
+
+
+@register_fake_tosa_op(
+    "DIM(Tensor input, *, int axis) -> SymInt[]",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def DIM(x: torch.Tensor, *, axis: int) -> list[IntLikeType]:
+    _require_shape_extension("DIM")
+    tosa_spec = get_context_spec()
+    supported_dtypes = _supported_dim_dtypes(tosa_spec)
+    if x.dtype not in supported_dtypes:
+        raise TosaValueError(
+            f"Unsupported dtype {x.dtype} for DIM. Supported dtypes are {supported_dtypes}",
+            op="DIM",
+        )
+    if axis < 0 or axis >= x.dim():
+        raise TosaValueError(
+            f"DIM axis {axis} is out of range for rank {x.dim()}",
+            op="DIM",
+        )
+    _require_known_positive(x.shape[axis], "DIM", "shape[axis]")
+    return [x.shape[axis]]
+
+
+@register_fake_tosa_op(
+    "DIV_CEIL_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def DIV_CEIL_SHAPE(
+    shape1: list[IntLikeType],
+    shape2: list[IntLikeType],
+) -> list[IntLikeType]:
+    _require_shape_extension("DIV_CEIL_SHAPE")
+    for lhs, rhs in zip(shape1, shape2):
+        _require_known_nonnegative(lhs, "DIV_CEIL_SHAPE", "input1")
+        _require_known_positive(rhs, "DIV_CEIL_SHAPE", "input2")
+    return _combine_shapes(
+        shape1,
+        shape2,
+        lambda a, b: FloorDiv(a + b - sympy.Integer(1), b),
+    )
+
+
+@register_fake_tosa_op(
+    "DIV_FLOOR_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",
     TosaSpecification.all_profiles_for_version("1.1"),
 )
 def DIV_FLOOR_SHAPE(
     shape1: list[IntLikeType],
     shape2: list[IntLikeType],
 ) -> list[IntLikeType]:
-    """DIV_SHAPE operator divides each element of the shape tensor by the given
-    denominator.
-    """
+    _require_shape_extension("DIV_FLOOR_SHAPE")
+    for lhs, rhs in zip(shape1, shape2):
+        _require_known_nonnegative(lhs, "DIV_FLOOR_SHAPE", "input1")
+        _require_known_positive(rhs, "DIV_FLOOR_SHAPE", "input2")
     return _combine_shapes(shape1, shape2, lambda a, b: FloorDiv(a, b))
 
 
 @register_fake_tosa_op(
-    "MUL_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",  # schema
+    "EXP2_SHAPE(SymInt[] input) -> SymInt[]",
     TosaSpecification.all_profiles_for_version("1.1"),
 )
-def MUL_SHAPE(
-    shape1: list[IntLikeType],
-    shape2: list[IntLikeType],
-) -> list[IntLikeType]:
-    """MUL_SHAPE operator multiplies each element of the shape tensor by the
-    given factor.
-    """
-
-    return _combine_shapes(shape1, shape2, lambda a, b: a * b)
+def EXP2_SHAPE(input: list[IntLikeType]) -> list[IntLikeType]:
+    _require_shape_extension("EXP2_SHAPE")
+    max_log2_size = 31 if getattr(get_context_spec(), "level_8k", False) else 63
+    for value in input:
+        _require_known_nonnegative(value, "EXP2_SHAPE", "input")
+        _require_known_less_than(value, max_log2_size, "EXP2_SHAPE", "input")
+    return _combine_shapes(
+        input,
+        [2] * len(input),
+        lambda a, _: sympy.Integer(2) ** a,
+    )
 
 
 @register_fake_tosa_op(
-    "MOD_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",  # schema
+    "LOG2_CEIL_SHAPE(SymInt[] input) -> SymInt[]",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def LOG2_CEIL_SHAPE(input: list[IntLikeType]) -> list[IntLikeType]:
+    _require_shape_extension("LOG2_CEIL_SHAPE")
+    for value in input:
+        _require_known_positive(value, "LOG2_CEIL_SHAPE", "input")
+    return _combine_shapes(
+        input,
+        [0] * len(input),
+        lambda a, _: sympy.ceiling(sympy.log(a, 2)),
+    )
+
+
+@register_fake_tosa_op(
+    "LOG2_FLOOR_SHAPE(SymInt[] input) -> SymInt[]",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def LOG2_FLOOR_SHAPE(input: list[IntLikeType]) -> list[IntLikeType]:
+    _require_shape_extension("LOG2_FLOOR_SHAPE")
+    for value in input:
+        _require_known_positive(value, "LOG2_FLOOR_SHAPE", "input")
+    return _combine_shapes(
+        input,
+        [0] * len(input),
+        lambda a, _: sympy.floor(sympy.log(a, 2)),
+    )
+
+
+@register_fake_tosa_op(
+    "MAX_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def MAX_SHAPE(
+    shape1: list[IntLikeType],
+    shape2: list[IntLikeType],
+) -> list[IntLikeType]:
+    _require_shape_extension("MAX_SHAPE")
+    return _combine_shapes(shape1, shape2, lambda a, b: sympy.Max(a, b))
+
+
+@register_fake_tosa_op(
+    "MIN_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def MIN_SHAPE(
+    shape1: list[IntLikeType],
+    shape2: list[IntLikeType],
+) -> list[IntLikeType]:
+    _require_shape_extension("MIN_SHAPE")
+    return _combine_shapes(shape1, shape2, lambda a, b: sympy.Min(a, b))
+
+
+@register_fake_tosa_op(
+    "MOD_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",
     TosaSpecification.all_profiles_for_version("1.1"),
 )
 def MOD_SHAPE(
     shape1: list[IntLikeType],
     shape2: list[IntLikeType],
 ) -> list[IntLikeType]:
-    """MOD_SHAPE operator computes the element-wise modulo of the first shape
-    tensor by the second.
-    """
-
+    _require_shape_extension("MOD_SHAPE")
+    for lhs, rhs in zip(shape1, shape2):
+        _require_known_nonnegative(lhs, "MOD_SHAPE", "input1")
+        _require_known_positive(rhs, "MOD_SHAPE", "input2")
     return _combine_shapes(shape1, shape2, lambda a, b: a % b)
+
+
+@register_fake_tosa_op(
+    "MUL_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def MUL_SHAPE(
+    shape1: list[IntLikeType],
+    shape2: list[IntLikeType],
+) -> list[IntLikeType]:
+    _require_shape_extension("MUL_SHAPE")
+    return _combine_shapes(shape1, shape2, lambda a, b: a * b)
+
+
+@register_fake_tosa_op(
+    "SLICE_SHAPE(SymInt[] input, SymInt[] start, SymInt[] size) -> SymInt[]",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def SLICE_SHAPE(
+    input: list[IntLikeType],
+    start: list[IntLikeType],
+    size: list[IntLikeType],
+) -> list[IntLikeType]:
+    _require_shape_extension("SLICE_SHAPE")
+    if len(start) != 1 or len(size) != 1:
+        raise TosaValueError(
+            "SLICE_SHAPE requires start[1] and size[1]",
+            op="SLICE_SHAPE",
+        )
+
+    size_value = _to_lowest_concrete_int(size[0], "SLICE_SHAPE", "size")
+    if size_value <= 0:
+        raise TosaValueError("SLICE_SHAPE requires size > 0", op="SLICE_SHAPE")
+
+    start_values = _to_finite_int_values(
+        start[0],
+        "SLICE_SHAPE",
+        "start",
+        max_values=len(input),
+    )
+    if start_values is None:
+        raise TosaValueError(
+            "SLICE_SHAPE requires compile-time constant start or a bounded symbolic "
+            "start with finitely many valid values",
+            op="SLICE_SHAPE",
+        )
+    if any(start_value < 0 for start_value in start_values):
+        raise TosaValueError("SLICE_SHAPE requires start >= 0", op="SLICE_SHAPE")
+    if any(start_value + size_value > len(input) for start_value in start_values):
+        raise TosaValueError(
+            "SLICE_SHAPE requires start + size within input bounds",
+            op="SLICE_SHAPE",
+        )
+
+    if len(start_values) == 1:
+        start_value = start_values[0]
+        return list(input[start_value : start_value + size_value])
+
+    start_expr = _to_sympy_expr(start[0])
+    result: list[IntLikeType] = []
+    for offset in range(size_value):
+        expr = sympy.Piecewise(
+            *[
+                (
+                    _to_sympy_expr(input[start_value + offset]),
+                    sympy.Eq(start_expr, sympy.Integer(start_value)),
+                )
+                for start_value in start_values
+            ]
+        )
+        if expr.is_number and expr.is_integer:
+            result.append(int(expr))
+            continue
+
+        shape_env = get_context_shape_env()
+        result.append(shape_env.create_symintnode(expr, hint=None))
+    return result
+
+
+@register_fake_tosa_op(
+    "SUB_SHAPE(SymInt[] shape1, SymInt[] shape2) -> SymInt[]",
+    TosaSpecification.all_profiles_for_version("1.1"),
+)
+def SUB_SHAPE(
+    shape1: list[IntLikeType],
+    shape2: list[IntLikeType],
+) -> list[IntLikeType]:
+    _require_shape_extension("SUB_SHAPE")
+    return _combine_shapes(shape1, shape2, lambda a, b: a - b)


### PR DESCRIPTION
Add fake-kernel support for the remaining TOSA shape operators: SLICE_SHAPE, EXP2_SHAPE, LOG2_CEIL_SHAPE, LOG2_FLOOR_SHAPE, MAX_SHAPE, MIN_SHAPE, DIV_CEIL_SHAPE, and ASSERT_EQUAL_SHAPE.

Tighten shape-op validation to better match the TOSA spec. DIM now validates supported dtypes and rejects non-positive dimensions, and EXP2_SHAPE enforces MAX_LOG2_SIZE including the 8k-level bound.

Make ASSERT_EQUAL_SHAPE use ShapeEnv bounds to reject provably mismatched symbolic dimensions without relying on SymBool truthiness.

Add regression coverage for invalid CONCAT_SHAPE inputs, DIM dtype and zero-dimension failures, EXP2_SHAPE bound checks, disjoint symbolic ASSERT_EQUAL_SHAPE mismatches, CONST_SHAPE on non-shape specs, and bounded-symbolic SLICE_SHAPE behavior.


cc @digantdesai @freddan80 @per @zingo @mansnils @Sebastian-Larsson @robell @rascani