### PR TITLE
Arm backend: Fix non-delegated typo

### DIFF
--- a/backends/arm/scripts/build_executor_runner.sh
+++ b/backends/arm/scripts/build_executor_runner.sh
@@ -54,7 +54,7 @@ help() {
     echo "  --et_build_root=<FOLDER>             Build output root folder to use, defaults to ${et_build_root}"
     echo "  --ethosu_tools_dir=<FOLDER>          Path to your Ethos-U tools dir if you not using default: ${ethosu_tools_dir}"
     echo "  --toolchain=<TOOLCHAIN>              Toolchain can be specified (arm-none-eabi-gcc, arm-zephyr-eabi-gcc). Default: ${toolchain}"
-    echo "  --select_ops_list=<OPS>              Comma separated list of portable (non delagated) kernels to include Default: ${select_ops_list}"
+    echo "  --select_ops_list=<OPS>              Comma separated list of portable (non-delegated) kernels to include Default: ${select_ops_list}"
     echo "                                         NOTE: This is used when select_ops_model is not possible to use, e.g. for semihosting or bundleio."
     echo "                                         See https://docs.pytorch.org/executorch/stable/kernel-library-selective-build.html for more information."
     exit 0

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -347,7 +347,7 @@ elseif(FOUND_OPS_IN_FILE)
 else()
   set(EXECUTORCH_SELECT_OPS_MODEL "")
   message(
-    "gen_oplist: No non delagated ops was found in ${ET_PTE_FILE_PATH} no ops added to build"
+    "gen_oplist: No non-delegated ops were found in ${ET_PTE_FILE_PATH}; no ops added to build"
   )
 endif()
 

--- a/zephyr/samples/hello-executorch/CMakeLists.txt
+++ b/zephyr/samples/hello-executorch/CMakeLists.txt
@@ -81,7 +81,7 @@ else()
   set(EXECUTORCH_SELECT_OPS_MODEL "")
   set(_EXECUTORCH_GEN_ZEPHYR_PORTABLE_OPS OFF)
   message(
-    "gen_oplist: No non delagated ops was found in ${ET_PTE_FILE_PATH} no ops added to build"
+    "gen_oplist: No non-delegated ops were found in ${ET_PTE_FILE_PATH}; no ops added to build"
   )
 endif()
 


### PR DESCRIPTION
Summary:
Fix user-facing Arm non-delegated operator messages.

Test plan:
bash -n backends/arm/scripts/build_executor_runner.sh
lintrunner -a --skip MYPY backends/arm/scripts/build_executor_runner.sh examples/arm/executor_runner/CMakeLists.txt zephyr/samples/hello-executorch/CMakeLists.txt
backends/arm/scripts/pre-push 1



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani