### PR TITLE
Update executorch-ubuntu-26.04-gcc15 docker image to ubuntu-26.04-gcc14

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -89,10 +89,10 @@ case "${IMAGE_NAME}" in
     OS_VERSION=24.04
     GCC_VERSION=14
     ;;
-  executorch-ubuntu-26.04-gcc15)
+  executorch-ubuntu-26.04-gcc14)
     LINTRUNNER=""
     OS_VERSION=26.04
-    GCC_VERSION=15
+    GCC_VERSION=14
     ;;
   *)
     echo "Invalid image name ${IMAGE_NAME}"

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -43,7 +43,7 @@ jobs:
           executorch-ubuntu-22.04-mediatek-sdk,
           executorch-ubuntu-22.04-clang12-android,
           executorch-ubuntu-24.04-gcc14,
-          executorch-ubuntu-26.04-gcc15,
+          executorch-ubuntu-26.04-gcc14,
         ]
         include:
           - docker-image-name: executorch-ubuntu-22.04-gcc11-aarch64


### PR DESCRIPTION
### Summary

There are too many build failures with gcc15. Highlighted in https://github.com/pytorch/executorch/pull/19917


cc @larryliu0820 @GregoryComer @psiddh @AdrianLundell @digantdesai @rascani