### PR TITLE
Add OSS guard tests for ET_UNWRAP/ET_UNWRAP_TOKENIZER expression contract (#20075)

### DIFF
--- a/extension/llm/runner/test/test_util.cpp
+++ b/extension/llm/runner/test/test_util.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/extension/llm/runner/util.h>
+#include <executorch/runtime/core/result.h>
 #include <executorch/runtime/platform/runtime.h>
 
 #include <gtest/gtest.h>
@@ -153,6 +154,34 @@ TEST(StopSafePrefixLenTest, HoldZeroDoesNotEmitDanglingUtf8LeadByte) {
   const std::string text = "ab\xc3";
   EXPECT_EQ(stop_safe_prefix_len(text, {"Z"}, hit), 2u);
   EXPECT_FALSE(hit);
+}
+
+::executorch::runtime::Result<int32_t> make_int_result(int32_t value, bool ok) {
+  if (ok) {
+    return value;
+  }
+  return ::executorch::runtime::Error::InvalidArgument;
+}
+
+// Uses ET_UNWRAP_TOKENIZER in expression position (on a prvalue, like real call
+// sites) to pin its expression-form contract (see util.h): a change requiring a
+// variable-name argument would stop this from compiling.
+::executorch::runtime::Error
+unwrap_tokenizer_expression(int32_t value, bool ok, int32_t& out) {
+  out = ET_UNWRAP_TOKENIZER(make_int_result(value, ok));
+  return ::executorch::runtime::Error::Ok;
+}
+
+TEST_F(ConvertToBFloat16Test, EtUnwrapTokenizerExpressionForm) {
+  int32_t out = -1;
+  auto ok_err = unwrap_tokenizer_expression(7, /*ok=*/true, out);
+  EXPECT_EQ(ok_err, ::executorch::runtime::Error::Ok);
+  EXPECT_EQ(out, 7);
+
+  out = -1;
+  auto bad_err = unwrap_tokenizer_expression(9, /*ok=*/false, out);
+  EXPECT_EQ(bad_err, ::executorch::runtime::Error::InvalidArgument);
+  EXPECT_EQ(out, -1);
 }
 
 } // namespace

--- a/runtime/core/test/error_handling_test.cpp
+++ b/runtime/core/test/error_handling_test.cpp
@@ -28,6 +28,21 @@ Result<uint64_t> get_abs(int64_t num) {
   }
 }
 
+// Helpers that use ET_UNWRAP in expression position. They pin the macro's
+// expression-form contract (see result.h): a change that turns ET_UNWRAP back
+// into a statement-only macro (requiring a variable-name argument) would stop
+// these from compiling.
+Result<uint64_t> double_abs_unwrap(int64_t num) {
+  uint64_t value = ET_UNWRAP(get_abs(num));
+  return value * 2;
+}
+
+Result<uint64_t> double_abs_unwrap_with_message(int64_t num) {
+  uint64_t value =
+      ET_UNWRAP(get_abs(num), "get_abs failed for %d", static_cast<int>(num));
+  return value * 2;
+}
+
 Result<std::string> get_op_name(int64_t op) {
   auto abs_result = get_abs(op);
   if (!abs_result.ok()) {
@@ -241,6 +256,28 @@ TEST(ErrorHandlingTest, ResultUnwrap) {
   auto res = get_op_name(-1);
   ASSERT_FALSE(res.ok());
   ASSERT_EQ(res.error(), Error::InvalidArgument);
+}
+
+TEST(ErrorHandlingTest, EtUnwrapExpressionForm) {
+  auto ok = double_abs_unwrap(5);
+  ASSERT_TRUE(ok.ok());
+  EXPECT_EQ(*ok, 10u);
+
+  auto err = double_abs_unwrap(-1);
+  EXPECT_FALSE(err.ok());
+  EXPECT_EQ(err.error(), Error::InvalidArgument);
+}
+
+TEST(ErrorHandlingTest, EtUnwrapExpressionFormWithMessage) {
+  executorch::runtime::runtime_init();
+
+  auto ok = double_abs_unwrap_with_message(4);
+  ASSERT_TRUE(ok.ok());
+  EXPECT_EQ(*ok, 8u);
+
+  auto err = double_abs_unwrap_with_message(-2);
+  EXPECT_FALSE(err.ok());
+  EXPECT_EQ(err.error(), Error::InvalidArgument);
 }
 
 TEST(ErrorHandlingTest, ResultNoCopy) {


### PR DESCRIPTION
Summary:

ET_UNWRAP (runtime/core/result.h) and ET_UNWRAP_TOKENIZER
(extension/llm/runner/util.h) are expression-form macros used as
`auto x = ET_UNWRAP(expr);` across 100+ call sites. No test anywhere exercised
either macro, so changing them to statement-only macros (as #19686 did)
compiled cleanly in OSS CI and only broke internal-only consumers
(cria/arvr/jarvis) at diff-train import time.

Add compile-time guard tests that use both macros in expression position
(success + error paths) so OSS Buck and CMake CI fail if the expression
contract is broken. Mirrored in fbcode + xplat.

- error_handling_test.cpp: EtUnwrapExpressionForm, EtUnwrapExpressionFormWithMessage
- test_util.cpp: EtUnwrapTokenizerExpressionForm

Differential Revision: D107684052


