### PR TITLE
Add executorch-et-log-disabled constraint honored by log.bzl (#20187)

### DIFF
--- a/runtime/platform/log.bzl
+++ b/runtime/platform/log.bzl
@@ -1,3 +1,5 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
 def et_logging_enabled():
     return native.read_config("executorch", "enable_et_log", "true") == "true"
 
@@ -16,7 +18,14 @@ def et_log_level():
 
 def get_et_logging_flags():
     if et_logging_enabled():
-        # On by default.
-        return ["-DET_MIN_LOG_LEVEL=" + et_log_level()]
+        if runtime.is_oss:
+            return ["-DET_MIN_LOG_LEVEL=" + et_log_level()]
+
+        # On by default; allow opt-out via constraint (the executorch.enable_et_log
+        # buckconfig above remains an independent way to disable logging).
+        return select({
+            "DEFAULT": ["-DET_MIN_LOG_LEVEL=" + et_log_level()],
+            "fbsource//xplat/executorch/tools/buck/constraints:executorch-et-log-disabled": ["-DET_LOG_ENABLED=0"],
+        })
     else:
         return ["-DET_LOG_ENABLED=0"]

--- a/tools/buck/constraints/BUCK
+++ b/tools/buck/constraints/BUCK
@@ -99,3 +99,22 @@ fb_native.constraint_value(
     constraint_setting = ":executorch-builtin-function-name",
     visibility = ["PUBLIC"],
 )
+
+fb_native.config_setting(
+    name = "executorch-et-log-disabled",
+    constraint_values = [
+        ":et-log-disabled",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+fb_native.constraint_setting(
+    name = "executorch-et-log",
+    visibility = ["PUBLIC"],
+)
+
+fb_native.constraint_value(
+    name = "et-log-disabled",
+    constraint_setting = ":executorch-et-log",
+    visibility = ["PUBLIC"],
+)


### PR DESCRIPTION
Summary:

Adds support to disable logging using BUCK constraint

Reviewed By: rascani

Differential Revision: D108152661


