### PR TITLE
portable: Add const to local vars to suppress CPPCHECK warning

### DIFF
--- a/kernels/portable/cpu/op_log_softmax.cpp
+++ b/kernels/portable/cpu/op_log_softmax.cpp
@@ -70,7 +70,7 @@ Tensor& log_softmax_out(
                   size,
                   stride);
 
-              ACC temp_sum = apply_unary_map_reduce_fn<CTYPE, ACC>(
+              const ACC exp_sum = apply_unary_map_reduce_fn<CTYPE, ACC>(
                   [max_in](const CTYPE val_in) {
                     return std::exp(
                         static_cast<ACC>(val_in) - static_cast<ACC>(max_in));
@@ -81,13 +81,13 @@ Tensor& log_softmax_out(
                   in_data + base,
                   size,
                   stride);
-              temp_sum = std::log(temp_sum);
+              const ACC log_sum = std::log(exp_sum);
 
               apply_unary_map_fn(
-                  [max_in, temp_sum](const CTYPE val_in) {
+                  [max_in, log_sum](const CTYPE val_in) {
                     return static_cast<CTYPE>(
                         static_cast<ACC>(val_in) - static_cast<ACC>(max_in) -
-                        temp_sum);
+                        log_sum);
                   },
                   in_data + base,
                   out_data + base,


### PR DESCRIPTION
`e93a285ebd "Extend CPPCHECK scope to portable kernels"`
My work branch was cut before this new lint coverage.

### Summary
CPPCHECK flagged apply_unary_map_reduce_fn<CTYPE, ACC> with a constStatement warning. This is a false positive — the code compiles correctly and the result is assigned to a variable used in subsequent computation. Adding const to the declarations suppresses the warning.

### Test
```bash
$ lintrunner op_softmax.cpp op_log_softmax.cpp op_mean.cpp op_sum.cpp \
             op_softmax_test.cpp op_log_softmax_test.cpp op_mean_test.cpp op_sum_test.cpp
ok  No lint issues.
```

cc @larryliu0820 @manuelcandales @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani