### PR TITLE
Arm backend: Fix FP8 conv and matmul TOSA lowering

### DIFF
--- a/backends/arm/_passes/rewrite_conv_pass.py
+++ b/backends/arm/_passes/rewrite_conv_pass.py
@@ -48,6 +48,8 @@ class RewriteConvPass(ArmPass):
     (CONV2D/DEPTHWISE/TRANSPOSE/CONV3D).
     """
 
+    _FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
+
     def __init__(self, exported_program: torch.export.ExportedProgram, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.exported_program = exported_program
@@ -146,11 +148,15 @@ class RewriteConvPass(ArmPass):
         graph_module: torch.fx.GraphModule,
         node: torch.fx.Node,
         weight_node: torch.fx.Node,
+        input_fake_tensor: torch.Tensor,
     ) -> torch.fx.Node:
         output_channels = get_first_fake_tensor(node).shape[1]
-        # add a node containing zeros if quantized, use int32, otherwise use float32
+        # Add a zero bias with the dtype TOSA expects: int32 for
+        # quantized conv, fp16 for FP8 conv, and the output dtype otherwise.
         if self._is_quantized_conv(node):
             bias_data = torch.zeros(size=(output_channels,), dtype=torch.int32)
+        elif input_fake_tensor.dtype in self._FP8_DTYPES:
+            bias_data = torch.zeros(size=(output_channels,), dtype=torch.float16)
         else:
             output_dtype = node.meta["val"].dtype
             bias_data = torch.zeros(size=(output_channels,), dtype=output_dtype)
@@ -173,6 +179,32 @@ class RewriteConvPass(ArmPass):
             self._mark_bias_as_int48_if_needed(node, bias_node)
         node.update_arg(2, bias_node)
         return bias_node
+
+    def _rewrite_fp8_bias(
+        self,
+        graph_module: torch.fx.GraphModule,
+        node: torch.fx.Node,
+        bias_node: torch.fx.Node,
+    ) -> torch.fx.Node:
+        bias_tensor = get_param_tensor(  # type: ignore[arg-type]
+            self.exported_program, bias_node
+        )
+        if bias_tensor is None:
+            raise RuntimeError(
+                f"Bias node {bias_node.name} is not a parameter or buffer"
+            )
+
+        kind = get_constant_placeholder_kind(self.exported_program, bias_node)
+        persistent_buffer = is_persistent_buffer(self.exported_program, bias_node)
+        with graph_module.graph.inserting_after(bias_node):
+            return create_constant_placeholder(
+                self.exported_program,
+                graph=graph_module.graph,
+                name=f"{node.name}_bias_fp16",
+                kind=kind,
+                data=bias_tensor.to(torch.float16),
+                persistent_buffer=persistent_buffer,
+            )
 
     def _rewrite_weight(
         self,
@@ -449,9 +481,12 @@ class RewriteConvPass(ArmPass):
 
             has_bias = bias is not None
             if not has_bias:
-                bias = self._add_bias(graph_module, node, weight)
+                bias = self._add_bias(graph_module, node, weight, input_fake_tensor)
             elif isinstance(bias, torch.fx.Node):
-                self._mark_bias_as_int48_if_needed(node, bias)
+                if input_fake_tensor.dtype in self._FP8_DTYPES:
+                    bias = self._rewrite_fp8_bias(graph_module, node, bias)
+                else:
+                    self._mark_bias_as_int48_if_needed(node, bias)
 
             conv_args: tuple[Any, ...]
             input_tensor_for_tosa_fake: torch.Tensor = input_fake_tensor

--- a/backends/arm/_passes/rewrite_matmul.py
+++ b/backends/arm/_passes/rewrite_matmul.py
@@ -105,11 +105,10 @@ class RewriteMatmulPass(ArmPass):
             elif (
                 x1_fake_tensor.dtype in self._WIDENING_INPUT_DTYPES
                 and x2_fake_tensor.dtype in self._WIDENING_INPUT_DTYPES
-                and output_fake_tensor.dtype not in self._WIDENING_INPUT_DTYPES
+                and output_fake_tensor.dtype != node_output_fake_tensor.dtype
             ):
-                # TOSA BF16/FP16/FP8 MATMUL outputs FP32, while the original
-                # exported node outputs BF16/FP16/FP8. Cast back to preserve
-                # the exported graph dtype.
+                # TOSA BF16/FP16/FP8 MATMUL widens the output. Cast back to
+                # preserve the exported graph dtype.
                 with graph_module.graph.inserting_after(tosa_matmul_node):
                     cast_node = create_node(
                         graph_module.graph,

--- a/backends/arm/operators/op_tosa_conv2d.py
+++ b/backends/arm/operators/op_tosa_conv2d.py
@@ -69,8 +69,22 @@ class Conv2dVisitor(NodeVisitor):
             valid_input_dtypes.append(ts.DType.BF16)
         if self.tosa_spec.support_extension("fp8e4m3"):
             valid_input_dtypes.append(ts.DType.FP8E4M3)
+            if inputs[0].dtype == ts.DType.FP8E4M3:
+                validate_valid_dtype(
+                    self.target, [inputs[1]], [ts.DType.FP8E4M3], self.tosa_spec
+                )
+                validate_valid_dtype(
+                    self.target, [inputs[2]], [ts.DType.FP16], self.tosa_spec
+                )
         if self.tosa_spec.support_extension("fp8e5m2"):
             valid_input_dtypes.append(ts.DType.FP8E5M2)
+            if inputs[0].dtype == ts.DType.FP8E5M2:
+                validate_valid_dtype(
+                    self.target, [inputs[1]], [ts.DType.FP8E5M2], self.tosa_spec
+                )
+                validate_valid_dtype(
+                    self.target, [inputs[2]], [ts.DType.FP16], self.tosa_spec
+                )
 
         validate_valid_dtype(
             self.target,

--- a/backends/arm/operators/op_tosa_matmul.py
+++ b/backends/arm/operators/op_tosa_matmul.py
@@ -62,7 +62,7 @@ class MatmulVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [output],
-            [ts.DType.INT32, ts.DType.INT48, ts.DType.FP32],
+            [ts.DType.INT32, ts.DType.INT48, ts.DType.FP16, ts.DType.FP32],
             self.tosa_spec,
         )
 

--- a/backends/arm/operators/op_tosa_transpose_conv2d.py
+++ b/backends/arm/operators/op_tosa_transpose_conv2d.py
@@ -80,7 +80,7 @@ class TransposeConv2dVisitor(NodeVisitor):
                     self.target, [inputs[1]], [ts.DType.FP8E4M3], self.tosa_spec
                 )
                 validate_valid_dtype(
-                    self.target, [inputs[2]], [ts.DType.FP8E4M3], self.tosa_spec
+                    self.target, [inputs[2]], [ts.DType.FP16], self.tosa_spec
                 )
         if self.tosa_spec.support_extension("fp8e5m2"):
             valid_input_dtypes.append(ts.DType.FP8E5M2)
@@ -89,7 +89,7 @@ class TransposeConv2dVisitor(NodeVisitor):
                     self.target, [inputs[1]], [ts.DType.FP8E5M2], self.tosa_spec
                 )
                 validate_valid_dtype(
-                    self.target, [inputs[2]], [ts.DType.FP8E5M2], self.tosa_spec
+                    self.target, [inputs[2]], [ts.DType.FP16], self.tosa_spec
                 )
 
         validate_valid_dtype(

--- a/backends/arm/test/ops/test_conv2d.py
+++ b/backends/arm/test/ops/test_conv2d.py
@@ -553,10 +553,6 @@ test_data_FP_fp8 = {
         "fp8e5m2",
     ),
 }
-_fp8_conv2d_tosa_ref_model_xfails = {
-    name: "MLETORCH-2238: Fix invalid FP8 CONV TOSA graphs" for name in test_data_FP_fp8
-}
-
 # Generate a new test set paired with per_channel_quant=True/False.
 test_data_INT = {
     f"{k},per_channel_quant={q}": (lambda v=v, q=q: (v(), q))
@@ -611,9 +607,7 @@ def test_convolution_2d_tosa_FP(test_data):
     pipeline.run()
 
 
-@common.parametrize(
-    "test_data", test_data_FP_fp8, xfails=_fp8_conv2d_tosa_ref_model_xfails
-)
+@common.parametrize("test_data", test_data_FP_fp8)
 def test_convolution_2d_tosa_FP_fp8(test_data):
     model, tosa_extension = test_data()
     pipeline = TosaPipelineFP[input_t](

--- a/backends/arm/test/ops/test_conv3d.py
+++ b/backends/arm/test/ops/test_conv3d.py
@@ -515,10 +515,6 @@ test_data_FP_fp8 = {
         "fp8e5m2",
     ),
 }
-_fp8_conv3d_tosa_ref_model_xfails = {
-    name: "MLETORCH-2238: Fix invalid FP8 CONV TOSA graphs" for name in test_data_FP_fp8
-}
-
 test_data_FP_bf16 = {
     "bf16_3x3": lambda: Conv3d(
         height=10,
@@ -611,9 +607,7 @@ def test_convolution_3d_tosa_FP(test_data):
     pipeline.run()
 
 
-@common.parametrize(
-    "test_data", test_data_FP_fp8, xfails=_fp8_conv3d_tosa_ref_model_xfails
-)
+@common.parametrize("test_data", test_data_FP_fp8)
 def test_convolution_3d_tosa_FP_fp8(test_data):
     model, tosa_extension = test_data()
     pipeline = TosaPipelineFP[input_t](

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -227,11 +227,6 @@ test_data_conv2d_FP_fp8 = {
         "fp8e5m2",
     ),
 }
-_fp8_depthwise_conv_tosa_ref_model_xfails = {
-    name: "MLETORCH-2238: Fix invalid FP8 CONV TOSA graphs"
-    for name in test_data_conv2d_FP_fp8
-}
-
 # Generate a new test set paired with per_channel_quant=True/False.
 test_data_conv2d_INT = {
     f"{k},per_channel_quant={q}": (lambda v=v, q=q: (v(), q))
@@ -293,11 +288,7 @@ def test_convolution_2d_tosa_FP_depthwise(test_data: torch.nn.Module):
     pipeline.run()
 
 
-@common.parametrize(
-    "test_data",
-    test_data_conv2d_FP_fp8,
-    xfails=_fp8_depthwise_conv_tosa_ref_model_xfails,
-)
+@common.parametrize("test_data", test_data_conv2d_FP_fp8)
 def test_convolution_2d_tosa_FP_fp8_depthwise(test_data):
     model, tosa_extension = test_data()
     pipeline = TosaPipelineFP[input_t](

--- a/backends/arm/test/ops/test_matmul.py
+++ b/backends/arm/test/ops/test_matmul.py
@@ -375,10 +375,6 @@ test_suite_fp8 = {
         (exir_op_mm_2d, exir_op_mm_2d),
     ),
 }
-fp8_xfails = {
-    name: "MLETORCH-2239: Fix invalid FP8 MATMUL TOSA graphs" for name in test_suite_fp8
-}
-
 xfails = {
     "double_input_randn_rand_1d_1d": "aten.dot.default is not supported",
     "double_input_randn_rand_2d_1d": "aten.mv.default is not supported",
@@ -401,7 +397,7 @@ def test_matmul_tosa_FP(test_case: test_case_t):
     pipeline.run()
 
 
-@common.parametrize("test_case", test_suite_fp8, xfails=fp8_xfails)
+@common.parametrize("test_case", test_suite_fp8)
 def test_matmul_tosa_FP_fp8(test_case: test_case_t):
     test_data = test_case()
     input_dtype = test_data.input_factory()[0].dtype

--- a/backends/arm/test/ops/test_transpose_conv2d.py
+++ b/backends/arm/test/ops/test_transpose_conv2d.py
@@ -267,9 +267,6 @@ test_data_FP8 = {
         "fp8e5m2",
     ),
 }
-_fp8_transpose_conv_tosa_ref_model_xfails = {
-    name: "MLETORCH-2238: Fix invalid FP8 CONV TOSA graphs" for name in test_data_FP8
-}
 
 
 @common.parametrize("test_data", test_data_FP | test_data_FP_fp16 | test_data_BF16)
@@ -287,9 +284,7 @@ def test_conv_transpose2d_tosa_FP(test_data):
     pipeline.run()
 
 
-@common.parametrize(
-    "test_data", test_data_FP8, xfails=_fp8_transpose_conv_tosa_ref_model_xfails
-)
+@common.parametrize("test_data", test_data_FP8)
 def test_conv_transpose2d_tosa_FP_fp8(test_data):
     model, tosa_extension = test_data()
     pipeline = TosaPipelineFP[input_t](

--- a/backends/arm/tosa/dialect/ops/conv2d.py
+++ b/backends/arm/tosa/dialect/ops/conv2d.py
@@ -63,15 +63,20 @@ def validate_conv2d_args_dtypes(  # noqa: C901
                 f"TOSA spec {tosa_spec} requires weights {weight.dtype} to be of the same type as input {x.dtype}",
                 op=op,
             )
-        if bias is not None and bias.dtype != x.dtype:
-            raise TosaValueError(
-                f"TOSA spec {tosa_spec} requires bias {bias.dtype} to be of the same type as input {x.dtype}",
-                op=op,
-            )
         if x.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
             output_dtype = torch.float16
         else:
             output_dtype = x.dtype
+        if bias is not None and bias.dtype != output_dtype:
+            if output_dtype != x.dtype:
+                raise TosaValueError(
+                    f"TOSA spec {tosa_spec} requires bias {bias.dtype} to be of the same type as output {output_dtype}",
+                    op=op,
+                )
+            raise TosaValueError(
+                f"TOSA spec {tosa_spec} requires bias {bias.dtype} to be of the same type as input {x.dtype}",
+                op=op,
+            )
     else:
         supported_types = (
             *(supported_int_types if tosa_spec.support_integer() else ()),

--- a/backends/arm/tosa/dialect/ops/matmul.py
+++ b/backends/arm/tosa/dialect/ops/matmul.py
@@ -56,13 +56,13 @@ def MATMUL(x1: torch.Tensor, x2: torch.Tensor) -> torch.Tensor:
             raise TosaValueError(
                 f"TOSA spec {tosa_spec} doesn't support fp8e4m3", op="MATMUL"
             )
-        dtype = torch.float32
+        dtype = torch.float16
     elif x1.dtype == torch.float8_e5m2:
         if not tosa_spec.support_extension("fp8e5m2"):
             raise TosaValueError(
                 f"TOSA spec {tosa_spec} doesn't support fp8e5m2", op="MATMUL"
             )
-        dtype = torch.float32
+        dtype = torch.float16
     else:
         raise TosaValueError(
             "Input tensors must be of type int8, float16, float32, bfloat16, "


### PR DESCRIPTION
Lower FP8 MATMUL with FP16 accumulation for TOSA 1.0 and keep the cast back to the exported graph dtype when the TOSA op widens the output.

Create and validate FP16 bias tensors for FP8 conv-family TOSA ops, matching the TOSA output domain. This fixes invalid FP8 conv and matmul TOSA lowering.

Change-Id: Ib2a12454e6df97535173eb8131c32c142a73544e

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani