### PR TITLE
Qualcomm: expose PAL headers via header map so QNN runtime builds under Buck

### DIFF
--- a/backends/qualcomm/runtime/targets.bzl
+++ b/backends/qualcomm/runtime/targets.bzl
@@ -35,6 +35,29 @@ def define_common_targets():
         ],
     )
 
+    # Platform Abstraction Layer. The headers are included as <pal/...> (matching
+    # the CMake build's `include_directories(runtime/pal/include)`). They are
+    # exposed through a header map (dict `exported_headers` with an empty
+    # namespace) instead of an `-I` flag, so the short <pal/...> include resolves
+    # identically under both the fbcode (`cpp_library`) and xplat
+    # (`fb_xplat_cxx_library`) rules, which do not share an include-dir attribute.
+    # Kept in their own library so the mapping does not disturb the runtime
+    # target's namespaced <executorch/...> exported headers.
+    runtime.cxx_library(
+        name = "pal",
+        srcs = glob([
+            "pal/src/linux/*.cpp",
+        ]),
+        exported_headers = {
+            "pal/DynamicLoading.h": "pal/include/pal/DynamicLoading.h",
+            "pal/Path.h": "pal/include/pal/Path.h",
+        },
+        header_namespace = "",
+        define_static_target = True,
+        platforms = [ANDROID],
+        visibility = ["PUBLIC"],
+    )
+
     # "runtime" target is used for offline compile, can be renamed to runtime_aot_build as a BE.
     for include_aot_qnn_lib in (True, False):
         qnn_build_suffix = ("" if include_aot_qnn_lib else "_android_build")
@@ -43,8 +66,6 @@ def define_common_targets():
             srcs = glob(
                 [
                     "*.cpp",
-                    "pal/src/linux/DynamicLoading.cpp",
-                    "pal/src/linux/Path.cpp",
                     "backends/*.cpp",
                     "backends/gpu/*.cpp",
                     "backends/htp/*.cpp",
@@ -60,8 +81,6 @@ def define_common_targets():
             exported_headers = glob(
                 [
                     "*.h",
-                    "pal/include/pal/DynamicLoading.h",
-                    "pal/include/pal/Path.h",
                     "backends/*.h",
                     "backends/gpu/*.h",
                     "backends/htp/*.h",
@@ -70,9 +89,6 @@ def define_common_targets():
                 ],
                 exclude = ["Logging.h"],
             ),
-            exported_preprocessor_flags = [
-                "-Ibackends/qualcomm/runtime/pal/include",
-            ],
             define_static_target = True,
             link_whole = True,  # needed for executorch/examples/models/llama:main to register QnnBackend
             platforms = [ANDROID],
@@ -91,6 +107,7 @@ def define_common_targets():
                 "//executorch/extension/tensor:tensor",
             ],
             exported_deps = [
+                ":pal",
                 "//executorch/runtime/backend:interface",
                 "//executorch/runtime/core/exec_aten/util:scalar_type_util",
                 "//executorch/runtime/core:event_tracer",


### PR DESCRIPTION
## Summary

The PAL support added the `pal/` sources and headers directly to the QNN `runtime` target and resolved `#include <pal/...>` with a hardcoded `-Ibackends/qualcomm/runtime/pal/include` preprocessor flag. That `-I` path is resolved relative to the Buck project root, so it does not resolve correctly across build roots and `#include <pal/DynamicLoading.h>` / `<pal/Path.h>` fail to compile when building the QNN runtime under Buck.

## Fix

Move the PAL sources and headers into a dedicated `pal` library and expose the headers through a **header map** (a dict `exported_headers` with an empty `header_namespace`) instead of an `-I` flag. `runtime` picks it up via `exported_deps`, so dependents that include `QnnImplementation.h` resolve `<pal/...>` too. This mirrors what the CMake build already does with `include_directories(runtime/pal/include)`, and does not disturb the `runtime` target's namespaced `<executorch/...>` exported headers.

No functional change — Buck build wiring only.