### PR TITLE
Log file_bytes in save_packed_index for orphan accumulation visibility (#20246)

### DIFF
--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -574,11 +574,18 @@ Error XNNWeightsCache::save_packed_index() {
     ET_LOG(Error, "fsync of packed cache failed (errno=%d)", errno);
     // Continue — data is in page cache; durability is best-effort.
   }
+  // Log the final file size (= index_start + trailer) so production
+  // logs surface unbounded growth from orphan packs: a same-name
+  // re-pack leaves the old packed bytes in the file even though the
+  // trailer drops the old entry. Monitoring file_bytes over time tells
+  // us when GC or a size cap is needed.
+  const size_t file_bytes = index_start + buf.size();
   ET_LOG(
       Info,
-      "Saved packed weight index: %u entries at offset %zu",
+      "Saved packed weight index: %u entries at offset %zu, file_bytes=%zu",
       entry_count,
-      index_start);
+      index_start,
+      file_bytes);
 
   // Promote freshly-packed entries to from_load now that they're durable
   // on disk, so delete_packed_data preserves them across unload/reload.


### PR DESCRIPTION
Summary:

Follow-up to D106717093. The cache file accumulates orphan packed
bytes when a same-name weight is re-packed (memcmp DIFFER →
look_up_or_insert returns SIZE_MAX → XNNPACK packs again →
old bytes stay in the file even though the new trailer doesn't
reference them). Long-term the file size grows without bound.

This log lets production syslog surface that growth: file_bytes
is the final cache file size after the trailer write, so monitoring
it over time tells us when an in-process GC pass or size cap is
needed.

Reviewed By: GregoryComer

Differential Revision: D108178965


