### PR TITLE
Arm backend: Add MXFP4/MXFP6 linear support

### DIFF
--- a/backends/arm/_passes/insert_rescales_pass.py
+++ b/backends/arm/_passes/insert_rescales_pass.py
@@ -18,6 +18,7 @@ from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import
 
 from executorch.backends.arm._passes.quant_args import QuantArgs
 from executorch.backends.arm.constants import DQ_OPS, Q_OPS
+from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 from torch.fx import GraphModule, Node
@@ -48,6 +49,8 @@ class InsertRescalePass(ArmPass):
             if not isinstance(meta_val, torch.Tensor):
                 continue
             if meta_val.dtype != torch.uint8:
+                continue
+            if node.meta.get(TosaSpecialDtype.meta_key()) == TosaSpecialDtype.FP4E2M1:
                 continue
             if node.op in ("placeholder", "output"):
                 continue

--- a/backends/arm/_passes/insert_rescales_pass.py
+++ b/backends/arm/_passes/insert_rescales_pass.py
@@ -36,6 +36,12 @@ class InsertRescalePass(ArmPass):
 
     _passes_required_after: Set[Type[ExportPass]] = set()
 
+    _mxfp_payload_dtypes = {
+        TosaSpecialDtype.FP4E2M1,
+        TosaSpecialDtype.FP6E2M3,
+        TosaSpecialDtype.FP6E3M2,
+    }
+
     def _ensure_uint8_io_only(self, graph_module: GraphModule) -> None:
         """Ensure uint8 tensors only appear at IO boundaries.
 
@@ -50,25 +56,25 @@ class InsertRescalePass(ArmPass):
                 continue
             if meta_val.dtype != torch.uint8:
                 continue
-            if node.meta.get(TosaSpecialDtype.meta_key()) == TosaSpecialDtype.FP4E2M1:
-                continue
             if node.op in ("placeholder", "output"):
                 continue
-            if node.op == "call_function" and node.target == operator.getitem:
-                if all(user.op == "output" for user in node.users):
+            if node.op == "call_function":
+                if node.target == operator.getitem and all(
+                    user.op == "output" for user in node.users
+                ):
                     continue
-            if (
-                node.op == "call_function"
-                and node.target
-                == exir_ops.edge.dim_order_ops._to_dim_order_copy.default
-            ):
-                # dim_order is a view-like transform; allow it to preserve uint8 at IO.
+                if node.target == exir_ops.backend.tosa.RESCALE.default:
+                    continue
+                if (
+                    node.target
+                    == exir_ops.edge.dim_order_ops._to_dim_order_copy.default
+                ):
+                    # dim_order is a view-like transform; allow it to preserve uint8 at IO.
+                    continue
+            if node.meta.get(TosaSpecialDtype.meta_key()) in self._mxfp_payload_dtypes:
+                # Sub-byte FP types are stored uint8 arrays, so we need an exception for those.
                 continue
-            if (
-                node.op == "call_function"
-                and node.target == exir_ops.backend.tosa.RESCALE.default
-            ):
-                continue
+
             raise ValueError(
                 f"Found internal uint8 tensor at node {node.name} "
                 f"({node.target}). Uint8 is only allowed at IO boundaries."

--- a/backends/arm/_passes/rewrite_mxfp_linear.py
+++ b/backends/arm/_passes/rewrite_mxfp_linear.py
@@ -8,28 +8,53 @@ from functools import reduce
 from typing import Any, cast, Sequence, Set, Type
 
 import torch
-from executorch.backends.arm._passes import ArmPass
+from executorch.backends.arm._passes import ArmOpTargetedPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
 )
+from executorch.backends.arm.ao_ext.mxfp import (
+    mxfp_dtype_to_str,
+    mxfp_str_to_dtype,
+    MXFPDType,
+)
 from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from torchao.prototype.mx_formats.mx_tensor import DTYPE_FP6_E2M3, DTYPE_FP6_E3M2
 
 
-def _get_block_scaled_payload_dtype(qdata: torch.Tensor) -> torch.dtype:
+def _get_weights_payload_dtype(
+    qdata_node: torch.fx.Node,
+    dtype: str = "",
+) -> MXFPDType:
+    if dtype:
+        return mxfp_str_to_dtype(dtype)
+    qdata = get_first_fake_tensor(qdata_node)
     if qdata.dtype == torch.uint8:
         return torch.float4_e2m1fn_x2
     return qdata.dtype
 
 
-def _mark_fp4_payload(node: torch.fx.Node, payload_dtype: torch.dtype) -> None:
+def _mark_mxfp_payload(node: torch.fx.Node, payload_dtype: MXFPDType) -> None:
+    """Annotate uint8-backed MXFP payload nodes with their TOSA dtype.
+
+    PyTorch represents sub-byte MXFP payloads as ``torch.uint8`` tensors, so
+    the tensor dtype alone cannot distinguish FP4E2M1, FP6E2M3, and FP6E3M2.
+    Store the logical TOSA dtype in node metadata so later lowering and
+    serialization treat the payload as MXFP data rather than ordinary uint8.
+    FP8 payloads have native PyTorch dtypes and do not need this metadata.
+
+    """
     if payload_dtype == torch.float4_e2m1fn_x2:
         node.meta[TosaSpecialDtype.meta_key()] = TosaSpecialDtype.FP4E2M1
+    elif payload_dtype == DTYPE_FP6_E2M3:
+        node.meta[TosaSpecialDtype.meta_key()] = TosaSpecialDtype.FP6E2M3
+    elif payload_dtype == DTYPE_FP6_E3M2:
+        node.meta[TosaSpecialDtype.meta_key()] = TosaSpecialDtype.FP6E3M2
 
 
-class RewriteMXFPLinearPass(ArmPass):
+class RewriteMXFPLinearPass(ArmOpTargetedPass):
     """Rewrite ``tosa_mxfp.linear`` into explicit TOSA MXFP operators.
 
     For each MXFP linear custom op, the pass:
@@ -44,15 +69,24 @@ class RewriteMXFPLinearPass(ArmPass):
 
     """
 
+    target_ops = {
+        torch.ops.tosa_mxfp.linear.default,
+        exir_ops.edge.tosa_mxfp.linear.default,
+    }
     _passes_required_after: Set[Type[ExportPass]] = set()
 
     def __init__(self, exported_program: torch.export.ExportedProgram, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.exported_program = exported_program
 
-    def _get_linear_args(
-        self, node: torch.fx.Node
-    ) -> tuple[torch.fx.Node, torch.fx.Node, torch.fx.Node, torch.fx.Node | None, int]:
+    def _get_linear_args(self, node: torch.fx.Node) -> tuple[
+        torch.fx.Node,
+        torch.fx.Node,
+        torch.fx.Node,
+        torch.fx.Node | None,
+        int,
+        MXFPDType,
+    ]:
         """Extract the MXFP linear operands from a custom-op node."""
         input_node = cast(torch.fx.Node, node.args[0])
         weight_qdata_node = cast(torch.fx.Node, node.args[1])
@@ -65,7 +99,26 @@ class RewriteMXFPLinearPass(ArmPass):
             int,
             node.args[4] if len(node.args) > 4 else node.kwargs.get("block_size", 32),
         )
-        return input_node, weight_qdata_node, weight_scale_node, bias_node, block_size
+        payload_dtype_str = cast(
+            str,
+            (
+                node.args[5]
+                if len(node.args) > 5
+                else node.kwargs.get(
+                    "weight_payload_dtype",
+                    node.kwargs.get("weight_dtype", ""),
+                )
+            ),
+        )
+        payload_dtype = _get_weights_payload_dtype(weight_qdata_node, payload_dtype_str)
+        return (
+            input_node,
+            weight_qdata_node,
+            weight_scale_node,
+            bias_node,
+            block_size,
+            payload_dtype,
+        )
 
     def _reshape_with_view(
         self,
@@ -96,14 +149,15 @@ class RewriteMXFPLinearPass(ArmPass):
         weight_qdata_node: torch.fx.Node,
         weight_scale_node: torch.fx.Node,
         block_size: int,
+        payload_dtype: MXFPDType,
     ) -> tuple[torch.fx.Node, torch.fx.Node]:
         """Create rank-3 inputs for the block-scaled cast and matmul ops."""
         graph = graph_module.graph
         input_fake = get_first_fake_tensor(input_node)
         weight_qdata_fake = get_first_fake_tensor(weight_qdata_node)
         weight_scale_fake = get_first_fake_tensor(weight_scale_node)
-        weight_dtype = _get_block_scaled_payload_dtype(weight_qdata_fake)
-        _mark_fp4_payload(weight_qdata_node, weight_dtype)
+        payload_dtype_str = mxfp_dtype_to_str(payload_dtype)
+        _mark_mxfp_payload(weight_qdata_node, payload_dtype)
 
         batches = reduce(operator.mul, input_fake.shape[:-1], 1)
         input_reshape_shape = [1, batches, input_fake.shape[-1]]
@@ -123,13 +177,13 @@ class RewriteMXFPLinearPass(ArmPass):
             graph=graph,
             op_target=exir_ops.backend.tosa.CAST_TO_BLOCK_SCALED.default,
             args=(input_reshaped, block_size),
-            kwargs={"output_dtype": weight_dtype},
+            kwargs={"output_dtype": payload_dtype_str},
             from_node=mxfp_linear_node,
         )
         cast_node.meta["val"] = exir_ops.backend.tosa.CAST_TO_BLOCK_SCALED.default(
             get_first_fake_tensor(input_reshaped),
             block_size,
-            output_dtype=weight_dtype,
+            output_dtype=payload_dtype_str,
         )
 
         input_qdata_node = create_node(
@@ -140,7 +194,7 @@ class RewriteMXFPLinearPass(ArmPass):
             from_node=mxfp_linear_node,
         )
         input_qdata_node.meta["val"] = cast_node.meta["val"][0]
-        _mark_fp4_payload(input_qdata_node, weight_dtype)
+        _mark_mxfp_payload(input_qdata_node, payload_dtype)
 
         input_scale_node = create_node(
             graph=graph,
@@ -165,8 +219,10 @@ class RewriteMXFPLinearPass(ArmPass):
         weight_qdata_node: torch.fx.Node,
         weight_scale_node: torch.fx.Node,
         block_size: int,
+        payload_dtype: MXFPDType,
     ) -> torch.fx.Node:
         """Insert ``MATMUL_T_BLOCK_SCALED`` with updated fake metadata."""
+        payload_dtype_str = mxfp_dtype_to_str(payload_dtype)
         matmul_node = create_node(
             graph=graph_module.graph,
             op_target=exir_ops.backend.tosa.MATMUL_T_BLOCK_SCALED.default,
@@ -177,7 +233,7 @@ class RewriteMXFPLinearPass(ArmPass):
                 weight_scale_node,
                 block_size,
             ),
-            kwargs={},
+            kwargs={"payload_dtype": payload_dtype_str},
             from_node=mxfp_linear_node,
         )
         matmul_node.meta["val"] = exir_ops.backend.tosa.MATMUL_T_BLOCK_SCALED.default(
@@ -186,6 +242,7 @@ class RewriteMXFPLinearPass(ArmPass):
             get_first_fake_tensor(weight_qdata_node),
             get_first_fake_tensor(weight_scale_node),
             block_size,
+            payload_dtype=payload_dtype_str,
         )
         return matmul_node
 
@@ -270,6 +327,7 @@ class RewriteMXFPLinearPass(ArmPass):
             weight_scale_node,
             bias_node,
             block_size,
+            payload_dtype,
         ) = self._get_linear_args(mxfp_linear_node)
 
         with graph.inserting_before(mxfp_linear_node):
@@ -283,6 +341,7 @@ class RewriteMXFPLinearPass(ArmPass):
                 weight_qdata_node,
                 weight_scale_node,
                 block_size,
+                payload_dtype,
             )
             matmul_node = self._create_matmul_node(
                 graph_module,
@@ -292,6 +351,7 @@ class RewriteMXFPLinearPass(ArmPass):
                 weight_qdata_node,
                 weight_scale_node,
                 block_size,
+                payload_dtype,
             )
 
         with graph.inserting_after(matmul_node):
@@ -314,10 +374,7 @@ class RewriteMXFPLinearPass(ArmPass):
         graph = graph_module.graph
 
         for node in list(graph.nodes):
-            if node.op != "call_function" or node.target not in (
-                torch.ops.tosa_mxfp.linear.default,
-                exir_ops.edge.tosa_mxfp.linear.default,
-            ):
+            if node.op != "call_function" or node.target not in self.target_ops:
                 continue
 
             modified = True

--- a/backends/arm/_passes/rewrite_mxfp_linear.py
+++ b/backends/arm/_passes/rewrite_mxfp_linear.py
@@ -13,8 +13,20 @@ from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
 )
+from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+
+
+def _get_block_scaled_payload_dtype(qdata: torch.Tensor) -> torch.dtype:
+    if qdata.dtype == torch.uint8:
+        return torch.float4_e2m1fn_x2
+    return qdata.dtype
+
+
+def _mark_fp4_payload(node: torch.fx.Node, payload_dtype: torch.dtype) -> None:
+    if payload_dtype == torch.float4_e2m1fn_x2:
+        node.meta[TosaSpecialDtype.meta_key()] = TosaSpecialDtype.FP4E2M1
 
 
 class RewriteMXFPLinearPass(ArmPass):
@@ -90,6 +102,8 @@ class RewriteMXFPLinearPass(ArmPass):
         input_fake = get_first_fake_tensor(input_node)
         weight_qdata_fake = get_first_fake_tensor(weight_qdata_node)
         weight_scale_fake = get_first_fake_tensor(weight_scale_node)
+        weight_dtype = _get_block_scaled_payload_dtype(weight_qdata_fake)
+        _mark_fp4_payload(weight_qdata_node, weight_dtype)
 
         batches = reduce(operator.mul, input_fake.shape[:-1], 1)
         input_reshape_shape = [1, batches, input_fake.shape[-1]]
@@ -109,13 +123,13 @@ class RewriteMXFPLinearPass(ArmPass):
             graph=graph,
             op_target=exir_ops.backend.tosa.CAST_TO_BLOCK_SCALED.default,
             args=(input_reshaped, block_size),
-            kwargs={"output_dtype": weight_qdata_fake.dtype},
+            kwargs={"output_dtype": weight_dtype},
             from_node=mxfp_linear_node,
         )
         cast_node.meta["val"] = exir_ops.backend.tosa.CAST_TO_BLOCK_SCALED.default(
             get_first_fake_tensor(input_reshaped),
             block_size,
-            output_dtype=weight_qdata_fake.dtype,
+            output_dtype=weight_dtype,
         )
 
         input_qdata_node = create_node(
@@ -126,6 +140,7 @@ class RewriteMXFPLinearPass(ArmPass):
             from_node=mxfp_linear_node,
         )
         input_qdata_node.meta["val"] = cast_node.meta["val"][0]
+        _mark_fp4_payload(input_qdata_node, weight_dtype)
 
         input_scale_node = create_node(
             graph=graph,

--- a/backends/arm/ao_ext/mxfp.py
+++ b/backends/arm/ao_ext/mxfp.py
@@ -32,7 +32,11 @@ class MXFPOpConfig(AOBaseConfig):
         return 32
 
     def __post_init__(self) -> None:
-        if self.weight_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+        if self.weight_dtype not in (
+            torch.float4_e2m1fn_x2,
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        ):
             raise ValueError(f"Unsupported weight_dtype: {self.weight_dtype}")
         if not isinstance(self.weight_scaling_mode, ScaleCalculationMode):
             raise ValueError(

--- a/backends/arm/ao_ext/mxfp.py
+++ b/backends/arm/ao_ext/mxfp.py
@@ -10,7 +10,54 @@ import torch
 from executorch.exir._warnings import experimental
 from torchao.core.config import AOBaseConfig
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
+from torchao.prototype.mx_formats.mx_tensor import DTYPE_FP6_E2M3, DTYPE_FP6_E3M2
 from torchao.quantization import quantize_
+
+
+# Pytorch lacks dtypes for the FP6 types, so we use ao's string representations for those.
+MXFPDType = torch.dtype | str
+
+
+SUPPORTED_MXFP_DTYPES: set[MXFPDType] = {
+    torch.float4_e2m1fn_x2,
+    torch.float8_e4m3fn,
+    torch.float8_e5m2,
+    # Use ao's string representations.
+    DTYPE_FP6_E2M3,
+    DTYPE_FP6_E3M2,
+}
+
+
+_DTYPE_TO_STR: dict[MXFPDType, str] = {
+    DTYPE_FP6_E2M3: "fp6e2m3",
+    DTYPE_FP6_E3M2: "fp6e3m2",
+    torch.float4_e2m1fn_x2: "f4e2m1",
+    torch.float8_e4m3fn: "f8e4m3",
+    torch.float8_e5m2: "f8e5m2",
+}
+
+
+_STR_TO_DTYPE = {value: key for (key, value) in _DTYPE_TO_STR.items()}
+
+
+def mxfp_dtype_to_str(dtype: MXFPDType) -> str:
+    try:
+        return _DTYPE_TO_STR[dtype]
+    except KeyError as e:
+        supported = ", ".join(str(dtype) for dtype in _DTYPE_TO_STR)
+        raise ValueError(
+            f"Unsupported MXFP dtype {dtype}. Supported dtypes: {supported}"
+        ) from e
+
+
+def mxfp_str_to_dtype(dtype: str) -> MXFPDType:
+    try:
+        return _STR_TO_DTYPE[dtype]
+    except KeyError as e:
+        supported = ", ".join(sorted(_STR_TO_DTYPE))
+        raise ValueError(
+            f"Unsupported MXFP dtype string {dtype!r}. Supported strings: {supported}"
+        ) from e
 
 
 def _match_supported_modules(module: torch.nn.Module, _name: str) -> bool:
@@ -23,7 +70,7 @@ def _match_supported_modules(module: torch.nn.Module, _name: str) -> bool:
 class MXFPOpConfig(AOBaseConfig):
     """Configuration for Arm MXFP source transforms."""
 
-    weight_dtype: torch.dtype = torch.float8_e4m3fn
+    weight_dtype: MXFPDType = torch.float8_e4m3fn
     weight_scaling_mode: ScaleCalculationMode = ScaleCalculationMode.RCEIL
 
     # Only block size of 32 is currently supported for now, so we hardcode it here.
@@ -32,11 +79,7 @@ class MXFPOpConfig(AOBaseConfig):
         return 32
 
     def __post_init__(self) -> None:
-        if self.weight_dtype not in (
-            torch.float4_e2m1fn_x2,
-            torch.float8_e4m3fn,
-            torch.float8_e5m2,
-        ):
+        if self.weight_dtype not in SUPPORTED_MXFP_DTYPES:
             raise ValueError(f"Unsupported weight_dtype: {self.weight_dtype}")
         if not isinstance(self.weight_scaling_mode, ScaleCalculationMode):
             raise ValueError(

--- a/backends/arm/ao_ext/ops/mxfp_linear_op.py
+++ b/backends/arm/ao_ext/ops/mxfp_linear_op.py
@@ -12,26 +12,46 @@ op during export.
 
 import torch
 import torch.nn.functional as F
-from executorch.backends.arm.ao_ext.mxfp import MXFPOpConfig
+from executorch.backends.arm.ao_ext.mxfp import (
+    mxfp_dtype_to_str,
+    mxfp_str_to_dtype,
+    MXFPDType,
+    MXFPOpConfig,
+)
 from executorch.backends.arm.ao_ext.mxfp_tosa_lib import MXFP_TOSA_LIB
 from torchao.prototype.mx_formats.config import ScaleCalculationMode
 from torchao.prototype.mx_formats.mx_tensor import to_dtype, to_mx
 
+
+# Define the custom TOSA operator. Note that weight_payload_dtype is needed as
+# an extra argument because sub-byte dtypes (FP4 and FP6) are contained
+# in uint8 tensors, meaning the weight tensor itself does not contain
+# the dtype.
 MXFP_TOSA_LIB.define(
     "linear(Tensor input, Tensor weight_qdata, Tensor weight_scale, "
-    "Tensor? bias=None, SymInt block_size=32) -> Tensor"
+    "Tensor? bias=None, SymInt block_size=32, str weight_payload_dtype='') -> Tensor"
 )
 
 
-def _get_mx_elem_dtype(weight_qdata: torch.Tensor) -> torch.dtype:
+def _get_mx_elem_dtype(
+    weight_qdata: torch.Tensor,
+    weight_payload_dtype: str = "",
+) -> MXFPDType:
+    if weight_payload_dtype:
+        return mxfp_str_to_dtype(weight_payload_dtype)
     if weight_qdata.dtype == torch.uint8:
         return torch.float4_e2m1fn_x2
     return weight_qdata.dtype
 
 
-def _get_num_input_features(weight_qdata: torch.Tensor) -> int:
+def _get_num_input_features(
+    weight_qdata: torch.Tensor, weight_payload_dtype: str = ""
+) -> int:
     num_input_features = weight_qdata.shape[-1]
-    if _get_mx_elem_dtype(weight_qdata) == torch.float4_e2m1fn_x2:
+    if weight_qdata.dtype == torch.uint8 and weight_payload_dtype == mxfp_dtype_to_str(
+        torch.float4_e2m1fn_x2
+    ):
+        # FP4 elements are packed pairwise in each byte in a uint8 tensor.
         num_input_features *= 2
     return num_input_features
 
@@ -43,6 +63,7 @@ def _mxfp_linear_fake(
     weight_scale: torch.Tensor,
     bias: torch.Tensor | None = None,
     block_size: int = 32,
+    weight_payload_dtype: str = "",
 ) -> torch.Tensor:
     if weight_qdata.ndim != 3:
         raise ValueError(
@@ -52,7 +73,7 @@ def _mxfp_linear_fake(
         raise ValueError(
             f"Expected weight_qdata batch dim to be 1, got {weight_qdata.shape[0]}"
         )
-    num_input_features = _get_num_input_features(weight_qdata)
+    num_input_features = _get_num_input_features(weight_qdata, weight_payload_dtype)
     if input.shape[-1] != num_input_features:
         raise ValueError(
             f"Input last dim {input.shape[-1]} must match linear in_features "
@@ -74,7 +95,7 @@ def _mxfp_linear_fake(
 
 def _cast_to_block_scaled_cpu_ref(
     input: torch.Tensor,
-    output_dtype: torch.dtype,
+    output_dtype: MXFPDType,
     block_size: int,
 ) -> torch.Tensor:
     """Emulate the current TOSA activation cast in eager mode."""
@@ -100,13 +121,14 @@ def _mxfp_linear_cpu(
     weight_scale: torch.Tensor,
     bias: torch.Tensor | None = None,
     block_size: int = 32,
+    weight_payload_dtype: str = "",
 ) -> torch.Tensor:
     """CPU reference implementation of the MXFP linear op."""
 
     if weight_qdata.ndim != 3 or weight_scale.ndim != 3:
         raise ValueError("Expected rank-3 weight tensors for MXFP linear")
 
-    elem_dtype = _get_mx_elem_dtype(weight_qdata)
+    elem_dtype = _get_mx_elem_dtype(weight_qdata, weight_payload_dtype)
 
     # Cast the input to block-scaled format and back again to match the
     # expected input format of the TOSA
@@ -140,6 +162,7 @@ class MXFPLinearOp(torch.nn.Module):
     ) -> None:
         super().__init__()
         self.config = config
+        self.weight_dtype = mxfp_dtype_to_str(config.weight_dtype)
 
         self.register_buffer("weight_qdata", weight_qdata, persistent=True)
         self.register_buffer("weight_scale", weight_scale, persistent=True)
@@ -162,6 +185,7 @@ class MXFPLinearOp(torch.nn.Module):
             self.weight_scale,
             self.bias,
             self.config.block_size,
+            self.weight_dtype,
         )
 
 

--- a/backends/arm/ao_ext/ops/mxfp_linear_op.py
+++ b/backends/arm/ao_ext/ops/mxfp_linear_op.py
@@ -23,6 +23,19 @@ MXFP_TOSA_LIB.define(
 )
 
 
+def _get_mx_elem_dtype(weight_qdata: torch.Tensor) -> torch.dtype:
+    if weight_qdata.dtype == torch.uint8:
+        return torch.float4_e2m1fn_x2
+    return weight_qdata.dtype
+
+
+def _get_num_input_features(weight_qdata: torch.Tensor) -> int:
+    num_input_features = weight_qdata.shape[-1]
+    if _get_mx_elem_dtype(weight_qdata) == torch.float4_e2m1fn_x2:
+        num_input_features *= 2
+    return num_input_features
+
+
 @torch.library.register_fake("tosa_mxfp::linear", lib=MXFP_TOSA_LIB)  # type: ignore[misc]
 def _mxfp_linear_fake(
     input: torch.Tensor,
@@ -39,15 +52,16 @@ def _mxfp_linear_fake(
         raise ValueError(
             f"Expected weight_qdata batch dim to be 1, got {weight_qdata.shape[0]}"
         )
-    if input.shape[-1] != weight_qdata.shape[-1]:
+    num_input_features = _get_num_input_features(weight_qdata)
+    if input.shape[-1] != num_input_features:
         raise ValueError(
             f"Input last dim {input.shape[-1]} must match linear in_features "
-            f"{weight_qdata.shape[-1]}"
+            f"{num_input_features}"
         )
     expected_scale_shape = (
         1,
         weight_qdata.shape[1],
-        weight_qdata.shape[-1] // block_size,
+        num_input_features // block_size,
     )
     if tuple(weight_scale.shape) != expected_scale_shape:
         raise ValueError(
@@ -92,17 +106,19 @@ def _mxfp_linear_cpu(
     if weight_qdata.ndim != 3 or weight_scale.ndim != 3:
         raise ValueError("Expected rank-3 weight tensors for MXFP linear")
 
+    elem_dtype = _get_mx_elem_dtype(weight_qdata)
+
     # Cast the input to block-scaled format and back again to match the
     # expected input format of the TOSA
     dequantized_input = _cast_to_block_scaled_cpu_ref(
         input,
-        weight_qdata.dtype,
+        elem_dtype,
         block_size,
     )
     dequantized_weight = to_dtype(
         weight_qdata,
         weight_scale,
-        weight_qdata.dtype,
+        elem_dtype,
         block_size,
         torch.float32,
     )

--- a/backends/arm/operators/op_tosa_matmul_t_block_scaled.py
+++ b/backends/arm/operators/op_tosa_matmul_t_block_scaled.py
@@ -53,7 +53,7 @@ class MatMulTBlockScaledVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [A_data, B_data],
-            [ts.DType.FP8E4M3, ts.DType.FP8E5M2],
+            [ts.DType.FP4E2M1, ts.DType.FP8E4M3, ts.DType.FP8E5M2],
             self.tosa_spec,
         )
         validate_valid_dtype(

--- a/backends/arm/operators/op_tosa_matmul_t_block_scaled.py
+++ b/backends/arm/operators/op_tosa_matmul_t_block_scaled.py
@@ -53,7 +53,13 @@ class MatMulTBlockScaledVisitor(NodeVisitor):
         validate_valid_dtype(
             self.target,
             [A_data, B_data],
-            [ts.DType.FP4E2M1, ts.DType.FP8E4M3, ts.DType.FP8E5M2],
+            [
+                ts.DType.FP4E2M1,
+                ts.DType.FP6E2M3,
+                ts.DType.FP6E3M2,
+                ts.DType.FP8E4M3,
+                ts.DType.FP8E5M2,
+            ],
             self.tosa_spec,
         )
         validate_valid_dtype(

--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -61,6 +61,20 @@ def _prepare_const_values_for_tosa_dtype(
     """Normalize constant storage to the expected TOSA serializer dtype."""
     if tosa_arg.dtype == ts.DType.INT48 and values.dtype != np.int64:
         return values.astype(np.int64)
+    if tosa_arg.dtype in (ts.DType.FP6E2M3, ts.DType.FP6E3M2):
+        if values.dtype == np.uint8:
+            try:
+                import ml_dtypes  # type: ignore[import-not-found]
+            except ImportError as e:
+                raise RuntimeError(
+                    "ml_dtypes is required to serialize FP6 tensors for TOSA. "
+                    "Have you run setup.sh?"
+                ) from e
+            ml_dtype = {
+                ts.DType.FP6E2M3: ml_dtypes.float6_e2m3fn,
+                ts.DType.FP6E3M2: ml_dtypes.float6_e3m2fn,
+            }[tosa_arg.dtype]
+            return values.view(ml_dtype)
     return values
 
 

--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -56,12 +56,66 @@ def _tensor_to_numpy(tensor: torch.Tensor) -> np.ndarray:
 
 
 def _prepare_const_values_for_tosa_dtype(
-    values: np.ndarray, tosa_dtype: ts.DType
+    values: np.ndarray, tosa_arg: TosaArg
 ) -> np.ndarray:
     """Normalize constant storage to the expected TOSA serializer dtype."""
-    if tosa_dtype == ts.DType.INT48 and values.dtype != np.int64:
+    if tosa_arg.dtype == ts.DType.INT48 and values.dtype != np.int64:
         return values.astype(np.int64)
     return values
+
+
+def _get_const_shape(values: np.ndarray, tosa_arg: TosaArg) -> list[int]:
+    """Return the TOSA logical shape for a serialized constant."""
+    if tosa_arg.dtype == ts.DType.FP4E2M1:
+        return normalize_symint(tosa_arg.shape)
+    return normalize_symint(values.shape)
+
+
+def _is_packed_fp4_const(values: np.ndarray, tosa_arg: TosaArg) -> bool:
+    """FP4 elements are pairwise in each byte of a uint8 tensor.
+
+    This function checks if the given values and TOSA argument represent a
+    packed FP4 constant.
+
+    """
+
+    return (
+        tosa_arg.dtype == ts.DType.FP4E2M1
+        and values.dtype == np.uint8
+        and values.shape[-1] * 2 == tosa_arg.shape[-1]
+    )
+
+
+def _add_const(
+    tosa_graph: Any,
+    values: np.ndarray,
+    tosa_arg: TosaArg,
+    name: str,
+) -> None:
+    """Add a constant, preserving packed FP4 storage when required."""
+    if _is_packed_fp4_const(values, tosa_arg):
+        # TOSA FP4 tensors have logical FP4 shape, but constants are stored as
+        # packed bytes (two values per byte). Add the raw bytes as INT8 first
+        # then set TOSA dtype and shape correctly on the tensor metadata.
+        tosa_graph.addConst(
+            normalize_symint(values.shape),
+            ts.DType.INT8,
+            values,
+            name=name,
+        )
+        tensor = tosa_graph.currRegion.currBasicBlock.tensors[name]
+        tensor.setDtype(ts.DType.FP4E2M1)
+        for dim, size in enumerate(normalize_symint(tosa_arg.shape)):
+            tensor.SetDimSize(dim, size)
+        return
+
+    prepared_values = _prepare_const_values_for_tosa_dtype(values, tosa_arg)
+    tosa_graph.addConst(
+        _get_const_shape(prepared_values, tosa_arg),
+        tosa_arg.dtype,
+        prepared_values,
+        name=name,
+    )
 
 
 def process_call_function(
@@ -154,16 +208,7 @@ def process_inputs_to_parameters(
             f"{type(parameter_data).__name__}"
         )
     parameter_values = _tensor_to_numpy(parameter_data)
-    parameter_values = _prepare_const_values_for_tosa_dtype(
-        parameter_values, tosa_arg.dtype
-    )
-
-    tosa_graph.addConst(
-        normalize_symint(parameter_values.shape),
-        tosa_arg.dtype,
-        parameter_values,
-        name=tosa_arg.name,
-    )
+    _add_const(tosa_graph, parameter_values, tosa_arg, name=tosa_arg.name)
 
 
 def process_inputs_to_buffers(
@@ -188,14 +233,7 @@ def process_inputs_to_buffers(
             f"{type(buffer_data).__name__}"
         )
     buffer_values = _tensor_to_numpy(buffer_data)
-    buffer_values = _prepare_const_values_for_tosa_dtype(buffer_values, tosa_arg.dtype)
-
-    tosa_graph.addConst(
-        normalize_symint(buffer_values.shape),
-        tosa_arg.dtype,
-        buffer_values,
-        name=tosa_arg.name,
-    )
+    _add_const(tosa_graph, buffer_values, tosa_arg, name=tosa_arg.name)
 
 
 def process_inputs_to_lifted_tensor_constants(
@@ -217,14 +255,7 @@ def process_inputs_to_lifted_tensor_constants(
         f"{type(tensor).__name__}"
     )
     tensor_values = _tensor_to_numpy(tensor)
-    tensor_values = _prepare_const_values_for_tosa_dtype(tensor_values, tosa_arg.dtype)
-
-    tosa_graph.addConst(
-        normalize_symint(tensor_values.shape),
-        tosa_arg.dtype,
-        tensor_values,
-        name=tosa_arg.name,
-    )
+    _add_const(tosa_graph, tensor_values, tosa_arg, name=tosa_arg.name)
 
 
 def _is_submodule_input(

--- a/backends/arm/test/misc/test_mxfp_linear_ao.py
+++ b/backends/arm/test/misc/test_mxfp_linear_ao.py
@@ -31,9 +31,45 @@ def test_mxfp_linear_quantize_swaps_module() -> None:
     assert tuple(model.linear.weight_scale.shape) == (1, 8, 1)
 
 
-def test_mxfp_linear_export_preserves_custom_op() -> None:
+def test_mxfp4_linear_quantize_swaps_module() -> None:
     model = LinearModule().eval()
-    to_mxfp(model, MXFPOpConfig())
+
+    to_mxfp(
+        model,
+        MXFPOpConfig(weight_dtype=torch.float4_e2m1fn_x2),
+    )
+
+    assert isinstance(model.linear, MXFPLinearOp)
+    assert model.linear.weight_qdata.dtype == torch.uint8
+    assert model.linear.weight_scale.dtype == torch.float8_e8m0fnu
+    assert tuple(model.linear.weight_qdata.shape) == (1, 8, 16)
+    assert tuple(model.linear.weight_scale.shape) == (1, 8, 1)
+
+
+def test_mxfp_linear_quantize_filter_fn_selects_modules() -> None:
+    class TwoLinearModule(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.selected = torch.nn.Linear(32, 8)
+            self.skipped = torch.nn.Linear(32, 8)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.selected(x) + self.skipped(x)
+
+    def _is_selected_linear(module: torch.nn.Module, fqn: str) -> bool:
+        return isinstance(module, torch.nn.Linear) and fqn == "selected"
+
+    model = TwoLinearModule().eval()
+
+    to_mxfp(model, MXFPOpConfig(), filter_fn=_is_selected_linear)
+
+    assert isinstance(model.selected, MXFPLinearOp)
+    assert isinstance(model.skipped, torch.nn.Linear)
+
+
+def _test_mxfp_linear_export_preserves_custom_op(config: MXFPOpConfig) -> None:
+    model = LinearModule().eval()
+    to_mxfp(model, config)
 
     exported = export(model, (torch.randn(4, 32),), strict=False)
 
@@ -44,3 +80,13 @@ def test_mxfp_linear_export_preserves_custom_op() -> None:
     ]
 
     assert torch.ops.tosa_mxfp.linear.default in targets
+
+
+def test_mxfp_linear_export_preserves_custom_op() -> None:
+    _test_mxfp_linear_export_preserves_custom_op(MXFPOpConfig())
+
+
+def test_mxfp4_linear_export_preserves_custom_op() -> None:
+    _test_mxfp_linear_export_preserves_custom_op(
+        MXFPOpConfig(weight_dtype=torch.float4_e2m1fn_x2)
+    )

--- a/backends/arm/test/misc/test_mxfp_linear_ao.py
+++ b/backends/arm/test/misc/test_mxfp_linear_ao.py
@@ -5,9 +5,11 @@
 
 import torch
 from executorch.backends.arm.ao_ext import MXFPOpConfig, to_mxfp
+from executorch.backends.arm.ao_ext.mxfp import mxfp_dtype_to_str, MXFPDType
 from executorch.backends.arm.ao_ext.ops import MXFPLinearOp
 
 from torch.export import export
+from torchao.prototype.mx_formats.mx_tensor import DTYPE_FP6_E2M3, DTYPE_FP6_E3M2
 
 
 class LinearModule(torch.nn.Module):
@@ -19,31 +21,56 @@ class LinearModule(torch.nn.Module):
         return self.linear(x)
 
 
-def test_mxfp_linear_quantize_swaps_module() -> None:
-    model = LinearModule().eval()
-
-    to_mxfp(model, MXFPOpConfig())
-
-    assert isinstance(model.linear, MXFPLinearOp)
-    assert model.linear.weight_qdata.dtype == torch.float8_e4m3fn
-    assert model.linear.weight_scale.dtype == torch.float8_e8m0fnu
-    assert tuple(model.linear.weight_qdata.shape) == (1, 8, 32)
-    assert tuple(model.linear.weight_scale.shape) == (1, 8, 1)
-
-
-def test_mxfp4_linear_quantize_swaps_module() -> None:
+def _test_mxfp_linear_quantize_swaps_module(
+    weight_dtype: MXFPDType,
+    expected_weight_qdata_dtype: torch.dtype,
+    expected_weight_qdata_shape: tuple[int, ...],
+) -> None:
     model = LinearModule().eval()
 
     to_mxfp(
         model,
-        MXFPOpConfig(weight_dtype=torch.float4_e2m1fn_x2),
+        MXFPOpConfig(weight_dtype=weight_dtype),
     )
 
     assert isinstance(model.linear, MXFPLinearOp)
-    assert model.linear.weight_qdata.dtype == torch.uint8
+    assert model.linear.weight_qdata.dtype == expected_weight_qdata_dtype
+    assert model.linear.weight_dtype == mxfp_dtype_to_str(weight_dtype)
     assert model.linear.weight_scale.dtype == torch.float8_e8m0fnu
-    assert tuple(model.linear.weight_qdata.shape) == (1, 8, 16)
+    assert tuple(model.linear.weight_qdata.shape) == expected_weight_qdata_shape
     assert tuple(model.linear.weight_scale.shape) == (1, 8, 1)
+
+
+def test_mxfp8_e4m3_linear_quantize_swaps_module() -> None:
+    _test_mxfp_linear_quantize_swaps_module(
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fn,
+        (1, 8, 32),
+    )
+
+
+def test_mxfp4_linear_quantize_swaps_module() -> None:
+    _test_mxfp_linear_quantize_swaps_module(
+        torch.float4_e2m1fn_x2,
+        torch.uint8,
+        (1, 8, 16),
+    )
+
+
+def test_mxfp6_e2m3_linear_quantize_swaps_module() -> None:
+    _test_mxfp_linear_quantize_swaps_module(
+        DTYPE_FP6_E2M3,
+        torch.uint8,
+        (1, 8, 32),
+    )
+
+
+def test_mxfp6_e3m2_linear_quantize_swaps_module() -> None:
+    _test_mxfp_linear_quantize_swaps_module(
+        DTYPE_FP6_E3M2,
+        torch.uint8,
+        (1, 8, 32),
+    )
 
 
 def test_mxfp_linear_quantize_filter_fn_selects_modules() -> None:
@@ -61,7 +88,11 @@ def test_mxfp_linear_quantize_filter_fn_selects_modules() -> None:
 
     model = TwoLinearModule().eval()
 
-    to_mxfp(model, MXFPOpConfig(), filter_fn=_is_selected_linear)
+    to_mxfp(
+        model,
+        MXFPOpConfig(weight_dtype=torch.float8_e4m3fn),
+        filter_fn=_is_selected_linear,
+    )
 
     assert isinstance(model.selected, MXFPLinearOp)
     assert isinstance(model.skipped, torch.nn.Linear)
@@ -82,11 +113,25 @@ def _test_mxfp_linear_export_preserves_custom_op(config: MXFPOpConfig) -> None:
     assert torch.ops.tosa_mxfp.linear.default in targets
 
 
-def test_mxfp_linear_export_preserves_custom_op() -> None:
-    _test_mxfp_linear_export_preserves_custom_op(MXFPOpConfig())
+def test_mxfp8_e4m3_linear_export_preserves_custom_op() -> None:
+    _test_mxfp_linear_export_preserves_custom_op(
+        MXFPOpConfig(weight_dtype=torch.float8_e4m3fn)
+    )
 
 
 def test_mxfp4_linear_export_preserves_custom_op() -> None:
     _test_mxfp_linear_export_preserves_custom_op(
         MXFPOpConfig(weight_dtype=torch.float4_e2m1fn_x2)
+    )
+
+
+def test_mxfp6_e2m3_linear_export_preserves_custom_op() -> None:
+    _test_mxfp_linear_export_preserves_custom_op(
+        MXFPOpConfig(weight_dtype=DTYPE_FP6_E2M3)
+    )
+
+
+def test_mxfp6_e3m2_linear_export_preserves_custom_op() -> None:
+    _test_mxfp_linear_export_preserves_custom_op(
+        MXFPOpConfig(weight_dtype=DTYPE_FP6_E3M2)
     )

--- a/backends/arm/test/misc/test_process_node.py
+++ b/backends/arm/test/misc/test_process_node.py
@@ -3,14 +3,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from types import SimpleNamespace
+from typing import cast
+
 import numpy as np
 import torch
 import tosa_serializer as ts
-from executorch.backends.arm.process_node import process_placeholder
-from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
+from executorch.backends.arm.process_node import _add_const, process_placeholder
+from executorch.backends.arm.tosa.mapping import TosaArg, TosaSpecialDtype
 from executorch.backends.arm.tosa.specification import TosaSpecification
 from executorch.exir import to_edge
 from torch._export.utils import is_param
+from tosa.TosaGraph import TosaGraph  # type: ignore[import-untyped]
 
 
 class Int32BiasModule(torch.nn.Module):
@@ -94,3 +98,35 @@ def test_process_placeholder_int48_normalizes_int32_const_values() -> None:
     assert tosa_graph.values is not None
     assert tosa_graph.values.dtype == np.int64
     assert tosa_graph.serialized_bytes == _expected_int48_bytes(module.bias)
+
+
+def test_add_const_fp4_in_packed_storage() -> None:
+    packed_values = np.array([0xDE, 0xFE, 0x6D, 0x55], dtype=np.uint8).reshape(
+        1,
+        1,
+        4,
+    )
+    tosa_arg = cast(
+        TosaArg,
+        SimpleNamespace(dtype=ts.DType.FP4E2M1, shape=(1, 1, 8)),
+    )
+    tosa_graph = ts.TosaSerializer()
+
+    _add_const(tosa_graph, packed_values, tosa_arg, name="fp4_weight")
+
+    graph = TosaGraph.GetRootAs(bytes(tosa_graph.serialize()), 0)
+    block = graph.Regions(0).Blocks(0)
+    tensors = {
+        block.Tensors(index).Name().decode(): block.Tensors(index)
+        for index in range(block.TensorsLength())
+    }
+    tensor = tensors["fp4_weight"]
+
+    assert tensor.Type() == ts.DType.FP4E2M1
+    assert [tensor.Shape(index) for index in range(tensor.ShapeLength())] == [1, 1, 8]
+    assert [tensor.Data(index) for index in range(tensor.DataLength())] == [
+        0xDE,
+        0xFE,
+        0x6D,
+        0x55,
+    ]

--- a/backends/arm/test/misc/test_process_node.py
+++ b/backends/arm/test/misc/test_process_node.py
@@ -14,7 +14,7 @@ from executorch.backends.arm.tosa.mapping import TosaArg, TosaSpecialDtype
 from executorch.backends.arm.tosa.specification import TosaSpecification
 from executorch.exir import to_edge
 from torch._export.utils import is_param
-from tosa.TosaGraph import TosaGraph  # type: ignore[import-untyped]
+from tosa.TosaGraph import TosaGraph  # type: ignore[import-not-found, import-untyped]
 from tosa_serializer.numpy_utils import pack_6bit_array
 
 

--- a/backends/arm/test/misc/test_process_node.py
+++ b/backends/arm/test/misc/test_process_node.py
@@ -15,6 +15,7 @@ from executorch.backends.arm.tosa.specification import TosaSpecification
 from executorch.exir import to_edge
 from torch._export.utils import is_param
 from tosa.TosaGraph import TosaGraph  # type: ignore[import-untyped]
+from tosa_serializer.numpy_utils import pack_6bit_array
 
 
 class Int32BiasModule(torch.nn.Module):
@@ -130,3 +131,42 @@ def test_add_const_fp4_in_packed_storage() -> None:
         0x6D,
         0x55,
     ]
+
+
+def _test_add_const_fp6_in_packed_storage(dtype: int) -> None:
+    values = np.arange(32, dtype=np.uint8).reshape(1, 1, 32)
+
+    tosa_arg = cast(
+        TosaArg,
+        SimpleNamespace(dtype=dtype, shape=(1, 1, 32)),
+    )
+    tosa_graph = ts.TosaSerializer()
+
+    _add_const(tosa_graph, values, tosa_arg, name="fp6_weight")
+
+    graph = TosaGraph.GetRootAs(bytes(tosa_graph.serialize()), 0)
+    block = graph.Regions(0).Blocks(0)
+    tensors = {
+        block.Tensors(index).Name().decode(): block.Tensors(index)
+        for index in range(block.TensorsLength())
+    }
+    tensor = tensors["fp6_weight"]
+
+    assert tensor.Type() == dtype
+    assert [tensor.Shape(index) for index in range(tensor.ShapeLength())] == [
+        1,
+        1,
+        32,
+    ]
+    assert tensor.DataLength() == 24
+    assert [tensor.Data(index) for index in range(tensor.DataLength())] == (
+        pack_6bit_array(values).reshape(-1).tolist()
+    )
+
+
+def test_add_const_fp6e2m3_in_packed_storage() -> None:
+    _test_add_const_fp6_in_packed_storage(ts.DType.FP6E2M3)
+
+
+def test_add_const_fp6e3m2_in_packed_storage() -> None:
+    _test_add_const_fp6_in_packed_storage(ts.DType.FP6E3M2)

--- a/backends/arm/test/misc/tosa_dialect/test_tosa_dialect_cast_to_block_scaled.py
+++ b/backends/arm/test/misc/tosa_dialect/test_tosa_dialect_cast_to_block_scaled.py
@@ -5,6 +5,7 @@
 
 import pytest
 import torch
+from executorch.backends.arm.ao_ext.mxfp import mxfp_dtype_to_str
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops import cast_to_block_scaled  # noqa: F401
 from executorch.backends.arm.tosa.specification import (
@@ -13,6 +14,7 @@ from executorch.backends.arm.tosa.specification import (
 )
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch._subclasses.fake_tensor import FakeTensorMode
+from torchao.prototype.mx_formats.mx_tensor import DTYPE_FP6_E2M3, DTYPE_FP6_E3M2
 
 
 def test_cast_to_block_scaled_requires_mxfp_extension() -> None:
@@ -27,7 +29,7 @@ def test_cast_to_block_scaled_requires_mxfp_extension() -> None:
             exir_ops.backend.tosa.CAST_TO_BLOCK_SCALED.default(
                 mode.from_tensor(sample_input),
                 32,
-                output_dtype=torch.float8_e4m3fn,
+                output_dtype=mxfp_dtype_to_str(torch.float8_e4m3fn),
             )
 
 
@@ -39,13 +41,55 @@ def test_cast_to_block_scaled_tosa_fp_mxfp() -> None:
         output_data, output_scale = exir_ops.backend.tosa.CAST_TO_BLOCK_SCALED.default(
             mode.from_tensor(sample_input),
             32,
-            output_dtype=torch.float8_e4m3fn,
+            output_dtype=mxfp_dtype_to_str(torch.float8_e4m3fn),
         )
 
     assert output_data.dtype == torch.float8_e4m3fn
     assert tuple(output_data.shape) == (2, 32)
     assert output_scale.dtype == torch.float8_e8m0fnu
     assert tuple(output_scale.shape) == (2, 1)
+
+
+def test_cast_to_block_scaled_tosa_fp_mxfp4() -> None:
+    tosa_spec = TosaSpecification.create_from_string("TOSA-1.1+FP+mxfp")
+    sample_input = torch.randn((2, 32), dtype=torch.float32)
+
+    with TosaLoweringContext(tosa_spec), FakeTensorMode() as mode:
+        output_data, output_scale = exir_ops.backend.tosa.CAST_TO_BLOCK_SCALED.default(
+            mode.from_tensor(sample_input),
+            32,
+            output_dtype=mxfp_dtype_to_str(torch.float4_e2m1fn_x2),
+        )
+
+    assert output_data.dtype == torch.uint8
+    assert tuple(output_data.shape) == (2, 16)
+    assert output_scale.dtype == torch.float8_e8m0fnu
+    assert tuple(output_scale.shape) == (2, 1)
+
+
+def _test_cast_to_block_scaled_tosa_fp_mxfp6(dtype: str) -> None:
+    tosa_spec = TosaSpecification.create_from_string("TOSA-1.1+FP+mxfp")
+    sample_input = torch.randn((2, 32), dtype=torch.float32)
+
+    with TosaLoweringContext(tosa_spec), FakeTensorMode() as mode:
+        output_data, output_scale = exir_ops.backend.tosa.CAST_TO_BLOCK_SCALED.default(
+            mode.from_tensor(sample_input),
+            32,
+            output_dtype=mxfp_dtype_to_str(dtype),
+        )
+
+    assert output_data.dtype == torch.uint8
+    assert tuple(output_data.shape) == (2, 32)
+    assert output_scale.dtype == torch.float8_e8m0fnu
+    assert tuple(output_scale.shape) == (2, 1)
+
+
+def test_cast_to_block_scaled_tosa_fp_mxfp6e2m3() -> None:
+    _test_cast_to_block_scaled_tosa_fp_mxfp6(DTYPE_FP6_E2M3)
+
+
+def test_cast_to_block_scaled_tosa_fp_mxfp6e3m2() -> None:
+    _test_cast_to_block_scaled_tosa_fp_mxfp6(DTYPE_FP6_E3M2)
 
 
 def test_cast_to_block_scaled_invalid_shape() -> None:
@@ -59,5 +103,5 @@ def test_cast_to_block_scaled_invalid_shape() -> None:
             exir_ops.backend.tosa.CAST_TO_BLOCK_SCALED.default(
                 mode.from_tensor(torch.randn((2, 30), dtype=torch.float32)),
                 32,
-                output_dtype=torch.float8_e4m3fn,
+                output_dtype=mxfp_dtype_to_str(torch.float8_e4m3fn),
             )

--- a/backends/arm/test/misc/tosa_dialect/test_tosa_dialect_mxfp_linear.py
+++ b/backends/arm/test/misc/tosa_dialect/test_tosa_dialect_mxfp_linear.py
@@ -5,6 +5,7 @@
 
 import pytest
 import torch
+from executorch.backends.arm.ao_ext.mxfp import mxfp_dtype_to_str, MXFPDType
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops import matmul_t_block_scaled  # noqa: F401
 from executorch.backends.arm.tosa.specification import (
@@ -13,6 +14,7 @@ from executorch.backends.arm.tosa.specification import (
 )
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch._subclasses.fake_tensor import FakeTensorMode
+from torchao.prototype.mx_formats.mx_tensor import DTYPE_FP6_E3M2
 
 
 def test_matmul_t_block_scaled_tosa_fp_mxfp() -> None:
@@ -33,6 +35,38 @@ def test_matmul_t_block_scaled_tosa_fp_mxfp() -> None:
 
     assert output.dtype == torch.float32
     assert tuple(output.shape) == (1, 4, 8)
+
+
+def _test_matmul_t_block_scaled_tosa_fp_subbyte(
+    payload_dtype: MXFPDType,
+    qdata_last_dim: int,
+) -> None:
+    tosa_spec = TosaSpecification.create_from_string("TOSA-1.1+FP+mxfp")
+    a_data = torch.empty((1, 4, qdata_last_dim), dtype=torch.uint8)
+    a_scale = torch.empty((1, 4, 1), dtype=torch.float8_e8m0fnu)
+    b_data = torch.empty((1, 8, qdata_last_dim), dtype=torch.uint8)
+    b_scale = torch.empty((1, 8, 1), dtype=torch.float8_e8m0fnu)
+
+    with TosaLoweringContext(tosa_spec), FakeTensorMode() as mode:
+        output = exir_ops.backend.tosa.MATMUL_T_BLOCK_SCALED.default(
+            mode.from_tensor(a_data),
+            mode.from_tensor(a_scale),
+            mode.from_tensor(b_data),
+            mode.from_tensor(b_scale),
+            32,
+            payload_dtype=mxfp_dtype_to_str(payload_dtype),
+        )
+
+    assert output.dtype == torch.float32
+    assert tuple(output.shape) == (1, 4, 8)
+
+
+def test_matmul_t_block_scaled_tosa_fp_mxfp4() -> None:
+    _test_matmul_t_block_scaled_tosa_fp_subbyte(torch.float4_e2m1fn_x2, 16)
+
+
+def test_matmul_t_block_scaled_tosa_fp_mxfp6() -> None:
+    _test_matmul_t_block_scaled_tosa_fp_subbyte(DTYPE_FP6_E3M2, 32)
 
 
 def test_matmul_t_block_scaled_invalid_scale_shape() -> None:

--- a/backends/arm/test/ops/mxfp/test_mxfp_linear.py
+++ b/backends/arm/test/ops/mxfp/test_mxfp_linear.py
@@ -18,6 +18,7 @@ from executorch.backends.arm.test.ops.mxfp.common import (
 from executorch.backends.arm.test.tester.analyze_output_utils import (
     compare_rel_frobenius_and_cosine_similarity,
 )
+from torchao.prototype.mx_formats.mx_tensor import DTYPE_FP6_E2M3, DTYPE_FP6_E3M2
 
 aten_op = "torch.ops.tosa_mxfp.linear.default"
 
@@ -324,6 +325,26 @@ def test_mxfp4_linear_tosa_FP(test_data: torch.Tensor) -> None:
     )
 
 
+@common.parametrize("test_data", test_data_fp)
+def test_mxfp6_e2m3_linear_tosa_FP(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_tosa_FP(
+        test_data,
+        MXFPOpConfig(weight_dtype=DTYPE_FP6_E2M3),
+        frobenius_threshold=0.2,
+        cosine_threshold=0.98,
+    )
+
+
+@common.parametrize("test_data", test_data_fp)
+def test_mxfp6_e3m2_linear_tosa_FP(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_tosa_FP(
+        test_data,
+        MXFPOpConfig(weight_dtype=DTYPE_FP6_E3M2),
+        frobenius_threshold=0.2,
+        cosine_threshold=0.98,
+    )
+
+
 @common.parametrize("test_data", test_data_vgf_fp, xfails=_vgf_xfails)
 @common.SkipIfNoModelConverter
 def test_mxfp8_linear_vgf(test_data: torch.Tensor) -> None:
@@ -343,6 +364,28 @@ def test_mxfp4_linear_vgf(test_data: torch.Tensor) -> None:
         MXFPOpConfig(weight_dtype=torch.float4_e2m1fn_x2),
         frobenius_threshold=0.3,
         cosine_threshold=0.95,
+    )
+
+
+@common.parametrize("test_data", test_data_vgf_fp, xfails=_vgf_xfails)
+@common.SkipIfNoModelConverter
+def test_mxfp6_e2m3_linear_vgf(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_vgf(
+        test_data,
+        MXFPOpConfig(weight_dtype=DTYPE_FP6_E2M3),
+        frobenius_threshold=0.2,
+        cosine_threshold=0.98,
+    )
+
+
+@common.parametrize("test_data", test_data_vgf_fp, xfails=_vgf_xfails)
+@common.SkipIfNoModelConverter
+def test_mxfp6_e3m2_linear_vgf(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_vgf(
+        test_data,
+        MXFPOpConfig(weight_dtype=DTYPE_FP6_E3M2),
+        frobenius_threshold=0.2,
+        cosine_threshold=0.98,
     )
 
 
@@ -370,4 +413,24 @@ def test_mxfp4_linear_eager_cpu(test_data: torch.Tensor) -> None:
         MXFPOpConfig(weight_dtype=torch.float4_e2m1fn_x2),
         frobenius_threshold=0.3,
         cosine_threshold=0.95,
+    )
+
+
+@common.parametrize("test_data", test_data_fp)
+def test_mxfp6_e2m3_linear_eager_cpu(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_eager_cpu(
+        test_data,
+        MXFPOpConfig(weight_dtype=DTYPE_FP6_E2M3),
+        frobenius_threshold=0.2,
+        cosine_threshold=0.98,
+    )
+
+
+@common.parametrize("test_data", test_data_fp)
+def test_mxfp6_e3m2_linear_eager_cpu(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_eager_cpu(
+        test_data,
+        MXFPOpConfig(weight_dtype=DTYPE_FP6_E3M2),
+        frobenius_threshold=0.2,
+        cosine_threshold=0.98,
     )

--- a/backends/arm/test/ops/mxfp/test_mxfp_linear.py
+++ b/backends/arm/test/ops/mxfp/test_mxfp_linear.py
@@ -10,7 +10,7 @@ from typing import Tuple
 
 import torch
 from executorch.backends.arm.ao_ext import MXFPOpConfig, to_mxfp
-from executorch.backends.arm.test import common as arm_common
+from executorch.backends.arm.test import common
 from executorch.backends.arm.test.ops.mxfp.common import (
     MXFPTosaPipelineFP,
     MXFPVgfPipeline,
@@ -22,9 +22,6 @@ from executorch.backends.arm.test.tester.analyze_output_utils import (
 aten_op = "torch.ops.tosa_mxfp.linear.default"
 
 input_t1 = Tuple[torch.Tensor]
-
-_MXFP_FROBENIUS_THRESHOLD = 0.06
-_MXFP_COSINE_THRESHOLD = 0.995
 
 
 def _block_input_rank1() -> torch.Tensor:
@@ -215,35 +212,45 @@ def _is_linear(module: torch.nn.Module, _fqn: str) -> bool:
     return isinstance(module, torch.nn.Linear)
 
 
-@arm_common.parametrize("test_data", test_data_fp)
-def test_mxfp_linear_tosa_FP(test_data) -> None:
+def _test_mxfp_linear_eager_cpu(
+    test_data,
+    config: MXFPOpConfig,
+    frobenius_threshold=0.3,
+    cosine_threshold=0.95,
+) -> None:
     test_input, out_features, has_bias, set_block_weights = test_data()
     in_features = test_input.shape[-1]
-    module = Linear(
+    ref_model = Linear(
         in_features=in_features,
         out_features=out_features,
         bias=has_bias,
     ).eval()
 
     if set_block_weights:
-        module.set_block_test_weights()
+        ref_model.set_block_test_weights()
+    test_model = copy.deepcopy(ref_model).eval()
 
-    pipeline = MXFPTosaPipelineFP[input_t1](
-        module,
-        (test_input,),
-        aten_op,
-        filter_fn=_is_linear,
-        frobenius_threshold=_MXFP_FROBENIUS_THRESHOLD,
-        cosine_threshold=_MXFP_COSINE_THRESHOLD,
-        tosa_version="1.1",
-        tosa_extensions=["mxfp"],
+    to_mxfp(test_model, config, filter_fn=_is_linear)
+
+    test_output = test_model(test_input)
+    ref_output = ref_model(test_input)
+
+    compare_rel_frobenius_and_cosine_similarity(
+        ref_output,
+        test_output,
+        quantization_parameters=None,
+        frobenius_threshold=frobenius_threshold,
+        cosine_threshold=cosine_threshold,
+        clean_reference=False,
     )
-    pipeline.run()
 
 
-@arm_common.parametrize("test_data", test_data_vgf_fp, xfails=_vgf_xfails)
-@arm_common.SkipIfNoModelConverter
-def test_mxfp_linear_vgf(test_data) -> None:
+def _test_mxfp_linear_vgf(
+    test_data,
+    config: MXFPOpConfig,
+    frobenius_threshold,
+    cosine_threshold,
+) -> None:
     test_input, out_features, has_bias, set_block_weights = test_data()
     in_features = test_input.shape[-1]
     module = Linear(
@@ -260,36 +267,107 @@ def test_mxfp_linear_vgf(test_data) -> None:
         (test_input,),
         aten_op,
         filter_fn=_is_linear,
-        frobenius_threshold=_MXFP_FROBENIUS_THRESHOLD,
-        cosine_threshold=_MXFP_COSINE_THRESHOLD,
+        frobenius_threshold=frobenius_threshold,
+        cosine_threshold=cosine_threshold,
+        mxfp_config=config,
         tosa_spec="TOSA-1.1+FP+mxfp",
     )
     pipeline.run()
 
 
-@arm_common.parametrize("test_data", test_data_fp)
-def test_mxfp_linear_eager_cpu(test_data) -> None:
+def _test_mxfp_linear_tosa_FP(
+    test_data,
+    config: MXFPOpConfig,
+    frobenius_threshold=0.08,
+    cosine_threshold=0.995,
+) -> None:
     test_input, out_features, has_bias, set_block_weights = test_data()
     in_features = test_input.shape[-1]
-    ref_model = Linear(
+    module = Linear(
         in_features=in_features,
         out_features=out_features,
         bias=has_bias,
     ).eval()
+
     if set_block_weights:
-        ref_model.set_block_test_weights()
-    test_model = copy.deepcopy(ref_model).eval()
+        module.set_block_test_weights()
 
-    to_mxfp(test_model, MXFPOpConfig(), filter_fn=_is_linear)
+    pipeline = MXFPTosaPipelineFP[input_t1](
+        module,
+        (test_input,),
+        aten_op,
+        filter_fn=_is_linear,
+        frobenius_threshold=frobenius_threshold,
+        cosine_threshold=cosine_threshold,
+        mxfp_config=config,
+        tosa_version="1.1",
+        tosa_extensions=["mxfp"],
+    )
+    pipeline.run()
 
-    test_output = test_model(test_input)
-    ref_output = ref_model(test_input)
 
-    compare_rel_frobenius_and_cosine_similarity(
-        ref_output,
-        test_output,
-        quantization_parameters=None,
-        frobenius_threshold=_MXFP_FROBENIUS_THRESHOLD,
-        cosine_threshold=_MXFP_COSINE_THRESHOLD,
-        clean_reference=False,
+@common.parametrize("test_data", test_data_fp)
+def test_mxfp8_linear_tosa_FP(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_tosa_FP(
+        test_data,
+        MXFPOpConfig(weight_dtype=torch.float8_e4m3fn),
+    )
+
+
+@common.parametrize("test_data", test_data_fp)
+def test_mxfp4_linear_tosa_FP(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_tosa_FP(
+        test_data,
+        MXFPOpConfig(weight_dtype=torch.float4_e2m1fn_x2),
+        frobenius_threshold=0.3,
+        cosine_threshold=0.95,
+    )
+
+
+@common.parametrize("test_data", test_data_vgf_fp, xfails=_vgf_xfails)
+@common.SkipIfNoModelConverter
+def test_mxfp8_linear_vgf(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_vgf(
+        test_data,
+        MXFPOpConfig(weight_dtype=torch.float8_e4m3fn),
+        frobenius_threshold=0.08,
+        cosine_threshold=0.995,
+    )
+
+
+@common.parametrize("test_data", test_data_vgf_fp, xfails=_vgf_xfails)
+@common.SkipIfNoModelConverter
+def test_mxfp4_linear_vgf(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_vgf(
+        test_data,
+        MXFPOpConfig(weight_dtype=torch.float4_e2m1fn_x2),
+        frobenius_threshold=0.3,
+        cosine_threshold=0.95,
+    )
+
+
+@common.parametrize("test_data", test_data_fp)
+def test_mxfp8_linear_eager_cpu(test_data: torch.Tensor) -> None:
+    """Check eager MXFP implementation.
+
+    The Arm lowering tests compare lowered output against the eager CPU
+    implementation, so the eager implementation must be accurate for it to be
+    used as a reference in other tests.
+
+    """
+    _test_mxfp_linear_eager_cpu(
+        test_data,
+        MXFPOpConfig(weight_dtype=torch.float8_e4m3fn),
+        frobenius_threshold=0.08,
+        cosine_threshold=0.995,
+    )
+
+
+@common.parametrize("test_data", test_data_fp)
+def test_mxfp4_linear_eager_cpu(test_data: torch.Tensor) -> None:
+    _test_mxfp_linear_eager_cpu(
+        test_data,
+        MXFPOpConfig(weight_dtype=torch.float4_e2m1fn_x2),
+        frobenius_threshold=0.3,
+        cosine_threshold=0.95,
     )

--- a/backends/arm/test/passes/test_rewrite_mxfp_linear_pass.py
+++ b/backends/arm/test/passes/test_rewrite_mxfp_linear_pass.py
@@ -9,12 +9,15 @@ import executorch.backends.arm.tosa.dialect  # noqa: F401
 import torch
 from executorch.backends.arm._passes.rewrite_mxfp_linear import RewriteMXFPLinearPass
 from executorch.backends.arm.ao_ext import MXFPOpConfig, to_mxfp
+from executorch.backends.arm.ao_ext.mxfp import mxfp_dtype_to_str
+from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
 from executorch.backends.arm.tosa.specification import (
     TosaLoweringContext,
     TosaSpecification,
 )
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.export import export
+from torchao.prototype.mx_formats.mx_tensor import DTYPE_FP6_E2M3
 
 
 class _LinearModule(torch.nn.Module):
@@ -49,9 +52,11 @@ def _get_nodes_from_target(
     ]
 
 
-def test_rewrite_mxfp_linear_replaces_custom_op() -> None:
+def _rewrite_linear_module(
+    config: MXFPOpConfig,
+) -> tuple[torch.fx.GraphModule, list[torch.fx.Node], list[torch.fx.Node]]:
     model = _LinearModule(bias=True).eval()
-    to_mxfp(model, MXFPOpConfig(), filter_fn=_is_linear)
+    to_mxfp(model, config, filter_fn=_is_linear)
     exported = export(model, (torch.randn(4, 5, 32),), strict=False)
     tosa_spec = TosaSpecification.create_from_string("TOSA-1.1+FP+mxfp")
 
@@ -66,6 +71,11 @@ def test_rewrite_mxfp_linear_replaces_custom_op() -> None:
     matmul_nodes = _get_nodes_from_target(
         graph_module, exir_ops.backend.tosa.MATMUL_T_BLOCK_SCALED.default
     )
+    return graph_module, cast_nodes, matmul_nodes
+
+
+def test_rewrite_mxfp_linear_replaces_custom_op() -> None:
+    graph_module, cast_nodes, matmul_nodes = _rewrite_linear_module(MXFPOpConfig())
 
     assert (
         len(_get_nodes_from_target(graph_module, torch.ops.tosa_mxfp.linear.default))
@@ -86,6 +96,34 @@ def test_rewrite_mxfp_linear_replaces_custom_op() -> None:
 
     output_node = graph_module.graph.output_node()
     assert tuple(output_node.meta["val"][0].shape) == (4, 5, 8)
+
+
+def test_rewrite_mxfp6_linear_marks_payload_dtype() -> None:
+    graph_module, cast_nodes, matmul_nodes = _rewrite_linear_module(
+        MXFPOpConfig(weight_dtype=DTYPE_FP6_E2M3)
+    )
+    cast_node = cast_nodes[0]
+    matmul_node = matmul_nodes[0]
+    input_qdata_node = next(
+        node
+        for node in graph_module.graph.nodes
+        if node.op == "call_function"
+        and node.target == operator.getitem
+        and node.args[0] == cast_node
+        and node.args[1] == 0
+    )
+    weight_qdata_node = matmul_node.args[2]
+    assert isinstance(weight_qdata_node, torch.fx.Node)
+
+    assert cast_node.kwargs["output_dtype"] == mxfp_dtype_to_str(DTYPE_FP6_E2M3)
+    assert matmul_node.kwargs["payload_dtype"] == mxfp_dtype_to_str(DTYPE_FP6_E2M3)
+    assert tuple(cast_node.meta["val"][0].shape) == (1, 4 * 5, 32)
+    assert (
+        input_qdata_node.meta[TosaSpecialDtype.meta_key()] == TosaSpecialDtype.FP6E2M3
+    )
+    assert (
+        weight_qdata_node.meta[TosaSpecialDtype.meta_key()] == TosaSpecialDtype.FP6E2M3
+    )
 
 
 def test_rewrite_mxfp_dual_linear() -> None:

--- a/backends/arm/tosa/dialect/ops/cast_to_block_scaled.py
+++ b/backends/arm/tosa/dialect/ops/cast_to_block_scaled.py
@@ -62,12 +62,20 @@ def CAST_TO_BLOCK_SCALED(
         )
 
     scale_tensor_dtype = torch.float8_e8m0fnu
-    if output_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+    if output_dtype not in (
+        torch.float4_e2m1fn_x2,
+        torch.float8_e4m3fn,
+        torch.float8_e5m2,
+    ):
         raise TosaValueError(
             f"Unsupported block-scaled output dtype {output_dtype}",
             op="CAST_TO_BLOCK_SCALED",
         )
     scale_shape = (*input.shape[:-1], input.shape[-1] // block_size)
-    output_data = torch.empty_like(input, dtype=output_dtype)
+    if output_dtype == torch.float4_e2m1fn_x2:
+        output_shape = (*input.shape[:-1], input.shape[-1] // 2)
+        output_data = input.new_empty(output_shape, dtype=torch.uint8)
+    else:
+        output_data = torch.empty_like(input, dtype=output_dtype)
     output_scale = input.new_empty(scale_shape, dtype=scale_tensor_dtype)
     return output_data, output_scale

--- a/backends/arm/tosa/dialect/ops/cast_to_block_scaled.py
+++ b/backends/arm/tosa/dialect/ops/cast_to_block_scaled.py
@@ -5,24 +5,28 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import torch
 
+from executorch.backends.arm.ao_ext.mxfp import mxfp_str_to_dtype
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
 from executorch.backends.arm.tosa.specification import (
     get_context_spec,
     TosaSpecification,
 )
+from torchao.prototype.mx_formats.mx_tensor import DTYPE_FP6_E2M3, DTYPE_FP6_E3M2
 
 
 @register_fake_tosa_op(
-    "CAST_TO_BLOCK_SCALED(Tensor input, SymInt block_size, ScalarType output_dtype) -> (Tensor, Tensor)",
+    "CAST_TO_BLOCK_SCALED(Tensor input, SymInt block_size, str output_dtype) -> (Tensor, Tensor)",
     [TosaSpecification.create_from_string("TOSA-1.1+FP")],
 )
 def CAST_TO_BLOCK_SCALED(
     input: torch.Tensor,
     block_size: int,
-    output_dtype: torch.dtype,
+    output_dtype: str,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     tosa_spec = get_context_spec()
 
@@ -62,8 +66,11 @@ def CAST_TO_BLOCK_SCALED(
         )
 
     scale_tensor_dtype = torch.float8_e8m0fnu
-    if output_dtype not in (
+    elem_dtype = mxfp_str_to_dtype(output_dtype)
+    if elem_dtype not in (
         torch.float4_e2m1fn_x2,
+        DTYPE_FP6_E2M3,
+        DTYPE_FP6_E3M2,
         torch.float8_e4m3fn,
         torch.float8_e5m2,
     ):
@@ -72,10 +79,12 @@ def CAST_TO_BLOCK_SCALED(
             op="CAST_TO_BLOCK_SCALED",
         )
     scale_shape = (*input.shape[:-1], input.shape[-1] // block_size)
-    if output_dtype == torch.float4_e2m1fn_x2:
+    if elem_dtype == torch.float4_e2m1fn_x2:
         output_shape = (*input.shape[:-1], input.shape[-1] // 2)
         output_data = input.new_empty(output_shape, dtype=torch.uint8)
+    elif elem_dtype in (DTYPE_FP6_E2M3, DTYPE_FP6_E3M2):
+        output_data = input.new_empty(input.shape, dtype=torch.uint8)
     else:
-        output_data = torch.empty_like(input, dtype=output_dtype)
+        output_data = torch.empty_like(input, dtype=cast(torch.dtype, elem_dtype))
     output_scale = input.new_empty(scale_shape, dtype=scale_tensor_dtype)
     return output_data, output_scale

--- a/backends/arm/tosa/dialect/ops/matmul_t_block_scaled.py
+++ b/backends/arm/tosa/dialect/ops/matmul_t_block_scaled.py
@@ -7,6 +7,11 @@ from __future__ import annotations
 
 import torch
 
+from executorch.backends.arm.ao_ext.mxfp import (
+    mxfp_str_to_dtype,
+    MXFPDType,
+    SUPPORTED_MXFP_DTYPES,
+)
 from executorch.backends.arm.tosa.dialect.lib import TosaValueError
 from executorch.backends.arm.tosa.dialect.ops_registration import register_fake_tosa_op
 from executorch.backends.arm.tosa.specification import (
@@ -28,15 +33,20 @@ def _validate_block_size(block_size: int) -> None:
         )
 
 
-def _get_payload_dtype(data: torch.Tensor) -> torch.dtype:
+def _get_payload_dtype(
+    data: torch.Tensor,
+    payload_dtype: str = "",
+) -> MXFPDType:
+    if payload_dtype:
+        return mxfp_str_to_dtype(payload_dtype)
     if data.dtype == torch.uint8:
         return torch.float4_e2m1fn_x2
     return data.dtype
 
 
-def _get_logical_last_dim(data: torch.Tensor) -> int:
+def _get_logical_last_dim(data: torch.Tensor, payload_dtype: str = "") -> int:
     last_dim = data.shape[-1]
-    if _get_payload_dtype(data) == torch.float4_e2m1fn_x2:
+    if _get_payload_dtype(data, payload_dtype) == torch.float4_e2m1fn_x2:
         return last_dim * 2
     return last_dim
 
@@ -46,14 +56,11 @@ def _validate_dtypes(
     A_scale: torch.Tensor,
     B_data: torch.Tensor,
     B_scale: torch.Tensor,
+    payload_dtype: str = "",
 ) -> None:
-    A_dtype = _get_payload_dtype(A_data)
-    B_dtype = _get_payload_dtype(B_data)
-    if A_dtype not in (
-        torch.float4_e2m1fn_x2,
-        torch.float8_e4m3fn,
-        torch.float8_e5m2,
-    ):
+    A_dtype = _get_payload_dtype(A_data, payload_dtype)
+    B_dtype = _get_payload_dtype(B_data, payload_dtype)
+    if A_dtype not in SUPPORTED_MXFP_DTYPES:
         raise TosaValueError(
             f"Unsupported A_data dtype {A_data.dtype}",
             op="MATMUL_T_BLOCK_SCALED",
@@ -76,6 +83,7 @@ def _validate_shapes(
     B_data: torch.Tensor,
     B_scale: torch.Tensor,
     block_size: int,
+    payload_dtype: str = "",
 ) -> tuple[int, int, int]:
     if A_data.ndim != 3 or A_scale.ndim != 3 or B_data.ndim != 3 or B_scale.ndim != 3:
         raise TosaValueError(
@@ -85,8 +93,8 @@ def _validate_shapes(
 
     N, H = A_data.shape[:2]
     D, W = B_data.shape[:2]
-    C = _get_logical_last_dim(A_data)
-    Cb = _get_logical_last_dim(B_data)
+    C = _get_logical_last_dim(A_data, payload_dtype)
+    Cb = _get_logical_last_dim(B_data, payload_dtype)
     if C != Cb:
         raise TosaValueError(
             f"A_data last dim {C} must match B_data last dim {Cb}",
@@ -121,7 +129,8 @@ def _validate_shapes(
 
 
 @register_fake_tosa_op(
-    "MATMUL_T_BLOCK_SCALED(Tensor A_data, Tensor A_scale, Tensor B_data, Tensor B_scale, SymInt block_size) -> Tensor",
+    "MATMUL_T_BLOCK_SCALED(Tensor A_data, Tensor A_scale, Tensor B_data, "
+    "Tensor B_scale, SymInt block_size, str payload_dtype='') -> Tensor",
     [TosaSpecification.create_from_string("TOSA-1.1+FP")],
 )
 def MATMUL_T_BLOCK_SCALED(
@@ -130,6 +139,7 @@ def MATMUL_T_BLOCK_SCALED(
     B_data: torch.Tensor,
     B_scale: torch.Tensor,
     block_size: int,
+    payload_dtype: str = "",
 ) -> torch.Tensor:
     tosa_spec = get_context_spec()
 
@@ -140,12 +150,13 @@ def MATMUL_T_BLOCK_SCALED(
         )
 
     _validate_block_size(block_size)
-    _validate_dtypes(A_data, A_scale, B_data, B_scale)
+    _validate_dtypes(A_data, A_scale, B_data, B_scale, payload_dtype)
     output_shape = _validate_shapes(
         A_data,
         A_scale,
         B_data,
         B_scale,
         block_size,
+        payload_dtype,
     )
     return A_data.new_empty(output_shape, dtype=torch.float32)

--- a/backends/arm/tosa/dialect/ops/matmul_t_block_scaled.py
+++ b/backends/arm/tosa/dialect/ops/matmul_t_block_scaled.py
@@ -28,18 +28,37 @@ def _validate_block_size(block_size: int) -> None:
         )
 
 
+def _get_payload_dtype(data: torch.Tensor) -> torch.dtype:
+    if data.dtype == torch.uint8:
+        return torch.float4_e2m1fn_x2
+    return data.dtype
+
+
+def _get_logical_last_dim(data: torch.Tensor) -> int:
+    last_dim = data.shape[-1]
+    if _get_payload_dtype(data) == torch.float4_e2m1fn_x2:
+        return last_dim * 2
+    return last_dim
+
+
 def _validate_dtypes(
     A_data: torch.Tensor,
     A_scale: torch.Tensor,
     B_data: torch.Tensor,
     B_scale: torch.Tensor,
 ) -> None:
-    if A_data.dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+    A_dtype = _get_payload_dtype(A_data)
+    B_dtype = _get_payload_dtype(B_data)
+    if A_dtype not in (
+        torch.float4_e2m1fn_x2,
+        torch.float8_e4m3fn,
+        torch.float8_e5m2,
+    ):
         raise TosaValueError(
             f"Unsupported A_data dtype {A_data.dtype}",
             op="MATMUL_T_BLOCK_SCALED",
         )
-    if B_data.dtype != A_data.dtype:
+    if B_dtype != A_dtype:
         raise TosaValueError(
             f"B_data dtype {B_data.dtype} must match A_data dtype {A_data.dtype}",
             op="MATMUL_T_BLOCK_SCALED",
@@ -64,8 +83,10 @@ def _validate_shapes(
             op="MATMUL_T_BLOCK_SCALED",
         )
 
-    N, H, C = A_data.shape
-    D, W, Cb = B_data.shape
+    N, H = A_data.shape[:2]
+    D, W = B_data.shape[:2]
+    C = _get_logical_last_dim(A_data)
+    Cb = _get_logical_last_dim(B_data)
     if C != Cb:
         raise TosaValueError(
             f"A_data last dim {C} must match B_data last dim {Cb}",

--- a/backends/arm/tosa/mapping.py
+++ b/backends/arm/tosa/mapping.py
@@ -36,6 +36,8 @@ class TosaSpecialDtype(Enum):
     """Special TOSA dtypes not natively expressed in PyTorch."""
 
     FP4E2M1 = ts.DType.FP4E2M1
+    FP6E2M3 = ts.DType.FP6E2M3
+    FP6E3M2 = ts.DType.FP6E3M2
     INT48 = ts.DType.INT48
     INT4 = ts.DType.INT4
     SHAPE = ts.DType.SHAPE
@@ -254,6 +256,12 @@ class TosaArg:
                 ):
                     return False
             case ts.DType.FP4E2M1:
+                if not tosa_spec.support_extension("mxfp"):
+                    return False
+            case ts.DType.FP6E2M3:
+                if not tosa_spec.support_extension("mxfp"):
+                    return False
+            case ts.DType.FP6E3M2:
                 if not tosa_spec.support_extension("mxfp"):
                     return False
 

--- a/backends/arm/tosa/mapping.py
+++ b/backends/arm/tosa/mapping.py
@@ -35,6 +35,7 @@ UNSUPPORTED_DTYPES = (
 class TosaSpecialDtype(Enum):
     """Special TOSA dtypes not natively expressed in PyTorch."""
 
+    FP4E2M1 = ts.DType.FP4E2M1
     INT48 = ts.DType.INT48
     INT4 = ts.DType.INT4
     SHAPE = ts.DType.SHAPE
@@ -102,6 +103,7 @@ def map_dtype(data_type: torch.dtype) -> Any:
         torch.float8_e4m3fn: ts.DType.FP8E4M3,
         torch.float8_e5m2: ts.DType.FP8E5M2,
         torch.float8_e8m0fnu: ts.DType.FP8UE8M0,
+        torch.float4_e2m1fn_x2: ts.DType.FP4E2M1,
         torch.int8: ts.DType.INT8,
         # TOSA uses signless int8; unsigned semantics are expressed via RESCALE.
         torch.uint8: ts.DType.INT8,
@@ -156,8 +158,10 @@ def extract_tensor_meta(meta):
         raise ValueError(
             f"Expected first value in node.meta['val'] to be FakeTensor, got {val.__class__}"
         )
-    dtype = map_dtype(val.dtype)
     shape = tuple(val.size())
+    if special_dtype == TosaSpecialDtype.FP4E2M1 and val.dtype == torch.uint8:
+        shape = (*shape[:-1], shape[-1] * 2)
+    dtype = map_dtype(val.dtype)
 
     return (dtype, shape)
 
@@ -248,6 +252,9 @@ class TosaArg:
                     tosa_spec.support_extension("fp8e5m2")
                     or tosa_spec.support_extension("mxfp")
                 ):
+                    return False
+            case ts.DType.FP4E2M1:
+                if not tosa_spec.support_extension("mxfp"):
                     return False
 
         return True

--- a/backends/arm/tosa/utils.py
+++ b/backends/arm/tosa/utils.py
@@ -164,6 +164,10 @@ def build_reshape_tosa(
 def normalize_symint(shape):
     """Dynamic shapes in executorch are represented with torch.SymInt objects in
     the shapes, in TOSA we do not have this concept and instead use -1.
+
+    This function replaces each symbolic dimension with -1. Static dimensions
+    are preserved unchanged.
+
     """
     removed_symints = tuple([-1 if isinstance(d, torch.SymInt) else d for d in shape])
     return list(removed_symints)


### PR DESCRIPTION
Add support for running `torch.nn.Linear` modules in MXFP4E2M1,
MXFP6E3M2 and MXFP6E2M3. Update the `MXFPOpConfig` to support
the data types.
    
Since `torch` lacks FP6 datatypes, the string-based definitions in
`torchao` are used as a workaround.
    
The custom TOSA op receives a new argument called
`str weight_payload_dtype` which tells which dtype is used for the
weights. The weight tensor itself does not contain this info since the
FP4 and FP6 formats are storted into uint8 tensors.
    
The CAST_TO_BLOCK_SCALED required to transform activations from/to MXFP
is also updated to support the new datatype. Its custom TOSA op gets a
`str output_dtype` similar to the `weight_payload_dtype` for the MXFP
linear op.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani