### PR TITLE
Fix ARM test listing failures caused by torch import at collection time (#20284)

### DIFF
--- a/backends/arm/test/conftest.py
+++ b/backends/arm/test/conftest.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib
 import logging
 import os
 import random
@@ -77,13 +78,20 @@ def set_random_seed():
         ARM_TEST_SEED=RANDOM pytest --config-file=/dev/null --verbose -s --color=yes  backends/arm/test/ops/test_avg_pool.py -k <TESTCASE>
     Rerun with a specific seed
         ARM_TEST_SEED=3478246 pytest --config-file=/dev/null --verbose -s --color=yes  backends/arm/test/ops/test_avg_pool.py -k <TESTCASE>
-
     """
     _set_random_seed()
 
 
 def _set_random_seed():
     import torch
+
+    # In fbcode @mode/opt, the `torch._utils` submodule is importable but is not
+    # bound as an attribute on `torch`. Importing `torch._dynamo` (pulled in via
+    # executorch.exir / torchao when a test module is collected) reads
+    # `torch._utils` directly and otherwise fails the whole listing with
+    # "module 'torch' has no attribute '_utils'". Bind it explicitly here, which
+    # runs before collection. Harmless elsewhere (the attribute is already set).
+    torch._utils = importlib.import_module("torch._utils")
 
     seed_env = os.environ.get("ARM_TEST_SEED", "0")
     if seed_env == "RANDOM":
@@ -109,9 +117,8 @@ def is_option_enabled(option: str, fail_if_not_enabled: bool = False) -> bool:
     """Returns whether an option is successfully enabled, i.e. if the flag was
     given to pytest and the necessary requirements are available.
 
-    The optional parameter 'fail_if_not_enabled' makes the function raise a
-    RuntimeError instead of returning False.
-
+    The optional parameter 'fail_if_not_enabled' makes the function
+    raise a RuntimeError instead of returning False.
     """
 
     if hasattr(pytest, "_test_options") and option in pytest._test_options and pytest._test_options[option]:  # type: ignore[attr-defined]
@@ -128,7 +135,6 @@ def get_option(option: str) -> Any | None:
 
     Args:
         option (str): The option to check for.
-
     """
     if option in pytest._test_options:  # type: ignore[attr-defined]
         return pytest._test_options[option]  # type: ignore[attr-defined]


### PR DESCRIPTION
Summary:

The ~180 ARM test listings fail in `fbcode//mode/opt` during pytest
collection with `AttributeError: module 'torch' has no attribute '_utils'`.

Root cause: `torch._utils` is importable but is not bound as an attribute on
the `torch` module, so importing `torch._dynamo` (pulled in via
`executorch.exir` / `torchao` when a test module is collected) reads
`torch._utils` directly and crashes the whole listing. This is independent of
the seed call and of CinderX lazy imports (already disabled for these targets,
verified at runtime).

The previous version guarded the early seed with try/except, which neither set
the seed internally nor actually fixed the listings (the crash originates in
test-module collection, not the seed call).

Fix: bind `torch._utils` explicitly in `_set_random_seed()`, which runs in
`pytest_configure` before collection, and drop the try/except so the
collection-time seeding from D108449705 is restored. The change is identical
for OSS and internal (a no-op where `torch._utils` is already bound), which
also addresses the reviewer ask to seed the same way for both.

Verified in `fbcode//mode/opt`: fixes ~170/180 listings and re-enables the
collection-time seed.

Known follow-up (T275980003): ~10 targets that import
`torchao.prototype.mx_formats` still fail on `torch.device` unbound during
torchao's import-time device probing — a separate torch/torchao issue.

Reviewed By: shoumikhin

Differential Revision: D108630941




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani