### PR TITLE
Register tosa_mxfp::linear op for operator_support import (forward fix for D108020149)

### DIFF
--- a/backends/arm/operator_support/TARGETS
+++ b/backends/arm/operator_support/TARGETS
@@ -4,6 +4,7 @@ runtime.python_library(
     name = "operator_support",
     srcs = glob(["*.py"]),
     deps = [
+        "//executorch/backends/arm:ao_ext",
         "//executorch/backends/arm:constants",
         "//executorch/backends/arm/_passes:passes",
         "//executorch/backends/arm/tosa:resize_utils",

--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -28,12 +28,8 @@ from executorch.backends.arm._passes.fuse_quantized_activation_pass import (
     FuseQuantizedActivationPass,
 )
 from executorch.backends.arm._passes.insert_table_ops import TableOps
-from executorch.backends.arm.common.annotation_meta import ArmAnnotationInfo
-# Importing this registers the ``tosa_mxfp::linear`` custom op that
-# ``MXOpsSupportList`` references at class-definition time below. Without it,
-# importing this module outside the Arm test suite (which imports ``ao_ext``)
-# fails with: AttributeError: '_OpNamespace' 'tosa_mxfp' has no attribute 'linear'.
 from executorch.backends.arm.ao_ext.ops import mxfp_linear_op  # noqa: F401
+from executorch.backends.arm.common.annotation_meta import ArmAnnotationInfo
 from executorch.backends.arm.constants import DQ_OPS, MAX_RANK, Q_OPS
 from executorch.backends.arm.operator_support.control_flow_support import (
     ControlFlowOpSupported,

--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -29,6 +29,11 @@ from executorch.backends.arm._passes.fuse_quantized_activation_pass import (
 )
 from executorch.backends.arm._passes.insert_table_ops import TableOps
 from executorch.backends.arm.common.annotation_meta import ArmAnnotationInfo
+# Importing this registers the ``tosa_mxfp::linear`` custom op that
+# ``MXOpsSupportList`` references at class-definition time below. Without it,
+# importing this module outside the Arm test suite (which imports ``ao_ext``)
+# fails with: AttributeError: '_OpNamespace' 'tosa_mxfp' has no attribute 'linear'.
+from executorch.backends.arm.ao_ext.ops import mxfp_linear_op  # noqa: F401
 from executorch.backends.arm.constants import DQ_OPS, MAX_RANK, Q_OPS
 from executorch.backends.arm.operator_support.control_flow_support import (
     ControlFlowOpSupported,


### PR DESCRIPTION
Summary:
Forward fix for D108020149 (Arm backend: Lower MXFP Linear to TOSA, #20065).

#20065 added the MXFP-Linear lowering, including an `MXOpsSupportList` operator-
support check whose class body references the new custom op at import time:

  class MXOpsSupportList(OperatorSupportBase):
      targets = (exir_ops.edge.tosa_mxfp.linear.default,)   # evaluated at import

`tosa_mxfp::linear` is defined/registered in backends/arm/ao_ext (mxfp_tosa_lib +
ops/mxfp_linear_op). But tosa_supported_operators.py never imports ao_ext, so the
op is only registered when something else imports ao_ext first — which the Arm
test suite does, but real export consumers do not. Any export path that imports
the Arm partitioner without ao_ext (e.g. the modai/sensor_ml Ethos-U blobgen
targets, arvr firmware nnlite gen) fails at import with:

  AttributeError: '_OpNamespace' 'tosa_mxfp' object has no attribute 'linear'

This broke ~100 sensor_ml/firmware blobgen + validation targets (malibu2 pdr/
jamba/hrtracker/ihop/sleepnet/sleepstager/hrnet, arvr nsf jamba), none of which
even use MXFP — they just import the Arm partitioner.

Fix: import the op-registration module in tosa_supported_operators.py so
`tosa_mxfp::linear` is registered before `MXOpsSupportList` (and the other class-
/runtime references) resolve it, and add the `//executorch/backends/arm:ao_ext`
Buck dep to the operator_support target. Applied to both fbcode and xplat.

Differential Revision: D108936369




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani