### PR TITLE
Bump PyTorch pin to nightly dev20260614

### DIFF
--- a/.ci/docker/ci_commit_pins/pytorch.txt
+++ b/.ci/docker/ci_commit_pins/pytorch.txt
@@ -1,1 +1,1 @@
-release/2.12
+40e21dcd4b92d59842b3e3b7f542f855dedddb91

--- a/runtime/core/portable_type/c10/c10/util/BFloat16-math.h
+++ b/runtime/core/portable_type/c10/c10/util/BFloat16-math.h
@@ -181,7 +181,7 @@ template <
     typename T,
     typename std::enable_if_t<c10::is_reduced_floating_point_v<T>, int> = 0>
 inline T rsqrt(T a) {
-  return 1.0 / std::sqrt(float(a));
+  return 1.0f / std::sqrt(float(a));
 }
 template <
     typename T,

--- a/runtime/core/portable_type/c10/c10/util/complex_math.h
+++ b/runtime/core/portable_type/c10/c10/util/complex_math.h
@@ -327,7 +327,7 @@ C10_HOST_DEVICE inline c10::complex<T> atanh(const c10::complex<T>& x) {
 template <typename T>
 C10_HOST_DEVICE inline c10::complex<T> log1p(const c10::complex<T>& z) {
 #if defined(__APPLE__) || defined(__MACOSX) || defined(__CUDACC__) || \
-    defined(__HIPCC__)
+    defined(__HIPCC__) || defined(__SYCL_DEVICE_ONLY__)
   // For Mac, the new implementation yielded a high relative error. Falling back
   // to the old version for now.
   // See https://github.com/numpy/numpy/pull/22611#issuecomment-1667945354

--- a/runtime/core/portable_type/c10/torch/headeronly/util/Half.h
+++ b/runtime/core/portable_type/c10/torch/headeronly/util/Half.h
@@ -236,7 +236,7 @@ C10_HOST_DEVICE inline float fp16_ieee_to_fp32_value(uint16_t h) {
   /*
    * - Choose either results of conversion of input as a normalized number, or
    * as a denormalized number, depending on the input exponent. The variable
-   * two_w contains input exponent in bits 27-31, therefore if its smaller than
+   * two_w contains input exponent in bits 27-31, therefore if it's smaller than
    * 2**27, the input is either a denormal number, or zero.
    * - Combine the result of conversion of exponent and mantissa with the sign
    * of the input number.

--- a/torch_pin.py
+++ b/torch_pin.py
@@ -1,2 +1,2 @@
 TORCH_VERSION = "2.12.0"
-# NIGHTLY_VERSION = "dev20260318" Temporarily pinning to stable release candidate. Revert https://github.com/pytorch/executorch/pull/18287
+NIGHTLY_VERSION = "dev20260614"


### PR DESCRIPTION
## Summary

Automated weekly PyTorch pin bump.

- Updates `NIGHTLY_VERSION` in `torch_pin.py` to `dev20260614`
- Updates `.ci/docker/ci_commit_pins/pytorch.txt` to the corresponding nightly commit hash
- Syncs c10 headers from PyTorch into `runtime/core/portable_type/c10/`

This PR was created automatically. If CI fails, Claude will attempt to fix issues (up to 3 attempts). If CI still fails, human review will be requested.

cc @jakeszwe