### PR TITLE
Extend CPPCHECK scope to prim ops

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -196,7 +196,6 @@ exclude_patterns = [
     'kernels/aten/**',
     'kernels/optimized/**',
     'kernels/portable/**',
-    'kernels/prim_ops/**',
     'kernels/quantized/**',
     'kernels/test/**',
 
@@ -227,6 +226,10 @@ command = [
     '--extra-arg=--suppress=toomanyconfigs',
     '--extra-arg=--suppress=unusedFunction:*.h',
     '--extra-arg=--suppress=unusedFunction:*.hpp',
+    # Prim ops use the same ExecuTorch macro idioms as portable kernels.
+    '--extra-arg=--suppress=unknownMacro:*kernels/prim_ops/*',
+    '--extra-arg=--suppress=syntaxError:*kernels/prim_ops/*',
+    '--extra-arg=--suppress=unusedFunction:*kernels/prim_ops/*',
     '--',
     '@{{PATHSFILE}}'
 ]


### PR DESCRIPTION
Remove the broad kernels/prim_ops CPPCHECK exclusion and keep the remaining suppressions scoped to that tree.

Prim ops use the same ExecuTorch macro idioms as portable kernels, including empty macro arguments that cppcheck does not parse reliably. Keep those parser suppressions local to prim_ops instead of adding inline suppressions throughout the file.

The only remaining unusedFunction report is for a helper used through the prim op registration implementation, so suppress that noise for the prim_ops tree as well.


Change-Id: I2bb1fdaae37d7bcd218015cb3037c370d9707e8b


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani