### PR TITLE
guard dimname after removal (#20071)

### DIFF
--- a/backends/arm/quantizer/quantization_annotator.py
+++ b/backends/arm/quantizer/quantization_annotator.py
@@ -547,7 +547,6 @@ _one_to_one_shared_input_qspec: set[OpOverload] = {
     torch.ops.aten.split.Tensor,
     torch.ops.aten.split_with_sizes.default,
     torch.ops.aten.split_copy.Tensor,
-    torch.ops.aten.transpose.Dimname,
     torch.ops.aten.transpose.int,
     torch.ops.aten.transpose_copy.int,
     torch.ops.aten.t_copy.default,
@@ -574,6 +573,15 @@ _one_to_one_shared_input_qspec: set[OpOverload] = {
     torch.ops.aten.neg.default,
     torch.ops.aten.detach_copy.default,
 }
+
+# Dimname has been removed from upstream PyTorch, but there may be a window
+# where developers in this backend are using a mainline build of this backend
+# with an older version of PyTorch.
+# TODO: remove this once the build has time to be propagated and majority of
+# dev expected to be unimpacted
+_transpose_dimname = getattr(torch.ops.aten.transpose, "Dimname", None)
+if _transpose_dimname is not None:
+    _one_to_one_shared_input_qspec.add(_transpose_dimname)
 
 _one_to_one_shared_input_or_input_act_qspec: set[OpOverload] = {
     torch.ops.aten.alias.default,


### PR DESCRIPTION
Summary:

PyTroch PR #173895 removed dim name support

This diff catches that this attribute may no longer be available, but retains backward compatibility as existing models may still have it and be re-exported/quantized/etc

Reviewed By: kirklandsign, digantdesai, jbschlosser

Differential Revision: D107662981


