### PR TITLE
Drop aten.transpose.Dimname from arm quantizer op list

### DIFF
--- a/backends/arm/quantizer/quantization_annotator.py
+++ b/backends/arm/quantizer/quantization_annotator.py
@@ -547,7 +547,6 @@ _one_to_one_shared_input_qspec: set[OpOverload] = {
     torch.ops.aten.split.Tensor,
     torch.ops.aten.split_with_sizes.default,
     torch.ops.aten.split_copy.Tensor,
-    torch.ops.aten.transpose.Dimname,
     torch.ops.aten.transpose.int,
     torch.ops.aten.transpose_copy.int,
     torch.ops.aten.t_copy.default,


### PR DESCRIPTION
Summary:
PyTorch removed named tensor support in D-equivalent of pytorch/pytorch#173895 ("Remove named tensor", commit 05c965e7f8a7), which deleted all `Dimname`-based op overloads from `native_functions.yaml`, including `aten::transpose.Dimname`. Builds picked up after that change no longer register the `Dimname` overload.

`executorch/backends/arm/quantizer/quantization_annotator.py` references `torch.ops.aten.transpose.Dimname` in a module-level constant list. As soon as that module is imported, evaluating the constant triggers `OpOverloadPacket.__getattr__('Dimname')` in `caffe2/torch/_ops.py`, which raises:

```
AttributeError: The underlying op of 'aten.transpose' has no overload name 'Dimname'
```

This breaks the PTQ step of the EMG release Ceres2 CC pipeline (FBLearner Flow run f1093420800) and any other workflow that imports the arm quantizer.

Fix: drop the `transpose.Dimname` entry. The same list already contains `transpose.int`, which is the only `transpose` overload still registered after the named-tensor removal. No other `.Dimname` references remain anywhere under `fbcode/executorch/`.

Differential Revision: D107675466




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani