### PR TITLE
Add test op alias to backend target (#20223)

### DIFF
--- a/backends/nxp/BUCK
+++ b/backends/nxp/BUCK
@@ -66,6 +66,9 @@ fbcode_target(_kind = runtime.python_library,
     srcs = glob(["backend/**/*.py"]),
     deps = [
         "fbsource//third-party/pypi/neutron_converter:neutron_converter",
+        "//caffe2:torch",
+        "//executorch/exir:lib",
+        "//executorch/backends/nxp/tests:ops_aliases",
     ],
 )
 

--- a/backends/nxp/tests/BUCK
+++ b/backends/nxp/tests/BUCK
@@ -5,6 +5,17 @@ load("@fbcode_macros//build_defs:python_pytest.bzl", "python_pytest")
 oncall("executorch")
 
 fbcode_target(_kind = runtime.python_library,
+    name = "ops_aliases",
+    srcs = [
+        "ops_aliases.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/exir:lib",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
     name = "models",
     srcs = [
         "models.py",


### PR DESCRIPTION
Summary:

The backend code now uses op alias, which lives in test code and was not a BUCK dependency.

Add the proper deps

Reviewed By: rascani

Differential Revision: D108305486


