### PR TITLE
Repair etvk.vma_dep=instantiated to share VMA via 3.2.0

### DIFF
--- a/backends/vulkan/runtime/vk_api/memory/vma_api.h
+++ b/backends/vulkan/runtime/vk_api/memory/vma_api.h
@@ -23,7 +23,10 @@
 #undef VMA_DYNAMIC_VULKAN_FUNCTIONS
 #define VMA_STATIC_VULKAN_FUNCTIONS 0
 #define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
-#define VMA_VULKAN_VERSION 1002000
+// Must match the 3.2.0 VulkanMemoryAllocatorInstantiated config
+// (vk_mem_alloc_instantiated.h) so struct layouts agree across translation
+// units and the pre-instantiated static lib.
+#define VMA_VULKAN_VERSION 1003000
 
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -191,7 +191,7 @@ def define_common_targets(is_fbcode = False):
 
         if vma_dep == "instantiated":
             VK_API_DEPS = [
-                "fbsource//third-party/VulkanMemoryAllocator/3.0.1:VulkanMemoryAllocatorInstantiated",
+                "fbsource//third-party/VulkanMemoryAllocator/3.2.0:VulkanMemoryAllocatorInstantiated",
             ]
         else:
             VK_API_DEPS = [


### PR DESCRIPTION
Summary:
Fixes the ExecuTorch Vulkan backend's `etvk.vma_dep=instantiated` mode so the backend links a single, shared VulkanMemoryAllocator (VMA) instead of instantiating its own. This is the prerequisite that lets a binary link both ET Vulkan and another VMA consumer (e.g. IGL/compphoto) without an `ld.lld: duplicate symbol: Vma*` collision.

Changes (both `fbcode` and `xplat` mirrors):
1. `backends/vulkan/targets.bzl`: repair the `etvk.vma_dep=instantiated` path, which pointed at `//third-party/VulkanMemoryAllocator/3.0.1:VulkanMemoryAllocatorInstantiated` — a package that no longer exists at HEAD (only `3.2.0` remains), so the mode was broken for everyone. Repoint it to `3.2.0:VulkanMemoryAllocatorInstantiated`, the same target IGL/compphoto already use, so VMA is linked exactly once.
2. `backends/vulkan/runtime/vk_api/memory/vma_api.h`: align the `ETVK_USE_META_VMA` branch `VMA_VULKAN_VERSION` from `1002000` to `1003000` to match the 3.2.0 instantiated lib's config (`vk_mem_alloc_instantiated.h`) so struct layouts agree across translation units and the pre-instantiated static lib (ABI safety).

Both changes only affect the opt-in `etvk.vma_dep=instantiated` mode (which was already broken/unused), so default `xplat` builds and all other ET consumers are byte-for-byte unchanged.

Differential Revision: D108337179


