### PR TITLE
Cap PyTorch build parallelism for all GCC docker images

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -102,7 +102,7 @@ esac
 TORCH_VERSION=$(cat ci_commit_pins/pytorch.txt)
 BUILD_DOCS=1
 
-if [[ "${GCC_VERSION:-}" == "11" && -z "${SKIP_PYTORCH:-}" ]]; then
+if [[ -n "${GCC_VERSION:-}" && -z "${SKIP_PYTORCH:-}" ]]; then
   PYTORCH_BUILD_MAX_JOBS=6
 fi
 


### PR DESCRIPTION
### Summary
The gcc14 docker build was intermittently timing out on linux.4xlarge runners because it built PyTorch from source with unlimited parallelism, unlike gcc11 which capped MAX_JOBS=6. Generalize the guard to all GCC variants so gcc14, gcc15, and future additions get the same protection.

Images that set SKIP_PYTORCH (gcc9-nopytorch, cuda-windows) are unaffected because the existing SKIP_PYTORCH guard excludes them.

Fixes #19881

### Test plan
CI