### PR TITLE
Route Module.loadMethod through makeExecutorchException for native log enrichment

### DIFF
--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.kt
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.kt
@@ -89,7 +89,8 @@ open class Module private constructor(moduleAbsolutePath: String, loadMode: Int,
       check(mHybridData.isValid) { "Module has been destroyed" }
       val errorCode = loadMethodNative(methodName)
       if (errorCode != 0) {
-        throw ExecutorchRuntimeException(errorCode, "Failed to load method: $methodName")
+        throw ExecutorchRuntimeException.makeExecutorchException(
+            errorCode, "Failed to load method: $methodName")
       }
     } finally {
       mLock.unlock()


### PR DESCRIPTION
Summary:
`Module.loadMethod` directly constructs `ExecutorchRuntimeException`, bypassing the `makeExecutorchException` factory that enriches error details with the native log tail (added in D107196396). As a result, the high-volume SceneX XNNPACK 0x12 `loadMethod` failures (`[ExecuTorch Error 0x12] Invalid argument: Failed to load method: forward`) never capture native diagnostic context — `nativeLog=` never appears in Scuba/QPL data.

Route the throw through the factory so these failures get the native log tail for triage. The change is applied to both the `xplat` and `fbcode` copies of `Module.kt` to keep them in sync, mirroring how D107196396 edited both copies of `ExecutorchRuntimeException.kt`.

For error code 0x12 (`INVALID_ARGUMENT`), `makeExecutorchException` returns `ExecutorchInvalidArgumentException`, a subclass of `ExecutorchRuntimeException` that carries the same `errorCode`, so existing `catch (ExecutorchRuntimeException)` and `getErrorCode()` consumers are unaffected. The enrichment runs only on the failure path (not per-call) and uses the static `readLogBufferStatic` JNI read, which takes a separate native mutex, so it does not re-enter the `mLock` held by `loadMethod`. The change is additive: when no native logs are available the message is byte-identical to today's.

This was authored with assistance from Claude.

Reviewed By: SS-JIA

Differential Revision: D108154606


