### PR TITLE
Extend CPPCHECK scope to kernel tests

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -195,7 +195,6 @@ exclude_patterns = [
     # Kernel areas to onboard separately.
     'kernels/optimized/**',
     'kernels/portable/**',
-    'kernels/test/**',
 
     # Runtime areas to onboard incrementally.
     'runtime/backend/**',
@@ -234,6 +233,16 @@ command = [
     '--extra-arg=--suppress=unusedFunction:*kernels/quantized/*',
     '--extra-arg=--suppress=constParameterReference:*kernels/quantized/*',
     '--extra-arg=--suppress=suspiciousFloatingPointCast:*kernels/quantized/*',
+    # Kernel tests use fixture helpers, generated-style test cases, and GTest
+    # macros that cppcheck cannot consistently resolve as direct use sites.
+    '--extra-arg=--suppress=unusedFunction:*kernels/test/*',
+    '--extra-arg=--suppress=unreadVariable:*kernels/test/*',
+    '--extra-arg=--suppress=unknownMacro:*kernels/test/*',
+    '--extra-arg=--suppress=syntaxError:*kernels/test/*',
+    '--extra-arg=--suppress=passedByValue:*kernels/test/*',
+    '--extra-arg=--suppress=duplicateBranch:*kernels/test/*',
+    '--extra-arg=--suppress=useStlAlgorithm:*kernels/test/*',
+    '--extra-arg=--suppress=functionStatic:*kernels/test/*',
     '--',
     '@{{PATHSFILE}}'
 ]


### PR DESCRIPTION
Remove the broad kernels/test CPPCHECK exclusion and keep the remaining suppressions scoped to that tree.

Kernel tests use fixture helpers, generated-style test data, and GTest macros that cppcheck cannot consistently resolve as direct use sites. Suppress those test-harness findings locally while keeping the rest of the CPPCHECK configuration active for kernels/test.


Change-Id: I033afb7b59b961a99d6716ff3faa068a0eed2f6a


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani