### PR TITLE
Init runtime PAL in RunnerTest (forward fix for D108707577)

### DIFF
--- a/extension/llm/runner/test/test_text_llm_runner.cpp
+++ b/extension/llm/runner/test/test_text_llm_runner.cpp
@@ -14,6 +14,7 @@
 #include <executorch/extension/llm/runner/text_token_generator.h>
 #include <executorch/extension/llm/sampler/logit_processor.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
+#include <executorch/runtime/platform/runtime.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -145,6 +146,10 @@ class CallbackCounter {
 // Test fixture for Runner tests - minimal setup
 class RunnerTest : public Test {
  protected:
+  void SetUp() override {
+    executorch::runtime::runtime_init();
+  }
+
   // Helper functions to create and set up mock objects
   std::unique_ptr<MockTokenizer> createMockTokenizer() {
     auto tokenizer = std::make_unique<MockTokenizer>();


### PR DESCRIPTION
Summary:
Forward fix for D108707577 (llm_runner: plumb prefill temperature, #20244).

The new test RunnerTest.TextTokenGeneratorRejectsTemperatureOutOfRange aborts:

  [ RUN ] RunnerTest.TextTokenGeneratorRejectsTemperatureOutOfRange
  ExecuTorch PAL must be initialized before call to et_pal_current_ticks()
  *** Signal 6 (SIGABRT) ***

The new test drives the temperature-rejection path, which emits an ET_LOG (and
thus calls et_pal_current_ticks()) before any model load. The RunnerTest fixture
never initializes the ExecuTorch runtime, so the timer call aborts. The valid-
temperature tests in the same fixture pass because their happy path does not log.

Fix: initialize the runtime in RunnerTest::SetUp(), matching the established
pattern used by the sibling tests in this same directory (test_text_prefiller,
test_util, test_wav_loader all call executorch::runtime::runtime_init() in
SetUp()). Applied to both the fbcode and xplat copies.

Differential Revision: D108831322


