### PR TITLE
Arm backend: smollm2 test scratch buffer / seq length increase

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -258,6 +258,7 @@ jobs:
           - test_arm_backend: test_pytest_models_ethos_u85
           - test_arm_backend: test_run_ethos_u85
           - test_arm_backend: test_smaller_stories_llama_tosa
+          - test_arm_backend: test_model_smollm2_135M_ethos_u85
           - test_arm_backend: test_memory_allocation
           - test_arm_backend: test_ootb_tests_ethos_u
           - test_arm_backend: test_ootb_tests_tosa

--- a/backends/arm/README.md
+++ b/backends/arm/README.md
@@ -251,7 +251,7 @@ Below is an overview of some of the testing options this script provides:
 | `test_arm_backend.sh test_pytest_ops_vkml`         | Runs operator unit tests for VKML/VGF specific use-cases.    |
 | `test_arm_backend.sh test_pytest_models_vkml`      | Runs model unit tests for VKML/VGF specific use-cases.       |
 | `test_arm_backend.sh test_run_vkml`                | Runs end-to-end unit tests for VKML/VGF specific use-cases.  |
-| `test_arm_backend.sh test_model_smollm2_135M`      | Runs some models with Corstone FVP.                          |
+| `test_arm_backend.sh test_model_smollm2_135M_ethos_u85`      | Runs smollm2_135M for Ethos-U85 specific use-cases.                          |
 | `test_arm_backend.sh test_ootb_tests_ethos_u`      | Runs out-of-the-box tests for Ethos-U.                       |
 | `test_arm_backend.sh test_ootb_tests_tosa`         | Runs out-of-the-box tests for TOSA.                          |
 | `test_arm_backend.sh test_ootb_tests_vgf`          | Runs out-of-the-box tests for VKML/VGF.                      |

--- a/backends/arm/test/test_arm_backend.sh
+++ b/backends/arm/test/test_arm_backend.sh
@@ -299,7 +299,7 @@ test_deit_e2e_ethos_u() {
 # ------------------------------------
 # -------- Miscellaneous tests -------
 # ------------------------------------
-test_model_smollm2_135M() {
+test_model_smollm2_135M_ethos_u85() {
     echo "${TEST_SUITE_NAME}: Test SmolLM2-135M on Ethos-U85"
 
     backends/arm/scripts/build_executorch.sh
@@ -309,7 +309,7 @@ test_model_smollm2_135M() {
         base.model_class=smollm2 \
         base.params=examples/models/smollm2/135M_config.json \
         debug.verbose=True model.enable_dynamic_shape=False quantization.pt2e_quantize="ethosu_8a8w" \
-        backend.ethosu.enabled=True backend.ethosu.target="ethos-u85-256" backend.ethosu.memory_mode=Dedicated_Sram_384KB
+        backend.ethosu.enabled=True backend.ethosu.target="ethos-u85-256" backend.ethosu.memory_mode=Dedicated_Sram_384KB export.max_seq_length=32
 
     # Build the arm_executor_runner application, pre-loading the pte in the DDR for faster linking
     local pte_addr="0x76000000"
@@ -322,8 +322,8 @@ test_model_smollm2_135M() {
       --memory_mode=Dedicated_Sram_384KB \
       --ethosu_tools_dir="${scratch_dir}" \
       --toolchain=arm-none-eabi-gcc \
-      --extra_build_flags="-DET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=0x20000" \
-      --select_ops_list="dim_order_ops::_to_dim_order_copy.out" 
+      --extra_build_flags="-DET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=0x100000" \
+      --select_ops_list="dim_order_ops::_to_dim_order_copy.out"
 
 
     # Deploy the application on the FVP in fast mode


### PR DESCRIPTION
- Increase the scratch buffer size to 1MB when running smollm2 test. This is due to hitting mem allocation failure on Ethos-U.
- Export pte with sequence length set to 32. This is due to an issue where executor runner hangs
- Renamed test_model_smollm2_135M to include ethos_u85 in name
- Added smollm2 test to ci trunk


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani