### PR TITLE
examples/llm_server: add OpenAI-compatible LLM server

### DIFF
--- a/.github/workflows/_llm_server.yml
+++ b/.github/workflows/_llm_server.yml
@@ -1,0 +1,53 @@
+name: LLM Server Tests
+
+on:
+  workflow_call:
+    inputs:
+      docker-image:
+        description: Docker image to use for Linux tests.
+        required: false
+        type: string
+        default: ci-image:executorch-ubuntu-22.04-clang12
+
+jobs:
+  linux:
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      runner: linux.2xlarge
+      docker-image: ${{ inputs.docker-image }}
+      submodules: recursive
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 60
+      script: |
+        set -eux
+
+        eval "$(conda shell.bash hook)"
+        CONDA_ENV=$(conda env list --json | jq -r ".envs | .[-1]")
+        conda activate "${CONDA_ENV}"
+
+        python -m pip install --progress-bar off \
+          -r examples/llm_server/python/requirements.txt \
+          httpx \
+          pytest
+
+        export PYTHONPATH="$(dirname "${PWD}"):${PYTHONPATH:-}"
+        export PYTHONDONTWRITEBYTECODE=1
+
+        python -m pytest -q examples/llm_server/python/tests
+
+        cmake -S . -B cmake-out \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=cmake-out \
+          -DEXECUTORCH_BUILD_EXTENSION_LLM=ON \
+          -DEXECUTORCH_BUILD_EXTENSION_LLM_RUNNER=ON
+        cmake --build cmake-out --target install -j "$(nproc)"
+
+        cmake -S examples/llm_server/cpp -B cmake-out/examples/llm_server/cpp \
+          -DCMAKE_PREFIX_PATH="${PWD}/cmake-out"
+        cmake --build cmake-out/examples/llm_server/cpp \
+          --target test_worker_prefill_plan test_worker_loop \
+          -j "$(nproc)"
+        ctest --test-dir cmake-out/examples/llm_server/cpp --output-on-failure

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -1038,6 +1038,20 @@ jobs:
       build-tool: cmake
       docker-image: ci-image:executorch-ubuntu-22.04-clang12
 
+  llm-server:
+    needs: [changed-files, run-decision]
+    if: |
+      contains(needs.changed-files.outputs.changed-files, 'examples/llm_server') ||
+      contains(needs.changed-files.outputs.changed-files, 'extension/llm/runner') ||
+      contains(needs.changed-files.outputs.changed-files, 'extension/llm/tokenizers') ||
+      contains(needs.changed-files.outputs.changed-files, '.github/workflows/_llm_server.yml') ||
+      contains(needs.changed-files.outputs.changed-files, '.github/workflows/trunk.yml') ||
+      needs.run-decision.outputs.is-full-run == 'true'
+    uses: ./.github/workflows/_llm_server.yml
+    permissions:
+      id-token: write
+      contents: read
+
   test-models-windows:
     needs: run-decision
     if: |

--- a/examples/llm_server/README.md
+++ b/examples/llm_server/README.md
@@ -1,0 +1,99 @@
+# ExecuTorch LLM Server
+
+OpenAI-compatible serving for ExecuTorch LLMs, so any OpenAI-compatible agent
+harness (pi, opencode, ...) can use ExecuTorch as a local backend.
+
+```
+examples/llm_server/
+  spec/          # language-neutral OpenAI contract ExecuTorch targets
+  conformance/   # one test suite every language server must pass
+  python/        # Python server implementation (current)
+  # cpp/         # future: no-Python single-binary server
+```
+
+**Which entry point:** `examples.llm_server.python.server` is the reusable
+OpenAI control plane for workers that accept the generic `--model_path` /
+`--tokenizer_path` flags. Model-specific examples can wrap the same control
+plane when they need extra flags or a different tool parser.
+
+Why this layout: the OpenAI contract is identical across languages, so the
+**spec** and **conformance** suite are shared, and each language gets its own
+implementation directory. The real cross-language reuse comes from the C++
+`LLMEngine`/`LLMSession` primitives underneath, packaged as process-isolated
+**worker binaries** that any control plane drives over a small JSONL protocol.
+See `python/README.md` to run it.
+
+Status: experimental, reliability-first and deliberately narrow. Implemented:
+`/health`, `/v1/models`, `/v1/chat/completions` (streaming + non-streaming),
+Hugging Face chat templates (`--hf-tokenizer`), `temperature` / `max_tokens` /
+`max_completion_tokens` / `stop`, Hermes tool calling by default
+(`<tool_call>...</tool_call>` JSON, complete calls only; model-specific launchers
+may select the Qwen XML format) with `tool_choice="none"`,
+structured API errors, and best-effort cancellation. One worker process with
+serialized execution; a worker can host isolated sessions on one weight load when its engine reports
+capacity > 1 (with warm append-only resume across turns). KV/prefix state lives inside the
+worker/session, not the control plane. Unsupported params (including `top_p`,
+`seed`, `n>1`, `reasoning_effort`, penalties, `logit_bias`, `response_format`,
+`logprobs`, and `tool_choice="required"`) are rejected with a structured 400
+rather than silently ignored. See `python/README.md` to run it and
+`spec/README.md` for the exact contract.
+
+## Use from pi (or any OpenAI-compatible harness)
+
+Point pi at the server to use ExecuTorch as a local backend for tool-use
+workflows. Launch the server:
+
+```bash
+python -m executorch.examples.llm_server.python.server \
+  --worker-bin <model-worker> \
+  --model-path <model.pte> \
+  --tokenizer-path <tokenizer.model-or-json> \
+  --hf-tokenizer <hf-model-or-local-dir> \
+  --model-id <model-id> \
+  --host 127.0.0.1 \
+  --port 8000
+```
+
+Useful optional flags (full reference in `python/README.md`):
+
+- `--no-think` — default `enable_thinking=false` for templates that support it
+  (e.g. Qwen3-style).
+- `--max-context N` — reject over-long prompts cleanly; use the export-time
+  context length.
+- `--allow-chatml-fallback` — approximate ChatML when the model has no HF
+  `chat_template`; experimentation only, not recommended for reliable tool use.
+
+Point pi at the server via `~/.pi/agent/models.json`:
+
+```json
+{ "providers": { "executorch": {
+    "baseUrl": "http://127.0.0.1:8000/v1", "api": "openai-completions",
+    "apiKey": "x", "models": [ { "id": "<model-id>",
+      "compat": { "sendSessionAffinityHeaders": true } } ] } } }
+```
+
+Other OpenAI-compatible clients use their own schema — generically: base URL
+`http://127.0.0.1:8000/v1`, the model id you passed to `--model-id`, and a dummy
+API key if one is required.
+
+Supported contract for pi:
+
+- Endpoint `POST /v1/chat/completions`; streaming supported.
+- Tool calls: the model's Hermes-style `<tool_call>...</tool_call>` output is
+  parsed and returned as OpenAI `tool_calls`. This generic server uses Hermes by
+  default; a model-specific server may select the Qwen XML format.
+- `tool_choice`: only `"auto"`, `"none"`, or unset.
+- Rejected with a structured 400 (`unsupported_parameter`), not silently
+  ignored: `tool_choice="required"` or specific-function forcing,
+  `response_format` JSON/constrained output, `logprobs`, `top_p` other than
+  `1.0`, and `seed`.
+
+Reliability guidance:
+
+- Use the model's real HF `chat_template` (`--hf-tokenizer`) for tool use, kept
+  aligned with the exported tokenizer/model.
+- If tool calls come back as plain text, confirm the model is emitting the
+  configured tool-call format's markers (Hermes for the generic server) and that
+  `tools` were included in the request.
+- If a request fails with `unsupported_parameter`, remove or disable that
+  OpenAI knob in your pi/client config.

--- a/examples/llm_server/__init__.py
+++ b/examples/llm_server/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/llm_server/conformance/test_openai_contract.py
+++ b/examples/llm_server/conformance/test_openai_contract.py
@@ -1,0 +1,207 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Language-neutral OpenAI-contract conformance tests.
+
+Runs against any base URL (ExecuTorch, llama.cpp, mlx-lm, ...) so every server
+implementation is validated against one shared spec. Point it at a running
+server:
+
+    OPENAI_BASE_URL=http://127.0.0.1:8000/v1 pytest test_openai_contract.py
+
+Skips automatically if no server is reachable.
+"""
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+
+BASE_URL = os.environ.get("OPENAI_BASE_URL", "http://127.0.0.1:8000/v1").rstrip("/")
+MODEL = os.environ.get("OPENAI_MODEL", "executorch")
+
+
+def _post(path: str, body: dict, stream: bool = False):
+    req = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    return urllib.request.urlopen(req, timeout=120)
+
+
+def _server_up() -> bool:
+    try:
+        urllib.request.urlopen(f"{BASE_URL}/models", timeout=5)
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _server_up(), reason="no OpenAI server at OPENAI_BASE_URL"
+)
+
+
+def test_models_listing():
+    with urllib.request.urlopen(f"{BASE_URL}/models", timeout=10) as r:
+        data = json.loads(r.read())
+    assert data["object"] == "list"
+    assert any("id" in m for m in data["data"])
+
+
+def test_chat_completion_nonstreaming():
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Say hello in one word."}],
+        "max_tokens": 16,
+        "temperature": 0.0,
+    }
+    with _post("/chat/completions", body) as r:
+        data = json.loads(r.read())
+    assert data["object"] == "chat.completion"
+    assert data["choices"][0]["message"]["role"] == "assistant"
+    assert isinstance(data["choices"][0]["message"]["content"], str)
+    assert data["choices"][0]["finish_reason"] is not None
+
+
+def test_chat_completion_streaming():
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Count to three."}],
+        "max_tokens": 32,
+        "stream": True,
+    }
+    saw_role = saw_content = saw_done = False
+    with _post("/chat/completions", body, stream=True) as r:
+        for raw in r:
+            line = raw.decode().strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:") :].strip()
+            if payload == "[DONE]":
+                saw_done = True
+                break
+            chunk = json.loads(payload)
+            assert chunk["object"] == "chat.completion.chunk"
+            delta = chunk["choices"][0]["delta"]
+            saw_role = saw_role or delta.get("role") == "assistant"
+            saw_content = saw_content or bool(delta.get("content"))
+    assert saw_role and saw_content and saw_done
+
+
+def test_multibyte_streaming_integrity():
+    # Byte-level BPE can split a multi-byte character across tokens; the stream
+    # must reassemble it, not abort with a UTF-8 decode error.
+    body = {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "Reply with exactly: 你好世界 🌍 café"}
+        ],
+        "max_tokens": 32,
+        "temperature": 0.0,
+        "stream": True,
+    }
+    content, saw_done, saw_error = "", False, False
+    with _post("/chat/completions", body, stream=True) as r:
+        for raw in r:
+            line = raw.decode().strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:") :].strip()
+            if payload == "[DONE]":
+                saw_done = True
+                break
+            chunk = json.loads(payload)
+            if "error" in chunk:
+                saw_error = True
+            content += (
+                chunk["choices"][0]["delta"].get("content", "")
+                if chunk.get("choices")
+                else ""
+            )
+    assert saw_done and not saw_error
+    assert isinstance(content, str) and content  # reassembled, valid UTF-8
+
+
+def test_usage_chunk_in_stream():
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "Say hi."}],
+        "max_tokens": 16,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    usage = None
+    with _post("/chat/completions", body, stream=True) as r:
+        for raw in r:
+            line = raw.decode().strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:") :].strip()
+            if payload == "[DONE]":
+                break
+            chunk = json.loads(payload)
+            if chunk.get("usage"):
+                usage = chunk["usage"]
+    assert usage is not None, "no usage chunk emitted with include_usage"
+    assert usage["prompt_tokens"] > 0 and usage["completion_tokens"] > 0
+    assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
+
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+
+def test_tool_call_response_shape():
+    body = {
+        "model": MODEL,
+        "messages": [
+            {"role": "user", "content": "What is the weather in Paris? Use the tool."}
+        ],
+        "tools": [WEATHER_TOOL],
+        "max_tokens": 128,
+        "temperature": 0.0,
+    }
+    with _post("/chat/completions", body) as r:
+        data = json.loads(r.read())
+    calls = data["choices"][0]["message"].get("tool_calls")
+    assert calls, "expected tool_calls in response"
+    tc = calls[0]
+    assert tc["type"] == "function"
+    assert tc["id"]
+    assert tc["function"]["name"] == "get_weather"
+    json.loads(tc["function"]["arguments"])  # arguments is a JSON string
+    assert data["choices"][0]["finish_reason"] == "tool_calls"
+
+
+def test_error_body_shape():
+    # Over-long prompt -> structured 400 (OpenAI error envelope), not a 500/drop.
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": "word " * 40000}],
+        "max_tokens": 8,
+    }
+    try:
+        _post("/chat/completions", body)
+        raise AssertionError("expected an HTTP error for over-long prompt")
+    except urllib.error.HTTPError as e:
+        assert 400 <= e.code < 500
+        err = json.loads(e.read())["error"]
+        assert err["message"] and err["type"]

--- a/examples/llm_server/cpp/CMakeLists.txt
+++ b/examples/llm_server/cpp/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Shared worker-loop tests for the example LLM server. Model-specific workers
+# live under examples/models/* and include worker_loop.h.
+
+cmake_minimum_required(VERSION 3.24)
+project(llm_server_workers)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
+
+set(_common_include_directories ${EXECUTORCH_ROOT}/..)
+# Vendored single-include nlohmann/json for the worker protocol (no new dep).
+set(_json_include
+    ${EXECUTORCH_ROOT}/extension/llm/tokenizers/third-party/json/single_include
+)
+
+# executorch
+list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
+find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
+executorch_target_link_options_shared_lib(executorch)
+
+set(test_link_libraries executorch extension_llm_session tokenizers::tokenizers)
+
+# Pure unit test for the warm-resume prefill planner (worker_prefill_plan.h). No
+# ET/model/tokenizer dependency, so it builds and runs standalone via ctest.
+enable_testing()
+add_executable(test_worker_prefill_plan test_worker_prefill_plan.cpp)
+target_include_directories(
+  test_worker_prefill_plan PUBLIC ${_common_include_directories}
+)
+add_test(NAME worker_prefill_plan COMMAND test_worker_prefill_plan)
+
+# Worker-loop harness (worker_handle_request + WorkerSessions) driven by a
+# scriptable fake LLMSession/Tokenizer/LLMEngine -- no model/GPU. It includes
+# the full worker_loop.h, so it needs the JSON include + the runtime/tokenizer
+# libs.
+add_executable(test_worker_loop test_worker_loop.cpp)
+target_include_directories(
+  test_worker_loop PUBLIC ${_common_include_directories} ${_json_include}
+)
+target_link_libraries(test_worker_loop PUBLIC ${test_link_libraries})
+add_test(NAME worker_loop COMMAND test_worker_loop)

--- a/examples/llm_server/cpp/test_worker_loop.cpp
+++ b/examples/llm_server/cpp/test_worker_loop.cpp
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Hermetic tests for worker_loop.h (worker_handle_request + WorkerSessions),
+// the highest-risk serving logic. A scriptable fake LLMSession / Tokenizer /
+// LLMEngine drives the real loop with NO model, tokenizer, or GPU. worker_emit
+// writes to std::cout, so each test captures stdout and parses the JSON events.
+// Self-contained assertions (no gtest) to match test_worker_prefill_plan.
+
+#include <executorch/examples/llm_server/cpp/worker_loop.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using executorch::extension::llm::DecodeResult;
+using executorch::extension::llm::LLMEngine;
+using executorch::extension::llm::LLMServingCapacity;
+using executorch::extension::llm::LLMSession;
+using executorch::extension::llm::SamplingConfig;
+using executorch::extension::llm::worker_handle_request;
+using executorch::extension::llm::WorkerSessions;
+using executorch::extension::llm::WorkerSessionState;
+using ETError = ::executorch::runtime::Error;
+template <typename T>
+using ETResult = ::executorch::runtime::Result<T>;
+
+namespace {
+int g_failures = 0;
+
+void check(const char* name, bool ok) {
+  printf("  [%s] %s\n", ok ? "PASS" : "FAIL", name);
+  if (!ok) {
+    ++g_failures;
+  }
+}
+
+// ---- Fake LLMSession: scriptable decode stream + injectable failures --------
+class FakeSession : public LLMSession {
+ public:
+  struct Step {
+    uint64_t id;
+    std::string piece;
+    bool is_eos;
+    bool is_terminal;
+  };
+  std::vector<Step> steps;
+  size_t step_i = 0;
+  int64_t pos = 0; // models the session's KV position
+
+  int prefill_calls = 0;
+  std::vector<size_t> prefill_sizes; // size of each prefill_tokens() call
+  std::vector<std::vector<uint64_t>> prefill_batches;
+  int fail_prefill_on = -1; // 0-based call index to fail (-1 = never)
+  int decode_calls = 0;
+  int fail_decode_on = -1;
+  int reset_calls = 0;
+  bool fail_reset = false;
+
+  ETError prefill_tokens(
+      const std::vector<uint64_t>& tokens,
+      const SamplingConfig* /*initial_sampling*/ = nullptr) override {
+    prefill_sizes.push_back(tokens.size());
+    prefill_batches.push_back(tokens);
+    if (prefill_calls++ == fail_prefill_on) {
+      return ETError::Internal; // failed AFTER (notionally) mutating state
+    }
+    pos += static_cast<int64_t>(tokens.size());
+    return ETError::Ok;
+  }
+
+  ETResult<DecodeResult> decode_one(const SamplingConfig& /*s*/) override {
+    if (decode_calls++ == fail_decode_on) {
+      return ETError::Internal;
+    }
+    if (step_i >= steps.size()) {
+      return DecodeResult{0, "", true, true}; // default: EOS/terminal
+    }
+    const Step s = steps[step_i++];
+    if (!s.is_terminal) {
+      pos += 1; // a forwarded token advances the cache position
+    }
+    return DecodeResult{s.id, s.piece, s.is_eos, s.is_terminal};
+  }
+
+  int64_t position() const override {
+    return pos;
+  }
+  ETError reset() override {
+    ++reset_calls;
+    if (fail_reset) {
+      return ETError::Internal;
+    }
+    pos = 0;
+    step_i = 0;
+    return ETError::Ok;
+  }
+  void stop() override {}
+};
+
+// ---- Fake Tokenizer: only needed to satisfy the signature; tests use {ids}
+// segments so encode() is not exercised on the hot paths. -------------------
+class FakeTokenizer : public ::tokenizers::Tokenizer {
+ public:
+  ::tokenizers::Error load(const std::string&) override {
+    initialized_ = true;
+    return ::tokenizers::Error::Ok;
+  }
+  ::tokenizers::Result<std::vector<uint64_t>> encode(
+      const std::string& input,
+      int8_t /*bos*/ = 0,
+      int8_t /*eos*/ = 0) const override {
+    std::vector<uint64_t>
+        out; // 1 id per byte (deterministic; unused by ids tests)
+    out.reserve(input.size());
+    std::transform(
+        input.begin(),
+        input.end(),
+        std::back_inserter(out),
+        [](unsigned char c) { return static_cast<uint64_t>(c); });
+    return out;
+  }
+  ::tokenizers::Result<std::string> decode(
+      uint64_t /*prev*/,
+      uint64_t /*token*/,
+      bool /*skip_special_tokens*/ = false) const override {
+    return std::string("");
+  }
+  ::tokenizers::Result<std::string> id_to_piece(uint64_t /*t*/) const override {
+    return std::string("");
+  }
+  ::tokenizers::Result<uint64_t> piece_to_id(
+      const std::string& /*t*/) const override {
+    return static_cast<uint64_t>(0);
+  }
+  bool is_loaded() const override {
+    return true;
+  }
+};
+
+class FakeEngine : public LLMEngine {
+ public:
+  int32_t capacity = 4;
+  ETResult<std::unique_ptr<LLMSession>> create_session() override {
+    return std::unique_ptr<LLMSession>(new FakeSession());
+  }
+  LLMServingCapacity serving_capacity() const override {
+    return LLMServingCapacity{capacity, 0};
+  }
+  const std::unordered_map<std::string, int64_t>& metadata() const override {
+    return md_;
+  }
+
+ private:
+  std::unordered_map<std::string, int64_t> md_;
+};
+
+// ---- stdout-capturing driver ------------------------------------------------
+struct Emitted {
+  std::string text; // concatenated {"token": ...} pieces
+  nlohmann::json done; // the {"done": true, ...} event
+  int token_events = 0;
+  bool threw = false;
+};
+
+Emitted run(
+    WorkerSessionState& st,
+    bool warm,
+    const nlohmann::json& req,
+    const std::unordered_map<std::string, int64_t>& md = {},
+    const std::vector<uint64_t>& prefix = {}) {
+  static FakeTokenizer tok;
+  std::ostringstream cap;
+  std::streambuf* old = std::cout.rdbuf(cap.rdbuf());
+  Emitted em;
+  try {
+    worker_handle_request(st, warm, tok, md, req, prefix);
+  } catch (const std::exception&) {
+    em.threw = true;
+  }
+  std::cout.rdbuf(old);
+  std::istringstream iss(cap.str());
+  std::string line;
+  while (std::getline(iss, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    auto j = nlohmann::json::parse(line);
+    if (j.contains("token")) {
+      em.text += j["token"].get<std::string>();
+      ++em.token_events;
+    }
+    if (j.contains("done")) {
+      em.done = j;
+    }
+  }
+  return em;
+}
+
+WorkerSessionState makeState() {
+  WorkerSessionState st;
+  st.session.reset(new FakeSession());
+  return st;
+}
+FakeSession& fake(WorkerSessionState& st) {
+  return *static_cast<FakeSession*>(st.session.get());
+}
+nlohmann::json idsReq(std::vector<uint64_t> ids, int64_t max_new = 8) {
+  return {{"max_new_tokens", max_new}, {"prompt_segments", {{{"ids", ids}}}}};
+}
+
+void test_new_full_prefill() {
+  auto st = makeState();
+  fake(st).steps = {{10, "a", false, false}, {0, "", true, true}};
+  auto em = run(st, /*warm=*/true, idsReq({1, 2, 3}));
+  check("new: reason=new", em.done["session_reset_reason"] == "new");
+  check("new: reset called once", fake(st).reset_calls == 1);
+  check(
+      "new: full prefill (3)",
+      fake(st).prefill_sizes == std::vector<size_t>{3});
+  check(
+      "new: reused=0 prefilled=3",
+      em.done["reused_prompt_tokens"] == 0 &&
+          em.done["prefilled_prompt_tokens"] == 3);
+  check(
+      "new: resident.size()==position()",
+      st.resident_token_ids.size() == (size_t)st.session->position());
+}
+
+void test_exact_prefix_warm_suffix() {
+  auto st = makeState();
+  // First turn establishes resident [1,2].
+  fake(st).steps = {{0, "", true, true}};
+  run(st, true, idsReq({1, 2}));
+  size_t resets_after_first = fake(st).reset_calls;
+  fake(st).steps = {{0, "", true, true}};
+  fake(st).prefill_sizes.clear();
+  // Second turn extends to [1,2,3] -> warm suffix prefill of just [3].
+  auto em = run(st, true, idsReq({1, 2, 3}));
+  check(
+      "warm: reason=exact_prefix",
+      em.done["session_reset_reason"] == "exact_prefix");
+  check(
+      "warm: prefill suffix only ([3])",
+      fake(st).prefill_sizes == std::vector<size_t>{1});
+  check(
+      "warm: reused=2 prefilled=1",
+      em.done["reused_prompt_tokens"] == 2 &&
+          em.done["prefilled_prompt_tokens"] == 1);
+  check("warm: no extra reset", fake(st).reset_calls == resets_after_first);
+  check(
+      "warm: resident.size()==position()",
+      st.resident_token_ids.size() == (size_t)st.session->position());
+}
+
+void test_mismatch_full_reset() {
+  auto st = makeState();
+  fake(st).steps = {{0, "", true, true}};
+  run(st, true, idsReq({1, 2}));
+  fake(st).steps = {{0, "", true, true}};
+  fake(st).prefill_sizes.clear();
+  auto em = run(st, true, idsReq({1, 9})); // divergent token
+  check(
+      "mismatch: reason=mismatch",
+      em.done["session_reset_reason"] == "mismatch");
+  check(
+      "mismatch: full prefill (2)",
+      fake(st).prefill_sizes == std::vector<size_t>{2});
+}
+
+void test_equal_prompt_no_empty_prefill() {
+  auto st = makeState();
+  fake(st).steps = {{0, "", true, true}};
+  run(st, true, idsReq({1, 2, 3}));
+  fake(st).steps = {{0, "", true, true}};
+  fake(st).prefill_sizes.clear();
+  auto em = run(st, true, idsReq({1, 2, 3})); // identical prompt
+  check("equal: reason=equal", em.done["session_reset_reason"] == "equal");
+  bool any_empty = false;
+  for (size_t s : fake(st).prefill_sizes) {
+    any_empty = any_empty || (s == 0);
+  }
+  check("equal: prefill_tokens never called with []", !any_empty);
+  check(
+      "equal: full reprefill (3)",
+      fake(st).prefill_sizes == std::vector<size_t>{3});
+}
+
+void test_anonymous_never_warm() {
+  auto st = makeState();
+  fake(st).steps = {{0, "", true, true}};
+  run(st, /*warm=*/false, idsReq({1, 2}));
+  fake(st).steps = {{0, "", true, true}};
+  fake(st).prefill_sizes.clear();
+  // Even though resident now matches a prefix, warm=false forces a full reset.
+  auto em = run(st, /*warm=*/false, idsReq({1, 2, 3}));
+  check(
+      "scratch: reason=new (warm disabled)",
+      em.done["session_reset_reason"] == "new");
+  check(
+      "scratch: full prefill (3)",
+      fake(st).prefill_sizes == std::vector<size_t>{3});
+}
+
+void test_generated_token_ids_excludes_terminal() {
+  auto st = makeState();
+  fake(st).steps = {
+      {10, "a", false, false}, {11, "b", false, false}, {0, "", true, true}};
+  auto em = run(st, true, idsReq({1, 2}));
+  check("genids: text=ab", em.text == "ab");
+  check("genids: completion_tokens=2", em.done["completion_tokens"] == 2);
+  std::vector<uint64_t> ids =
+      em.done["generated_token_ids"].get<std::vector<uint64_t>>();
+  check(
+      "genids: ==[10,11] (terminal EOS excluded)",
+      ids == std::vector<uint64_t>{10, 11});
+  check("genids: finish=stop (EOS)", em.done["finish_reason"] == "stop");
+  check(
+      "genids: resident.size()==position()",
+      st.resident_token_ids.size() == (size_t)st.session->position());
+}
+
+void test_prompt_prefix_ids_prepend_text_prompt_once() {
+  auto st = makeState();
+  fake(st).steps = {{0, "", true, true}};
+  auto em =
+      run(st,
+          /*warm=*/true,
+          {{"max_new_tokens", 1}, {"prompt", "ab"}},
+          {},
+          {2});
+  check("prefix: prompt_tokens includes prefix", em.done["prompt_tokens"] == 3);
+  check(
+      "prefix: prefilled ids == [2,'a','b']",
+      fake(st).prefill_batches ==
+          std::vector<std::vector<uint64_t>>{
+              {2, static_cast<uint64_t>('a'), static_cast<uint64_t>('b')}});
+}
+
+void test_stop_string_marks_dirty_and_omits_ids() {
+  auto st = makeState();
+  fake(st).steps = {
+      {10, "a", false, false},
+      {11, "b", false, false},
+      {12, "X", false, false}};
+  nlohmann::json req = idsReq({1, 2});
+  req["stop"] = {"X"};
+  auto em = run(st, true, req);
+  check("stop: text=ab (stop trimmed)", em.text == "ab");
+  check("stop: finish=stop", em.done["finish_reason"] == "stop");
+  check(
+      "stop: no generated_token_ids", !em.done.contains("generated_token_ids"));
+  check("stop: session marked dirty", st.dirty);
+}
+
+void test_prefill_failure_marks_dirty() {
+  auto st = makeState();
+  fake(st).fail_prefill_on = 0;
+  auto em = run(st, true, idsReq({1, 2, 3}));
+  check("prefill-fail: threw", em.threw);
+  check("prefill-fail: dirty", st.dirty);
+}
+
+void test_decode_failure_marks_dirty() {
+  auto st = makeState();
+  fake(st).fail_decode_on = 0;
+  auto em = run(st, true, idsReq({1, 2, 3}));
+  check("decode-fail: threw", em.threw);
+  check("decode-fail: dirty", st.dirty);
+}
+
+void test_utf8_split_across_pieces_emits_once_intact() {
+  auto st = makeState();
+  // "é" = 0xC3 0xA9, split across two decode pieces; must emit once, intact.
+  fake(st).steps = {
+      {10, std::string("\xC3"), false, false},
+      {11, std::string("\xA9"), false, false},
+      {0, "", true, true}};
+  auto em = run(st, true, idsReq({1}));
+  check(
+      "utf8: emitted bytes == C3 A9 intact",
+      em.text == std::string("\xC3\xA9"));
+  check("utf8: not emitted as a partial first byte", em.token_events == 1);
+}
+
+void test_stop_straddles_pieces() {
+  auto st = makeState();
+  // stop "ab" arrives across two pieces "a","b": nothing should be emitted.
+  fake(st).steps = {
+      {10, "a", false, false},
+      {11, "b", false, false},
+      {12, "c", false, false}};
+  nlohmann::json req = idsReq({1});
+  req["stop"] = {"ab"};
+  auto em = run(st, true, req);
+  check("stop-straddle: nothing emitted", em.text.empty());
+  check("stop-straddle: finish=stop", em.done["finish_reason"] == "stop");
+  check("stop-straddle: dirty", st.dirty);
+}
+
+void test_reset_named_only_clears_on_success() {
+  FakeEngine engine;
+  WorkerSessions sessions(engine);
+  std::string code;
+  WorkerSessionState* st = sessions.open_named("s", code);
+  check("reset_named: session opened", st != nullptr);
+  if (st == nullptr) {
+    return;
+  }
+  st->resident_token_ids = {1, 2, 3};
+  auto& s = *static_cast<FakeSession*>(st->session.get());
+
+  // Failed reset: must report error AND leave resident state intact (lockstep).
+  s.fail_reset = true;
+  ETError err = sessions.reset_named("s");
+  check("reset_named: failed reset reports error", err != ETError::Ok);
+  check(
+      "reset_named: resident intact after failed reset",
+      st->resident_token_ids.size() == 3);
+
+  // Successful reset: clears resident state.
+  s.fail_reset = false;
+  err = sessions.reset_named("s");
+  check("reset_named: success reports Ok", err == ETError::Ok);
+  check(
+      "reset_named: resident cleared after success",
+      st->resident_token_ids.empty());
+
+  // Absent session is an idempotent no-op (Ok).
+  check(
+      "reset_named: absent id is Ok",
+      sessions.reset_named("nope") == ETError::Ok);
+}
+
+} // namespace
+
+int main() {
+  printf("worker_loop.h harness:\n");
+  test_new_full_prefill();
+  test_exact_prefix_warm_suffix();
+  test_mismatch_full_reset();
+  test_equal_prompt_no_empty_prefill();
+  test_anonymous_never_warm();
+  test_generated_token_ids_excludes_terminal();
+  test_prompt_prefix_ids_prepend_text_prompt_once();
+  test_stop_string_marks_dirty_and_omits_ids();
+  test_prefill_failure_marks_dirty();
+  test_decode_failure_marks_dirty();
+  test_utf8_split_across_pieces_emits_once_intact();
+  test_stop_straddles_pieces();
+  test_reset_named_only_clears_on_success();
+  printf(
+      "\n%s (%d failure(s))\n",
+      g_failures ? "FAILURES" : "ALL PASS",
+      g_failures);
+  return g_failures ? 1 : 0;
+}

--- a/examples/llm_server/cpp/test_worker_prefill_plan.cpp
+++ b/examples/llm_server/cpp/test_worker_prefill_plan.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Unit tests for plan_prefill() (warm-resume decision). No model/session/ET
+// runtime dependency -- the header is pure, so this compiles and runs
+// standalone. Self-contained assertions (no gtest) so it has no build deps.
+
+#include <executorch/examples/llm_server/cpp/worker_prefill_plan.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using executorch::extension::llm::plan_prefill;
+using executorch::extension::llm::PrefillPlan;
+
+namespace {
+int g_failures = 0;
+
+void expect(
+    const char* name,
+    const PrefillPlan& p,
+    PrefillPlan::Action action,
+    size_t suffix_start,
+    const char* reason) {
+  bool ok = p.action == action && p.suffix_start == suffix_start &&
+      std::strcmp(p.reason, reason) == 0;
+  if (!ok) {
+    ++g_failures;
+    printf(
+        "  [FAIL] %s: got action=%d suffix_start=%zu reason=%s\n",
+        name,
+        (int)p.action,
+        p.suffix_start,
+        p.reason);
+  } else {
+    printf("  [PASS] %s\n", name);
+  }
+}
+} // namespace
+
+int main() {
+  using V = std::vector<uint64_t>;
+
+  // First request: nothing resident -> full prefill, "new".
+  expect(
+      "new (resident empty)",
+      plan_prefill(V{}, V{1, 2, 3}, false),
+      PrefillPlan::kFull,
+      0,
+      "new");
+
+  // Exact token extension -> prefill only the suffix.
+  expect(
+      "exact_prefix (suffix reuse)",
+      plan_prefill(V{1, 2, 3}, V{1, 2, 3, 4, 5}, false),
+      PrefillPlan::kSuffix,
+      3,
+      "exact_prefix");
+
+  // Single-token extension still reuses.
+  expect(
+      "exact_prefix (one-token suffix)",
+      plan_prefill(V{1, 2, 3}, V{1, 2, 3, 4}, false),
+      PrefillPlan::kSuffix,
+      3,
+      "exact_prefix");
+
+  // Divergent token -> mismatch, full reset.
+  expect(
+      "mismatch (divergent token)",
+      plan_prefill(V{1, 2, 3}, V{1, 2, 9, 4}, false),
+      PrefillPlan::kFull,
+      0,
+      "mismatch");
+
+  // Prompt shorter than resident (rewind) -> mismatch, full reset.
+  expect(
+      "mismatch (prompt shorter)",
+      plan_prefill(V{1, 2, 3}, V{1, 2}, false),
+      PrefillPlan::kFull,
+      0,
+      "mismatch");
+
+  // Dirty wins even over an otherwise-exact extension.
+  expect(
+      "dirty (overrides exact prefix)",
+      plan_prefill(V{1, 2, 3}, V{1, 2, 3, 4}, true),
+      PrefillPlan::kFull,
+      0,
+      "dirty");
+
+  // Prompt identical to resident -> reset + full (no empty-suffix prefill).
+  expect(
+      "equal (prompt == resident)",
+      plan_prefill(V{1, 2, 3}, V{1, 2, 3}, false),
+      PrefillPlan::kFull,
+      0,
+      "equal");
+
+  // Dirty + empty resident still resets as dirty (dirty checked first).
+  expect(
+      "dirty (empty resident)",
+      plan_prefill(V{}, V{1, 2}, true),
+      PrefillPlan::kFull,
+      0,
+      "dirty");
+
+  printf(
+      "\n%s (%d failure(s))\n",
+      g_failures == 0 ? "ALL PASS" : "FAILED",
+      g_failures);
+  return g_failures == 0 ? 0 : 1;
+}

--- a/examples/llm_server/cpp/worker_loop.h
+++ b/examples/llm_server/cpp/worker_loop.h
@@ -1,0 +1,485 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Shared model-worker generation loop + JSONL protocol for every model worker
+// (for example, model-specific workers like qwen3_5_moe_worker): a worker
+// constructs its engine + tokenizer and calls
+// run_worker_stdio_loop(); the protocol, session routing, and decode loop live
+// here once.
+//
+// The worker owns one LLMEngine (weights loaded once) and serves multiple
+// isolated LLMSessions keyed by session_id, up to the engine's serving
+// capacity; anonymous requests (no session_id) share one scratch session that
+// is reset every request. Execution is synchronous: one in-flight request at a
+// time.
+//
+// Warm resume: a named session keeps its decoded context across requests. The
+// new prompt's token ids are matched against the session's resident token ids;
+// on an exact prefix only the suffix is prefilled (continuing at pos>0). The
+// match is exact-token (never retokenized text) and falls back to a full
+// reset+prefill whenever exact reuse can't be proven, so it is always correct.
+// See plan_prefill().
+//
+// Protocol (one JSON object per line; matches worker_client.py). stdout carries
+// ONLY protocol JSON; logs go to stderr (ET_LOG):
+//   worker -> stdout, once:    {"ready": true, "max_sessions": int,
+//                               "max_named_sessions": int}
+//   client -> stdin:
+//     generate: {"max_new_tokens": int, "temperature": float, "stop":
+//     [str,...],
+//                "session_id"?: str, and exactly one prompt form:
+//                  "prompt": str
+//                  "prompt_segments": [{"text": str} | {"ids": [int,...]}]}
+//     open/close/reset: {"op": "open"|"close"|"reset", "session_id": str}
+//   worker -> stdout:
+//     generate: {"token": str} *  (streamed), then
+//               {"done": true, "prompt_tokens": int, "completion_tokens": int,
+//                "finish_reason": "stop"|"length",
+//                "reused_prompt_tokens": int, "prefilled_prompt_tokens": int,
+//                "session_reset_reason": str
+//                (new|exact_prefix|mismatch|dirty|equal),
+//                "generated_token_ids"?: [int,...]}  // omitted if stop-trimmed
+//     open/close/reset: {"opened"|"closed"|"reset": true, "session_id": str}
+//     error:    {"error": str, "code"?: str}  // capacity_exhausted |
+//                                              // unsupported_session
+
+#include <nlohmann/json.hpp>
+
+#include <executorch/examples/llm_server/cpp/worker_prefill_plan.h>
+#include <executorch/extension/llm/runner/constants.h>
+#include <executorch/extension/llm/runner/llm_session.h>
+#include <executorch/extension/llm/runner/util.h>
+#include <pytorch/tokenizers/tokenizer.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace executorch {
+namespace extension {
+namespace llm {
+
+// Emit one protocol object as a JSON line on stdout. error_handler::replace
+// keeps a stray invalid UTF-8 byte (byte-level BPE) from aborting
+// serialization.
+inline void worker_emit(const nlohmann::json& obj) {
+  std::cout << obj.dump(
+                   -1, ' ', false, nlohmann::json::error_handler_t::replace)
+            << "\n";
+  std::cout.flush();
+}
+
+// A named session plus the warm-resume bookkeeping the worker maintains for it.
+// Invariant (while not mid-mutation): resident_token_ids.size() ==
+// session->position() -- the resident ids are exactly the tokens currently in
+// the session's KV/recurrent state, in order.
+struct WorkerSessionState {
+  std::unique_ptr<LLMSession> session;
+  std::vector<uint64_t> resident_token_ids;
+  // Set when the resident state can no longer be trusted as an exact token
+  // prefix (e.g. a stop-string trimmed the emitted text mid-token, or a
+  // prefill/decode failed after mutating state). Forces a reset next request.
+  bool dirty = false;
+};
+
+// One generation request against a session. Encodes the prompt, chooses a
+// prefill plan (warm suffix reuse for named sessions, or a full reset+prefill),
+// then streams complete-UTF-8 text pieces from decode_one(). A terminal step
+// (EOS or cooperative stop) ends generation and is not emitted or counted.
+// Maintains st.resident_token_ids / st.dirty. Throws std::runtime_error on
+// failure; the caller reports it as {"error": ...}.
+inline void worker_handle_request(
+    WorkerSessionState& st,
+    bool warm,
+    ::tokenizers::Tokenizer& tokenizer,
+    const std::unordered_map<std::string, int64_t>& metadata,
+    const nlohmann::json& req,
+    const std::vector<uint64_t>& prompt_prefix_ids = {}) {
+  LLMSession& session = *st.session;
+  int64_t max_new = req.value("max_new_tokens", static_cast<int64_t>(-1));
+  const float temperature = req.value("temperature", 0.0f);
+  // Stop strings (the request's `stop` sequences): terminate at the token
+  // boundary where one appears so we don't generate to EOS/max_new past it. The
+  // control plane also enforces these as a backstop.
+  const std::vector<std::string> stops =
+      req.value("stop", std::vector<std::string>{});
+
+  // The prompt is either a single rendered string ("prompt") or an ordered list
+  // of segments ("prompt_segments"), each a {"text": ...} chunk to tokenize or
+  // a
+  // {"ids": [...]} run of literal token ids. Segments let the control plane
+  // splice the exact generated token ids of prior assistant turns back in,
+  // instead of re-tokenizing the chat template's lossy re-rendering of them (so
+  // warm resume can hit on tool-use turns). Text is encoded with no special
+  // tokens (already rendered), matching the runner's own encode path.
+  const bool has_prompt = req.contains("prompt");
+  const bool has_segments = req.contains("prompt_segments");
+  if (has_prompt == has_segments) {
+    throw std::runtime_error(
+        "exactly one of prompt / prompt_segments is required");
+  }
+  std::vector<uint64_t> ids = prompt_prefix_ids;
+  auto encode_text = [&](const std::string& text) {
+    auto enc = tokenizer.encode(text, /*bos=*/0, /*eos=*/0);
+    if (!enc.ok()) {
+      throw std::runtime_error("prompt encode failed");
+    }
+    ids.insert(ids.end(), enc->begin(), enc->end());
+  };
+  if (has_segments) {
+    for (const auto& seg : req.at("prompt_segments")) {
+      if (seg.contains("ids")) {
+        const auto& raw_ids = seg.at("ids");
+        std::transform(
+            raw_ids.begin(),
+            raw_ids.end(),
+            std::back_inserter(ids),
+            [](const auto& id) { return id.template get<uint64_t>(); });
+      } else if (seg.contains("text")) {
+        encode_text(seg.at("text").get<std::string>());
+      } else {
+        throw std::runtime_error("prompt_segment needs `text` or `ids`");
+      }
+    }
+  } else {
+    encode_text(req.at("prompt").get<std::string>());
+  }
+  if (ids.empty()) {
+    throw std::runtime_error("empty prompt");
+  }
+  const int64_t num_prompt = static_cast<int64_t>(ids.size());
+
+  // Bound generation to the context window: default to filling the remaining
+  // room, and clamp an explicit max_new_tokens too, so decode never steps past
+  // the window (which would error mid-generation after partial output). The
+  // bound is on the FULL prompt length (= pos after prefill), regardless of how
+  // much is reused.
+  const auto ctx_it = metadata.find(kMaxContextLen);
+  if (ctx_it != metadata.end()) {
+    const int64_t room = ctx_it->second - num_prompt;
+    if (room <= 0) {
+      throw std::runtime_error(
+          "prompt fills the context window; no room to generate");
+    }
+    if (max_new <= 0 || max_new > room) {
+      max_new = room;
+    }
+  } else if (max_new <= 0) {
+    max_new = 2048;
+  }
+
+  // Decide full vs warm-suffix prefill. Anonymous (scratch) and warm-disabled
+  // sessions always full-prefill from a clean state.
+  PrefillPlan plan = warm ? plan_prefill(st.resident_token_ids, ids, st.dirty)
+                          : PrefillPlan{PrefillPlan::kFull, 0, "new"};
+  int64_t reused = 0;
+  std::vector<uint64_t> to_prefill;
+  if (plan.action == PrefillPlan::kSuffix) {
+    reused = static_cast<int64_t>(plan.suffix_start);
+    to_prefill.assign(ids.begin() + plan.suffix_start, ids.end());
+  } else {
+    if (session.reset() != ::executorch::runtime::Error::Ok) {
+      st.dirty = true;
+      throw std::runtime_error("session reset failed");
+    }
+    st.resident_token_ids.clear();
+    st.dirty = false;
+    to_prefill = ids;
+  }
+  const int64_t prefilled = static_cast<int64_t>(to_prefill.size());
+
+  SamplingConfig sampling;
+  sampling.temperature = temperature;
+  if (session.prefill_tokens(to_prefill, &sampling) !=
+      ::executorch::runtime::Error::Ok) {
+    st.dirty = true; // state may be partially mutated; force a reset next time
+    throw std::runtime_error("prefill failed");
+  }
+  // The resident state now equals the full prompt (resident prefix + prefilled
+  // suffix, or the whole prompt). Keep the invariant
+  // resident.size()==position().
+  st.resident_token_ids = ids;
+
+  std::string buf; // bytes not yet forming a complete UTF-8 prefix
+  std::string pending; // complete-UTF-8 text held back for stop-string matching
+  int64_t num_generated = 0;
+  std::string finish = "length"; // EOS or stop string -> "stop"
+  bool stop_string = false; // a request stop string was matched
+  for (int64_t step = 0; step < max_new; ++step) {
+    auto step_result = session.decode_one(sampling);
+    if (step_result.error() != ::executorch::runtime::Error::Ok) {
+      st.dirty = true;
+      throw std::runtime_error("decode failed");
+    }
+    const auto& d = step_result.get();
+    if (d.is_terminal) {
+      finish = "stop";
+      // Terminal step (EOS / cooperative stop): the terminal token is neither
+      // emitted as text nor counted in num_generated -> completion_tokens. This
+      // is intentional -- completion_tokens reflects the visible completion the
+      // client received, not internal forward steps; an EOS the user never sees
+      // is not part of that count.
+      break;
+    }
+    // The token was forwarded into the cache (pos advanced); track it so the
+    // resident-ids/position invariant holds. EOS/terminal tokens are not
+    // forwarded, so they are not appended (above).
+    st.resident_token_ids.push_back(d.token_id);
+    ++num_generated;
+    buf += d.text_piece;
+    const size_t cut = utf8_complete_prefix_len(buf);
+    if (cut > 0) {
+      pending += buf.substr(0, cut);
+      buf.erase(0, cut);
+    }
+    bool stop_hit = false;
+    const size_t safe = stop_safe_prefix_len(pending, stops, stop_hit);
+    if (safe > 0) {
+      worker_emit({{"token", pending.substr(0, safe)}});
+      pending.erase(0, safe);
+    }
+    if (stop_hit) {
+      finish = "stop"; // reached a stop string: drop it and everything after
+      stop_string = true;
+      // Trimming at the stop means the next turn's prompt won't be an exact
+      // token extension of resident, so force a reset (no false prefix match).
+      //
+      // CONTRACT: every *string* stop is non-resumable this way (trim + dirty +
+      // omit generated_token_ids) -- right for user/request and content-cleanup
+      // stops, which change visible text. A clean turn terminator stays
+      // warm-resumable only if the engine surfaces it as a terminal/EOS token
+      // id (handled above via d.is_terminal; e.g. Qwen adds <|im_end|> to
+      // eos_ids).
+      st.dirty = true;
+      break;
+    }
+  }
+  if (!stop_string) {
+    // EOS or length: flush held-back text + any trailing incomplete bytes
+    // (replaced if invalid). A stop-string hit drops the remainder instead.
+    pending += buf;
+    if (!pending.empty()) {
+      worker_emit({{"token", pending}});
+    }
+  }
+  // finish_reason: "stop" if the model emitted EOS or hit a stop string, else
+  // "length" -- it ran to max_new (possibly clamped to the context window).
+  // reused/prefilled sum to prompt_tokens; session_reset_reason explains the
+  // prefill plan (for measuring warm-resume hit rate).
+  nlohmann::json done = {
+      {"done", true},
+      {"prompt_tokens", num_prompt},
+      {"completion_tokens", num_generated},
+      {"finish_reason", finish},
+      {"reused_prompt_tokens", reused},
+      {"prefilled_prompt_tokens", prefilled},
+      {"session_reset_reason", plan.reason}};
+  // generated_token_ids = the (non-terminal) tokens made resident this turn,
+  // for the control plane to splice back as an `ids` segment. Only emit them
+  // when they faithfully decode to the emitted text: a stop-string trim kept
+  // the post-stop tokens resident but dropped them from the output, so splicing
+  // them would inject text the client never saw. Omitting them makes the
+  // control plane record this turn as not resumable (falls back to a text
+  // re-render).
+  if (!stop_string) {
+    done["generated_token_ids"] = std::vector<uint64_t>(
+        st.resident_token_ids.end() - num_generated,
+        st.resident_token_ids.end());
+  }
+  worker_emit(done);
+}
+
+// Owns the engine's sessions for one worker: named sessions keyed by id plus a
+// single scratch session for anonymous requests. Single-threaded (driven by the
+// stdio loop), so no internal locking.
+class WorkerSessions {
+ public:
+  explicit WorkerSessions(LLMEngine& engine)
+      : engine_(engine),
+        // Reserve one capacity slot for the scratch (anonymous) session when
+        // the backend can host more than one; a single-session backend hosts
+        // only the scratch and reports 0 named sessions.
+        max_named_(std::max(
+            0,
+            engine.serving_capacity()
+                    .max_physical_sessions_without_weight_duplication -
+                1)) {}
+
+  int32_t max_named() const {
+    return max_named_;
+  }
+
+  // Resolve (and admit, creating on first use) a named session. Returns nullptr
+  // and sets code on failure: "unsupported_session" when the backend hosts no
+  // named sessions, "capacity_exhausted" when all named slots are taken.
+  WorkerSessionState* open_named(const std::string& id, std::string& code) {
+    auto it = named_.find(id);
+    if (it != named_.end()) {
+      return &it->second; // idempotent open / reuse across requests
+    }
+    if (max_named_ == 0) {
+      code = "unsupported_session";
+      return nullptr;
+    }
+    if (static_cast<int32_t>(named_.size()) >= max_named_) {
+      code = "capacity_exhausted";
+      return nullptr;
+    }
+    auto result = engine_.create_session();
+    if (result.error() != ::executorch::runtime::Error::Ok) {
+      code = "capacity_exhausted"; // engine-side capacity backstop
+      return nullptr;
+    }
+    WorkerSessionState& st = named_[id];
+    st.session = std::move(result.get());
+    return &st;
+  }
+
+  // Destroy a named session (freeing its per-session state); idempotent.
+  void close_named(const std::string& id) {
+    named_.erase(id);
+  }
+
+  // Clear a named session's context (reset KV/recurrent + resident ids) while
+  // keeping its capacity slot allocated. No-op if the session doesn't exist.
+  // Returns Ok (including the absent no-op); on a failed reset returns the
+  // session's error and leaves resident state intact, so the control plane
+  // keeps its transcript in lockstep instead of clearing it after a failed
+  // reset.
+  ::executorch::runtime::Error reset_named(const std::string& id) {
+    auto it = named_.find(id);
+    if (it == named_.end()) {
+      return ::executorch::runtime::Error::Ok;
+    }
+    auto err = it->second.session->reset();
+    if (err != ::executorch::runtime::Error::Ok) {
+      return err;
+    }
+    it->second.resident_token_ids.clear();
+    it->second.dirty = false;
+    return ::executorch::runtime::Error::Ok;
+  }
+
+  // The scratch session for anonymous requests, created on first use. Throws if
+  // the engine cannot create it.
+  WorkerSessionState* scratch() {
+    if (!scratch_.session) {
+      auto result = engine_.create_session();
+      if (result.error() != ::executorch::runtime::Error::Ok) {
+        throw std::runtime_error("failed to create scratch session");
+      }
+      scratch_.session = std::move(result.get());
+    }
+    return &scratch_;
+  }
+
+ private:
+  LLMEngine& engine_;
+  int32_t max_named_;
+  std::unordered_map<std::string, WorkerSessionState> named_;
+  WorkerSessionState scratch_;
+};
+
+// Emit {"ready": true, ...}, then read JSONL requests from stdin and dispatch
+// each (generate / open / close / reset), reporting exceptions as
+// {"error": ...} and continuing to serve. Returns 0 when stdin closes.
+// enable_warm_resume gates warm suffix reuse for named sessions (off -> every
+// request resets and re-prefills; useful for A/B measurement).
+inline int run_worker_stdio_loop(
+    LLMEngine& engine,
+    ::tokenizers::Tokenizer& tokenizer,
+    const std::unordered_map<std::string, int64_t>& metadata,
+    bool enable_warm_resume = true,
+    const std::vector<uint64_t>& prompt_prefix_ids = {}) {
+  WorkerSessions sessions(engine);
+  worker_emit(
+      {{"ready", true},
+       {"max_sessions",
+        engine.serving_capacity()
+            .max_physical_sessions_without_weight_duplication},
+       {"max_named_sessions", sessions.max_named()}});
+
+  std::string line;
+  while (std::getline(std::cin, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    try {
+      const nlohmann::json req = nlohmann::json::parse(line);
+      const std::string op = req.value("op", std::string{});
+
+      if (op == "open" || op == "close" || op == "reset") {
+        const std::string id = req.at("session_id").get<std::string>();
+        if (id.empty()) {
+          throw std::runtime_error("session_id required for op");
+        }
+        if (op == "close") {
+          sessions.close_named(id);
+          worker_emit({{"closed", true}, {"session_id", id}});
+        } else if (op == "reset") {
+          // idempotent (no-op if absent); only acks success if the reset took
+          if (sessions.reset_named(id) != ::executorch::runtime::Error::Ok) {
+            worker_emit(
+                {{"error", "session reset failed"}, {"session_id", id}});
+          } else {
+            worker_emit({{"reset", true}, {"session_id", id}});
+          }
+        } else { // open
+          std::string code;
+          if (sessions.open_named(id, code) == nullptr) {
+            worker_emit(
+                {{"error", "cannot open session"},
+                 {"code", code},
+                 {"session_id", id}});
+          } else {
+            worker_emit({{"opened", true}, {"session_id", id}});
+          }
+        }
+        continue;
+      }
+
+      // Generation. A session_id routes to its named session (admitted on first
+      // use, warm-resumable); its absence uses the shared scratch session,
+      // which is always reset per request.
+      const std::string id = req.value("session_id", std::string{});
+      WorkerSessionState* st = nullptr;
+      bool warm = false;
+      if (id.empty()) {
+        st = sessions.scratch();
+      } else {
+        std::string code;
+        st = sessions.open_named(id, code);
+        if (st == nullptr) {
+          worker_emit(
+              {{"error", "cannot open session"},
+               {"code", code},
+               {"session_id", id}});
+          continue;
+        }
+        warm = enable_warm_resume;
+      }
+      worker_handle_request(
+          *st, warm, tokenizer, metadata, req, prompt_prefix_ids);
+    } catch (const std::exception& e) { // report and keep serving
+      worker_emit({{"error", std::string(e.what())}});
+    }
+  }
+  return 0;
+}
+
+} // namespace llm
+} // namespace extension
+} // namespace executorch

--- a/examples/llm_server/cpp/worker_prefill_plan.h
+++ b/examples/llm_server/cpp/worker_prefill_plan.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// Pure warm-resume prefill decision for the model worker (no model/session/ET
+// dependency, so it is unit-testable in isolation). Given a named session's
+// resident token ids (exactly the tokens currently in its KV/recurrent state),
+// the new request's prompt token ids, and whether the session is dirty, decide
+// whether to reset + full-prefill or to keep the state and prefill only the
+// suffix. The decision is exact-token (never string / retokenized text), so a
+// kSuffix plan is always a correct continuation; anything uncertain falls back
+// to kFull. See worker_loop.h for how the plan is executed.
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace executorch {
+namespace extension {
+namespace llm {
+
+struct PrefillPlan {
+  enum Action {
+    kFull, // reset + prefill the whole prompt
+    kSuffix // keep state, prefill prompt_ids[suffix_start:] at pos>0
+  } action;
+  size_t suffix_start; // index in prompt_ids where prefill begins (0 for kFull)
+  // Reported as session_reset_reason: "new" (no resident), "exact_prefix"
+  // (suffix reuse), "dirty", "mismatch", "equal" (prompt == resident).
+  const char* reason;
+};
+
+inline PrefillPlan plan_prefill(
+    const std::vector<uint64_t>& resident,
+    const std::vector<uint64_t>& prompt,
+    bool dirty) {
+  if (dirty) {
+    return {PrefillPlan::kFull, 0, "dirty"};
+  }
+  if (resident.empty()) {
+    return {PrefillPlan::kFull, 0, "new"};
+  }
+  if (prompt.size() < resident.size()) {
+    return {PrefillPlan::kFull, 0, "mismatch"};
+  }
+  for (size_t i = 0; i < resident.size(); ++i) {
+    if (prompt[i] != resident[i]) {
+      return {PrefillPlan::kFull, 0, "mismatch"};
+    }
+  }
+  if (prompt.size() == resident.size()) {
+    // Prompt is exactly the resident state (no new tokens). The ideal would be
+    // to skip prefill and decode straight from the session's pending token, but
+    // the LLMSession API exposes no "is there a valid pending token?" query, so
+    // we conservatively reset + full prefill rather than risk
+    // prefill_tokens([]) or decoding from a stale/absent pending. Rare in
+    // practice (a new turn adds tokens); a session pending-state query is a
+    // possible later optimization.
+    return {PrefillPlan::kFull, 0, "equal"};
+  }
+  return {PrefillPlan::kSuffix, resident.size(), "exact_prefix"};
+}
+
+} // namespace llm
+} // namespace extension
+} // namespace executorch

--- a/examples/llm_server/python/README.md
+++ b/examples/llm_server/python/README.md
@@ -1,0 +1,208 @@
+# ExecuTorch LLM Server — Python
+
+A thin OpenAI-compatible HTTP server for ExecuTorch LLMs. The Python process is
+the **control plane** only — HTTP, OpenAI protocol, chat templating, tool
+parsing, request validation. Model execution runs in a separate **C++ worker
+process** that the server drives over a small JSONL protocol.
+The control plane never loads a model, links a backend, or imports a runtime
+pybind.
+
+## Install
+
+```bash
+pip install -r requirements.txt
+# transformers is optional but recommended for model-correct chat templates
+pip install transformers
+```
+
+The server itself is pure Python (fastapi, pydantic, httpx). The model runs in a
+C++ worker binary, usually built from a model example. `../cpp` contains the
+shared worker-loop headers and tests used by those workers.
+
+### Model & runtime requirements
+
+LLM `.pte` files exported via `export_llm` use ExecuTorch custom/quantized ops:
+`use_sdpa_with_kv_cache` → `llama::custom_sdpa`, and quantized exports
+(`embedding_quantize`, `8da4w`, ...) → `quantized_decomposed` ops. The worker
+binary links the kernel libraries that provide them (the C++ equivalents of
+`-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON` /
+`-DEXECUTORCH_BUILD_EXTENSION_LLM_RUNNER=ON`); see the canonical
+[Llama README](../../../examples/models/llama/README.md). Without them the
+worker fails to load the method.
+
+Tokenizer: pass the model's tokenizer — `tokenizer.json` (HF, e.g. Qwen3) or
+`tokenizer.model` (Llama); the worker auto-detects. If you see an RE2 lookahead
+warning it falls back to PCRE2 and still works (build with
+`-DSUPPORT_REGEX_LOOKAHEAD=ON` for the native regex path).
+
+## Run
+
+```bash
+python -m executorch.examples.llm_server.python.server \
+    --worker-bin /path/to/model_worker \
+    --model-path /path/to/model.pte \
+    --tokenizer-path /path/to/tokenizer.bin \
+    --hf-tokenizer Qwen/Qwen2.5-Coder-7B-Instruct \
+    --model-id qwen2.5-coder \
+    --host 127.0.0.1 --port 8000
+```
+
+The server spawns the worker (it blocks until the worker has loaded the model and
+reported ready, so a slow load surfaces at startup, not on the first request).
+
+`--hf-tokenizer` is **required** (it applies the model's real `chat_template`)
+unless you pass `--allow-chatml-fallback` to opt into approximate generic ChatML
+— which is wrong for many instruct/tool models and can't reproduce controls like
+`enable_thinking`.
+
+Key flags:
+
+| Flag | Effect |
+|------|--------|
+| `--hf-tokenizer` | model's HF chat template (required unless fallback) |
+| `--allow-chatml-fallback` | opt into approximate ChatML when no HF tokenizer |
+| `--no-think` | default `enable_thinking=False` (e.g. Qwen3) |
+| `--max-context N` | reject over-long prompts with 400 instead of failing mid-gen |
+| `--num-runners N` | Worker processes — **1 only** (one worker hosts many isolated sessions on one weight load; more would duplicate weights) |
+| `--worker-bin PATH` | path to a model worker binary that speaks the llm_server JSONL protocol |
+
+## Smoke test
+
+```bash
+curl http://127.0.0.1:8000/health
+curl http://127.0.0.1:8000/v1/models
+curl http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"<model-id>","messages":[{"role":"user","content":"hello"}]}'
+```
+
+## Sessions
+
+When the worker reports named-session capacity (a worker whose engine supports
+it, usually launched with `--max-sessions N >= 2`), a request can target a
+persistent per-conversation session:
+
+- body `session_id`, or headers `X-ExecuTorch-Session-ID` / `session_id` /
+  `x-session-affinity` (body wins) — a stable id reuses that session's KV across
+  turns (warm resume).
+- `POST /v1/sessions/{id}/reset` — clear its context, keep the slot.
+- `DELETE /v1/sessions/{id}` — free its context and slot.
+
+## Use from an agent harness
+
+- **opencode** (`opencode.json`):
+  ```json
+  { "provider": { "executorch": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": { "baseURL": "http://127.0.0.1:8000/v1" },
+      "models": { "qwen2.5-coder": { "name": "Qwen2.5-Coder (ExecuTorch)" } } } } }
+  ```
+- **pi** (`~/.pi/agent/models.json`):
+  ```json
+  { "providers": { "executorch": {
+      "baseUrl": "http://127.0.0.1:8000/v1", "api": "openai-completions",
+      "apiKey": "x", "models": [ { "id": "qwen2.5-coder",
+        "compat": { "sendSessionAffinityHeaders": true } } ] } } }
+  ```
+  `compat.sendSessionAffinityHeaders` makes pi route each conversation to its own
+  session (per-conversation isolation + warm resume); without it every request
+  uses the anonymous scratch session.
+
+## Validate
+
+Two layers, both contract-focused (assert on the wire, not internals):
+
+```bash
+# 1. Hermetic unit tests — fake worker, no model/GPU/subprocess, fast (CI-friendly).
+pip install pytest httpx
+pytest tests/
+
+# 2. Conformance — black-box, against a LIVE server (real model, or llama.cpp/mlx-lm).
+OPENAI_BASE_URL=http://127.0.0.1:8000/v1 pytest ../conformance/test_openai_contract.py
+```
+
+`tests/` builds a `SessionRuntime` over a single `FakeRunner` worker, so the
+real server/protocol/streaming code is tested over HTTP without a `.pte`. The
+worker JSONL protocol is covered separately by `tests/test_worker_client.py`.
+
+## Architecture
+
+Control plane (this dir, Python): an OpenAI adapter (`serving_chat`) over a
+stateful `SessionRuntime` over one `WorkerClient` — server, protocol, chat
+templating, streaming bridge, tool parsing — no CUDA, no model, no pybind. Data
+plane (C++): a worker process that owns all model state
+(many isolated sessions on one weight load, warm-resume prefix logic) and does
+all token stepping and KV mutation; it speaks one JSON object per line on
+stdin/stdout.
+
+The JSONL protocol — `generate` / `open` / `close` / `reset` ops, the `prompt` /
+`prompt_segments` prompt forms, warm-resume stats, and `generated_token_ids` — is
+defined in `cpp/worker_loop.h` (the worker side, the canonical reference) and
+driven by `worker_client.py` (the Python transport); stdout carries protocol JSON
+only, logs go to stderr.
+
+Process isolation is the reliable shape for CUDA/AOTI models: executing the model
+inside a live asyncio server process can segfault (validated with Qwen3.5-MoE);
+the worker is a plain process with no asyncio loop, and the control plane only
+does blocking pipe I/O on its executor thread.
+
+| File | Role |
+|------|------|
+| `server.py` | FastAPI app, routes, CLI entrypoint, worker spawn |
+| `protocol.py` | OpenAI request/response schemas |
+| `chat_template.py` | messages (+tools) → prompt string |
+| `worker_client.py` | spawn a worker process + drive it over JSONL (raw transport) |
+| `session_runtime.py` | stateful runtime over one worker: open/generate/reset/close + streaming bridge |
+| `openai_transcript.py` | OpenAI token-ID warm-resume state (fingerprints + sentinel splicing) |
+| `serving_chat.py` | `/v1/chat/completions` OpenAI adapter (streaming + non-streaming, stop, tools) |
+| `tool_parsers/` | Hermes/Qwen `<tool_call>` parser only |
+| `cpp/worker_loop.h` | shared C++ worker JSONL protocol/session loop |
+
+### Model workers
+
+A model ships its own worker binary under its example (for example, a Qwen worker
+constructs `Qwen35MoEEngine`) that speaks the same JSONL protocol, plus a
+launcher that points this control plane at that binary via `--worker-bin`. The
+dependency points one way: a model example may reuse the generic control plane;
+the generic control plane never imports an example. Backend specifics
+(CUDA/AOTI, Metal) stay inside the worker.
+
+## Scope & caveats
+
+Deliberately narrow (reliability-first): Hermes/Qwen tool calling only;
+unsupported sampling params are rejected, not ignored. **One worker process,
+serialized execution** (one in-flight request; concurrent requests queue).
+Session capacity is determined by the worker/engine — a single worker hosts many
+isolated sessions on one weight load — so `--num-runners` accepts 1; extra worker
+processes would each carry their own copy of the weights.
+
+Workers that report capacity 1 serve only the anonymous scratch session (no named
+`session_id`s, no warm resume). Named sessions, warm resume, and token-ID
+splicing activate only when the worker's engine reports capacity > 1.
+
+**Cancellation is best-effort, and it head-of-line blocks.** `WorkerClient.stop()`
+is a no-op, and `SessionRuntime.generate_stream()` holds the single worker lock until
+the worker naturally finishes. On client disconnect/cancellation the server calls
+`stop()` then awaits the in-flight worker request, so the abandoned generation runs to
+completion **and blocks every other session on that worker until it does** — a long or
+runaway generation stalls all concurrent requests (including a subagent fan-out).
+A disconnected client does **not** interrupt the C++ worker mid-generation. Real
+interruption needs a future protocol change — e.g. a control pipe, non-blocking stdin
+polling between decode steps, or request ids plus an out-of-band cancel op.
+
+**Warm resume needs true turn terminators surfaced as EOS/terminal token ids, not just
+string stops.** The worker treats every *string* stop the same — it trims the output,
+marks the session dirty, and omits `generated_token_ids` — which is correct for
+user/request stops and broad content-cleanup stops (they change visible text, so the
+turn is non-resumable). A clean model turn terminator is only resumable if the engine
+surfaces it as a terminal/EOS **token id** (the Qwen engine adds `<|im_end|>` to
+`eos_ids`, so it ends the turn before string-stop matching and stays resumable). A
+backend whose terminator is only a string stop would mark every turn dirty and never
+warm-resume; distinguishing resumable terminators from trim-stops in the protocol is
+future work.
+
+There is **no global (cross-session) prefix cache**; per-session append-only warm
+resume is worker-side (for engines that support it), and all KV/resident state
+lives inside the worker/session, never the Python control plane. Multiple workers,
+weight sharing across sessions on a backend that supports it, adaptive thinking,
+and multi-session subagents are future work.

--- a/examples/llm_server/python/__init__.py
+++ b/examples/llm_server/python/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""OpenAI-compatible server for ExecuTorch LLMs (Python implementation)."""

--- a/examples/llm_server/python/chat_template.py
+++ b/examples/llm_server/python/chat_template.py
@@ -1,0 +1,338 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Render OpenAI chat messages into a single prompt string.
+
+The ExecuTorch runner tokenizes a plain prompt; chat formatting is the server's
+job (control plane). We require the model's own Hugging Face ``chat_template``
+(via ``--hf-tokenizer``) for correct, tool-aware, reasoning-aware formatting.
+The generic ChatML fallback is opt-in only (``allow_fallback``): it is
+approximate and cannot reproduce model-specific controls (e.g. enable_thinking),
+so it must be a deliberate choice rather than a silent default.
+"""
+
+import json
+import logging
+from typing import Any, Optional
+
+from .protocol import ChatMessage
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_SPECIAL_TOKENS = ["<|im_end|>", "<|endoftext|>", "<|eot_id|>", "<|end|>"]
+
+# Chat turn terminators eligible to be used as generation stop strings. This is a
+# deliberate allowlist of end-of-turn / end-of-text tokens -- NOT the tokenizer's
+# full special-token set. Structural/tool delimiters (e.g. <tool_call>) must reach
+# the tool parser, so they are intentionally excluded: using them as hard stops
+# would truncate a tool call before it is ever parsed.
+_TURN_TERMINATORS = (
+    "<|im_end|>",
+    "<|endoftext|>",
+    "<|eot_id|>",
+    "<|end|>",
+    "<|end_of_text|>",
+    "<end_of_turn>",
+    "<turn|>",
+    "</s>",
+)
+
+_TOOL_RESPONSE_GENERATION_PROMPT_MARKERS = (
+    "<tool_response|>",
+    "<tool_response|>\n",
+    "<turn|>\n",
+)
+
+
+def _content_text(content) -> str:
+    """Best-effort text for the ChatML fallback: a str as-is, or the concatenated
+    text parts of an OpenAI list-content message (non-text parts dropped). Avoids
+    rendering a Python repr of structured content. None -> empty string."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                out.append(str(part.get("text", "")))
+            elif isinstance(part, str):
+                out.append(part)
+        return "".join(out)
+    return str(content or "")
+
+
+def _decode_tool_call_arguments(messages: list[dict[str, Any]]) -> None:
+    """In-place: parse each tool call's ``function.arguments`` from a JSON string
+    into an object.
+
+    OpenAI sends assistant tool-call arguments as a JSON-encoded string, but HF
+    chat templates expect a mapping (e.g. Qwen renders ``arguments|items`` into
+    ``<parameter=…>`` tags). Without this, a multi-turn tool conversation makes
+    the template raise "Can only get item pairs from a mapping". Left as-is if
+    the value isn't valid JSON, so a template that wants the raw string still works.
+    """
+    for m in messages:
+        for tc in m.get("tool_calls") or []:
+            fn = tc.get("function")
+            if not isinstance(fn, dict):
+                continue
+            args = fn.get("arguments")
+            if isinstance(args, str):
+                try:
+                    fn["arguments"] = json.loads(args)
+                except (ValueError, TypeError):
+                    pass
+
+
+class ChatTemplate:
+    def __init__(
+        self,
+        hf_tokenizer_path: Optional[str] = None,
+        default_template_kwargs: Optional[dict[str, Any]] = None,
+        allow_fallback: bool = False,
+        assistant_header: str = "<|im_start|>assistant\n",
+        strip_rendered_prefix: str = "",
+        strip_rendered_bos: bool = False,
+        append_generation_prompt_after_tool_response: bool = False,
+        tool_response_generation_prompt_markers: Optional[tuple[str, ...]] = None,
+    ):
+        if strip_rendered_prefix and strip_rendered_bos:
+            raise ValueError("use either strip_rendered_prefix or strip_rendered_bos")
+        # Server-level defaults (e.g. {"enable_thinking": False}); per-request
+        # chat_template_kwargs override these.
+        self._defaults = default_template_kwargs or {}
+        self._assistant_header = assistant_header
+        self._strip_rendered_prefix = strip_rendered_prefix
+        self._append_generation_prompt_after_tool_response = (
+            append_generation_prompt_after_tool_response
+        )
+        self._tool_response_generation_prompt_markers = (
+            tool_response_generation_prompt_markers
+            or _TOOL_RESPONSE_GENERATION_PROMPT_MARKERS
+        )
+        # Cache of the (deterministic) generation scaffold per resolved mode, so
+        # warm-resume bookkeeping doesn't re-render a probe prompt every request.
+        self._preamble_cache: dict[tuple, str] = {}
+        self._hf = None
+        if hf_tokenizer_path:
+            from transformers import AutoTokenizer
+
+            self._hf = AutoTokenizer.from_pretrained(hf_tokenizer_path)
+            if self._hf.chat_template is None:
+                self._hf = None
+                if not allow_fallback:
+                    raise ValueError(
+                        f"HF tokenizer at {hf_tokenizer_path} has no chat_template; "
+                        "pass an explicit fallback flag to use approximate ChatML."
+                    )
+                logger.warning(
+                    "No chat_template at %s; using approximate ChatML.",
+                    hf_tokenizer_path,
+                )
+            if strip_rendered_bos:
+                bos = getattr(self._hf, "bos_token", None)
+                if not isinstance(bos, str) or not bos:
+                    raise ValueError(
+                        "strip_rendered_bos requires a tokenizer with bos_token"
+                    )
+                self._strip_rendered_prefix = bos
+        elif not allow_fallback:
+            raise ValueError(
+                "A chat template is required: pass --hf-tokenizer for the model's own "
+                "template, or opt into approximate ChatML with --allow-chatml-fallback."
+            )
+        elif strip_rendered_bos:
+            raise ValueError("strip_rendered_bos requires --hf-tokenizer")
+        else:
+            logger.warning(
+                "No --hf-tokenizer; using approximate ChatML (no thinking control)."
+            )
+
+    def render(
+        self,
+        messages: list[ChatMessage],
+        tools: Optional[list[dict[str, Any]]] = None,
+        template_kwargs: Optional[dict[str, Any]] = None,
+    ) -> str:
+        kwargs = {**self._defaults, **(template_kwargs or {})}
+        if self._hf is not None:
+            dumped = [m.model_dump(exclude_none=True) for m in messages]
+            _decode_tool_call_arguments(dumped)
+            rendered = self._hf.apply_chat_template(
+                dumped,
+                tools=tools,
+                add_generation_prompt=True,
+                tokenize=False,
+                **kwargs,
+            )
+            if self._strip_rendered_prefix and rendered.startswith(
+                self._strip_rendered_prefix
+            ):
+                rendered = rendered[len(self._strip_rendered_prefix) :]
+            elif self._strip_rendered_prefix:
+                raise ValueError(
+                    "rendered prompt did not start with configured strip prefix "
+                    f"{self._strip_rendered_prefix!r}"
+                )
+            return self._maybe_append_tool_response_generation_prompt(
+                rendered, messages, tools, kwargs
+            )
+        return self._fallback(messages)
+
+    def _maybe_append_tool_response_generation_prompt(
+        self,
+        rendered: str,
+        messages: list[ChatMessage],
+        tools: Optional[list[dict[str, Any]]],
+        template_kwargs: dict[str, Any],
+    ) -> str:
+        if (
+            not self._append_generation_prompt_after_tool_response
+            or not messages
+            or messages[-1].role != "tool"
+        ):
+            return rendered
+        has_prompt_marker = any(
+            rendered.endswith(marker)
+            for marker in self._tool_response_generation_prompt_markers
+        )
+        if not has_prompt_marker and not rendered.endswith(self._assistant_header):
+            return rendered
+
+        prompt = self._assistant_header + self.generation_preamble(
+            template_kwargs=template_kwargs, tools=tools
+        )
+        if not prompt or rendered.endswith(prompt):
+            return rendered
+        if rendered.endswith(self._assistant_header):
+            return rendered + prompt[len(self._assistant_header) :]
+        return rendered + prompt
+
+    def generation_preamble(
+        self,
+        template_kwargs: Optional[dict[str, Any]] = None,
+        tools: Optional[list[dict[str, Any]]] = None,
+    ) -> str:
+        """The deterministic text the generation prompt appends after the final
+        ``<|im_start|>assistant\\n`` for this mode (Qwen3 no-think:
+        ``<think>\\n\\n</think>\\n\\n``; think: ``<think>\\n``; ``""`` for
+        templates that add no scaffold). The worker prefills this into resident
+        KV, so warm-resume splicing must reproduce it ahead of a turn's generated
+        ids. Computed by rendering a trivial prompt with the same mode resolution
+        AND ``tools`` as :meth:`render`, taking the text after the final assistant
+        header. ``tools`` is threaded (and keyed) so that if a template ever makes
+        the post-header scaffold tool-dependent, the stored preamble still matches
+        the resident one (for Qwen3 the scaffold is tool-independent -> same key).
+        Returns ``""`` for the fallback / no-scaffold templates (fix is a no-op).
+        """
+        if self._hf is None:
+            return ""
+        merged = {**self._defaults, **(template_kwargs or {})}
+        if tools:
+            try:
+                tools_key = json.dumps(
+                    tools, sort_keys=True, ensure_ascii=False, default=str
+                )
+            except (TypeError, ValueError):
+                tools_key = repr(tools)
+        else:
+            tools_key = None
+        key = (tuple(sorted((k, repr(v)) for k, v in merged.items())), tools_key)
+        cached = self._preamble_cache.get(key)
+        if cached is not None:
+            return cached
+        rendered = self.render(
+            [ChatMessage(role="user", content="")],
+            tools=tools,
+            template_kwargs=template_kwargs,
+        )
+        marker = self._assistant_header
+        idx = rendered.rfind(marker)
+        preamble = rendered[idx + len(marker) :] if idx != -1 else ""
+        self._preamble_cache[key] = preamble
+        return preamble
+
+    def assistant_header(self) -> str:
+        return self._assistant_header
+
+    def chat_template_str(self) -> Optional[str]:
+        """Raw chat-template string (for tool-format auto-detection), if available."""
+        return (
+            getattr(self._hf, "chat_template", None) if self._hf is not None else None
+        )
+
+    def count_tokens(self, prompt: str) -> Optional[int]:
+        """Token count for the rendered prompt, or None if no tokenizer is available."""
+        if self._hf is not None:
+            # The prompt is already rendered (apply_chat_template includes the
+            # control tokens), so encode without re-adding BOS/EOS — matching the
+            # session/prefix-cache paths, so the count isn't inflated and
+            # near-limit requests aren't falsely rejected under --max-context.
+            return len(self._hf.encode(prompt, add_special_tokens=False))
+        return None
+
+    def turn_stop_sequences(self) -> list[str]:
+        """Generation stop strings: model/template-specific *turn terminators*
+        only -- the tokenizer's EOS plus known chat turn-end tokens -- NOT the
+        full special-token set.
+
+        Structural/tool delimiters (e.g. <tool_call>) are deliberately excluded:
+        if a tokenizer registers them as special, using the whole special set as
+        hard stops would halt generation at the delimiter and truncate the tool
+        call before the parser ever sees it. Whitespace-only tokens are dropped.
+        User-supplied request `stop` strings are handled separately and are not
+        affected by this set.
+
+        May return [] if the tokenizer has no eos_token and registers none of the
+        known terminators as special; in that case end-of-turn detection relies
+        entirely on the worker's EOS-by-token-id check (e.g. the Qwen engine adds
+        <|im_end|> to eos_ids), so the string set here is only a backstop.
+        """
+        if self._hf is None:
+            return list(_DEFAULT_SPECIAL_TOKENS)
+        specials = {
+            t
+            for t in (getattr(self._hf, "all_special_tokens", []) or [])
+            if isinstance(t, str) and t.strip()
+        }
+        out: list[str] = []
+        eos = getattr(self._hf, "eos_token", None)
+        if isinstance(eos, str) and eos.strip():
+            out.append(eos)
+        for t in _TURN_TERMINATORS:
+            if t in specials and t not in out:
+                out.append(t)
+        return out
+
+    def special_tokens(self) -> list[str]:
+        """ALL special-token strings, for final content cleanup -- stripping any
+        special token that leaked into visible output. Deliberately broad, and
+        distinct from turn_stop_sequences(): this set must NOT be used as
+        generation stops or pre-parse truncation (that would halt/cut a tool call
+        at a structural delimiter), only to scrub trailing specials from the
+        already-parsed visible content. Whitespace-only tokens are dropped so a
+        stray '  ' token can't truncate content at the first double space.
+        """
+        if self._hf is not None:
+            toks = list(getattr(self._hf, "all_special_tokens", []) or [])
+            return [t for t in toks if isinstance(t, str) and t.strip()]
+        return list(_DEFAULT_SPECIAL_TOKENS)
+
+    @staticmethod
+    def _fallback(messages: list[ChatMessage]) -> str:
+        # Approximate ChatML, TEXT-ONLY. Provide --hf-tokenizer for model-correct
+        # formatting (reasoning controls like enable_thinking, and structured
+        # tool/multimodal turns, which this fallback cannot reproduce). This path
+        # renders only text content: assistant `tool_calls` and a tool-role
+        # `tool_call_id` are dropped, so it is NOT a correctness path for tool or
+        # multimodal conversations -- use a real --hf-tokenizer for those.
+        parts = []
+        for m in messages:
+            content = _content_text(m.content)
+            parts.append(f"<|im_start|>{m.role}\n{content}<|im_end|>")
+        parts.append("<|im_start|>assistant\n")
+        return "\n".join(parts)

--- a/examples/llm_server/python/errors.py
+++ b/examples/llm_server/python/errors.py
@@ -1,0 +1,105 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""OpenAI-shaped API errors.
+
+Raising these lets the server return a structured `{"error": {...}}` body with
+the right HTTP status instead of dropping the connection.
+"""
+
+from typing import Optional
+
+
+class APIError(Exception):
+    def __init__(
+        self, status: int, message: str, err_type: str, code: Optional[str] = None
+    ):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+        self.err_type = err_type
+        self.code = code
+
+    def body(self) -> dict:
+        return {
+            "error": {"message": self.message, "type": self.err_type, "code": self.code}
+        }
+
+
+class ContextLengthExceeded(APIError):
+    def __init__(self, num_tokens: int, max_context: int, completion_tokens: int = 0):
+        # completion_tokens > 0: the prompt fits but prompt + requested
+        # max_tokens would run past the window — reject up front rather than
+        # fail (or truncate) mid-generation.
+        if completion_tokens > 0:
+            message = (
+                f"This model's maximum context length is {max_context} tokens. "
+                f"However, you requested {num_tokens + completion_tokens} tokens "
+                f"({num_tokens} in the messages, {completion_tokens} in the "
+                f"completion). Please reduce the length of the messages or "
+                f"completion."
+            )
+        else:
+            message = (
+                f"This model's maximum context length is {max_context} tokens, "
+                f"but the request has {num_tokens} prompt tokens."
+            )
+        super().__init__(
+            status=400,
+            message=message,
+            err_type="invalid_request_error",
+            code="context_length_exceeded",
+        )
+
+
+class GenerationError(APIError):
+    def __init__(self, detail: str):
+        super().__init__(
+            status=500, message=f"Generation failed: {detail}", err_type="server_error"
+        )
+
+
+class ModelNotFound(APIError):
+    def __init__(self, requested: str, served: str):
+        super().__init__(
+            status=404,
+            message=f"Model {requested!r} not found. This server serves {served!r}.",
+            err_type="invalid_request_error",
+            code="model_not_found",
+        )
+
+
+class InvalidSessionId(APIError):
+    def __init__(self, detail: str):
+        super().__init__(
+            status=400,
+            message=f"Invalid session_id: {detail}",
+            err_type="invalid_request_error",
+            code="invalid_session_id",
+        )
+
+
+class SessionCapacity(APIError):
+    """A worker rejected an explicit session_id: the backend hosts no named
+    sessions (unsupported_session -> 400) or all session slots are taken
+    (capacity_exhausted -> 429)."""
+
+    def __init__(self, code: str):
+        if code == "unsupported_session":
+            super().__init__(
+                status=400,
+                message="This server hosts a single session; omit session_id.",
+                err_type="invalid_request_error",
+                code=code,
+            )
+        else:
+            super().__init__(
+                status=429,
+                message="Session capacity exhausted; reuse an existing session_id "
+                "or retry later.",
+                err_type="capacity_error",
+                code="capacity_exhausted",
+            )

--- a/examples/llm_server/python/openai_transcript.py
+++ b/examples/llm_server/python/openai_transcript.py
@@ -1,0 +1,337 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""OpenAI/chat-template transcript state for token-ID warm resume.
+
+Adapter-specific glue, not runtime infrastructure: it knows ChatMessages,
+tool_calls, the ChatTemplate, sentinels, and assistant fingerprints (the runtime
+only sees a PromptInput). It makes warm resume survive the chat template's lossy
+re-render of prior assistant turns -- especially tool calls, which re-render from
+parsed structure and don't re-tokenize to what the model generated.
+
+Per session it stores, for each assistant turn it produced, the exact generated
+token ids and a fingerprint of the response. On the next request each prior
+assistant turn is replaced with a sentinel, the conversation is rendered once,
+and the rendered text is split on the sentinels with the stored ids spliced back
+in -- only for turns whose fingerprint matches the incoming message (an edited,
+branched, or reused history is never substituted with stale ids) and whose ids
+are present (a stop-trimmed turn is left as text). The worker's exact-token
+prefix check is the final backstop.
+"""
+
+import hashlib
+import json
+import re
+import uuid
+from typing import Optional
+
+from .chat_template import ChatTemplate
+from .protocol import ChatMessage
+from .session_runtime import PromptInput
+
+# The assistant header that precedes a turn's generation scaffold + content.
+_ASSIST_HDR = "<|im_start|>assistant\n"
+# A scaffold region is exactly empty (history strips it before the last user) or
+# one of the Qwen3 think scaffolds (history preserves the empty block after the
+# last user; the open form is the think-mode generation preamble). Anything else
+# in that region is unrecognized -> the splice falls back to plain text.
+_THINK_SCAFFOLD_RE = re.compile(r"\A(?:<think>\n\n</think>\n\n|<think>\n)?\Z")
+_GEMMA_TOOL_CALL_START = "<|tool_call>"
+_GEMMA_TOOL_CALL_END = "<tool_call|>"
+_GEMMA_QUOTE = '<|"|>'
+
+
+def _normalize_tool_args(args):
+    """OpenAI tool-call ``arguments`` are JSON strings a client may reserialize
+    with different whitespace or key order while preserving the same value (e.g.
+    a server-emitted ``{"command": "x"}`` echoed back compact as
+    ``{"command":"x"}``). Parse to an object so the fingerprint compares the
+    semantic payload, not bytes -- the outer sort_keys dump then canonicalizes
+    it. A non-JSON string (or already-structured args) is returned unchanged, so
+    it stays byte-sensitive."""
+    if isinstance(args, str):
+        try:
+            return json.loads(args)
+        except (ValueError, TypeError):
+            return args
+    return args
+
+
+def _find_gemma_tool_call_span(rendered: str, search_pos: int):
+    start = rendered.find(_GEMMA_TOOL_CALL_START, search_pos)
+    if start == -1:
+        return None
+    i = start + len(_GEMMA_TOOL_CALL_START)
+    in_string = False
+    depth = 0
+    saw_object = False
+    while i < len(rendered):
+        if rendered.startswith(_GEMMA_QUOTE, i):
+            in_string = not in_string
+            i += len(_GEMMA_QUOTE)
+            continue
+        if not in_string:
+            if rendered.startswith(_GEMMA_TOOL_CALL_END, i):
+                if saw_object and depth == 0:
+                    return start, i + len(_GEMMA_TOOL_CALL_END)
+            ch = rendered[i]
+            if ch in "{[":
+                depth += 1
+                saw_object = saw_object or ch == "{"
+            elif ch in "}]":
+                if depth == 0:
+                    return None
+                depth -= 1
+        i += 1
+    return None
+
+
+class OpenAITranscriptState:
+    def __init__(self, template: ChatTemplate):
+        self._template = template
+        self._assist_hdr = (
+            template.assistant_header()
+            if hasattr(template, "assistant_header")
+            else _ASSIST_HDR
+        )
+        # session_id -> [{"fp": str, "ids": list[int] | None}, ...] (one per
+        # assistant turn we produced, in order). Cleared on reset/close.
+        self._turns: dict[str, list[dict]] = {}
+
+    @staticmethod
+    def _assistant_fingerprint(content, tool_calls) -> str:
+        """Stable fingerprint of an assistant turn's semantic payload (content +
+        each tool call's name/arguments; the random call id is ignored). Used to
+        confirm an incoming assistant message is the one we generated before
+        splicing its stored token ids."""
+        norm = []
+        for tc in tool_calls or []:
+            fn = getattr(tc, "function", None)
+            if fn is not None:
+                name, args = getattr(fn, "name", None), getattr(fn, "arguments", None)
+            elif isinstance(tc, dict):
+                f = tc.get("function", {})
+                name, args = f.get("name"), f.get("arguments")
+            else:
+                continue
+            norm.append([name, _normalize_tool_args(args)])
+        blob = json.dumps([content or "", norm], sort_keys=True, ensure_ascii=False)
+        return hashlib.sha1(blob.encode("utf-8")).hexdigest()
+
+    def _normalize_scaffold(self, text_chunk: str, preamble: str) -> Optional[str]:
+        """Force the scaffold region (between the last assistant header in
+        `text_chunk` and its end) to equal `preamble`, so the worker re-tokenizes
+        the exact resident scaffold. The region is empty (history stripped it ->
+        insert) or a think scaffold (history preserved it -> replace). Returns the
+        adjusted text, or None if it isn't a recognized scaffold (-> text fallback)."""
+        # No scaffold for this turn's mode/template: nothing to reproduce, so
+        # leave the chunk untouched -- and don't require the Qwen/ChatML header,
+        # so token-id splicing still works for templates with a different
+        # assistant header (the fix stays a true no-op for non-think models).
+        if not preamble:
+            return text_chunk
+        h = text_chunk.rfind(self._assist_hdr)
+        if h == -1:
+            return None
+        base = h + len(self._assist_hdr)
+        region = text_chunk[base:]
+        if region == preamble:
+            return text_chunk
+        if not _THINK_SCAFFOLD_RE.match(region):
+            return None
+        return text_chunk[:base] + preamble
+
+    def _split_on_sentinels(
+        self, rendered: str, sub: dict[str, dict]
+    ) -> Optional[list[dict]]:
+        """Split `rendered` on the sentinels into alternating {"text"} chunks and
+        {"ids"} runs (each sentinel -> sub[sentinel] = {"ids", "preamble"}). The
+        {text} chunk before each {ids} run has its assistant scaffold normalized
+        to that turn's stored preamble. Returns None if any pre-sentinel scaffold
+        region is ambiguous (caller falls back to plain text)."""
+        pattern = re.compile("|".join(re.escape(s) for s in sub))
+        segments: list[dict] = []
+        pos = 0
+        for mobj in pattern.finditer(rendered):
+            norm = self._normalize_scaffold(
+                rendered[pos : mobj.start()], sub[mobj.group()]["preamble"]
+            )
+            if norm is None:
+                return None
+            if norm:
+                segments.append({"text": norm})
+            segments.append({"ids": sub[mobj.group()]["ids"]})
+            pos = mobj.end()
+        if pos < len(rendered):
+            segments.append({"text": rendered[pos:]})
+        return segments
+
+    def _split_gemma_tool_call_spans(
+        self,
+        rendered: str,
+        messages: list[ChatMessage],
+        splice: dict[int, dict],
+    ) -> Optional[list[dict]]:
+        segments: list[dict] = []
+        pos = 0
+
+        for i, msg in enumerate(messages):
+            tool_calls = msg.tool_calls if msg.role == "assistant" else None
+            if not tool_calls:
+                continue
+
+            start = None
+            end = pos
+            for _ in tool_calls:
+                span = _find_gemma_tool_call_span(rendered, end)
+                if span is None:
+                    return None
+                span_start, span_end = span
+                if start is None:
+                    start = span_start
+                end = span_end
+            if start is None:
+                return None
+
+            if i in splice:
+                norm = self._normalize_scaffold(
+                    rendered[pos:start], splice[i]["preamble"]
+                )
+                if norm is None:
+                    return None
+                if norm:
+                    segments.append({"text": norm})
+                segments.append({"ids": splice[i]["ids"]})
+            else:
+                segments.append({"text": rendered[pos:end]})
+            pos = end
+
+        if pos < len(rendered):
+            segments.append({"text": rendered[pos:]})
+        return segments
+
+    def build_prompt_input(
+        self,
+        *,
+        session_id: Optional[str],
+        messages: list[ChatMessage],
+        rendered_prompt: str,
+        tools,
+        template_kwargs,
+    ) -> PromptInput:
+        """Return a PromptInput: token-ID segments when this session has faithful
+        stored ids for matching prior assistant turns, else the plain rendered
+        text. Each incoming assistant turn is matched IN ORDER against the stored
+        records and only spliced when (a) its fingerprint matches what we returned
+        (else the history diverged -> stop, splice nothing further) and (b) we
+        kept faithful ids for it (a stop-trimmed turn's None -> rendered as text).
+        Falls back to text on a sentinel collision or a render that
+        dropped/duplicated a sentinel."""
+        stored = self._turns.get(session_id or "")
+        if not stored:
+            return PromptInput(text=rendered_prompt)
+        # Positional: stored[k] is the k-th assistant turn WE generated, matched
+        # against the k-th assistant message in the request. A client-injected
+        # turn (few-shot exemplar, pre-seeded turn, reused session) shifts that
+        # alignment -> fingerprint mismatch at k -> stop splicing. Always safe
+        # (text fallback + worker prefix backstop); just a lower hit rate.
+        positions = [i for i, m in enumerate(messages) if m.role == "assistant"]
+        splice: dict[int, dict] = {}  # message index -> {"ids", "preamble"}
+        diverged_at = None
+        for k, pos in enumerate(positions):
+            if k >= len(stored):
+                break
+            m = messages[pos]
+            if self._assistant_fingerprint(m.content, m.tool_calls) != stored[k]["fp"]:
+                diverged_at = k  # this stored turn and every later one are stale
+                break
+            if stored[k]["ids"] is not None:
+                splice[pos] = {
+                    "ids": stored[k]["ids"],
+                    "preamble": stored[k].get("preamble", ""),
+                }
+        if diverged_at is not None:
+            # Drop the stale tail from the first mismatch so an edited/branched
+            # earlier turn can't shadow future requests; the matched prefix still
+            # splices, the rest stays text until reset/close. Safe either way:
+            # stale ids are never spliced and the worker's prefix check backstops.
+            del stored[diverged_at:]
+        if not splice:
+            return PromptInput(text=rendered_prompt)
+        tool_splice = {
+            pos: data
+            for pos, data in splice.items()
+            if messages[pos].tool_calls and not (messages[pos].content or "")
+        }
+        if tool_splice and _GEMMA_TOOL_CALL_START in rendered_prompt:
+            segments = self._split_gemma_tool_call_spans(
+                rendered_prompt, messages, tool_splice
+            )
+            return (
+                PromptInput(segments=segments)
+                if segments is not None
+                else PromptInput(text=rendered_prompt)
+            )
+        token = uuid.uuid4().hex
+        sentinel_at = {pos: f"<<ETSEG{j}_{token}>>" for j, pos in enumerate(splice)}
+        sub = {sentinel_at[pos]: splice[pos] for pos in splice}
+        # A sentinel must not already occur in the rendered output.
+        if any(s in rendered_prompt for s in sub):
+            return PromptInput(text=rendered_prompt)
+        modified = [
+            (
+                ChatMessage(role="assistant", content=sentinel_at[i])
+                if i in sentinel_at
+                else m
+            )
+            for i, m in enumerate(messages)
+        ]
+        rendered = self._template.render(
+            modified, tools=tools, template_kwargs=template_kwargs
+        )
+        # Each sentinel must survive templating exactly once, else fall back.
+        if any(rendered.count(s) != 1 for s in sub):
+            return PromptInput(text=rendered_prompt)
+        # Splice ids and normalize each turn's scaffold; None => ambiguous region.
+        segments = self._split_on_sentinels(rendered, sub)
+        if segments is None:
+            return PromptInput(text=rendered_prompt)
+        return PromptInput(segments=segments)
+
+    def record_assistant_turn(
+        self,
+        *,
+        session_id: Optional[str],
+        content,
+        tool_calls,
+        generated_token_ids: list,
+        prior_turns: int,
+        preamble: str = "",
+    ) -> None:
+        """Record this turn's {fingerprint, generated ids, generation preamble} at
+        `prior_turns` (the assistant-turn count of the request it answers).
+        Records at/after that index are dropped first, so a regenerated/branched
+        turn replaces stale records rather than shadowing later hits. ids is None
+        when the worker omitted them (stop-trimmed -> non-resumable), kept for
+        positional alignment. `preamble` is the generation scaffold (e.g. the
+        Qwen3 `<think>` block) reproduced ahead of the spliced ids next request."""
+        if not session_id:
+            return
+        turns = self._turns.setdefault(session_id, [])
+        del turns[prior_turns:]
+        turns.append(
+            {
+                "fp": self._assistant_fingerprint(content, tool_calls),
+                "ids": list(generated_token_ids) if generated_token_ids else None,
+                "preamble": preamble,
+            }
+        )
+
+    def reset(self, session_id: str) -> None:
+        self._turns.pop(session_id, None)
+
+    def close(self, session_id: str) -> None:
+        self._turns.pop(session_id, None)

--- a/examples/llm_server/python/protocol.py
+++ b/examples/llm_server/python/protocol.py
@@ -1,0 +1,153 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""OpenAI-compatible request/response schemas for the ExecuTorch LLM server.
+
+This is the Python view of the contract defined in ``examples/llm_server/spec``.
+Any language server must serialize to the same shapes; the conformance suite in
+``examples/llm_server/conformance`` validates them.
+"""
+
+import time
+import uuid
+from typing import Any, Literal, Optional, Union
+
+from pydantic import BaseModel, Field
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex}"
+
+
+class FunctionCall(BaseModel):
+    name: Optional[str] = None
+    arguments: Optional[str] = None
+
+
+class ToolCall(BaseModel):
+    index: Optional[int] = None
+    id: Optional[str] = None
+    type: Literal["function"] = "function"
+    function: FunctionCall
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: Optional[Union[str, list[dict[str, Any]]]] = None
+    name: Optional[str] = None
+    tool_calls: Optional[list[ToolCall]] = None
+    tool_call_id: Optional[str] = None
+
+
+class StreamOptions(BaseModel):
+    include_usage: bool = False
+
+
+class ChatCompletionRequest(BaseModel):
+    model: Optional[str] = None
+    messages: list[ChatMessage]
+    stream: bool = False
+    stream_options: Optional[StreamOptions] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    max_tokens: Optional[int] = None
+    max_completion_tokens: Optional[int] = None
+    stop: Optional[Union[str, list[str]]] = None
+    n: int = 1
+    seed: Optional[int] = None
+    # Sampling knobs that change generation output. We don't plumb these, so they
+    # are modeled (not dropped) in order to be rejected with a clear error rather
+    # than silently ignored — see serving_chat's unsupported-parameter check.
+    frequency_penalty: Optional[float] = None
+    presence_penalty: Optional[float] = None
+    top_k: Optional[int] = None
+    logit_bias: Optional[dict[str, float]] = None
+    # Output-contract fields: modeled (not dropped) so we reject the ones we
+    # can't honor rather than returning an output that violates what was asked.
+    response_format: Optional[dict[str, Any]] = None
+    logprobs: Optional[bool] = None
+    top_logprobs: Optional[int] = None
+    parallel_tool_calls: Optional[bool] = None
+    # Per-request chat-template controls, e.g. {"enable_thinking": false} for Qwen3.
+    chat_template_kwargs: Optional[dict[str, Any]] = None
+    # Vendor extension: route this request to a persistent, isolated session (its
+    # own KV/recurrent context) on a multi-session worker; requests sharing a
+    # session_id continue the same context. Anonymous (a transient scratch
+    # session) when unset. Also accepted via the X-ExecuTorch-Session-ID header.
+    session_id: Optional[str] = None
+    # Accepted now so the contract is stable; parsing/enforcement land in M2/M5.
+    tools: Optional[list[dict[str, Any]]] = None
+    tool_choice: Optional[Union[str, dict[str, Any]]] = None
+    reasoning_effort: Optional[str] = None
+
+    def resolved_max_tokens(self) -> int:
+        # `is not None` (not `or`): an explicit 0 must not be treated as unset.
+        # Callers validate positivity; -1 means "unset / auto".
+        if self.max_completion_tokens is not None:
+            return self.max_completion_tokens
+        if self.max_tokens is not None:
+            return self.max_tokens
+        return -1
+
+
+class Usage(BaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+class ResponseMessage(BaseModel):
+    role: str = "assistant"
+    content: Optional[str] = None
+    tool_calls: Optional[list[ToolCall]] = None
+
+
+class Choice(BaseModel):
+    index: int = 0
+    message: ResponseMessage
+    finish_reason: Optional[str] = None
+
+
+class ChatCompletionResponse(BaseModel):
+    id: str = Field(default_factory=lambda: _new_id("chatcmpl"))
+    object: Literal["chat.completion"] = "chat.completion"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: list[Choice]
+    usage: Usage = Field(default_factory=Usage)
+
+
+class DeltaMessage(BaseModel):
+    role: Optional[str] = None
+    content: Optional[str] = None
+    tool_calls: Optional[list[ToolCall]] = None
+
+
+class ChunkChoice(BaseModel):
+    index: int = 0
+    delta: DeltaMessage
+    finish_reason: Optional[str] = None
+
+
+class ChatCompletionChunk(BaseModel):
+    id: str
+    object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    model: str
+    choices: list[ChunkChoice]
+    usage: Optional[Usage] = None
+
+
+class ModelCard(BaseModel):
+    id: str
+    object: Literal["model"] = "model"
+    created: int = Field(default_factory=lambda: int(time.time()))
+    owned_by: str = "executorch"
+
+
+class ModelList(BaseModel):
+    object: Literal["list"] = "list"
+    data: list[ModelCard]

--- a/examples/llm_server/python/requirements.txt
+++ b/examples/llm_server/python/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.110
+uvicorn[standard]>=0.27
+pydantic>=2.0
+# Optional but recommended for model-correct chat templating (--hf-tokenizer):
+# transformers>=4.40

--- a/examples/llm_server/python/server.py
+++ b/examples/llm_server/python/server.py
@@ -1,0 +1,244 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""OpenAI-compatible HTTP server for ExecuTorch LLMs.
+
+Point any OpenAI-compatible agent harness (pi, opencode, ...) at
+``http://<host>:<port>/v1``.
+
+This process is the CONTROL PLANE only: FastAPI/uvicorn + OpenAI protocol, chat
+templating, tool parsing, request validation. It runs NO model code and imports
+no runtime pybind. Model execution lives in a separate C++ worker process driven
+over JSONL via WorkerClient.
+
+One worker process, serialized execution (one in-flight request; concurrent
+requests queue). Session capacity is set by the worker/engine -- a single worker
+hosts many isolated sessions on one weight load; extra worker processes would
+duplicate the weights, so `--num-runners` accepts 1.
+
+Example:
+    python -m executorch.examples.llm_server.python.server \\
+        --worker-bin /path/to/model_worker \\
+        --model-path model.pte --tokenizer-path tokenizer.bin \\
+        --hf-tokenizer Qwen/Qwen2.5-Coder-7B-Instruct --model-id qwen2.5-coder
+"""
+
+import argparse
+import logging
+import os
+
+from typing import Awaitable, Callable, Optional
+
+from fastapi import FastAPI, Header
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from .chat_template import ChatTemplate
+from .errors import APIError
+from .protocol import ChatCompletionRequest, ModelCard, ModelList
+from .serving_chat import ServingChat
+from .session_runtime import SessionRuntime
+from .tool_parsers import HermesDetector
+from .worker_client import spawn_worker
+
+logger = logging.getLogger(__name__)
+
+
+def _spawn(args):
+    """Spawn the C++ model worker and return a ready WorkerClient."""
+    env = dict(os.environ)
+    conda = os.environ.get("CONDA_PREFIX")
+    if conda:
+        env["LD_LIBRARY_PATH"] = f"{conda}/lib:" + env.get("LD_LIBRARY_PATH", "")
+    cmd = [
+        args.worker_bin,
+        "--model_path",
+        args.model_path,
+        "--tokenizer_path",
+        args.tokenizer_path,
+    ]
+    logger.info("Starting model worker subprocess (loads the model once)...")
+    return spawn_worker(cmd, env=env)
+
+
+def _resolve_session_id(
+    req: ChatCompletionRequest,
+    x_executorch_session_id: Optional[str],
+    session_id_header: Optional[str],
+    x_session_affinity: Optional[str],
+) -> Optional[str]:
+    # Session id precedence: body field wins, else the X-ExecuTorch-Session-ID /
+    # session_id / x-session-affinity headers (in that order). Aliases let clients
+    # that already emit a stable per-conversation id for cache affinity (e.g. pi's
+    # sendSessionAffinityHeaders) route to a session with no extra config.
+    if req.session_id is not None:
+        return req.session_id
+    return x_executorch_session_id or session_id_header or x_session_affinity
+
+
+async def _session_op(
+    op: Callable[[str], Awaitable[None]], session_id: str, ok: dict
+) -> JSONResponse:
+    # Shared shape for the session vendor-extension routes (close/reset): run the
+    # idempotent op, mapping APIError to a structured JSON error.
+    try:
+        await op(session_id)
+    except APIError as e:
+        return JSONResponse(e.body(), status_code=e.status)
+    return JSONResponse(ok)
+
+
+def build_app(serving: ServingChat, model_id: str) -> FastAPI:
+    app = FastAPI(title="ExecuTorch LLM Server")
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.get("/v1/models")
+    async def list_models() -> ModelList:
+        return ModelList(data=[ModelCard(id=model_id)])
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(
+        req: ChatCompletionRequest,
+        # FastAPI dependency: the Header() call in the default is required.
+        # `session_id` is matched verbatim (underscore).
+        x_executorch_session_id: Optional[str] = Header(default=None),  # noqa: B008
+        session_id_header: Optional[str] = Header(  # noqa: B008
+            default=None, alias="session_id"
+        ),
+        x_session_affinity: Optional[str] = Header(default=None),  # noqa: B008
+    ):
+        # Typed param → FastAPI validates the body and returns 422 on bad input.
+        # APIError (e.g. context_length_exceeded) → structured 4xx/5xx, never a
+        # dropped connection. Mid-stream failures are handled inside the stream.
+        req.session_id = _resolve_session_id(
+            req, x_executorch_session_id, session_id_header, x_session_affinity
+        )
+        try:
+            result = await serving.create(req)
+        except APIError as e:
+            return JSONResponse(e.body(), status_code=e.status)
+        if req.stream:
+            return StreamingResponse(result, media_type="text/event-stream")
+        return JSONResponse(result.model_dump(exclude_none=True))
+
+    @app.delete("/v1/sessions/{session_id}")
+    async def close_session(session_id: str):
+        # Free a named session's state + capacity slot (vendor extension; idempotent).
+        return await _session_op(
+            serving.close_session,
+            session_id,
+            {"closed": True, "session_id": session_id},
+        )
+
+    @app.post("/v1/sessions/{session_id}/reset")
+    async def reset_session(session_id: str):
+        # Clear a named session's context but keep its slot (vendor extension;
+        # idempotent): reuse a slot for a new conversation without reopening it.
+        return await _session_op(
+            serving.reset_session,
+            session_id,
+            {"reset": True, "session_id": session_id},
+        )
+
+    return app
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="ExecuTorch OpenAI-compatible LLM server")
+    p.add_argument(
+        "--model-path",
+        required=True,
+        help="Path to the self-contained .pte model (external .ptd weights are not "
+        "supported by the generic text worker; use a model-specific launcher).",
+    )
+    p.add_argument("--tokenizer-path", required=True, help="Path to the tokenizer")
+    p.add_argument(
+        "--hf-tokenizer",
+        default=None,
+        help="HF tokenizer id/dir for model-correct chat templating (required unless "
+        "--allow-chatml-fallback).",
+    )
+    p.add_argument(
+        "--allow-chatml-fallback",
+        action="store_true",
+        help="Allow approximate generic ChatML templating when --hf-tokenizer is absent. "
+        "Off by default: the fallback can't reproduce model-specific controls.",
+    )
+    p.add_argument(
+        "--model-id", default="executorch", help="Model id reported on /v1/models"
+    )
+    p.add_argument(
+        "--no-think",
+        action="store_true",
+        help="Default reasoning off (sends enable_thinking=False to the chat template, "
+        "e.g. Qwen3). Per-request chat_template_kwargs still override this.",
+    )
+    p.add_argument(
+        "--max-context",
+        type=int,
+        default=None,
+        help="Model context window; if set (and a tokenizer is available), prompts that "
+        "exceed it are rejected with 400 context_length_exceeded instead of failing mid-generation. "
+        "Set this to match the value used at export.",
+    )
+    p.add_argument(
+        "--num-runners",
+        type=int,
+        default=1,
+        help="Worker processes. 1 only: one worker hosts many isolated sessions "
+        "on a single weight load; more workers would duplicate the weights.",
+    )
+    p.add_argument(
+        "--worker-bin",
+        required=True,
+        help="Path to a model worker binary that speaks the llm_server JSONL protocol "
+        "and accepts --model_path / --tokenizer_path.",
+    )
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8000)
+    args = p.parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    if args.num_runners != 1:
+        p.error(
+            "Only 1 worker process is supported (it hosts many isolated sessions "
+            "on one weight load); more workers would duplicate the weights."
+        )
+
+    default_template_kwargs = {"enable_thinking": False} if args.no_think else None
+    # Requires --hf-tokenizer unless --allow-chatml-fallback (raises otherwise).
+    template = ChatTemplate(
+        args.hf_tokenizer,
+        default_template_kwargs=default_template_kwargs,
+        allow_fallback=args.allow_chatml_fallback,
+    )
+    worker = _spawn(args)  # one worker hosting many isolated sessions
+    runtime = SessionRuntime(worker)
+    serving = ServingChat(
+        runtime,
+        template,
+        args.model_id,
+        max_context=args.max_context,
+        # Hermes JSON is the generic default; a model-specific server (e.g. a
+        # Qwen launcher) selects the Qwen XML detector instead.
+        tool_detector_cls=HermesDetector,
+    )
+
+    app = build_app(serving, args.model_id)
+
+    @app.on_event("shutdown")
+    def _stop_worker():
+        runtime.close_worker()
+
+    import uvicorn  # imported here so build_app() is usable without the ASGI server
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/llm_server/python/serving_chat.py
+++ b/examples/llm_server/python/serving_chat.py
@@ -1,0 +1,639 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""/v1/chat/completions OpenAI adapter: validates requests, renders the chat
+template, parses tool calls, and formats OpenAI responses. It owns no model or
+session state -- generation goes through SessionRuntime, and the token-ID warm-
+resume transcript lives in OpenAITranscriptState."""
+
+import json
+import logging
+import math
+from typing import AsyncIterator, Callable, Optional
+
+from .chat_template import ChatTemplate
+from .errors import (
+    APIError,
+    ContextLengthExceeded,
+    GenerationError,
+    InvalidSessionId,
+    ModelNotFound,
+    SessionCapacity,
+)
+from .openai_transcript import OpenAITranscriptState
+from .protocol import (
+    _new_id,
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    Choice,
+    ChunkChoice,
+    DeltaMessage,
+    FunctionCall,
+    ResponseMessage,
+    ToolCall,
+    Usage,
+)
+from .session_runtime import GenerationOptions, GenStats, PromptInput, SessionRuntime
+from .tool_parsers import HermesDetector, ToolCallItem
+from .worker_client import WorkerError
+
+logger = logging.getLogger(__name__)
+
+_SESSION_ID_MAX_LEN = 128
+
+
+def _earliest_stop(text: str, stops: list[str]) -> Optional[int]:
+    """Index of the earliest special-token occurrence in `text`, or None."""
+    best = None
+    for s in stops:
+        i = text.find(s)
+        if i != -1 and (best is None or i < best):
+            best = i
+    return best
+
+
+class ServingChat:
+    def __init__(
+        self,
+        runtime: SessionRuntime,
+        template: ChatTemplate,
+        model_id: str,
+        max_context: Optional[int] = None,
+        tool_detector_cls: Optional[type[HermesDetector]] = None,
+        prompt_token_offset: int = 0,
+        content_filter: Optional[Callable[[str], str]] = None,
+        content_filter_specials: Optional[set[str]] = None,
+    ):
+        self._runtime = runtime
+        self._template = template
+        self._model_id = model_id
+        self._max_context = max_context
+        self._prompt_token_offset = prompt_token_offset
+        self._content_filter = content_filter
+        # Detector CLASS; a fresh instance is created per request so streaming
+        # state is never shared across concurrent requests.
+        self._tool_detector_cls = tool_detector_cls
+        # Two distinct sets (see chat_template); create() combines them per path:
+        #  * _stops: NARROW turn terminators (e.g. <|im_end|>). The ONLY stop set
+        #    for tool turns -- excludes structural/tool delimiters so a <tool_call>
+        #    is never halted or cut before _extract_tools sees it. Also used by
+        #    _truncate_raw (pre-parse truncation on the tool path).
+        #  * _content_specials: BROAD all-special-tokens set. For PLAIN chat it is
+        #    added to the worker/clean stop set (create() -> gen_stops) so a leaked
+        #    special halts the worker (-> dirty, ids omitted, non-resumable) and
+        #    never reaches the client, AND it backs _strip_specials for final
+        #    cleanup of already-parsed visible content.
+        self._stops = template.turn_stop_sequences()
+        handled = content_filter_specials or set()
+        self._content_specials = [
+            t for t in template.special_tokens() if t not in handled
+        ]
+        # OpenAI/chat-template token-ID warm-resume state. Adapter-side,
+        # not runtime; kept in lockstep with the worker's session state by
+        # clearing both on reset/close.
+        self._transcript = OpenAITranscriptState(template)
+
+    @staticmethod
+    def _tool_schemas(req: ChatCompletionRequest) -> dict[str, dict]:
+        """Map each defined tool name to its JSON-schema ``parameters`` object.
+
+        The detector uses the key set to validate names and the schema to coerce
+        values to their declared types (the Qwen XML format is stringly-typed)."""
+        schemas = {}
+        for t in req.tools or []:
+            fn = t.get("function", {}) if isinstance(t, dict) else {}
+            name = fn.get("name")
+            if name:
+                schemas[name] = fn.get("parameters") or {}
+        return schemas
+
+    def _strip_specials(self, text: str) -> str:
+        # Broad set: scrub ANY special token that leaked into already-parsed
+        # visible content (not the narrow generation-stop set).
+        cut = _earliest_stop(text, self._content_specials)
+        return text[:cut] if cut is not None else text
+
+    def _visible_content(self, text: str) -> str:
+        if self._content_filter is not None:
+            text = self._content_filter(text)
+        return self._strip_specials(text)
+
+    @staticmethod
+    def _to_openai_tool_call(item: ToolCallItem) -> ToolCall:
+        return ToolCall(
+            index=item.tool_index,
+            id=_new_id("call"),
+            type="function",
+            function=FunctionCall(name=item.name, arguments=item.arguments),
+        )
+
+    def _tools_active(self, req: ChatCompletionRequest) -> bool:
+        # tool_choice="none" disables tools even when the client sends them.
+        return bool(self._tool_detector_cls and req.tools and req.tool_choice != "none")
+
+    @staticmethod
+    def _request_stops(req: ChatCompletionRequest) -> list[str]:
+        s = req.stop
+        if not s:
+            return []
+        return [s] if isinstance(s, str) else [x for x in s if x]
+
+    @staticmethod
+    def _apply_stop(text: str, stops: list[str]) -> str:
+        """Truncate at the earliest stop string (the stop itself is excluded)."""
+        cut = _earliest_stop(text, stops)
+        return text[:cut] if cut is not None else text
+
+    def _truncate_raw(self, text: str, req: ChatCompletionRequest) -> str:
+        """Cut raw model output at the earliest special token or request stop
+        sequence BEFORE tool parsing, so a tool call (or any text) past the stop
+        boundary is neither parsed nor emitted."""
+        return self._apply_stop(text, self._stops + self._request_stops(req))
+
+    async def _collect_until_stop(self, stream: AsyncIterator[str], stops: list[str]):
+        """Accumulate a buffered (non-streamed) generation into one string,
+        halting the runtime early once a stop string (special token or request
+        stop) appears, then draining so stats finalize. Returns (text, stopped):
+        `stopped` lets the caller force finish_reason="stop" even when tokens
+        queued before the runtime observed stop() pushed the count to max_tokens."""
+        text = ""
+        stopped = False
+        async for tok in stream:
+            text += tok
+            if stops and _earliest_stop(text, stops) is not None:
+                stopped = True
+                self._runtime.stop()
+                async for _ in stream:  # drain so stats_cb fires
+                    pass
+                break
+        return text, stopped
+
+    def _extract_tools(self, req: ChatCompletionRequest, text: str):
+        """Returns (tool_calls | None, content_text). Falls back to plain text."""
+        if self._tools_active(req):
+            parsed = self._tool_detector_cls().detect_and_parse(
+                text, self._tool_schemas(req)
+            )
+            if parsed.calls:
+                content = self._visible_content(parsed.normal_text) or None
+                return [self._to_openai_tool_call(c) for c in parsed.calls], content
+            text = parsed.normal_text
+        return None, self._visible_content(text)
+
+    async def _clean(
+        self, stream: AsyncIterator[str], stops: list[str], on_stop=None
+    ) -> AsyncIterator[str]:
+        # Yield text up to the earliest stop string (special token or request
+        # `stop`), buffering across tokens so a stop spanning chunks is caught.
+        # On a hit: optionally stop the runner early, then drain the source so it
+        # finalizes (usage stats recorded, worker thread joined).
+        hold = (
+            max((len(s) for s in stops), default=1) - 1
+        )  # keep a possible partial-stop tail
+        buf = ""
+        async for token in stream:
+            buf += token
+            cut = _earliest_stop(buf, stops)
+            if cut is not None:
+                if cut > 0:
+                    yield buf[:cut]
+                if on_stop is not None:
+                    on_stop()
+                async for _ in stream:  # drain so stats_cb fires
+                    pass
+                return
+            if hold == 0:
+                yield buf
+                buf = ""
+            elif len(buf) > hold:
+                yield buf[:-hold]
+                buf = buf[-hold:]
+        if buf:
+            yield buf
+
+    def _options(
+        self, req: ChatCompletionRequest, stops: list[str]
+    ) -> GenerationOptions:
+        return GenerationOptions(
+            max_new_tokens=req.resolved_max_tokens(),
+            temperature=req.temperature if req.temperature is not None else 0.0,
+            # Worker stop set, chosen per path in create() (see __init__ for the
+            # two sets); the server re-applies it in _clean/_collect_until_stop.
+            stop=stops,
+        )
+
+    @staticmethod
+    def _validate_session_id(session_id: str) -> None:
+        # Keep it boring: non-empty printable ASCII (no spaces/control), <=128.
+        if not session_id or len(session_id) > _SESSION_ID_MAX_LEN:
+            raise InvalidSessionId(f"must be 1-{_SESSION_ID_MAX_LEN} characters")
+        if not all(0x21 <= ord(c) <= 0x7E for c in session_id):
+            raise InvalidSessionId("must be printable ASCII with no spaces")
+
+    async def _preflight_session(self, session_id: str) -> None:
+        """Reserve the session before any response bytes are emitted so a
+        capacity refusal becomes an HTTP status, not an SSE error event."""
+        try:
+            await self._runtime.open(session_id)
+        except WorkerError as e:
+            if e.code in ("capacity_exhausted", "unsupported_session"):
+                raise SessionCapacity(e.code)
+            raise GenerationError(str(e))
+
+    async def close_session(self, session_id: str) -> None:
+        # Lockstep: do the fallible worker op FIRST, then clear the (best-effort,
+        # can't-fail) transcript. If the worker op fails both retain old state,
+        # so they never drift.
+        self._validate_session_id(session_id)
+        try:
+            await self._runtime.close(session_id)
+        except WorkerError as e:
+            raise GenerationError(str(e))
+        self._transcript.close(session_id)
+
+    async def reset_session(self, session_id: str) -> None:
+        # Lockstep: worker op first (fallible), then clear the transcript.
+        self._validate_session_id(session_id)
+        try:
+            await self._runtime.reset(session_id)
+        except WorkerError as e:
+            raise GenerationError(str(e))
+        self._transcript.reset(session_id)
+
+    def _finish_reason(
+        self,
+        req: ChatCompletionRequest,
+        completion_tokens: int,
+        tool_calls=None,
+        stopped: bool = False,
+        worker_finish: Optional[str] = None,
+    ) -> str:
+        # Precedence: tool call > stop boundary > worker reason > length heuristic.
+        # `stopped` (a server-side stop sequence / special token) wins even over
+        # the worker, since that truncation happened in the control plane.
+        if tool_calls:
+            return "tool_calls"
+        if stopped:
+            return "stop"
+        # The worker knows whether it hit EOS ("stop") or ran to max_new ("length",
+        # possibly a clamp to the context window) — trust it over the token-count
+        # heuristic, which can't see a silent clamp.
+        if worker_finish in ("stop", "length"):
+            return worker_finish
+        mt = req.resolved_max_tokens()
+        return "length" if mt and mt > 0 and completion_tokens >= mt else "stop"
+
+    @staticmethod
+    def _reject_invalid_values(req: ChatCompletionRequest) -> None:
+        """Reject out-of-range values (invalid_value); these take precedence over
+        the unsupported-parameter error."""
+        if req.temperature is not None and (
+            not math.isfinite(req.temperature)
+            or req.temperature < 0.0
+            or req.temperature > 2.0
+        ):
+            raise APIError(
+                400,
+                f"temperature must be between 0 and 2 (got {req.temperature}).",
+                "invalid_request_error",
+                "invalid_value",
+            )
+        # max_tokens / max_completion_tokens, if given, must be positive integers
+        # (OpenAI rejects 0 and negatives; our -1 sentinel means "unset/auto").
+        for field_name in ("max_tokens", "max_completion_tokens"):
+            v = getattr(req, field_name)
+            if v is not None and v <= 0:
+                raise APIError(
+                    400,
+                    f"{field_name} must be a positive integer (got {v}).",
+                    "invalid_request_error",
+                    "invalid_value",
+                )
+
+    @staticmethod
+    def _reject_unsupported_params(req: ChatCompletionRequest) -> None:
+        """Reject params we don't honor rather than silently ignoring them (a
+        client relying on e.g. top_p/seed/logprobs would otherwise get wrong
+        behavior). Only the no-op/default value of each passes: top_p exactly
+        1.0; penalties 0; response_format type "text"; tool_choice none/auto/
+        unset; parallel_tool_calls true (false can't be guaranteed without
+        constraining); logprobs are not returned at all."""
+        rf = req.response_format
+        flags = [
+            (req.n != 1, "n>1"),
+            (req.top_p is not None and req.top_p != 1.0, "top_p"),
+            (req.seed is not None, "seed"),
+            (req.reasoning_effort is not None, "reasoning_effort"),
+            (bool(req.frequency_penalty), "frequency_penalty"),
+            (bool(req.presence_penalty), "presence_penalty"),
+            (req.top_k is not None, "top_k"),
+            (bool(req.logit_bias), "logit_bias"),
+            (
+                bool(rf) and rf.get("type", "text") != "text",
+                "response_format (only 'text')",
+            ),
+            (bool(req.logprobs), "logprobs"),
+            (req.top_logprobs is not None, "top_logprobs"),
+            (req.parallel_tool_calls is False, "parallel_tool_calls=false"),
+            (
+                req.tool_choice not in (None, "none", "auto"),
+                "tool_choice (only 'none' or 'auto')",
+            ),
+        ]
+        unsupported = [label for cond, label in flags if cond]
+        if unsupported:
+            raise APIError(
+                400,
+                f"Unsupported parameter(s): {', '.join(unsupported)}. This server honors "
+                "temperature, max_tokens/max_completion_tokens, stop, and tools for the "
+                "configured tool-call format.",
+                "invalid_request_error",
+                "unsupported_parameter",
+            )
+
+    def _count_prompt_tokens(self, prompt: PromptInput) -> Optional[int]:
+        """Token count of what the worker will actually assemble: the rendered
+        text, or for token-ID segments sum(len(ids)) for {ids} runs + the
+        tokenized length of {text} chunks. None when no tokenizer is available to
+        count text (the worker still enforces the real context limit)."""
+        if prompt.text is not None:
+            count = self._template.count_tokens(prompt.text)
+            return None if count is None else count + self._prompt_token_offset
+        total = self._prompt_token_offset
+        for seg in prompt.segments:
+            if "ids" in seg:
+                total += len(seg["ids"])
+            else:
+                c = self._template.count_tokens(seg["text"])
+                if c is None:
+                    return None
+                total += c
+        return total
+
+    async def create(self, req: ChatCompletionRequest):
+        if req.model is not None and req.model != self._model_id:
+            raise ModelNotFound(req.model, self._model_id)
+        self._reject_invalid_values(req)
+        self._reject_unsupported_params(req)
+        if req.session_id is not None:
+            self._validate_session_id(req.session_id)
+        # tool_choice="none" must hide tools from the model: if we still render
+        # the tool schemas, the model can emit a <tool_call> that we'd surface as
+        # plain text (parsing is disabled), instead of a normal answer.
+        template_tools = None if req.tool_choice == "none" else req.tools
+        prompt = self._template.render(
+            req.messages, tools=template_tools, template_kwargs=req.chat_template_kwargs
+        )
+        # Token-ID segments splice prior assistant turns' exact ids so warm resume
+        # survives the template's lossy tool-call re-render; plain text when
+        # there's nothing to splice or on ambiguity (the worker verifies the
+        # exact-token prefix regardless).
+        prompt_input = self._transcript.build_prompt_input(
+            session_id=req.session_id,
+            messages=req.messages,
+            rendered_prompt=prompt,
+            tools=template_tools,
+            template_kwargs=req.chat_template_kwargs,
+        )
+        # Pre-flight context check against the tokens the worker will actually
+        # assemble: for segments that is sum(len(ids)) + tokenized text, not the
+        # rendered string, so a near-limit prompt agrees with the worker rather
+        # than false-400ing or failing mid-decode. Only when a tokenizer exists.
+        if self._max_context:
+            count = self._count_prompt_tokens(prompt_input)
+            if count is not None:
+                if count >= self._max_context:
+                    raise ContextLengthExceeded(count, self._max_context)
+                # An explicit max_tokens that wouldn't fit alongside the prompt
+                # must be rejected here, not run until the worker hits the context
+                # limit mid-decode (a 500 / streaming error after partial output).
+                requested = req.resolved_max_tokens()
+                if requested > 0 and count + requested > self._max_context:
+                    raise ContextLengthExceeded(count, self._max_context, requested)
+        # Per-path worker stop set (see __init__ for the two sets and why): tool
+        # turns use the narrow set; plain chat adds the broad content specials.
+        if self._tools_active(req):
+            gen_stops = self._stops + self._request_stops(req)
+        else:
+            gen_stops = self._stops + self._content_specials + self._request_stops(req)
+        options = self._options(req, gen_stops)
+        # The generation scaffold the worker will prefill ahead of this turn's
+        # tokens (e.g. Qwen3 <think> block), resolved with the same per-request
+        # mode AND tools as the render; recorded per turn so warm-resume splicing
+        # reproduces the exact resident scaffold even if the mode changes between
+        # requests.
+        preamble = self._template.generation_preamble(
+            req.chat_template_kwargs, tools=template_tools
+        )
+        # Admit the session up front (before the stream's first chunk) so a
+        # capacity refusal is an HTTP status, not a mid-stream error event.
+        if req.session_id is not None:
+            await self._preflight_session(req.session_id)
+        if req.stream:
+            return self._stream(req, prompt_input, options, preamble, gen_stops)
+        return await self._complete(req, prompt_input, options, preamble, gen_stops)
+
+    async def _complete(
+        self,
+        req: ChatCompletionRequest,
+        prompt: PromptInput,
+        options: GenerationOptions,
+        preamble: str = "",
+        gen_stops: Optional[list[str]] = None,
+    ) -> ChatCompletionResponse:
+        # Same stop set the worker was given (per-path: narrow for tools, broad
+        # content specials added for plain chat); falls back to narrow if a caller
+        # didn't supply it.
+        stops = (
+            gen_stops
+            if gen_stops is not None
+            else self._stops + self._request_stops(req)
+        )
+        stats = GenStats()
+        try:
+            # Collect raw text (markers intact for tool parsing), halting early
+            # at a stop boundary (special token or request stop).
+            text, stopped = await self._collect_until_stop(
+                self._runtime.generate_stream(req.session_id, prompt, options, stats),
+                stops,
+            )
+        except Exception as e:  # noqa: BLE001 - surface as a structured API error
+            raise GenerationError(str(e))
+        # Bound the raw output at the first stop/special token BEFORE tool
+        # parsing, so a call after the stop boundary is not parsed/emitted.
+        tool_calls, content = self._extract_tools(req, self._truncate_raw(text, req))
+        # Record after the response is finalized: the fingerprint is of exactly
+        # what we return (content + tool_calls), so the next turn can confirm the
+        # client echoed this turn before splicing its ids.
+        self._transcript.record_assistant_turn(
+            session_id=req.session_id,
+            content=content,
+            tool_calls=tool_calls,
+            generated_token_ids=stats.generated_token_ids,
+            prior_turns=sum(1 for m in req.messages if m.role == "assistant"),
+            preamble=preamble,
+        )
+        finish = self._finish_reason(
+            req, stats.completion_tokens, tool_calls, stopped, stats.finish_reason
+        )
+        return ChatCompletionResponse(
+            model=self._model_id,
+            choices=[
+                Choice(
+                    message=ResponseMessage(content=content, tool_calls=tool_calls),
+                    finish_reason=finish,
+                )
+            ],
+            usage=Usage(
+                prompt_tokens=stats.prompt_tokens,
+                completion_tokens=stats.completion_tokens,
+                total_tokens=stats.prompt_tokens + stats.completion_tokens,
+            ),
+        )
+
+    async def _stream_plain_content(
+        self,
+        req: ChatCompletionRequest,
+        prompt: PromptInput,
+        options: GenerationOptions,
+        stats: GenStats,
+        stops: list[str],
+        stop_hit: list[bool],
+    ) -> AsyncIterator[str]:
+        if self._content_filter is not None:
+            raw, stop_hit[0] = await self._collect_until_stop(
+                self._runtime.generate_stream(req.session_id, prompt, options, stats),
+                stops,
+            )
+            content = self._visible_content(self._apply_stop(raw, stops))
+            if content:
+                yield content
+            return
+
+        def on_stop():
+            stop_hit[0] = True
+            self._runtime.stop()
+
+        async for token in self._clean(
+            self._runtime.generate_stream(req.session_id, prompt, options, stats),
+            stops,
+            on_stop=on_stop,
+        ):
+            yield token
+
+    async def _stream(
+        self,
+        req: ChatCompletionRequest,
+        prompt: PromptInput,
+        options: GenerationOptions,
+        preamble: str = "",
+        gen_stops: Optional[list[str]] = None,
+    ) -> AsyncIterator[str]:
+        cid = _new_id("chatcmpl")
+
+        def chunk(delta: DeltaMessage, finish=None) -> str:
+            c = ChatCompletionChunk(
+                id=cid,
+                model=self._model_id,
+                choices=[ChunkChoice(delta=delta, finish_reason=finish)],
+            )
+            return f"data: {c.model_dump_json(exclude_none=True)}\n\n"
+
+        yield chunk(DeltaMessage(role="assistant"))
+        error: Optional[Exception] = None
+        use_tools = self._tools_active(req)
+        tool_calls = None
+        content = None
+
+        stats = GenStats()
+        stop_hit = [False]  # set when a stop boundary is reached (forces finish="stop")
+        # Per-path stop set from create(): for plain chat this includes the broad
+        # content specials, so _clean cuts a leaked special out of the stream (and
+        # the worker, given the same set, halts + omits ids -> non-resumable turn).
+        stops = (
+            gen_stops
+            if gen_stops is not None
+            else self._stops + self._request_stops(req)
+        )
+        try:
+            if use_tools:
+                # Buffer the (usually short) tool response, parse once.
+                # Halt early at a stop boundary, and bound the raw output
+                # BEFORE parsing so post-stop tool calls / text don't leak.
+                raw, stop_hit[0] = await self._collect_until_stop(
+                    self._runtime.generate_stream(
+                        req.session_id, prompt, options, stats
+                    ),
+                    stops,
+                )
+                tool_calls, content = self._extract_tools(
+                    req, self._truncate_raw(raw, req)
+                )
+            else:
+                streamed: list[str] = []
+                async for token in self._stream_plain_content(
+                    req, prompt, options, stats, stops, stop_hit
+                ):
+                    streamed.append(token)
+                    yield chunk(DeltaMessage(content=token))
+                content = "".join(streamed)  # for the session fingerprint
+        except (
+            Exception
+        ) as e:  # noqa: BLE001 - emit a structured error event, never drop the socket
+            error = e
+
+        if error is not None:
+            err = {
+                "message": f"Generation failed: {error}",
+                "type": "server_error",
+                "code": None,
+            }
+            yield f"data: {json.dumps({'error': err})}\n\n"
+            yield "data: [DONE]\n\n"
+            return
+        self._transcript.record_assistant_turn(
+            session_id=req.session_id,
+            content=content,
+            tool_calls=tool_calls,
+            generated_token_ids=stats.generated_token_ids,
+            prior_turns=sum(1 for m in req.messages if m.role == "assistant"),
+            preamble=preamble,
+        )
+
+        if use_tools:
+            if content:
+                yield chunk(DeltaMessage(content=content))
+            for tc in tool_calls or []:
+                yield chunk(DeltaMessage(tool_calls=[tc]))
+            finish = self._finish_reason(
+                req,
+                stats.completion_tokens,
+                tool_calls,
+                stop_hit[0],
+                stats.finish_reason,
+            )
+        else:
+            finish = self._finish_reason(
+                req,
+                stats.completion_tokens,
+                stopped=stop_hit[0],
+                worker_finish=stats.finish_reason,
+            )
+        yield chunk(DeltaMessage(), finish=finish)
+        if req.stream_options and req.stream_options.include_usage:
+            usage_chunk = ChatCompletionChunk(
+                id=cid,
+                model=self._model_id,
+                choices=[],
+                usage=Usage(
+                    prompt_tokens=stats.prompt_tokens,
+                    completion_tokens=stats.completion_tokens,
+                    total_tokens=stats.prompt_tokens + stats.completion_tokens,
+                ),
+            )
+            yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"
+        yield "data: [DONE]\n\n"

--- a/examples/llm_server/python/session_runtime.py
+++ b/examples/llm_server/python/session_runtime.py
@@ -1,0 +1,240 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Python's stateful local-LLM runtime over one C++ worker process.
+
+This is the internal boundary between protocol adapters (OpenAI chat, future
+native/agent surfaces) and the worker. The adapter speaks sessions, prompts, and
+generation parameters; the worker (driven over JSONL by a WorkerClient) owns all
+model execution and session state (KV/recurrent, resident token ids, warm-resume
+prefix logic). The Python server never loads a model, links a backend, or imports
+a runtime pybind.
+
+A SessionRuntime owns exactly one worker and serializes access to it (one
+in-flight request at a time), bridging the worker's blocking generate() into an
+async token stream. Multi-worker scheduling / named-session affinity is out of
+scope: a single worker already hosts many isolated sessions on one weight load,
+routed by session_id inside the worker.
+"""
+
+import asyncio
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import AsyncIterator, Optional
+
+logger = logging.getLogger(__name__)
+
+_SENTINEL = object()
+
+
+@dataclass
+class PromptInput:
+    """A prompt as either a single rendered string or token-ID segments. Exactly
+    one of `text` / `segments` is set. Segments ([{"text": str} | {"ids": [int]}])
+    let an adapter splice exact prior-turn token ids in place of a lossy
+    re-render (see openai_transcript)."""
+
+    text: Optional[str] = None
+    segments: Optional[list] = None
+
+    def __post_init__(self):
+        if (self.text is None) == (self.segments is None):
+            raise ValueError("exactly one of PromptInput.text / .segments must be set")
+        if self.segments is not None and not self.segments:
+            raise ValueError("PromptInput.segments must be non-empty")
+
+
+@dataclass
+class GenerationOptions:
+    """Sampling/length knobs forwarded to the worker (only what we honor today)."""
+
+    max_new_tokens: int
+    temperature: float = 0.0
+    stop: list[str] = field(default_factory=list)
+
+
+@dataclass
+class GenStats:
+    """Per-request metadata the worker reports at the end of generation."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    # Worker-reported stop reason ("stop" | "length"), or None if not reported.
+    finish_reason: Optional[str] = None
+    # Warm-resume accounting: tokens served from the session's resident
+    # state vs prefilled this request, and why.
+    reused_prompt_tokens: int = 0
+    prefilled_prompt_tokens: int = 0
+    session_reset_reason: Optional[str] = None
+    # Exact token ids generated this turn, for an adapter's transcript
+    # store. Empty when the worker doesn't report them (e.g. a stop-trimmed turn).
+    generated_token_ids: list = field(default_factory=list)
+
+
+# Forwarded to WorkerClient.generate() as the per-request config it reads fields
+# off; keeps that low-level contract unchanged while the runtime's public surface
+# is PromptInput + GenerationOptions + session_id.
+@dataclass
+class _WorkerRequest:
+    max_new_tokens: int
+    temperature: float
+    stop: list[str]
+    session_id: Optional[str]
+    prompt_segments: Optional[list]
+
+
+class _GenerationBridge:
+    def __init__(
+        self, worker, prompt_text: str, request: _WorkerRequest, stats: GenStats
+    ):
+        self._worker = worker
+        self._prompt_text = prompt_text
+        self._request = request
+        self._stats = stats
+        self._loop = asyncio.get_running_loop()
+        self.queue: asyncio.Queue = asyncio.Queue()
+        self.drop_tokens = threading.Event()
+
+    def _enqueue_if_live(self, item) -> None:
+        if not self.drop_tokens.is_set():
+            self.queue.put_nowait(item)
+
+    def token_cb(self, token: str) -> None:
+        if not self.drop_tokens.is_set():
+            self._loop.call_soon_threadsafe(self._enqueue_if_live, token)
+
+    def stats_cb(self, s) -> None:
+        self._stats.prompt_tokens = s.num_prompt_tokens
+        self._stats.completion_tokens = s.num_generated_tokens
+        self._stats.finish_reason = getattr(s, "finish_reason", None)
+        self._stats.reused_prompt_tokens = getattr(s, "reused_prompt_tokens", 0)
+        self._stats.prefilled_prompt_tokens = getattr(s, "prefilled_prompt_tokens", 0)
+        self._stats.session_reset_reason = getattr(s, "session_reset_reason", None)
+        self._stats.generated_token_ids = getattr(s, "generated_token_ids", [])
+
+    def run(self) -> None:
+        try:
+            self._worker.generate(
+                self._prompt_text, self._request, self.token_cb, self.stats_cb
+            )
+        except Exception as e:  # noqa: BLE001 - surface to the stream consumer
+            self._loop.call_soon_threadsafe(self.queue.put_nowait, e)
+        finally:
+            self._loop.call_soon_threadsafe(self.queue.put_nowait, _SENTINEL)
+
+    async def items(self) -> AsyncIterator[str]:
+        while True:
+            item = await self.queue.get()
+            if item is _SENTINEL:
+                return
+            if isinstance(item, Exception):
+                raise item
+            yield item
+
+    def drain(self) -> None:
+        while True:
+            try:
+                self.queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+
+    async def finish_after_cancel(self, fut: asyncio.Future) -> None:
+        self.drop_tokens.set()
+        task = asyncio.current_task()
+        uncancel = getattr(task, "uncancel", None) if task else None
+        if uncancel is not None:
+            uncancel()
+        await fut
+        self.drain()
+
+    async def finish(self, fut: asyncio.Future) -> None:
+        if not fut.done():
+            await fut
+        self.drop_tokens.set()
+        self.drain()
+
+
+class SessionRuntime:
+    """Stateful runtime over a single worker. `worker` is a WorkerClient (a fake
+    in tests) exposing generate()/stop()/close() and the session ops
+    open_session/reset_session/close_session."""
+
+    def __init__(self, worker):
+        self._worker = worker
+        # One executor thread; the lock guarantees the worker is never driven by
+        # two requests at once (it is single-in-flight).
+        self._executor = ThreadPoolExecutor(max_workers=1)
+        self._lock = asyncio.Lock()
+
+    async def open(self, session_id: str) -> None:
+        """Admit a named session before generation so a capacity refusal surfaces
+        up front (the adapter maps it to an HTTP status) rather than mid-stream.
+        Idempotent."""
+        await self._session_op("open_session", session_id)
+
+    async def reset(self, session_id: str) -> None:
+        """Clear a named session's context (KV/recurrent + resident ids) but keep
+        its capacity slot. Idempotent."""
+        await self._session_op("reset_session", session_id)
+
+    async def close(self, session_id: str) -> None:
+        """Destroy a named session, freeing its state and slot. Idempotent."""
+        await self._session_op("close_session", session_id)
+
+    async def _session_op(self, method: str, session_id: str) -> None:
+        op = getattr(self._worker, method, None)
+        if op is None:
+            return  # worker doesn't support sessions (e.g. a minimal fake)
+        loop = asyncio.get_running_loop()
+        async with self._lock:
+            await loop.run_in_executor(self._executor, op, session_id)
+
+    def stop(self) -> None:
+        """Request the in-flight generation stop at the next token boundary."""
+        self._worker.stop()
+
+    async def generate_stream(
+        self,
+        session_id: Optional[str],
+        prompt: PromptInput,
+        options: GenerationOptions,
+        stats: Optional[GenStats] = None,
+    ) -> AsyncIterator[str]:
+        """Yield generated text pieces from the worker, holding the worker lock
+        for the whole generation. `stats` (if given) is filled in place with the
+        worker's terminal metadata (per-request, so concurrent callers don't
+        race). session_id None routes to the worker's anonymous scratch session."""
+        out_stats = stats if stats is not None else GenStats()
+        req = _WorkerRequest(
+            max_new_tokens=options.max_new_tokens,
+            temperature=options.temperature,
+            stop=list(options.stop),
+            session_id=session_id,
+            prompt_segments=prompt.segments,
+        )
+        bridge = _GenerationBridge(self._worker, prompt.text or "", req, out_stats)
+
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            fut = loop.run_in_executor(self._executor, bridge.run)
+            try:
+                async for item in bridge.items():
+                    yield item
+            except asyncio.CancelledError:
+                self._worker.stop()
+                await bridge.finish_after_cancel(fut)
+                raise
+            finally:
+                await bridge.finish(fut)
+
+    def close_worker(self) -> None:
+        """Shut the worker process down and the executor (called at shutdown)."""
+        close = getattr(self._worker, "close", None)
+        if close is not None:
+            close()
+        self._executor.shutdown(wait=False, cancel_futures=True)

--- a/examples/llm_server/python/tests/conftest.py
+++ b/examples/llm_server/python/tests/conftest.py
@@ -1,0 +1,143 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Fixtures for hermetic contract tests.
+
+We build a SessionRuntime over a single FakeRunner worker, so the tests exercise
+the real server, protocol, templating, and streaming code over the HTTP boundary
+with NO model, tokenizer, GPU, or worker subprocess. This mirrors ExecuTorch's
+fake_llm_executor approach: fake the worker, test the real surface.
+
+The control plane imports no runtime pybind; only fastapi, pydantic, httpx, and
+pytest are required.
+"""
+
+import pytest
+
+from executorch.examples.llm_server.python.chat_template import ChatTemplate
+from executorch.examples.llm_server.python.server import build_app
+from executorch.examples.llm_server.python.serving_chat import ServingChat
+from executorch.examples.llm_server.python.session_runtime import SessionRuntime
+from executorch.examples.llm_server.python.tool_parsers import HermesDetector
+from executorch.examples.llm_server.python.worker_client import WorkerError
+from fastapi.testclient import TestClient
+
+
+class _FakeStats:
+    num_prompt_tokens = 5
+    num_generated_tokens = 0
+    finish_reason = None
+
+
+class FakeRunner:
+    """Canned engine: emits fixed tokens, records the config it was given.
+
+    With max_named_sessions > 0 it also models the worker's session admission:
+    open_session() enforces capacity and reports structured WorkerError codes,
+    matching the real worker's contract."""
+
+    def __init__(
+        self, tokens, fail=False, finish_reason=None, max_named_sessions=0, gen_ids=None
+    ):
+        self._tokens = list(tokens)
+        self._fail = fail
+        self._finish_reason = finish_reason  # worker-reported stop reason, if any
+        self._gen_ids = list(gen_ids or [])  # ids reported per turn
+        self.captured_config = None
+        self.stopped = False
+        self.reset_count = 0
+        self.max_named_sessions = max_named_sessions
+        self.open_named = set()  # currently-open named sessions
+        self.opened_log = []  # every successful open, in order
+        self.reset_log = []  # every reset_session call, in order
+
+    def reset(self):
+        self.reset_count += 1
+
+    def stop(self):
+        self.stopped = True
+
+    def open_session(self, session_id):
+        if session_id in self.open_named:
+            return  # idempotent
+        if self.max_named_sessions == 0:
+            raise WorkerError("no named sessions", code="unsupported_session")
+        if len(self.open_named) >= self.max_named_sessions:
+            raise WorkerError("session capacity exhausted", code="capacity_exhausted")
+        self.open_named.add(session_id)
+        self.opened_log.append(session_id)
+
+    def close_session(self, session_id):
+        self.open_named.discard(session_id)
+
+    def reset_session(self, session_id):
+        # Clears context but keeps the slot (stays in open_named).
+        self.reset_log.append(session_id)
+
+    def generate(self, prompt, config, token_callback=None, stats_callback=None):
+        self.captured_config = config
+        if self._fail:
+            raise RuntimeError("Generation failed")
+        for tok in self._tokens:
+            if token_callback:
+                token_callback(tok)
+        if stats_callback:
+            stats = _FakeStats()
+            stats.num_generated_tokens = len(self._tokens)
+            stats.finish_reason = self._finish_reason
+            stats.generated_token_ids = list(self._gen_ids)
+            stats_callback(stats)
+
+
+class _FakeTokenizer:
+    """Minimal stand-in for an HF tokenizer (counting + templating)."""
+
+    all_special_tokens: list = []
+
+    def __init__(self, prompt_tokens):
+        self._n = prompt_tokens
+
+    def encode(self, text, add_special_tokens=False):
+        return [0] * self._n
+
+    def apply_chat_template(
+        self, messages, tools, add_generation_prompt, tokenize, **kwargs
+    ):
+        return "PROMPT"
+
+
+@pytest.fixture
+def make_client():
+    def _make(
+        tokens=("Hello", ", ", "world"),
+        max_context=None,
+        prompt_tokens=None,
+        fail=False,
+        finish_reason=None,
+        max_named_sessions=0,
+        gen_ids=None,
+    ):
+        fake = FakeRunner(
+            tokens,
+            fail=fail,
+            finish_reason=finish_reason,
+            max_named_sessions=max_named_sessions,
+            gen_ids=gen_ids,
+        )
+        runtime = SessionRuntime(fake)  # one fake worker
+        template = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)
+        if prompt_tokens is not None:
+            template._hf = _FakeTokenizer(prompt_tokens)
+        serving = ServingChat(
+            runtime,
+            template,
+            "test-model",
+            max_context=max_context,
+            tool_detector_cls=HermesDetector,
+        )
+        return TestClient(build_app(serving, "test-model")), fake
+
+    return _make

--- a/examples/llm_server/python/tests/test_contract.py
+++ b/examples/llm_server/python/tests/test_contract.py
@@ -1,0 +1,457 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Hermetic OpenAI-contract tests (fake engine, no model/GPU).
+
+These assert on the public HTTP/wire contract only — response object shapes,
+the streaming chunk protocol, status codes — never on internal classes or
+methods. Implementation can change freely as long as these pass.
+"""
+
+import json
+
+import pytest
+
+
+def _sse_chunks(text):
+    chunks, done = [], False
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:") :].strip()
+        if payload == "[DONE]":
+            done = True
+            continue
+        chunks.append(json.loads(payload))
+    return chunks, done
+
+
+def test_health(make_client):
+    client, _ = make_client()
+    assert client.get("/health").json() == {"status": "ok"}
+
+
+def test_models_listing_shape(make_client):
+    client, _ = make_client()
+    body = client.get("/v1/models").json()
+    assert body["object"] == "list"
+    assert body["data"][0]["id"] == "test-model"
+    assert body["data"][0]["object"] == "model"
+
+
+def test_chat_nonstreaming_shape(make_client):
+    client, _ = make_client(tokens=["Hello", ", ", "world"])
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "chat.completion"
+    choice = body["choices"][0]
+    assert choice["message"]["role"] == "assistant"
+    assert choice["message"]["content"] == "Hello, world"
+    assert choice["finish_reason"] == "stop"
+    for k in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        assert k in body["usage"]
+    assert body["usage"]["total_tokens"] == (
+        body["usage"]["prompt_tokens"] + body["usage"]["completion_tokens"]
+    )
+
+
+def test_unknown_model_is_rejected(make_client):
+    client, _ = make_client()
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "other-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["code"] == "model_not_found"
+
+
+def test_chat_streaming_protocol(make_client):
+    client, _ = make_client(tokens=["a", "b", "c"])
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    chunks, done = _sse_chunks(resp.text)
+    assert done, "stream must terminate with data: [DONE]"
+    assert all(c["object"] == "chat.completion.chunk" for c in chunks)
+    assert chunks[0]["choices"][0]["delta"].get("role") == "assistant"
+    content = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks)
+    assert content == "abc"
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+def test_request_params_forwarded_to_generation(make_client):
+    # Contract behavior: the server must honor max_tokens/temperature.
+    client, fake = make_client()
+    client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 7,
+            "temperature": 0.1,
+        },
+    )
+    assert fake.captured_config.max_new_tokens == 7
+    assert abs(fake.captured_config.temperature - 0.1) < 1e-6
+
+
+def test_special_tokens_forwarded_to_worker_as_stops(make_client):
+    # The worker must be told to stop at the model's end-of-turn special tokens
+    # (e.g. <|im_end|>), not just request `stop` sequences. Otherwise a worker
+    # whose EOS-by-token-id check misses the turn end runs to max_new (or errors
+    # forwarding its own end token) past it -- the worker would report "decode failed"
+    # seen on a real model. (Forwarding only request stops would leave this [].)
+    client, fake = make_client()
+    client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert "<|im_end|>" in (fake.captured_config.stop or [])
+
+
+def test_request_stop_forwarded_to_worker(make_client):
+    # A request `stop` sequence must reach the worker (so it can terminate early),
+    # not only be applied by the Python backstop. The stop tests elsewhere pass
+    # via that backstop even if forwarding regresses; this asserts forwarding.
+    client, fake = make_client()
+    client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stop": ["STOP"],
+        },
+    )
+    # stop == special tokens + request stops, so check membership (not equality).
+    assert "STOP" in (fake.captured_config.stop or [])
+
+
+def test_tools_field_accepted(make_client):
+    # tools is part of the contract even before parsing is enforced (M2).
+    client, _ = make_client()
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {"type": "function", "function": {"name": "f", "parameters": {}}}
+            ],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["message"]["role"] == "assistant"
+
+
+def test_invalid_request_returns_422(make_client):
+    client, _ = make_client()
+    resp = client.post(
+        "/v1/chat/completions", json={"model": "test-model"}
+    )  # no messages
+    assert resp.status_code == 422
+
+
+def test_special_tokens_stripped_nonstreaming(make_client):
+    # The runner may decode EOS/special tokens to text; they must not leak.
+    client, _ = make_client(tokens=["Hello", " world", "<|im_end|>", "LEAK"])
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.json()["choices"][0]["message"]["content"] == "Hello world"
+
+
+def test_usage_populated_when_special_token_cuts_early(make_client):
+    # Regression: cutting at a special token must not skip usage stats.
+    client, _ = make_client(tokens=["Hello", "<|im_end|>", "LEAK"])
+    body = client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+    ).json()
+    assert body["choices"][0]["message"]["content"] == "Hello"
+    assert body["usage"]["completion_tokens"] > 0
+
+
+def test_special_tokens_stripped_streaming(make_client):
+    client, _ = make_client(tokens=["Hello", " world", "<|im_end|>", "LEAK"])
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    )
+    chunks, _ = _sse_chunks(resp.text)
+    content = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks)
+    assert content == "Hello world"
+    assert "LEAK" not in content and "<|im_end|>" not in content
+
+
+# (1) Context-size-exceeded -> structured 400, both modes (not a dropped socket).
+def test_context_length_exceeded_returns_400(make_client):
+    client, _ = make_client(max_context=2048, prompt_tokens=2940)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "x" * 100}],
+        },
+    )
+    assert resp.status_code == 400
+    err = resp.json()["error"]
+    assert err["code"] == "context_length_exceeded"
+    assert err["type"] == "invalid_request_error"
+
+
+def test_context_length_exceeded_streaming_returns_400(make_client):
+    client, _ = make_client(max_context=2048, prompt_tokens=2940)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "x"}],
+            "stream": True,
+        },
+    )
+    # Pre-flight check rejects before the stream starts -> clean 400, no SSE.
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "context_length_exceeded"
+
+
+def test_prompt_plus_max_tokens_exceeding_context_returns_400(make_client):
+    # Prompt fits (100 < 2048) but prompt + max_tokens (100 + 2000) > 2048: must
+    # reject up front, not run until the worker hits the limit mid-decode.
+    client, _ = make_client(max_context=2048, prompt_tokens=100)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 2000,
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "context_length_exceeded"
+
+
+def test_prompt_plus_max_tokens_within_context_ok(make_client):
+    # Prompt + max_tokens (100 + 100) <= 2048: must NOT be rejected.
+    client, _ = make_client(max_context=2048, prompt_tokens=100)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        },
+    )
+    assert resp.status_code == 200
+
+
+# (1) Mid-generation failure -> structured error, never a dropped connection.
+def test_generation_failure_returns_structured_error(make_client):
+    client, _ = make_client(fail=True)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 500
+    assert resp.json()["error"]["type"] == "server_error"
+
+
+def test_generation_failure_streaming_emits_error_event(make_client):
+    client, _ = make_client(fail=True)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    )
+    assert resp.status_code == 200  # headers already sent; error arrives as an event
+    chunks, done = _sse_chunks(resp.text)
+    assert done
+    assert any("error" in c for c in chunks)
+
+
+# (3) finish_reason == "length" when max_tokens is hit.
+def test_finish_reason_length_when_max_tokens_hit(make_client):
+    client, _ = make_client(tokens=["a", "b", "c"])  # 3 generated tokens
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 3,
+        },
+    )
+    assert resp.json()["choices"][0]["finish_reason"] == "length"
+
+
+def test_finish_reason_stop_when_under_max_tokens(make_client):
+    client, _ = make_client(tokens=["a", "b", "c"])
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        },
+    )
+    assert resp.json()["choices"][0]["finish_reason"] == "stop"
+
+
+# Worker-reported finish_reason: the worker may silently clamp max_new to the
+# context window, so the token-count heuristic can't tell a real stop from a
+# truncation. Trust the worker's reason.
+def test_worker_reported_length_overrides_token_count(make_client):
+    # 3 tokens generated (< requested 100) but the worker says it ran to the cap
+    # (a context clamp): finish_reason must be "length", not "stop".
+    client, _ = make_client(tokens=["a", "b", "c"], finish_reason="length")
+    body = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        },
+    ).json()
+    assert body["choices"][0]["finish_reason"] == "length"
+
+
+def test_worker_reported_stop_overrides_token_count(make_client):
+    # 3 tokens with max_tokens=3 (heuristic would say "length"), but the worker
+    # reports EOS: finish_reason must be "stop".
+    client, _ = make_client(tokens=["a", "b", "c"], finish_reason="stop")
+    body = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 3,
+        },
+    ).json()
+    assert body["choices"][0]["finish_reason"] == "stop"
+
+
+def test_server_stop_sequence_wins_over_worker_length(make_client):
+    # A server-side stop sequence is truncation in the control plane; it must
+    # win even when the worker would report "length".
+    client, _ = make_client(
+        tokens=["Hello ", "world ", "STOP", " x"], finish_reason="length"
+    )
+    body = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stop": ["STOP"],
+            "max_tokens": 100,
+        },
+    ).json()
+    assert body["choices"][0]["finish_reason"] == "stop"
+    assert "STOP" not in (body["choices"][0]["message"]["content"] or "")
+
+
+# (4) Error-variant matrix: malformed requests -> consistent 422.
+@pytest.mark.parametrize(
+    "bad_body",
+    [
+        {"model": "m"},  # missing messages
+        {"model": "m", "messages": "not-a-list"},
+        {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "temperature": "hot",
+        },
+        {
+            "model": "m",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": "maybe",
+        },
+        {"model": "m", "messages": [{"content": "no role"}]},
+    ],
+)
+def test_invalid_requests_return_422(make_client, bad_body):
+    client, _ = make_client()
+    assert client.post("/v1/chat/completions", json=bad_body).status_code == 422
+
+
+# (6) Streaming usage when stream_options.include_usage is set.
+def test_streaming_usage_included(make_client):
+    client, _ = make_client(tokens=["a", "b"])
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        },
+    )
+    chunks, _ = _sse_chunks(resp.text)
+    usage_chunks = [c for c in chunks if c.get("usage")]
+    assert usage_chunks, "expected a chunk carrying usage"
+    u = usage_chunks[-1]["usage"]
+    assert u["total_tokens"] == u["prompt_tokens"] + u["completion_tokens"]
+
+
+def test_streaming_usage_absent_by_default(make_client):
+    client, _ = make_client(tokens=["a", "b"])
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    )
+    chunks, _ = _sse_chunks(resp.text)
+    assert not any(c.get("usage") for c in chunks)
+
+
+# (2) Unicode/multibyte content survives streaming intact.
+def test_unicode_streaming_integrity(make_client):
+    pieces = ["café ", "日本語 ", "😀", "🎉"]
+    client, _ = make_client(tokens=pieces)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    )
+    chunks, _ = _sse_chunks(
+        resp.text
+    )  # _sse_chunks uses json.loads -> validates UTF-8/JSON
+    content = "".join(c["choices"][0]["delta"].get("content") or "" for c in chunks)
+    assert content == "".join(pieces)
+
+
+def test_unicode_nonstreaming_integrity(make_client):
+    pieces = ["café ", "日本語 ", "😀"]
+    client, _ = make_client(tokens=pieces)
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.json()["choices"][0]["message"]["content"] == "".join(pieces)

--- a/examples/llm_server/python/tests/test_gemma_tool_parser.py
+++ b/examples/llm_server/python/tests/test_gemma_tool_parser.py
@@ -1,0 +1,131 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for GemmaToolCallDetector."""
+
+import json
+
+from executorch.examples.llm_server.python.tool_parsers import GemmaToolCallDetector
+
+_TOOLS = {
+    "get_weather": {
+        "type": "object",
+        "properties": {
+            "city": {"type": "string"},
+            "units": {"type": "string"},
+        },
+    },
+    "add": {
+        "type": "object",
+        "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+    },
+    "set_alarm": {
+        "type": "object",
+        "properties": {
+            "enabled": {"type": "boolean"},
+            "labels": {"type": "array", "items": {"type": "string"}},
+            "meta": {
+                "type": "object",
+                "properties": {"priority": {"type": "integer"}},
+            },
+        },
+    },
+}
+
+
+def _parse(text, tools=_TOOLS):
+    return GemmaToolCallDetector().detect_and_parse(text, tools)
+
+
+def test_basic_call():
+    text = (
+        '<|tool_call>call:get_weather{city:<|"|>Paris<|"|>,'
+        'units:<|"|>celsius<|"|>}<tool_call|>'
+    )
+    r = _parse(text)
+    assert len(r.calls) == 1
+    assert r.calls[0].name == "get_weather"
+    assert json.loads(r.calls[0].arguments) == {
+        "city": "Paris",
+        "units": "celsius",
+    }
+    assert r.normal_text == ""
+
+
+def test_multiple_calls_and_indices():
+    text = (
+        "<|tool_call>call:add{a:1,b:2}<tool_call|>"
+        "<|tool_call>call:add{a:3,b:4}<tool_call|>"
+    )
+    r = _parse(text)
+    assert [c.tool_index for c in r.calls] == [0, 1]
+    assert [json.loads(c.arguments) for c in r.calls] == [
+        {"a": 1, "b": 2},
+        {"a": 3, "b": 4},
+    ]
+
+
+def test_nested_values():
+    text = (
+        '<|tool_call>call:set_alarm{enabled:true,labels:[<|"|>wake<|"|>,'
+        '<|"|>work<|"|>],meta:{<|"|>priority<|"|>:5}}<tool_call|>'
+    )
+    r = _parse(text)
+    assert json.loads(r.calls[0].arguments) == {
+        "enabled": True,
+        "labels": ["wake", "work"],
+        "meta": {"priority": 5},
+    }
+
+
+def test_leading_text_preserved():
+    r = _parse("Checking.<|tool_call>call:add{a:1,b:2}<tool_call|>")
+    assert r.normal_text == "Checking."
+    assert len(r.calls) == 1
+
+
+def test_no_tool_call_is_plain_text():
+    text = "The weather is nice."
+    r = _parse(text)
+    assert r.calls == []
+    assert r.normal_text == text
+
+
+def test_undefined_tool_degrades_to_full_text():
+    text = "<|tool_call>call:delete_everything{x:1}<tool_call|>"
+    r = _parse(text)
+    assert r.calls == []
+    assert r.normal_text == text
+
+
+def test_truncated_call_degrades_without_leaking_markup():
+    r = _parse('Sure <|tool_call>call:get_weather{city:<|"|>Par')
+    assert r.calls == []
+    assert r.normal_text == "Sure"
+
+
+def test_malformed_call_degrades_without_leaking_markup():
+    r = _parse('Lead <|tool_call>call:get_weather{city:<|"|>Paris<tool_call|>')
+    assert r.calls == []
+    assert r.normal_text == "Lead"
+
+
+def test_string_typed_bare_value_preserves_raw():
+    tools = {"f": {"type": "object", "properties": {"code": {"type": "string"}}}}
+    r = _parse("<|tool_call>call:f{code:007}<tool_call|>", tools)
+    assert json.loads(r.calls[0].arguments) == {"code": "007"}
+
+
+def test_integer_typed_bare_value_is_int():
+    tools = {"f": {"type": "object", "properties": {"n": {"type": "integer"}}}}
+    r = _parse("<|tool_call>call:f{n:007}<tool_call|>", tools)
+    assert json.loads(r.calls[0].arguments) == {"n": 7}
+
+
+def test_untyped_bare_vs_quoted_distinction():
+    tools = {"f": {"type": "object", "properties": {}}}
+    r = _parse('<|tool_call>call:f{a:5,b:<|"|>5<|"|>}<tool_call|>', tools)
+    assert json.loads(r.calls[0].arguments) == {"a": 5, "b": "5"}

--- a/examples/llm_server/python/tests/test_hermes_tool_parser.py
+++ b/examples/llm_server/python/tests/test_hermes_tool_parser.py
@@ -1,0 +1,100 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for HermesDetector (Hermes/Qwen JSON <tool_call> format).
+
+Covers the explicit all-or-nothing malformed-call policy and the no-markup-leak
+guarantee: an undefined/malformed/truncated call degrades to the leading text
+with the <tool_call> markup stripped, never surfaced to the client.
+"""
+
+import json
+
+from executorch.examples.llm_server.python.tool_parsers import HermesDetector
+
+_TOOLS = {
+    "get_weather": {"type": "object", "properties": {"city": {"type": "string"}}},
+    "echo": {"type": "object", "properties": {"text": {"type": "string"}}},
+}
+
+
+def _parse(text, tools=_TOOLS):
+    return HermesDetector().detect_and_parse(text, tools)
+
+
+def test_basic_call():
+    text = (
+        '<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>'
+    )
+    r = _parse(text)
+    assert len(r.calls) == 1 and r.calls[0].name == "get_weather"
+    assert json.loads(r.calls[0].arguments) == {"city": "Paris"}
+
+
+def test_multiple_calls_still_parse():
+    text = (
+        '<tool_call>{"name": "echo", "arguments": {"text": "a"}}</tool_call>'
+        '<tool_call>{"name": "echo", "arguments": {"text": "b"}}</tool_call>'
+    )
+    r = _parse(text)
+    assert [json.loads(c.arguments)["text"] for c in r.calls] == ["a", "b"]
+
+
+def test_no_tool_call_is_passthrough():
+    r = _parse("just some text")
+    assert not r.calls and r.normal_text == "just some text"
+
+
+def test_malformed_block_with_valid_sibling_degrades_no_leak():
+    # All-or-nothing: one malformed block degrades the WHOLE response (the valid
+    # sibling is NOT emitted in isolation), and no <tool_call> markup leaks.
+    text = (
+        'lead<tool_call>{"name": "echo", "arguments": {"text": "ok"}}</tool_call>'
+        "<tool_call>{bad json}</tool_call>"
+    )
+    r = _parse(text)
+    assert not r.calls
+    assert "<tool_call>" not in r.normal_text
+    assert r.normal_text == "lead"
+
+
+def test_unclosed_marker_degrades_no_leak():
+    text = 'lead<tool_call>{"name": "echo", "arguments": {"text": "x"}}'
+    r = _parse(text)
+    assert not r.calls
+    assert "<tool_call>" not in r.normal_text
+    assert r.normal_text == "lead"
+
+
+def test_string_value_containing_close_marker_not_truncated():
+    # A JSON string value containing literal </tool_call> must not truncate the
+    # captured JSON (raw_decode parses the whole object regardless).
+    text = (
+        '<tool_call>{"name": "echo", "arguments": '
+        '{"text": "a </tool_call> b"}}</tool_call>'
+    )
+    r = _parse(text)
+    assert len(r.calls) == 1
+    assert json.loads(r.calls[0].arguments) == {"text": "a </tool_call> b"}
+
+
+def test_arguments_null_falls_back_to_parameters():
+    text = (
+        '<tool_call>{"name": "echo", "arguments": null, '
+        '"parameters": {"text": "p"}}</tool_call>'
+    )
+    r = _parse(text)
+    assert json.loads(r.calls[0].arguments) == {"text": "p"}
+
+
+def test_undefined_tool_degrades_to_full_text():
+    # A WELL-FORMED call to an undefined tool degrades the whole response to
+    # visible text (unchanged policy: surface the model's intent, never a partial
+    # set). This differs from the malformed/truncated case, which strips markup.
+    text = 'hi<tool_call>{"name": "nope", "arguments": {}}</tool_call>'
+    r = _parse(text)
+    assert not r.calls
+    assert "<tool_call>" in r.normal_text  # full text, markup visible

--- a/examples/llm_server/python/tests/test_qwen_tool_parser.py
+++ b/examples/llm_server/python/tests/test_qwen_tool_parser.py
@@ -1,0 +1,218 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for QwenFunctionCallDetector (Qwen XML <function=…> tool format)."""
+
+import json
+
+from executorch.examples.llm_server.python.tool_parsers import QwenFunctionCallDetector
+
+# name -> JSON-schema `parameters` (as the server passes it to the detector).
+_TOOLS = {
+    "get_weather": {"type": "object", "properties": {"city": {"type": "string"}}},
+    "add": {
+        "type": "object",
+        "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+    },
+}
+
+
+def _parse(text, tools=_TOOLS):
+    return QwenFunctionCallDetector().detect_and_parse(text, tools)
+
+
+def test_basic_call():
+    text = (
+        "<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n"
+        "</parameter>\n</function>\n</tool_call>"
+    )
+    r = _parse(text)
+    assert len(r.calls) == 1
+    assert r.calls[0].name == "get_weather"
+    assert json.loads(r.calls[0].arguments) == {"city": "Paris"}
+    assert r.normal_text == ""
+
+
+def test_observed_model_output():
+    # The exact shape seen from Qwen3.5-MoE during the live smoke.
+    text = (
+        "<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n"
+        "</parameter>\n</function>\n</tool_call>"
+    )
+    r = _parse(text)
+    assert [c.name for c in r.calls] == ["get_weather"]
+
+
+def test_numeric_and_multi_param_coercion():
+    text = (
+        "<function=add><parameter=a>2</parameter>"
+        "<parameter=b>3</parameter></function>"
+    )
+    r = _parse(text)
+    assert json.loads(r.calls[0].arguments) == {"a": 2, "b": 3}
+
+
+def test_multiple_calls():
+    text = (
+        "<function=get_weather><parameter=city>Paris</parameter></function>"
+        "<function=add><parameter=a>1</parameter></function>"
+    )
+    r = _parse(text)
+    assert [c.name for c in r.calls] == ["get_weather", "add"]
+    assert [c.tool_index for c in r.calls] == [0, 1]
+
+
+def test_leading_text_preserved():
+    text = "Let me check.<function=get_weather><parameter=city>Paris</parameter></function>"
+    r = _parse(text)
+    assert r.normal_text == "Let me check."
+    assert len(r.calls) == 1
+
+
+def test_no_tool_call_is_plain_text():
+    text = "The capital of France is Paris."
+    r = _parse(text)
+    assert r.calls == []
+    assert r.normal_text == text
+
+
+def test_undefined_tool_degrades_to_text():
+    # A call to a tool not in the request -> whole response kept as visible text.
+    text = "<function=delete_everything><parameter=x>1</parameter></function>"
+    r = _parse(text)
+    assert r.calls == []
+    assert r.normal_text == text
+
+
+def test_missing_tool_call_wrapper_still_parses():
+    # Tolerate a truncated/absent <tool_call> wrapper as long as the function
+    # block is complete.
+    text = "<function=get_weather><parameter=city>Paris</parameter></function>"
+    r = _parse(text)
+    assert len(r.calls) == 1
+    assert json.loads(r.calls[0].arguments) == {"city": "Paris"}
+
+
+# Schema-aware coercion: the XML format is stringly-typed, so values must be cast
+# to the declared schema type (the cause of several BFCL function-calling misses).
+def test_boolean_value_coerced_by_schema():
+    tools = {"f": {"properties": {"flag": {"type": "boolean"}}}}
+    # The model writes a non-JSON capitalized "True"; the schema says boolean.
+    text = "<function=f><parameter=flag>True</parameter></function>"
+    r = _parse(text, tools)
+    assert json.loads(r.calls[0].arguments) == {"flag": True}
+
+
+def test_string_schema_keeps_numeric_literal_as_string():
+    tools = {"f": {"properties": {"id": {"type": "string"}}}}
+    # A numeric-looking value the schema declares as a string must NOT become int.
+    text = "<function=f><parameter=id>1234</parameter></function>"
+    r = _parse(text, tools)
+    args = json.loads(r.calls[0].arguments)
+    assert args == {"id": "1234"} and isinstance(args["id"], str)
+
+
+def test_untyped_param_falls_back_to_json_guess():
+    # No declared type -> best-effort JSON guess (so loosely-typed tools still work).
+    tools = {"f": {"properties": {}}}
+    text = (
+        "<function=f><parameter=n>42</parameter>"
+        "<parameter=items>[1, 2]</parameter></function>"
+    )
+    r = _parse(text, tools)
+    assert json.loads(r.calls[0].arguments) == {"n": 42, "items": [1, 2]}
+
+
+_TYPED = {
+    "code_tool": {"type": "object", "properties": {"code": {"type": "string"}}},
+    "calc": {
+        "type": "object",
+        "properties": {
+            "n": {"type": "integer"},
+            "x": {"type": "number"},
+            "flag": {"type": "boolean"},
+        },
+    },
+}
+
+
+def test_param_value_with_literal_parameter_close():
+    # A value containing literal </parameter> must be preserved, not truncated.
+    text = "<function=code_tool><parameter=code>a </parameter> b</parameter></function>"
+    r = _parse(text, _TYPED)
+    assert json.loads(r.calls[0].arguments) == {"code": "a </parameter> b"}
+
+
+def test_param_value_with_function_markup():
+    # A value containing <function=...> markup must stay in the value, not split.
+    text = (
+        "<function=code_tool><parameter=code>x = <function=foo></parameter></function>"
+    )
+    r = _parse(text, _TYPED)
+    assert len(r.calls) == 1
+    assert json.loads(r.calls[0].arguments) == {"code": "x = <function=foo>"}
+
+
+def test_declared_integer_with_float_string_kept_raw():
+    text = "<function=calc><parameter=n>10.0</parameter></function>"
+    val = json.loads(_parse(text, _TYPED).calls[0].arguments)["n"]
+    assert val == "10.0" and isinstance(val, str)  # not float 10.0
+
+
+def test_declared_boolean_with_one_kept_raw():
+    text = "<function=calc><parameter=flag>1</parameter></function>"
+    val = json.loads(_parse(text, _TYPED).calls[0].arguments)["flag"]
+    assert val == "1" and isinstance(val, str)  # not int 1
+
+
+def test_declared_integer_with_underscores_kept_raw():
+    text = "<function=calc><parameter=n>1_000</parameter></function>"
+    val = json.loads(_parse(text, _TYPED).calls[0].arguments)["n"]
+    assert val == "1_000" and isinstance(val, str)  # not int 1000
+
+
+def _reject_bare_constant(c):
+    # json.loads parse_constant hook: fires only for bare NaN/Infinity/-Infinity.
+    raise AssertionError(f"emitted bare non-finite constant: {c}")
+
+
+def test_declared_number_non_finite_never_emitted():
+    for bad in ("NaN", "Infinity", "-Infinity", "1e999"):
+        text = f"<function=calc><parameter=x>{bad}</parameter></function>"
+        args = _parse(text, _TYPED).calls[0].arguments
+        # Strict-client safe: no bare NaN/Infinity constant in the emitted JSON.
+        json.loads(args, parse_constant=_reject_bare_constant)
+        assert json.loads(args)["x"] == bad  # kept as the raw string
+
+
+def test_multiple_valid_calls_still_parse():
+    text = (
+        "<function=add><parameter=a>1</parameter><parameter=b>2</parameter></function>"
+        "<function=add><parameter=a>3</parameter><parameter=b>4</parameter></function>"
+    )
+    r = _parse(text)
+    assert [json.loads(c.arguments) for c in r.calls] == [
+        {"a": 1, "b": 2},
+        {"a": 3, "b": 4},
+    ]
+
+
+def test_truncated_call_degrades_without_leaking_markup():
+    # A call cut off by max_tokens (no closing tags) must NOT leak the partial
+    # <function=...> markup -- only the leading text survives (mirrors Hermes).
+    text = "Sure! <function=get_weather><parameter=city>Paris"
+    r = _parse(text, _TYPED)
+    assert not r.calls
+    assert "<function=" not in r.normal_text
+    assert r.normal_text == "Sure!"
+
+
+def test_truncated_tool_call_wrapper_no_leak():
+    text = "ok <tool_call>\n<function=get_weather><parameter=city>Par"
+    r = _parse(text, _TYPED)
+    assert not r.calls
+    assert "<tool_call>" not in r.normal_text and "<function=" not in r.normal_text
+    assert r.normal_text == "ok"

--- a/examples/llm_server/python/tests/test_sampling_params.py
+++ b/examples/llm_server/python/tests/test_sampling_params.py
@@ -1,0 +1,269 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Contract tests for sampling/control params: stop sequences, n, tool_choice.
+
+These exercise the real server over the HTTP boundary with a FakeRunner.
+"""
+
+import json
+
+CALL = (
+    '<tool_call>\n{"name": "get_weather", "arguments": {"city": "Paris"}}\n</tool_call>'
+)
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {"name": "get_weather", "parameters": {}},
+}
+
+
+def _body(**kw):
+    b = {"model": "test-model", "messages": [{"role": "user", "content": "hi"}]}
+    b.update(kw)
+    return b
+
+
+def test_n_greater_than_one_is_rejected(make_client):
+    client, _ = make_client()
+    r = client.post("/v1/chat/completions", json=_body(n=2))
+    assert r.status_code == 400
+    assert r.json()["error"]["type"] == "invalid_request_error"
+    assert r.json()["error"]["code"] == "unsupported_parameter"
+
+
+def test_unsupported_params_rejected(make_client):
+    client, _ = make_client()
+    for param in (
+        {"top_p": 0.5},
+        {"top_p": 2.0},  # > 1.0 is not a no-op either — only exactly 1.0/unset is
+        {"seed": 42},
+        {"reasoning_effort": "high"},
+        {"frequency_penalty": 1.0},
+        {"presence_penalty": -0.5},
+        {"top_k": 40},
+        {"logit_bias": {"123": 5.0}},
+        {"response_format": {"type": "json_object"}},
+        {"logprobs": True},
+        {"top_logprobs": 5},
+        {"parallel_tool_calls": False},
+    ):
+        r = client.post("/v1/chat/completions", json=_body(**param))
+        assert r.status_code == 400, param
+        assert r.json()["error"]["code"] == "unsupported_parameter", param
+
+
+def test_nonpositive_max_tokens_rejected(make_client):
+    # max_tokens=0/-2 must not be silently treated as "unbounded" (the `or` bug);
+    # 0 and negatives are invalid for both field names.
+    client, _ = make_client()
+    for param in (
+        {"max_tokens": 0},
+        {"max_tokens": -2},
+        {"max_completion_tokens": 0},
+        {"max_completion_tokens": -2},
+    ):
+        r = client.post("/v1/chat/completions", json=_body(**param))
+        assert r.status_code == 400, param
+        assert r.json()["error"]["type"] == "invalid_request_error", param
+
+
+def test_temperature_range_rejected(make_client):
+    client, _ = make_client()
+    for param in (
+        {"temperature": -1},
+        {"temperature": -0.1},
+        {"temperature": 2.1},
+        {"temperature": 3},
+    ):
+        r = client.post("/v1/chat/completions", json=_body(**param))
+        assert r.status_code == 400, param
+        assert r.json()["error"]["code"] == "invalid_value", param
+
+
+def test_noop_output_contract_fields_accepted(make_client):
+    # The default/no-op forms must NOT be rejected (don't break OpenAI clients
+    # that send them explicitly).
+    client, _ = make_client()
+    r = client.post(
+        "/v1/chat/completions",
+        json=_body(
+            response_format={"type": "text"},
+            parallel_tool_calls=True,
+            max_tokens=8,
+        ),
+    )
+    assert r.status_code == 200
+
+
+def test_zero_penalties_and_unknown_fields_accepted(make_client):
+    # frequency/presence_penalty=0.0 are no-ops; unknown non-generation fields
+    # (user/store/metadata) are ignored, not rejected (don't break OpenAI clients).
+    client, _ = make_client()
+    r = client.post(
+        "/v1/chat/completions",
+        json=_body(
+            frequency_penalty=0.0,
+            presence_penalty=0.0,
+            user="abc",
+            store=False,
+            metadata={"k": "v"},
+            max_tokens=8,
+        ),
+    )
+    assert r.status_code == 200
+
+
+def test_unsupported_tool_choice_rejected(make_client):
+    # "required" / a specific-function choice would need constrained decoding to
+    # force/restrict the call; the server rejects rather than silently treating as "auto".
+    client, _ = make_client()
+    for choice in (
+        "required",
+        {"type": "function", "function": {"name": "get_weather"}},
+    ):
+        r = client.post(
+            "/v1/chat/completions",
+            json=_body(tools=[WEATHER_TOOL], tool_choice=choice, max_tokens=8),
+        )
+        assert r.status_code == 400, choice
+        assert r.json()["error"]["code"] == "unsupported_parameter", choice
+
+
+def test_supported_params_accepted(make_client):
+    # top_p=1.0 (no-op) and temperature/max_tokens must NOT be rejected; neither
+    # should tool_choice "auto" / "none".
+    client, _ = make_client()
+    for temperature in (0.0, 1.0, 2.0):
+        r = client.post(
+            "/v1/chat/completions",
+            json=_body(top_p=1.0, temperature=temperature, max_tokens=8),
+        )
+        assert r.status_code == 200, temperature
+    for choice in ("auto", "none"):
+        r = client.post(
+            "/v1/chat/completions",
+            json=_body(tools=[WEATHER_TOOL], tool_choice=choice, max_tokens=8),
+        )
+        assert r.status_code == 200, choice
+
+
+def test_stop_sequence_truncates_nonstreaming(make_client):
+    client, _ = make_client(tokens=["Hello ", "world ", "STOP", " ignored"])
+    r = client.post("/v1/chat/completions", json=_body(stop=["STOP"], max_tokens=32))
+    assert r.status_code == 200
+    content = r.json()["choices"][0]["message"]["content"]
+    assert content == "Hello world "
+    assert "STOP" not in content
+
+
+def test_stop_sequence_truncates_streaming(make_client):
+    client, _ = make_client(tokens=["Hello ", "world ", "STOP", " ignored"])
+    content = ""
+    with client.stream(
+        "POST", "/v1/chat/completions", json=_body(stop=["STOP"], stream=True)
+    ) as r:
+        for line in r.iter_lines():
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:") :].strip()
+            if payload == "[DONE]":
+                break
+            delta = json.loads(payload)["choices"][0]["delta"]
+            content += delta.get("content") or ""
+    assert content == "Hello world "
+    assert "STOP" not in content
+
+
+def test_stop_forces_finish_reason_over_length_nonstreaming(make_client):
+    # 4 tokens emitted (completion reaches max_tokens=4) AND a stop is hit:
+    # finish_reason must be "stop" (boundary), not "length".
+    client, _ = make_client(tokens=["a ", "b ", "STOP", " c"])
+    body = client.post(
+        "/v1/chat/completions", json=_body(stop=["STOP"], max_tokens=4)
+    ).json()
+    assert body["choices"][0]["finish_reason"] == "stop"
+    assert "STOP" not in (body["choices"][0]["message"]["content"] or "")
+
+
+def test_stop_forces_finish_reason_over_length_streaming(make_client):
+    client, _ = make_client(tokens=["a ", "b ", "STOP", " c"])
+    finish = None
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json=_body(stop=["STOP"], max_tokens=4, stream=True),
+    ) as r:
+        for line in r.iter_lines():
+            if not line.startswith("data:"):
+                continue
+            p = line[len("data:") :].strip()
+            if p == "[DONE]":
+                break
+            fr = json.loads(p)["choices"][0].get("finish_reason")
+            if fr:
+                finish = fr
+    assert finish == "stop"
+
+
+_STOP_THEN_CALL = (
+    'Answer STOP <tool_call>\n{"name": "get_weather", "arguments": {}}\n</tool_call>'
+)
+
+
+def test_stop_before_tool_call_nonstreaming(make_client):
+    # Stop boundary precedes a tool call (in one chunk, so truncation — not just
+    # early-stop — must catch it): the call must NOT be parsed/emitted.
+    client, _ = make_client(tokens=[_STOP_THEN_CALL])
+    r = client.post(
+        "/v1/chat/completions",
+        json=_body(tools=[WEATHER_TOOL], stop=["STOP"], max_tokens=64),
+    )
+    msg = r.json()["choices"][0]["message"]
+    assert msg.get("tool_calls") is None
+    assert "STOP" not in (msg.get("content") or "")
+
+
+def test_stop_before_tool_call_streaming(make_client):
+    client, _ = make_client(tokens=[_STOP_THEN_CALL])
+    saw_tool, content = False, ""
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json=_body(tools=[WEATHER_TOOL], stop=["STOP"], stream=True),
+    ) as r:
+        for line in r.iter_lines():
+            if not line.startswith("data:"):
+                continue
+            p = line[len("data:") :].strip()
+            if p == "[DONE]":
+                break
+            delta = json.loads(p)["choices"][0]["delta"]
+            if delta.get("tool_calls"):
+                saw_tool = True
+            content += delta.get("content") or ""
+    assert not saw_tool
+    assert "STOP" not in content
+
+
+def test_tool_choice_none_disables_tools(make_client):
+    client, _ = make_client(tokens=[CALL])
+    r = client.post(
+        "/v1/chat/completions",
+        json=_body(tools=[WEATHER_TOOL], tool_choice="none", max_tokens=64),
+    )
+    msg = r.json()["choices"][0]["message"]
+    assert msg.get("tool_calls") is None  # tools disabled -> returned as text
+    assert r.json()["choices"][0]["finish_reason"] != "tool_calls"
+
+
+def test_tool_choice_default_still_parses(make_client):
+    # Sanity: without tool_choice="none", the same call IS parsed as a tool call.
+    client, _ = make_client(tokens=[CALL])
+    r = client.post(
+        "/v1/chat/completions", json=_body(tools=[WEATHER_TOOL], max_tokens=64)
+    )
+    calls = r.json()["choices"][0]["message"].get("tool_calls")
+    assert calls and calls[0]["function"]["name"] == "get_weather"

--- a/examples/llm_server/python/tests/test_session_runtime.py
+++ b/examples/llm_server/python/tests/test_session_runtime.py
@@ -1,0 +1,234 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""SessionRuntime tests: session-op routing, the blocking->async stream bridge,
+cancellation, and worker shutdown. A fake worker stands in for the WorkerClient
+(no model, GPU, or subprocess). asyncio.run keeps the test bodies sync."""
+
+import asyncio
+import threading
+
+from executorch.examples.llm_server.python import session_runtime as session_runtime_mod
+from executorch.examples.llm_server.python.session_runtime import (
+    GenerationOptions,
+    GenStats,
+    PromptInput,
+    SessionRuntime,
+)
+
+_OPTS = GenerationOptions(max_new_tokens=8)
+
+
+def _text(s="hi") -> PromptInput:
+    return PromptInput(text=s)
+
+
+class _Worker:
+    """Records session ops + process close; emits nothing on generate."""
+
+    def __init__(self):
+        self.opened, self.reset_ids, self.closed_ids = [], [], []
+        self.proc_closed = False
+
+    def open_session(self, sid):
+        self.opened.append(sid)
+
+    def reset_session(self, sid):
+        self.reset_ids.append(sid)
+
+    def close_session(self, sid):
+        self.closed_ids.append(sid)
+
+    def close(self):
+        self.proc_closed = True
+
+    def stop(self):
+        pass
+
+    def generate(self, prompt, config, token_callback=None, stats_callback=None):
+        pass
+
+
+def test_session_ops_route_to_worker():
+    async def scenario():
+        w = _Worker()
+        rt = SessionRuntime(w)
+        await rt.open("a")
+        await rt.reset("a")
+        await rt.close("a")
+        return w
+
+    w = asyncio.run(scenario())
+    assert w.opened == ["a"] and w.reset_ids == ["a"] and w.closed_ids == ["a"]
+
+
+def test_session_ops_noop_when_worker_lacks_support():
+    # A minimal worker without session ops: the runtime silently no-ops.
+    class _Bare:
+        def stop(self):
+            pass
+
+        def generate(self, *a, **k):
+            pass
+
+    async def scenario():
+        rt = SessionRuntime(_Bare())
+        await rt.open("a")
+        await rt.reset("a")
+        await rt.close("a")
+
+    asyncio.run(scenario())  # must not raise
+
+
+def test_generate_stream_yields_and_fills_stats():
+    class _Echo:
+        def stop(self):
+            pass
+
+        def generate(self, prompt, config, token_callback=None, stats_callback=None):
+            token_callback("Hello")
+            token_callback(" world")
+
+            class S:
+                num_prompt_tokens = 3
+                num_generated_tokens = 2
+                finish_reason = "stop"
+                generated_token_ids = [10, 11]
+
+            stats_callback(S())
+
+    async def scenario():
+        rt = SessionRuntime(_Echo())
+        stats = GenStats()
+        out = [t async for t in rt.generate_stream("a", _text(), _OPTS, stats)]
+        return out, stats
+
+    out, stats = asyncio.run(scenario())
+    assert "".join(out) == "Hello world"
+    assert stats.completion_tokens == 2
+    assert stats.finish_reason == "stop"
+    assert stats.generated_token_ids == [10, 11]
+
+
+def test_generate_stream_forwards_session_and_segments_to_worker():
+    captured = {}
+
+    class _Cap:
+        def stop(self):
+            pass
+
+        def generate(self, prompt, config, token_callback=None, stats_callback=None):
+            captured["session_id"] = config.session_id
+            captured["segments"] = config.prompt_segments
+            captured["prompt"] = prompt
+
+    async def scenario():
+        rt = SessionRuntime(_Cap())
+        seg = PromptInput(segments=[{"text": "a"}, {"ids": [1, 2]}])
+        async for _ in rt.generate_stream("sess", seg, _OPTS, GenStats()):
+            pass
+
+    asyncio.run(scenario())
+    assert captured["session_id"] == "sess"
+    assert captured["segments"] == [{"text": "a"}, {"ids": [1, 2]}]
+
+
+def test_cancellation_calls_worker_stop():
+    class _Blocking:
+        def __init__(self):
+            self._gate = threading.Event()
+            self.stopped = False
+
+        def stop(self):
+            self.stopped = True
+            self._gate.set()
+
+        def generate(self, prompt, config, token_callback=None, stats_callback=None):
+            token_callback("TOKEN")
+            self._gate.wait(timeout=5)
+
+    async def scenario():
+        w = _Blocking()
+        rt = SessionRuntime(w)
+        agen = rt.generate_stream("a", _text(), _OPTS).__aiter__()
+        assert await agen.__anext__() == "TOKEN"  # worker now blocking
+        nxt = asyncio.ensure_future(agen.__anext__())
+        await asyncio.sleep(0.05)
+        nxt.cancel()
+        try:
+            await nxt
+        except asyncio.CancelledError:
+            pass
+        for _ in range(100):  # let the worker observe stop()
+            if w.stopped:
+                break
+            await asyncio.sleep(0.02)
+        await agen.aclose()
+        return w
+
+    w = asyncio.run(scenario())
+    assert w.stopped
+
+
+def test_cancellation_drops_late_worker_tokens(monkeypatch):
+    class _CountingQueue(asyncio.Queue):
+        put_count = 0
+
+        def put_nowait(self, item):
+            type(self).put_count += 1
+            return super().put_nowait(item)
+
+    monkeypatch.setattr(session_runtime_mod.asyncio, "Queue", _CountingQueue)
+
+    class _SpamAfterStop:
+        def __init__(self):
+            self._gate = threading.Event()
+            self.stopped = False
+
+        def stop(self):
+            self.stopped = True
+            self._gate.set()
+
+        def generate(self, prompt, config, token_callback=None, stats_callback=None):
+            token_callback("TOKEN")
+            self._gate.wait(timeout=5)
+            for _ in range(1000):
+                token_callback("DROP")
+
+    async def scenario():
+        _CountingQueue.put_count = 0
+        w = _SpamAfterStop()
+        rt = SessionRuntime(w)
+        agen = rt.generate_stream("a", _text(), _OPTS).__aiter__()
+        assert await agen.__anext__() == "TOKEN"
+        nxt = asyncio.ensure_future(agen.__anext__())
+        await asyncio.sleep(0.05)
+        nxt.cancel()
+        try:
+            await nxt
+        except asyncio.CancelledError:
+            pass
+        await agen.aclose()
+        return w.stopped, _CountingQueue.put_count
+
+    stopped, put_count = asyncio.run(scenario())
+    assert stopped
+    assert put_count < 10
+
+
+def test_close_worker_shuts_down_worker():
+    w = _Worker()
+    SessionRuntime(w).close_worker()
+    assert w.proc_closed
+
+
+def test_prompt_input_requires_exactly_one():
+    import pytest
+
+    with pytest.raises(ValueError):
+        PromptInput()
+    with pytest.raises(ValueError):
+        PromptInput(text="x", segments=[{"text": "y"}])

--- a/examples/llm_server/python/tests/test_sessions.py
+++ b/examples/llm_server/python/tests/test_sessions.py
@@ -1,0 +1,426 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Session-routing contract tests (fake worker, no model/GPU).
+
+One worker hosts multiple isolated sessions, routed by session_id, admitted
+up front so capacity refusals are HTTP statuses rather than mid-stream errors.
+These assert the HTTP/wire contract only.
+"""
+
+import asyncio
+
+import pytest
+
+from executorch.examples.llm_server.python.chat_template import ChatTemplate
+from executorch.examples.llm_server.python.errors import GenerationError
+from executorch.examples.llm_server.python.serving_chat import ServingChat
+from executorch.examples.llm_server.python.worker_client import WorkerError
+
+
+def _chat(client, *, session_id=None, headers=None):
+    body = {"model": "test-model", "messages": [{"role": "user", "content": "hi"}]}
+    if session_id is not None:
+        body["session_id"] = session_id
+    return client.post("/v1/chat/completions", json=body, headers=headers or {})
+
+
+def test_session_id_routed_and_opened(make_client):
+    client, fake = make_client(max_named_sessions=2)
+    resp = _chat(client, session_id="abc")
+    assert resp.status_code == 200
+    # Admitted before generation, and forwarded to the worker's generate().
+    assert fake.opened_log == ["abc"]
+    assert fake.captured_config.session_id == "abc"
+
+
+def test_reusing_session_id_is_idempotent(make_client):
+    client, fake = make_client(max_named_sessions=1)
+    assert _chat(client, session_id="s").status_code == 200
+    assert _chat(client, session_id="s").status_code == 200
+    # Same id reused, not re-admitted into a second slot.
+    assert fake.opened_log == ["s"]
+
+
+def test_anonymous_request_does_not_open_named(make_client):
+    client, fake = make_client(max_named_sessions=2)
+    assert _chat(client).status_code == 200
+    assert fake.opened_log == []
+    assert fake.captured_config.session_id is None
+
+
+def test_explicit_session_unsupported_when_single_session(make_client):
+    # max_named_sessions=0: backend hosts only the scratch session.
+    client, _ = make_client(max_named_sessions=0)
+    resp = _chat(client, session_id="abc")
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "unsupported_session"
+
+
+def test_capacity_exhausted_returns_429(make_client):
+    client, _ = make_client(max_named_sessions=1)
+    assert _chat(client, session_id="a").status_code == 200
+    resp = _chat(client, session_id="b")  # second distinct id, no free slot
+    assert resp.status_code == 429
+    assert resp.json()["error"]["code"] == "capacity_exhausted"
+
+
+def test_close_frees_a_slot(make_client):
+    client, _ = make_client(max_named_sessions=1)
+    assert _chat(client, session_id="a").status_code == 200
+    deleted = client.delete("/v1/sessions/a")
+    assert deleted.status_code == 200
+    assert deleted.json() == {"closed": True, "session_id": "a"}
+    # The freed slot now admits a different session.
+    assert _chat(client, session_id="b").status_code == 200
+
+
+def test_invalid_session_id_rejected_before_worker(make_client):
+    client, fake = make_client(max_named_sessions=2)
+    resp = _chat(client, session_id="has space")
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_session_id"
+    assert fake.opened_log == []  # never reached the worker
+
+
+def test_session_id_too_long_rejected(make_client):
+    client, _ = make_client(max_named_sessions=2)
+    resp = _chat(client, session_id="x" * 129)
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_session_id"
+
+
+def test_session_id_header_alias(make_client):
+    client, fake = make_client(max_named_sessions=2)
+    resp = _chat(client, headers={"X-ExecuTorch-Session-ID": "from-header"})
+    assert resp.status_code == 200
+    assert fake.opened_log == ["from-header"]
+
+
+def test_body_session_id_wins_over_header(make_client):
+    client, fake = make_client(max_named_sessions=2)
+    resp = _chat(
+        client, session_id="from-body", headers={"X-ExecuTorch-Session-ID": "from-hdr"}
+    )
+    assert resp.status_code == 200
+    assert fake.opened_log == ["from-body"]
+
+
+def test_session_id_underscore_header_alias(make_client):
+    # pi's sendSessionAffinityHeaders emits a verbatim `session_id` header.
+    client, fake = make_client(max_named_sessions=2)
+    resp = _chat(client, headers={"session_id": "from-session-id"})
+    assert resp.status_code == 200
+    assert fake.opened_log == ["from-session-id"]
+
+
+def test_x_session_affinity_header_alias(make_client):
+    client, fake = make_client(max_named_sessions=2)
+    resp = _chat(client, headers={"x-session-affinity": "from-affinity"})
+    assert resp.status_code == 200
+    assert fake.opened_log == ["from-affinity"]
+
+
+def test_session_header_precedence(make_client):
+    # X-ExecuTorch-Session-ID > session_id > x-session-affinity (no body field).
+    client, fake = make_client(max_named_sessions=3)
+    resp = _chat(
+        client,
+        headers={
+            "X-ExecuTorch-Session-ID": "xet",
+            "session_id": "sid",
+            "x-session-affinity": "aff",
+        },
+    )
+    assert resp.status_code == 200
+    assert fake.opened_log == ["xet"]
+
+
+def _chat_msgs(client, messages, session_id):
+    return client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "session_id": session_id, "messages": messages},
+    )
+
+
+# The fake worker streams tokens ("Hello", ", ", "world"), so the assistant
+# content we return (and the client must echo back to match the fingerprint) is:
+_FAKE_REPLY = "Hello, world"
+
+
+def test_token_id_segments_splice_prior_assistant_turn(make_client):
+    # Splices turn-1's stored generated ids back as an exact {ids} run on turn 2,
+    # only because the client echoes back the assistant turn we generated.
+    client, fake = make_client(max_named_sessions=2, gen_ids=[7, 8, 9])
+    assert (
+        _chat_msgs(client, [{"role": "user", "content": "hi"}], "s").status_code == 200
+    )
+    # First turn has no prior assistant turn -> plain text prompt.
+    assert fake.captured_config.prompt_segments is None
+
+    turn2 = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": _FAKE_REPLY},  # matches what we returned
+        {"role": "user", "content": "more"},
+    ]
+    assert _chat_msgs(client, turn2, "s").status_code == 200
+    segs = fake.captured_config.prompt_segments
+    assert segs is not None, "expected token-ID segments on the second turn"
+    # The stored generated ids are spliced in as an exact id run...
+    assert any(s.get("ids") == [7, 8, 9] for s in segs)
+    # ...bracketed by text segments (template glue + the new user turn).
+    assert any("text" in s for s in segs)
+
+
+def test_edited_assistant_turn_not_spliced(make_client):
+    # P1 guard: if the client edits a prior assistant turn (or reuses the session
+    # for a different conversation), the stale ids must NOT be spliced -- the
+    # fingerprint mismatches and we fall back to text.
+    client, fake = make_client(max_named_sessions=2, gen_ids=[7, 8, 9])
+    _chat_msgs(client, [{"role": "user", "content": "hi"}], "s")
+    turn2 = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "EDITED - not what the model generated"},
+        {"role": "user", "content": "more"},
+    ]
+    assert _chat_msgs(client, turn2, "s").status_code == 200
+    assert fake.captured_config.prompt_segments is None
+
+
+def test_stop_trimmed_turn_not_spliced(make_client):
+    # P1/P2 guard: a stop-trimmed turn (worker omits generated_token_ids ->
+    # recorded ids=None) is never spliced, even when the turn fingerprint matches,
+    # so unseen post-stop tokens can't be injected into a later prompt.
+    client, fake = make_client(max_named_sessions=2, gen_ids=[])  # [] => ids None
+    _chat_msgs(client, [{"role": "user", "content": "hi"}], "s")
+    turn2 = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": _FAKE_REPLY},  # fingerprint matches
+        {"role": "user", "content": "more"},
+    ]
+    assert _chat_msgs(client, turn2, "s").status_code == 200
+    assert fake.captured_config.prompt_segments is None
+
+
+def test_no_segments_for_anonymous_requests(make_client):
+    client, fake = make_client(max_named_sessions=2, gen_ids=[1, 2])
+    client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert fake.captured_config.prompt_segments is None
+
+
+def test_reset_clears_stored_ids(make_client):
+    # After reset, the next turn has no stored ids to splice -> plain text again.
+    client, fake = make_client(max_named_sessions=2, gen_ids=[5, 6])
+    _chat_msgs(client, [{"role": "user", "content": "hi"}], "s")
+    client.post("/v1/sessions/s/reset")
+    turn2 = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "reply"},
+        {"role": "user", "content": "more"},
+    ]
+    _chat_msgs(client, turn2, "s")
+    assert fake.captured_config.prompt_segments is None
+
+
+def test_reset_endpoint_clears_context_but_keeps_slot(make_client):
+    # max_named=1: open "a", reset it, then a *different* id must still 429 —
+    # proving reset cleared context without freeing the slot (unlike DELETE).
+    client, fake = make_client(max_named_sessions=1)
+    assert _chat(client, session_id="a").status_code == 200
+    r = client.post("/v1/sessions/a/reset")
+    assert r.status_code == 200
+    assert r.json() == {"reset": True, "session_id": "a"}
+    assert fake.reset_log == ["a"]
+    assert _chat(client, session_id="b").status_code == 429  # slot still held
+
+
+def test_reset_invalid_session_id_rejected(make_client):
+    client, _ = make_client(max_named_sessions=2)
+    r = client.post("/v1/sessions/has%20space/reset")
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "invalid_session_id"
+
+
+class _RaisingRuntime:
+    """Runtime whose worker ops fail, to exercise the lockstep invariant."""
+
+    async def open(self, sid):
+        pass
+
+    async def reset(self, sid):
+        raise WorkerError("worker down")
+
+    async def close(self, sid):
+        raise WorkerError("worker down")
+
+
+@pytest.mark.parametrize("op", ["reset_session", "close_session"])
+def test_worker_op_failure_keeps_transcript(op):
+    # Lockstep invariant: if the worker reset/close fails, the adapter transcript
+    # must NOT be cleared -- both retain old state so they never drift.
+    template = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)
+    serving = ServingChat(_RaisingRuntime(), template, "test-model")
+    serving._transcript.record_assistant_turn(
+        session_id="s",
+        content="hi",
+        tool_calls=None,
+        generated_token_ids=[1, 2],
+        prior_turns=0,
+    )
+
+    async def go():
+        with pytest.raises(GenerationError):
+            await getattr(serving, op)("s")
+
+    asyncio.run(go())
+    assert serving._transcript._turns.get(
+        "s"
+    ), "transcript cleared despite worker failure"
+
+
+def test_record_assistant_turn_replaces_stale_at_position():
+    # A regenerated/branched turn under the same session_id must REPLACE the
+    # record at its position (prior_turns), not append, so a later turn can still
+    # splice the regenerated ids instead of breaking on a stale fingerprint.
+    from executorch.examples.llm_server.python.openai_transcript import (
+        OpenAITranscriptState,
+    )
+
+    t = OpenAITranscriptState(ChatTemplate(hf_tokenizer_path=None, allow_fallback=True))
+    t.record_assistant_turn(
+        session_id="s",
+        content="a0",
+        tool_calls=None,
+        generated_token_ids=[1],
+        prior_turns=0,
+    )
+    t.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[2],
+        prior_turns=1,
+    )
+    assert [r["ids"] for r in t._turns["s"]] == [[1], [2]]
+    # regenerate turn 2 (same prior_turns) -> replaces stale [2], no stale tail
+    t.record_assistant_turn(
+        session_id="s",
+        content="a1b",
+        tool_calls=None,
+        generated_token_ids=[3],
+        prior_turns=1,
+    )
+    assert [r["ids"] for r in t._turns["s"]] == [[1], [3]]
+
+
+def test_divergence_truncates_stale_tail():
+    # Editing an EARLIER assistant turn (divergence at k) prunes the stale tail
+    # from k so it can't keep shadowing future requests; nothing is spliced and
+    # the matched prefix is kept. (Restoring hits for the edited turn isn't
+    # possible -- we never generated its ids -- but staleness is bounded.)
+    from executorch.examples.llm_server.python.openai_transcript import (
+        OpenAITranscriptState,
+    )
+    from executorch.examples.llm_server.python.protocol import ChatMessage
+
+    t = OpenAITranscriptState(ChatTemplate(hf_tokenizer_path=None, allow_fallback=True))
+    t.record_assistant_turn(
+        session_id="s",
+        content="a0",
+        tool_calls=None,
+        generated_token_ids=[1],
+        prior_turns=0,
+    )
+    t.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[2],
+        prior_turns=1,
+    )
+    msgs = [
+        ChatMessage(role="user", content="u0"),
+        ChatMessage(role="assistant", content="a0-EDITED"),
+        ChatMessage(role="user", content="u1"),
+    ]
+    out = t.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt="X",
+        tools=None,
+        template_kwargs=None,
+    )
+    assert out.text == "X"  # diverged -> plain text fallback
+    assert t._turns["s"] == []  # stale tail pruned from the first mismatch
+
+
+class _HFToolSpecials:
+    # Tokenizer that marks a turn terminator AND tool/structural delimiters special.
+    all_special_tokens = ["<|im_end|>", "<tool_call>", "</tool_call>", "<|box_start|>"]
+    eos_token = "<|im_end|>"
+
+
+def test_stop_set_narrow_but_strip_set_broad():
+    # The generation/pre-parse-truncation set is
+    # NARROW (turn terminators only) so a <tool_call> is never halted or cut
+    # before the parser sees it; the final content-strip set stays BROAD so stray
+    # specials can't leak into visible content.
+    from types import SimpleNamespace
+
+    template = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)
+    template._hf = _HFToolSpecials()
+    serving = ServingChat(_RaisingRuntime(), template, "test-model")
+
+    assert "<|im_end|>" in serving._stops  # terminator kept
+    assert "<tool_call>" not in serving._stops  # delimiter excluded
+    assert "</tool_call>" not in serving._stops
+    assert "<|box_start|>" not in serving._stops
+
+    assert "<tool_call>" in serving._content_specials  # broad strip keeps it
+    assert "<|box_start|>" in serving._content_specials
+
+    # The insidious site: _truncate_raw must NOT cut at <tool_call> (it uses the
+    # narrow set), so the full tool-call markup survives to the parser.
+    raw = (
+        "sure<tool_call>\n<function=f>\n<parameter=x>\n1\n"
+        "</parameter>\n</function>\n</tool_call>"
+    )
+    assert serving._truncate_raw(raw, SimpleNamespace(stop=None)) == raw
+
+
+def test_injected_assistant_exemplar_falls_back_to_text():
+    # A client-injected assistant turn we never generated (few-shot exemplar /
+    # pre-seeded turn) shifts the ordinal alignment -> fingerprint mismatch ->
+    # safe text fallback (no stale ids spliced).
+    from executorch.examples.llm_server.python.openai_transcript import (
+        OpenAITranscriptState,
+    )
+    from executorch.examples.llm_server.python.protocol import ChatMessage
+
+    t = OpenAITranscriptState(ChatTemplate(hf_tokenizer_path=None, allow_fallback=True))
+    t.record_assistant_turn(
+        session_id="s",
+        content="a0",
+        tool_calls=None,
+        generated_token_ids=[1, 2],
+        prior_turns=0,
+    )
+    msgs = [
+        ChatMessage(role="user", content="u0"),
+        ChatMessage(role="assistant", content="INJECTED EXEMPLAR"),  # not ours
+        ChatMessage(role="user", content="u1"),
+    ]
+    out = t.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt="X",
+        tools=None,
+        template_kwargs=None,
+    )
+    assert out.text == "X" and out.segments is None  # safe text fallback

--- a/examples/llm_server/python/tests/test_streaming_stops.py
+++ b/examples/llm_server/python/tests/test_streaming_stops.py
@@ -1,0 +1,274 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Plain-chat streaming special-token cleanup.
+
+Non-streaming scrubs broad content specials (the full all_special_tokens set) from
+visible content via _strip_specials. Plain-chat streaming must be consistent: a
+broad special that is NOT a turn terminator (e.g. <|fim_pad|>) must not reach the
+client, and -- since trimming it makes the turn's visible text != generated text
+-- the worker halts (omitting ids), so the turn is recorded non-resumable. Tool
+turns keep the narrow terminator set so a <tool_call> is never cut before parsing.
+"""
+
+import json
+
+from executorch.examples.llm_server.python.chat_template import ChatTemplate
+from executorch.examples.llm_server.python.server import build_app
+from executorch.examples.llm_server.python.serving_chat import ServingChat
+from executorch.examples.llm_server.python.session_runtime import SessionRuntime
+from executorch.examples.llm_server.python.tool_parsers import HermesDetector
+from executorch.examples.llm_server.python.worker_client import WorkerError
+from fastapi.testclient import TestClient
+
+FIM = "<|fim_pad|>"  # a broad content special that is NOT a turn terminator
+CHANNEL_OPEN = "<|channel>"
+CHANNEL_CLOSE = "<channel|>"
+THINK = "<|think|>"
+CHANNEL_SPECIALS = {CHANNEL_OPEN, CHANNEL_CLOSE, THINK}
+WEATHER_TOOLS = [
+    {"type": "function", "function": {"name": "get_weather", "parameters": {}}}
+]
+
+
+class _SpecialTok:
+    """Fake HF tokenizer whose special set is broader than the turn terminators:
+    eos=<|im_end|> (a terminator) plus <|fim_pad|> (broad-only)."""
+
+    eos_token = "<|im_end|>"
+    all_special_tokens = ["<|im_end|>", FIM, CHANNEL_OPEN, CHANNEL_CLOSE, THINK]
+
+    def encode(self, text, add_special_tokens=False):
+        return [0] * 5
+
+    def apply_chat_template(
+        self, messages, tools, add_generation_prompt, tokenize, **kw
+    ):
+        return "PROMPT"
+
+
+class _Runner:
+    """Fake worker. With honor_stops it models the real worker's stop-trim: a
+    stop string halts generation, the stop and everything after is dropped, and
+    the turn is non-resumable (generated_token_ids omitted)."""
+
+    def __init__(self, tokens, gen_ids=None, honor_stops=False, max_named=4):
+        self._tokens = list(tokens)
+        self._gen_ids = list(gen_ids or [])
+        self._honor = honor_stops
+        self.max_named_sessions = max_named
+        self.open_named = set()
+        self.captured_config = None
+
+    def reset(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def open_session(self, sid):
+        if sid in self.open_named:
+            return
+        if self.max_named_sessions == 0:
+            raise WorkerError("no named sessions", code="unsupported_session")
+        if len(self.open_named) >= self.max_named_sessions:
+            raise WorkerError("capacity", code="capacity_exhausted")
+        self.open_named.add(sid)
+
+    def close_session(self, sid):
+        self.open_named.discard(sid)
+
+    def reset_session(self, sid):
+        pass
+
+    def generate(self, prompt, config, token_callback=None, stats_callback=None):
+        self.captured_config = config
+        stops = list(getattr(config, "stop", []) or []) if self._honor else []
+        emitted, trimmed = 0, False
+        for tok in self._tokens:
+            if any(s and s in tok for s in stops):
+                trimmed = True
+                break
+            if token_callback:
+                token_callback(tok)
+            emitted += 1
+        if stats_callback:
+            stats = type("S", (), {})()
+            stats.num_prompt_tokens = 5
+            stats.num_generated_tokens = emitted
+            stats.finish_reason = "stop" if trimmed else None
+            stats.generated_token_ids = [] if trimmed else list(self._gen_ids)
+            stats_callback(stats)
+
+
+def _serving(
+    tokens,
+    honor_stops=False,
+    gen_ids=None,
+    content_filter=None,
+    content_filter_specials=None,
+):
+    runner = _Runner(tokens, gen_ids=gen_ids, honor_stops=honor_stops)
+    template = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)
+    template._hf = _SpecialTok()
+    serving = ServingChat(
+        SessionRuntime(runner),
+        template,
+        "test-model",
+        tool_detector_cls=HermesDetector,
+        content_filter=content_filter,
+        content_filter_specials=content_filter_specials,
+    )
+    return serving, runner
+
+
+def _client(serving):
+    return TestClient(build_app(serving, "test-model"))
+
+
+def _sse_content(text):
+    content, finish = "", None
+    for line in text.splitlines():
+        if line.startswith("data:") and "[DONE]" not in line:
+            d = json.loads(line[5:])
+            for ch in d.get("choices", []):
+                content += (ch.get("delta", {}) or {}).get("content") or ""
+                if ch.get("finish_reason"):
+                    finish = ch["finish_reason"]
+    return content, finish
+
+
+def test_plain_chat_worker_stops_include_broad_specials():
+    serving, runner = _serving(["hi"])
+    _client(serving).post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert FIM in (runner.captured_config.stop or [])
+
+
+def test_tool_path_worker_stops_exclude_broad_specials():
+    serving, runner = _serving(["hi"])
+    _client(serving).post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": WEATHER_TOOLS,
+        },
+    )
+    # Tool turns keep the narrow set so a structural/tool delimiter isn't cut.
+    assert FIM not in (runner.captured_config.stop or [])
+
+
+def test_plain_chat_streaming_does_not_leak_broad_special():
+    serving, _ = _serving(["Hi", FIM, "leak"])
+    r = _client(serving).post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    )
+    content, finish = _sse_content(r.text)
+    assert content == "Hi"  # the special and everything after is cut
+    assert FIM not in content
+    assert finish == "stop"
+
+
+def test_plain_chat_streaming_applies_content_filter():
+    def strip_channel(text):
+        return text.replace(f"{CHANNEL_OPEN}secret{CHANNEL_CLOSE}", "").strip()
+
+    serving, runner = _serving(
+        ["Visible ", CHANNEL_OPEN, "secret", CHANNEL_CLOSE],
+        content_filter=strip_channel,
+        content_filter_specials=CHANNEL_SPECIALS,
+    )
+    r = _client(serving).post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    )
+    content, _ = _sse_content(r.text)
+    assert content == "Visible"
+    assert CHANNEL_OPEN not in content and CHANNEL_CLOSE not in content
+    assert CHANNEL_OPEN not in (runner.captured_config.stop or [])
+
+
+def test_plain_chat_nonstreaming_matches_streaming_visible():
+    serving, _ = _serving(["Hi", FIM, "leak"])
+    r = _client(serving).post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    choice = r.json()["choices"][0]
+    assert choice["message"]["content"] == "Hi"
+    assert choice["finish_reason"] == "stop"
+
+
+def test_tool_streaming_not_broken_by_broad_special():
+    tc = '<tool_call>\n{"name": "get_weather", "arguments": {}}\n</tool_call>'
+    serving, _ = _serving([tc])
+    r = _client(serving).post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": WEATHER_TOOLS,
+            "stream": True,
+        },
+    )
+    chunks = [
+        json.loads(line[5:])
+        for line in r.text.splitlines()
+        if line.startswith("data:") and "[DONE]" not in line
+    ]
+    finishes = [
+        c["choices"][0]["finish_reason"]
+        for c in chunks
+        if c["choices"][0].get("finish_reason")
+    ]
+    has_tool = any(
+        (c["choices"][0].get("delta") or {}).get("tool_calls") for c in chunks
+    )
+    assert "tool_calls" in finishes and has_tool
+
+
+def test_plain_chat_broad_stop_marks_turn_nonresumable():
+    # honor_stops: the worker trims at the broad special and omits ids; the
+    # transcript must record the turn as non-resumable (ids=None), not splice ids
+    # for text the client never saw.
+    serving, _ = _serving(["Hi", FIM, "leak"], honor_stops=True, gen_ids=[1, 2, 3])
+    r = _client(serving).post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "session_id": "s",
+        },
+    )
+    assert r.json()["choices"][0]["message"]["content"] == "Hi"
+    assert serving._transcript._turns["s"][0]["ids"] is None
+
+
+def test_user_request_stop_trims_and_nonresumable():
+    serving, _ = _serving(["keep", "STOPHERE", "drop"], honor_stops=True, gen_ids=[9])
+    r = _client(serving).post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "session_id": "s",
+            "stop": "STOPHERE",
+        },
+    )
+    assert r.json()["choices"][0]["message"]["content"] == "keep"
+    assert serving._transcript._turns["s"][0]["ids"] is None

--- a/examples/llm_server/python/tests/test_template.py
+++ b/examples/llm_server/python/tests/test_template.py
@@ -1,0 +1,382 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Contract tests for chat-template kwargs (e.g. enable_thinking) passthrough."""
+
+import pytest
+
+from executorch.examples.llm_server.python.chat_template import ChatTemplate
+from executorch.examples.llm_server.python.protocol import (
+    ChatMessage,
+    FunctionCall,
+    ToolCall,
+)
+
+
+class _FakeHF:
+    def __init__(self):
+        self.seen_kwargs = None
+        self.seen_messages = None
+        self.encode_add_special = None
+        self.chat_template = "fake"
+        self.bos_token = "<bos>"
+
+    def apply_chat_template(
+        self, messages, tools, add_generation_prompt, tokenize, **kwargs
+    ):
+        self.seen_kwargs = kwargs
+        self.seen_messages = messages
+        return "PROMPT"
+
+    # Default add_special_tokens=True mirrors real HF tokenizers (so a caller
+    # that forgets to disable specials would over-count).
+    def encode(self, text, add_special_tokens=True):
+        self.encode_add_special = add_special_tokens
+        return list(range(len(text)))  # 1 id per char, deterministic
+
+
+class _GemmaToolResponseHF(_FakeHF):
+    def __init__(
+        self,
+        tool_prompt="<|turn>model\n<|tool_response>response:x<tool_response|>",
+        preamble="<|channel>thought\n<channel|>",
+    ):
+        super().__init__()
+        self.tool_prompt = tool_prompt
+        self.preamble = preamble
+
+    def apply_chat_template(
+        self, messages, tools, add_generation_prompt, tokenize, **kwargs
+    ):
+        self.seen_kwargs = kwargs
+        self.seen_messages = messages
+        if messages and messages[-1]["role"] == "tool":
+            return self.tool_prompt
+        return "<|turn>user\n<turn|>\n<|turn>model\n" + self.preamble
+
+
+def _template_with_fake(defaults=None):
+    t = ChatTemplate(
+        hf_tokenizer_path=None, allow_fallback=True, default_template_kwargs=defaults
+    )
+    fake = _FakeHF()
+    t._hf = fake
+    return t, fake
+
+
+def _template_with_gemma_tool_response_fake(
+    tool_prompt="<|turn>model\n<|tool_response>response:x<tool_response|>",
+    preamble="<|channel>thought\n<channel|>",
+    append=False,
+):
+    t = ChatTemplate(
+        hf_tokenizer_path=None,
+        allow_fallback=True,
+        assistant_header="<|turn>model\n",
+        append_generation_prompt_after_tool_response=append,
+    )
+    fake = _GemmaToolResponseHF(tool_prompt=tool_prompt, preamble=preamble)
+    t._hf = fake
+    return t, fake
+
+
+def test_count_tokens_excludes_special_tokens():
+    # The rendered prompt already carries control tokens, so count_tokens must
+    # encode with add_special_tokens=False (matching the session/prefix-cache
+    # paths) — not the tokenizer's default True, which double-counts BOS/EOS and
+    # can falsely reject near-limit requests under --max-context.
+    t, fake = _template_with_fake()
+    n = t.count_tokens("PROMPT")
+    assert fake.encode_add_special is False
+    assert n == len("PROMPT")
+
+
+def test_default_template_kwargs_applied():
+    t, fake = _template_with_fake(defaults={"enable_thinking": False})
+    t.render([ChatMessage(role="user", content="hi")])
+    assert fake.seen_kwargs == {"enable_thinking": False}
+
+
+def test_per_request_kwargs_override_defaults():
+    t, fake = _template_with_fake(defaults={"enable_thinking": False})
+    t.render(
+        [ChatMessage(role="user", content="hi")],
+        template_kwargs={"enable_thinking": True},
+    )
+    assert fake.seen_kwargs["enable_thinking"] is True
+
+
+def test_no_kwargs_when_none():
+    t, fake = _template_with_fake(defaults=None)
+    t.render([ChatMessage(role="user", content="hi")])
+    assert fake.seen_kwargs == {}
+
+
+def test_strip_rendered_prefix_before_worker_tokenization():
+    t = ChatTemplate(
+        hf_tokenizer_path=None, allow_fallback=True, strip_rendered_prefix="PRO"
+    )
+    fake = _FakeHF()
+    t._hf = fake
+    out = t.render([ChatMessage(role="user", content="hi")])
+    assert out == "MPT"
+    assert fake.seen_messages[0]["content"] == "hi"
+
+
+def test_strip_rendered_prefix_fails_if_missing():
+    t = ChatTemplate(
+        hf_tokenizer_path=None, allow_fallback=True, strip_rendered_prefix="MISS"
+    )
+    t._hf = _FakeHF()
+    with pytest.raises(ValueError, match="strip prefix"):
+        t.render([ChatMessage(role="user", content="hi")])
+
+
+def test_strip_rendered_bos_uses_tokenizer_bos(monkeypatch):
+    transformers = pytest.importorskip("transformers")
+    fake = _FakeHF()
+
+    def apply_chat_template(messages, tools, add_generation_prompt, tokenize, **kwargs):
+        fake.seen_messages = messages
+        return "<bos>PROMPT"
+
+    fake.apply_chat_template = apply_chat_template
+    monkeypatch.setattr(
+        transformers.AutoTokenizer, "from_pretrained", lambda _path: fake
+    )
+    t = ChatTemplate("unused", strip_rendered_bos=True)
+    assert t.render([ChatMessage(role="user", content="hi")]) == "PROMPT"
+
+
+def test_fallback_ignores_kwargs_without_hf():
+    # No HF tokenizer → ChatML fallback, must not raise on kwargs.
+    t = ChatTemplate(
+        hf_tokenizer_path=None,
+        allow_fallback=True,
+        default_template_kwargs={"enable_thinking": False},
+    )
+    out = t.render([ChatMessage(role="user", content="hi")], template_kwargs={"x": 1})
+    assert "<|im_start|>user" in out and out.endswith("<|im_start|>assistant\n")
+
+
+def test_tool_response_generation_prompt_disabled_by_default():
+    t, _ = _template_with_gemma_tool_response_fake(append=False)
+    out = t.render([ChatMessage(role="tool", tool_call_id="c1", content="ok")])
+    assert out.endswith("<tool_response|>")
+    assert "<|channel>thought" not in out
+
+
+def test_tool_response_generation_prompt_appended_for_gemma():
+    t, _ = _template_with_gemma_tool_response_fake(append=True)
+    out = t.render([ChatMessage(role="tool", tool_call_id="c1", content="ok")])
+    assert out.endswith("<tool_response|><|turn>model\n<|channel>thought\n<channel|>")
+
+
+def test_tool_response_generation_prompt_handles_turn_end_case():
+    t, _ = _template_with_gemma_tool_response_fake(
+        tool_prompt="<|turn>model\nLet me check.<turn|>\n",
+        preamble="",
+        append=True,
+    )
+    out = t.render([ChatMessage(role="tool", tool_call_id="c1", content="ok")])
+    assert out.endswith("<turn|>\n<|turn>model\n")
+
+
+def test_tool_response_generation_prompt_not_double_inserted():
+    t, _ = _template_with_gemma_tool_response_fake(
+        tool_prompt=(
+            "<|turn>model\n<|tool_response>response:x<tool_response|>"
+            "<|turn>model\n<|channel>thought\n<channel|>"
+        ),
+        append=True,
+    )
+    out = t.render([ChatMessage(role="tool", tool_call_id="c1", content="ok")])
+    assert out.count("<|turn>model\n") == 2
+    assert out.count("<|channel>thought\n<channel|>") == 1
+
+
+def test_tool_response_generation_prompt_completes_header_only_prompt():
+    t, _ = _template_with_gemma_tool_response_fake(
+        tool_prompt="<|turn>model\n<|tool_response>response:x<tool_response|><|turn>model\n",
+        append=True,
+    )
+    out = t.render([ChatMessage(role="tool", tool_call_id="c1", content="ok")])
+    assert out.endswith("<|turn>model\n<|channel>thought\n<channel|>")
+    assert out.count("<|turn>model\n") == 2
+
+
+def test_tool_response_generation_prompt_requires_final_tool_message():
+    t, _ = _template_with_gemma_tool_response_fake(
+        tool_prompt="<|turn>model\n<|tool_response>response:x<tool_response|>",
+        append=True,
+    )
+    out = t.render([ChatMessage(role="user", content="ok")])
+    assert out == "<|turn>user\n<turn|>\n<|turn>model\n<|channel>thought\n<channel|>"
+
+
+# (5) Chat-template behaviors: multi-turn ordering, system message, roles.
+def test_multi_turn_order_preserved():
+    t = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)
+    out = t.render(
+        [
+            ChatMessage(role="user", content="first"),
+            ChatMessage(role="assistant", content="second"),
+            ChatMessage(role="user", content="third"),
+        ]
+    )
+    assert out.index("first") < out.index("second") < out.index("third")
+    assert out.endswith("<|im_start|>assistant\n")  # generation prompt appended
+
+
+def test_system_message_rendered():
+    t = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)
+    out = t.render(
+        [
+            ChatMessage(role="system", content="You are terse."),
+            ChatMessage(role="user", content="hi"),
+        ]
+    )
+    assert "<|im_start|>system\nYou are terse." in out
+
+
+def test_each_role_labeled():
+    t = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)
+    out = t.render(
+        [
+            ChatMessage(role="system", content="s"),
+            ChatMessage(role="user", content="u"),
+            ChatMessage(role="assistant", content="a"),
+        ]
+    )
+    for role in ("system", "user", "assistant"):
+        assert f"<|im_start|>{role}" in out
+
+
+# Tool round-trip: a turn-2 request (assistant tool_call + tool result) must
+# serialize into the shape any HF chat template consumes — the multi-turn loop
+# breaks at turn 2 otherwise. OpenAI sends tool-call arguments as a JSON string;
+# HF templates expect a mapping (Qwen renders `arguments|items`), so the server
+# decodes it before templating.
+def test_tool_call_arguments_decoded_for_template():
+    t, fake = _template_with_fake()
+    t.render(
+        [
+            ChatMessage(role="user", content="weather?"),
+            ChatMessage(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        index=0,
+                        id="c1",
+                        type="function",
+                        function=FunctionCall(
+                            name="get_weather", arguments='{"city": "Paris"}'
+                        ),
+                    )
+                ],
+            ),
+            ChatMessage(role="tool", tool_call_id="c1", content='{"temp_c": 18}'),
+        ]
+    )
+    msgs = fake.seen_messages
+    asst = next(m for m in msgs if m["role"] == "assistant")
+    assert asst["tool_calls"][0]["function"]["name"] == "get_weather"
+    # Decoded from the JSON string into a mapping the template can iterate.
+    assert asst["tool_calls"][0]["function"]["arguments"] == {"city": "Paris"}
+    tool = next(m for m in msgs if m["role"] == "tool")
+    assert tool["tool_call_id"] == "c1" and "temp_c" in tool["content"]
+
+
+def test_tool_call_non_json_arguments_left_as_string():
+    # A non-JSON arguments value must not crash; it passes through unchanged.
+    t, fake = _template_with_fake()
+    t.render(
+        [
+            ChatMessage(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        index=0,
+                        id="c1",
+                        type="function",
+                        function=FunctionCall(name="f", arguments="not json"),
+                    )
+                ],
+            )
+        ]
+    )
+    asst = next(m for m in fake.seen_messages if m["role"] == "assistant")
+    assert asst["tool_calls"][0]["function"]["arguments"] == "not json"
+
+
+class _HFSpecials:
+    """Minimal fake HF tokenizer exposing all_special_tokens / eos_token."""
+
+    def __init__(self, all_special_tokens, eos_token="<|im_end|>"):
+        self.all_special_tokens = list(all_special_tokens)
+        self.eos_token = eos_token
+
+
+def _template_with_specials(all_special_tokens, eos_token="<|im_end|>"):
+    t = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)
+    t._hf = _HFSpecials(all_special_tokens, eos_token)
+    return t
+
+
+def test_turn_stop_excludes_tool_delimiters():
+    # A tokenizer that marks BOTH a turn terminator and tool/structural delimiters
+    # as special: the stop set must keep the terminator and drop the delimiters,
+    # else generation halts at <tool_call> before the parser sees the call.
+    t = _template_with_specials(
+        ["<|im_end|>", "<tool_call>", "</tool_call>", "<|box_start|>"],
+        eos_token="<|im_end|>",
+    )
+    stops = t.turn_stop_sequences()
+    assert "<|im_end|>" in stops
+    assert "<tool_call>" not in stops
+    assert "</tool_call>" not in stops
+    assert "<|box_start|>" not in stops
+
+
+def test_turn_stop_includes_eos_and_known_terminators():
+    t = _template_with_specials(
+        ["<|endoftext|>", "<|eot_id|>", "<tool_call>"], eos_token="<|endoftext|>"
+    )
+    stops = t.turn_stop_sequences()
+    assert "<|endoftext|>" in stops  # the tokenizer EOS
+    assert "<|eot_id|>" in stops  # allowlisted terminator registered as special
+    assert "<tool_call>" not in stops
+
+
+def test_turn_stop_drops_whitespace_only_specials():
+    t = _template_with_specials(["<|im_end|>", "  ", "\n", ""], eos_token="<|im_end|>")
+    stops = t.turn_stop_sequences()
+    assert all(s.strip() for s in stops)
+    assert "  " not in stops and "\n" not in stops
+
+
+def test_turn_stop_fallback_without_hf_is_narrow():
+    t = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)  # no _hf
+    stops = t.turn_stop_sequences()
+    assert "<|im_end|>" in stops
+    assert "<tool_call>" not in stops
+
+
+def test_fallback_extracts_text_parts_not_repr():
+    # The ChatML fallback renders list-content text parts, not a Python repr.
+    t = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)  # no _hf
+    msg = ChatMessage(
+        role="user",
+        content=[
+            {"type": "text", "text": "hello"},
+            {"type": "image_url", "image_url": {}},
+        ],
+    )
+    out = t.render([msg])
+    assert "hello" in out
+    assert "image_url" not in out and "{'type'" not in out  # no repr leak

--- a/examples/llm_server/python/tests/test_tool_calls.py
+++ b/examples/llm_server/python/tests/test_tool_calls.py
@@ -1,0 +1,221 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tool-calling tests (HTTP contract via the server).
+
+Hermes/Qwen format only. The server buffers the model's full output and parses
+it once into complete OpenAI tool_calls; parse failures degrade to visible text.
+"""
+
+import json
+
+WEATHER_TOOLS = [
+    {
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {"type": "object"}},
+    }
+]
+
+
+def _call_text(name, args):
+    return f'<tool_call>\n{{"name": "{name}", "arguments": {json.dumps(args)}}}\n</tool_call>'
+
+
+# --- HTTP contract: non-streaming ---------------------------------------
+
+
+def test_tool_call_nonstreaming(make_client):
+    client, _ = make_client(tokens=[_call_text("get_weather", {"city": "Paris"})])
+    body = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather in Paris?"}],
+            "tools": WEATHER_TOOLS,
+        },
+    ).json()
+    choice = body["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    tc = choice["message"]["tool_calls"][0]
+    assert tc["type"] == "function"
+    assert tc["function"]["name"] == "get_weather"
+    assert json.loads(tc["function"]["arguments"]) == {"city": "Paris"}
+
+
+def test_tool_call_streaming(make_client):
+    client, _ = make_client(tokens=[_call_text("get_weather", {"city": "Paris"})])
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": WEATHER_TOOLS,
+            "stream": True,
+        },
+    )
+    # Reuse the contract helper's SSE parsing.
+    chunks = []
+    for line in resp.text.splitlines():
+        line = line.strip()
+        if line.startswith("data:") and "[DONE]" not in line:
+            chunks.append(json.loads(line[len("data:") :].strip()))
+    tool_deltas = [
+        c["choices"][0]["delta"]["tool_calls"][0]
+        for c in chunks
+        if c["choices"] and c["choices"][0]["delta"].get("tool_calls")
+    ]
+    assert tool_deltas and tool_deltas[0]["function"]["name"] == "get_weather"
+    assert chunks[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+
+def test_undefined_tool_is_not_called(make_client):
+    # Model calls a tool not in the request's tools -> no tool_calls; the raw
+    # call stays visible as content (degrade to text, never silent drop).
+    client, _ = make_client(tokens=[_call_text("rm_rf", {"path": "/"})])
+    body = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": WEATHER_TOOLS,
+        },
+    ).json()
+    msg = body["choices"][0]["message"]
+    assert msg.get("tool_calls") is None
+    assert "rm_rf" in (msg.get("content") or "")  # not dropped — visible as text
+
+
+def test_mixed_valid_and_undefined_tool_degrades_to_text(make_client):
+    # A response with one valid + one undefined call must NOT emit the valid one
+    # while silently dropping the undefined one — the whole response degrades to
+    # visible text so the model's full intent is preserved.
+    client, _ = make_client(
+        tokens=[
+            _call_text("get_weather", {"city": "Paris"})
+            + _call_text("rm_rf", {"path": "/"})
+        ]
+    )
+    msg = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": WEATHER_TOOLS,
+        },
+    ).json()["choices"][0]["message"]
+    assert msg.get("tool_calls") is None  # no partial set
+    content = msg.get("content") or ""
+    assert "rm_rf" in content and "get_weather" in content  # full intent visible
+
+
+def test_tool_choice_none_omits_tools_from_prompt():
+    from executorch.examples.llm_server.python.chat_template import ChatTemplate
+    from executorch.examples.llm_server.python.server import build_app
+    from executorch.examples.llm_server.python.serving_chat import ServingChat
+    from executorch.examples.llm_server.python.session_runtime import SessionRuntime
+    from executorch.examples.llm_server.python.tool_parsers import HermesDetector
+
+    # tool_choice="none" must NOT inject tool schemas into the chat template; if it
+    # did, the model could still emit a <tool_call> that we'd surface as plain text
+    # (parsing is disabled for "none"). Assert via a recording tokenizer.
+    from fastapi.testclient import TestClient
+
+    class _RecordingTok:
+        all_special_tokens: list = []
+
+        def __init__(self):
+            self.tools_seen = "UNSET"
+
+        def encode(self, text):
+            return [0]
+
+        def apply_chat_template(
+            self, messages, tools, add_generation_prompt, tokenize, **kwargs
+        ):
+            self.tools_seen = tools
+            return "PROMPT"
+
+    class _Runner:
+        def reset(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def generate(self, prompt, config, token_callback=None, stats_callback=None):
+            if token_callback:
+                token_callback("ok")
+
+    rec = _RecordingTok()
+    template = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)
+    template._hf = rec
+    runtime = SessionRuntime(_Runner())
+    serving = ServingChat(
+        runtime, template, "test-model", tool_detector_cls=HermesDetector
+    )
+    client = TestClient(build_app(serving, "test-model"))
+    body = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": WEATHER_TOOLS,
+        "max_tokens": 8,
+    }
+
+    assert (
+        client.post(
+            "/v1/chat/completions", json={**body, "tool_choice": "none"}
+        ).status_code
+        == 200
+    )
+    assert rec.tools_seen is None  # tools omitted from the rendered prompt
+
+    # Control: default ("auto") still passes the tools through to the template.
+    assert client.post("/v1/chat/completions", json=body).status_code == 200
+    assert rec.tools_seen == WEATHER_TOOLS
+
+
+def test_malformed_tool_call_falls_back_to_text(make_client):
+    # Broken JSON inside the markers must not crash; degrade to visible text.
+    client, _ = make_client(tokens=["<tool_call>\n{not json}\n</tool_call>"])
+    resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": WEATHER_TOOLS,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["choices"][0]["message"].get("tool_calls") is None
+
+
+def test_no_tools_field_means_text_even_if_markers_present(make_client):
+    # Without a tools array, tool markers are just content (not parsed).
+    client, _ = make_client(tokens=[_call_text("get_weather", {"city": "X"})])
+    body = client.post(
+        "/v1/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "hi"}]},
+    ).json()
+    assert body["choices"][0]["message"].get("tool_calls") is None
+
+
+def test_parallel_calls_in_one_message(make_client):
+    # Two complete <tool_call> blocks in one output -> two structured calls.
+    tokens = [
+        _call_text("get_weather", {"city": "A"})
+        + _call_text("get_weather", {"city": "B"})
+    ]
+    client, _ = make_client(tokens=tokens)
+    body = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather in A and B?"}],
+            "tools": WEATHER_TOOLS,
+        },
+    ).json()
+    calls = body["choices"][0]["message"]["tool_calls"]
+    assert [json.loads(c["function"]["arguments"])["city"] for c in calls] == ["A", "B"]

--- a/examples/llm_server/python/tests/test_warm_resume_scaffold.py
+++ b/examples/llm_server/python/tests/test_warm_resume_scaffold.py
@@ -1,0 +1,745 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Warm-resume generation-scaffold reproduction.
+
+Qwen3's template prefills a deterministic ``<think>`` scaffold into the
+generation prompt (so it lands in resident KV) but strips it when re-rendering a
+turn as history *before* the last user message, while *preserving* it (as the
+empty block) for turns after. The token-ID splice must reproduce each turn's
+exact resident scaffold ahead of its generated ids, normalizing whatever the
+history render put there -- inserting when stripped, replacing when a different
+form was preserved -- so the worker's exact-token prefix check lands.
+"""
+
+import os
+
+import pytest
+
+from executorch.examples.llm_server.python.chat_template import ChatTemplate
+from executorch.examples.llm_server.python.openai_transcript import (
+    OpenAITranscriptState,
+)
+from executorch.examples.llm_server.python.protocol import (
+    ChatMessage,
+    FunctionCall,
+    ToolCall,
+)
+
+HDR = "<|im_start|>assistant\n"
+NOTHINK = "<think>\n\n</think>\n\n"  # no-think generation preamble / preserved block
+THINK = "<think>\n"  # think-mode generation preamble
+GEMMA_HDR = "<|turn>model\n"
+GEMMA_PREAMBLE = "<|channel>thought\n<channel|>"
+
+
+def _msgs(*pairs):
+    return [ChatMessage(role=r, content=c) for r, c in pairs]
+
+
+class _FakeQwen:
+    """Mimics Qwen3 scaffold behavior in render(): the generation prompt appends
+    the mode scaffold after the assistant header; history strips the scaffold for
+    assistant turns before the last user message and preserves the empty block
+    for turns after it (true in both modes -- the case that needs normalize)."""
+
+    def __init__(self, default_thinking=False):
+        self._default_thinking = default_thinking
+
+    def _gen(self, kw):
+        thinking = (kw or {}).get("enable_thinking", self._default_thinking)
+        return THINK if thinking else NOTHINK
+
+    def render(self, messages, tools=None, template_kwargs=None):
+        last_user = max(
+            (i for i, m in enumerate(messages) if m.role == "user"), default=-1
+        )
+        out = []
+        for i, m in enumerate(messages):
+            c = m.content if isinstance(m.content, str) else ""
+            if m.role == "assistant" and i > last_user:
+                out.append(f"{HDR}{NOTHINK}{c}<|im_end|>\n")  # preserved empty block
+            else:
+                out.append(f"<|im_start|>{m.role}\n{c}<|im_end|>\n")
+        out.append(HDR + self._gen(template_kwargs))
+        return "".join(out)
+
+
+class _FakePlain:
+    """No-scaffold ChatML template (preamble '')."""
+
+    def render(self, messages, tools=None, template_kwargs=None):
+        out = [
+            f"<|im_start|>{m.role}\n"
+            f"{m.content if isinstance(m.content, str) else ''}<|im_end|>\n"
+            for m in messages
+        ]
+        out.append(HDR)
+        return "".join(out)
+
+
+class _FakeOtherHeader:
+    """No-scaffold template whose assistant header is NOT the Qwen/ChatML one
+    (Llama-style), to prove token-id splicing isn't disabled for templates that
+    don't use ``<|im_start|>assistant\\n`` when the preamble is ''."""
+
+    OHDR = "<|start_header_id|>assistant<|end_header_id|>\n\n"
+
+    def render(self, messages, tools=None, template_kwargs=None):
+        out = []
+        for m in messages:
+            c = m.content if isinstance(m.content, str) else ""
+            if m.role == "assistant":
+                out.append(f"{self.OHDR}{c}<|eot_id|>")
+            else:
+                out.append(
+                    f"<|start_header_id|>{m.role}<|end_header_id|>\n\n{c}<|eot_id|>"
+                )
+        out.append(self.OHDR)
+        return "".join(out)
+
+
+class _FakeGemma:
+    def assistant_header(self):
+        return GEMMA_HDR
+
+    def render(self, messages, tools=None, template_kwargs=None):
+        out = ["<bos>"]
+        for m in messages:
+            role = "model" if m.role == "assistant" else m.role
+            content = m.content if isinstance(m.content, str) else ""
+            out.append(f"<|turn>{role}\n{content}<turn|>\n")
+        out.append(GEMMA_HDR + GEMMA_PREAMBLE)
+        return "".join(out)
+
+
+def _ids_index(segs, ids):
+    for i, s in enumerate(segs):
+        if s.get("ids") == ids:
+            return i
+    return -1
+
+
+def _text_before_ids(segs, ids):
+    i = _ids_index(segs, ids)
+    assert i > 0 and "text" in segs[i - 1], "expected a {text} segment before {ids}"
+    return segs[i - 1]["text"]
+
+
+def _scaffold_before(segs, ids):
+    """The scaffold region: text after the last assistant header preceding ids."""
+    return _text_before_ids(segs, ids).rsplit(HDR, 1)[-1]
+
+
+# --- 5a. Hermetic unit tests (no model) -------------------------------------
+
+
+def test_nothink_ordinary_append_inserts_scaffold():
+    st = OpenAITranscriptState(_FakeQwen(default_thinking=False))
+    st.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[10, 11, 12],
+        prior_turns=0,
+        preamble=NOTHINK,
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", "a1"), ("user", "u2"))
+    kw = {"enable_thinking": False}
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=st._template.render(msgs, template_kwargs=kw),
+        tools=None,
+        template_kwargs=kw,
+    )
+    assert pi.segments is not None
+    # History stripped the scaffold; the fix inserts exactly one copy.
+    assert _scaffold_before(pi.segments, [10, 11, 12]) == NOTHINK
+    assert _text_before_ids(pi.segments, [10, 11, 12]).count(NOTHINK) == 1
+
+
+def test_think_ordinary_append_inserts_open_scaffold():
+    st = OpenAITranscriptState(_FakeQwen(default_thinking=True))
+    st.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[1, 2],
+        prior_turns=0,
+        preamble=THINK,
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", "a1"), ("user", "u2"))
+    kw = {"enable_thinking": True}
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=st._template.render(msgs, template_kwargs=kw),
+        tools=None,
+        template_kwargs=kw,
+    )
+    assert pi.segments is not None
+    assert _scaffold_before(pi.segments, [1, 2]) == THINK
+
+
+def test_think_toolloop_normalizes_preserved_scaffold():
+    # Turn generated in THINK mode (preamble open-think) but rendered as a
+    # post-last-user turn, where history preserves the *empty* block. The fix
+    # must REPLACE that block with the stored open-think preamble -- not keep it
+    # (wrong scaffold) and not append a second one (double-insert).
+    st = OpenAITranscriptState(_FakeQwen(default_thinking=True))
+    st.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[7, 8, 9],
+        prior_turns=0,
+        preamble=THINK,
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", "a1"))  # a1 AFTER last user
+    kw = {"enable_thinking": True}
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=st._template.render(msgs, template_kwargs=kw),
+        tools=None,
+        template_kwargs=kw,
+    )
+    assert pi.segments is not None
+    assert _scaffold_before(pi.segments, [7, 8, 9]) == THINK
+    # the preserved empty block was replaced, not kept and not doubled
+    assert NOTHINK not in _text_before_ids(pi.segments, [7, 8, 9])
+
+
+def test_no_scaffold_template_is_unchanged():
+    st = OpenAITranscriptState(_FakePlain())
+    st.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[5],
+        prior_turns=0,
+        preamble="",
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", "a1"), ("user", "u2"))
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=st._template.render(msgs),
+        tools=None,
+        template_kwargs=None,
+    )
+    assert pi.segments is not None
+    assert _scaffold_before(pi.segments, [5]) == ""  # nothing inserted, no regression
+
+
+def test_non_qwen_header_no_scaffold_still_splices():
+    # Regression: a no-scaffold template whose assistant header isn't the
+    # Qwen/ChatML one must still get token-id splicing (the normalization is a
+    # no-op when preamble == "", not a hard requirement for the Qwen header).
+    st = OpenAITranscriptState(_FakeOtherHeader())
+    st.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[9, 9],
+        prior_turns=0,
+        preamble="",
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", "a1"), ("user", "u2"))
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=st._template.render(msgs),
+        tools=None,
+        template_kwargs=None,
+    )
+    assert pi.segments is not None  # splicing NOT disabled by the missing header
+    assert any(s.get("ids") == [9, 9] for s in pi.segments)  # ids actually spliced
+
+
+def test_custom_assistant_header_inserts_scaffold():
+    st = OpenAITranscriptState(_FakeGemma())
+    st.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[4, 5],
+        prior_turns=0,
+        preamble=GEMMA_PREAMBLE,
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", "a1"), ("user", "u2"))
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=st._template.render(msgs),
+        tools=None,
+        template_kwargs=None,
+    )
+    assert pi.segments is not None
+    before = _text_before_ids(pi.segments, [4, 5])
+    assert before.rsplit(GEMMA_HDR, 1)[-1] == GEMMA_PREAMBLE
+
+
+def test_stop_trimmed_turn_falls_back_to_text():
+    st = OpenAITranscriptState(_FakeQwen())
+    st.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[],  # stop-trimmed -> ids None -> not resumable
+        prior_turns=0,
+        preamble=NOTHINK,
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", "a1"), ("user", "u2"))
+    kw = {"enable_thinking": False}
+    rendered = st._template.render(msgs, template_kwargs=kw)
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=rendered,
+        tools=None,
+        template_kwargs=kw,
+    )
+    assert pi.segments is None and pi.text == rendered
+
+
+def test_fingerprint_mismatch_falls_back_to_text():
+    st = OpenAITranscriptState(_FakeQwen())
+    st.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[10],
+        prior_turns=0,
+        preamble=NOTHINK,
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", "EDITED"), ("user", "u2"))
+    kw = {"enable_thinking": False}
+    rendered = st._template.render(msgs, template_kwargs=kw)
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=rendered,
+        tools=None,
+        template_kwargs=kw,
+    )
+    assert pi.segments is None and pi.text == rendered
+
+
+def test_mode_switch_uses_per_turn_scaffold():
+    st = OpenAITranscriptState(_FakeQwen())
+    st.record_assistant_turn(
+        session_id="s",
+        content="a1",
+        tool_calls=None,
+        generated_token_ids=[1],
+        prior_turns=0,
+        preamble=NOTHINK,  # turn 1 generated no-think
+    )
+    st.record_assistant_turn(
+        session_id="s",
+        content="a2",
+        tool_calls=None,
+        generated_token_ids=[2],
+        prior_turns=1,
+        preamble=THINK,  # turn 2 generated think
+    )
+    msgs = _msgs(
+        ("user", "u1"),
+        ("assistant", "a1"),
+        ("user", "u2"),
+        ("assistant", "a2"),
+        ("user", "u3"),
+    )
+    kw = {"enable_thinking": True}
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=st._template.render(msgs, template_kwargs=kw),
+        tools=None,
+        template_kwargs=kw,
+    )
+    assert pi.segments is not None
+    assert _scaffold_before(pi.segments, [1]) == NOTHINK
+    assert _scaffold_before(pi.segments, [2]) == THINK
+
+
+# --- Tool-call argument fingerprint canonicalization ------------------------
+
+
+def _fp(content, tool_calls):
+    return OpenAITranscriptState._assistant_fingerprint(content, tool_calls)
+
+
+def _dtc(name, args):
+    return {"function": {"name": name, "arguments": args}}
+
+
+def test_fingerprint_ignores_tool_arg_whitespace():
+    assert _fp(None, [_dtc("bash", '{"command": "echo hi"}')]) == _fp(
+        None, [_dtc("bash", '{"command":"echo hi"}')]
+    )
+
+
+def test_fingerprint_ignores_tool_arg_key_order():
+    assert _fp(None, [_dtc("f", '{"x": 1, "y": 2}')]) == _fp(
+        None, [_dtc("f", '{"y": 2, "x": 1}')]
+    )
+
+
+def test_fingerprint_invalid_json_args_stay_byte_sensitive():
+    # Non-JSON arguments can't be canonicalized, so they stay literal: a
+    # genuinely different string remains a different turn.
+    assert _fp(None, [_dtc("f", "not json {")]) != _fp(
+        None, [_dtc("f", "not json {  ")]
+    )
+
+
+def test_fingerprint_non_string_args_match_equivalent_json_string():
+    # Already-structured args hash stably and match the equivalent JSON string.
+    assert _fp(None, [_dtc("f", {"x": 1})]) == _fp(None, [_dtc("f", '{"x": 1}')])
+
+
+def test_tool_turn_splices_despite_reserialized_args():
+    # End-to-end: the server recorded a spaced arguments string; the client echoes
+    # the same call back compact (the real pi behavior). The turn must still
+    # fingerprint-match and splice -- not prune to a text fallback.
+    st = OpenAITranscriptState(_FakeQwen())
+    st.record_assistant_turn(
+        session_id="s",
+        content=None,
+        tool_calls=[
+            ToolCall(
+                index=0,
+                id="c1",
+                type="function",
+                function=FunctionCall(name="bash", arguments='{"command": "echo hi"}'),
+            )
+        ],
+        generated_token_ids=[1, 2, 3],
+        prior_turns=0,
+        preamble=NOTHINK,
+    )
+    echoed = ChatMessage(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            ToolCall(
+                index=0,
+                id="c1",
+                type="function",
+                function=FunctionCall(name="bash", arguments='{"command":"echo hi"}'),
+            )
+        ],
+    )
+    msgs = [
+        ChatMessage(role="user", content="u1"),
+        echoed,
+        ChatMessage(role="user", content="u2"),
+    ]
+    kw = {"enable_thinking": False}
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=st._template.render(msgs, template_kwargs=kw),
+        tools=None,
+        template_kwargs=kw,
+    )
+    assert pi.segments is not None  # matched + spliced, not pruned to text
+    assert any(s.get("ids") == [1, 2, 3] for s in pi.segments)
+
+
+def test_gemma_tool_span_ignores_close_marker_inside_string():
+    st = OpenAITranscriptState(_FakeGemma())
+    call = ToolCall(
+        id="call_1",
+        function=FunctionCall(
+            name="bash", arguments='{"command":"printf <tool_call|> ok"}'
+        ),
+    )
+    st.record_assistant_turn(
+        session_id="s",
+        content="",
+        tool_calls=[call],
+        generated_token_ids=[101, 102, 103],
+        prior_turns=0,
+        preamble="",
+    )
+    msgs = [
+        ChatMessage(role="user", content="u1"),
+        ChatMessage(role="assistant", content="", tool_calls=[call]),
+        ChatMessage(role="tool", tool_call_id="call_1", content="done"),
+    ]
+    rendered = (
+        "<bos><|turn>user\nu1<turn|>\n"
+        "<|turn>model\n"
+        '<|tool_call>call:bash{command:<|"|>printf <tool_call|> ok<|"|>}<tool_call|>'
+        "<|tool_response>done<tool_response|>"
+    )
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=rendered,
+        tools=None,
+        template_kwargs=None,
+    )
+    assert pi.segments is not None
+    assert any(s.get("ids") == [101, 102, 103] for s in pi.segments)
+    suffix = "".join(
+        s.get("text", "")
+        for s in pi.segments[_ids_index(pi.segments, [101, 102, 103]) + 1 :]
+    )
+    assert suffix == "<|tool_response>done<tool_response|>"
+
+
+# --- 5b. Token-level fidelity against the real tokenizer (gated/skipped) -----
+
+_MODEL = os.environ.get(
+    "QWEN_HF_DIR", "/home/mnachin/local/scripts/models/Qwen3.5-35B-A3B-HQQ-INT4"
+)
+_HAVE_MODEL = os.path.isdir(_MODEL)
+_skip = pytest.mark.skipif(
+    not _HAVE_MODEL, reason=f"real Qwen tokenizer dir not present: {_MODEL}"
+)
+
+
+def _real_template_and_enc():
+    pytest.importorskip("transformers")
+    from executorch.examples.llm_server.python.chat_template import ChatTemplate
+    from transformers import AutoTokenizer
+
+    tmpl = ChatTemplate(hf_tokenizer_path=_MODEL)
+    tok = AutoTokenizer.from_pretrained(_MODEL)
+    # Encode the way the worker does: no extra special tokens (the rendered text
+    # already contains the literal <|im_*|> / <think> control strings).
+    return tmpl, (lambda s: tok.encode(s, add_special_tokens=False))
+
+
+def _assemble(segs, enc):
+    out = []
+    for seg in segs:
+        out += seg["ids"] if "ids" in seg else enc(seg["text"])
+    return out
+
+
+_GEMMA_MODEL = os.environ.get(
+    "GEMMA_HF_DIR", "/home/mnachin/local/scripts/models/gemma-4-31B-it-HQQ-INT4"
+)
+_HAVE_GEMMA = os.path.isdir(_GEMMA_MODEL)
+_skip_gemma = pytest.mark.skipif(
+    not _HAVE_GEMMA, reason=f"real Gemma tokenizer dir not present: {_GEMMA_MODEL}"
+)
+
+
+def _real_gemma_template_and_enc(strip_bos=True):
+    pytest.importorskip("transformers")
+    from transformers import AutoTokenizer
+
+    tmpl = ChatTemplate(
+        hf_tokenizer_path=_GEMMA_MODEL,
+        assistant_header=GEMMA_HDR,
+        strip_rendered_bos=strip_bos,
+    )
+    tok = AutoTokenizer.from_pretrained(_GEMMA_MODEL)
+    return tmpl, tok, (lambda s: tok.encode(s, add_special_tokens=False))
+
+
+@_skip_gemma
+def test_gemma_real_template_bos_strip_matches_full_render_ids():
+    stripped, tok, enc = _real_gemma_template_and_enc(strip_bos=True)
+    full, _, _ = _real_gemma_template_and_enc(strip_bos=False)
+    msgs = _msgs(("user", "What is the capital of France?"))
+    full_render = full.render(msgs)
+    stripped_render = stripped.render(msgs)
+
+    assert full_render.startswith(tok.bos_token)
+    assert not stripped_render.startswith(tok.bos_token)
+    assert [tok.bos_token_id] + enc(stripped_render) == enc(full_render)
+
+
+@_skip_gemma
+def test_gemma_real_template_warm_resume_prefix_with_bos_prefix():
+    tmpl, tok, enc = _real_gemma_template_and_enc(strip_bos=True)
+    st = OpenAITranscriptState(tmpl)
+    content = "The capital is Paris."
+    gen_ids = enc(content)
+    first_prompt = tmpl.render(_msgs(("user", "u1")))
+    resident = [tok.bos_token_id] + enc(first_prompt) + gen_ids
+    st.record_assistant_turn(
+        session_id="s",
+        content=content,
+        tool_calls=None,
+        generated_token_ids=gen_ids,
+        prior_turns=0,
+        preamble=tmpl.generation_preamble(),
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", content), ("user", "u2"))
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=tmpl.render(msgs),
+        tools=None,
+        template_kwargs=None,
+    )
+    assert pi.segments is not None
+    assembled = [tok.bos_token_id] + _assemble(pi.segments, enc)
+    assert assembled[: len(resident)] == resident
+
+
+@_skip_gemma
+def test_gemma_real_template_post_tool_splices_call_and_keeps_tool_response():
+    tmpl, tok, enc = _real_gemma_template_and_enc(strip_bos=True)
+    st = OpenAITranscriptState(tmpl)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "description": "Run bash",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            },
+        }
+    ]
+    call = ToolCall(
+        id="call_1",
+        function=FunctionCall(name="bash", arguments='{"command":"echo hello42"}'),
+    )
+    raw_call = '<|tool_call>call:bash{command:<|"|>echo hello42<|"|>}<tool_call|>'
+    gen_ids = enc(raw_call)
+    first_prompt = tmpl.render(_msgs(("user", "Run echo hello42")), tools=tools)
+    resident = [tok.bos_token_id] + enc(first_prompt) + gen_ids
+    st.record_assistant_turn(
+        session_id="s",
+        content="",
+        tool_calls=[call],
+        generated_token_ids=gen_ids,
+        prior_turns=0,
+        preamble=tmpl.generation_preamble(tools=tools),
+    )
+    msgs = [
+        ChatMessage(role="user", content="Run echo hello42"),
+        ChatMessage(role="assistant", content="", tool_calls=[call]),
+        ChatMessage(role="tool", tool_call_id="call_1", content="hello42"),
+    ]
+    rendered = tmpl.render(msgs, tools=tools)
+    assert rendered.endswith("<tool_response|>")
+
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=rendered,
+        tools=tools,
+        template_kwargs=None,
+    )
+    assert pi.segments is not None
+    assembled = [tok.bos_token_id] + _assemble(pi.segments, enc)
+    assert assembled[: len(resident)] == resident
+
+    suffix_text = "".join(seg.get("text", "") for seg in pi.segments)
+    assert "<|tool_response>" in suffix_text
+    assert "hello42" in suffix_text
+
+
+@_skip
+@pytest.mark.parametrize("thinking", [False, True])
+def test_token_level_exact_prefix_ordinary(thinking):
+    tmpl, enc = _real_template_and_enc()
+    kw = {"enable_thinking": thinking}
+    st = OpenAITranscriptState(tmpl)
+    content = "Mercury, Venus, Earth."
+    gen_ids = enc(content)  # stand-in for the worker's generated_token_ids
+    gen_prompt1 = tmpl.render(_msgs(("user", "u1")), template_kwargs=kw)
+    resident = enc(gen_prompt1) + gen_ids
+    st.record_assistant_turn(
+        session_id="s",
+        content=content,
+        tool_calls=None,
+        generated_token_ids=gen_ids,
+        prior_turns=0,
+        preamble=tmpl.generation_preamble(kw),
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", content), ("user", "u2"))
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=tmpl.render(msgs, template_kwargs=kw),
+        tools=None,
+        template_kwargs=kw,
+    )
+    assert pi.segments is not None
+    assembled = _assemble(pi.segments, enc)
+    # resident is an exact token prefix => plan_prefill returns exact_prefix and
+    # reuses exactly len(resident) tokens.
+    assert assembled[: len(resident)] == resident
+
+
+@_skip
+def test_token_level_exact_prefix_toolloop_think():
+    # Mandatory: post-last-user turn where the template preserves a think block
+    # before the sentinel; the fix must normalize it to the stored open-think
+    # preamble so the token prefix still lands.
+    tmpl, enc = _real_template_and_enc()
+    kw = {"enable_thinking": True}
+    st = OpenAITranscriptState(tmpl)
+    content = "result is 42"
+    gen_ids = enc(content)
+    gen_prompt1 = tmpl.render(_msgs(("user", "u1")), template_kwargs=kw)
+    resident = enc(gen_prompt1) + gen_ids
+    st.record_assistant_turn(
+        session_id="s",
+        content=content,
+        tool_calls=None,
+        generated_token_ids=gen_ids,
+        prior_turns=0,
+        preamble=tmpl.generation_preamble(kw),
+    )
+    msgs = _msgs(("user", "u1"), ("assistant", content))  # a1 AFTER last user
+    pi = st.build_prompt_input(
+        session_id="s",
+        messages=msgs,
+        rendered_prompt=tmpl.render(msgs, template_kwargs=kw),
+        tools=None,
+        template_kwargs=kw,
+    )
+    assert pi.segments is not None
+    assembled = _assemble(pi.segments, enc)
+    assert assembled[: len(resident)] == resident
+
+
+# --- generation_preamble threads tools ------------------------------------
+
+
+def test_generation_preamble_threads_tools():
+    # generation_preamble must pass `tools` to the render probe and key the cache
+    # on them, so a template whose post-header scaffold depends on tools gets the
+    # right preamble for each (and never serves a stale cached one).
+    class _ToolScaffoldTok:
+        eos_token = "<|im_end|>"
+        all_special_tokens = ["<|im_end|>"]
+
+        def encode(self, text, add_special_tokens=False):
+            return [0]
+
+        def apply_chat_template(
+            self, messages, tools, add_generation_prompt, tokenize, **kwargs
+        ):
+            scaffold = "<tools-on>" if tools else "<tools-off>"
+            return "<|im_start|>assistant\n" + scaffold
+
+    t = ChatTemplate(hf_tokenizer_path=None, allow_fallback=True)
+    t._hf = _ToolScaffoldTok()
+    assert t.generation_preamble(tools=None) == "<tools-off>"
+    assert (
+        t.generation_preamble(tools=[{"type": "function", "function": {"name": "f"}}])
+        == "<tools-on>"
+    )
+    # cached separately -> the no-tool value is not shadowed by the tool one
+    assert t.generation_preamble(tools=None) == "<tools-off>"

--- a/examples/llm_server/python/tests/test_worker_client.py
+++ b/examples/llm_server/python/tests/test_worker_client.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for the generic WorkerClient JSONL protocol (no model/GPU/subprocess).
+
+A fake process stands in for the C++ worker: it records what the client writes
+and replays a scripted sequence of JSONL response lines.
+"""
+
+import json
+from dataclasses import dataclass, field
+
+import pytest
+
+from executorch.examples.llm_server.python.worker_client import (
+    spawn_worker,
+    WorkerClient,
+    WorkerError,
+)
+
+
+class _FakeStdin:
+    def __init__(self):
+        self.written = []
+
+    def write(self, s):
+        self.written.append(s)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class _FakeStdout:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def readline(self):
+        return self._lines.pop(0) if self._lines else ""
+
+
+class _FakeProc:
+    def __init__(self, stdout_lines, returncode=None):
+        self.stdin = _FakeStdin()
+        self.stdout = _FakeStdout(stdout_lines)
+        self._returncode = returncode
+
+    def poll(self):
+        return self._returncode
+
+    @property
+    def returncode(self):
+        return self._returncode
+
+
+@dataclass
+class _Cfg:
+    max_new_tokens: int = 64
+    temperature: float = 0.0
+    stop: list = field(default_factory=list)
+    session_id: str = None
+
+
+def _lines(*objs):
+    return [json.dumps(o) + "\n" for o in objs]
+
+
+def test_generate_streams_tokens_then_stats():
+    proc = _FakeProc(
+        _lines(
+            {"token": "Hello"},
+            {"token": " world"},
+            {"done": True, "prompt_tokens": 4, "completion_tokens": 2},
+        )
+    )
+    client = WorkerClient(proc)
+    out, stats = [], {}
+    client.generate(
+        "hi",
+        _Cfg(temperature=0.7),
+        token_callback=out.append,
+        stats_callback=lambda s: stats.update(
+            prompt=s.num_prompt_tokens, gen=s.num_generated_tokens
+        ),
+    )
+    assert "".join(out) == "Hello world"
+    assert stats == {"prompt": 4, "gen": 2}
+    # The request carried prompt + sampling, one JSON line.
+    sent = json.loads(proc.stdin.written[0])
+    assert sent == {
+        "prompt": "hi",
+        "max_new_tokens": 64,
+        "temperature": 0.7,
+        "stop": [],
+    }
+
+
+def test_generate_forwards_stop_sequences():
+    proc = _FakeProc(_lines({"done": True, "prompt_tokens": 1, "completion_tokens": 0}))
+    WorkerClient(proc).generate("hi", _Cfg(stop=["STOP", "\n\n"]))
+    sent = json.loads(proc.stdin.written[0])
+    assert sent["stop"] == ["STOP", "\n\n"]
+
+
+def test_generate_reports_finish_reason():
+    proc = _FakeProc(
+        _lines(
+            {"token": "hi"},
+            {
+                "done": True,
+                "prompt_tokens": 2,
+                "completion_tokens": 1,
+                "finish_reason": "length",
+            },
+        )
+    )
+    seen = {}
+    WorkerClient(proc).generate(
+        "hi", _Cfg(), stats_callback=lambda s: seen.update(fr=s.finish_reason)
+    )
+    assert seen["fr"] == "length"
+
+
+def test_error_message_raises_worker_error():
+    proc = _FakeProc(_lines({"error": "boom"}))
+    with pytest.raises(WorkerError, match="boom"):
+        WorkerClient(proc).generate("hi", _Cfg())
+
+
+def test_generate_non_json_raises_worker_error():
+    proc = _FakeProc(["worker log on stdout\n"])
+    with pytest.raises(WorkerError, match="invalid worker JSON"):
+        WorkerClient(proc).generate("hi", _Cfg())
+
+
+def test_generate_unexpected_json_raises_worker_error():
+    proc = _FakeProc(_lines({"progress": "loading"}))
+    with pytest.raises(WorkerError, match="unexpected worker response"):
+        WorkerClient(proc).generate("hi", _Cfg())
+
+
+def test_exit_mid_request_raises():
+    proc = _FakeProc([])  # readline() -> "" means the worker exited
+    with pytest.raises(WorkerError, match="exited mid-request"):
+        WorkerClient(proc).generate("hi", _Cfg())
+
+
+def test_generate_on_dead_worker_raises():
+    proc = _FakeProc([], returncode=1)
+    with pytest.raises(WorkerError, match="worker exited"):
+        WorkerClient(proc).generate("hi", _Cfg())
+
+
+def test_generate_includes_session_id_when_set():
+    proc = _FakeProc(_lines({"done": True, "prompt_tokens": 1, "completion_tokens": 0}))
+    WorkerClient(proc).generate("hi", _Cfg(session_id="abc"))
+    assert json.loads(proc.stdin.written[0])["session_id"] == "abc"
+
+
+def test_generate_omits_session_id_when_unset():
+    proc = _FakeProc(_lines({"done": True, "prompt_tokens": 1, "completion_tokens": 0}))
+    WorkerClient(proc).generate("hi", _Cfg())
+    assert "session_id" not in json.loads(proc.stdin.written[0])
+
+
+def test_open_session_sends_op_and_acks():
+    proc = _FakeProc(_lines({"opened": True, "session_id": "abc"}))
+    WorkerClient(proc).open_session("abc")
+    assert json.loads(proc.stdin.written[0]) == {"op": "open", "session_id": "abc"}
+
+
+def test_open_session_capacity_error_carries_code():
+    proc = _FakeProc(_lines({"error": "full", "code": "capacity_exhausted"}))
+    with pytest.raises(WorkerError) as ei:
+        WorkerClient(proc).open_session("abc")
+    assert ei.value.code == "capacity_exhausted"
+
+
+def test_op_non_json_raises_worker_error():
+    proc = _FakeProc(["worker log on stdout\n"])
+    with pytest.raises(WorkerError, match="invalid worker JSON"):
+        WorkerClient(proc).open_session("abc")
+
+
+def test_close_session_sends_op_and_acks():
+    proc = _FakeProc(_lines({"closed": True, "session_id": "abc"}))
+    WorkerClient(proc).close_session("abc")
+    assert json.loads(proc.stdin.written[0]) == {"op": "close", "session_id": "abc"}
+
+
+def test_reset_session_sends_op_and_acks():
+    proc = _FakeProc(_lines({"reset": True, "session_id": "abc"}))
+    WorkerClient(proc).reset_session("abc")
+    assert json.loads(proc.stdin.written[0]) == {"op": "reset", "session_id": "abc"}
+
+
+def test_generate_parses_warm_resume_metrics():
+    proc = _FakeProc(
+        _lines(
+            {"token": "hi"},
+            {
+                "done": True,
+                "prompt_tokens": 100,
+                "completion_tokens": 1,
+                "finish_reason": "stop",
+                "reused_prompt_tokens": 90,
+                "prefilled_prompt_tokens": 10,
+                "session_reset_reason": "exact_prefix",
+            },
+        )
+    )
+    seen = {}
+    WorkerClient(proc).generate(
+        "hi", _Cfg(session_id="s"), stats_callback=lambda s: seen.update(s=s)
+    )
+    st = seen["s"]
+    assert st.reused_prompt_tokens == 90
+    assert st.prefilled_prompt_tokens == 10
+    assert st.session_reset_reason == "exact_prefix"
+
+
+def test_spawn_worker_waits_for_ready():
+    proc = _FakeProc(_lines({"ready": True, "max_named_sessions": 3}))
+    client = spawn_worker(
+        ["/fake/worker", "--model_path", "m"], popen=lambda *a, **k: proc
+    )
+    assert isinstance(client, WorkerClient)
+    assert client.max_named_sessions == 3
+
+
+def test_spawn_worker_not_ready_raises():
+    proc = _FakeProc(_lines({"oops": True}))
+    with pytest.raises(WorkerError, match="did not report ready"):
+        spawn_worker(["/fake/worker"], popen=lambda *a, **k: proc)
+
+
+def test_spawn_worker_non_json_raises_worker_error():
+    proc = _FakeProc(["worker log on stdout\n"])
+    with pytest.raises(WorkerError, match="invalid worker JSON"):
+        spawn_worker(["/fake/worker"], popen=lambda *a, **k: proc)
+
+
+def test_spawn_worker_no_output_raises():
+    proc = _FakeProc([])
+    with pytest.raises(WorkerError, match="failed to start"):
+        spawn_worker(["/fake/worker"], popen=lambda *a, **k: proc)

--- a/examples/llm_server/python/tool_parsers/__init__.py
+++ b/examples/llm_server/python/tool_parsers/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tool-call parsing. Pick the parser matching your model:
+
+- HermesDetector: JSON inside <tool_call>…</tool_call> (Qwen2.5/3, Hermes).
+- GemmaToolCallDetector: Gemma <|tool_call>call:NAME{...}<tool_call|>.
+- QwenFunctionCallDetector: Qwen XML <function=…><parameter=…> (Qwen3.5-MoE /
+  Qwen3-Coder).
+
+The server buffers the model's full output and parses it once into complete
+OpenAI tool_calls; parse failures degrade to visible text.
+"""
+
+from .gemma import GemmaToolCallDetector
+from .hermes import HermesDetector
+from .qwen import QwenFunctionCallDetector
+from .types import ParseResult, ToolCallItem
+
+__all__ = [
+    "HermesDetector",
+    "GemmaToolCallDetector",
+    "QwenFunctionCallDetector",
+    "ParseResult",
+    "ToolCallItem",
+]

--- a/examples/llm_server/python/tool_parsers/gemma.py
+++ b/examples/llm_server/python/tool_parsers/gemma.py
@@ -1,0 +1,258 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Gemma tool calls: <|tool_call>call:NAME{key:value}<tool_call|>."""
+
+import json
+import logging
+import math
+import re
+from typing import Any, Optional
+
+from .types import ParseResult, ToolCallItem
+
+logger = logging.getLogger(__name__)
+
+_BOT = "<|tool_call>"
+_EOT = "<tool_call|>"
+_QUOTE = '<|"|>'
+_INT_RE = re.compile(r"[+-]?[0-9]+$")
+_NUM_RE = re.compile(r"[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$")
+
+
+class _UndefinedToolCall(Exception):
+    pass
+
+
+class _Bare(str):
+    __slots__ = ()
+
+
+class _Parser:
+    def __init__(self, text: str):
+        self.text = text
+        self.i = 0
+
+    def _skip_ws(self) -> None:
+        while self.i < len(self.text) and self.text[self.i].isspace():
+            self.i += 1
+
+    def _expect(self, token: str) -> None:
+        self._skip_ws()
+        if not self.text.startswith(token, self.i):
+            raise ValueError(f"expected {token!r}")
+        self.i += len(token)
+
+    def parse_call(self) -> tuple[str, dict[str, Any]]:
+        self._expect("call:")
+        start = self.i
+        while self.i < len(self.text) and self.text[self.i] not in "{ \t\r\n":
+            self.i += 1
+        name = self.text[start : self.i].strip()
+        if not name:
+            raise ValueError("missing tool name")
+        args = self._parse_object()
+        self._skip_ws()
+        if self.i != len(self.text):
+            raise ValueError("trailing garbage")
+        return name, args
+
+    def _parse_object(self) -> dict[str, Any]:
+        self._expect("{")
+        out: dict[str, Any] = {}
+        self._skip_ws()
+        if self.i < len(self.text) and self.text[self.i] == "}":
+            self.i += 1
+            return out
+        while True:
+            key = self._parse_key()
+            self._expect(":")
+            out[key] = self._parse_value()
+            self._skip_ws()
+            if self.i >= len(self.text):
+                raise ValueError("unclosed object")
+            if self.text[self.i] == "}":
+                self.i += 1
+                return out
+            self._expect(",")
+
+    def _parse_key(self) -> str:
+        self._skip_ws()
+        if self.text.startswith(_QUOTE, self.i):
+            return self._parse_string()
+        start = self.i
+        while self.i < len(self.text) and self.text[self.i] not in ": \t\r\n":
+            self.i += 1
+        key = self.text[start : self.i].strip()
+        if not key:
+            raise ValueError("missing key")
+        return key
+
+    def _parse_value(self) -> Any:
+        self._skip_ws()
+        if self.text.startswith(_QUOTE, self.i):
+            return self._parse_string()
+        if self.i < len(self.text) and self.text[self.i] == "{":
+            return self._parse_object()
+        if self.i < len(self.text) and self.text[self.i] == "[":
+            return self._parse_array()
+        return self._parse_bare()
+
+    def _parse_string(self) -> str:
+        self._expect(_QUOTE)
+        end = self.text.find(_QUOTE, self.i)
+        if end == -1:
+            raise ValueError("unclosed string")
+        value = self.text[self.i : end]
+        self.i = end + len(_QUOTE)
+        return value
+
+    def _parse_array(self) -> list[Any]:
+        self._expect("[")
+        out = []
+        self._skip_ws()
+        if self.i < len(self.text) and self.text[self.i] == "]":
+            self.i += 1
+            return out
+        while True:
+            out.append(self._parse_value())
+            self._skip_ws()
+            if self.i >= len(self.text):
+                raise ValueError("unclosed array")
+            if self.text[self.i] == "]":
+                self.i += 1
+                return out
+            self._expect(",")
+
+    def _parse_bare(self) -> _Bare:
+        start = self.i
+        while self.i < len(self.text) and self.text[self.i] not in ",]}":
+            self.i += 1
+        return _Bare(self.text[start : self.i].strip())
+
+
+def _guess_scalar(raw: str) -> Any:
+    low = raw.lower()
+    if low == "true":
+        return True
+    if low == "false":
+        return False
+    if low == "null":
+        return None
+    if _INT_RE.match(raw):
+        return int(raw)
+    if _NUM_RE.match(raw):
+        value = float(raw)
+        if math.isfinite(value):
+            return value
+    return str(raw)
+
+
+def _schema_type(schema: dict[str, Any]) -> Optional[str]:
+    typ = schema.get("type")
+    if isinstance(typ, list):
+        typ = next((t for t in typ if t != "null"), typ[0] if typ else None)
+    return typ
+
+
+def _coerce_string(value: Any) -> Any:
+    return str(value)
+
+
+def _coerce_bool(value: Any) -> Any:
+    low = str(value).strip().lower()
+    if low == "true":
+        return True
+    if low == "false":
+        return False
+    return str(value)
+
+
+def _coerce_int(value: Any) -> Any:
+    s = str(value).strip()
+    return int(s) if _INT_RE.match(s) else str(value)
+
+
+def _coerce_number(value: Any) -> Any:
+    s = str(value).strip()
+    if _NUM_RE.match(s):
+        parsed = float(s)
+        if math.isfinite(parsed):
+            return parsed
+    return str(value)
+
+
+_SCALAR_COERCERS = {
+    "string": _coerce_string,
+    "boolean": _coerce_bool,
+    "integer": _coerce_int,
+    "number": _coerce_number,
+}
+
+
+def _coerce(value: Any, schema: Optional[dict[str, Any]]) -> Any:
+    if isinstance(value, dict):
+        props = (schema or {}).get("properties") or {}
+        return {k: _coerce(v, props.get(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        items = (schema or {}).get("items")
+        item_schema = items if isinstance(items, dict) else None
+        return [_coerce(v, item_schema) for v in value]
+    typ = _schema_type(schema) if schema else None
+    coercer = _SCALAR_COERCERS.get(typ)
+    if coercer is not None:
+        return coercer(value)
+    return _guess_scalar(value) if isinstance(value, _Bare) else value
+
+
+class GemmaToolCallDetector:
+    bot_token = _BOT
+
+    def __init__(self):
+        self._next_index = 0
+
+    def detect_and_parse(self, text: str, tools: dict[str, dict]) -> ParseResult:
+        if _BOT not in text:
+            return ParseResult(normal_text=text)
+        normal = text[: text.find(_BOT)].strip()
+        try:
+            calls = self._parse_calls(text, tools)
+        except _UndefinedToolCall as e:
+            logger.debug("undefined tool %s; returning raw text (no partial calls)", e)
+            return ParseResult(normal_text=text)
+        except Exception as e:  # noqa: BLE001 - never crash
+            logger.debug("malformed Gemma tool call (%s); degrading to leading text", e)
+            return ParseResult(normal_text=normal)
+        return (
+            ParseResult(normal_text=normal, calls=calls) if calls else ParseResult(text)
+        )
+
+    def _parse_calls(self, text: str, tools: dict[str, dict]) -> list[ToolCallItem]:
+        calls = []
+        pos = 0
+        while True:
+            start = text.find(_BOT, pos)
+            if start == -1:
+                break
+            body_start = start + len(_BOT)
+            end = text.find(_EOT, body_start)
+            if end == -1:
+                raise ValueError("unclosed Gemma tool call")
+            name, args = _Parser(text[body_start:end]).parse_call()
+            if name not in tools:
+                raise _UndefinedToolCall(repr(name))
+            schema = tools.get(name) or {}
+            item = ToolCallItem(
+                tool_index=self._next_index,
+                name=name,
+                arguments=json.dumps(
+                    _coerce(args, schema), ensure_ascii=False, allow_nan=False
+                ),
+            )
+            self._next_index += 1
+            calls.append(item)
+            pos = end + len(_EOT)
+        return calls

--- a/examples/llm_server/python/tool_parsers/hermes.py
+++ b/examples/llm_server/python/tool_parsers/hermes.py
@@ -1,0 +1,119 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Hermes-style tool calls: <tool_call>{"name": ..., "arguments": {...}}</tool_call>.
+
+Used by Qwen2.5/Qwen3 (and Hermes models); the Qwen XML format is handled
+separately by QwenFunctionCallDetector. The server buffers a model's full output
+and parses it once into complete OpenAI tool_calls (no partial-fragment
+streaming).
+
+Malformed-call policy (explicit): ALL-OR-NOTHING. If any <tool_call> block is
+malformed, names an undefined tool, or is truncated/unclosed, the WHOLE response
+degrades -- no partial call set is emitted. When it degrades, the raw
+<tool_call>...</tool_call> markup is NOT leaked into visible content: only the
+leading text before the first marker is returned. Never crashes.
+"""
+
+import json
+import logging
+from typing import Any, Optional
+
+from .types import ParseResult, ToolCallItem
+
+logger = logging.getLogger(__name__)
+
+_BOT = "<tool_call>"
+_EOT = "</tool_call>"
+_DECODER = json.JSONDecoder()
+
+
+class _UndefinedToolCall(Exception):
+    """A <tool_call> named a tool not in the request's `tools`. Degrades the
+    WHOLE response to visible text rather than emitting a partial set — never
+    silently drop an undefined call while keeping its siblings (spec)."""
+
+
+class HermesDetector:
+    """Parses Hermes/Qwen tool calls. Create a fresh instance per request (it
+    holds the per-request tool-call index); never share across requests."""
+
+    bot_token = "<tool_call>"
+
+    def __init__(self):
+        self._next_index = 0
+
+    def detect_and_parse(self, text: str, tools: dict[str, dict]) -> ParseResult:
+        """Return leading text + any complete tool calls. On no/undefined/
+        malformed call, degrade to the leading text BEFORE the first marker --
+        never leak the raw <tool_call> markup into visible content."""
+        if _BOT not in text:
+            return ParseResult(normal_text=text)
+        # Leading text before the first marker; this is what we show if parsing
+        # degrades, so the structural markup is never surfaced to the client.
+        normal = text[: text.find(_BOT)].strip()
+        try:
+            calls = self._parse_calls(text, tools)
+        except _UndefinedToolCall as e:
+            # Well-formed call to an undefined tool: degrade the WHOLE response to
+            # visible text (surface the model's intent; never emit a partial set).
+            logger.debug("undefined tool %s; returning raw text (no partial calls)", e)
+            return ParseResult(normal_text=text)
+        except Exception as e:  # noqa: BLE001 - never crash
+            # Genuinely malformed / truncated / unclosed markup: degrade to the
+            # leading text so the partial <tool_call> garbage is NOT surfaced.
+            logger.debug("malformed tool call (%s); degrading to leading text", e)
+            return ParseResult(normal_text=normal)
+        if not calls:
+            return ParseResult(normal_text=text)
+        return ParseResult(normal_text=normal, calls=calls)
+
+    def _parse_calls(self, text: str, tools: dict[str, dict]) -> list[ToolCallItem]:
+        """All-or-nothing: any malformed/unclosed block raises (caller degrades).
+
+        Each block's JSON is parsed with raw_decode rather than a non-greedy
+        regex, so a string value that itself contains '</tool_call>' does not
+        truncate the captured JSON. The block must be closed by '</tool_call>'.
+        """
+        calls = []
+        pos = 0
+        while True:
+            start = text.find(_BOT, pos)
+            if start == -1:
+                break
+            s = start + len(_BOT)
+            while s < len(text) and text[s].isspace():
+                s += 1
+            obj, end = _DECODER.raw_decode(text, s)  # JSONDecodeError -> degrade
+            close = text.find(_EOT, end)
+            if close == -1 or text[end:close].strip():
+                raise ValueError("unclosed or trailing-garbage <tool_call> block")
+            pos = close + len(_EOT)
+            for entry in obj if isinstance(obj, list) else [obj]:
+                if not isinstance(entry, dict):
+                    raise ValueError("tool call entry is not an object")
+                # `parameters` is the fallback ONLY when `arguments` is absent or
+                # explicitly null (get-with-default misses the explicit-null case).
+                args = entry.get("arguments")
+                if args is None:
+                    args = entry.get("parameters")
+                calls.append(self._make_item(entry.get("name"), args, tools))
+        return calls
+
+    def _make_item(
+        self, name: Optional[str], arguments: Any, tools: dict[str, dict]
+    ) -> ToolCallItem:
+        if not name or name not in tools:
+            raise _UndefinedToolCall(repr(name))
+        item = ToolCallItem(
+            tool_index=self._next_index,
+            name=name,
+            arguments=json.dumps(
+                arguments if arguments is not None else {}, ensure_ascii=False
+            ),
+        )
+        self._next_index += 1
+        return item

--- a/examples/llm_server/python/tool_parsers/qwen.py
+++ b/examples/llm_server/python/tool_parsers/qwen.py
@@ -1,0 +1,193 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Qwen XML-style tool calls: <function=NAME><parameter=K>V</parameter></function>.
+
+Emitted by Qwen3.5-MoE / Qwen3-Coder (typically wrapped in <tool_call>…
+</tool_call>), e.g.:
+
+    <tool_call>
+    <function=get_weather>
+    <parameter=city>
+    Paris
+    </parameter>
+    </function>
+    </tool_call>
+
+This is a DIFFERENT format from HermesDetector (JSON inside <tool_call>); pick the
+detector that matches your model. Detection triggers only on the unambiguous
+`<function=…>` marker so ordinary prose is not misclassified. Parse failures fall
+back to visible text — never a crash or a silent drop.
+"""
+
+import json
+import logging
+import math
+import re
+from typing import Any, Optional
+
+from .types import ParseResult, ToolCallItem
+
+logger = logging.getLogger(__name__)
+
+# Structural matching, NOT first-close-wins. A parameter value runs to the
+# </parameter> that is followed by the next <parameter= or the end of the
+# function body; a function body runs to the </function> that is followed by the
+# next <function=, the tool-call wrapper, or end. This preserves a value that
+# itself contains literal </parameter>, </function>, or <function=...> markup
+# instead of silently truncating the call at the first delimiter (Qwen3-Coder
+# emitting code/markup is a realistic trigger).
+# Bound: a value containing the exact sequence "</parameter><parameter=" (or
+# "</function><function=") can still mis-split. That adversarial case would need a
+# full structural scanner; it is out of scope here (the realistic cases are fixed).
+_FUNCTION_RE = re.compile(
+    r"<function=([^>\s]+)\s*>(.*?)</function>\s*(?=<function=|</tool_call>|<tool_call>|\Z)",
+    re.DOTALL,
+)
+_PARAMETER_RE = re.compile(
+    r"<parameter=([^>\s]+)\s*>(.*?)</parameter>\s*(?=<parameter=|\Z)",
+    re.DOTALL,
+)
+_INT_RE = re.compile(r"[+-]?[0-9]+$")
+_NUM_RE = re.compile(r"[+-]?(?:[0-9]+\.?[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$")
+
+
+class _UndefinedToolCall(Exception):
+    """A call named a tool not in the request's `tools`. Degrades the WHOLE
+    response to visible text rather than emitting a partial set (spec)."""
+
+
+def _coerce(value: str, declared_type: Optional[str]) -> Any:
+    """Cast a raw XML parameter string to the type declared in the tool's JSON
+    schema.
+
+    The Qwen XML format is stringly-typed (`<parameter=k>v</parameter>`), so
+    without the schema we'd have to guess. Coercing to the declared type keeps the
+    emitted OpenAI tool_call schema-valid.
+
+    On a DECLARED type whose strict cast fails, keep the raw string rather than
+    falling through to a JSON guess that would emit a *different* JSON type (the
+    bug this guards): `integer` + "10.0" must not become float 10.0; `boolean` +
+    "1" must not become int 1; underscore numerics ("1_000") are not accepted for
+    numeric types. Non-finite floats (NaN/Infinity/1e999) are never emitted -- they
+    are kept as the raw string -- so `arguments` is always valid JSON. Only when
+    the type is unknown do we make a JSON guess (then raw string), so
+    untyped/loosely-typed params keep working.
+    """
+    v = value.strip()
+    if declared_type == "string":
+        return value
+    if declared_type == "boolean":
+        low = v.lower()
+        if low == "true":
+            return True
+        if low == "false":
+            return False
+        return value  # not a valid bool literal -> keep raw, don't mistype
+    if declared_type == "integer":
+        # strict: digits only (no float, no underscores)
+        return int(v) if _INT_RE.match(v) else value
+    if declared_type == "number":
+        if _NUM_RE.match(v):
+            f = float(v)
+            if math.isfinite(f):
+                return f
+        return value  # non-numeric / non-finite -> keep raw, never emit NaN/Inf
+    # Unknown declared type: a JSON guess, but reject non-finite (json.loads
+    # parses NaN/Infinity by default, which json.dumps would then re-emit).
+    try:
+        guess = json.loads(value)
+    except (ValueError, TypeError):
+        return value
+    if isinstance(guess, float) and not math.isfinite(guess):
+        return value
+    return guess
+
+
+class QwenFunctionCallDetector:
+    """Parses Qwen's XML tool-call format. Create a fresh instance per request
+    (it holds the per-request tool-call index); never share across requests."""
+
+    bot_token = "<tool_call>"
+
+    def __init__(self):
+        self._next_index = 0
+
+    def detect_and_parse(self, text: str, tools: dict[str, dict]) -> ParseResult:
+        """Return leading text + any complete tool calls.
+
+        Degrade policy (mirrors HermesDetector):
+         * No tool marker at all -> return the text unchanged.
+         * A WELL-FORMED call to an undefined tool -> degrade the whole response
+           to the full visible text (surface the model's intent; never a partial
+           set).
+         * A TRUNCATED/partial call (a <function=/<tool_call> marker present but
+           no complete <function=…></function>, e.g. cut by max_tokens) or other
+           malformed markup -> degrade to the LEADING text before the first
+           marker, so the raw markup is never leaked to the client as content.
+
+        `tools` maps each defined tool name to its JSON-schema ``parameters``
+        object; the schema is used to coerce stringly-typed XML values to their
+        declared types (and the key set validates names)."""
+        first = _FUNCTION_RE.search(text)
+        if first is None:
+            # No complete call. If a tool marker is present the call was
+            # truncated/partial -> strip it; otherwise there is no tool intent.
+            markers = [
+                i
+                for i in (text.find(self.bot_token), text.find("<function="))
+                if i != -1
+            ]
+            if markers:
+                return ParseResult(normal_text=text[: min(markers)].strip())
+            return ParseResult(normal_text=text)
+        # Leading text ends at the <tool_call> wrapper if present, else at the
+        # first <function=…> tag.
+        cut = text.find(self.bot_token)
+        if cut == -1 or cut > first.start():
+            cut = first.start()
+        normal = text[:cut].strip()
+        try:
+            calls = self._parse_calls(text, tools)
+        except _UndefinedToolCall as e:
+            # well-formed call to an undefined tool: surface full text (no partial set)
+            logger.debug("undefined tool %s; returning raw text (no partial calls)", e)
+            return ParseResult(normal_text=text)
+        except Exception as e:  # noqa: BLE001 - never crash
+            # malformed markup: degrade to leading text (don't leak partial markup)
+            logger.debug("malformed tool call (%s); degrading to leading text", e)
+            return ParseResult(normal_text=normal)
+        if not calls:
+            return ParseResult(normal_text=text)
+        return ParseResult(normal_text=normal, calls=calls)
+
+    def _parse_calls(self, text: str, tools: dict[str, dict]) -> list[ToolCallItem]:
+        calls = []
+        for fm in _FUNCTION_RE.finditer(text):
+            name, body = fm.group(1), fm.group(2)
+            props = (tools.get(name) or {}).get("properties", {})
+            args = {}
+            for pm in _PARAMETER_RE.finditer(body):
+                key = pm.group(1)
+                args[key] = _coerce(pm.group(2).strip(), props.get(key, {}).get("type"))
+            calls.append(self._make_item(name, args, tools))
+        return calls
+
+    def _make_item(
+        self, name: Optional[str], arguments: dict, tools: dict[str, dict]
+    ) -> ToolCallItem:
+        if not name or name not in tools:
+            raise _UndefinedToolCall(repr(name))
+        item = ToolCallItem(
+            tool_index=self._next_index,
+            name=name,
+            # allow_nan=False: belt-and-suspenders so a non-finite that escaped
+            # _coerce raises (-> caught -> text fallback) rather than emitting
+            # invalid JSON (NaN/Infinity) a strict client would reject.
+            arguments=json.dumps(arguments, ensure_ascii=False, allow_nan=False),
+        )
+        self._next_index += 1
+        return item

--- a/examples/llm_server/python/tool_parsers/types.py
+++ b/examples/llm_server/python/tool_parsers/types.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Protocol-agnostic tool-parsing types.
+
+Kept independent of the OpenAI wire schema so the parser package is reusable;
+serving_chat translates these into OpenAI tool_calls / deltas at the edge.
+Design adapted from SGLang's core_types, with explicit per-request state.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class ToolCallItem:
+    """A parsed tool call. `arguments` is a JSON string (the full arguments —
+    this server emits complete calls, not fragments)."""
+
+    tool_index: int
+    name: Optional[str] = None
+    arguments: str = ""
+
+
+@dataclass
+class ParseResult:
+    """Outcome of a parse: free text plus any tool calls found."""
+
+    normal_text: str = ""
+    calls: list[ToolCallItem] = field(default_factory=list)

--- a/examples/llm_server/python/worker_client.py
+++ b/examples/llm_server/python/worker_client.py
@@ -1,0 +1,265 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Generic control-plane client for a model-execution worker process.
+
+Model execution runs in a separate C++ worker process — the Python server is
+HTTP/control plane only and never loads a model, links a backend, or imports a
+pybind module. This client spawns a worker binary and drives generation over
+JSONL on the worker's stdin/stdout. The protocol is model-agnostic: the same
+client serves a TextLLM worker, a Qwen worker, or any future model worker; only
+the binary and its launch args differ.
+
+Protocol (one JSON object per line; full reference in cpp/worker_loop.h): a
+per-request `generate` (a `prompt` or `prompt_segments` form, optional
+`session_id`) streams `{"token"}` then a `{"done", ...}` carrying warm-resume
+stats and optional `generated_token_ids`; `open`/`close`/`reset` ops manage named
+sessions; failures return `{"error", "code"?}`. The shapes this client builds and
+parses are in generate()/_on_done() below.
+
+The worker's stdout carries ONLY protocol JSON; its logs go to stderr. One
+request at a time per worker; the caller (SessionRuntime) serializes. A worker
+hosts one engine and routes requests to per-session_id state (anonymous requests
+share a scratch session); execution is synchronous.
+"""
+
+import json
+import logging
+import subprocess
+import threading
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WorkerStats:
+    """Usage reported by a worker at the end of a request."""
+
+    num_prompt_tokens: int = 0
+    num_generated_tokens: int = 0
+    # Why generation stopped, as the worker saw it: "stop" (EOS / cooperative
+    # stop) or "length" (ran to max_new, possibly clamped to the context window).
+    # None if the worker didn't report it (older worker / fake).
+    finish_reason: Optional[str] = None
+    # Warm-resume accounting: how many prompt tokens were served from the
+    # session's resident KV state vs actually prefilled this request, and why
+    # ("new"|"exact_prefix"|"dirty"|"mismatch"|"equal"). Not exposed as OpenAI
+    # usage; logged for measuring warm-resume hit rate. None on older workers.
+    reused_prompt_tokens: int = 0
+    prefilled_prompt_tokens: int = 0
+    session_reset_reason: Optional[str] = None
+    # The exact (non-terminal) token ids generated this turn. The control plane
+    # stores these per session and splices them back as an `ids` prompt segment
+    # next turn, so a prior assistant span is an exact token extension instead of
+    # a lossy chat-template re-render. Empty on older workers.
+    generated_token_ids: list = field(default_factory=list)
+
+
+class WorkerError(RuntimeError):
+    """A worker process failed, exited, or reported a generation error.
+
+    `code` carries the worker's structured error code when present
+    ("capacity_exhausted", "unsupported_session"), so the HTTP layer can map it
+    to the right status; None for unstructured failures.
+    """
+
+    def __init__(self, message: str, code: Optional[str] = None):
+        super().__init__(message)
+        self.code = code
+
+
+def _decode_worker_json(line: str) -> dict:
+    try:
+        msg = json.loads(line)
+    except json.JSONDecodeError as e:
+        raise WorkerError(f"invalid worker JSON: {line.rstrip()!r}") from e
+    if not isinstance(msg, dict):
+        raise WorkerError(f"invalid worker message: expected object, got {msg!r}")
+    return msg
+
+
+class WorkerClient:
+    """Drives one model-execution worker process over JSONL (raw transport).
+
+    Exposes ``generate(prompt, config, token_callback, stats_callback)`` /
+    ``stop()`` plus the session ops ``open_session`` / ``close_session`` /
+    ``reset_session`` that SessionRuntime drives. Calls are serialized by a lock
+    and by SessionRuntime (one in-flight request). The control plane never
+    executes model code.
+    """
+
+    def __init__(self, proc: subprocess.Popen, max_named_sessions: int = 0):
+        self._proc = proc
+        self._lock = threading.Lock()
+        # Named sessions this worker can host (0 = scratch-only / single session).
+        self.max_named_sessions = max_named_sessions
+
+    def reset(self) -> None:
+        # Legacy no-op; reset is explicit via reset_session, or handled by the
+        # worker's prefill plan.
+        pass
+
+    def stop(self) -> None:
+        # No-op: a worker request is synchronous over the JSONL pipe and is
+        # NOT interruptible mid-generation. The in-flight request runs to
+        # completion and head-of-line blocks every other session on this worker
+        # until it finishes. Real cancellation needs a protocol change (a control
+        # pipe, non-blocking stdin polling between decode steps, or request ids +
+        # an out-of-band cancel op).
+        pass
+
+    def open_session(self, session_id: str) -> None:
+        """Admit a named session (idempotent). Raises WorkerError with a `code`
+        ("capacity_exhausted" / "unsupported_session") if the worker refuses."""
+        self._op({"op": "open", "session_id": session_id}, ack_key="opened")
+
+    def close_session(self, session_id: str) -> None:
+        """Destroy a named session, freeing its state (idempotent)."""
+        self._op({"op": "close", "session_id": session_id}, ack_key="closed")
+
+    def reset_session(self, session_id: str) -> None:
+        """Clear a named session's context (KV/recurrent + resident tokens) but
+        keep its capacity slot allocated (idempotent)."""
+        self._op({"op": "reset", "session_id": session_id}, ack_key="reset")
+
+    def _op(self, request: dict, ack_key: str) -> None:
+        with self._lock:
+            if self._proc.poll() is not None:
+                raise WorkerError(
+                    f"worker exited (code {self._proc.returncode}); restart the server"
+                )
+            try:
+                self._proc.stdin.write(json.dumps(request) + "\n")
+                self._proc.stdin.flush()
+            except (BrokenPipeError, ValueError) as e:
+                raise WorkerError("worker stdin is closed") from e
+            line = self._proc.stdout.readline()
+            if not line:
+                raise WorkerError("worker exited mid-request")
+            msg = _decode_worker_json(line)
+            if msg.get(ack_key):
+                return
+            if "error" in msg:
+                raise WorkerError(msg["error"], code=msg.get("code"))
+            raise WorkerError(f"unexpected worker response: {msg}")
+
+    @staticmethod
+    def _on_done(msg: dict, stats_callback) -> None:
+        reason = msg.get("session_reset_reason")
+        if reason is not None and logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "warm-resume: reason=%s reused=%d prefilled=%d",
+                reason,
+                msg.get("reused_prompt_tokens", 0),
+                msg.get("prefilled_prompt_tokens", 0),
+            )
+        if stats_callback is not None:
+            stats_callback(
+                WorkerStats(
+                    num_prompt_tokens=msg.get("prompt_tokens", 0),
+                    num_generated_tokens=msg.get("completion_tokens", 0),
+                    finish_reason=msg.get("finish_reason"),
+                    reused_prompt_tokens=msg.get("reused_prompt_tokens", 0),
+                    prefilled_prompt_tokens=msg.get("prefilled_prompt_tokens", 0),
+                    session_reset_reason=reason,
+                    generated_token_ids=msg.get("generated_token_ids", []),
+                )
+            )
+
+    def generate(self, prompt, config, token_callback=None, stats_callback=None):
+        request = {
+            "max_new_tokens": getattr(config, "max_new_tokens", -1),
+            "temperature": getattr(config, "temperature", 0.0),
+            "stop": list(getattr(config, "stop", []) or []),
+        }
+        # Token-ID segments take precedence over the rendered string:
+        # they let prior assistant spans be exact id runs, not lossy re-renders.
+        # `is not None` (not truthiness): segments is a distinct prompt form, kept
+        # whatever its content (the worker validates non-empty).
+        segments = getattr(config, "prompt_segments", None)
+        if segments is not None:
+            request["prompt_segments"] = segments
+        else:
+            request["prompt"] = prompt
+        session_id = getattr(config, "session_id", None)
+        if session_id:
+            request["session_id"] = session_id
+        with self._lock:
+            if self._proc.poll() is not None:
+                raise WorkerError(
+                    f"worker exited (code {self._proc.returncode}); restart the server"
+                )
+            try:
+                self._proc.stdin.write(json.dumps(request) + "\n")
+                self._proc.stdin.flush()
+            except (BrokenPipeError, ValueError) as e:
+                raise WorkerError("worker stdin is closed") from e
+
+            while True:
+                line = self._proc.stdout.readline()
+                if not line:
+                    raise WorkerError("worker exited mid-request")
+                msg = _decode_worker_json(line)
+                if "token" in msg:
+                    if token_callback is not None:
+                        token_callback(msg["token"])
+                elif msg.get("done"):
+                    self._on_done(msg, stats_callback)
+                    return
+                elif "error" in msg:
+                    raise WorkerError(msg["error"], code=msg.get("code"))
+                else:
+                    raise WorkerError(f"unexpected worker response: {msg}")
+
+    def close(self) -> None:
+        """Terminate the worker process (called at server shutdown)."""
+        if self._proc.poll() is not None:
+            return
+        try:
+            if self._proc.stdin is not None:
+                self._proc.stdin.close()
+        except OSError:
+            pass
+        try:
+            self._proc.terminate()
+            self._proc.wait(timeout=5)
+        except Exception:  # noqa: BLE001 - shutdown best-effort
+            self._proc.kill()
+
+
+def spawn_worker(
+    cmd: Sequence[str],
+    env: Optional[dict] = None,
+    cwd: Optional[str] = None,
+    popen: Callable[..., subprocess.Popen] = subprocess.Popen,
+) -> WorkerClient:
+    """Start a worker process and block until it reports ``{"ready": true}``.
+
+    `cmd` is the worker binary and its launch args (model/tokenizer paths). The
+    worker loads the model once before reporting ready, so a slow load surfaces
+    here rather than on the first request.
+    """
+    logger.info("Starting model worker: %s", cmd[0])
+    proc = popen(
+        list(cmd),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=env,
+        cwd=cwd,
+    )
+    line = proc.stdout.readline()
+    if not line:
+        raise WorkerError("worker failed to start (no output; check its stderr).")
+    msg = _decode_worker_json(line)
+    if not msg.get("ready"):
+        raise WorkerError(f"worker did not report ready: {msg}")
+    max_named = int(msg.get("max_named_sessions", 0))
+    logger.info("Model worker ready (max_named_sessions=%d).", max_named)
+    return WorkerClient(proc, max_named_sessions=max_named)

--- a/examples/llm_server/spec/README.md
+++ b/examples/llm_server/spec/README.md
@@ -1,0 +1,81 @@
+# ExecuTorch LLM Server — Contract Spec
+
+The language-neutral contract every ExecuTorch LLM server (Python today, C++
+later) implements. The conformance suite in `../conformance` validates an
+implementation against this spec by hitting a live server, so it is independent
+of language and engine.
+
+## Supported endpoints
+
+| Endpoint | Status |
+|----------|--------|
+| `GET /v1/models` | implemented |
+| `POST /v1/chat/completions` (stream + non-stream) | implemented |
+| `GET /health` | implemented |
+| `POST /v1/completions` | planned |
+
+## `POST /v1/chat/completions`
+
+OpenAI Chat Completions subset. **Honored** request fields: `model`, `messages`,
+`stream`, `temperature`, `max_tokens` / `max_completion_tokens`, `stop`, `tools`,
+`tool_choice` (only `"none"` to disable tools, or `"auto"`/unset for default
+parsing), `stream_options.include_usage`, and `chat_template_kwargs` (e.g.
+`enable_thinking`).
+`model` must match the id returned by `/v1/models`; unknown ids return
+`404 model_not_found`.
+
+**Rejected** with `400 invalid_request_error` (`code: "unsupported_parameter"`)
+rather than silently ignored — a client relying on them would otherwise get
+wrong behavior: `top_p` (anything other than `1.0`), `seed`, `n` (> 1),
+`reasoning_effort`, `frequency_penalty`/`presence_penalty` (nonzero), `top_k`,
+`logit_bias`, `tool_choice` = `"required"` or a specific-function choice
+(forcing/restricting a call needs constrained decoding, not implemented),
+`response_format` other than `{"type": "text"}` (no constrained JSON),
+`logprobs`/`top_logprobs` (not returned), and `parallel_tool_calls: false`
+(single-call can't be guaranteed without constraining). Unknown fields that
+don't affect the output (e.g. `user`, `store`, `metadata`) are accepted and
+ignored.
+
+Non-streaming response: `chat.completion` with one `choice`
+(`message.role = "assistant"`, string `content` or `tool_calls`, `finish_reason`
+∈ `stop` | `length` | `tool_calls`) and a `usage` block.
+
+Streaming response: `text/event-stream` of `chat.completion.chunk` objects —
+first chunk carries `delta.role = "assistant"`, subsequent chunks carry
+`delta.content` (or buffered `delta.tool_calls`), a final chunk carries
+`finish_reason`, optionally a usage-only chunk (with
+`stream_options.include_usage`), terminated by `data: [DONE]`.
+
+### Tool calling
+
+Two output formats are accepted: Hermes-style JSON
+(`<tool_call>{"name":...,"arguments":{...}}</tool_call>`, used by Qwen2.5/Qwen3)
+and Qwen XML-style (`<function=NAME><parameter=K>V</parameter></function>`,
+typically wrapped in `<tool_call>`, used by Qwen3.5-MoE / Qwen3-Coder). The
+server buffers the model's full output and emits **complete** OpenAI
+`tool_calls` (no partial-argument fragments). Calls to tools absent from the
+request, and malformed tool calls, degrade to visible text — never a crash or
+silent drop. `tool_choice="none"` disables tool parsing.
+
+### Errors & cancellation
+
+Errors return `{"error": {"message", "type", "code"}}` with an appropriate
+status (e.g. `400 context_length_exceeded` when `--max-context` is set and the
+prompt exceeds it). A mid-stream failure emits an `error` SSE event then
+`[DONE]` rather than dropping the socket. Cancellation is best-effort: on a
+client disconnect the control plane stops consuming the stream (`stop()`), but
+the worker runs the in-flight request to completion — there is no mid-generation
+interrupt protocol. Because execution is serialized on one worker, an abandoned
+generation also **head-of-line blocks** every other session until it finishes;
+real interruption (a control pipe / between-step stdin poll / request-id cancel
+op) is future work.
+
+### Prefix / KV reuse
+
+No global (cross-session) prefix cache: the control plane holds no KV state and
+does no prefix-reuse routing, so a system prompt shared by two different sessions
+is prefilled independently for each. Per-session append-only warm resume *is*
+implemented worker-side for engines that support it — a named session whose next
+request is an exact-token extension of its resident context prefills only the new
+suffix. All KV/resident state lives inside the worker/session, never the control
+plane.


### PR DESCRIPTION
Add the reusable OpenAI-compatible control plane and worker protocol for local ExecuTorch LLM serving under examples/llm_server. The Python side owns HTTP, chat templating, tool parsing, validation, session routing, warm-resume transcript splicing, and streaming. The C++ side provides the shared JSONL worker loop and warm-resume prefill planner that model-specific worker binaries can reuse while keeping model execution out of Python.

This intentionally lands as one server PR rather than a staged extension/llm/server stack. Model workers live under examples/models and include the shared worker_loop.h; this PR does not reintroduce the postponed generic TextLLM worker.

https://github.com/pytorch/executorch/issues/20001