### PR TITLE
Avoid std::accumulate in reduce_add

### DIFF
--- a/kernels/portable/cpu/targets.bzl
+++ b/kernels/portable/cpu/targets.bzl
@@ -44,6 +44,7 @@ def define_common_targets():
         exported_deps = [
             "//executorch/runtime/core/portable_type/c10/c10:c10",
             "//executorch/runtime/platform:compiler",
+            "//executorch/runtime/platform:platform",
         ],
         srcs = [],
         exported_headers = ["vec_ops.h"],

--- a/kernels/portable/cpu/test/vec_ops_test.cpp
+++ b/kernels/portable/cpu/test/vec_ops_test.cpp
@@ -66,6 +66,26 @@ TEST(VecScalefTest, Smoke) {
   EXPECT_EQ(out[4], 32);
 }
 
+TEST(ReduceAddTest, Smoke) {
+  constexpr size_t kNumVals = 5;
+  int64_t in[kNumVals] = {-2, -1, 0, 3, 7};
+
+  EXPECT_EQ(torch::executor::reduce_add(in, kNumVals), 7);
+}
+
+#if GTEST_HAS_DEATH_TEST
+TEST(ReduceAddTest, AdditionOverflowDies) {
+  float in[] = {
+      std::numeric_limits<float>::max(),
+      std::numeric_limits<float>::max(),
+  };
+
+  EXPECT_DEATH(
+      torch::executor::reduce_add(in, /*size=*/2),
+      "Float addition overflow");
+}
+#endif // GTEST_HAS_DEATH_TEST
+
 TEST(VecPowerfTest, Smoke) {
   constexpr size_t kNumVals = 5;
   float in[kNumVals] = {-2, -1, 0, 1, 2};

--- a/kernels/portable/cpu/vec_ops.h
+++ b/kernels/portable/cpu/vec_ops.h
@@ -10,12 +10,13 @@
 #pragma once
 
 #include <c10/util/irange.h>
+#include <c10/util/overflows.h>
+#include <executorch/runtime/platform/assert.h>
 #include <executorch/runtime/platform/compiler.h>
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
-#include <numeric>
 #include <type_traits>
 /**
  * @file
@@ -168,7 +169,25 @@ inline void vec_addmm(
 /// Returns the sum of all elements in `x`, which must have `size` elements.
 template <typename T>
 inline float reduce_add(const T* x, size_t size) {
-  return std::accumulate(x, x + size, 0.f);
+  float sum = 0.f;
+  for (const auto i : c10::irange(size)) {
+    if constexpr (std::is_arithmetic_v<T>) {
+      ET_CHECK_MSG(
+          !c10::overflows<float>(x[i]),
+          "Float conversion overflow in reduce_add at index %zu",
+          static_cast<size_t>(i));
+    }
+    const float value = static_cast<float>(x[i]);
+    const float next = sum + value;
+    if (std::isfinite(sum) && std::isfinite(value)) {
+      ET_CHECK_MSG(
+          std::isfinite(next),
+          "Float addition overflow in reduce_add at index %zu",
+          static_cast<size_t>(i));
+    }
+    sum = next;
+  }
+  return sum;
 }
 
 /// Returns the sum of the squares of all elements in `x`, which must have


### PR DESCRIPTION
Summary:
- Replace reduce_add std::accumulate usage with an explicit indexed loop using c10::irange.
- Use c10::overflows<float> before arithmetic source types are converted to the float accumulator, then check the actual float add result for finite inputs.
- Drop the now-unused <numeric> include, add direct reduce_add smoke/death coverage, and update the Buck target deps for the new platform assert include.

Test Plan:
- git diff --check origin/main..HEAD
- c++ -std=c++17 -DC10_USING_CUSTOM_GENERATED_MACROS -I/private/tmp/executorch-vec-ops-accumulate/src -I/private/tmp/executorch-vec-ops-accumulate/runtime/core/portable_type/c10 -fsyntax-only -x c++ - <<'CPP' ...
- cmake -S /private/tmp/executorch-vec-ops-cmake-real/executorch -B /private/tmp/executorch-vec-ops-cmake-real/build -GNinja -DCMAKE_BUILD_TYPE=Debug -DEXECUTORCH_BUILD_TESTS=OFF -DEXECUTORCH_BUILD_PORTABLE_OPS=ON -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF -DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=OFF -DEXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR=OFF -DEXECUTORCH_BUILD_EXTENSION_EVALUE_UTIL=OFF -DEXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=OFF -DEXECUTORCH_BUILD_CPUINFO=OFF -DEXECUTORCH_BUILD_PTHREADPOOL=OFF
- cmake --build /private/tmp/executorch-vec-ops-cmake-real/build --target portable_kernels --parallel 8

Not run:
- buck2 test //kernels/portable/cpu/test:vec_ops_test: blocked because this GitHub checkout has .buckconfig but no .buck2 dotslash file.
- lintrunner/commit hook: blocked by missing lintrunner_adapters in the local Python environment.

Authored with Claude.