### PR TITLE
Fix Samsung backend PassManager import broken by #20025

### DIFF
--- a/backends/samsung/enn_preprocess.py
+++ b/backends/samsung/enn_preprocess.py
@@ -39,7 +39,7 @@ from executorch.exir.backend.backend_details import (
     PreprocessResult,
 )
 
-from executorch.exir.passes import PassManager
+from executorch.exir.pass_manager import PassManager
 
 from torch.export.exported_program import ExportedProgram
 


### PR DESCRIPTION
#20025 ("Arm backend: Migrate pass manager to exported program") changed `exir/passes/__init__.py` to re-export `ExportedProgramPassManager` instead of `PassManager`. The Samsung backend still imports `PassManager` from `executorch.exir.passes`, so every Samsung model export now fails at import:

```
ImportError: cannot import name 'PassManager' from 'executorch.exir.passes'
```

This has made `test-samsung-quantmodels-linux` red on every main commit since 2026-06-11 14:52 UTC and is blocking viable/strict promotion (stale ~31h).

The legacy `PassManager` class still exists in `executorch.exir.pass_manager`. The Samsung backend runs passes on a GraphModule (`enn_preprocess_passes(edge_program.graph_module)`), which is exactly what the legacy `PassManager` is for, not the new `ExportedProgramPassManager`. This repoints the import to its canonical module and restores the previous behavior.

cc @usamahz
