### PR TITLE
CI: validate cadence build gate on fork export

### DIFF
--- a/backends/cadence/build_cadence_runner.sh
+++ b/backends/cadence/build_cadence_runner.sh
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # Builds cadence_runner and prints its path.
+# Invoked by the cpu-build job in .github/workflows/build-cadence-runner.yml.
 
 set -euo pipefail
 


### PR DESCRIPTION
Summary:
Trivial comment-only change to backends/cadence/build_cadence_runner.sh to
trigger the Cadence Build & Test workflow on a fresh export PR, validating the
landed pull_request_target label gate runs hifi-build/vision-build with creds.

Differential Revision: D108964780


