### PR TITLE
Drop mig false capability from tests (#20309)

### DIFF
--- a/backends/cuda/tests/TARGETS
+++ b/backends/cuda/tests/TARGETS
@@ -24,8 +24,7 @@ python_unittest_remote_gpu(
     ],
     keep_gpu_sections = True,
     remote_execution = re_test_utils.remote_execution(
-        subplatform = "A100",
-        mig = "false",
+        subplatform = "A100-exclusive",
         platform = "gpu-remote-execution",
     ),
 )


### PR DESCRIPTION
Summary:

This should be explicitly requested via the subplatform cap now.

Differential Revision: D108613314


