### PR TITLE
Add `exp` support using new Neutron flow

### DIFF
--- a/backends/nxp/backend/edge_program_converter.py
+++ b/backends/nxp/backend/edge_program_converter.py
@@ -39,6 +39,7 @@ functions_converters = {
     exir_ops.edge.dim_order_ops._clone_dim_order.default: CloneConverter,  # noqa F405
     exir_ops.edge.aten.constant_pad_nd.default: ConstantPadNDConverter,  # noqa F405
     exir_ops.edge.aten.convolution.default: ConvolutionConverter,  # noqa F405
+    exir_ops.edge.aten.exp.default: ExpConverter,  # noqa F405
     exir_ops.edge.aten.hardtanh.default: HardTanhConverter,  # noqa F405
     exir_ops.edge.aten.leaky_relu.default: LeakyReluConverter,  # noqa F405
     exir_ops.edge.aten.log.default: LogConverter,  # noqa F405

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/__init__.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/__init__.py
@@ -31,6 +31,9 @@ from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters
 from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.convolution_converter import (
     ConvolutionConverter,
 )
+from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.exp_converter import (
+    ExpConverter,
+)
 from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.getitem_converter import (
     GetItemConverter,
 )
@@ -111,6 +114,7 @@ __all__ = [
     "CloneConverter",
     "ConstantPadNDConverter",
     "ConvolutionConverter",
+    "ExpConverter",
     "GetItemConverter",
     "HardTanhConverter",
     "LeakyReluConverter",

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/exp_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/exp_converter.py
@@ -1,0 +1,59 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import torch
+from executorch.backends.nxp.backend.ir.converter.node_converter import (
+    CustomDelegationOptions,
+    NeutronTargetSpec,
+    NodeConverter,
+)
+from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.exp_options import (
+    Exp,
+)
+from torch.fx import Node
+from torch.nn import Parameter
+
+
+class ExpConverter(NodeConverter):
+
+    @staticmethod
+    def _is_supported_in_IR(
+        node: Node,
+        parameters_mapping: dict[str, Parameter],
+        custom_delegation_options: CustomDelegationOptions,
+    ) -> bool:
+        return True
+
+    @staticmethod
+    def _is_supported_on_target(
+        node: Node,
+        neutron_target_spec: NeutronTargetSpec,
+        parameters_mapping: dict[str, Parameter],
+        custom_delegation_options: CustomDelegationOptions,
+    ) -> bool:
+        # Requirements specified by the new Neutron flow documentation.
+        # Input and Output must be INT8/UINT8.
+        if not NodeConverter.uses_quantization_type_for_io(
+            node,
+            supported_types=[torch.int8, torch.uint8],
+            input_indices=[0],
+            output_indices=[0],
+        ):
+            return False
+        return True
+
+    def convert(self, node: Node):
+        """Convert the `aten.exp.default` operator to Neutron IR `Exp`.
+        The schema is:
+            aten::exp(
+                Tensor self
+            ) -> Tensor
+        """
+
+        self.assert_convertible(node)
+
+        t_op = self._create_tflite_op_with_io_tensors(node)
+        t_op.builtin_options = Exp()
+
+        self.builder.append_operators([t_op])

--- a/backends/nxp/neutron_partitioner.py
+++ b/backends/nxp/neutron_partitioner.py
@@ -212,6 +212,7 @@ supported_ops = {
     exir_ops.edge.dim_order_ops._clone_dim_order.default: CloneConverter,  # noqa F405
     exir_ops.edge.aten.constant_pad_nd.default: ConstantPadNDConverter,  # noqa F405
     exir_ops.edge.aten.convolution.default: ConvolutionConverter,  # noqa F405
+    exir_ops.edge.aten.exp.default: ExpConverter,  # noqa F405
     exir_ops.edge.aten.hardtanh.default: HardTanhConverter,  # noqa F405
     exir_ops.edge.aten.leaky_relu.default: LeakyReluConverter,  # noqa F405
     exir_ops.edge.aten.log.default: LogConverter,  # noqa F405

--- a/backends/nxp/quantizer/neutron_quantizer.py
+++ b/backends/nxp/quantizer/neutron_quantizer.py
@@ -25,6 +25,7 @@ from executorch.backends.nxp.quantizer.patterns import (
     Conv2dPattern,
     ConvTranspose2dPattern,
     DropoutPattern,
+    ExpPattern,
     FlattenPattern,
     HardTanhInPlacePattern,
     HardTanhPattern,
@@ -270,6 +271,7 @@ class NeutronQuantizer(ComposableQuantizer):
                     ConvTranspose2dPattern(self, is_qat=is_qat), static_qconfig
                 ),
                 OpQuantizer(DropoutPattern(is_qat=is_qat), static_qconfig),
+                OpQuantizer(ExpPattern(is_qat=is_qat), static_qconfig),
                 OpQuantizer(FlattenPattern(is_qat=is_qat), static_qconfig),
                 OpQuantizer(HardTanhPattern(is_qat=is_qat), static_qconfig),
                 OpQuantizer(HardTanhInPlacePattern(is_qat=is_qat), static_qconfig),

--- a/backends/nxp/quantizer/patterns.py
+++ b/backends/nxp/quantizer/patterns.py
@@ -709,6 +709,15 @@ class DropoutPattern(SharedSpecPattern):
         return [torch.ops.aten.dropout.default]
 
 
+class ExpPattern(SharedSpecPattern):
+    """
+    Quantizer for Exp operator.
+    """
+
+    def partition_types(self):
+        return [torch.ops.aten.exp.default]
+
+
 class FlattenPattern(SharedSpecPattern):
     """
     Quantizer for Flatten operator.

--- a/backends/nxp/tests/ir/converter/node_converter/test_exp_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_exp_converter.py
@@ -35,7 +35,7 @@ class ExpModule(torch.nn.Module):
 
 
 class TestExpNewNeutronFlow:
-    def test__basic_nsys_inference(self, mocker):
+    def test__basic_nsys_inference(self, mocker, request):
         input_shape = (256,)
         model = ExpModule()
         graph_verifier = DetailedGraphVerifier(
@@ -45,6 +45,7 @@ class TestExpNewNeutronFlow:
             model,
             input_shape,
             graph_verifier,
+            request,
             dataset_creator=LinearRampDatasetCreator(),
         )
 
@@ -56,7 +57,7 @@ class TestExpNewNeutronFlow:
             pytest.param((1, 3, 16, 16), id="4D"),
         ],
     )
-    def test__basic_nsys_inference__qat(self, mocker, input_shape, use_qat):
+    def test__basic_nsys_inference__qat(self, mocker, request, input_shape, use_qat):
         model = ExpModule()
         graph_verifier = DetailedGraphVerifier(
             mocker, expected_delegated_ops={Exp: 1}, expected_non_delegated_ops={}
@@ -65,6 +66,7 @@ class TestExpNewNeutronFlow:
             model,
             input_shape,
             graph_verifier,
+            request,
             dataset_creator=RandomDatasetCreator(low=-1.0, high=1.0),
             use_qat=use_qat,
         )

--- a/backends/nxp/tests/ir/converter/node_converter/test_exp_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_exp_converter.py
@@ -1,0 +1,70 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import numpy as np
+
+# noinspection PyUnusedImports
+import pytest
+import torch
+
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
+from executorch.backends.nxp.tests.ops_aliases import Exp
+from executorch.backends.nxp.tests.use_qat import *  # noqa F403
+from executorch.backends.nxp.tests.dataset_creator import (
+    LinearRampDatasetCreator,
+    RandomDatasetCreator,
+)
+
+
+@pytest.fixture(autouse=True)
+def reseed_model_per_test_run():
+    torch.manual_seed(42)
+    np.random.seed(23)
+
+
+class ExpModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return torch.exp(x)
+
+
+class TestExpNewNeutronFlow:
+    def test__basic_nsys_inference(self, mocker):
+        input_shape = (256,)
+        model = ExpModule()
+        graph_verifier = DetailedGraphVerifier(
+            mocker, expected_delegated_ops={Exp: 1}, expected_non_delegated_ops={}
+        )
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            dataset_creator=LinearRampDatasetCreator(),
+        )
+
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            pytest.param((17, 2), id="2D"),
+            pytest.param((1, 3, 10), id="3D"),
+            pytest.param((1, 3, 16, 16), id="4D"),
+        ],
+    )
+    def test__basic_nsys_inference__qat(self, mocker, input_shape, use_qat):
+        model = ExpModule()
+        graph_verifier = DetailedGraphVerifier(
+            mocker, expected_delegated_ops={Exp: 1}, expected_non_delegated_ops={}
+        )
+        lower_run_compare(
+            model,
+            input_shape,
+            graph_verifier,
+            dataset_creator=RandomDatasetCreator(low=-1.0, high=1.0),
+            use_qat=use_qat,
+        )

--- a/backends/nxp/tests/ops_aliases.py
+++ b/backends/nxp/tests/ops_aliases.py
@@ -26,6 +26,7 @@ Convolution = exir_ops.edge.aten.convolution.default
 DequantizePerChannel = exir_ops.edge.quantized_decomposed.dequantize_per_channel.default
 DequantizePerTensor = exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default
 ExecutorchDelegateCall = torch.ops.higher_order.executorch_call_delegate
+Exp = exir_ops.edge.aten.exp.default
 GetItem = operator.getitem
 HardTanh = exir_ops.edge.aten.hardtanh.default
 HardTanh_ = exir_ops.edge.aten.hardtanh_.default

--- a/docs/source/backends/nxp/op-support.csv
+++ b/docs/source/backends/nxp/op-support.csv
@@ -13,6 +13,7 @@ aten.constant_pad_nd.default,int8,static int8,"H or W padding only"
 aten.convolution.default,int8,static int8,"1D or 2D convolution, constant weights, groups=1 or groups=channels_count (depthwise)"
 aten.dim_order_ops._clone_dim_order.default,,, "See aten.clone.default"
 aten.div.Tensor,int8,static int8,"divisor - static tensor or scalar value, one dimension must satisfy %8 = 0 or scalar division (all dims = 1)"
+aten.exp.default,int8,static int8,
 aten.hardtanh.default,int8,static int8,"supported ranges: <0,6>, <-1, 1>, <0,1>, <0,inf>"
 aten.leaky_relu.default,int8,static int8,
 aten.log.default,int8,static int8,


### PR DESCRIPTION
### Summary
NXP backend: Enable aten.exp with new Neutron flow.

### Test plan
Tests provided.


cc @robert-kalmar @JakeStevens @digantdesai @rascani