### PR TITLE
NXP backend: Enable `cat` with new Neutron flow.

### DIFF
--- a/backends/nxp/backend/custom_delegation_options.py
+++ b/backends/nxp/backend/custom_delegation_options.py
@@ -11,13 +11,6 @@ from dataclasses import dataclass
 class CustomDelegationOptions:
     """The class allows the user to specify details which affect which nodes will be delegated."""
 
-    # Neutron requires the channel dimension to be multiple of `num_macs` for concatenation (cat op).
-    #  Due to different dim ordering in torch (channel_first) and Neutron IR (channel last), dim of the channel is
-    #  ambiguous. Cat converter will defensively require both possible dimension index for the channels to be multiple
-    #  of `num_macs`. The `force_delegate_cat` allows the user to turn off the defensive check if from the model design
-    #  it is known this constraint will be satisfied.
-    force_delegate_cat: bool = False
-
     # Proposed partitions which only contain Neutron no-ops are normally not delegated, as the NeutronConverter would
     #  not create any NeutronGraph that can be called. This is done by the partitioner itself, and is not handled by
     #  the individual node converters.

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/cat_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/cat_converter.py
@@ -8,13 +8,7 @@ import torch
 from executorch.backends.nxp.backend.custom_delegation_options import (
     CustomDelegationOptions,
 )
-from executorch.backends.nxp.backend.data_format import NXP_NODE_FORMAT
-from executorch.backends.nxp.backend.edge_helper import previous_non_qdq_node
 from executorch.backends.nxp.backend.ir.converter.conversion import translator
-from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
-    apply_permutation_to,
-    create_channels_first_to_channels_last_permutation,
-)
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     _is_dequant_node,
     _is_quant_node,
@@ -25,7 +19,6 @@ from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.concate
 )
 from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from torch.fx import Node
-from torch.fx.passes.infra.partitioner import Partition
 from torch.nn import Parameter
 
 
@@ -83,56 +76,12 @@ class CatConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
-        if custom_delegation_options.force_delegate_cat:
-            return True
-
-        dim = CatConverter._get_normalized_dim(node)
-
-        # Neutron requires the channels to be a multiple of `num_macs`. The channels could either be the second or the
-        #  last dimension, depending on the formats of the node.
-        if node.meta[NXP_NODE_FORMAT].is_channels_first():
-            # During conversion to IR, the shape will be permuted to channels last, and the dimension on index
-            #  `1` will end up being the channels (last dim in NHWC).
-            channels_index = 1
-            to_nhwc_perm = create_channels_first_to_channels_last_permutation(
-                len(node.meta["val"].shape), True
-            )
-            dim = to_nhwc_perm.index(
-                dim
-            )  # Make sure the dim points to the NHWC dimension.
-        else:
-            # The shape will not be permuted during conversion, so the channels will remain the last dimension.
-            channels_index = -1
-
-        input_channels = [
-            _get_shape(input_)[channels_index] for input_ in node.all_input_nodes
-        ]
-        output_channels = _get_shape(node)[channels_index]
-
-        num_macs = neutron_target_spec.get_num_macs()
-        input_shapes = [_get_shape(input_) for input_ in node.all_input_nodes]
-        if any((input_channel % num_macs) != 0 for input_channel in input_channels):
-            # neutron-library/src/utils/NeutronLibraryInterrogation.cpp#1492
-
-            # If all input shapes are equal, the neutron is able to pad the last dimension of the inputs.
-            if not (
-                input_shapes.count(input_shapes[0]) == len(input_shapes)
-                and dim == len(input_shapes[0]) - 1
-            ):
-                return False
-
-        if (output_channels % num_macs) != 0:
-            # neutron-library/src/utils/NeutronLibraryInterrogation.cpp#1493
-
-            # If all input shapes are equal, the neutron is able to pad the last dimension of the output.
-            if not (
-                input_shapes.count(input_shapes[0]) == len(input_shapes)
-                and dim == len(input_shapes[0]) - 1
-            ):
-                return False
-
-        if len(node.all_input_nodes) < 2:  # Not supported on Neutron
-            # TODO Try to skip the operator if this case is realistic.
+        # `cat` uses a list of inputs as its first argument, so the indices are tuples of (0, i).
+        input_indices = [(0, i) for i in range(len(node.args[0]))]
+        supported_types = [torch.int8, torch.uint8]
+        if not NodeConverter.uses_quantization_type_for_io(
+            node, supported_types, input_indices=input_indices, output_indices=[0]
+        ):
             return False
 
         return True
@@ -150,50 +99,14 @@ class CatConverter(NodeConverter):
 
         return True
 
-    @classmethod
-    def supports_partitioning_result(
-        cls,
-        node: Node,
-        partition_list: list[Partition],
-        custom_delegation_options: CustomDelegationOptions,
-        neutron_target_spec: NeutronTargetSpec,
-        parameters_mapping: dict[str, Parameter],
-    ) -> bool:
-        # There is a bug in the NeutronConverter, where if none of the input dimensions before the one referenced by
-        #  `dim` are `!= 1`, the `Concat` is not delegated.
-        # This only happens when the inputs to the `Concat` are model inputs, and not outputs of other
-        #  operators.
-        cat_partition = [p for p in partition_list if node in p.nodes][0]
-        cat_inputs = map(previous_non_qdq_node, node.args[0])
-
-        if not all(
-            input_.op == "call_function" and input_ in cat_partition.nodes
-            for input_ in cat_inputs
-        ):
-            # Some inputs of the `cat` are NOT in the same partition as `cat`.
-            dim = CatConverter._get_normalized_dim(node)
-            input_shapes = [list(n.meta["val"].shape) for n in node.args[0]]
-            if node.meta[NXP_NODE_FORMAT].is_channels_first():
-                # Transform the shapes to channels last.
-                to_nhwc_perm = create_channels_first_to_channels_last_permutation(
-                    len(node.meta["val"].shape), True
-                )
-                input_shapes = [
-                    apply_permutation_to(shape, to_nhwc_perm) for shape in input_shapes
-                ]
-
-                # Transform the `dim` to refer to a channels last dimension.
-                dim = to_nhwc_perm.index(dim)
-
-            for input_shape in input_shapes:
-                if not any(d != 1 for d in input_shape[:dim]):
-                    # Do not delegate if there are no "non-1" dimensions in the shape before the `dim` dimension.
-                    return False
-
-        return True
-
     def convert(self, node: Node):
-        """Convert the 'aten.cat' operator to TFLite 'Concatenation'."""
+        """Convert the 'aten.cat' operator to NeutronIR 'Concatenation'.
+        The ExecuTorch schema is:
+            cat(
+                Tensor[] tensors,
+                int dim=0
+            ) -> Tensor
+        """
         self.assert_convertible(node)
 
         t_op = self._create_tflite_op_with_io_tensors(node)
@@ -205,5 +118,5 @@ class CatConverter(NodeConverter):
                 t_op.tmp_inputs[0].rank
             )[dim]
 
-        t_op.builtin_options = Concatenation(dim)
+        t_op.builtin_options = Concatenation(int(dim))
         self.builder.append_operators([t_op])

--- a/backends/nxp/tests/generic_tests/test_context_sensitive_delegation.py
+++ b/backends/nxp/tests/generic_tests/test_context_sensitive_delegation.py
@@ -120,7 +120,15 @@ def test_noop_partitions__concatenate_one_tensor_and_add_zeros():
     )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="Neutron Converter currently supports these 2 noops in sequence.",
+)
 def test_noop_partitions__concatenate_one_tensor_and_add_zeros__forced_delegation():
+    # When the noop `Concatenate` and noop `Add` are in sequence, Neutron Converter supports them. This edge case is
+    #  not reflected in our logic. But as this edge case is extremely rare (and even if it ever happened in a real
+    #  model, the consequences would be minimal), fixing it is not a priority.
+
     input_shape = (1, 2, 3, 4)
     module = ConcatAddNoOpModel(input_shape)
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_cat_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_cat_converter.py
@@ -25,10 +25,6 @@ from executorch.backends.nxp.tests.ops_aliases import (
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 
-def _normalized_dim(dim, rank):
-    return dim if dim >= 0 else dim + rank
-
-
 @pytest.fixture(autouse=True)
 def reseed_model_per_test_run():
     torch.manual_seed(23)
@@ -64,7 +60,7 @@ class TestCat:
         input_shape = (2, 3, 5)
         num_inputs = 2
 
-        input_shapes = [ModelInputSpec(input_shape)] * num_inputs
+        input_shapes = [ModelInputSpec(input_shape) for _ in range(num_inputs)]
         model = CatModule(1)
         graph_verifier = DetailedGraphVerifier(
             mocker, expected_delegated_ops={Cat: 1}, expected_non_delegated_ops={}
@@ -76,7 +72,7 @@ class TestCat:
     @pytest.mark.parametrize("num_inputs", [2, 5], ids=lambda n: f"n={n}")
     def test__same_shapes(self, mocker, dim, num_inputs):
         input_shape = (2, 3, 5)
-        input_shapes = [ModelInputSpec(input_shape)] * num_inputs
+        input_shapes = [ModelInputSpec(input_shape) for _ in range(num_inputs)]
 
         model = CatModule(dim)
         graph_verifier = DetailedGraphVerifier(
@@ -89,7 +85,7 @@ class TestCat:
     @pytest.mark.parametrize("num_inputs", [2, 5], ids=lambda n: f"n={n}")
     def test__same_shapes__channels_first(self, mocker, dim, num_inputs):
         input_shape = (2, 3, 4, 5)
-        input_shapes = [ModelInputSpec(input_shape)] * num_inputs
+        input_shapes = [ModelInputSpec(input_shape) for _ in range(num_inputs)]
 
         model = CatMaxPoolModule(dim)
         graph_verifier = DetailedGraphVerifier(

--- a/backends/nxp/tests/ir/converter/node_converter/test_cat_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_cat_converter.py
@@ -4,24 +4,24 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
+
+# noinspection PyUnusedImports
 import pytest
 import torch
 
-from executorch.backends.nxp.backend.custom_delegation_options import (
-    CustomDelegationOptions,
+from executorch.backends.nxp.tests.executorch_pipeline import (
+    ModelInputSpec,
+    to_quantized_edge_program,
 )
-from executorch.backends.nxp.backend.edge_program_converter import (
-    EdgeProgramToIRConverter,
+from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
+from executorch.backends.nxp.tests.ops_aliases import (
+    Cat,
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
 )
-from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
-from executorch.backends.nxp.tests.executors import (
-    convert_run_compare,
-    graph_contains_any_of_ops,
-    ToNCHWPreprocess,
-    ToNHWCPreprocess,
-)
-from executorch.exir.dialects._ops import ops as exir_ops
-from torch.export import ExportedProgram
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 
@@ -45,458 +45,123 @@ class CatModule(torch.nn.Module):
         return torch.cat(list(inputs), self.dim)
 
 
-class AddCatModule(torch.nn.Module):
+class CatMaxPoolModule(torch.nn.Module):
 
     def __init__(self, dim: int):
         super().__init__()
         self.dim = dim
-
-    def forward(self, *inputs: torch.Tensor):
-        inputs = [input_ + input_ for input_ in inputs]
-
-        return torch.cat(list(inputs), self.dim)
-
-
-class CatConvModule(torch.nn.Module):
-
-    def __init__(self, dim: int, channels: int = 4):
-        super().__init__()
-        self.dim = dim
-        self.conv = torch.nn.Conv2d(channels, channels, 2)
+        self.max_pool_2d = torch.nn.MaxPool2d(kernel_size=1)
 
     def forward(self, *inputs: torch.Tensor):
         x = torch.cat(list(inputs), self.dim)
-        return self.conv(x)
-
-
-@pytest.mark.parametrize(
-    "rank, num_inputs, dim",
-    [
-        pytest.param(2, 2, 1, id="2D, 2 inputs, dim=1"),
-        pytest.param(2, 2, -1, id="2D, 2 inputs, dim=-1"),
-        pytest.param(2, 3, 1, id="2D, 3 inputs, dim=1"),
-        pytest.param(2, 3, -1, id="2D, 3 inputs, dim=-1"),
-        pytest.param(2, 4, -1, id="2D, 4 inputs, dim=-1"),
-        pytest.param(3, 2, 1, id="3D, 2 inputs, dim=1"),
-        pytest.param(3, 2, -1, id="3D, 2 inputs, dim=-1"),
-        pytest.param(3, 5, -1, id="3D, 5 inputs, dim=-2"),
-        pytest.param(4, 2, -1, id="4D, 2 inputs, dim=-1"),
-        pytest.param(4, 3, 2, id="4D, 3 inputs, dim=2"),
-        pytest.param(4, 5, -3, id="4D, 5 inputs, dim=-3"),
-    ],
-)
-def test_cat__same_shapes(dim, num_inputs, rank, mocker, use_qat):
-    input_shape = tuple([8, 8, 8, 8][:rank])
-
-    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-
-    quantized_program = to_quantized_edge_program(
-        CatModule(dim), [input_shape] * num_inputs, use_qat=use_qat
-    ).exported_program()
-
-    # Make sure the `Cat` was delegated.
-    assert not graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert any("lowered_module" in node.name for node in quantized_program.graph.nodes)
-
-    tflite_flatbuffers_model, io_formats = converter_spy.spy_return
-    exported_program: ExportedProgram = converter_spy.call_args.args[1]
-    input_data = {
-        i: (np.random.random(input_shape) * 50).astype(np.int8)
-        for i in range(num_inputs)
-    }
-    convert_run_compare(
-        exported_program,
-        tfl_model=tflite_flatbuffers_model,
-        input_data=input_data,
-        atol=1,
-    )
-
-
-@pytest.mark.parametrize("dim", [3, -2, -3])
-@pytest.mark.parametrize("num_inputs", [2, 5])
-def test_cat__channels_first__same_shapes(dim, num_inputs, mocker, use_qat):
-    input_shape = (2, 8, 6, 8)
-    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-
-    channels = input_shape[1] if dim not in {1, -3} else input_shape[1] * num_inputs
-    quantized_program = to_quantized_edge_program(
-        CatConvModule(dim, channels),
-        [input_shape] * num_inputs,
-        use_qat=use_qat,
-        use_neutron_for_format_conversion=False,
-    ).exported_program()
-
-    # Make sure the `Cat` was delegated.
-    assert not graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert any("lowered_module" in node.name for node in quantized_program.graph.nodes)
-
-    tflite_flatbuffers_model, io_formats = converter_spy.spy_return
-    exported_program: ExportedProgram = converter_spy.call_args.args[1]
-    input_data = {
-        i: (np.random.random(input_shape) * 50).astype(np.int8)
-        for i in range(num_inputs)
-    }
-    convert_run_compare(
-        exported_program,
-        tfl_model=tflite_flatbuffers_model,
-        input_data=input_data,
-        tflite_input_preprocess=ToNHWCPreprocess(),
-        tflite_output_preprocess=ToNCHWPreprocess(),
-        atol=1,
-    )
-
-
-@pytest.mark.parametrize(
-    "dim, input_shape",
-    [
-        pytest.param(0, (1, 8, 8, 8), id="axis = 0"),
-        pytest.param(0, (8, 8, 8, 8), id="axis = 0, no `1s` in the shape."),
-        pytest.param(-4, (1, 8, 8, 8), id="axis = -4"),
-        pytest.param(1, (1, 1, 8, 8), id="axis = 1"),
-        pytest.param(-3, (1, 1, 8, 8), id="axis = -3"),
-        pytest.param(2, (1, 1, 1, 8), id="axis = 2"),
-        pytest.param(-2, (1, 1, 1, 8), id="axis = -2"),
-    ],
-)
-def test_cat__unsupported__imxrt700(dim, input_shape, use_qat):
-    """This test is conjoined with the one below (`test_cat__context_dependent__imxrt700`).
-    In this case, the inputs of the `cat` are NOT compute ops, so the `cat` is NOT delegated.
-    """
-    num_inputs = 2
-    quantized_program = to_quantized_edge_program(
-        CatModule(dim), [input_shape] * num_inputs, target="imxrt700", use_qat=use_qat
-    ).exported_program()
-
-    # Make sure the `Cat` was NOT delegated.
-    assert graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert not any(
-        "lowered_module" in node.name for node in quantized_program.graph.nodes
-    )
-
-
-@pytest.mark.parametrize(
-    "dim, input_shape",
-    [
-        pytest.param(0, (1, 8, 8, 8), id="axis = 0"),
-        pytest.param(0, (8, 8, 8, 8), id="axis = 0, no `1s` in the shape."),
-        pytest.param(-4, (1, 8, 8, 8), id="axis = -4"),
-        pytest.param(1, (1, 1, 8, 8), id="axis = 1"),
-        pytest.param(-3, (1, 1, 8, 8), id="axis = -3"),
-        pytest.param(2, (1, 1, 1, 8), id="axis = 2"),
-        pytest.param(-2, (1, 1, 1, 8), id="axis = -2"),
-    ],
-)
-def test_cat__context_dependent__imxrt700(dim, input_shape, use_qat):
-    """This test is conjoined with the one above (`test_cat__unsupported__imxrt700`).
-    In this case, the inputs of the `cat` are compute ops, so the `cat` is delegated.
-    """
-    num_inputs = 2
-    ep = to_quantized_edge_program(
-        AddCatModule(dim),
-        [input_shape] * num_inputs,
-        target="imxrt700",
-        use_qat=use_qat,
-    ).exported_program()
-
-    # Make sure the `Cat` was delegated.
-    assert not graph_contains_any_of_ops(ep.graph, [exir_ops.edge.aten.cat.default])
-    assert any("lowered_module" in node.name for node in ep.graph.nodes)
-
-
-@pytest.mark.parametrize(
-    "rank, num_inputs, dim",
-    [
-        pytest.param(2, 2, 1, id="2D, 2 inputs, dim=1"),
-        pytest.param(2, 2, -1, id="2D, 2 inputs, dim=-1"),
-        pytest.param(2, 3, 1, id="2D, 3 inputs, dim=1"),
-        pytest.param(2, 3, -1, id="2D, 3 inputs, dim=-1"),
-        pytest.param(2, 4, -1, id="2D, 4 inputs, dim=-1"),
-        pytest.param(3, 2, 1, id="3D, 2 inputs, dim=1"),
-        pytest.param(3, 2, -1, id="3D, 2 inputs, dim=-1"),
-        pytest.param(3, 5, -1, id="3D, 5 inputs, dim=-2"),
-        pytest.param(4, 2, -1, id="4D, 2 inputs, dim=-1"),
-        pytest.param(4, 3, 2, id="4D, 3 inputs, dim=2"),
-        pytest.param(4, 5, -3, id="4D, 5 inputs, dim=-3"),
-    ],
-)
-def test_cat__different_shapes(dim, num_inputs, rank, mocker, use_qat):
-    input_shape = tuple([2, 8, 8, 8, 8][-rank:])
-
-    # The shape of every input will be different along the concatenated dimension.
-    input_shapes = []
-    for i in range(num_inputs):
-        tmp_shape = list(input_shape)
-        tmp_shape[dim] = 8 * (i + 1)  # RT700 requires multiples of 8 for the channels.
-        input_shapes.append(tuple(tmp_shape))
-
-    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-
-    quantized_program = to_quantized_edge_program(
-        CatModule(dim), input_shapes, use_qat=use_qat
-    ).exported_program()
-
-    # Make sure the `Cat` was delegated.
-    assert not graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert any("lowered_module" in node.name for node in quantized_program.graph.nodes)
-
-    tflite_flatbuffers_model, io_formats = converter_spy.spy_return
-    exported_program: ExportedProgram = converter_spy.call_args.args[1]
-    input_data = {
-        i: (np.random.random(shape) * 50).astype(np.int8)
-        for i, shape in enumerate(input_shapes)
-    }
-    convert_run_compare(
-        exported_program,
-        tfl_model=tflite_flatbuffers_model,
-        input_data=input_data,
-        atol=1,
-    )
-
-
-@pytest.mark.parametrize("dim", [1, -1, -2], ids=lambda dim: f"dim = {dim}")
-@pytest.mark.parametrize(
-    "num_inputs", [2, 5], ids=lambda num_inputs: f"num_inputs = {num_inputs}"
-)
-def test_cat__channels_first__different_shapes(dim, num_inputs, mocker, use_qat):
-    input_shape = (2, 8, 6, 8)
-
-    # The shape of every input will be different along the concatenated dimension.
-    input_shapes = []
-    for i in range(num_inputs):
-        tmp_shape = list(input_shape)
-        tmp_shape[dim] = 8 * (
-            i + 1
-        )  # Neutron only supports channels that are multiples of 8 (on RT700).
-        input_shapes.append(tuple(tmp_shape))
-
-    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-
-    channels = (
-        sum(shape[1] for shape in input_shapes) if dim in [1, -3] else input_shape[1]
-    )
-    quantized_program = to_quantized_edge_program(
-        CatConvModule(dim, channels),
-        input_shapes,
-        use_qat=use_qat,
-        use_neutron_for_format_conversion=False,
-    ).exported_program()
-
-    # Make sure the `Cat` was delegated.
-    assert not graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert any("lowered_module" in node.name for node in quantized_program.graph.nodes)
-
-    tflite_flatbuffers_model, io_formats = converter_spy.spy_return
-    exported_program: ExportedProgram = converter_spy.call_args.args[1]
-    input_data = {
-        i: (np.random.random(shape) * 50).astype(np.int8)
-        for i, shape in enumerate(input_shapes)
-    }
-    convert_run_compare(
-        exported_program,
-        tfl_model=tflite_flatbuffers_model,
-        input_data=input_data,
-        tflite_input_preprocess=ToNHWCPreprocess(),
-        tflite_output_preprocess=ToNCHWPreprocess(),
-        atol=1,
-    )
-
-
-def test_cat__different_shapes__unsupported_channels__imxrt700(use_qat):
-    input_shape = (2, 4, 6, 7)  # (channels % 8) != 0
-
-    num_inputs = 2
-    dim = -1
-
-    # The shape of every input will be different along the concatenated dimension.
-    input_shapes = []
-    for i in range(num_inputs):
-        tmp_shape = list(input_shape)
-        tmp_shape[dim] = i + 2
-        input_shapes.append(tuple(tmp_shape))
-
-    quantized_program = to_quantized_edge_program(
-        CatModule(dim), input_shapes, target="imxrt700", use_qat=use_qat
-    ).exported_program()
-
-    # Make sure the `Cat` was NOT delegated.
-    assert graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert not any(
-        "lowered_module" in node.name for node in quantized_program.graph.nodes
-    )
-
-
-def test_cat__force_delegate(use_qat):
-    target = "imxrt700"
-
-    # The Partitioner doesn't know if the `8` or the `1` will become the channels in the IR. Therefore, it would
-    #  normally not delegate the `cat`. But we know that the `8` will be the channels, so we can force the delegation.
-    input_shape = (8, 1, 8)
-
-    quantized_program = to_quantized_edge_program(
-        CatModule(1),
-        [input_shape, input_shape],
-        target=target,
-        custom_delegation_options=CustomDelegationOptions(force_delegate_cat=True),
-        use_qat=use_qat,
-    ).exported_program()
-
-    # Make sure the `Cat` was delegated.
-    assert not graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert any("lowered_module" in node.name for node in quantized_program.graph.nodes)
-
-
-def test_cat__same_shapes_converter_padding_last_dimension(use_qat):
-    target = "imxrt700"
-
-    # The Converter is capable of padding the last dimension of `cat` with the same input shapes.
-    input_shape = (3, 1, 3)
-
-    quantized_program = to_quantized_edge_program(
-        CatModule(2),
-        [input_shape, input_shape],
-        target=target,
-        custom_delegation_options=CustomDelegationOptions(),
-        use_qat=use_qat,
-    ).exported_program()
-
-    # Make sure the `Cat` was delegated.
-    assert not graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert any("lowered_module" in node.name for node in quantized_program.graph.nodes)
-
-
-def test_cat__same_shapes__channels_first__padding_channels(use_qat):
-    target = "imxrt700"
-
-    # The Converter is capable of padding the last dimension of `cat` with the same input shapes.
-    input_shape = (1, 2, 3, 4)
-
-    quantized_program = to_quantized_edge_program(
-        CatConvModule(1),
-        [input_shape, input_shape],
-        target=target,
-        custom_delegation_options=CustomDelegationOptions(),
-        use_qat=use_qat,
-    ).exported_program()
-
-    # Make sure the `Cat` was delegated.
-    assert not graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert any("lowered_module" in node.name for node in quantized_program.graph.nodes)
-
-
-def test_cat__same_shapes_converter_padding_middle_dimension(use_qat):
-    target = "imxrt700"
-
-    # The Converter is not capable of padding the middle dimensions of `cat` with the same input shapes.
-    input_shape = (3, 1, 3)
-
-    quantized_program = to_quantized_edge_program(
-        CatModule(1),
-        [input_shape, input_shape],
-        target=target,
-        custom_delegation_options=CustomDelegationOptions(),
-        use_qat=use_qat,
-    ).exported_program()
-
-    # Make sure the `Cat` was NOT delegated.
-    assert graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert not any(
-        "lowered_module" in node.name for node in quantized_program.graph.nodes
-    )
-
-
-def test_cat__format_specific_support__formatless(mocker, use_qat):
-    # The last dim will end up being the channels, as the format is `formatless`.
-    # Only the last dim satisfies the Neutron requirements for the channels.
-    input_shape = (3, 3, 3, 8)
-    num_inputs = 2
-    dim = 2
-
-    input_shapes = [input_shape] * num_inputs
-
-    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-
-    quantized_program = to_quantized_edge_program(
-        CatModule(dim), input_shapes, use_qat=use_qat
-    ).exported_program()
-
-    # Make sure the `Cat` was delegated.
-    assert not graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert any("lowered_module" in node.name for node in quantized_program.graph.nodes)
-
-    tflite_flatbuffers_model, io_formats = converter_spy.spy_return
-    exported_program: ExportedProgram = converter_spy.call_args.args[1]
-    input_data = {
-        i: (np.random.random(shape) * 50).astype(np.int8)
-        for i, shape in enumerate(input_shapes)
-    }
-    convert_run_compare(
-        exported_program,
-        tfl_model=tflite_flatbuffers_model,
-        input_data=input_data,
-        atol=1,
-    )
-
-
-def test_cat__format_specific_support__channels_first(mocker, use_qat):
-    # The second dim will end up being the channels, as the format is `formatless`.
-    # Only the second dim satisfies the Neutron requirements for the channels.
-    input_shape = (3, 8, 3, 3)
-    num_inputs = 2
-    dim = 2
-
-    input_shapes = [input_shape] * num_inputs
-
-    converter_spy = mocker.spy(EdgeProgramToIRConverter, "convert_program")
-
-    channels = (
-        sum(shape[1] for shape in input_shapes) if dim in [1, -3] else input_shape[1]
-    )
-    quantized_program = to_quantized_edge_program(
-        CatConvModule(dim, channels),
-        input_shapes,
-        use_qat=use_qat,
-        use_neutron_for_format_conversion=False,
-    ).exported_program()
-
-    # Make sure the `Cat` was delegated.
-    assert not graph_contains_any_of_ops(
-        graph=quantized_program.graph, ops=[exir_ops.edge.aten.cat.default]
-    )
-    assert any("lowered_module" in node.name for node in quantized_program.graph.nodes)
-
-    tflite_flatbuffers_model, io_formats = converter_spy.spy_return
-    exported_program: ExportedProgram = converter_spy.call_args.args[1]
-    input_data = {
-        i: (np.random.random(shape) * 50).astype(np.int8)
-        for i, shape in enumerate(input_shapes)
-    }
-    convert_run_compare(
-        exported_program,
-        tfl_model=tflite_flatbuffers_model,
-        input_data=input_data,
-        tflite_input_preprocess=ToNHWCPreprocess(),
-        tflite_output_preprocess=ToNCHWPreprocess(),
-        atol=1,
-    )
+        x = self.max_pool_2d(x)
+        return x
+
+
+class TestCat:
+
+    def test__qat(self, mocker, use_qat):
+        input_shape = (2, 3, 5)
+        num_inputs = 2
+
+        input_shapes = [ModelInputSpec(input_shape)] * num_inputs
+        model = CatModule(1)
+        graph_verifier = DetailedGraphVerifier(
+            mocker, expected_delegated_ops={Cat: 1}, expected_non_delegated_ops={}
+        )
+
+        lower_run_compare(model, input_shapes, graph_verifier, use_qat=use_qat)
+
+    @pytest.mark.parametrize("dim", list(range(-3, 3)), ids=lambda dim: f"dim={dim}")
+    @pytest.mark.parametrize("num_inputs", [2, 5], ids=lambda n: f"n={n}")
+    def test__same_shapes(self, mocker, dim, num_inputs):
+        input_shape = (2, 3, 5)
+        input_shapes = [ModelInputSpec(input_shape)] * num_inputs
+
+        model = CatModule(dim)
+        graph_verifier = DetailedGraphVerifier(
+            mocker, expected_delegated_ops={Cat: 1}, expected_non_delegated_ops={}
+        )
+
+        lower_run_compare(model, input_shapes, graph_verifier)
+
+    @pytest.mark.parametrize("dim", [0, -3, 2, -1], ids=lambda dim: f"dim={dim}")
+    @pytest.mark.parametrize("num_inputs", [2, 5], ids=lambda n: f"n={n}")
+    def test__same_shapes__channels_first(self, mocker, dim, num_inputs):
+        input_shape = (2, 3, 4, 5)
+        input_shapes = [ModelInputSpec(input_shape)] * num_inputs
+
+        model = CatMaxPoolModule(dim)
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops={Cat: 1, MaxPool2DWithIndices: 1, GetItem: 1},
+            expected_non_delegated_ops={},
+        )
+
+        lower_run_compare(model, input_shapes, graph_verifier)
+
+    @pytest.mark.parametrize("dim", [0, -1], ids=lambda dim: f"dim={dim}")
+    @pytest.mark.parametrize("rank", [2, 3, 4], ids=lambda rank: f"rank={rank}")
+    @pytest.mark.parametrize("num_inputs", [2, 3], ids=lambda n: f"n={n}")
+    def test__different_shapes(self, mocker, dim, rank, num_inputs):
+        # The input shapes can only differ in the `dim` dimension. So we can just assign a different one for each input.
+        # e.g. [(2, 3, 4), (3, 3, 4), (4, 3, 4), (5, 3, 4), (6, 3, 4)]
+        base_shape = [i + 2 for i in range(rank)]
+        input_shapes = [list(base_shape) for _ in range(num_inputs)]
+        for i, input_shape in enumerate(input_shapes):
+            input_shape[dim] = i + 2
+        input_shapes = list(map(tuple, input_shapes))
+
+        model = CatModule(dim)
+        graph_verifier = DetailedGraphVerifier(
+            mocker, expected_delegated_ops={Cat: 1}, expected_non_delegated_ops={}
+        )
+
+        lower_run_compare(model, input_shapes, graph_verifier)
+
+    @pytest.mark.parametrize("dim", [1, -1], ids=lambda dim: f"dim={dim}")
+    @pytest.mark.parametrize("num_inputs", [2, 5], ids=lambda n: f"n={n}")
+    def test__different_shapes__channels_first(self, mocker, dim, num_inputs):
+        # The input shapes can only differ in the `dim` dimension. So we can just assign a different one for each input.
+        # e.g. [(1, 3, 4, 5), (2, 3, 4, 5)]
+        base_shape = (2, 3, 4, 5)
+        input_shapes = [list(base_shape) for _ in range(num_inputs)]
+        for i, input_shape in enumerate(input_shapes):
+            input_shape[dim] = i + 2
+        input_shapes = list(map(tuple, input_shapes))
+
+        model = CatMaxPoolModule(dim)
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops={Cat: 1, MaxPool2DWithIndices: 1, GetItem: 1},
+            expected_non_delegated_ops={},
+        )
+
+        lower_run_compare(model, input_shapes, graph_verifier)
+
+    def test__single_input__alone_in_partition__not_delegated(self):
+        # The operator is a noop, and there is no other op in the model. The Neutron Converter would produce an empty
+        #  graph, so the `cat` is not delegated.
+        input_shape = [ModelInputSpec((2, 3, 5))]
+        model = CatModule(1)
+
+        delegated_ep = to_quantized_edge_program(model, input_shape).exported_program()
+
+        # Make sure the `cat` was NOT delegated.
+        assert not graph_contains_any_of_ops(
+            delegated_ep.graph, [ExecutorchDelegateCall]
+        )
+        assert graph_contains_any_of_ops(delegated_ep.graph, [Cat])
+
+    def test__single_input__not_alone_in_partition__delegated(self, mocker):
+        # The operator is a noop, but there is another op in the model, so they are both delegated.
+        input_shape = [ModelInputSpec((2, 3, 4, 5))]
+
+        model = CatMaxPoolModule(1)
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops={Cat: 1, MaxPool2DWithIndices: 1, GetItem: 1},
+            expected_non_delegated_ops={},
+        )
+
+        lower_run_compare(model, input_shape, graph_verifier)


### PR DESCRIPTION
### Summary
This PR enables the delegation of the `cat` operator to Neutron. The updated version has basically no restrictions, and all cases are supported.

### Test plan
Unit tests provided.


cc @robert-kalmar @JakeStevens @digantdesai @rascani