### PR TITLE
qwen3_5_moe: add CUDA Engine/Session execution path

### DIFF
--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -406,8 +406,9 @@ if [ "$MODEL_NAME" = "qwen3_5_moe" ]; then
 
   # Download prequantized model outside OUTPUT_DIR to avoid uploading on failure
   LOCAL_MODEL_DIR=$(mktemp -d)
-  INDUCTOR_CACHE=$(mktemp -d)
-  trap 'rm -rf "$LOCAL_MODEL_DIR" "$INDUCTOR_CACHE"' EXIT
+  INDUCTOR_CACHE=$(mktemp -d "${RUNNER_TEMP:-/tmp}/inductor_cache_XXXXXX")
+  INDUCTOR_TMPDIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/tmpdir_XXXXXX")
+  trap 'rm -rf "$LOCAL_MODEL_DIR" "$INDUCTOR_CACHE" "$INDUCTOR_TMPDIR"' EXIT
 
   python -c "from huggingface_hub import snapshot_download; snapshot_download('${HF_MODEL}', local_dir='${LOCAL_MODEL_DIR}')"
 
@@ -427,6 +428,7 @@ if [ "$MODEL_NAME" = "qwen3_5_moe" ]; then
   # Export to .pte/.ptd (short cache dir avoids objcopy symbol length issues)
   echo "::group::Export"
   EXPORT_LOG=$(mktemp)
+  TMPDIR="$INDUCTOR_TMPDIR" \
   TORCHINDUCTOR_CACHE_DIR="$INDUCTOR_CACHE" \
   python -m executorch.examples.models.qwen3_5_moe.export \
       --prequantized "$LOCAL_MODEL_DIR" \
@@ -473,8 +475,9 @@ if [ "$MODEL_NAME" = "gemma4_31b" ]; then
 
   # Download prequantized model outside OUTPUT_DIR to avoid uploading on failure
   LOCAL_MODEL_DIR=$(mktemp -d)
-  INDUCTOR_CACHE=$(mktemp -d)
-  trap 'rm -rf "$LOCAL_MODEL_DIR" "$INDUCTOR_CACHE"' EXIT
+  INDUCTOR_CACHE=$(mktemp -d "${RUNNER_TEMP:-/tmp}/inductor_cache_XXXXXX")
+  INDUCTOR_TMPDIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/tmpdir_XXXXXX")
+  trap 'rm -rf "$LOCAL_MODEL_DIR" "$INDUCTOR_CACHE" "$INDUCTOR_TMPDIR"' EXIT
 
   python -c "from huggingface_hub import snapshot_download; snapshot_download('${HF_MODEL}', local_dir='${LOCAL_MODEL_DIR}')"
 
@@ -498,6 +501,7 @@ if [ "$MODEL_NAME" = "gemma4_31b" ]; then
 
   # Export to .pte/.ptd (short cache dir avoids objcopy symbol length issues)
   echo "::group::Export"
+  TMPDIR="$INDUCTOR_TMPDIR" \
   TORCHINDUCTOR_CACHE_DIR="$INDUCTOR_CACHE" \
   python -m executorch.examples.models.gemma4_31b.export \
       --prequantized "$LOCAL_MODEL_DIR" \

--- a/Makefile
+++ b/Makefile
@@ -433,11 +433,12 @@ voxtral_tts-cuda:
 qwen3_5_moe-cuda:
 	@echo "==> Building and installing ExecuTorch with CUDA..."
 	cmake --workflow --preset llm-release-cuda
-	@echo "==> Building Qwen3.5 MoE runner with CUDA..."
+	@echo "==> Building Qwen3.5 MoE runner and no-bleed test with CUDA..."
 	cd examples/models/qwen3_5_moe && cmake --workflow --preset qwen3-5-moe-cuda
 	@echo ""
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/qwen3_5_moe/qwen3_5_moe_runner"
+	@echo "  Test:   cmake-out/examples/models/qwen3_5_moe/test_qwen35_moe_nobleed"
 
 gemma4_31b-cuda:
 	@echo "==> Building and installing ExecuTorch with CUDA..."

--- a/examples/models/qwen3_5_moe/CMakeLists.txt
+++ b/examples/models/qwen3_5_moe/CMakeLists.txt
@@ -15,6 +15,9 @@ set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 
 set(_common_include_directories ${EXECUTORCH_ROOT}/..)
+set(_json_include
+    ${EXECUTORCH_ROOT}/extension/llm/tokenizers/third-party/json/single_include
+)
 
 # gflags
 set(gflags_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party/gflags)
@@ -60,13 +63,26 @@ endif()
 # Tokenizer
 list(APPEND link_libraries tokenizers::tokenizers)
 
-add_executable(qwen3_5_moe_runner main.cpp)
+add_executable(qwen3_5_moe_runner main.cpp qwen35_moe_engine.cpp)
 target_include_directories(
-  qwen3_5_moe_runner PUBLIC ${_common_include_directories}
+  qwen3_5_moe_runner PUBLIC ${_common_include_directories} ${_json_include}
 )
 target_link_libraries(qwen3_5_moe_runner PUBLIC ${link_libraries})
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_link_options_gc_sections(qwen3_5_moe_runner)
   target_link_options(qwen3_5_moe_runner PRIVATE "LINKER:-s")
+endif()
+
+if(EXECUTORCH_BUILD_CUDA)
+  enable_testing()
+  add_executable(
+    test_qwen35_moe_nobleed test_qwen35_moe_nobleed.cpp qwen35_moe_engine.cpp
+  )
+  target_include_directories(
+    test_qwen35_moe_nobleed PUBLIC ${_common_include_directories}
+                                   ${_json_include}
+  )
+  target_link_libraries(test_qwen35_moe_nobleed PUBLIC ${link_libraries})
+  add_test(NAME qwen_nobleed COMMAND test_qwen35_moe_nobleed)
 endif()

--- a/examples/models/qwen3_5_moe/CMakePresets.json
+++ b/examples/models/qwen3_5_moe/CMakePresets.json
@@ -41,9 +41,9 @@
     "buildPresets": [
         {
             "name": "qwen3-5-moe-cuda",
-            "displayName": "Build Qwen3.5 MoE runner (CUDA)",
+            "displayName": "Build Qwen3.5 MoE runner + no-bleed test (CUDA)",
             "configurePreset": "qwen3-5-moe-cuda",
-            "targets": ["qwen3_5_moe_runner"]
+            "targets": ["qwen3_5_moe_runner", "test_qwen35_moe_nobleed"]
         },
         {
             "name": "qwen3-5-moe-metal",

--- a/examples/models/qwen3_5_moe/README.md
+++ b/examples/models/qwen3_5_moe/README.md
@@ -100,7 +100,7 @@ It can be uploaded to HuggingFace Hub for easy sharing.
 
 ExecuTorch must be installed from source first (see
 [Prerequisites](#prerequisites)). The `make` target handles building
-core libraries and the runner binary.
+core libraries, the runner binary, and the CUDA no-bleed test binary.
 
 ```bash
 make qwen3_5_moe-cuda
@@ -108,6 +108,10 @@ make qwen3_5_moe-cuda
 
 This builds ExecuTorch with CUDA backend support, then the runner binary
 at `cmake-out/examples/models/qwen3_5_moe/qwen3_5_moe_runner`.
+
+The runner is a thin CLI over `Qwen35MoEEngine` and `Qwen35MoESession`.
+On CUDA, the engine loads the model weights once and can create multiple
+isolated sessions by rebinding the model's mutable buffers before execution.
 
 ## Run
 
@@ -133,8 +137,28 @@ cmake-out/examples/models/qwen3_5_moe/qwen3_5_moe_runner \
 | `--data_path` | (none) | Path to `.ptd` delegate data file (required for CUDA) |
 | `--tokenizer_path` | (required) | Path to HuggingFace `tokenizer.json` |
 | `--prompt` | `"Hello"` | Input prompt text |
+| `--prompt_file` | (none) | Path to a prompt file (overrides `--prompt`) |
 | `--temperature` | `0.8` | Sampling temperature (0 = greedy) |
 | `--max_new_tokens` | `128` | Maximum tokens to generate |
+| `--warmup` | `0` | Warmup iterations to discard before timing |
+| `--num_iters` | `1` | Timed iterations to average after warmup |
+| `--cuda_graph` | `false` | CUDA-only decode graph capture for single-session runner use |
+
+`--cuda_graph` is intentionally single-session only. CUDA graph replay captures
+device pointers, so it is not combined with per-session mutable-state rebinding.
+
+### CUDA no-bleed test
+
+The CUDA build also produces `test_qwen35_moe_nobleed`, which validates that two
+sessions can interleave prefill/decode on one loaded model without sharing
+mutable state:
+
+```bash
+QWEN_MODEL_PATH=qwen35_moe_exports/model.pte \
+QWEN_DATA_PATH=qwen35_moe_exports/aoti_cuda_blob.ptd \
+QWEN_TOKENIZER_PATH=~/models/Qwen3.5-35B-A3B/tokenizer.json \
+  cmake-out/examples/models/qwen3_5_moe/test_qwen35_moe_nobleed
+```
 
 ## Troubleshooting
 

--- a/examples/models/qwen3_5_moe/export.py
+++ b/examples/models/qwen3_5_moe/export.py
@@ -624,9 +624,8 @@ def _materialize_buffers(model, config):
     Replaces meta buffers with real tensors on CPU, recomputes RoPE
     inv_freq and causal masks. State buffers (KV cache, conv/recurrent
     state) are zero-initialized registered buffers. On the CUDA/AOTI backend
-    they are lifted into the delegate as constants and shared across methods at
-    runtime via the backend's per-FQN buffer cache; backends that keep them at
-    the graph level instead share them via share_mutable_buffers.
+    they are lifted into the delegate as named constants; per-session sharing
+    and isolation are handled by runtime rebinding.
     """
     # Masks stay bool, inv_freq stays float32.
     for fqn, buf in list(model.named_buffers()):
@@ -915,6 +914,47 @@ def _export_metal(model, config, args):
     print("Done!")
 
 
+def _qwen_mutable_buffer_fqns(model):
+    from executorch.examples.models.qwen3_5_moe.model import GatedDeltaNet, KVCache
+
+    fqns = []
+    for prefix, module in model.named_modules():
+        if module.__class__.__name__ == "TurboQuantKVCache":
+            fqns += [
+                f"{prefix}.k_packed",
+                f"{prefix}.k_norms",
+                f"{prefix}.v_packed",
+                f"{prefix}.v_norms",
+            ]
+        elif isinstance(module, KVCache):
+            fqns += [f"{prefix}.k_cache", f"{prefix}.v_cache"]
+        elif isinstance(module, GatedDeltaNet):
+            fqns += [f"{prefix}.conv_state", f"{prefix}.recurrent_state"]
+
+    named = dict(model.named_buffers())
+    missing = [f for f in fqns if f not in named]
+    if missing:
+        raise RuntimeError(
+            f"Qwen mutable-buffer contract references missing buffers: {missing}"
+        )
+    if not fqns:
+        raise RuntimeError("Qwen mutable-buffer contract is empty")
+    return sorted(fqns)
+
+
+def _mutable_buffer_metadata_json(model):
+    import json
+
+    fqns = _qwen_mutable_buffer_fqns(model)
+    named = dict(model.named_buffers())
+    total = sum(named[f].numel() * named[f].element_size() for f in fqns)
+    print(
+        f"  Recorded {len(fqns)} mutable buffers "
+        f"({total} B / {total / 1024:.1f} KiB per session)"
+    )
+    return json.dumps({"version": 1, "mutable_buffers": fqns})
+
+
 def _export_cuda(model, config, args):
     """Export model to .pte via torch.export + CUDA backend.
 
@@ -923,13 +963,9 @@ def _export_cuda(model, config, args):
       - "prefill": prefill path (T>=2), batched tensor-core MoE kernel
         via fused_moe_batched_gemm, with dynamic sequence length.
 
-    Both methods share mutable state buffers (KV cache, conv_state,
-    recurrent_state): the model uses registered buffers with in-place
-    updates (no state in/out args). On the CUDA/AOTI backend these buffers
-    are lifted into the delegate as constants and shared across the
-    decode/prefill methods at runtime via the backend's per-FQN buffer cache
-    (share_mutable_buffers is left off for CUDA); backends that keep them at
-    the graph level instead share them via share_mutable_buffers.
+    The model uses registered buffers with in-place updates for KV,
+    conv_state, and recurrent_state. The export records which named buffers
+    are per-session mutable state.
     """
     import torch._inductor.config as inductor_config
 
@@ -1006,6 +1042,7 @@ def _export_cuda(model, config, args):
         "use_kv_cache": True,
         "use_sdpa_with_kv_cache": False,
         "enable_dynamic_shape": True,
+        "get_mutable_buffer_metadata": _mutable_buffer_metadata_json(model),
     }
     et_prog = to_edge_transform_and_lower(
         {"decode": decode_ep, "prefill": prefill_ep},
@@ -1037,7 +1074,9 @@ def _export_cuda(model, config, args):
         config=ExecutorchBackendConfig(
             extract_delegate_segments=True,
             do_quant_fusion_and_const_prop=True,
-            memory_planning_pass=MemoryPlanningPass(alloc_graph_input=False),
+            memory_planning_pass=MemoryPlanningPass(
+                alloc_graph_input=False,
+            ),
             emit_mutable_buffer_names=True,
         ),
     )

--- a/examples/models/qwen3_5_moe/main.cpp
+++ b/examples/models/qwen3_5_moe/main.cpp
@@ -6,17 +6,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Thin CLI over Qwen35MoEEngine / Qwen35MoESession: parse flags, build the
+// engine + a session, encode the prompt, prefill_tokens(), then loop
+// decode_one() printing pieces and timing/stats. All model execution lives in
+// qwen35_moe_engine.{h,cpp}.
+
 #include <gflags/gflags.h>
 
-#include <executorch/extension/llm/runner/llm_runner_helper.h>
+#include <executorch/examples/models/qwen3_5_moe/qwen35_moe_engine.h>
 #include <executorch/extension/llm/runner/stats.h>
 #include <executorch/extension/llm/runner/util.h>
-#include <executorch/extension/module/module.h>
-#include <executorch/extension/tensor/tensor.h>
-#include <executorch/runtime/backend/interface.h>
-#include <executorch/runtime/backend/options.h>
 #include <executorch/runtime/platform/log.h>
-#include <pytorch/tokenizers/hf_tokenizer.h>
 
 #include <algorithm>
 #include <cinttypes>
@@ -26,8 +26,6 @@
 
 #ifdef EXECUTORCH_BUILD_CUDA
 #include <cuda_runtime.h>
-#else
-#include <executorch/extension/llm/sampler/util.h>
 #endif
 
 DEFINE_string(model_path, "", "Model .pte file path.");
@@ -40,61 +38,20 @@ DEFINE_string(
     "Path to file containing prompt text (overrides --prompt).");
 DEFINE_double(temperature, 0.8, "Sampling temperature (0 = greedy).");
 DEFINE_int32(max_new_tokens, 128, "Maximum tokens to generate.");
+DEFINE_int32(
+    warmup,
+    0,
+    "Warmup iterations to discard before timing. One model load; the session is "
+    "reset between iterations. Warmup ramps GPU clocks so the timed iterations "
+    "reflect steady state.");
+DEFINE_int32(num_iters, 1, "Timed iterations to average (after warmup).");
 DEFINE_bool(
     cuda_graph,
     false,
-    "Enable CUDA graph for decode method. CUDA only.");
+    "Enable CUDA graph for the decode method. CUDA only; single-session mode.");
 
 namespace llm = ::executorch::extension::llm;
-using ::executorch::extension::from_blob;
-using ::executorch::extension::Module;
-using ::executorch::extension::TensorPtr;
 using ::executorch::runtime::Error;
-using ::executorch::runtime::EValue;
-
-using SizesType = executorch::aten::SizesType;
-
-// Convert a model output tensor to the next sampled token id.
-//
-// On the CUDA build, the model fuses the sampler in (see sampler.py /
-// Qwen35MoE.forward) and returns a single sampled token id as a [B, 1]
-// float tensor; we just copy that scalar back from device.
-//
-// On non-CUDA builds (Metal / MLX / CPU), the model returns raw logits
-// of shape [B, T, V] in the model dtype (typically bf16). We sample on
-// CPU via the shared `llm::logits_to_token` helper, which accepts a
-// temperature (0 = greedy / argmax).
-static uint64_t read_token(const executorch::aten::Tensor& output) {
-#ifdef EXECUTORCH_BUILD_CUDA
-  const void* ptr = output.const_data_ptr();
-
-  cudaPointerAttributes attrs;
-  bool on_device = cudaPointerGetAttributes(&attrs, ptr) == cudaSuccess &&
-      attrs.type == cudaMemoryTypeDevice;
-
-  float val;
-  if (on_device) {
-    cudaError_t err =
-        cudaMemcpy(&val, ptr, sizeof(float), cudaMemcpyDeviceToHost);
-    if (err != cudaSuccess) {
-      ET_LOG(
-          Error,
-          "read_token: cudaMemcpy D2H failed: %s",
-          cudaGetErrorString(err));
-      return 0;
-    }
-  } else {
-    memcpy(&val, ptr, sizeof(float));
-  }
-  return static_cast<uint64_t>(val);
-#else
-  // logits_to_token handles 2D / 3D logits and Float / Half / BFloat16 /
-  // UInt16 dtypes. Negative temperatures are clamped to 0 (greedy).
-  const float temp =
-      FLAGS_temperature <= 0.0 ? 0.0f : static_cast<float>(FLAGS_temperature);
-  return static_cast<uint64_t>(llm::logits_to_token(output, temp));
-#endif
-}
 
 int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -111,28 +68,6 @@ int main(int argc, char** argv) {
   llm::Stats stats;
 
 #ifdef EXECUTORCH_BUILD_CUDA
-  // GPU memory before load
-  size_t gpu_free_bytes = 0, gpu_total_bytes = 0;
-  cudaMemGetInfo(&gpu_free_bytes, &gpu_total_bytes);
-  stats.gpu_total_bytes = gpu_total_bytes;
-  stats.gpu_free_before_load_bytes = gpu_free_bytes;
-#endif
-
-  stats.model_load_start_ms = llm::time_in_ms();
-
-  // Load tokenizer
-  auto tokenizer = std::make_unique<tokenizers::HFTokenizer>();
-  auto tok_status = tokenizer->load(FLAGS_tokenizer_path);
-  if (tok_status != tokenizers::Error::Ok) {
-    ET_LOG(
-        Error,
-        "Failed to load tokenizer from %s",
-        FLAGS_tokenizer_path.c_str());
-    return 1;
-  }
-
-#ifdef EXECUTORCH_BUILD_CUDA
-  // GPU memory: before load
   {
     size_t free = 0, total = 0;
     if (cudaMemGetInfo(&free, &total) == cudaSuccess) {
@@ -144,87 +79,37 @@ int main(int argc, char** argv) {
 
   stats.model_load_start_ms = llm::time_in_ms();
 
-  std::vector<std::string> data_files;
-  if (!FLAGS_data_path.empty()) {
-    data_files.push_back(FLAGS_data_path);
-  }
-  auto module = std::make_unique<Module>(
-      FLAGS_model_path,
-      data_files,
-      Module::LoadMode::File,
-      /*event_tracer=*/nullptr,
-      /*memory_allocator=*/nullptr,
-      /*temp_allocator=*/nullptr);
-
-  // Get metadata
-  auto metadata_result = llm::get_llm_metadata(tokenizer.get(), module.get());
-  if (metadata_result.error() != Error::Ok) {
-    ET_LOG(Error, "Failed to get metadata from model");
-    return 1;
-  }
-  auto metadata = metadata_result.get();
-
-#ifdef EXECUTORCH_BUILD_CUDA
-  // Set CUDA graph option if requested (must be before load_method)
-  if (FLAGS_cuda_graph) {
-    executorch::runtime::BackendOptions<2> cuda_opts;
-    cuda_opts.set_option("enable_cuda_graph_for_method", "decode");
-    executorch::runtime::set_option("CudaBackend", cuda_opts.view());
-    printf("CUDA graph enabled for decode method\n");
-  }
-#else
+  // Build engine (reads tokenizer + metadata) and a session (loads weights and
+  // the prefill/decode methods).
+  llm::Qwen35MoEConfig config;
+  config.model_path = FLAGS_model_path;
+  config.data_path = FLAGS_data_path;
+  config.tokenizer_path = FLAGS_tokenizer_path;
+  config.enable_cuda_graph = FLAGS_cuda_graph;
+#ifndef EXECUTORCH_BUILD_CUDA
   if (FLAGS_cuda_graph) {
     ET_LOG(Info, "--cuda_graph ignored on non-CUDA build");
   }
 #endif
 
   printf("Loading methods...\n");
-
-#ifdef EXECUTORCH_BUILD_CUDA
-  // Enable cross-method per-FQN weight sharing in the CUDA backend so that
-  // prefill and decode (which share KV cache and other mutable buffers /
-  // weights) avoid duplicate GPU allocations. This is critical for fitting
-  // Qwen 3.5 MoE on a single GPU. MUST be set BEFORE load_method, since the
-  // backend reads this flag during init() to decide between the per-weight
-  // cache path and the legacy per-method blob load.
-  {
-    executorch::runtime::BackendOptions<1> backend_options;
-    auto set_err =
-        backend_options.set_option("weight_sharing_across_methods", true);
-    if (set_err != Error::Ok) {
-      ET_LOG(
-          Error,
-          "Failed to construct weight_sharing_across_methods option: %d",
-          static_cast<int>(set_err));
-      return 1;
-    }
-    const auto opt_err =
-        executorch::runtime::set_option("CudaBackend", backend_options.view());
-    if (opt_err != Error::Ok) {
-      ET_LOG(
-          Error,
-          "Failed to enable weight_sharing_across_methods: %d",
-          static_cast<int>(opt_err));
-      return 1;
-    }
-  }
-#endif
-
-  auto err = module->load_method("prefill");
-  if (err != Error::Ok) {
-    ET_LOG(Error, "Failed to load prefill method");
+  auto engine_result = llm::Qwen35MoEEngine::create(config);
+  if (engine_result.error() != Error::Ok) {
+    ET_LOG(Error, "Failed to create Qwen3.5 MoE engine");
     return 1;
   }
-  err = module->load_method("decode");
-  if (err != Error::Ok) {
-    ET_LOG(Error, "Failed to load decode method");
+  auto engine = std::move(engine_result.get());
+
+  auto session_result = engine->create_session();
+  if (session_result.error() != Error::Ok) {
+    ET_LOG(Error, "Failed to create session");
     return 1;
   }
+  auto session = std::move(session_result.get());
 
   stats.model_load_end_ms = llm::time_in_ms();
 
 #ifdef EXECUTORCH_BUILD_CUDA
-  // GPU memory: after load
   {
     size_t free = 0, total = 0;
     if (cudaMemGetInfo(&free, &total) == cudaSuccess) {
@@ -233,10 +118,7 @@ int main(int argc, char** argv) {
   }
 #endif
 
-  // Get EOS ids
-  auto eos_ids = llm::get_eos_ids(tokenizer.get(), module.get());
-
-  // Read prompt from file or flag
+  // Read prompt from file or flag.
   std::string prompt_text = FLAGS_prompt;
   if (!FLAGS_prompt_file.empty()) {
     std::ifstream f(FLAGS_prompt_file);
@@ -249,157 +131,101 @@ int main(int argc, char** argv) {
         (std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
   }
 
-  // Encode prompt
-  auto encode_result = tokenizer->encode(prompt_text);
+  // Encode prompt via the engine's tokenizer.
+  auto encode_result = engine->tokenizer()->encode(prompt_text);
   if (!encode_result.ok()) {
     ET_LOG(Error, "Failed to encode prompt");
     return 1;
   }
-  auto prompt_tokens = std::move(*encode_result);
-  int64_t num_prompt_tokens = prompt_tokens.size();
+  std::vector<uint64_t> prompt_tokens = std::move(*encode_result);
+  const int64_t num_prompt_tokens = static_cast<int64_t>(prompt_tokens.size());
   printf("Prompt tokens: %" PRId64 "\n", num_prompt_tokens);
 
   stats.num_prompt_tokens = num_prompt_tokens;
-  stats.inference_start_ms = llm::time_in_ms();
 
-  // ---------------------------------------------------------------
-  // Sampling tensors (shared between prefill and decode)
-  // ---------------------------------------------------------------
-  auto S = [](int64_t v) -> SizesType { return static_cast<SizesType>(v); };
+  // Warmup + timed iterations on one loaded session (reset between). The first
+  // FLAGS_warmup iterations are discarded; they let allocator growth and GPU
+  // clock ramp settle so the timed iterations reflect steady state. Text is
+  // printed only on the first iteration (coherence check).
+  llm::SamplingConfig sampling;
+  sampling.temperature = static_cast<float>(FLAGS_temperature);
+  const int total_iters = FLAGS_warmup + std::max(1, FLAGS_num_iters);
+  std::vector<double> prefill_tps_samples;
+  std::vector<double> decode_tps_samples;
+  double prefill_ms = 0.0;
+  int64_t num_generated = 0;
 
-#ifdef EXECUTORCH_BUILD_CUDA
-  // CUDA build: model fuses the sampler in. Pass a temperature tensor as
-  // a third input. Use a very small temperature for greedy to avoid
-  // division by zero while keeping the Gumbel noise negligible relative
-  // to logit differences.
-  float temp_val =
-      FLAGS_temperature <= 0.0 ? 1e-6f : static_cast<float>(FLAGS_temperature);
-  auto temp_tensor =
-      from_blob(&temp_val, {1}, executorch::aten::ScalarType::Float);
-#endif
-
-  stats.inference_start_ms = llm::time_in_ms();
-  stats.num_prompt_tokens = num_prompt_tokens;
-
-  // ---------------------------------------------------------------
-  // Prefill
-  // ---------------------------------------------------------------
-  uint64_t cur_token = 0;
-
-  // Use prefill method for T>=2, decode method for T=1
-  // (prefill was exported with min seq_len=2)
-  std::string run_method = "prefill";
-  if (num_prompt_tokens == 1) {
-    run_method = "decode";
-  }
-
-  std::vector<int64_t> pos_data(num_prompt_tokens);
-  for (int64_t i = 0; i < num_prompt_tokens; i++) {
-    pos_data[i] = i;
-  }
-  std::vector<int64_t> token_data(prompt_tokens.begin(), prompt_tokens.end());
-  auto tokens_tensor = from_blob(
-      token_data.data(),
-      {1, S(num_prompt_tokens)},
-      executorch::aten::ScalarType::Long);
-  auto pos_tensor = from_blob(
-      pos_data.data(),
-      {S(num_prompt_tokens)},
-      executorch::aten::ScalarType::Long);
-
-  std::vector<EValue> prefill_inputs;
-  prefill_inputs.push_back(tokens_tensor);
-  prefill_inputs.push_back(pos_tensor);
-#ifdef EXECUTORCH_BUILD_CUDA
-  prefill_inputs.push_back(temp_tensor);
-#endif
-
-  auto prefill_result = module->execute(run_method, prefill_inputs);
-  if (prefill_result.error() != Error::Ok) {
-    ET_LOG(Error, "Prefill failed");
-    return 1;
-  }
-  auto& prefill_outputs = prefill_result.get();
-
-  cur_token = read_token(prefill_outputs[0].toTensor());
-
-  stats.prompt_eval_end_ms = llm::time_in_ms();
-  stats.first_token_ms = stats.prompt_eval_end_ms;
-  double prefill_ms =
-      (double)(stats.prompt_eval_end_ms - stats.inference_start_ms);
-  printf(
-      "Prefill: %" PRId64 " tokens in %.1f ms (%.1f tok/s)\n",
-      num_prompt_tokens,
-      prefill_ms,
-      num_prompt_tokens / prefill_ms * stats.SCALING_FACTOR_UNITS_PER_SECOND);
-
-#ifdef EXECUTORCH_BUILD_CUDA
-  // Synchronize CUDA device to ensure prefill's writes to shared mutable
-  // buffers (KV cache, conv_state, recurrent_state) are visible to the
-  // decode method, which may run on a different CUDA stream.
-  cudaDeviceSynchronize();
-#endif
-
-  // ---------------------------------------------------------------
-  // Decode — generate tokens one at a time
-  // ---------------------------------------------------------------
-  int64_t pos = num_prompt_tokens;
-  uint64_t prev_token;
-
-  std::vector<int64_t> decode_token_data = {static_cast<int64_t>(cur_token)};
-  std::vector<int64_t> decode_pos_data = {pos};
-  auto decode_tokens = from_blob(
-      decode_token_data.data(), {1, 1}, executorch::aten::ScalarType::Long);
-  auto decode_pos = from_blob(
-      decode_pos_data.data(), {1}, executorch::aten::ScalarType::Long);
-
-  for (int32_t step = 0; step < FLAGS_max_new_tokens; step++) {
-    decode_token_data[0] = static_cast<int64_t>(cur_token);
-    decode_pos_data[0] = pos;
-
-    std::vector<EValue> decode_inputs;
-    decode_inputs.push_back(EValue(decode_tokens));
-    decode_inputs.push_back(EValue(decode_pos));
-#ifdef EXECUTORCH_BUILD_CUDA
-    decode_inputs.push_back(EValue(temp_tensor));
-#endif
-
-    auto decode_result = module->execute("decode", decode_inputs);
-    if (decode_result.error() != Error::Ok) {
-      ET_LOG(Error, "Decode step %d failed", step);
+  for (int iter = 0; iter < total_iters; ++iter) {
+    if (iter > 0 && session->reset() != Error::Ok) {
+      ET_LOG(Error, "Session reset failed before iteration %d", iter);
       return 1;
     }
-    auto& decode_outputs = decode_result.get();
+    const bool measured = iter >= FLAGS_warmup;
+    const bool print_text = (iter == 0);
 
-    prev_token = cur_token;
-    cur_token = read_token(decode_outputs[0].toTensor());
-
-    if (step == 0) {
-      stats.first_token_ms = llm::time_in_ms();
+    stats.inference_start_ms = llm::time_in_ms();
+    if (session->prefill_tokens(prompt_tokens, &sampling) != Error::Ok) {
+      ET_LOG(Error, "Prefill failed");
+      return 1;
     }
+    stats.prompt_eval_end_ms = llm::time_in_ms();
+    stats.first_token_ms = stats.prompt_eval_end_ms;
 
-    pos++;
-
-    auto decode_str = tokenizer->decode(prev_token, cur_token);
-    if (decode_str.ok()) {
-      printf("%s", decode_str->c_str());
-      fflush(stdout);
+    num_generated = 0;
+    for (int32_t step = 0; step < FLAGS_max_new_tokens; step++) {
+      auto step_result = session->decode_one(sampling);
+      if (step_result.error() != Error::Ok) {
+        ET_LOG(Error, "Decode step %d failed", step);
+        return 1;
+      }
+      const auto& d = step_result.get();
+      // A terminal step is the loop terminator, not generated output.
+      if (d.is_terminal) {
+        if (print_text) {
+          printf("\n");
+        }
+        break;
+      }
+      num_generated++;
+      if (step == 0) {
+        stats.first_token_ms = llm::time_in_ms();
+      }
+      if (print_text && !d.text_piece.empty()) {
+        fwrite(d.text_piece.data(), 1, d.text_piece.size(), stdout);
+        fflush(stdout);
+      }
     }
+    stats.inference_end_ms = llm::time_in_ms();
+    stats.num_generated_tokens = num_generated;
 
-    if (eos_ids.find(cur_token) != eos_ids.end()) {
-      printf("\n");
-      break;
+    prefill_ms = (double)(stats.prompt_eval_end_ms - stats.inference_start_ms);
+    const double decode_ms_iter =
+        (double)(stats.inference_end_ms - stats.prompt_eval_end_ms);
+    const double pf_tps =
+        num_prompt_tokens / prefill_ms * stats.SCALING_FACTOR_UNITS_PER_SECOND;
+    const double dc_tps =
+        num_generated / decode_ms_iter * stats.SCALING_FACTOR_UNITS_PER_SECOND;
+    printf(
+        "[iter %d%s] prefill %.1f tok/s (%" PRId64
+        " tok, %.1f ms) | "
+        "decode %.1f tok/s (%" PRId64 " tok, %.1f ms)\n",
+        iter,
+        measured ? "" : " warmup",
+        pf_tps,
+        num_prompt_tokens,
+        prefill_ms,
+        dc_tps,
+        num_generated,
+        decode_ms_iter);
+    if (measured) {
+      prefill_tps_samples.push_back(pf_tps);
+      decode_tps_samples.push_back(dc_tps);
     }
   }
 
-  stats.inference_end_ms = llm::time_in_ms();
-
   printf("\n");
-  int64_t num_generated = pos - num_prompt_tokens;
-  stats.num_generated_tokens = num_generated;
 
 #ifdef EXECUTORCH_BUILD_CUDA
-  // GPU memory: after generate + peak usage
   {
     size_t free = 0, total = 0;
     if (cudaMemGetInfo(&free, &total) == cudaSuccess) {
@@ -417,8 +243,7 @@ int main(int argc, char** argv) {
 #endif
 
   printf("\n");
-
-  double decode_ms =
+  const double decode_ms =
       (double)(stats.inference_end_ms - stats.prompt_eval_end_ms);
   printf(
       "Prefill: %" PRId64 " tokens in %.1f ms (%.1f tok/s)\n",
@@ -432,21 +257,20 @@ int main(int argc, char** argv) {
       num_generated / decode_ms * stats.SCALING_FACTOR_UNITS_PER_SECOND);
   printf("Prompt tokens: %" PRId64 "\n", num_prompt_tokens);
 
-  // Structured stats report (matches stats.h print_report)
   printf("PyTorchObserver %s\n", llm::stats_to_json_string(stats).c_str());
 
-  double ms_per_s = stats.SCALING_FACTOR_UNITS_PER_SECOND;
-
-  double model_load_s =
+  const double ms_per_s = stats.SCALING_FACTOR_UNITS_PER_SECOND;
+  const double model_load_s =
       (double)(stats.model_load_end_ms - stats.model_load_start_ms) / ms_per_s;
-  double inference_time_ms =
+  const double inference_time_ms =
       (double)(stats.inference_end_ms - stats.inference_start_ms);
-  double prompt_eval_ms =
+  const double prompt_eval_ms =
       (double)(stats.prompt_eval_end_ms - stats.inference_start_ms);
-  double eval_ms = (double)(stats.inference_end_ms - stats.prompt_eval_end_ms);
-  double ttft_s =
+  const double eval_ms =
+      (double)(stats.inference_end_ms - stats.prompt_eval_end_ms);
+  const double ttft_s =
       (double)(stats.first_token_ms - stats.inference_start_ms) / ms_per_s;
-  double sampling_s = (double)stats.aggregate_sampling_time_ms / ms_per_s;
+  const double sampling_s = (double)stats.aggregate_sampling_time_ms / ms_per_s;
 
   printf("\n");
   printf(
@@ -474,7 +298,6 @@ int main(int argc, char** argv) {
       stats.num_prompt_tokens + stats.num_generated_tokens,
       sampling_s);
 
-  // GPU memory reporting
   if (stats.gpu_total_bytes != static_cast<uint64_t>(-1)) {
     printf(
         "\tGPU total memory: %.2f MB\n",
@@ -497,6 +320,25 @@ int main(int argc, char** argv) {
     if (stats.gpu_peak_usage_mb >= 0.0) {
       printf("\tGPU peak usage: %.2f MB\n", stats.gpu_peak_usage_mb);
     }
+  }
+
+  if (!prefill_tps_samples.empty()) {
+    auto mean = [](const std::vector<double>& v) {
+      double s = 0.0;
+      for (double x : v) {
+        s += x;
+      }
+      return s / v.size();
+    };
+    printf(
+        "\n=== mean over %zu timed iter(s) (warmup %d) | prompt %" PRId64
+        ", gen %" PRId64 " ===\n",
+        prefill_tps_samples.size(),
+        FLAGS_warmup,
+        num_prompt_tokens,
+        num_generated);
+    printf("\tPrefill: %.1f tok/s\n", mean(prefill_tps_samples));
+    printf("\tDecode:  %.1f tok/s\n", mean(decode_tps_samples));
   }
 
   return 0;

--- a/examples/models/qwen3_5_moe/qwen35_moe_engine.cpp
+++ b/examples/models/qwen3_5_moe/qwen35_moe_engine.cpp
@@ -1,0 +1,604 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/examples/models/qwen3_5_moe/qwen35_moe_engine.h>
+
+#include <executorch/extension/llm/runner/llm_runner_helper.h>
+#include <executorch/extension/tensor/tensor.h>
+#include <executorch/runtime/backend/interface.h>
+#include <executorch/runtime/backend/options.h>
+#include <executorch/runtime/platform/log.h>
+#include <pytorch/tokenizers/hf_tokenizer.h>
+
+#include <cinttypes>
+#include <cmath>
+#include <cstring>
+
+#ifdef EXECUTORCH_BUILD_CUDA
+#include <cuda_runtime.h>
+#include <executorch/backends/cuda/runtime/cuda_mutable_state.h>
+#include <nlohmann/json.hpp>
+#else
+#include <executorch/extension/llm/sampler/util.h>
+#endif
+
+namespace executorch::extension::llm {
+
+using ::executorch::extension::from_blob;
+using ::executorch::extension::Module;
+using ::executorch::extension::TensorPtr;
+using ::executorch::runtime::Error;
+using ::executorch::runtime::EValue;
+using ::executorch::runtime::Result;
+using SizesType = executorch::aten::SizesType;
+
+namespace {
+
+Result<uint64_t> read_sampled_token(
+    const executorch::aten::Tensor& output,
+    float temperature) {
+#ifdef EXECUTORCH_BUILD_CUDA
+  (void)temperature;
+  const void* ptr = output.const_data_ptr();
+  cudaPointerAttributes attrs;
+  const bool on_device = cudaPointerGetAttributes(&attrs, ptr) == cudaSuccess &&
+      attrs.type == cudaMemoryTypeDevice;
+  float val = 0.0f;
+  if (on_device) {
+    if (cudaMemcpy(&val, ptr, sizeof(float), cudaMemcpyDeviceToHost) !=
+        cudaSuccess) {
+      ET_LOG(Error, "read_sampled_token: cudaMemcpy D2H failed");
+      return Error::Internal;
+    }
+  } else {
+    std::memcpy(&val, ptr, sizeof(float));
+  }
+  return static_cast<uint64_t>(llrintf(val));
+#else
+  return static_cast<uint64_t>(
+      logits_to_token(output, temperature < 0.0f ? 0.0f : temperature));
+#endif
+}
+
+Result<std::unique_ptr<Module>> build_qwen_module(
+    const Qwen35MoEConfig& config) {
+  std::vector<std::string> data_files;
+  if (!config.data_path.empty()) {
+    data_files.push_back(config.data_path);
+  }
+  auto module = std::make_unique<Module>(
+      config.model_path,
+      data_files,
+      Module::LoadMode::File,
+      /*event_tracer=*/nullptr,
+      /*memory_allocator=*/nullptr,
+      /*temp_allocator=*/nullptr,
+      /*share_memory_arenas=*/false);
+
+#ifdef EXECUTORCH_BUILD_CUDA
+  if (config.enable_cuda_graph) {
+    executorch::runtime::BackendOptions<2> cuda_opts;
+    ET_CHECK_OK_OR_RETURN_ERROR(
+        cuda_opts.set_option("enable_cuda_graph_for_method", "decode"));
+    ET_CHECK_OK_OR_RETURN_ERROR(
+        executorch::runtime::set_option("CudaBackend", cuda_opts.view()));
+    ET_LOG(Info, "Qwen35MoEEngine: CUDA graph enabled for decode method");
+  }
+  {
+    executorch::runtime::BackendOptions<1> backend_options;
+    ET_CHECK_OK_OR_RETURN_ERROR(
+        backend_options.set_option("weight_sharing_across_methods", true));
+    ET_CHECK_OK_OR_RETURN_ERROR(
+        executorch::runtime::set_option("CudaBackend", backend_options.view()));
+  }
+#endif
+
+  ET_CHECK_OK_OR_RETURN_ERROR(module->load_method("prefill"));
+  ET_CHECK_OK_OR_RETURN_ERROR(module->load_method("decode"));
+  return module;
+}
+
+#ifdef EXECUTORCH_BUILD_CUDA
+Error register_mutable_fqns(
+    Module* module,
+    ::executorch::backends::cuda::MutableStateContextOwner& mutable_state) {
+  auto res = module->execute("get_mutable_buffer_metadata");
+  if (res.error() != Error::Ok) {
+    ET_LOG(
+        Info,
+        "Qwen35MoEEngine: model has no get_mutable_buffer_metadata; "
+        "multi-session disabled");
+    return res.error();
+  }
+  const auto& outs = res.get();
+  if (outs.empty() || !outs[0].isString()) {
+    ET_LOG(Error, "get_mutable_buffer_metadata did not return a string");
+    return Error::InvalidProgram;
+  }
+  std::string json_str(outs[0].toString());
+  auto j = nlohmann::json::parse(json_str, nullptr, /*allow_exceptions=*/false);
+  if (j.is_discarded() || !j.is_object()) {
+    ET_LOG(Error, "get_mutable_buffer_metadata is not a valid JSON object");
+    return Error::InvalidProgram;
+  }
+  if (!j.contains("version") || !j["version"].is_number_integer() ||
+      j["version"].get<int>() != 1) {
+    ET_LOG(Error, "get_mutable_buffer_metadata: unsupported/missing version");
+    return Error::InvalidProgram;
+  }
+  if (!j.contains("mutable_buffers") || !j["mutable_buffers"].is_array() ||
+      j["mutable_buffers"].empty()) {
+    ET_LOG(
+        Error,
+        "get_mutable_buffer_metadata: mutable_buffers must be a non-empty array");
+    return Error::InvalidProgram;
+  }
+  std::vector<std::string> fqns;
+  for (const auto& f : j["mutable_buffers"]) {
+    if (!f.is_string() || f.get<std::string>().empty()) {
+      ET_LOG(
+          Error,
+          "get_mutable_buffer_metadata: every mutable_buffers entry must be a "
+          "non-empty string");
+      return Error::InvalidProgram;
+    }
+    fqns.push_back(f.get<std::string>());
+  }
+  mutable_state.register_fqns(fqns);
+  return Error::Ok;
+}
+#endif
+
+class Qwen35MoESession : public LLMSession {
+ public:
+  Qwen35MoESession(
+      Module* module,
+      std::mutex* exec_mutex,
+      std::atomic<int>* live_sessions,
+      ::tokenizers::Tokenizer* tokenizer,
+      std::unordered_map<std::string, int64_t> metadata,
+      std::unordered_set<uint64_t> eos_ids
+#ifdef EXECUTORCH_BUILD_CUDA
+      ,
+      ::executorch::backends::cuda::MutableStateContextOwner* mutable_state,
+      int session_token
+#endif
+      )
+      : module_(module),
+        exec_mutex_(exec_mutex),
+        live_sessions_(live_sessions),
+        tokenizer_(tokenizer),
+        metadata_(std::move(metadata)),
+        eos_ids_(std::move(eos_ids))
+#ifdef EXECUTORCH_BUILD_CUDA
+        ,
+        mutable_state_(mutable_state),
+        session_token_(session_token)
+#endif
+  {
+    decode_tokens_ = from_blob(
+        decode_token_data_, {1, 1}, executorch::aten::ScalarType::Long);
+    decode_pos_ =
+        from_blob(decode_pos_data_, {1}, executorch::aten::ScalarType::Long);
+#ifdef EXECUTORCH_BUILD_CUDA
+    temp_tensor_ =
+        from_blob(&temp_val_, {1}, executorch::aten::ScalarType::Float);
+#endif
+  }
+
+  ~Qwen35MoESession() override {
+#ifdef EXECUTORCH_BUILD_CUDA
+    if (mutable_state_ != nullptr &&
+        session_token_ != ::executorch::backends::cuda::kNoMutableSession) {
+      mutable_state_->destroy_session(session_token_);
+    }
+#endif
+    if (live_sessions_ != nullptr) {
+      live_sessions_->fetch_sub(1);
+    }
+  }
+
+  Error prefill_tokens(
+      const std::vector<uint64_t>& tokens,
+      const SamplingConfig* initial_sampling) override {
+    if (tokens.empty()) {
+      ET_LOG(Error, "prefill_tokens: empty token list");
+      return Error::InvalidArgument;
+    }
+    float first_token_temp = temperature_;
+    if (initial_sampling != nullptr) {
+      if (initial_sampling->top_p != 1.0f || initial_sampling->top_k != 0 ||
+          initial_sampling->seed != 0) {
+        ET_LOG(
+            Error,
+            "prefill_tokens: only temperature is supported; top_p/top_k/seed "
+            "are not yet implemented");
+        return Error::NotSupported;
+      }
+      first_token_temp = initial_sampling->temperature;
+    }
+    if (!valid_temperature(first_token_temp)) {
+      ET_LOG(Error, "prefill_tokens: temperature must be -1 or in [0, 1]");
+      return Error::InvalidArgument;
+    }
+    const int64_t T = static_cast<int64_t>(tokens.size());
+    const auto ctx_it = metadata_.find(kMaxContextLen);
+    if (ctx_it != metadata_.end() && pos_ + T >= ctx_it->second) {
+      ET_LOG(
+          Error,
+          "prefill_tokens would leave no room to generate (pos %" PRId64
+          " + %" PRId64 " >= max_context %" PRId64 ")",
+          pos_,
+          T,
+          ctx_it->second);
+      return Error::InvalidArgument;
+    }
+
+    stop_.store(false, std::memory_order_relaxed);
+    std::vector<int64_t> token_data(tokens.begin(), tokens.end());
+    std::vector<int64_t> pos_data(T);
+    for (int64_t i = 0; i < T; ++i) {
+      pos_data[i] = pos_ + i;
+    }
+    auto tokens_tensor = from_blob(
+        token_data.data(),
+        {1, static_cast<SizesType>(T)},
+        executorch::aten::ScalarType::Long);
+    auto pos_tensor = from_blob(
+        pos_data.data(),
+        {static_cast<SizesType>(T)},
+        executorch::aten::ScalarType::Long);
+
+    const char* method = (T >= 2) ? "prefill" : "decode";
+    std::vector<EValue> inputs;
+    inputs.push_back(tokens_tensor);
+    inputs.push_back(pos_tensor);
+#ifdef EXECUTORCH_BUILD_CUDA
+    set_temp(first_token_temp);
+    inputs.push_back(EValue(temp_tensor_));
+#endif
+    auto sampled =
+        run_locked(method, inputs, first_token_temp, /*sync_after=*/true);
+    ET_CHECK_OK_OR_RETURN_ERROR(sampled.error());
+    pending_ = sampled.get();
+    prev_decode_token_.reset();
+    pos_ += T;
+    return Error::Ok;
+  }
+
+  Result<DecodeResult> decode_one(const SamplingConfig& sampling) override {
+    if (sampling.top_p != 1.0f || sampling.top_k != 0 || sampling.seed != 0) {
+      ET_LOG(
+          Error,
+          "Qwen35MoESession: only temperature is supported; top_p/top_k/seed "
+          "are not implemented");
+      return Error::NotSupported;
+    }
+    if (!valid_temperature(sampling.temperature)) {
+      ET_LOG(Error, "decode_one: temperature must be -1 or in [0, 1]");
+      return Error::InvalidArgument;
+    }
+    ET_CHECK_OR_RETURN_ERROR(
+        pending_.has_value(),
+        InvalidState,
+        "decode_one requires a pending token; call prefill_tokens() first");
+    temperature_ = sampling.temperature;
+
+    if (stop_.load(std::memory_order_relaxed)) {
+      return DecodeResult{0, "", /*is_eos=*/false, /*is_terminal=*/true};
+    }
+
+    const uint64_t token = pending_.value();
+    const bool is_eos = eos_ids_.find(token) != eos_ids_.end();
+
+    const uint64_t prev = prev_decode_token_.value_or(token);
+    auto dec = tokenizer_->decode(prev, token);
+    if (!dec.ok()) {
+      ET_LOG(
+          Error,
+          "Tokenizers error code %d",
+          static_cast<uint32_t>(dec.error()));
+      return Error::InvalidArgument;
+    }
+    std::string text_piece = std::move(*dec);
+
+    if (is_eos) {
+      pending_.reset();
+      return DecodeResult{
+          token, std::move(text_piece), is_eos, /*is_terminal=*/true};
+    }
+
+    const auto ctx_it = metadata_.find(kMaxContextLen);
+    if (ctx_it != metadata_.end()) {
+      ET_CHECK_OR_RETURN_ERROR(
+          pos_ < ctx_it->second,
+          InvalidArgument,
+          "decode_one would exceed context capacity: pos_ %" PRId64
+          " >= max_context %" PRId64,
+          pos_,
+          ctx_it->second);
+    }
+
+    decode_token_data_[0] = static_cast<int64_t>(token);
+    decode_pos_data_[0] = pos_;
+    std::vector<EValue> inputs;
+    inputs.push_back(EValue(decode_tokens_));
+    inputs.push_back(EValue(decode_pos_));
+#ifdef EXECUTORCH_BUILD_CUDA
+    set_temp(temperature_);
+    inputs.push_back(EValue(temp_tensor_));
+#endif
+    auto sampled =
+        run_locked("decode", inputs, temperature_, /*sync_after=*/false);
+    ET_CHECK_OK_OR_RETURN_ERROR(sampled.error());
+    pending_ = sampled.get();
+    prev_decode_token_ = token;
+    pos_ += 1;
+    return DecodeResult{
+        token, std::move(text_piece), /*is_eos=*/false, /*is_terminal=*/false};
+  }
+
+  int64_t position() const override {
+    return pos_;
+  }
+
+  Error reset() override {
+    pos_ = 0;
+    pending_.reset();
+    prev_decode_token_.reset();
+    stop_.store(false, std::memory_order_relaxed);
+    return Error::Ok;
+  }
+
+  void stop() override {
+    stop_.store(true, std::memory_order_relaxed);
+  }
+
+ private:
+  static bool valid_temperature(float temperature) {
+    return temperature == -1.0f || (temperature >= 0.0f && temperature <= 1.0f);
+  }
+
+#ifdef EXECUTORCH_BUILD_CUDA
+  void set_temp(float t) {
+    temp_val_ = (t <= 0.0f) ? 1e-6f : t;
+  }
+#endif
+
+  Result<uint64_t> run_locked(
+      const char* method,
+      std::vector<EValue>& inputs,
+      float temperature,
+      bool sync_after) {
+    std::lock_guard<std::mutex> guard(*exec_mutex_);
+#ifdef EXECUTORCH_BUILD_CUDA
+    Result<std::vector<EValue>> res = mutable_state_ != nullptr
+        ? mutable_state_->with_active_session(
+              session_token_,
+              [&]() { return module_->execute(method, inputs); })
+        : module_->execute(method, inputs);
+#else
+    auto res = module_->execute(method, inputs);
+#endif
+    ET_CHECK_OK_OR_RETURN_ERROR(res.error());
+    auto sampled = read_sampled_token(res.get()[0].toTensor(), temperature);
+    ET_CHECK_OK_OR_RETURN_ERROR(sampled.error());
+#ifdef EXECUTORCH_BUILD_CUDA
+    if (sync_after && cudaDeviceSynchronize() != cudaSuccess) {
+      ET_LOG(Error, "run_locked: cudaDeviceSynchronize failed");
+      return Error::Internal;
+    }
+#else
+    (void)sync_after;
+#endif
+    return sampled.get();
+  }
+
+  Module* module_;
+  std::mutex* exec_mutex_;
+  std::atomic<int>* live_sessions_;
+  ::tokenizers::Tokenizer* tokenizer_;
+  std::unordered_map<std::string, int64_t> metadata_;
+  std::unordered_set<uint64_t> eos_ids_;
+
+  int64_t pos_ = 0;
+  std::optional<uint64_t> pending_;
+  std::optional<uint64_t> prev_decode_token_;
+  float temperature_ = -1.0f;
+  std::atomic<bool> stop_{false};
+
+  int64_t decode_token_data_[1] = {0};
+  int64_t decode_pos_data_[1] = {0};
+  TensorPtr decode_tokens_;
+  TensorPtr decode_pos_;
+#ifdef EXECUTORCH_BUILD_CUDA
+  ::executorch::backends::cuda::MutableStateContextOwner* mutable_state_ =
+      nullptr;
+  int session_token_ = ::executorch::backends::cuda::kNoMutableSession;
+  float temp_val_ = 1e-6f;
+  TensorPtr temp_tensor_;
+#endif
+};
+
+} // namespace
+
+Result<std::unique_ptr<Qwen35MoEEngine>> Qwen35MoEEngine::create(
+    const Qwen35MoEConfig& config) {
+  if (config.model_path.empty() || config.tokenizer_path.empty()) {
+    ET_LOG(
+        Error, "Qwen35MoEEngine: model_path and tokenizer_path are required");
+    return Error::InvalidArgument;
+  }
+
+  auto tokenizer = std::make_unique<::tokenizers::HFTokenizer>();
+  if (tokenizer->load(config.tokenizer_path) != ::tokenizers::Error::Ok) {
+    ET_LOG(
+        Error,
+        "Qwen35MoEEngine: failed to load tokenizer from %s",
+        config.tokenizer_path.c_str());
+    return Error::InvalidArgument;
+  }
+
+  // Read metadata + eos from a lightweight Module (program + tiny metadata
+  // methods only; the heavy prefill/decode weights are NOT loaded here).
+  std::vector<std::string> data_files;
+  if (!config.data_path.empty()) {
+    data_files.push_back(config.data_path);
+  }
+  auto meta_module = std::make_unique<Module>(
+      config.model_path, data_files, Module::LoadMode::File);
+  auto metadata_result = get_llm_metadata(tokenizer.get(), meta_module.get());
+  if (metadata_result.error() != Error::Ok) {
+    ET_LOG(Error, "Qwen35MoEEngine: failed to read metadata");
+    return metadata_result.error();
+  }
+  auto eos_ids = get_eos_ids(tokenizer.get(), meta_module.get());
+  // This export's metadata doesn't carry the chat-turn EOS (config.json has no
+  // eos_token_id and the .pte exports no get_eos_ids method), so get_eos_ids()
+  // misses it and a session would never terminate; it would decode to
+  // max_new_tokens every turn. <|im_end|> ends every Qwen assistant turn; add
+  // it explicitly so decode_one() stops at end of turn.
+  if (auto im_end = tokenizer->piece_to_id("<|im_end|>"); im_end.ok()) {
+    eos_ids.insert(*im_end);
+  } else {
+    ET_LOG(
+        Error,
+        "Qwen35MoEEngine: could not resolve <|im_end|> token id; the model may "
+        "not stop at end of turn");
+  }
+
+#ifdef EXECUTORCH_BUILD_CUDA
+  std::unique_ptr<::executorch::backends::cuda::MutableStateContextOwner>
+      mutable_state;
+  if (config.enable_cuda_graph) {
+    ET_LOG(
+        Info,
+        "Qwen35MoEEngine: CUDA graph requested; per-session rebinding disabled "
+        "and serving capacity clamped to 1 session.");
+  } else {
+    auto candidate = std::make_unique<
+        ::executorch::backends::cuda::MutableStateContextOwner>();
+    if (Error e = register_mutable_fqns(meta_module.get(), *candidate);
+        e == Error::Ok) {
+      mutable_state = std::move(candidate);
+    } else {
+      ET_LOG(
+          Info,
+          "Qwen35MoEEngine: mutable-buffer metadata unavailable or invalid; "
+          "serving capacity clamped to 1 session.");
+    }
+  }
+#endif
+
+#ifdef EXECUTORCH_BUILD_CUDA
+  auto module_res = mutable_state != nullptr
+      ? mutable_state->with_load_scope(
+            [&]() { return build_qwen_module(config); })
+      : build_qwen_module(config);
+#else
+  auto module_res = build_qwen_module(config);
+#endif
+  if (module_res.error() != Error::Ok) {
+    return module_res.error();
+  }
+  std::unique_ptr<Module> shared_module = std::move(module_res.get());
+
+  bool rebind_available = false;
+#ifdef EXECUTORCH_BUILD_CUDA
+  rebind_available = mutable_state != nullptr && mutable_state->available();
+  if (rebind_available) {
+    if (mutable_state->validate_coverage() != Error::Ok) {
+      ET_LOG(
+          Error,
+          "Qwen35MoEEngine: mutable-buffer coverage check failed; disabling "
+          "multi-session (capacity clamped to 1).");
+      rebind_available = false;
+    }
+  }
+  if (!rebind_available) {
+    ET_LOG(
+        Info,
+        "Qwen35MoEEngine: per-session rebinding unavailable; serving capacity "
+        "clamped to 1 session.");
+  }
+#endif
+
+  return std::unique_ptr<Qwen35MoEEngine>(new Qwen35MoEEngine(
+      config,
+      std::move(tokenizer),
+      metadata_result.get(),
+      std::move(eos_ids),
+      std::move(shared_module),
+      rebind_available
+#ifdef EXECUTORCH_BUILD_CUDA
+      ,
+      std::move(mutable_state)
+#endif
+          ));
+}
+
+Qwen35MoEEngine::~Qwen35MoEEngine() = default;
+
+Result<std::unique_ptr<LLMSession>> Qwen35MoEEngine::create_session() {
+  // Enforce serving_capacity(): without rebinding, capacity is 1, so a second
+  // session would silently share the resident KV/conv/recurrent state. Reserve
+  // a slot under the exec lock (released in ~Qwen35MoESession).
+  const int cap =
+      serving_capacity().max_physical_sessions_without_weight_duplication;
+  {
+    std::lock_guard<std::mutex> g(exec_mutex_);
+    if (live_sessions_.load() >= cap) {
+      ET_LOG(
+          Error,
+          "Qwen35MoEEngine: at session capacity (%d); refusing create_session "
+          "(would share state or duplicate weights)",
+          cap);
+      return Error::InvalidState;
+    }
+    live_sessions_.fetch_add(1);
+  }
+
+  int token = -1; // kNoMutableSession: single-session / no rebind
+#ifdef EXECUTORCH_BUILD_CUDA
+  if (rebind_available_) {
+    auto t = mutable_state_->create_session();
+    if (t.error() != Error::Ok) {
+      live_sessions_.fetch_sub(1);
+      return t.error();
+    }
+    token = t.get();
+  }
+#endif
+  return std::unique_ptr<LLMSession>(new Qwen35MoESession(
+      shared_module_.get(),
+      &exec_mutex_,
+      &live_sessions_,
+      tokenizer_.get(),
+      metadata_,
+      eos_ids_
+#ifdef EXECUTORCH_BUILD_CUDA
+      ,
+      mutable_state_.get(),
+      token
+#endif
+      ));
+}
+
+LLMServingCapacity Qwen35MoEEngine::serving_capacity() const {
+  LLMServingCapacity cap; // default: 1 session, 0 bytes (unknown)
+#ifdef EXECUTORCH_BUILD_CUDA
+  if (rebind_available_) {
+    cap.max_physical_sessions_without_weight_duplication =
+        config_.max_sessions > 1 ? config_.max_sessions : 1;
+    cap.estimated_bytes_per_session = mutable_state_->bytes_per_session();
+  }
+#endif
+  return cap;
+}
+
+} // namespace executorch::extension::llm

--- a/examples/models/qwen3_5_moe/qwen35_moe_engine.h
+++ b/examples/models/qwen3_5_moe/qwen35_moe_engine.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Engine/Session adapter for the Qwen3.5 MoE exported prefill/decode methods.
+// CUDA builds can host multiple sessions on one loaded model by rebinding the
+// model's mutable buffers before each execute.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <executorch/extension/llm/runner/llm_session.h>
+#include <executorch/extension/module/module.h>
+#include <executorch/runtime/core/result.h>
+#include <pytorch/tokenizers/tokenizer.h>
+
+#ifdef EXECUTORCH_BUILD_CUDA
+#include <executorch/backends/cuda/runtime/cuda_mutable_state.h>
+#endif
+
+namespace executorch::extension::llm {
+
+/// Immutable configuration for a Qwen3.5 MoE engine.
+struct Qwen35MoEConfig {
+  std::string model_path; // .pte
+  std::string data_path; // .ptd (CUDA delegate blob); empty if none
+  std::string tokenizer_path; // HuggingFace tokenizer.json
+  // Clamped to 1 if the backend cannot isolate per-session mutable state.
+  int32_t max_sessions = 1;
+  // CUDA-only: graph-capture decode for single-session runner use. Incompatible
+  // with per-session mutable-state rebinding, so capacity remains 1.
+  bool enable_cuda_graph = false;
+};
+
+/// Engine over one loaded Qwen3.5 MoE program.
+class ET_EXPERIMENTAL Qwen35MoEEngine : public LLMEngine {
+ public:
+  static ::executorch::runtime::Result<std::unique_ptr<Qwen35MoEEngine>> create(
+      const Qwen35MoEConfig& config);
+
+  ~Qwen35MoEEngine() override;
+
+  ::executorch::runtime::Result<std::unique_ptr<LLMSession>> create_session()
+      override;
+
+  LLMServingCapacity serving_capacity() const override;
+
+  const std::unordered_map<std::string, int64_t>& metadata() const override {
+    return metadata_;
+  }
+
+  // Non-owning; valid for the engine's lifetime.
+  ::tokenizers::Tokenizer* tokenizer() const {
+    return tokenizer_.get();
+  }
+
+  Qwen35MoEEngine(const Qwen35MoEEngine&) = delete;
+  Qwen35MoEEngine& operator=(const Qwen35MoEEngine&) = delete;
+
+ private:
+  Qwen35MoEEngine(
+      Qwen35MoEConfig config,
+      std::unique_ptr<::tokenizers::Tokenizer> tokenizer,
+      std::unordered_map<std::string, int64_t> metadata,
+      std::unordered_set<uint64_t> eos_ids,
+      std::unique_ptr<Module> shared_module,
+      bool rebind_available
+#ifdef EXECUTORCH_BUILD_CUDA
+      ,
+      std::unique_ptr<::executorch::backends::cuda::MutableStateContextOwner>
+          mutable_state
+#endif
+      )
+      : config_(std::move(config)),
+        tokenizer_(std::move(tokenizer)),
+        metadata_(std::move(metadata)),
+        eos_ids_(std::move(eos_ids)),
+        shared_module_(std::move(shared_module)),
+        rebind_available_(rebind_available)
+#ifdef EXECUTORCH_BUILD_CUDA
+        ,
+        mutable_state_(std::move(mutable_state))
+#endif
+  {
+  }
+
+  Qwen35MoEConfig config_;
+  std::unique_ptr<::tokenizers::Tokenizer> tokenizer_;
+  std::unordered_map<std::string, int64_t> metadata_;
+  std::unordered_set<uint64_t> eos_ids_;
+
+  std::unique_ptr<Module> shared_module_;
+  std::mutex exec_mutex_;
+  bool rebind_available_ = false;
+#ifdef EXECUTORCH_BUILD_CUDA
+  std::unique_ptr<::executorch::backends::cuda::MutableStateContextOwner>
+      mutable_state_;
+#endif
+  std::atomic<int> live_sessions_{0};
+};
+
+} // namespace executorch::extension::llm

--- a/examples/models/qwen3_5_moe/test_qwen35_moe_nobleed.cpp
+++ b/examples/models/qwen3_5_moe/test_qwen35_moe_nobleed.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// CUDA integration proof for one loaded Qwen model with isolated sessions.
+// Set QWEN_MODEL_PATH, QWEN_DATA_PATH, and QWEN_TOKENIZER_PATH to run it.
+
+#include <executorch/examples/models/qwen3_5_moe/qwen35_moe_engine.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+namespace llm = ::executorch::extension::llm;
+using ::executorch::runtime::Error;
+
+namespace {
+int g_failures = 0;
+void check(const char* name, bool ok) {
+  printf("  [%s] %s\n", ok ? "PASS" : "FAIL", name);
+  if (!ok) {
+    ++g_failures;
+  }
+}
+
+const char* env(const char* k) {
+  const char* v = std::getenv(k);
+  return (v && *v) ? v : nullptr;
+}
+
+std::vector<uint64_t> encode(llm::Qwen35MoEEngine& e, const std::string& s) {
+  auto r = e.tokenizer()->encode(s);
+  return r.ok() ? std::move(*r) : std::vector<uint64_t>{};
+}
+
+std::vector<uint64_t>
+solo_decode(llm::LLMSession& s, std::vector<uint64_t> prompt, int n) {
+  llm::SamplingConfig samp;
+  std::vector<uint64_t> out;
+  if (s.prefill_tokens(prompt, &samp) != Error::Ok) {
+    return out;
+  }
+  for (int i = 0; i < n; ++i) {
+    auto r = s.decode_one(samp);
+    if (r.error() != Error::Ok || r.get().is_terminal) {
+      break;
+    }
+    out.push_back(r.get().token_id);
+  }
+  return out;
+}
+
+int64_t gpu_free() {
+  size_t free = 0, total = 0;
+  return cudaMemGetInfo(&free, &total) == cudaSuccess
+      ? static_cast<int64_t>(free)
+      : -1;
+}
+
+} // namespace
+
+int main() {
+  const char* model = env("QWEN_MODEL_PATH");
+  const char* tok = env("QWEN_TOKENIZER_PATH");
+  if (!model || !tok) {
+    printf(
+        "SKIP: integration proof needs QWEN_MODEL_PATH / QWEN_TOKENIZER_PATH "
+        "(+ QWEN_DATA_PATH) on a CUDA box.\n");
+    return g_failures ? 1 : 0;
+  }
+  llm::Qwen35MoEConfig config;
+  config.model_path = model;
+  config.data_path = env("QWEN_DATA_PATH") ? env("QWEN_DATA_PATH") : "";
+  config.tokenizer_path = tok;
+  config.max_sessions = 4;
+
+  auto engine_r = llm::Qwen35MoEEngine::create(config);
+  if (engine_r.error() != Error::Ok) {
+    printf("SKIP: engine create failed (no CUDA device / bad paths).\n");
+    return 0;
+  }
+  auto engine = std::move(engine_r.get());
+  printf("no-bleed integration proof:\n");
+
+  const int kN = 24;
+  auto prompt_a = encode(*engine, "List three colors:");
+  auto prompt_b =
+      encode(*engine, "Name two countries in Europe and explain why.");
+  check("prompts encoded", !prompt_a.empty() && !prompt_b.empty());
+
+  auto sa_r = engine->create_session();
+  check("create session A", sa_r.error() == Error::Ok);
+  std::vector<uint64_t> ids_solo;
+  if (sa_r.error() == Error::Ok) {
+    auto sa = std::move(sa_r.get());
+    ids_solo = solo_decode(*sa, prompt_a, kN);
+  }
+  check("solo produced tokens", !ids_solo.empty());
+
+  auto a2_r = engine->create_session();
+  auto b_r = engine->create_session();
+  check("create A2 + B", a2_r.error() == Error::Ok && b_r.error() == Error::Ok);
+  std::vector<uint64_t> ids_a2, ids_b;
+  if (a2_r.error() == Error::Ok && b_r.error() == Error::Ok) {
+    auto a2 = std::move(a2_r.get());
+    auto b = std::move(b_r.get());
+    llm::SamplingConfig samp;
+    bool ok = a2->prefill_tokens(prompt_a, &samp) == Error::Ok &&
+        b->prefill_tokens(prompt_b, &samp) == Error::Ok;
+    check("interleaved prefills", ok);
+    bool a_done = false, b_done = false;
+    for (int i = 0; i < kN && ok; ++i) {
+      if (!a_done) {
+        auto r = a2->decode_one(samp);
+        if (r.error() != Error::Ok || r.get().is_terminal) {
+          a_done = true;
+        } else {
+          ids_a2.push_back(r.get().token_id);
+        }
+      }
+      if (!b_done) {
+        auto r = b->decode_one(samp);
+        if (r.error() != Error::Ok || r.get().is_terminal) {
+          b_done = true;
+        } else {
+          ids_b.push_back(r.get().token_id);
+        }
+      }
+    }
+  }
+
+  check(
+      "no bleed: A interleaved == A solo (bit-identical)", ids_a2 == ids_solo);
+  check("B ran a distinct conversation", !ids_b.empty() && ids_b != ids_solo);
+
+  const int64_t est = engine->serving_capacity().estimated_bytes_per_session;
+  {
+    int64_t free_before = gpu_free();
+    auto extra_r = engine->create_session();
+    if (extra_r.error() == Error::Ok) {
+      auto extra = std::move(extra_r.get());
+      llm::SamplingConfig samp;
+      extra->prefill_tokens(prompt_a, &samp);
+      int64_t free_after = gpu_free();
+      if (free_before > 0 && free_after > 0) {
+        const int64_t delta = free_before - free_after;
+        printf(
+            "    extra-session GPU delta=%lld bytes (est/session=%lld)\n",
+            (long long)delta,
+            (long long)est);
+        check(
+            "extra session is state-sized (>0, < 4 GB, not an ~18 GB reload)",
+            delta > 0 && delta < (4LL << 30));
+        if (est > 0) {
+          check(
+              "memory delta within 2x of estimated_bytes_per_session",
+              delta <= est * 2 + (256LL << 20));
+        }
+      }
+    }
+  }
+
+  std::vector<std::unique_ptr<llm::LLMSession>> held;
+  while (true) {
+    auto r = engine->create_session();
+    if (r.error() != Error::Ok) {
+      break;
+    }
+    held.push_back(std::move(r.get()));
+    if (held.size() > (size_t)config.max_sessions + 2) {
+      break;
+    }
+  }
+  check(
+      "capacity enforced: create_session fails past max_sessions",
+      held.size() <= (size_t)config.max_sessions);
+
+  printf(
+      "\n%s (%d failure(s))\n",
+      g_failures ? "FAILURES" : "ALL PASS",
+      g_failures);
+  return g_failures ? 1 : 0;
+}


### PR DESCRIPTION
Add a Qwen3.5-MoE execution adapter on top of the new LLMEngine/LLMSession and CUDA mutable-state foundations. The engine loads one physical model, registers exported mutable-buffer metadata, and creates isolated sessions that rebind their own KV/conv/recurrent state before execution while sharing model weights.

Keep the existing CLI behavior by making main.cpp a thin wrapper over the engine/session path. The export now records the model-specific mutable-buffer FQNs, and the CUDA build includes a no-bleed integration proof that interleaves two sessions on one loaded model and checks state isolation, memory growth, and capacity enforcement.

This intentionally leaves OpenAI serving, worker loops, warm resume, and per-model serving wrappers for later PRs.


https://github.com/pytorch/executorch/issues/20001


Will do Gemma4 31B in later PRs

CI already exercises the main.cpp, which wraps around QwenEngine and QwenSession