### PR TITLE
Setuptools symlinks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -684,6 +684,22 @@ class CustomBuildPy(build_py):
     a file to a different relative location under the output package directory.
     """
 
+    def analyze_manifest(self):
+        super().analyze_manifest()
+        # Recent versions of setuptools may include bare directory symlinks from version
+        # control (e.g. src/executorch/{backends,codegen,data,...} ->
+        # ../../<name>) in manifest_files. These exist for editable mode but
+        # break regular installs: build_package_data passes them to copy_file,
+        # which calls os.path.isfile() and gets False for a symlink-to-directory.
+        if not self.editable_mode:
+            _root = os.path.dirname(os.path.abspath(__file__))
+            for _pkg in list(self.manifest_files):
+                self.manifest_files[_pkg] = [
+                    _f
+                    for _f in self.manifest_files[_pkg]
+                    if os.path.isfile(os.path.join(_root, _f))
+                ]
+
     def run(self):
         # Copy python files to the output directory. This set of files is
         # defined by the py_module list and package_data patterns.


### PR DESCRIPTION
### Summary

    build_py: filter directory symlinks from manifest_files in non-editable mode
    
    Recent setuptools includes bare directory symlinks (e.g.
    src/executorch/backends -> ../../backends) from version control in
    manifest_files. These exist for editable mode but break regular
    installs: build_package_data passes them to copy_file, which calls
    os.path.isfile() and gets False for a symlink-to-directory.
    
    Override analyze_manifest() to filter out non-regular-file entries
    after the parent populates manifest_files, guarded by editable_mode.

Fixes #20091

### Test plan

Run the command in the bug report with the problematic Python version as reported.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani