### PR TITLE
Fix Windows CUDA build: guard extension_cuda compile options to CXX

### DIFF
--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -16,6 +16,7 @@ on:
       - .github/workflows/cuda-windows.yml
       - backends/cuda/**
       - backends/aoti/**
+      - extension/cuda/**
   workflow_dispatch:
 
 concurrency:
@@ -49,6 +50,7 @@ jobs:
       (
         contains(needs.changed-files.outputs.changed-files, 'backends/cuda') ||
         contains(needs.changed-files.outputs.changed-files, 'backends/aoti') ||
+        contains(needs.changed-files.outputs.changed-files, 'extension/cuda') ||
         contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda-windows.yml') ||
         needs.run-decision.outputs.is-full-run == 'true'
       )
@@ -150,6 +152,7 @@ jobs:
       (
         contains(needs.changed-files.outputs.changed-files, 'backends/cuda') ||
         contains(needs.changed-files.outputs.changed-files, 'backends/aoti') ||
+        contains(needs.changed-files.outputs.changed-files, 'extension/cuda') ||
         contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda-windows.yml') ||
         needs.run-decision.outputs.is-full-run == 'true'
       )

--- a/extension/cuda/CMakeLists.txt
+++ b/extension/cuda/CMakeLists.txt
@@ -25,7 +25,9 @@ find_package(CUDAToolkit REQUIRED)
 add_library(extension_cuda SHARED caller_stream.cpp)
 target_link_libraries(extension_cuda PUBLIC CUDA::cudart)
 target_include_directories(extension_cuda PUBLIC ${_common_include_directories})
-target_compile_options(extension_cuda PUBLIC ${_common_compile_options})
+target_compile_options(
+  extension_cuda PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${_common_compile_options}>"
+)
 target_compile_definitions(
   extension_cuda PRIVATE EXECUTORCH_EXTENSION_CUDA_BUILDING
 )


### PR DESCRIPTION
## Problem
The Windows CUDA e2e build (`test-model-cuda-windows-e2e`) fails compiling the `aoti_cuda_shims` `.cu` kernels:
```
nvcc fatal : A single input file is required for a non-link phase when an outputfile is specified
```
The build fails -> `--target install` never finishes -> `executorchConfig.cmake` is missing -> every example-runner `find_package(executorch)` fails -> all 6 models go red.

## Root cause
`extension/cuda/CMakeLists.txt` applied `${_common_compile_options}` **PUBLIC, unguarded** (it expands to `/wd4996` on MSVC). #20158 linked `extension_cuda` into `slimtensor`'s INTERFACE, so the flag propagates `extension_cuda -> slimtensor -> aoti_cuda_shims` into the `.cu` nvcc compile as a bare `/wd4996`, which nvcc parses as a second input file. Every other target in the CUDA stack already guards these with `$<COMPILE_LANGUAGE:CXX>`; this one didn't.

## Fix
Guard the compile options with `$<COMPILE_LANGUAGE:CXX>`, matching the rest of the stack.
