### PR TITLE
Use MS_SYNC for finalize_for_runtime to avoid compressor pressure (#20294)

### DIFF
--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -576,11 +576,18 @@ Error XNNWeightsCache::save_packed_index() {
     ET_LOG(Error, "fsync of packed cache failed (errno=%d)", errno);
     // Continue — data is in page cache; durability is best-effort.
   }
+  // Log the final file size (= index_start + trailer) so production
+  // logs surface unbounded growth from orphan packs: a same-name
+  // re-pack leaves the old packed bytes in the file even though the
+  // trailer drops the old entry. Monitoring file_bytes over time tells
+  // us when GC or a size cap is needed.
+  const size_t file_bytes = index_start + buf.size();
   ET_LOG(
       Info,
-      "Saved packed weight index: %u entries at offset %zu",
+      "Saved packed weight index: %u entries at offset %zu, file_bytes=%zu",
       entry_count,
-      index_start);
+      index_start,
+      file_bytes);
 
   // Promote freshly-packed entries to from_load now that they're durable
   // on disk, so delete_packed_data preserves them across unload/reload.

--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -214,19 +214,19 @@ Result<std::vector<std::string>> XNNWeightsCache::finalize_for_runtime() {
   }
 
 #ifndef _WIN32
-  // Schedule async flush for newly added regions only.
-  // MS_ASYNC returns immediately; OS flushes in the background.
+  // Synchronous flush for newly added regions. MS_SYNC blocks until the
+  // dirty pages are written to disk and marked clean
   if (mmap_regions_.size() > mmap_regions_synced_) {
     size_t new_count = mmap_regions_.size() - mmap_regions_synced_;
     for (size_t i = mmap_regions_synced_; i < mmap_regions_.size(); ++i) {
       if (mmap_regions_[i].addr != nullptr) {
-        msync(mmap_regions_[i].addr, mmap_regions_[i].size, MS_ASYNC);
+        msync(mmap_regions_[i].addr, mmap_regions_[i].size, MS_SYNC);
       }
     }
     mmap_regions_synced_ = mmap_regions_.size();
     ET_LOG(
         Info,
-        "Scheduled async flush: %zu new regions (%zu total), %zu MB packed weights",
+        "Synced %zu new regions (%zu total), %zu MB packed weights",
         new_count,
         mmap_regions_.size(),
         packed_file_used_ / (1024 * 1024));

--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -141,16 +141,19 @@ Error XNNWeightsCache::initialize_for_runtime(
     return Error::Ok;
   }
 
-  // Already loaded earlier this session; just reopen the write fd that
-  // save_packed_index() closed. Subsequent reserve_space can extend the
-  // file for any entries not in the saved trailer.
-  if (cache_loaded_) {
+  // Entries already in memory (from a prior load_packed_cache or a prior
+  // fresh-write session). Just reopen the write fd that save_packed_index
+  // closed; subsequent reserve_space can extend the file. Using metadata
+  // emptiness (not a separate flag) as the gate avoids a latent bug
+  // where fresh-write→save→re-init re-enters load_packed_cache and
+  // double-mmaps the same file.
+  if (!name_to_packed_data_metadata_.empty()) {
     packed_file_fd_ = open_locked(packed_cache_path_, O_RDWR);
     return Error::Ok;
   }
 
-  // First init for this path: try to load the saved trailer; on success
-  // open a write fd for any new entries. If load fails, fall through to
+  // No in-memory entries: try to load the saved trailer; on success open
+  // a write fd for any new entries. If load fails, fall through to
   // fresh-write below.
   if (load_packed_cache()) {
     ET_LOG(
@@ -280,7 +283,6 @@ void XNNWeightsCache::full_unload() {
   packed_data_ptrs_.clear();
   ptr_to_file_offset_.clear();
   file_ptr_to_region_index_.clear();
-  cache_loaded_ = false;
   if (packed_file_fd_ >= 0) {
     close(packed_file_fd_);
     packed_file_fd_ = -1;
@@ -714,7 +716,6 @@ bool XNNWeightsCache::load_packed_cache() {
     name_to_packed_data_metadata_[name] = meta;
   }
 
-  cache_loaded_ = true;
   packed_file_used_ = index_start;
   // In-memory state matches the on-disk trailer; the next save would be
   // a no-op. Initialize watermark so save_packed_index short-circuits.

--- a/backends/xnnpack/runtime/XNNWeightsCache.h
+++ b/backends/xnnpack/runtime/XNNWeightsCache.h
@@ -39,10 +39,8 @@ struct PackedDataMeta {
   bool in_current_runtime{};
   // True if this entry's bytes are persisted in the on-disk cache file
   // (either originally loaded via load_packed_cache, or freshly packed
-  // and then save_packed_index-ed). Used by delete_packed_data to
-  // detect when all persistent entries are gone, at which point
-  // cache_loaded_ is auto-invalidated so the next init re-enters
-  // load_packed_cache and reuses the saved file instead of re-packing.
+  // and then save_packed_index-ed). delete_packed_data preserves these
+  // entries so the next init reuses the saved file instead of re-packing.
   bool from_load{false};
   // Per-ukernel seed from xnn_weights_cache_look_up_key.seed. XNNPACK
   // guarantees this is consistent across runs of the same ukernel; when
@@ -195,10 +193,6 @@ class XNNWeightsCache {
   std::string packed_cache_path_;
   int packed_file_fd_{-1};
   size_t packed_file_used_{0};
-  // True once load_packed_cache() has populated metadata from a saved
-  // index, OR once a fresh-write session has been persisted to disk via
-  // save_packed_index() (so subsequent inits can load from it).
-  bool cache_loaded_{false};
   // Tracks file offset of each file-backed allocation. Used by
   // save_packed_index() to serialize (name → offset, size) index.
   std::unordered_map<void*, size_t> ptr_to_file_offset_;


### PR DESCRIPTION
Summary:

Switch the msync in finalize_for_runtime from MS_ASYNC to MS_SYNC.
MS_ASYNC schedules the writeback but doesn't wait for completion;
if the app backgrounds before the OS finishes flushing, iOS can
put the still-dirty mmap pages into the compressor (compressor
handles dirty file-backed pages too, not just anon). On re-activation
those pages decompress into phys_footprint, causing a 700 → 1400 MB
spike that the user observed in production.

MS_SYNC guarantees pages are clean before finalize returns, so the
OS evicts them on memory pressure instead of compressing — eviction
is free for clean file-backed pages (re-read from file on next
access), while decompression adds to phys_footprint.

Cost: ~hundreds of ms in finalize for a 500 MB fresh write, paid
once per pack session. Acceptable since model load is already
expected to be slow.

Differential Revision: D108178966


