### PR TITLE
Arm backend: Bump vela to 5.1.0

### DIFF
--- a/backends/arm/requirements-arm-ethos-u.txt
+++ b/backends/arm/requirements-arm-ethos-u.txt
@@ -5,5 +5,5 @@
 
 # These dependencies need to match pyproject.toml
 
-ethos-u-vela == 5.0.0
+ethos-u-vela == 5.1.0
 pte-adapter-model-explorer == 0.0.2

--- a/backends/arm/test/ops/test_index_copy.py
+++ b/backends/arm/test/ops/test_index_copy.py
@@ -93,12 +93,6 @@ class IndexCopyModule(torch.nn.Module):
         return x.index_copy(dim, index, y)
 
 
-xfails_u85 = {
-    "rand_single_index_not_zero_out_of_place": "MLETORCH-1949: index_copy (SCATTER/INDEX_PUT) produces incorrect results for non-zero indices on U85",
-    "rand_single_index_not_zero_in_place": "MLETORCH-1949: index_copy (SCATTER/INDEX_PUT) produces incorrect results for non-zero indices on U85",
-}
-
-
 @common.parametrize("test_data", IndexCopyModule.test_data)
 def test_index_copy_tosa_FP(test_data):
     inputs, inplace = test_data()
@@ -139,7 +133,7 @@ def test_index_copy_u55_INT(test_data):
     pipeline.run()
 
 
-@common.parametrize("test_data", IndexCopyModule.test_data, xfails=xfails_u85)
+@common.parametrize("test_data", IndexCopyModule.test_data)
 @common.XfailIfNoCorstone320
 def test_index_copy_u85_INT(test_data):
     inputs, inplace = test_data()

--- a/backends/arm/test/ops/test_index_put.py
+++ b/backends/arm/test/ops/test_index_put.py
@@ -404,7 +404,6 @@ def test_index_put_u55_INT(test_module: input_t):
 @common.parametrize(
     "test_module",
     test_data_suite_fp | test_data_int,
-    xfails={"none_indices_4": "Incorrect numerical behavior: MLBEDSW-11589"},
 )
 def test_index_put_u85_INT(test_module: input_t):
     """same_index test case already supported on u85 even though it is not

--- a/backends/arm/test/ops/test_layer_norm.py
+++ b/backends/arm/test/ops/test_layer_norm.py
@@ -179,13 +179,7 @@ def test_native_layer_norm_tosa_INT_a16w8(test_data):
     pipeline.run()
 
 
-@common.parametrize(
-    "test_data",
-    test_data_suite,
-    xfails={
-        "randn_last_dim": "MLETORCH-1834 - 16A8W native_layer_norm output diff for certain configurations."
-    },
-)
+@common.parametrize("test_data", test_data_suite)
 @common.XfailIfNoCorstone300
 def test_native_layer_norm_16a8w_u55_INT(test_data):
     """Test layer_norm with int16 I/O quantization for U55."""
@@ -196,18 +190,13 @@ def test_native_layer_norm_16a8w_u55_INT(test_data):
         "torch.ops.aten.sub.Tensor",
         symmetric_io_quantization=True,
         a16w8_quantization=True,
-        qtol=128,
+        qtol=400,
         epsilon=2**-16,
     )
     pipeline.run()
 
 
-u85_xfails_16a8w = {
-    "randn_last_dim": "MLETORCH-1834 - 16A8W native_layer_norm output diff for certain configurations.",
-}
-
-
-@common.parametrize("test_data", test_data_suite, xfails=u85_xfails_16a8w)
+@common.parametrize("test_data", test_data_suite)
 @common.XfailIfNoCorstone320
 def test_native_layer_norm_16a8w_u85_INT(test_data):
     """Test layer_norm with int16 I/O quantization for U85."""
@@ -218,7 +207,7 @@ def test_native_layer_norm_16a8w_u85_INT(test_data):
         "torch.ops.aten.sub.Tensor",
         symmetric_io_quantization=True,
         a16w8_quantization=True,
-        qtol=128,
+        qtol=400,
         epsilon=2**-16,
     )
     pipeline.run()

--- a/backends/arm/test/ops/test_unary_combos.py
+++ b/backends/arm/test/ops/test_unary_combos.py
@@ -104,9 +104,7 @@ def test_add_tensor_tosa_INT_combos(model_cls):
 
 
 @common.XfailIfNoCorstone300
-@common.parametrize(
-    "model_cls", MODEL_DATA, xfails={"NegAdd": "Numerical failure. MLBEDSW-11581"}
-)
+@common.parametrize("model_cls", MODEL_DATA)
 def test_add_tensor_u55_INT_combos(model_cls):
     m, inputs, exir = _build(model_cls)
     p = EthosU55PipelineINT[Tensor1](

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ ethos_u = [
   # AoT ethos_u dependencies
   # Keep this in sync with AoT deps backends/arm/requirements-arm-ethos-u.txt and
   # backends/arm/requirements-arm-tosa.txt.
-  "ethos-u-vela==5.0.0",
+  "ethos-u-vela==5.1.0",
   "ml_dtypes==0.5.1",
   "tosa-tools==2026.2.1",
 ]


### PR DESCRIPTION
Bumps vela to 5.1.0 and removes xfails that been fixed.

cc @digantdesai @freddan80 @per @zingo @mansnils @Sebastian-Larsson @robell @rascani