### PR TITLE
NXP backend: Enable `MM` and `AddMM` with new Neutron flow.

### DIFF
--- a/backends/nxp/backend/edge_helper.py
+++ b/backends/nxp/backend/edge_helper.py
@@ -109,6 +109,43 @@ def node_is_effectively_static_tensor(
     )
 
 
+def weights_are_effectively_static(
+    node: Node, parameters_mapping: dict[str, Parameter], weight_index: int = 1
+) -> bool:
+    """Neutron IR sometimes requires some weights to be static. This method checks if this is the case for the
+        provided `node`.
+
+    Sometimes a `permute_copy` is inserted to transpose the weights during edge lowering. The `permute_copy` is
+    then removed during conversion to Neutron IR if it transposes static data. In those cases, the weights will be
+    static. Therefore, it is ok if the weights are produced by a `permute_copy` with a static input.
+
+    :param node: Tensor node to check for data.
+    :param parameters_mapping: Dict mapping tensor names to their static data. Should be inferred from the
+                                `state_dict` attribute of an edge program.
+    :param weight_index: Index to the `node.args` where the weight is located. Defaults to 1.
+    :return: True if the weight at the given index is effectively static.
+    """
+
+    def _is_permute_copy(node_: Node) -> bool:
+        return hasattr(node_, "target") and node_.target == PermuteCopy
+
+    if (
+        _is_dequantize(dq_node := node.args[weight_index])
+        and _is_quantize(q_node := dq_node.args[0])
+        and _is_permute_copy(permute_copy_node := q_node.args[0])
+    ):
+        # The weights are produced by a `permute_copy`. Its input (the weights) must be static.
+        return node_is_effectively_static_tensor(
+            permute_copy_node.args[0], parameters_mapping
+        )
+
+    else:
+        # There is no `permute_copy`. The weights must be static directly.
+        return node_is_effectively_static_tensor(
+            node.args[weight_index], parameters_mapping
+        )
+
+
 def try_get_tensor_constant_from_node(
     graph_module: GraphModule, node: Node
 ) -> Parameter | None:

--- a/backends/nxp/backend/ir/converter/node_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converter.py
@@ -255,7 +255,7 @@ class NodeConverter(ABC):
     def is_node_alone_in_partition(
         node: Node,
         partition_list: list[Partition],
-        filter_fn: Callable[[Node], bool] | None = None,
+        filter_fn: Callable[[Node], bool] = is_not_qdq_node,
     ) -> bool:
         """Return True if `node` is the only node in its partition for which `filter_fn`
         returns True.
@@ -269,9 +269,6 @@ class NodeConverter(ABC):
         :param filter_fn: Predicate applied to nodes in the partition. `node` is considered alone if it is the only node
                            for which this predicate returns True. By default, Q/Dq nodes are ignored.
         """
-        if filter_fn is None:
-            filter_fn = is_not_qdq_node
-
         partitions = [p for p in partition_list if node in p.nodes]
         if len(partitions) != 1:
             raise ValueError(

--- a/backends/nxp/backend/ir/converter/node_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converter.py
@@ -253,7 +253,9 @@ class NodeConverter(ABC):
 
     @staticmethod
     def is_node_alone_in_partition(
-        node: Node, partition_list: list[Partition], filter_fn: Callable[[Node], bool]
+        node: Node,
+        partition_list: list[Partition],
+        filter_fn: Callable[[Node], bool] | None = None,
     ) -> bool:
         """Return True if `node` is the only node in its partition for which `filter_fn`
         returns True.
@@ -264,10 +266,12 @@ class NodeConverter(ABC):
 
         :param node: The torch.fx.Node to check.
         :param partition_list: List of proposed partitions.
-        :param filter_fn: Predicate applied to nodes in the partition.
-                        `node` is considered alone if it is the only node
-                        for which this predicate returns True.
+        :param filter_fn: Predicate applied to nodes in the partition. `node` is considered alone if it is the only node
+                           for which this predicate returns True. By default, Q/Dq nodes are ignored.
         """
+        if filter_fn is None:
+            filter_fn = is_not_qdq_node
+
         partitions = [p for p in partition_list if node in p.nodes]
         if len(partitions) != 1:
             raise ValueError(

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/addmm_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/addmm_converter.py
@@ -1,9 +1,15 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from executorch.backends.nxp.backend.edge_helper import input_rank
+import torch
+
+from executorch.backends.nxp.backend.edge_helper import (
+    input_rank,
+    node_is_effectively_static_tensor,
+    weights_are_effectively_static,
+)
 from executorch.backends.nxp.backend.ir.converter.conversion.common import OpsList
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
@@ -12,8 +18,16 @@ from executorch.backends.nxp.backend.ir.converter.node_converter import (
 from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options import (
     fully_connected_options,
 )
+
+from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from torch.fx import Node
 from torch.nn import Parameter
+
+
+# The edge operator signature is: aten.addmm(bias, input, weight, *, beta=1, alpha=1)
+MAIN_INPUT_IDX = 1
+WEIGHT_IDX = 2
+BIAS_IDX = 0
 
 
 class AddMMConverter(NodeConverter):
@@ -29,12 +43,67 @@ class AddMMConverter(NodeConverter):
             return False
 
         # The weights must be 2D.
-        if input_rank(node, 2) != 2:
+        if input_rank(node, WEIGHT_IDX) != 2:
+            return False
+
+        alpha, beta = node.kwargs.get("alpha", 1), node.kwargs.get("beta", 1)
+        if alpha != 1 or beta != 1:
+            # As these cases seem rare, conversion is not implemented for the time being.
+            return False
+
+        return True
+
+    @staticmethod
+    def _is_supported_on_target(
+        node: Node,
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
+        custom_delegation_options: CustomDelegationOptions,
+    ) -> bool:
+        # Main input and output must be `int8` or `uint8`.
+        if not NodeConverter.uses_quantization_type_for_io(
+            node, [torch.int8, torch.uint8], [MAIN_INPUT_IDX], [0]
+        ):
+            return False
+
+        # Weights must be `int8`.
+        if not NodeConverter.uses_quantization_type_for_io(
+            node, [torch.int8], [WEIGHT_IDX], []
+        ):
+            return False
+
+        # Bias must be `int32`.
+        if not NodeConverter.uses_quantization_type_for_io(
+            node, [torch.int32], [BIAS_IDX], []
+        ):
+            return False
+
+        # Weights must be constant.
+        if not weights_are_effectively_static(
+            node, parameters_mapping, weight_index=WEIGHT_IDX
+        ):
+            return False
+
+        # The bias must be constant.
+        if not node_is_effectively_static_tensor(
+            node.args[BIAS_IDX], parameters_mapping
+        ):
             return False
 
         return True
 
     def convert(self, node: Node):
+        """Convert the `aten.addmm` operator to NeutronIR `FullyConnected`.
+        The schema is:
+            addmm(
+                Tensor self,
+                Tensor mat1,
+                Tensor mat2,
+                *,
+                Scalar beta=1,
+                Scalar alpha=1
+            ) -> Tensor
+        """
         self.assert_convertible(node)
 
         t_op = self._create_tflite_op_with_io_tensors(node)
@@ -47,14 +116,14 @@ class AddMMConverter(NodeConverter):
         w = t_op.tmp_inputs[2]
         y = t_op.tmp_outputs[0]
 
-        # Assign the operator its TFLite inputs and outputs
+        # Assign the operator its Neutron IR inputs and outputs
         t_op.tmp_inputs = [x, w, bias]
         t_op.tmp_outputs = [y]
 
         ops = OpsList(middle_op=t_op)
 
         # The `aten.addmm` uses main input with shape [M, N] and the weights have the shape [N, O].
-        # TFLite `FullyConnected` requires the weights to have shape [O, N] (if the main input has shape [M, N]).
+        # Neutron IR `FullyConnected` requires the weights to have shape [O, N] (if the main input has shape [M, N]).
         # Insert a `Transpose` operator to permute the weights to achieve correct conversion. (The `Transpose` will not
         #  be present in the output model if the weights are static.)
         ops.add_pre(self.builder.create_transpose_operator_before(t_op, 1, [1, 0]))

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/addmm_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/addmm_converter.py
@@ -51,6 +51,15 @@ class AddMMConverter(NodeConverter):
             # As these cases seem rare, conversion is not implemented for the time being.
             return False
 
+        # The `aten.addmm` operator allows any bias shape, as long as it is broadcastable with the result of the matrix
+        #  multiplication. That means it supports 4 different shapes: [N, P], [1, P], [P], [1] (provided the MM result
+        #  has shape [N, P]). Out of these 4, Neutron IR allows only [1, P] and [P], both of which are supported on
+        #  Neutron.
+        bias_shape = list(node.args[BIAS_IDX].meta["val"].shape)
+        _, p = node.meta["val"].shape
+        if bias_shape not in [[1, p], [p]]:
+            return False
+
         return True
 
     @staticmethod

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/clamp_converter.py
@@ -18,7 +18,6 @@ from executorch.backends.nxp.backend.ir.converter.node_converter import (
     _is_dequant_node,
     _is_quant_node,
     CustomDelegationOptions,
-    is_not_qdq_node,
     NodeConverter,
 )
 from executorch.backends.nxp.backend.ir.converter.quantization_utils import (
@@ -147,9 +146,7 @@ class ClampConverter(NodeConverter):
         # and at the same time the node does not satisfy delegation requirements.
         # In contrast, ReLUN1To1 and ReLU0To1 are supported and delegated successfully.
         if bounds in cls.RELU_COMPATIBLE_BOUNDS.values():
-            is_alone_in_partition = cls.is_node_alone_in_partition(
-                node, partition_list, filter_fn=is_not_qdq_node
-            )
+            is_alone_in_partition = cls.is_node_alone_in_partition(node, partition_list)
             if is_alone_in_partition:
                 # noinspection PyTypeChecker
                 return is_clamp_preserved_under_quantization(

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/mean_dim_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/mean_dim_converter.py
@@ -13,7 +13,6 @@ from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
 )
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
-    is_not_qdq_node,
     NodeConverter,
 )
 from executorch.backends.nxp.backend.ir.converter.node_converters.shared.reduce_utils import (
@@ -42,9 +41,7 @@ class MeanDimConverter(NodeConverter):
         dim, keepdim = MeanDimConverter._get_attrs(node)
         input_shape = node.args[0].meta["val"].shape
 
-        is_alone_in_partition = cls.is_node_alone_in_partition(
-            node, partition_list, filter_fn=is_not_qdq_node
-        )
+        is_alone_in_partition = cls.is_node_alone_in_partition(node, partition_list)
 
         if is_alone_in_partition and keepdim and all(input_shape[d] == 1 for d in dim):
             # The operator is a no-op, so the Neutron Converter will skip it. If it's the only node in the

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/mm_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/mm_converter.py
@@ -1,9 +1,14 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from executorch.backends.nxp.backend.edge_helper import input_rank
+import torch
+
+from executorch.backends.nxp.backend.edge_helper import (
+    input_rank,
+    weights_are_effectively_static,
+)
 from executorch.backends.nxp.backend.ir.converter.conversion.common import OpsList
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
@@ -12,6 +17,7 @@ from executorch.backends.nxp.backend.ir.converter.node_converter import (
 from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options import (
     fully_connected_options,
 )
+from executorch.backends.nxp.backend.neutron_target_spec import NeutronTargetSpec
 from torch.fx import Node
 from torch.nn import Parameter
 
@@ -33,8 +39,37 @@ class MMConverter(NodeConverter):
 
         return True
 
+    @staticmethod
+    def _is_supported_on_target(
+        node: Node,
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
+        custom_delegation_options: CustomDelegationOptions,
+    ) -> bool:
+        # Main input and output must be `int8` or `uint8`.
+        if not NodeConverter.uses_quantization_type_for_io(
+            node, [torch.int8, torch.uint8], [0], [0]
+        ):
+            return False
+
+        # Weights must be `int8`.
+        if not NodeConverter.uses_quantization_type_for_io(node, [torch.int8], [1], []):
+            return False
+
+        # Weights must be static.
+        if not weights_are_effectively_static(node, parameters_mapping):
+            return False
+
+        return True
+
     def convert(self, node: Node):
-        """Convert the `aten.mm` operator to TFLite `FullyConnected` without a bias input."""
+        """Convert the `aten.mm` operator to Neutron IR `FullyConnected` without a bias input.
+        The schema is:
+            mm(
+                Tensor self,
+                Tensor mat2
+            ) -> Tensor
+        """
         self.assert_convertible(node)
 
         t_op = self._create_tflite_op_with_io_tensors(node)
@@ -44,14 +79,14 @@ class MMConverter(NodeConverter):
         w = t_op.tmp_inputs[1]
         y = t_op.tmp_outputs[0]
 
-        # Assign the operator its TFLite inputs and outputs
+        # Assign the operator its Neutron IR inputs and outputs
         t_op.tmp_inputs = [x, w]
         t_op.tmp_outputs = [y]
 
         ops = OpsList(middle_op=t_op)
 
         # The `aten.mm` uses main input with shape [M, N] and the weights have the shape [N, O].
-        # TFLite `FullyConnected` requires the weights to have shape [O, N] (if the main input has shape [M, N]).
+        # Neutron IR `FullyConnected` requires the weights to have shape [O, N] (if the main input has shape [M, N]).
         # Insert a `Transpose` operator to permute the weights to achieve correct conversion. (The `Transpose` will not
         #  be present in the output model if the weights are static.)
         ops.add_pre(self.builder.create_transpose_operator_before(t_op, 1, [1, 0]))

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/permute_copy_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/permute_copy_converter.py
@@ -27,6 +27,7 @@ from executorch.backends.nxp.backend.neutron_operator_support import (
     transposition_is_supported_on_neutron,
 )
 from torch.fx import Node
+from torch.fx.passes.infra.partitioner import Partition
 from torch.nn import Parameter
 
 Permutation = list[int]
@@ -379,6 +380,26 @@ class PermuteCopyConverter(NodeConverter):
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
         if not NodeConverter._has_shared_q_params_if_quantized(node):
+            return False
+
+        return True
+
+    @classmethod
+    def supports_partitioning_result(
+        cls,
+        node: Node,
+        partition_list: list[Partition],
+        custom_delegation_options: CustomDelegationOptions,
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
+    ) -> bool:
+        has_static_input = node_is_effectively_static_tensor(
+            node.args[0], parameters_mapping
+        )
+        is_alone_in_partition = cls.is_node_alone_in_partition(node, partition_list)
+        if has_static_input and is_alone_in_partition:
+            # Transpose with a static input is a no-op on Neutron. If it was the only operator in the partition,
+            #  Neutron Converter would produce and empty graph, so delegation is prohibited.
             return False
 
         return True

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/relu_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/relu_converter.py
@@ -9,7 +9,6 @@ from executorch.backends.nxp.backend.graph_utils import (
 )
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
-    is_not_qdq_node,
     NodeConverter,
     Partition,
 )
@@ -52,9 +51,7 @@ class ReLUConverter(NodeConverter):
         neutron_target_spec: NeutronTargetSpec,
         parameters_mapping: dict[str, Parameter],
     ) -> bool:
-        is_alone_in_partition = cls.is_node_alone_in_partition(
-            node, partition_list, filter_fn=is_not_qdq_node
-        )
+        is_alone_in_partition = cls.is_node_alone_in_partition(node, partition_list)
         if is_alone_in_partition:
             return is_clamp_preserved_under_quantization(node)
 

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_bilinear2d_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_bilinear2d_converter.py
@@ -9,7 +9,6 @@ import torch
 from executorch.backends.nxp.backend.edge_helper import node_has_well_defined_shape
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
-    is_not_qdq_node,
     NodeConverter,
     requires_channels_first_format,
 )
@@ -37,9 +36,7 @@ class UpsampleBilinear2DConverter(NodeConverter):
     ) -> bool:
         input_shape = node.all_input_nodes[0].meta["val"].shape
         output_shape = node.meta["val"].shape
-        is_alone_in_partition = cls.is_node_alone_in_partition(
-            node, partition_list, filter_fn=is_not_qdq_node
-        )
+        is_alone_in_partition = cls.is_node_alone_in_partition(node, partition_list)
 
         if is_alone_in_partition and input_shape == output_shape:
             # The operator is a no-op, so the Neutron Converter will skip it. If it's the only node in the

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_nearest2d_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_nearest2d_converter.py
@@ -9,7 +9,6 @@ import torch
 from executorch.backends.nxp.backend.edge_helper import node_has_well_defined_shape
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
-    is_not_qdq_node,
     NodeConverter,
     requires_channels_first_format,
 )
@@ -39,9 +38,7 @@ class UpsampleNearest2DConverter(NodeConverter):
         parameters_mapping: dict[str, Parameter],
     ) -> bool:
         h_scale, w_scale = cls._get_effective_scales(node)
-        is_alone_in_partition = cls.is_node_alone_in_partition(
-            node, partition_list, filter_fn=is_not_qdq_node
-        )
+        is_alone_in_partition = cls.is_node_alone_in_partition(node, partition_list)
 
         if is_alone_in_partition and h_scale == w_scale == 1:
             # The operator is a no-op, so the Neutron Converter will skip it. If it's the only node in the

--- a/backends/nxp/edge_passes/move_auxiliary_operator_into_separate_qdq_cluster_pass.py
+++ b/backends/nxp/edge_passes/move_auxiliary_operator_into_separate_qdq_cluster_pass.py
@@ -9,6 +9,7 @@ import torch
 
 from executorch.backends.nxp.edge_passes.neutron_edge_pass import NeutronEdgePass
 from executorch.backends.nxp.neutron_partitioner import QDQClusterRecognizer
+from executorch.backends.nxp.tests.ops_aliases import PermuteCopy
 
 # noinspection PyProtectedMember
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -109,9 +110,11 @@ class MoveLeadingAuxiliaryOperatorIntoSeparateQDQClusterPass(NeutronEdgePass):
     main_cluster_node_to_auxiliary_nodes = {
         AddMM: [
             ViewCopy,
+            PermuteCopy,
         ],
         MM: [
             ViewCopy,
+            PermuteCopy,
         ],
         ViewCopy: [Clone, CloneDimOrder],
         Conv: [

--- a/backends/nxp/tests/generic_tests/test_integration.py
+++ b/backends/nxp/tests/generic_tests/test_integration.py
@@ -1,10 +1,12 @@
-# Copyright 2024-2025 NXP
+# Copyright 2024-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 import executorch.extension.pybindings.portable_lib
 import executorch.kernels.quantized  # noqa F401
+from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
+from executorch.backends.nxp.tests.ops_aliases import AddMM, Convolution
 from executorch.backends.nxp.tests.use_qat import *  # noqa F401
 
 from executorch.backends.nxp.tests.executorch_pipeline import (
@@ -29,12 +31,10 @@ def test_conv_fc_softmax__to_executorch_program(use_qat):
     delegation_info = get_delegation_info(program.graph_module)
     assert delegation_info.num_delegated_subgraphs == 1
     assert delegation_info.num_non_delegated_nodes == 11
-    assert delegation_info.num_delegated_nodes == 13
+    assert delegation_info.num_delegated_nodes == 15
 
-    for node in program.graph.nodes:
-        # Make sure Convolution and AddMM are delegated
-        assert "convolution" not in node.name
-        assert "addmm" not in node.name
+    # Make sure Convolution and AddMM are delegated.
+    assert not graph_contains_any_of_ops(program.graph, [Convolution, AddMM])
 
 
 def test_cifarnet(use_qat):
@@ -47,7 +47,8 @@ def test_cifarnet(use_qat):
     delegation_info = get_delegation_info(exec_prog.exported_program().graph_module)
     assert delegation_info.num_delegated_subgraphs == 1
     assert delegation_info.num_non_delegated_nodes == 11
-    assert delegation_info.num_delegated_nodes == 45
+    assert delegation_info.num_delegated_nodes == 47
 
     nodes = list(exec_prog.exported_program().graph.nodes)
+    # `nodes[2].target` is an OpOverload (not and EdgeOpOverload that we usually test against), so just check the name.
     assert nodes[2].name == "quantized_decomposed_quantize_per_tensor_default"

--- a/backends/nxp/tests/ir/converter/node_converter/test_addmm_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_addmm_converter.py
@@ -1,96 +1,158 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
-
-import kgb
 import numpy as np
+
+# noinspection PyUnusedImports
+import pytest
 import torch
 
-from executorch.backends.nxp.backend.edge_program_converter import (
-    EdgeProgramToIRConverter,
-)
+from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
-from executorch.backends.nxp.tests.executors import (
-    convert_run_compare,
-    graph_contains_any_of_ops,
-)
+from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier, Operator
 from executorch.backends.nxp.tests.models import AddmmModule, LinearModule
-from executorch.exir.dialects._ops import ops as exir_ops
-from parameterized import parameterized
-from torch.export import ExportedProgram
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
+from executorch.backends.nxp.tests.ops_aliases import (
+    AddMM,
+    ExecutorchDelegateCall,
+    MM,
+    PermuteCopy,
+    ViewCopy,
+)
+from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 
-class TestAddmmConversion(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        torch.manual_seed(23)
-        np.random.seed(42)
+@pytest.fixture(autouse=True)
+def reseed_model_per_test_run():
+    torch.manual_seed(42)
+    np.random.seed(23)
 
-    @parameterized.expand([("QAT", True), ("PTQ", False)])
-    def test_addmm_conversion(self, _, use_qat: bool):
-        with kgb.spy_on(
-            EdgeProgramToIRConverter.convert_program,
-            call_original=True,
-            owner=EdgeProgramToIRConverter,
-        ) as converter_spy:
-            input_shape = (1, 32)
-            model = AddmmModule(input_shape[1])
 
-            edge_program = to_quantized_edge_program(
-                model, input_shape, use_qat=use_qat
-            ).exported_program()
+class TestAddMM:
 
-            # Make sure that all nodes were delegated.
-            assert not graph_contains_any_of_ops(
-                graph=edge_program.graph, ops=[exir_ops.edge.aten.addmm.default]
-            )
-            assert any(
-                "lowered_module" in node.name for node in edge_program.graph.nodes
-            )
+    # noinspection PyMethodMayBeStatic
+    def assert_delegated(
+        self,
+        model,
+        input_shape,
+        mocker,
+        use_qat=False,
+        expected_delegated_ops: dict[Operator, int] | None = None,
+    ):
+        if expected_delegated_ops is None:
+            expected_delegated_ops = {AddMM: 1}
 
-            tflite_flatbuffers_model, *_ = converter_spy.calls[-1].return_value
-            exported_program: ExportedProgram = converter_spy.calls[-1].args[0]
-            input_data = (np.random.random(input_shape).astype(np.float32) * 50).astype(
-                np.int8
-            )
-            convert_run_compare(
-                exported_program,
-                input_data,
-                tfl_model=tflite_flatbuffers_model,
-            )
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops=expected_delegated_ops,
+            expected_non_delegated_ops={},
+        )
 
-    @parameterized.expand([("QAT", True), ("PTQ", False)])
-    def test_linear_conversion__with_bias(self, _, use_qat: bool):
-        with kgb.spy_on(
-            EdgeProgramToIRConverter.convert_program,
-            call_original=True,
-            owner=EdgeProgramToIRConverter,
-        ) as converter_spy:
-            input_shape = (10, 32)
-            model = LinearModule(bias=True)
+        # Create a RandomDatasetCreator that covers also negative numbers to properly test the operator.
+        dataset_creator = RandomDatasetCreator(low=-2, high=2)
 
-            edge_program = to_quantized_edge_program(
-                model, input_shape, use_qat=use_qat
-            ).exported_program()
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            dataset_creator,
+            use_qat=use_qat,
+        )
 
-            # Make sure that all nodes were delegated.
-            assert not graph_contains_any_of_ops(
-                graph=edge_program.graph, ops=[exir_ops.edge.aten.addmm.default]
-            )
-            assert any(
-                "lowered_module" in node.name for node in edge_program.graph.nodes
-            )
+    # noinspection PyMethodMayBeStatic
+    def assert_not_delegated(self, model, input_shape):
+        delegated_ep = to_quantized_edge_program(model, input_shape).exported_program()
 
-            tflite_flatbuffers_model, *_ = converter_spy.calls[-1].return_value
-            exported_program: ExportedProgram = converter_spy.calls[-1].args[0]
-            input_data = (np.random.random(input_shape).astype(np.float32) * 50).astype(
-                np.int8
-            )
-            convert_run_compare(
-                exported_program,
-                input_data,
-                tfl_model=tflite_flatbuffers_model,
-            )
+        assert not graph_contains_any_of_ops(
+            delegated_ep.graph, [ExecutorchDelegateCall]
+        )
+        assert graph_contains_any_of_ops(delegated_ep.graph, [AddMM, MM])
+
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            # PyTorch allows only 2D inputs.
+            (1, 32),
+            (3, 11),
+        ],
+        ids=lambda s: f"input_shape = {s}",
+    )
+    def test__from_addmm(self, mocker, use_qat, input_shape: tuple[int, ...]):
+        model = AddmmModule(input_shape[-1])
+        self.assert_delegated(model, input_shape, mocker, use_qat=use_qat)
+
+    def test__from_addmm__unsupported_alpha(self):
+        input_shape = (1, 8)
+        model = AddmmModule(input_shape[-1], alpha=0.42)
+        self.assert_not_delegated(model, input_shape)
+
+    def test__from_addmm__unsupported_beta(self):
+        input_shape = (1, 8)
+        model = AddmmModule(input_shape[-1], beta=0.42)
+        self.assert_not_delegated(model, input_shape)
+
+    @pytest.mark.parametrize(
+        "alpha",
+        [1, 1.0],
+        ids=lambda a: f"alpha = {a}",
+    )
+    def test__from_addmm__supported_alpha(self, mocker, use_qat, alpha):
+        input_shape = (1, 8)
+        model = AddmmModule(input_shape[-1], alpha=alpha)
+        self.assert_delegated(model, input_shape, mocker, use_qat)
+
+    @pytest.mark.parametrize(
+        "beta",
+        [1, 1.0],
+        ids=lambda b: f"beta = {b}",
+    )
+    def test__from_addmm__supported_beta(self, mocker, use_qat, beta):
+        input_shape = (1, 8)
+        model = AddmmModule(input_shape[-1], beta=beta)
+        self.assert_delegated(model, input_shape, mocker, use_qat)
+
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            (1, 32),
+            (3, 11),
+        ],
+        ids=lambda s: f"input_shape = {s}",
+    )
+    def test__from_linear_with_bias__2d(
+        self, mocker, use_qat, input_shape: tuple[int, ...]
+    ):
+        model = LinearModule(bias=True, in_features=input_shape[-1], out_features=7)
+        self.assert_delegated(
+            model,
+            input_shape,
+            mocker,
+            use_qat=use_qat,
+            expected_delegated_ops={AddMM: 1, PermuteCopy: 1},
+        )
+
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            (1, 3, 8),
+            (2, 3, 5),
+            (2, 3, 3, 3),
+        ],
+        ids=lambda s: f"input_shape = {s}",
+    )
+    def test__from_linear_with_bias__higher_ranks(
+        self, mocker, use_qat, input_shape: tuple[int, ...]
+    ):
+        # More than 2D cases get reshaped to 2D, so two extra view_copy nodes are delegated.
+
+        model = LinearModule(bias=True, in_features=input_shape[-1], out_features=7)
+        self.assert_delegated(
+            model,
+            input_shape,
+            mocker,
+            use_qat=use_qat,
+            expected_delegated_ops={AddMM: 1, PermuteCopy: 1, ViewCopy: 2},
+        )

--- a/backends/nxp/tests/ir/converter/node_converter/test_addmm_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_addmm_converter.py
@@ -39,6 +39,7 @@ class TestAddMM:
         model,
         input_shape,
         mocker,
+        request,
         use_qat=False,
         expected_delegated_ops: dict[Operator, int] | None = None,
     ):
@@ -58,6 +59,7 @@ class TestAddMM:
             model,
             input_shape,
             graph_verifier,
+            request,
             dataset_creator,
             use_qat=use_qat,
         )
@@ -80,9 +82,37 @@ class TestAddMM:
         ],
         ids=lambda s: f"input_shape = {s}",
     )
-    def test__from_addmm(self, mocker, use_qat, input_shape: tuple[int, ...]):
+    def test__from_addmm(self, mocker, request, use_qat, input_shape: tuple[int, ...]):
         model = AddmmModule(input_shape[-1])
-        self.assert_delegated(model, input_shape, mocker, use_qat=use_qat)
+        self.assert_delegated(model, input_shape, mocker, request, use_qat=use_qat)
+
+    @pytest.mark.parametrize(
+        "bias_shape",
+        [
+            (1, 7),
+            (7,),
+        ],
+        ids=lambda s: f"bias_shape = {s}",
+    )
+    def test__from_addmm__bias_shapes__supported(
+        self, mocker, request, use_qat, bias_shape: tuple[int, ...]
+    ):
+        input_shape = (3, 11)
+        model = AddmmModule(input_shape[-1], bias_shape=bias_shape)
+        self.assert_delegated(model, input_shape, mocker, request, use_qat=use_qat)
+
+    @pytest.mark.parametrize(
+        "bias_shape",
+        [
+            (3, 7),
+            (1,),
+        ],
+        ids=lambda s: f"bias_shape = {s}",
+    )
+    def test__from_addmm__bias_shapes__unsupported(self, bias_shape: tuple[int, ...]):
+        input_shape = (3, 11)
+        model = AddmmModule(input_shape[-1], bias_shape=bias_shape)
+        self.assert_not_delegated(model, input_shape)
 
     def test__from_addmm__unsupported_alpha(self):
         input_shape = (1, 8)
@@ -99,20 +129,20 @@ class TestAddMM:
         [1, 1.0],
         ids=lambda a: f"alpha = {a}",
     )
-    def test__from_addmm__supported_alpha(self, mocker, use_qat, alpha):
+    def test__from_addmm__supported_alpha(self, mocker, request, use_qat, alpha):
         input_shape = (1, 8)
         model = AddmmModule(input_shape[-1], alpha=alpha)
-        self.assert_delegated(model, input_shape, mocker, use_qat)
+        self.assert_delegated(model, input_shape, mocker, request, use_qat)
 
     @pytest.mark.parametrize(
         "beta",
         [1, 1.0],
         ids=lambda b: f"beta = {b}",
     )
-    def test__from_addmm__supported_beta(self, mocker, use_qat, beta):
+    def test__from_addmm__supported_beta(self, mocker, request, use_qat, beta):
         input_shape = (1, 8)
         model = AddmmModule(input_shape[-1], beta=beta)
-        self.assert_delegated(model, input_shape, mocker, use_qat)
+        self.assert_delegated(model, input_shape, mocker, request, use_qat)
 
     @pytest.mark.parametrize(
         "input_shape",
@@ -123,13 +153,14 @@ class TestAddMM:
         ids=lambda s: f"input_shape = {s}",
     )
     def test__from_linear_with_bias__2d(
-        self, mocker, use_qat, input_shape: tuple[int, ...]
+        self, mocker, request, use_qat, input_shape: tuple[int, ...]
     ):
         model = LinearModule(bias=True, in_features=input_shape[-1], out_features=7)
         self.assert_delegated(
             model,
             input_shape,
             mocker,
+            request,
             use_qat=use_qat,
             expected_delegated_ops={AddMM: 1, PermuteCopy: 1},
         )
@@ -144,7 +175,7 @@ class TestAddMM:
         ids=lambda s: f"input_shape = {s}",
     )
     def test__from_linear_with_bias__higher_ranks(
-        self, mocker, use_qat, input_shape: tuple[int, ...]
+        self, mocker, request, use_qat, input_shape: tuple[int, ...]
     ):
         # More than 2D cases get reshaped to 2D, so two extra view_copy nodes are delegated.
 
@@ -153,6 +184,7 @@ class TestAddMM:
             model,
             input_shape,
             mocker,
+            request,
             use_qat=use_qat,
             expected_delegated_ops={AddMM: 1, PermuteCopy: 1, ViewCopy: 2},
         )

--- a/backends/nxp/tests/ir/converter/node_converter/test_mm_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_mm_converter.py
@@ -31,6 +31,7 @@ class TestMM:
         model,
         input_shape,
         mocker,
+        request,
         use_qat=False,
         expected_delegated_ops: dict[Operator, int] | None = None,
     ):
@@ -50,6 +51,7 @@ class TestMM:
             model,
             input_shape,
             graph_verifier,
+            request,
             dataset_creator,
             use_qat=use_qat,
         )
@@ -63,9 +65,9 @@ class TestMM:
         ],
         ids=lambda s: f"input_shape = {s}",
     )
-    def test__from_mm(self, mocker, use_qat, input_shape: tuple[int, ...]):
+    def test__from_mm(self, mocker, request, use_qat, input_shape: tuple[int, ...]):
         model = MmModule(input_shape[-1])
-        self.assert_delegated(model, input_shape, mocker, use_qat=use_qat)
+        self.assert_delegated(model, input_shape, mocker, request, use_qat=use_qat)
 
     @pytest.mark.parametrize(
         "input_shape",
@@ -76,13 +78,14 @@ class TestMM:
         ids=lambda s: f"input_shape = {s}",
     )
     def test__from_linear_without_bias(
-        self, mocker, use_qat, input_shape: tuple[int, ...]
+        self, mocker, request, use_qat, input_shape: tuple[int, ...]
     ):
         model = LinearModule(bias=False, in_features=input_shape[-1], out_features=7)
         self.assert_delegated(
             model,
             input_shape,
             mocker,
+            request,
             use_qat=use_qat,
             expected_delegated_ops={MM: 1, PermuteCopy: 1},
         )
@@ -97,7 +100,7 @@ class TestMM:
         ids=lambda s: f"input_shape = {s}",
     )
     def test__from_linear_without_bias__higher_ranks(
-        self, mocker, use_qat, input_shape: tuple[int, ...]
+        self, mocker, request, use_qat, input_shape: tuple[int, ...]
     ):
         # More than 2D cases get reshaped to 2D, so two extra view_copy nodes are delegated.
 
@@ -106,6 +109,7 @@ class TestMM:
             model,
             input_shape,
             mocker,
+            request,
             use_qat=use_qat,
             expected_delegated_ops={MM: 1, PermuteCopy: 1, ViewCopy: 2},
         )

--- a/backends/nxp/tests/ir/converter/node_converter/test_mm_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_mm_converter.py
@@ -1,97 +1,111 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
-
-import kgb
 import numpy as np
+
+# noinspection PyUnusedImports
+import pytest
 import torch
 
-from executorch.backends.nxp.backend.edge_program_converter import (
-    EdgeProgramToIRConverter,
-)
-from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
-from executorch.backends.nxp.tests.executors import (
-    convert_run_compare,
-    graph_contains_any_of_ops,
-)
+from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier, Operator
 from executorch.backends.nxp.tests.models import LinearModule, MmModule
-from executorch.exir.dialects._ops import ops as exir_ops
-from parameterized import parameterized
-from torch.export import ExportedProgram
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
+from executorch.backends.nxp.tests.ops_aliases import MM, PermuteCopy, ViewCopy
+from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 
-class TestMmConversion(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        torch.manual_seed(23)
-        np.random.seed(42)
+@pytest.fixture(autouse=True)
+def reseed_model_per_test_run():
+    torch.manual_seed(42)
+    np.random.seed(23)
 
-    @parameterized.expand([("QAT", True), ("PTQ", False)])
-    def test_mm_conversion(self, _, use_qat: bool):
-        with kgb.spy_on(
-            EdgeProgramToIRConverter.convert_program,
-            call_original=True,
-            owner=EdgeProgramToIRConverter,
-        ) as converter_spy:
-            input_shape = (1, 32)
-            model = MmModule(input_shape[1])
 
-            edge_program = to_quantized_edge_program(
-                model, input_shape, use_qat=use_qat
-            ).exported_program()
+class TestMM:
 
-            # Make sure that all nodes were delegated.
-            assert not graph_contains_any_of_ops(
-                graph=edge_program.graph, ops=[exir_ops.edge.aten.mm.default]
-            )
-            assert any(
-                "lowered_module" in node.name for node in edge_program.graph.nodes
-            )
+    # noinspection PyMethodMayBeStatic
+    def assert_delegated(
+        self,
+        model,
+        input_shape,
+        mocker,
+        use_qat=False,
+        expected_delegated_ops: dict[Operator, int] | None = None,
+    ):
+        if expected_delegated_ops is None:
+            expected_delegated_ops = {MM: 1}
 
-            tflite_flatbuffers_model, *_ = converter_spy.calls[-1].return_value
-            exported_program: ExportedProgram = converter_spy.calls[-1].args[0]
-            input_data = (np.random.random(input_shape).astype(np.float32) * 50).astype(
-                np.int8
-            )
-            convert_run_compare(
-                exported_program,
-                input_data,
-                tfl_model=tflite_flatbuffers_model,
-                atol=1.0,
-            )
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops=expected_delegated_ops,
+            expected_non_delegated_ops={},
+        )
 
-    @parameterized.expand([("QAT", True), ("PTQ", False)])
-    def test_linear_conversion__without_bias(self, _, use_qat: bool):
-        with kgb.spy_on(
-            EdgeProgramToIRConverter.convert_program,
-            call_original=True,
-            owner=EdgeProgramToIRConverter,
-        ) as converter_spy:
-            input_shape = (10, 32)
-            model = LinearModule(bias=False)
+        # Create a RandomDatasetCreator that covers also negative numbers to properly test the operator.
+        dataset_creator = RandomDatasetCreator(low=-2, high=2)
 
-            edge_program = to_quantized_edge_program(
-                model, input_shape, use_qat=use_qat
-            ).exported_program()
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            dataset_creator,
+            use_qat=use_qat,
+        )
 
-            # Make sure that all nodes were delegated.
-            assert not graph_contains_any_of_ops(
-                graph=edge_program.graph, ops=[exir_ops.edge.aten.mm.default]
-            )
-            assert any(
-                "lowered_module" in node.name for node in edge_program.graph.nodes
-            )
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            # PyTorch allows only 2D inputs.
+            (1, 32),
+            (3, 11),
+        ],
+        ids=lambda s: f"input_shape = {s}",
+    )
+    def test__from_mm(self, mocker, use_qat, input_shape: tuple[int, ...]):
+        model = MmModule(input_shape[-1])
+        self.assert_delegated(model, input_shape, mocker, use_qat=use_qat)
 
-            tflite_flatbuffers_model, *_ = converter_spy.calls[-1].return_value
-            exported_program: ExportedProgram = converter_spy.calls[-1].args[0]
-            input_data = (np.random.random(input_shape).astype(np.float32) * 50).astype(
-                np.int8
-            )
-            convert_run_compare(
-                exported_program,
-                input_data,
-                tfl_model=tflite_flatbuffers_model,
-            )
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            (1, 32),
+            (3, 11),
+        ],
+        ids=lambda s: f"input_shape = {s}",
+    )
+    def test__from_linear_without_bias(
+        self, mocker, use_qat, input_shape: tuple[int, ...]
+    ):
+        model = LinearModule(bias=False, in_features=input_shape[-1], out_features=7)
+        self.assert_delegated(
+            model,
+            input_shape,
+            mocker,
+            use_qat=use_qat,
+            expected_delegated_ops={MM: 1, PermuteCopy: 1},
+        )
+
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            (1, 3, 8),
+            (2, 3, 5),
+            (2, 3, 3, 3),
+        ],
+        ids=lambda s: f"input_shape = {s}",
+    )
+    def test__from_linear_without_bias__higher_ranks(
+        self, mocker, use_qat, input_shape: tuple[int, ...]
+    ):
+        # More than 2D cases get reshaped to 2D, so two extra view_copy nodes are delegated.
+
+        model = LinearModule(bias=False, in_features=input_shape[-1], out_features=7)
+        self.assert_delegated(
+            model,
+            input_shape,
+            mocker,
+            use_qat=use_qat,
+            expected_delegated_ops={MM: 1, PermuteCopy: 1, ViewCopy: 2},
+        )

--- a/backends/nxp/tests/ir/converter/node_converter/test_relu_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_relu_converter.py
@@ -14,7 +14,7 @@ from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.models import Conv2dModule, LinearModule, ReLUModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 from executorch.backends.nxp.tests.ops_aliases import (
-    AddMm,
+    AddMM,
     Convolution,
     DequantizePerChannel,
     DequantizePerTensor,
@@ -105,7 +105,7 @@ class TestReLU:
         graph_verifier = DetailedGraphVerifier(
             mocker=mocker,
             expected_delegated_ops=(
-                {Convolution: 1, Relu: 1} if is_conv_module else {AddMm: 1, Relu: 1}
+                {Convolution: 1, Relu: 1} if is_conv_module else {AddMM: 1, Relu: 1}
             ),
             expected_non_delegated_ops={},
             ops_to_ignore={

--- a/backends/nxp/tests/ir/edge_passes/test_edge_passes.py
+++ b/backends/nxp/tests/ir/edge_passes/test_edge_passes.py
@@ -255,19 +255,19 @@ class TestEdgePasses(unittest.TestCase):
 
             # Check linear and activation are in separate QDQ clusters
             nodes = list(exported_program.graph.nodes)
-            assert len(nodes) == 13
+            assert len(nodes) == 15
             assert _is_dequantize(nodes[5])
             assert (
                 neutron_target_spec.neutron_target_info.is_fusable_conv_or_linear__edge(
-                    nodes[7]
+                    nodes[9]
                 )
             )
-            assert _is_quantize(nodes[8])
-            assert _is_dequantize(nodes[9])
+            assert _is_quantize(nodes[10])
+            assert _is_dequantize(nodes[11])
             assert neutron_target_spec.neutron_target_info.is_supported_fused_activation__edge(
-                nodes[10]
+                nodes[12]
             )
-            assert _is_quantize(nodes[11])
+            assert _is_quantize(nodes[13])
 
     @parameterized.expand(
         [

--- a/backends/nxp/tests/models.py
+++ b/backends/nxp/tests/models.py
@@ -258,10 +258,13 @@ class AddmmModule(torch.nn.Module):
         out_channels: int = 7,
         alpha: float | None = None,
         beta: float | None = None,
+        bias_shape=None,
     ):
+        if bias_shape is None:
+            bias_shape = (out_channels,)
         super().__init__()
         self.weight = torch.nn.Parameter(torch.empty(in_channels, out_channels))
-        self.bias = torch.nn.Parameter(torch.empty(out_channels))
+        self.bias = torch.nn.Parameter(torch.empty(bias_shape))
         torch.nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
         fan_in, _ = torch.nn.init._calculate_fan_in_and_fan_out(self.weight)
         bound = 1 / math.sqrt(fan_in)

--- a/backends/nxp/tests/models.py
+++ b/backends/nxp/tests/models.py
@@ -252,24 +252,36 @@ class SliceTensorConvModule(torch.nn.Module):
 
 
 class AddmmModule(torch.nn.Module):
-    def __init__(self, in_channels: int):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int = 7,
+        alpha: float | None = None,
+        beta: float | None = None,
+    ):
         super().__init__()
-        self.weight = torch.nn.Parameter(torch.empty(in_channels, in_channels))
-        self.bias = torch.nn.Parameter(torch.empty(in_channels))
+        self.weight = torch.nn.Parameter(torch.empty(in_channels, out_channels))
+        self.bias = torch.nn.Parameter(torch.empty(out_channels))
         torch.nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
         fan_in, _ = torch.nn.init._calculate_fan_in_and_fan_out(self.weight)
         bound = 1 / math.sqrt(fan_in)
         torch.nn.init.uniform_(self.bias, -bound, bound)
         self.eval()
 
+        self.kwargs = {}
+        if alpha is not None:
+            self.kwargs["alpha"] = alpha
+        if beta is not None:
+            self.kwargs["beta"] = beta
+
     def forward(self, x):
-        return torch.addmm(self.bias, x, self.weight)
+        return torch.addmm(self.bias, x, self.weight, **self.kwargs)
 
 
 class MmModule(torch.nn.Module):
-    def __init__(self, in_channels: int):
+    def __init__(self, in_channels: int, out_channels: int = 7):
         super().__init__()
-        self.weight = torch.nn.Parameter(torch.empty(in_channels, in_channels))
+        self.weight = torch.nn.Parameter(torch.empty(in_channels, out_channels))
         torch.nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
         self.eval()
 

--- a/backends/nxp/tests/ops_aliases.py
+++ b/backends/nxp/tests/ops_aliases.py
@@ -13,7 +13,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 
 Abs = exir_ops.edge.aten.abs.default
 AdaptiveAvgPool2D = exir_ops.edge.aten._adaptive_avg_pool2d.default
-AddMm = exir_ops.edge.aten.addmm.default
+AddMM = exir_ops.edge.aten.addmm.default
 AddTensor = exir_ops.edge.aten.add.Tensor
 AvgPool2D = exir_ops.edge.aten.avg_pool2d.default
 BMM = exir_ops.edge.aten.bmm.default
@@ -32,6 +32,7 @@ HardTanh = exir_ops.edge.aten.hardtanh.default
 HardTanh_ = exir_ops.edge.aten.hardtanh_.default
 LeakyRelu = exir_ops.edge.aten.leaky_relu.default
 Log = exir_ops.edge.aten.log.default
+MM = exir_ops.edge.aten.mm.default
 MaxPool2D = exir_ops.edge.aten.max_pool2d.default
 MaxPool2DWithIndices = exir_ops.edge.aten.max_pool2d_with_indices.default
 MeanDim = exir_ops.edge.aten.mean.dim
@@ -40,7 +41,6 @@ Neg = exir_ops.edge.aten.neg.default
 PermuteCopy = exir_ops.edge.aten.permute_copy.default
 QuantizePerChannel = exir_ops.edge.quantized_decomposed.quantize_per_channel.default
 QuantizePerTensor = exir_ops.edge.quantized_decomposed.quantize_per_tensor.default
-PermuteCopy = exir_ops.edge.aten.permute_copy.default
 Relu = exir_ops.edge.aten.relu.default
 Sigmoid = exir_ops.edge.aten.sigmoid.default
 Slice = exir_ops.edge.aten.slice.Tensor

--- a/backends/nxp/tests/use_qat.py
+++ b/backends/nxp/tests/use_qat.py
@@ -1,3 +1,8 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import pytest
 
 

--- a/backends/nxp/tests/use_qat.py
+++ b/backends/nxp/tests/use_qat.py
@@ -8,4 +8,9 @@ def use_qat(request):
 
 def pytest_generate_tests(metafunc):
     if "use_qat" in metafunc.fixturenames:
-        metafunc.parametrize("use_qat", [True, False], indirect=True)
+        metafunc.parametrize(
+            "use_qat",
+            [True, False],
+            indirect=True,
+            ids=lambda use_qat: "QAT" if use_qat else "PTQ",
+        )


### PR DESCRIPTION
### Summary
This PR enables the `MM` and `AddMM` operators in the NXP backend using the new Neutron C MLIR flow. 

### Test plan
Unit tests provided.


cc @robert-kalmar @JakeStevens @digantdesai @rascani