### PR TITLE
XNNPACK graph runtime: stub in-tree operator interface

### DIFF
--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -108,6 +108,7 @@ list(
   backends/xnnpack/runtime/core/quant_params.cpp
   backends/xnnpack/runtime/graph/graph.cpp
   backends/xnnpack/runtime/graph/graph_builder.cpp
+  backends/xnnpack/runtime/operators/operator.cpp
 )
 
 list(TRANSFORM _xnnpack_backend__srcs PREPEND "${EXECUTORCH_ROOT}/")

--- a/backends/xnnpack/runtime/operators/operator.cpp
+++ b/backends/xnnpack/runtime/operators/operator.cpp
@@ -1,0 +1,20 @@
+#include <executorch/backends/xnnpack/runtime/operators/operator.h>
+
+#include <executorch/runtime/platform/log.h>
+
+namespace executorch::backends::xnnpack::operators {
+
+std::unique_ptr<Operator> create_operator(graph::Operator op) {
+  // No in-tree operators are available yet; the graph runtime currently
+  // supports only XNNPACK-delegated subgraphs. Reaching this point means a
+  // node was routed to an in-tree kernel that has not been added. Return null
+  // so the caller can fail cleanly rather than aborting.
+  ET_LOG(
+      Error,
+      "No in-tree kernel for operator %d; only XNNPACK-delegated nodes are "
+      "supported",
+      static_cast<int>(op));
+  return nullptr;
+}
+
+} // namespace executorch::backends::xnnpack::operators

--- a/backends/xnnpack/runtime/operators/operator.h
+++ b/backends/xnnpack/runtime/operators/operator.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/core/tensor.h>
+#include <executorch/backends/xnnpack/runtime/graph/node.h>
+#include <executorch/backends/xnnpack/runtime/graph/operator.h>
+#include <executorch/backends/xnnpack/runtime/graph/tensor_spec.h>
+#include <executorch/runtime/core/span.h>
+
+#include <memory>
+
+namespace executorch::backends::xnnpack::operators {
+
+class Operator {
+ public:
+  virtual void setup(runtime::Span<const graph::ConstantArg> constant_args) {};
+  virtual void prepare(
+      runtime::Span<core::Tensor*> inputs,
+      runtime::Span<core::Tensor*> outputs) {};
+  virtual void reshape(runtime::Span<const graph::TensorSpec> input_specs) {};
+  virtual void execute(
+      runtime::Span<core::Tensor*> inputs,
+      runtime::Span<core::Tensor*> outputs) = 0;
+  virtual ~Operator() = default;
+};
+
+std::unique_ptr<Operator> create_operator(graph::Operator op);
+
+} // namespace executorch::backends::xnnpack::operators


### PR DESCRIPTION
Adds the Operator base interface and the create_operator factory. The factory
is intentionally stubbed: no in-tree operators are wired up yet, so the graph
runtime supports only XNNPACK-delegated subgraphs. The concrete operators and
their kernels land in a later change.

Authored with Claude.