### PR TITLE
Guard nil `asset.contentURL` in `ETCoreMLModel initWithAsset:`

### DIFF
--- a/backends/apple/coreml/runtime/delegate/ETCoreMLModel.mm
+++ b/backends/apple/coreml/runtime/delegate/ETCoreMLModel.mm
@@ -194,7 +194,15 @@ void reset_state_for_feature_name(NSString *feature_name, MLState *state) {
         return nil;
     }
 
-    MLModel *mlModel = [MLModel modelWithContentsOfURL:asset.contentURL
+    NSURL *contentURL = asset.contentURL;
+    if (contentURL == nil) {
+        ETCoreMLLogErrorAndSetNSError(error,
+                                      ETCoreMLErrorCorruptedModel,
+                                      "asset.contentURL is nil");
+        return nil;
+    }
+
+    MLModel *mlModel = [MLModel modelWithContentsOfURL:contentURL
                                          configuration:configuration
                                                  error:error];
     if (!mlModel) {


### PR DESCRIPTION
Summary:
Fixes EXC_BAD_ACCESS / KERN_INVALID_ADDRESS in `-[ETCoreMLModel initWithAsset:configuration:orderedInputNames:orderedOutputNames:error:]` at `xplat/executorch/backends/apple/coreml/runtime/delegate/ETCoreMLModel.mm:197`.

Root cause: the initializer calls `[asset keepAliveAndReturnError:]` which validates the asset's file lock but does not validate that `asset.contentURL` is non-nil. When the compiled `.mlmodelc` was reaped from disk between the lock and the load (or the asset was never fully materialized), `asset.contentURL` returns nil. `+[MLModel modelWithContentsOfURL:configuration:error:]` does not tolerate a nil URL — it deref's into CoreML internals and faults.

Fix: capture `asset.contentURL` into a local, return nil with `ETCoreMLErrorCorruptedModel` populated in the out-error if the URL is nil. No behavior change for valid assets — callers already handle the documented `nil` + `error` contract.

Differential Revision: D108334793


