### PR TITLE
Bump tokenizers submodule to fix sentencepiece GCC 15 build

### DIFF
--- a/examples/models/parakeet/tokenizer_utils.cpp
+++ b/examples/models/parakeet/tokenizer_utils.cpp
@@ -8,6 +8,10 @@
 
 namespace {
 
+// SentencePiece's word-boundary marker, spelled as UTF-8 bytes so this remains
+// a const char[] literal when compiled as C++20.
+constexpr char kSentencePieceWordBoundary[] = "\xE2\x96\x81";
+
 bool is_whitespace_only(const std::string& token) {
   if (token.empty()) {
     return true;
@@ -36,7 +40,7 @@ bool is_special_token(const std::string& token) {
   if (token.rfind("##", 0) == 0) {
     return true;
   }
-  if (token.rfind(u8"▁", 0) == 0) {
+  if (token.rfind(kSentencePieceWordBoundary, 0) == 0) {
     return true;
   }
   if (is_whitespace_only(token)) {


### PR DESCRIPTION
### Summary
Updates extension/llm/tokenizers to include
meta-pytorch/tokenizers#193, which bumps the sentencepiece submodule to pick up a missing `#include <cstdint>` (google/sentencepiece#1109).

Without this, `pytorch_tokenizers` fails to compile inside the `executorch-ubuntu-26.04-gcc15` docker image, blocking the RISC-V baremetal CI (#19917).

### Test plan
CI