### PR TITLE
Remove non-existent aten.transpose.Dimname overload from quantizer

### DIFF
--- a/backends/arm/quantizer/quantization_annotator.py
+++ b/backends/arm/quantizer/quantization_annotator.py
@@ -547,7 +547,6 @@ _one_to_one_shared_input_qspec: set[OpOverload] = {
     torch.ops.aten.split.Tensor,
     torch.ops.aten.split_with_sizes.default,
     torch.ops.aten.split_copy.Tensor,
-    torch.ops.aten.transpose.Dimname,
     torch.ops.aten.transpose.int,
     torch.ops.aten.transpose_copy.int,
     torch.ops.aten.t_copy.default,


### PR DESCRIPTION
Summary:
The Arm quantizer's `_one_to_one_shared_input_qspec` set references
`torch.ops.aten.transpose.Dimname` at module load time. This named-tensor
overload no longer exists in the currently pinned torch version, so simply
importing `quantization_annotator.py` raises:

    AttributeError: The underlying op of 'aten.transpose' has no overload name 'Dimname'

Because nearly every Arm test imports this module transitively
(test_pipeline -> arm_tester -> quantizer -> quantization_annotator), the
import error broke test listing/collection across the whole Arm backend test
suite (e.g. fbcode//executorch/backends/arm/test:decompose_int_pow_pass failed
at listing with 'collected 0 items / 1 error').

The `.Dimname` overload is for named tensors, which never appear in exported
edge-dialect graphs, so it is never matched in practice. Removing the line is
safe and restores all Arm tests.

Differential Revision: D107688878




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani