### PR TITLE
WeightsCacheManager: per-cache-path instances (#20337)

### DIFF
--- a/backends/xnnpack/runtime/XNNExecutor.h
+++ b/backends/xnnpack/runtime/XNNExecutor.h
@@ -25,6 +25,9 @@ namespace backends {
 namespace xnnpack {
 namespace delegate {
 
+// Forward-declared to keep XNNWeightsCache.h out of this header.
+class XNNWeightsCache;
+
 class XNNExecutor {
  private:
   std::unique_ptr<xnn_runtime, decltype(&xnn_delete_runtime)> runtime_{
@@ -37,6 +40,10 @@ class XNNExecutor {
   std::vector<xnn_external_value> externals_;
   std::vector<std::string> packed_data_names_;
   std::shared_ptr<XNNWorkspace> workspace_;
+  // Owned so the cache outlives delete_packed_data in destroy(),
+  // even when every other executor sharing it is gone. Empty when no
+  // file-backed cache is in use.
+  std::shared_ptr<XNNWeightsCache> weights_cache_;
   std::atomic<bool> in_use_{false};
   std::atomic<bool> destroyed_{false};
 
@@ -69,6 +76,20 @@ class XNNExecutor {
 
   inline std::shared_ptr<XNNWorkspace> get_workspace() {
     return workspace_;
+  }
+
+  // Set once by XNNPACKBackend::init after compileModel succeeds. Pass
+  // an empty shared_ptr if no file-backed cache is in use for this PTE
+  // (treated identically to never calling this).
+  inline void set_weights_cache(std::shared_ptr<XNNWeightsCache> cache) {
+    weights_cache_ = std::move(cache);
+  }
+
+  // Returns the per-PTE weights cache shared_ptr (may be empty). Used
+  // by XNNPACKBackend::execute to lock the cache's mutex around runtime
+  // invocation, and by destroy() to invoke delete_packed_data.
+  inline std::shared_ptr<XNNWeightsCache> get_weights_cache() const {
+    return weights_cache_;
   }
 
   /**

--- a/backends/xnnpack/runtime/XNNPACKBackend.cpp
+++ b/backends/xnnpack/runtime/XNNPACKBackend.cpp
@@ -91,18 +91,28 @@ class XnnpackBackend final
     auto workspace = workspace_result.get();
 
     bool use_weight_cache = options_.resolve_weight_cache(context);
-    // Hold the lock for the entire init-compile-finalize sequence to prevent
-    // concurrent inits from resetting is_finalized_ or overwriting
-    // named_data_map_ while compileModel is using the shared weights cache.
-    std::unique_lock<std::mutex> lock_weights_cache(
-        options_.weights_cache_mutex(), std::defer_lock);
+    // Per-path weights cache: same-path PTEs share an instance and
+    // serialize on its mutex; different paths run in parallel.
+    std::shared_ptr<xnnpack::delegate::XNNWeightsCache> weights_cache;
+    std::unique_lock<std::mutex> lock_weights_cache;
     if (use_weight_cache) {
-      lock_weights_cache.lock();
+      // Only honor a path coming through runtime_spec (per-PTE opt-in).
+      // Reading the backend-singleton global would let a non-opt-in PTE
+      // inherit another model's cache file.
+      std::string cache_path;
+      auto path_spec = context.get_runtime_spec<const char*>(
+          xnnpack::packed_cache_path_option_key);
+      if (path_spec.ok()) {
+        cache_path = path_spec.get();
+      }
+      auto wc_result = options_.get_or_create_weights_cache(cache_path);
+      if (!wc_result.ok()) {
+        return wc_result.error();
+      }
+      weights_cache = wc_result.get();
+      lock_weights_cache = std::unique_lock<std::mutex>(weights_cache->mutex());
 
-      const auto& cache_path = options_.get_packed_cache_path();
-      options_.weights_cache().set_packed_cache_path(cache_path);
-
-      options_.weights_cache().initialize_for_runtime(
+      weights_cache->initialize_for_runtime(
           context.get_runtime_allocator(), named_data_map);
       workspace->set_uses_weight_cache();
     }
@@ -118,7 +128,7 @@ class XnnpackBackend final
         processed->data(),
         processed->size(),
         executor,
-        &options_.weights_cache(),
+        weights_cache.get(),
         workspace_ptr,
         named_data_map,
         use_weight_cache);
@@ -135,6 +145,12 @@ class XnnpackBackend final
       return err;
     }
 
+    // Hand the cache to the executor (held by shared_ptr so it
+    // outlives any sibling executors that share it).
+    if (use_weight_cache) {
+      executor->set_weights_cache(std::move(weights_cache));
+    }
+
     return executor;
   }
 
@@ -146,10 +162,12 @@ class XnnpackBackend final
 
     auto workspace = executor->get_workspace();
 
-    std::unique_lock<std::mutex> lock_weights_cache(
-        options_.weights_cache_mutex(), std::defer_lock);
-    if (executor->uses_weight_cache() || workspace->uses_weight_cache()) {
-      lock_weights_cache.lock();
+    // Lock the cache shared with sibling executors at the same path.
+    // Empty cache → PTE didn't opt into file-backed mode.
+    auto cache = executor->get_weights_cache();
+    std::unique_lock<std::mutex> lock_weights_cache;
+    if (cache) {
+      lock_weights_cache = std::unique_lock<std::mutex>(cache->mutex());
     }
 
     auto [raii_lock, _] = workspace->acquire();
@@ -176,17 +194,21 @@ class XnnpackBackend final
     if (handle != nullptr) {
       auto executor = static_cast<xnnpack::delegate::XNNExecutor*>(handle);
       auto workspace = executor->get_workspace();
+      auto cache = executor->get_weights_cache();
 
-      const std::lock_guard<std::mutex> lock_weights_cache(
-          options_.weights_cache_mutex());
+      // Local shared_ptr keeps the instance alive through
+      // delete_packed_data even if the executor was the last holder.
+      std::unique_lock<std::mutex> lock_weights_cache;
+      if (cache) {
+        lock_weights_cache = std::unique_lock<std::mutex>(cache->mutex());
+      }
 
 #ifdef ENABLE_XNNPACK_PROFILING
       executor->print_avg_op_timings();
 #endif
 
-      if (executor->uses_weight_cache()) {
-        options_.weights_cache().delete_packed_data(
-            executor->get_packed_data_names());
+      if (cache && executor->uses_weight_cache()) {
+        cache->delete_packed_data(executor->get_packed_data_names());
       }
 
       // This is needed to serialize access to xnn_delete_runtime which is not
@@ -237,7 +259,9 @@ class XnnpackBackend final
   mutable xnnpack::XnnpackBackendOptions options_;
 
   // Lock hierarchy for mutexes:
-  //   options_.weights_cache_mutex()
+  //   weights_cache_manager_.meta_mutex_  (leaf — held only during
+  //                                        get_or_create map ops)
+  //   XNNWeightsCache::instance_mutex_    (one per cache instance)
   //   workspace_meta_mutex_
   //   workspace_mutex_ (owned by executor)
 };

--- a/backends/xnnpack/runtime/XNNWeightsCache.h
+++ b/backends/xnnpack/runtime/XNNWeightsCache.h
@@ -14,6 +14,7 @@
 #include <executorch/runtime/core/memory_allocator.h>
 #include <executorch/runtime/core/result.h>
 #include <executorch/runtime/executor/pte_data_map.h>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -139,20 +140,27 @@ class XNNWeightsCache {
   Error delete_packed_data(const std::vector<std::string>& packed_names);
 
   /**
-   * Set the path for the file-backed packed weight storage.
-   * When set, reserve_space() allocates from a MAP_SHARED file instead
-   * of heap, and finalize_for_runtime() calls msync to make pages clean.
+   * Set the file-backed storage path. When set, reserve_space()
+   * allocates from a MAP_SHARED file instead of heap, and
+   * finalize_for_runtime() msyncs pages.
    *
-   * The path MUST be unique per XNNWeightsCache instance — sharing it
-   * across instances (or processes) would mean O_TRUNC corrupts the other
-   * holder's mappings (SIGBUS on access). initialize_for_runtime() takes
-   * an advisory exclusive flock on the file; if the lock fails the mmap
-   * path is disabled for this instance and allocations fall back to heap.
+   * Call once, before any other method, and never again. Two
+   * instances sharing the same path will corrupt each other on
+   * O_TRUNC (SIGBUS); the manager prevents this by per-path dedup.
    */
   void set_packed_cache_path(const std::string& path);
 
   /** Save packed weight index so subsequent loads skip packing. */
   Error save_packed_index();
+
+  /**
+   * Per-instance mutex. The cache has no internal synchronization;
+   * callers must hold this around every method call and every
+   * XNNPACK callback that touches the cache during xnn_create_runtime.
+   */
+  std::mutex& mutex() noexcept {
+    return instance_mutex_;
+  }
 
  private:
   static constexpr uint32_t kCacheMagic = 0x58505743; // "XPWC"
@@ -214,6 +222,10 @@ class XNNWeightsCache {
   // For file-backed packed allocations, maps the returned ptr to its index
   // in mmap_regions_, so delete_packed_data() can munmap when ref_count==0.
   std::unordered_map<void*, size_t> file_ptr_to_region_index_;
+
+  // See mutex() for the locking contract — caller-owned, no internal
+  // use within this class.
+  std::mutex instance_mutex_;
 
   // Function pointers to override XNNPACK's default xnn_weights_cache_provider
   // functions.

--- a/backends/xnnpack/runtime/XNNWeightsCacheManager.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCacheManager.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/xnnpack/runtime/XNNWeightsCacheManager.h>
+
+#include <executorch/runtime/core/error.h>
+
+#include <utility>
+#include <vector>
+
+namespace executorch::backends::xnnpack {
+
+using executorch::runtime::Error;
+using executorch::runtime::Result;
+
+Result<std::shared_ptr<delegate::XNNWeightsCache>>
+XNNWeightsCacheManager::get_or_create(const std::string& cache_file_path) {
+  // Empty path → one shared heap-only instance. See header for why.
+  if (cache_file_path.empty()) {
+    std::scoped_lock<std::mutex> lock(empty_path_mutex_);
+    if (auto live = empty_path_cache_.lock()) {
+      return live;
+    }
+    auto cache = std::make_shared<delegate::XNNWeightsCache>();
+    empty_path_cache_ = cache;
+    return cache;
+  }
+
+  std::scoped_lock<std::mutex> lock(meta_mutex_);
+  auto it = caches_.find(cache_file_path);
+  if (it != caches_.end()) {
+    if (auto live = it->second.lock()) {
+      return live;
+    }
+    caches_.erase(it);
+  }
+
+  auto cache = std::make_shared<delegate::XNNWeightsCache>();
+  // Set path before publishing into the map so concurrent callers
+  // observe a fully initialized instance.
+  cache->set_packed_cache_path(cache_file_path);
+  caches_[cache_file_path] = cache;
+  return cache;
+}
+
+Error XNNWeightsCacheManager::save_all() {
+  // Snapshot live shared_ptrs under meta_mutex_, then release it
+  // before per-instance save (honors lock order, lets get_or_create
+  // on unrelated paths proceed during the save walk).
+  std::vector<std::shared_ptr<delegate::XNNWeightsCache>> live;
+  {
+    std::scoped_lock<std::mutex> lock(meta_mutex_);
+    live.reserve(caches_.size());
+    for (auto it = caches_.begin(); it != caches_.end();) {
+      if (auto cache = it->second.lock()) {
+        live.push_back(std::move(cache));
+        ++it;
+      } else {
+        it = caches_.erase(it);
+      }
+    }
+  }
+
+  Error first_err = Error::Ok;
+  for (auto& cache : live) {
+    std::lock_guard<std::mutex> lock(cache->mutex());
+    Error err = cache->save_packed_index();
+    if (err != Error::Ok && first_err == Error::Ok) {
+      first_err = err;
+    }
+  }
+  return first_err;
+}
+
+size_t XNNWeightsCacheManager::live_count() const {
+  std::scoped_lock<std::mutex> lock(meta_mutex_);
+  size_t count = 0;
+  for (const auto& entry : caches_) {
+    if (!entry.second.expired()) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+} // namespace executorch::backends::xnnpack

--- a/backends/xnnpack/runtime/XNNWeightsCacheManager.h
+++ b/backends/xnnpack/runtime/XNNWeightsCacheManager.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/backends/xnnpack/runtime/XNNWeightsCache.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/result.h>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace executorch::backends::xnnpack {
+
+/**
+ * One `XNNWeightsCache` per cache file path. Mirrors
+ * `XNNWorkspaceManager`'s PerModel pattern with `weak_ptr` so
+ * instances live as long as the executors owning them.
+ *
+ * Per-path keying prevents `initialize_for_runtime` from a second
+ * path tearing down the first path's fd / mmap regions (SIGBUS).
+ *
+ * Empty path returns one shared heap-only instance so callers
+ * without a file still get XNNPACK's in-memory name dedup.
+ *
+ * Lock order: `meta_mutex_` → `XNNWeightsCache::mutex()` →
+ * `XNNWorkspaceManager::workspace_meta_mutex_` → `XNNWorkspace::mutex_`.
+ */
+class XNNWeightsCacheManager {
+ public:
+  XNNWeightsCacheManager() = default;
+  ~XNNWeightsCacheManager() = default;
+
+  XNNWeightsCacheManager(const XNNWeightsCacheManager&) = delete;
+  XNNWeightsCacheManager& operator=(const XNNWeightsCacheManager&) = delete;
+  XNNWeightsCacheManager(XNNWeightsCacheManager&&) = delete;
+  XNNWeightsCacheManager& operator=(XNNWeightsCacheManager&&) = delete;
+
+  /** Shared `XNNWeightsCache` for `cache_file_path`. Empty path
+   * returns one shared heap-only instance. Never null on success. */
+  runtime::Result<std::shared_ptr<delegate::XNNWeightsCache>> get_or_create(
+      const std::string& cache_file_path);
+
+  /** Walk live caches and call `save_packed_index()` on each under
+   * its per-instance mutex. Returns the first error; keeps going so
+   * one failure doesn't strand the others. Opportunistically erases
+   * expired weak_ptrs. */
+  runtime::Error save_all();
+
+  /** Test-only: count of live (non-expired) entries. */
+  size_t live_count() const;
+
+ private:
+  mutable std::mutex meta_mutex_;
+  std::unordered_map<std::string, std::weak_ptr<delegate::XNNWeightsCache>>
+      caches_;
+
+  // Separate slot for the empty-path (heap-only) cache to avoid
+  // string-hashing and contention with mmap-path callers.
+  mutable std::mutex empty_path_mutex_;
+  std::weak_ptr<delegate::XNNWeightsCache> empty_path_cache_;
+};
+
+} // namespace executorch::backends::xnnpack

--- a/backends/xnnpack/runtime/XnnpackBackendOptions.cpp
+++ b/backends/xnnpack/runtime/XnnpackBackendOptions.cpp
@@ -39,6 +39,7 @@ Error XnnpackBackendOptions::get_option(BackendOption& option) const {
     option.value = weight_cache_enabled_.load();
   } else if (strcmp(option.key, packed_cache_path_option_key) == 0) {
     std::array<char, runtime::kMaxOptionValueLength> arr{};
+    const std::lock_guard<std::mutex> lock(path_mutex_);
     size_t len =
         std::min(packed_cache_path_.size(), runtime::kMaxOptionValueLength - 1);
     memcpy(arr.data(), packed_cache_path_.data(), len);
@@ -79,10 +80,9 @@ Error XnnpackBackendOptions::set_option(const BackendOption& option) {
       ET_LOG(Error, "XNNPACK packed cache path must be a string.");
       return Error::InvalidArgument;
     }
-    // Same lock as weights_cache_: init() reads packed_cache_path_ under
-    // weights_cache_mutex_ and feeds it straight into the cache, so an
-    // unprotected write here would race with that read.
-    const std::lock_guard<std::mutex> lock(weights_cache_mutex_);
+    // path_mutex_ also guards get_packed_cache_path so the read in
+    // XNNPACKBackend::init never tears against a concurrent write here.
+    const std::lock_guard<std::mutex> lock(path_mutex_);
     packed_cache_path_ = std::string(val->data());
     ET_LOG(
         Debug,
@@ -101,17 +101,23 @@ Error XnnpackBackendOptions::set_option(const BackendOption& option) {
   return Error::Ok;
 }
 
-delegate::XNNWeightsCache& XnnpackBackendOptions::weights_cache() {
-  return weights_cache_;
+XNNWeightsCacheManager& XnnpackBackendOptions::weights_cache_manager() {
+  return weights_cache_manager_;
 }
 
-std::mutex& XnnpackBackendOptions::weights_cache_mutex() {
-  return weights_cache_mutex_;
+const XNNWeightsCacheManager& XnnpackBackendOptions::weights_cache_manager()
+    const {
+  return weights_cache_manager_;
+}
+
+runtime::Result<std::shared_ptr<delegate::XNNWeightsCache>>
+XnnpackBackendOptions::get_or_create_weights_cache(
+    const std::string& cache_file_path) {
+  return weights_cache_manager_.get_or_create(cache_file_path);
 }
 
 Error XnnpackBackendOptions::save_weights_cache_locked() {
-  const std::lock_guard<std::mutex> lock(weights_cache_mutex_);
-  return weights_cache_.save_packed_index();
+  return weights_cache_manager_.save_all();
 }
 
 bool XnnpackBackendOptions::resolve_weight_cache(
@@ -152,11 +158,13 @@ const XNNWorkspaceManager& XnnpackBackendOptions::workspace_manager() const {
   return workspace_manager_;
 }
 
-const std::string& XnnpackBackendOptions::get_packed_cache_path() const {
+std::string XnnpackBackendOptions::get_packed_cache_path() const {
+  const std::lock_guard<std::mutex> lock(path_mutex_);
   return packed_cache_path_;
 }
 
 void XnnpackBackendOptions::set_packed_cache_path(const std::string& path) {
+  const std::lock_guard<std::mutex> lock(path_mutex_);
   packed_cache_path_ = path;
 }
 

--- a/backends/xnnpack/runtime/XnnpackBackendOptions.h
+++ b/backends/xnnpack/runtime/XnnpackBackendOptions.h
@@ -10,6 +10,7 @@
 
 #include <executorch/backends/xnnpack/runtime/XNNPACKBackend.h>
 #include <executorch/backends/xnnpack/runtime/XNNWeightsCache.h>
+#include <executorch/backends/xnnpack/runtime/XNNWeightsCacheManager.h>
 #include <executorch/backends/xnnpack/runtime/XNNWorkspaceManager.h>
 #include <executorch/runtime/backend/backend_init_context.h>
 #include <executorch/runtime/backend/options.h>
@@ -17,7 +18,9 @@
 #include <executorch/runtime/core/result.h>
 
 #include <atomic>
+#include <memory>
 #include <mutex>
+#include <string>
 
 namespace executorch::backends::xnnpack {
 
@@ -43,46 +46,41 @@ class XnnpackBackendOptions {
   XNNWorkspaceManager& workspace_manager();
   const XNNWorkspaceManager& workspace_manager() const;
 
-  const std::string& get_packed_cache_path() const;
+  // Returns a copy of the most-recently-set packed cache path. Copied
+  // under path_mutex_ to avoid tearing while set_option is concurrently
+  // running. Callers receive a snapshot; subsequent set_option calls
+  // do not affect the returned string.
+  std::string get_packed_cache_path() const;
   void set_packed_cache_path(const std::string& path);
 
-  // Shared XNNWeightsCache (one instance per backend, like the workspace
-  // manager). The cache itself is not internally synchronized; callers
-  // MUST hold weights_cache_mutex() around every weights_cache() call —
-  // including reading the reference and calling any method on it. The
-  // same mutex also protects packed_cache_path_, so a typical
-  // load/init/compile sequence holds one lock for the whole block:
+  // Returns a shared XNNWeightsCache via the backend-owned manager.
+  // Same non-empty path → same shared instance. Different paths →
+  // independent instances. Empty path → one shared heap-only instance
+  // across all empty-path callers (so XNNPACK's in-memory name dedup
+  // still works).
   //
-  //   std::lock_guard lock(options.weights_cache_mutex());
-  //   options.weights_cache().set_packed_cache_path(
-  //       options.get_packed_cache_path());
-  //   options.weights_cache().initialize_for_runtime(...);
-  //   XNNCompiler::compileModel(..., &options.weights_cache(), ...);
-  //
-  // The mutex is intentionally exposed (rather than wrapping every
-  // method) because XNNCompiler needs a raw cache pointer to pass into
-  // XNNPACK callbacks that fire during xnn_create_runtime; those
-  // callbacks must run under the same lock as the surrounding init.
-  delegate::XNNWeightsCache& weights_cache();
-  std::mutex& weights_cache_mutex();
+  // The caller MUST hold the returned instance's XNNWeightsCache::mutex()
+  // around every cache-method call, including the XNNPACK callbacks
+  // invoked during xnn_create_runtime.
+  runtime::Result<std::shared_ptr<delegate::XNNWeightsCache>>
+  get_or_create_weights_cache(const std::string& cache_file_path);
 
-  // Invokes save_packed_index() on the cache while holding the cache
-  // mutex. Returns the cache's error code; the caller does not need to
-  // grab the mutex itself. This is the entry point used by set_option()
-  // when `save_weight_cache_on_disk_option_key` is requested.
+  // Returns the manager directly. Useful for tests and for the
+  // `save_weight_cache_on_disk` option side-effect path. Production
+  // callers should prefer get_or_create_weights_cache().
+  XNNWeightsCacheManager& weights_cache_manager();
+  const XNNWeightsCacheManager& weights_cache_manager() const;
+
+  // Walks every live cache instance the manager has handed out and
+  // invokes save_packed_index() on each (under each instance's own
+  // mutex). Used by set_option() when `save_weight_cache_on_disk` is
+  // requested. Returns the first error encountered; continues
+  // attempting every instance.
   runtime::Error save_weights_cache_locked();
 
  private:
   XNNWorkspaceManager workspace_manager_;
-
-  // Weights cache is shared across all delegate instances. Owned here so
-  // that all backend-option-keyed state (workspace manager, weights cache,
-  // packed-cache path) lives in a single place; XnnpackBackend holds an
-  // XnnpackBackendOptions and delegates synchronization to its mutex.
-  // Protects weights_cache_ AND packed_cache_path_ (init reads the path
-  // while holding this lock and hands it to the cache).
-  std::mutex weights_cache_mutex_;
-  delegate::XNNWeightsCache weights_cache_;
+  XNNWeightsCacheManager weights_cache_manager_;
 
 #ifdef ENABLE_XNNPACK_SHARED_WORKSPACE
   std::atomic<WorkspaceSharingMode> sharing_mode_{WorkspaceSharingMode::Global};
@@ -97,6 +95,17 @@ class XnnpackBackendOptions {
   std::atomic<bool> weight_cache_enabled_{false};
 #endif
 
+  // The most-recently-set packed cache path. Today's callers (Cria
+  // runner) set this via set_option(packed_cache_path_option_key) per
+  // PTE, then invoke init() which reads it and calls
+  // get_or_create_weights_cache(). path_mutex_ serializes the
+  // set / get pair so a concurrent set_option from another caller
+  // doesn't tear the string mid-read.
+  //
+  // This is a transport for the path option only — the path itself
+  // is owned per-cache-instance inside XNNWeightsCache, set once by
+  // the manager before publishing the shared_ptr.
+  mutable std::mutex path_mutex_;
   std::string packed_cache_path_;
 };
 

--- a/backends/xnnpack/test/runtime/test_xnn_weights_cache_manager.cpp
+++ b/backends/xnnpack/test/runtime/test_xnn_weights_cache_manager.cpp
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <executorch/backends/xnnpack/runtime/XNNWeightsCache.h>
+#include <executorch/backends/xnnpack/runtime/XNNWeightsCacheManager.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/result.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using executorch::backends::xnnpack::XNNWeightsCacheManager;
+using executorch::backends::xnnpack::delegate::XNNWeightsCache;
+using executorch::runtime::Error;
+
+class XNNWeightsCacheManagerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Log calls will abort if PAL is not initialized.
+    executorch::runtime::runtime_init();
+    manager_ = std::make_unique<XNNWeightsCacheManager>();
+  }
+
+  std::unique_ptr<XNNWeightsCacheManager> manager_;
+};
+
+// --- Core dedup semantics ---
+
+TEST_F(XNNWeightsCacheManagerTest, SamePathReturnsSameInstance) {
+  auto a = manager_->get_or_create("/tmp/test_cache_same.bin");
+  auto b = manager_->get_or_create("/tmp/test_cache_same.bin");
+  ASSERT_TRUE(a.ok());
+  ASSERT_TRUE(b.ok());
+  EXPECT_EQ(a.get().get(), b.get().get())
+      << "same path must return the same shared instance";
+}
+
+TEST_F(XNNWeightsCacheManagerTest, DifferentPathsReturnDifferentInstances) {
+  auto a = manager_->get_or_create("/tmp/test_cache_a.bin");
+  auto b = manager_->get_or_create("/tmp/test_cache_b.bin");
+  ASSERT_TRUE(a.ok());
+  ASSERT_TRUE(b.ok());
+  EXPECT_NE(a.get().get(), b.get().get())
+      << "different paths must return independent instances";
+}
+
+TEST_F(XNNWeightsCacheManagerTest, EmptyPathSharedAcrossCallers) {
+  auto a = manager_->get_or_create("");
+  auto b = manager_->get_or_create("");
+  ASSERT_TRUE(a.ok());
+  ASSERT_TRUE(b.ok());
+  ASSERT_NE(a.get(), nullptr);
+  ASSERT_NE(b.get(), nullptr);
+  // Empty-path sharing keeps XNNPACK's name-based dedup working
+  // across PTEs (otherwise each init re-packs every weight).
+  EXPECT_EQ(a.get().get(), b.get().get());
+  EXPECT_EQ(manager_->live_count(), 0u)
+      << "empty-path sharing is kept off the path-keyed map";
+}
+
+TEST_F(XNNWeightsCacheManagerTest, EmptyPathRecreatedAfterAllRefsDrop) {
+  XNNWeightsCache* first_addr = nullptr;
+  {
+    auto a = manager_->get_or_create("");
+    ASSERT_TRUE(a.ok());
+    first_addr = a.get().get();
+  }
+  // All shared_ptrs dropped → weak_ptr expires → next call gets a
+  // fresh instance. Verifies the empty-path cache is not pinned for
+  // the manager's lifetime.
+  auto b = manager_->get_or_create("");
+  ASSERT_TRUE(b.ok());
+  EXPECT_NE(b.get().get(), first_addr);
+}
+
+TEST_F(XNNWeightsCacheManagerTest, EmptyPathDoesNotShareWithMmapPath) {
+  auto empty = manager_->get_or_create("");
+  auto mmap = manager_->get_or_create("/tmp/test_cache_isolation.bin");
+  ASSERT_TRUE(empty.ok());
+  ASSERT_TRUE(mmap.ok());
+  // Empty-path cache stays separate from any mmap-path cache —
+  // mmap-path caller's fd/flock state must never leak into a
+  // heap-only caller's instance.
+  EXPECT_NE(empty.get().get(), mmap.get().get());
+  EXPECT_EQ(manager_->live_count(), 1u)
+      << "only the mmap-path call registers in the path-keyed map";
+}
+
+// --- weak_ptr cleanup ---
+
+TEST_F(XNNWeightsCacheManagerTest, ExpiredEntryDoesNotLeak) {
+  {
+    auto a = manager_->get_or_create("/tmp/test_cache_expire.bin");
+    ASSERT_TRUE(a.ok());
+    EXPECT_EQ(manager_->live_count(), 1u);
+  }
+  // shared_ptr dropped → weak_ptr in map is now expired. Live count
+  // reports 0 even though the dead entry is still in the map.
+  EXPECT_EQ(manager_->live_count(), 0u);
+}
+
+TEST_F(XNNWeightsCacheManagerTest, ExpiredEntryRecreatedOnNextCall) {
+  void* first_addr = nullptr;
+  {
+    auto a = manager_->get_or_create("/tmp/test_cache_recreate.bin");
+    ASSERT_TRUE(a.ok());
+    first_addr = a.get().get();
+  }
+  // Address re-use is allowed but not required; the only guarantee is
+  // that we get a usable instance, not a dangling shared_ptr.
+  auto b = manager_->get_or_create("/tmp/test_cache_recreate.bin");
+  ASSERT_TRUE(b.ok());
+  ASSERT_NE(b.get(), nullptr);
+  // Live count should be 1 again — the stale entry was erased and
+  // replaced.
+  EXPECT_EQ(manager_->live_count(), 1u);
+  // Quiet the unused-variable warning when ABI prevents address reuse.
+  (void)first_addr;
+}
+
+// --- Concurrent same-path returns the same instance ---
+
+TEST_F(XNNWeightsCacheManagerTest, ConcurrentSamePathSameInstance) {
+  constexpr int kThreads = 16;
+  std::vector<std::shared_ptr<XNNWeightsCache>> results(kThreads);
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  std::atomic<int> ready{0};
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([this, &results, &ready, i] {
+      // Spin to maximize the chance of true concurrent entry into
+      // get_or_create.
+      ready.fetch_add(1, std::memory_order_acq_rel);
+      while (ready.load(std::memory_order_acquire) < kThreads) {
+        std::this_thread::yield();
+      }
+      auto r = manager_->get_or_create("/tmp/test_cache_race.bin");
+      ASSERT_TRUE(r.ok());
+      results[i] = r.get();
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+  // All N threads must hold the exact same instance pointer.
+  for (int i = 1; i < kThreads; ++i) {
+    EXPECT_EQ(results[0].get(), results[i].get())
+        << "thread " << i << " got a different instance";
+  }
+  EXPECT_EQ(manager_->live_count(), 1u);
+}
+
+TEST_F(XNNWeightsCacheManagerTest, ConcurrentDifferentPathsIndependent) {
+  // Different paths must not block each other beyond the brief
+  // meta_mutex_ window. We can't easily measure wall-clock parallelism
+  // in a unit test, but we CAN assert each thread gets its own
+  // instance with no collisions.
+  constexpr int kThreads = 8;
+  std::vector<std::shared_ptr<XNNWeightsCache>> results(kThreads);
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([this, &results, i] {
+      std::string path = "/tmp/test_cache_diff_" + std::to_string(i) + ".bin";
+      auto r = manager_->get_or_create(path);
+      ASSERT_TRUE(r.ok());
+      results[i] = r.get();
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+  for (int i = 0; i < kThreads; ++i) {
+    for (int j = i + 1; j < kThreads; ++j) {
+      EXPECT_NE(results[i].get(), results[j].get());
+    }
+  }
+  EXPECT_EQ(manager_->live_count(), kThreads);
+}
+
+// --- save_all walks live caches ---
+
+TEST_F(XNNWeightsCacheManagerTest, SaveAllNoLiveInstancesIsOk) {
+  EXPECT_EQ(manager_->save_all(), Error::Ok);
+}
+
+TEST_F(XNNWeightsCacheManagerTest, SaveAllWalksLiveCaches) {
+  auto a = manager_->get_or_create("/tmp/test_cache_save_a.bin");
+  auto b = manager_->get_or_create("/tmp/test_cache_save_b.bin");
+  ASSERT_TRUE(a.ok());
+  ASSERT_TRUE(b.ok());
+  EXPECT_EQ(manager_->live_count(), 2u);
+  // Both caches are still live (held by a/b shared_ptrs above). Neither
+  // has been through initialize_for_runtime, so save_packed_index
+  // short-circuits on fd<0 and returns Ok.
+  EXPECT_EQ(manager_->save_all(), Error::Ok);
+}
+
+TEST_F(XNNWeightsCacheManagerTest, SaveAllSkipsExpiredEntries) {
+  {
+    auto a = manager_->get_or_create("/tmp/test_cache_save_expired.bin");
+    ASSERT_TRUE(a.ok());
+  }
+  // The entry's weak_ptr is now expired. save_all must not crash on
+  // the dead entry; opportunistically erases it.
+  EXPECT_EQ(manager_->save_all(), Error::Ok);
+  EXPECT_EQ(manager_->live_count(), 0u);
+}
+
+// --- Path is set on the instance before publishing ---
+
+TEST_F(XNNWeightsCacheManagerTest, NonEmptyPathRegistersInMap) {
+  auto a = manager_->get_or_create("/tmp/test_cache_register.bin");
+  ASSERT_TRUE(a.ok());
+  EXPECT_EQ(manager_->live_count(), 1u);
+}

--- a/backends/xnnpack/test/targets.bzl
+++ b/backends/xnnpack/test/targets.bzl
@@ -45,6 +45,16 @@ def define_common_targets():
     )
 
     runtime.cxx_test(
+        name = "test_xnn_weights_cache_manager",
+        srcs = ["runtime/test_xnn_weights_cache_manager.cpp"],
+        deps = [
+            third_party_dep("XNNPACK"),
+            "//executorch/backends/xnnpack:xnnpack_backend",
+            "//executorch/runtime/executor:pte_data_map",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "test_xnn_data_separation",
         srcs = ["runtime/test_xnn_data_separation.cpp"],
         deps = [

--- a/shim_et/xplat/executorch/build/build_variables.bzl
+++ b/shim_et/xplat/executorch/build/build_variables.bzl
@@ -477,6 +477,7 @@ XNNPACK_BACKEND_BUCK_SRCS = [
     "runtime/XNNHeader.cpp",
     "runtime/XNNPACKBackend.cpp",
     "runtime/XNNWeightsCache.cpp",
+    "runtime/XNNWeightsCacheManager.cpp",
     "runtime/XNNWorkspaceManager.cpp",
     "runtime/XnnpackBackendOptions.cpp",
     "runtime/profiling/XNNProfiler.cpp",


### PR DESCRIPTION
Summary:

Split `XNNWeightsCache` out of its de-facto singleton lifetime (one instance per `XnnpackBackend`, shared across every PTE that opted into the file-backed cache) into a per-cache-file-path instance dispensed by a new `XNNWeightsCacheManager`. Mirrors the `XNNWorkspaceManager` PerModel pattern: same path → same shared instance; different paths → independent instances; empty path → one shared heap-only instance so XNNPACK's in-memory name dedup still works across PTEs.

The singleton design was forced today because `XnnpackBackendOptions::weights_cache_` is a by-value member and `XnnpackBackend` itself is a namespace-scope global (`XNNPACKBackend.cpp:246`). For PTEs that genuinely share a cache file the singleton's per-entry refcounting works, but two PTEs with **different** packed-cache paths hit the same `XNNWeightsCache` instance, so the second PTE's `initialize_for_runtime` calls `ftruncate(0)` on the file under the first PTE's still-live mmap regions — every subsequent access SIGBUSes (P2369924970 traces this). The clue the prior fix added — the warning in `XNNWeightsCache.h:147-151` "the path MUST be unique per `XNNWeightsCache` instance" — is enforced here at the manager level rather than relying on each caller to honor it.

Design:

`XNNWeightsCacheManager` (new, mirrors `XNNWorkspaceManager`):
- `std::unordered_map<std::string, std::weak_ptr<XNNWeightsCache>> caches_` keyed by absolute cache file path.
- `get_or_create(path)` looks up the path under a single `meta_mutex_`; if a live `weak_ptr` exists, returns the shared instance, otherwise constructs a new one, calls `set_packed_cache_path(path)` BEFORE registering it, and stores a `weak_ptr`.
- `meta_mutex_` is held only during the map op — never across any call into `XNNWeightsCache`, so different-path callers proceed in parallel after the brief window.
- `save_all()` snapshots live shared_ptrs under `meta_mutex_`, then iterates outside the meta lock and acquires each instance's own mutex around `save_packed_index()`.
- Empty path uses a separate `empty_path_cache_` (weak_ptr) + `empty_path_mutex_`: all heap-only callers (NGTTS sub-runners, FLLM classifier, PLLM methods when mmap MC is off) share one instance so XNNPACK's in-memory `look_up_or_insert` name dedup catches duplicate weights across PTEs and across methods within a PTE. Without this sharing, every `XnnpackBackend::init` allocated its own packed copy of every weight, regressing heap-only memory by ~500 MB on LoRA-multimethod PLLM (paste P2380809516: app_phys peak 1731 MB with per-instance vs ~1260 MB with the prior process-singleton). The hazard the per-path keying motivates — non-opt-in PTE inheriting an opt-in PTE's path and writing into its mmap file — never applies to empty-path callers because they hold no path / no fd / no mmap regions, so sharing among empty-path callers carries no isolation cost.
- Expired `weak_ptr` entries are erased opportunistically on the next `get_or_create` / `save_all` for that path. Stale entries from never-revisited paths linger; cost is one string + weak_ptr per dead entry. Acceptable per `XNNWorkspaceManager` precedent.

`XNNWeightsCache`:
- New `std::mutex instance_mutex_` member + `mutex()` accessor. The class has no internal synchronization; callers are responsible for holding `mutex()` around every method invocation, INCLUDING the XNNPACK callback paths (`look_up`, `reserve_space`, `look_up_or_insert`) that fire during `xnn_create_runtime`.
- `set_packed_cache_path` is documented as call-once-before-publish: production callers go through the manager, which sets the path before installing the `shared_ptr` in the map, so no other thread can observe the instance yet. Tests that construct the class directly must respect this contract.

`XnnpackBackendOptions`:
- Replaced `XNNWeightsCache weights_cache_` + `std::mutex weights_cache_mutex_` with `XNNWeightsCacheManager weights_cache_manager_`.
- New `get_or_create_weights_cache(path)` thin wrapper around the manager.
- `save_weights_cache_locked()` now walks every live cache via the manager's `save_all()`.
- `packed_cache_path_` keeps a small `path_mutex_` to serialize the `set_option(packed_cache_path_option_key)` → `init()` read; this is just transport for the option value, the path's authoritative home is per-instance inside each cache.

`XNNPACKBackend`:
- `init`: pulls the path from per-PTE `runtime_spec` (see "Per-PTE caller signal" below), asks the manager for the shared `XNNWeightsCache`, locks its `mutex()` for the entire init→compileModel sequence, then publishes the `shared_ptr` into the executor via the new `XNNExecutor::set_weights_cache`. Same-path PTEs serialize on the same instance mutex; different-path PTEs hold different mutexes and proceed in parallel — the singleton design forced full serialization here.
- `execute`: lock the per-executor cache's mutex (if any) instead of the global one. Concurrent execute on independent caches now runs in parallel.
- `destroy`: lock the per-executor cache's mutex, call `delete_packed_data`. The local `shared_ptr` keeps the instance alive across `delete_packed_data` even if dropping it from the executor was the last outside reference.

`XNNExecutor`:
- New `std::shared_ptr<XNNWeightsCache> weights_cache_` member, set once after `compileModel`. Forward-declared (rather than including `XNNWeightsCache.h`) to keep the transitive `pte_data_map.h` dependency out of the executor's public header — preserves the existing `xnnexecutor_test` build dep set.

Per-PTE caller signal (the FLLM / NGTTS isolation guarantee):

The manager's per-path dedup is necessary but not sufficient — if a non-opt-in PTE inherits an opt-in PTE's globally-set path, the manager hands it the same shared instance and the non-opt-in PTE's `reserve_space` writes into the opt-in model's mmap file. Investigation of the three on-device loaders confirms the concrete risk: cria PLLM pushes `packed_cache_path_option_key` globally (`runner_interface.h:365-373`), but NGTTS sub-runners (`AcousticRunner` / `HfMimiRunner` / `SemanticLmRunner` at `executorch/examples/models/fb/llama4/runner/*.cpp`) bypass cria entirely and never push a path, and the cria FLLM classifier path skips the push when `FactoryMetaData::useMmapPackedWeights = false` (`CriaHost.cpp:220-224`). All three loaders run in the same process and share one `XnnpackBackend` global (`XNNPACKBackend.cpp:246`).

Two complementary changes lock this down:

1. `XNNPACKBackend::init` no longer reads `options_.get_packed_cache_path()` (shared backend-singleton state). It reads the path strictly from `BackendInitContext::get_runtime_spec<const char*>(packed_cache_path_option_key)` — the only per-PTE signal that proves THIS PTE explicitly opted in. If `runtime_spec` carries no path, `cache_path` is empty and the manager hands the shared `empty_path_cache_` (per the empty-path branch above). Non-opt-in PTEs are guaranteed isolated from the mmap-path file regardless of what the global path happens to hold; they still dedupe against one another in the shared empty-path cache.

2. cria `runner_interface.h::loadModel()` no longer pushes XNNPACK options globally via `executorch::runtime::set_option`. It now builds a `BackendOptions<3>` carrying path / `weight_cache_option_key` / `workspace_sharing_mode_option_key`, wraps it in a `LoadBackendOptionsMap`, and passes that map to every `Module::load_method` call (primary, multimethod loop, YOCO prefill/decode). The `BackendOptions` and map both live on the `loadModel` stack frame, which extends through every `load_method` call — Span lifetime requirements satisfied. Per-PTE options propagate into the backend's `BackendInitContext::runtime_spec` via `Method::init`'s `LoadBackendOptionsMap` path (`method.cpp:957-963`). Non-opt-in cria PTEs and non-cria loaders (NGTTS, direct-Module) simply don't pass a map → empty runtime_spec → init forces empty path → shared heap-only instance with dedup.

Lock hierarchy (updated):
- `weights_cache_manager_.meta_mutex_` (leaf — only during path-keyed map ops, never held across calls into instances)
- `weights_cache_manager_.empty_path_mutex_` (leaf — only during empty-path weak_ptr lookup/store)
- `XNNWeightsCache::instance_mutex_` (one per cache)
- `workspace_meta_mutex_`
- `workspace_mutex_` (owned by executor)

Race-condition / corner-case coverage:
- Same-path concurrent `get_or_create`: serialize on `meta_mutex_`, both return the same shared instance.
- Different-path concurrent `get_or_create`: parallel after the brief `meta_mutex_` window.
- Mid-load contention: same-path callers serialize on the instance mutex around `initialize_for_runtime`.
- Cross-PTE clobbering (the original bug): impossible — each path owns its own instance.
- Cross-process same-path: existing `flock(LOCK_EX|LOCK_NB)` defense untouched.
- Cache file deleted on disk: existing mmap stays valid (unix unlink semantics); manager doesn't track disk state.
- Process shutdown mid-save: executor-held `shared_ptr` outlives the manager map; instance destruction follows the executor's normal teardown.
- XNNPACK seed mismatch / cache format bump: existing per-entry seed reject + v1-trailer reject paths untouched.
- Empty path: shared via `empty_path_cache_` weak_ptr; recreated when all shared_ptrs drop; never collides with any mmap-path instance.
- Concurrent same-cache execute + destroy: serialize on the instance mutex.
- Stale global path inherited by non-opt-in PTE: prevented by the runtime_spec-only path read in init.

Mirrored to `fbcode/executorch/backends/xnnpack/runtime/`. The cria change lives only under `xplat/cria/` (no fbcode mirror).

### Test plan
Built `fbsource//xplat/executorch/backends/xnnpack:xnnpack_backend` on linux, Apple, Android, and `fbcode//executorch/backends/xnnpack:xnnpack_backend` on linux — all green. Built downstream consumers to verify the API change is binary-compatible: `fbsource//xplat/cria/core:cria{Apple,Android}`, `fbsource//xplat/sgr/ml_service/modules/llm:lib_sgr_llmApple`, `fbsource//xplat/assistant/oacr/trims/modules/ondevice_modules:mwa_ondevice_moduleApple` — all green.

```
buck2 test \
  fbcode//executorch/backends/xnnpack/test:test_xnn_weights_cache_manager \
  fbcode//executorch/backends/xnnpack/test:test_xnn_weights_cache \
  fbcode//executorch/backends/xnnpack/test:test_workspace_manager \
  fbcode//executorch/backends/xnnpack/test:xnnexecutor_test
→ Pass 38. Fail 0. Build failure 0.
```

The new `test_xnn_weights_cache_manager` exercises 13 hazard cases the manager handles: `SamePathReturnsSameInstance`, `DifferentPathsReturnDifferentInstances`, `EmptyPathSharedAcrossCallers`, `EmptyPathRecreatedAfterAllRefsDrop`, `EmptyPathDoesNotShareWithMmapPath`, `ExpiredEntryDoesNotLeak`, `ExpiredEntryRecreatedOnNextCall`, `ConcurrentSamePathSameInstance` (16-thread fan-in), `ConcurrentDifferentPathsIndependent` (8-thread fan-out), `SaveAllNoLiveInstancesIsOk`, `SaveAllWalksLiveCaches`, `SaveAllSkipsExpiredEntries`, `NonEmptyPathRegistersInMap`.

Cria runner tests (`fbsource//xplat/cria/core/runner/tests/...`): Pass 938, Fail 0. The 18 `Fatal` entries reported by buck2 (`PrefillReturnsLogits`, `PrefillMapsParams`, `PrefillStringPrompt`, etc.) reproduce identically on this commit's parent (605126226e, no cria change, no init guard) with the same OpenMP/MKL/ASan SEGV stack — `kmp_basic_flag_native::done_check` → `__kmp_hyper_barrier_release` triggered by `mkl_blas_sgemm_omp_driver_v1` racing with `pthread_create` from `pthreadpool_create_v2`. These are pre-existing flakes in the asan-ubsan platform configuration, not caused by either the manager refactor or the runtime_spec migration.

`arc lint -a` clean across all 22 changed/added files (11 xplat + 11 fbcode mirrors; cria is xplat-only).

Differential Revision: D108431510


