### PR TITLE
Auto-save XNNPACK packed cache trailer at compile end

### DIFF
--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -233,6 +233,13 @@ Result<std::vector<std::string>> XNNWeightsCache::finalize_for_runtime() {
   }
 #endif
 
+  // Auto-trigger save_packed_index when this compile session added new
+  // packed entries to the file.
+  if (!packed_cache_path_.empty() &&
+      mmap_regions_.size() > mmap_regions_at_last_save_) {
+    (void)save_packed_index();
+  }
+
   return packed_data_names;
 }
 
@@ -600,13 +607,21 @@ Error XNNWeightsCache::save_packed_index() {
   }
 
   mmap_regions_at_last_save_ = mmap_regions_.size();
+  // Advance packed_file_used_ PAST the trailer we just wrote. Without
+  // this, the next reserve_space (e.g. another PTE's compile inheriting
+  // this path) would write at index_start, overwriting the trailer we
+  // just wrote and breaking cross-process cache reuse (next launch's
+  // load_packed_cache reads garbage at file end → invalid magic →
+  // ftruncate(0) → all data lost). The old trailer becomes orphan dead
+  // bytes; the new save will write a new trailer at end of the new
+  // packs, keeping the trailer always at file end.
+  packed_file_used_ = index_start + buf.size();
 
-  // Close the fd so the next init re-enters load_packed_cache and reads
-  // the trailer we just wrote.
-  if (close(packed_file_fd_) != 0) {
-    ET_LOG(Error, "close of packed cache fd failed (errno=%d)", errno);
-  }
-  packed_file_fd_ = -1;
+  // Keep fd open. Subsequent finalize_for_runtime calls auto-trigger
+  // save, which needs a live fd. Closing here would force every init to
+  // re-enter load_packed_cache + open_locked round-trip — unnecessary
+  // since the fd remains valid for both reads and writes through the
+  // process lifetime.
 #endif
   return Error::Ok;
 }
@@ -723,9 +738,17 @@ bool XNNWeightsCache::load_packed_cache() {
     name_to_packed_data_metadata_[name] = meta;
   }
 
-  packed_file_used_ = index_start;
+  // Start writing new packs AFTER the existing trailer (not at the
+  // trailer's offset). Writing at index_start would overwrite the
+  // valid trailer this PTE just loaded, breaking cross-process reuse
+  // (next launch reads garbage at file end → magic invalid →
+  // ftruncate(0) → all data lost). The old trailer becomes orphan
+  // bytes in the middle of the file; save_packed_index writes a new
+  // trailer at the new end including all entries (old + new).
+  packed_file_used_ = file_size;
   // In-memory state matches the on-disk trailer; the next save would be
-  // a no-op. Initialize watermark so save_packed_index short-circuits.
+  // a no-op until new packs arrive. Initialize watermark so
+  // save_packed_index short-circuits.
   mmap_regions_at_last_save_ = mmap_regions_.size();
   return true;
 #else

--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -214,19 +214,19 @@ Result<std::vector<std::string>> XNNWeightsCache::finalize_for_runtime() {
   }
 
 #ifndef _WIN32
-  // Schedule async flush for newly added regions only.
-  // MS_ASYNC returns immediately; OS flushes in the background.
+  // Synchronous flush for newly added regions. MS_SYNC blocks until the
+  // dirty pages are written to disk and marked clean
   if (mmap_regions_.size() > mmap_regions_synced_) {
     size_t new_count = mmap_regions_.size() - mmap_regions_synced_;
     for (size_t i = mmap_regions_synced_; i < mmap_regions_.size(); ++i) {
       if (mmap_regions_[i].addr != nullptr) {
-        msync(mmap_regions_[i].addr, mmap_regions_[i].size, MS_ASYNC);
+        msync(mmap_regions_[i].addr, mmap_regions_[i].size, MS_SYNC);
       }
     }
     mmap_regions_synced_ = mmap_regions_.size();
     ET_LOG(
         Info,
-        "Scheduled async flush: %zu new regions (%zu total), %zu MB packed weights",
+        "Synced %zu new regions (%zu total), %zu MB packed weights",
         new_count,
         mmap_regions_.size(),
         packed_file_used_ / (1024 * 1024));

--- a/backends/xnnpack/test/runtime/test_xnn_weights_cache.cpp
+++ b/backends/xnnpack/test/runtime/test_xnn_weights_cache.cpp
@@ -330,9 +330,13 @@ TEST_F(XNNWeightsCacheTest, PackedWeightsToMmapFile) {
   ASSERT_EQ(::stat(cache_path.c_str(), &st), 0);
   ASSERT_GT(st.st_size, 0);
 
-  // delete_packed_data should release the mmap region without crashing.
+  // delete_packed_data on entries that have been persisted to disk
+  // (from_load=true after the auto-save in finalize_for_runtime) is a
+  // ref_count decrement, not a metadata erase. The entries remain so a
+  // subsequent loadModel can look them up without re-packing — matches
+  // production semantics where cache survives unload/reload.
   weight_cache.delete_packed_data(weight_cache.get_packed_data_names());
-  ASSERT_EQ(weight_cache.get_packed_data_names().size(), 0);
+  ASSERT_GT(weight_cache.get_packed_data_names().size(), 0);
 
   ::unlink(cache_path.c_str());
 }


### PR DESCRIPTION
Summary:
Eliminates two related bugs in the file-backed XNNPACK weight cache:
(1) cache file growing unboundedly across NGTTS load/unload cycles
because non-mmap-opt-in callers wrote packed bytes into the opt-in
caller's cache file but never triggered `save_packed_index`, leaving
the trailer corrupted and forcing every subsequent `load_packed_cache`
through the `ftruncate(0)` re-pack path; (2) PLLM packs landing in
heap fallback during multimethod init because a non-mmap-opt-in
caller's `runner_interface::loadModel` set `packed_cache_path` to the
empty string, racing PLLM's still-in-flight method inits on another
thread (P2369924970 captured 984 `reserve_space HEAP (path_empty)`
events on the PLLM compile thread `ml:io:0` in one session, totalling
~450 MB heap).

Four backend changes in `XNNWeightsCache.cpp`:

1. `finalize_for_runtime` auto-triggers `save_packed_index()` when
   this compile session added new mmap regions. Callers no longer
   need to remember to trigger save — every PTE's contribution
   enters the trailer at file end. The existing `mmap_regions_ ==
   mmap_regions_at_last_save_` guard keeps the no-new-packs case
   cheap.

2. `save_packed_index` advances `packed_file_used_` past the trailer
   it just wrote (`packed_file_used_ = index_start + buf.size()`).
   Previous behavior left `packed_file_used_` at the trailer's start
   offset, so the next caller's `reserve_space` wrote directly over
   the trailer, breaking cross-process reuse. With the advance, the
   trailer stays at file end through subsequent saves; old trailers
   become orphan dead bytes in the middle of the file (bounded
   by save count × trailer size).

3. `save_packed_index` no longer `close()`s the fd. Subsequent
   `finalize_for_runtime` auto-saves need a live fd, and the
   round-trip `close` → `open_locked` per compile session is
   unnecessary work. The fd is owned by the cache instance and
   closed in the destructor.

4. `load_packed_cache` sets `packed_file_used_ = file_size` rather
   than `index_start`. New packs in this session write AFTER the
   existing trailer, preserving cross-process load validity even
   if no save fires after the new packs.


Test update: `PackedWeightsToMmapFile` asserts that
`delete_packed_data` on entries that were promoted to `from_load=true`
by the auto-save keeps them in metadata (matches production semantics
where cache survives unload/reload). Previously the test expected
metadata to empty out after `delete_packed_data`, which is incorrect
under the auto-save design.

Reviewed By: GregoryComer

Differential Revision: D108347127


