### PR TITLE
ovr_config | build_mode | Migrate constraint refs from aliases to subtargets. (#20318)

### DIFF
--- a/backends/test/targets.bzl
+++ b/backends/test/targets.bzl
@@ -71,7 +71,7 @@ def define_common_targets(is_fbcode = False):
             deps = multi_method_delegate_test_deps,
             env = modules_env,
             modifiers = [
-                "ovr_config//build_mode/constraints:sanitizer",
+                "ovr_config//build_mode/constraints:build_mode[sanitizer]",
                 "ovr_config//build_mode:sanitizer_type[tsan]",
             ],
         )


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/executorch/pull/20318

Reviewed By: 8Keep

Differential Revision: D108831239


