### PR TITLE
Add missing evalue dep to test_cuda_mutable_state (forward fix for D108707549)

### DIFF
--- a/backends/cuda/runtime/TARGETS
+++ b/backends/cuda/runtime/TARGETS
@@ -151,6 +151,7 @@ cpp_unittest(
         "//executorch/backends/aoti/slim/core:slimtensor",
         "//executorch/backends/aoti/slim/factory:from_blob",
         "//executorch/runtime/core:core",
+        "//executorch/runtime/core:evalue",
         "//executorch/runtime/platform:platform",
     ],
     external_deps = [


### PR DESCRIPTION
Summary:
Forward fix for D108707549 (cuda: add per-session mutable state rebinding, #20241).

The new `test_cuda_mutable_state` cpp_unittest fails to compile internally:

  test/test_cuda_mutable_state.cpp -> cuda_delegate_handle.h
    -> aoti_delegate_handle.h:12: fatal error:
       'executorch/runtime/core/evalue.h' file not found

The test includes the delegate-handle header chain, which pulls in
<executorch/runtime/core/evalue.h>, but the test target's deps only list
//executorch/runtime/core:core (not :evalue). cuda_backend.cpp itself compiles
because it reaches evalue transitively through deps the test does not have
(e.g. runtime/backend:interface, exec_aten/util:tensor_util). On GitHub the
CMake build picks evalue.h up via broad include dirs, so this only surfaces in
the internal Buck build.

Fix: add //executorch/runtime/core:evalue to the test target's deps in both the
fbcode and xplat TARGETS.

Differential Revision: D108829495


