### PR TITLE
NXP backend: Extend `unittest-nxp-neutron` job timeout to 120 minutes.

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1400,7 +1400,7 @@ jobs:
       docker-image: ci-image:executorch-ubuntu-22.04-clang12
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-      timeout: 90
+      timeout: 120
       script: |
         set -eux
 


### PR DESCRIPTION
### Summary
This is a temporary fix to enable our workflow. A propper fix (test parallelism) is currently being worked on.

### Test plan
N/A


cc @robert-kalmar @JakeStevens @digantdesai @rascani