### PR TITLE
Extend CPPCHECK scope to quantized kernels

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -196,7 +196,6 @@ exclude_patterns = [
     'kernels/aten/**',
     'kernels/optimized/**',
     'kernels/portable/**',
-    'kernels/quantized/**',
     'kernels/test/**',
 
     # Runtime areas to onboard incrementally.
@@ -230,6 +229,12 @@ command = [
     '--extra-arg=--suppress=unknownMacro:*kernels/prim_ops/*',
     '--extra-arg=--suppress=syntaxError:*kernels/prim_ops/*',
     '--extra-arg=--suppress=unusedFunction:*kernels/prim_ops/*',
+    # Quantized kernels have NEON-gated code and registration helpers that
+    # cppcheck cannot see in every configuration.
+    '--extra-arg=--suppress=unreadVariable:*kernels/quantized/*',
+    '--extra-arg=--suppress=unusedFunction:*kernels/quantized/*',
+    '--extra-arg=--suppress=constParameterReference:*kernels/quantized/*',
+    '--extra-arg=--suppress=suspiciousFloatingPointCast:*kernels/quantized/*',
     '--',
     '@{{PATHSFILE}}'
 ]


### PR DESCRIPTION
Remove the broad kernels/quantized CPPCHECK exclusion and keep the remaining suppressions scoped to that tree.

Quantized kernels include NEON-gated paths, registration helpers, and intentional floating point narrowing for quantization behavior. Cppcheck does not see every configuration or call path, so keep those findings suppressed only for kernels/quantized.


Change-Id: I0d8b5e3fdf4523f929c75aa373a520ab92178e75


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani