### PR TITLE
[ET-VK][conv2d_dw] Fix test requesting nonexistent sned b1x1 shader

### DIFF
--- a/backends/vulkan/test/custom_ops/impl/TestConv2dDw.cpp
+++ b/backends/vulkan/test/custom_ops/impl/TestConv2dDw.cpp
@@ -53,7 +53,13 @@ static std::string pick_conv2d_dw_shader_with_selector(
   if (is_3x3) {
     kernel_name += "_output_tile_3x3";
     if (impl_selector == "b1x1") {
-      kernel_name += "_b1x1";
+      // The _b1x1 batch-tile variant exists only for the non-sned family;
+      // sned (stride != dilation) shaders are not batch-tiled. Match
+      // pick_conv2d_dw_shader and only append it when stride == dilation,
+      // otherwise fall back to the un-suffixed sned shader.
+      if (stride_equals_dilation) {
+        kernel_name += "_b1x1";
+      }
     } else if (impl_selector == "b4x2") {
       // b4x2 is the default (no suffix)
     } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #20312
* __->__ #20343

The test_conv2d_dw benchmark aborted on device (SIGABRT) with an uncaught vkcompute::vkapi::Error from ShaderRegistry::get_shader_info: "Could not find ShaderInfo with name conv2d_dw_sned_output_tile_3x3_b1x1_float". pick_conv2d_dw_shader_with_selector in TestConv2dDw.cpp appended the _b1x1 batch-tile infix for any 3x3 case whenever impl_selector == "b1x1", with no stride_equals_dilation guard. For a strided 3x3 case it had already appended _sned, producing conv2d_dw_sned_output_tile_3x3_b1x1_float — a variant the sned shader family never generates (sned shaders are not batch-tiled; only the non-sned conv2d_dw_output_tile family has _b1x1 variants).

This guards the forced _b1x1 append on stride_equals_dilation, matching the production pick_conv2d_dw_shader in Conv2dDW.cpp. A forced b1x1 selector on a strided 3x3 case now falls back to the existing un-suffixed sned shader instead of requesting an unbacked variant.

Differential Revision: [D108916041](https://our.internmc.facebook.com/intern/diff/D108916041/)