### PR TITLE
Expose executorch.__version__

### DIFF
--- a/src/executorch/__init__.py
+++ b/src/executorch/__init__.py
@@ -9,11 +9,12 @@
 try:
     # ``version.py`` is generated at build time from ``version.txt`` (the single
     # source of truth) by ``setup.py``, mirroring ``torch/version.py``.
-    from executorch.version import __version__, git_version  # noqa: F401
-except ImportError:
-    # Source tree / namespace import without a build: fall back to the installed
-    # distribution metadata, then to a sentinel, so ``import executorch`` never
-    # fails just because the version is unknown.
+    from .version import __version__, git_version  # noqa: F401
+except ModuleNotFoundError:
+    # No generated ``version.py`` (e.g. an unbuilt source tree): fall back to the
+    # installed distribution metadata, then to a sentinel, so ``import executorch``
+    # never fails just because the version is unknown. A malformed (present but
+    # broken) ``version.py`` still raises, surfacing real packaging problems.
     try:
         from importlib.metadata import PackageNotFoundError, version as _version
 

--- a/src/executorch/__init__.py
+++ b/src/executorch/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""ExecuTorch: A unified ML stack for on-device inference."""
+
+try:
+    # ``version.py`` is generated at build time from ``version.txt`` (the single
+    # source of truth) by ``setup.py``, mirroring ``torch/version.py``.
+    from executorch.version import __version__, git_version  # noqa: F401
+except ImportError:
+    # Source tree / namespace import without a build: fall back to the installed
+    # distribution metadata, then to a sentinel, so ``import executorch`` never
+    # fails just because the version is unknown.
+    try:
+        from importlib.metadata import PackageNotFoundError, version as _version
+
+        try:
+            __version__ = _version("executorch")
+        except PackageNotFoundError:
+            __version__ = "0.0.0+unknown"
+    except Exception:
+        __version__ = "0.0.0+unknown"
+    git_version = None
+
+__all__ = ["__version__", "git_version"]

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+
+class VersionTest(unittest.TestCase):
+    def test_version_attributes_exposed(self) -> None:
+        # ``import executorch`` must succeed and expose the conventional
+        # ``__version__``/``git_version`` attributes (resolved from the generated
+        # version.py, or a graceful fallback in an unbuilt source tree).
+        import executorch
+
+        self.assertIsInstance(executorch.__version__, str)
+        self.assertTrue(executorch.__version__)
+        self.assertTrue(hasattr(executorch, "git_version"))


### PR DESCRIPTION
## Summary

`import executorch; executorch.__version__` currently raises `AttributeError`, even though `torch.__version__`, `numpy.__version__`, etc. all work. The version data already exists: `setup.py` generates `executorch/version.py` (with `__version__` and `git_version`) from `version.txt` at build time, mirroring `torch/version.py`. But `executorch` has no top-level `__init__.py` to re-export it, so the generated module is never surfaced on the package. (`executorch.version.__version__` works today; the conventional `executorch.__version__` does not.)

This adds `src/executorch/__init__.py` that re-exports the generated version, with a graceful fallback so `import executorch` never fails in an unbuilt source tree:

- built wheel / editable install -> uses the generated `executorch/version.py` (exact build version + git hash);
- otherwise -> falls back to installed distribution metadata via `importlib.metadata`;
- otherwise -> `0.0.0+unknown` (never raises).

`version.txt` stays the single source of truth; no version string is hardcoded, and `setup.py` is unchanged (it already generates `version.py` in this directory).

## Note for reviewers

This promotes `executorch` from an implicit (PEP 420) namespace package to a regular package. For the single-wheel layout this is the conventional setup and matches `torch`/`numpy`, but please confirm no consumer relies on namespace-package merging of `executorch.*` across multiple roots.

## Test plan

```python
import executorch
print(executorch.__version__)   # e.g. 1.4.0a0+<githash>
print(executorch.git_version)
```
