### PR TITLE
Extend CPPCHECK scope to portable kernels

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -194,7 +194,6 @@ exclude_patterns = [
 
     # Kernel areas to onboard separately.
     'kernels/optimized/**',
-    'kernels/portable/**',
 
     # Runtime areas to onboard incrementally.
     'runtime/backend/**',
@@ -243,6 +242,23 @@ command = [
     '--extra-arg=--suppress=duplicateBranch:*kernels/test/*',
     '--extra-arg=--suppress=useStlAlgorithm:*kernels/test/*',
     '--extra-arg=--suppress=functionStatic:*kernels/test/*',
+    # Portable kernels are referenced through generated registration tables,
+    # which cppcheck CTU does not see as direct C++ calls.
+    '--extra-arg=--suppress=unusedFunction:*kernels/portable/*',
+    # Cppcheck does not parse several ExecuTorch macro idioms used heavily in
+    # portable kernels, including empty macro arguments and printf-style macros
+    # concatenated into string literals.
+    '--extra-arg=--suppress=unknownMacro:*kernels/portable/*',
+    '--extra-arg=--suppress=syntaxError:*kernels/portable/*',
+    # Keep style-only portable-kernel findings scoped to this tree rather than
+    # rewriting broad helper code for lint-only advice.
+    '--extra-arg=--suppress=useStlAlgorithm:*kernels/portable/*',
+    '--extra-arg=--suppress=variableScope:*kernels/portable/*',
+    '--extra-arg=--suppress=constParameterReference:*kernels/portable/*',
+    '--extra-arg=--suppress=constParameterPointer:*kernels/portable/*',
+    '--extra-arg=--suppress=functionStatic:*kernels/portable/*',
+    '--extra-arg=--suppress=knownConditionTrueFalse:*kernels/portable/*',
+    '--extra-arg=--suppress=invalidFunctionArg:*kernels/portable/*',
     '--',
     '@{{PATHSFILE}}'
 ]

--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
+ * Copyright 2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -241,7 +242,7 @@ bool check_permute_copy_args(const Tensor& in, IntArrayRef dims, Tensor& out) {
     size_t dim = dims[i] >= 0 ? dims[i] : in.dim() + dims[i];
 
     // Internal check, since we have already validated this
-    ET_LOG_AND_RETURN_IF_FALSE(dim < kTensorDimensionLimit && dim >= 0);
+    ET_LOG_AND_RETURN_IF_FALSE(dim < kTensorDimensionLimit);
 
     // Check that the dimension hasn't been seen previously.
     ET_CHECK_OR_RETURN_FALSE(

--- a/kernels/portable/cpu/util/test/reduce_test.cpp
+++ b/kernels/portable/cpu/util/test/reduce_test.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
+ * Copyright 2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -50,8 +51,6 @@ void _apply_over_dim_list(
 
 TEST(ReduceUtilTest, ApplyOverDim) {
   TensorFactory<ScalarType::Long> tf;
-  optional<ArrayRef<int64_t>> dim_list;
-
   Tensor in = tf.zeros({2, 4, 5, 3});
   _apply_over_dim(in, 0);
   // clang-format off
@@ -85,8 +84,6 @@ TEST(ReduceUtilTest, ApplyOverDim) {
   // clang-format on
 
   in = tf.zeros({2, 4, 5, 3});
-  int64_t dim_array_2[1] = {2};
-  dim_list = optional<ArrayRef<int64_t>>(ArrayRef<int64_t>{dim_array_2, 1});
   _apply_over_dim(in, 2);
   // clang-format off
   EXPECT_TENSOR_EQ(in, tf.make({2, 4, 5, 3}, {
@@ -103,8 +100,6 @@ TEST(ReduceUtilTest, ApplyOverDim) {
   // clang-format on
 
   in = tf.zeros({2, 4, 5, 3});
-  int64_t dim_array_3[1] = {3};
-  dim_list = optional<ArrayRef<int64_t>>(ArrayRef<int64_t>{dim_array_3, 1});
   _apply_over_dim(in, 3);
   // clang-format off
   EXPECT_TENSOR_EQ(in, tf.make({2, 4, 5, 3}, {
@@ -470,7 +465,7 @@ TEST(ReduceUtilTest, ApplyOnZeroDimTensorOverDimListNonEmpty) {
       optional<ArrayRef<int64_t>>(ArrayRef<int64_t>{dim_array_0, 1});
 
   Tensor in = tf.ones({});
-  _apply_over_dim_list(in, dim_list), "";
+  _apply_over_dim_list(in, dim_list);
   EXPECT_TENSOR_EQ(in, tf.make({}, {0}));
 }
 


### PR DESCRIPTION
Remove the broad kernels/portable CPPCHECK exclusion and keep the remaining suppressions scoped to the portable tree.

Portable kernel entry points are referenced through generated registration tables, which cppcheck CTU does not see as direct C++ calls. Suppress the resulting unusedFunction reports for this tree.

Cppcheck also does not parse several ExecuTorch macro idioms used heavily in portable kernels, including empty macro arguments and printf-style macros concatenated into string literals. Keep those parser suppressions scoped to portable kernels instead of adding inline suppressions throughout the tree.

Fix small real findings by removing an impossible unsigned comparison and cleaning up unused test setup plus a stray comma expression.


Change-Id: I6279a123b487d32b5811fdbe46ae4f2e82dcabd5


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani