### PR TITLE
[cadence] Run cadence CI on PR: pull_request (same-repo) + pull_request_target (fork exports)

### DIFF
--- a/.github/workflows/build-cadence-runner.yml
+++ b/.github/workflows/build-cadence-runner.yml
@@ -19,36 +19,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  gate:
-    runs-on: ubuntu-latest
-    outputs:
-      run-cadence: ${{ steps.decide.outputs.run }}
-    steps:
-      - id: decide
-        env:
-          EVENT: ${{ github.event_name }}
-          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-          HAS_CLA: ${{ contains(github.event.pull_request.labels.*.name, 'CLA Signed') }}
-          HAS_EXPORT: ${{ contains(github.event.pull_request.labels.*.name, 'meta-exported') }}
-        run: |
-          run=false
-          case "${EVENT}" in
-            push|schedule|workflow_dispatch)
-              run=true
-              ;;
-            pull_request)
-              [ "${IS_FORK}" = "false" ] && run=true
-              ;;
-            pull_request_target)
-              if [ "${IS_FORK}" = "true" ] && [ "${HAS_CLA}" = "true" ] && [ "${HAS_EXPORT}" = "true" ]; then
-                run=true
-              fi
-              ;;
-          esac
-          echo "run=${run}" >> "${GITHUB_OUTPUT}"
-
+  # Same-repo PRs run on pull_request, which reads the PR's own workflow AND code
+  # -- so CI changes, new test jobs, code, and tests are all validated pre-merge.
+  # Fork PRs can't get credentials (OIDC) on pull_request, so Meta-exported forks
+  # (labeled CLA Signed + meta-exported) run on pull_request_target instead. The
+  # run condition is inlined per job (GitHub Actions has no YAML anchors and env
+  # is unavailable in job-level if), so keep the copies in sync.
   cpu-build:
-    if: github.event_name != 'pull_request_target'
+    if: >-
+      github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'CLA Signed') && contains(github.event.pull_request.labels.*.name, 'meta-exported'))
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
       id-token: write
@@ -58,7 +40,7 @@ jobs:
       runner: linux.2xlarge
       docker-image: ci-image:executorch-ubuntu-22.04-clang12
       submodules: recursive
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.sha || github.sha }}
       timeout: 90
       upload-artifact: cadence-runner-build
       script: |
@@ -75,21 +57,28 @@ jobs:
 
   cpu-test:
     needs: cpu-build
-    if: github.event_name != 'pull_request_target'
+    if: >-
+      github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'CLA Signed') && contains(github.event.pull_request.labels.*.name, 'meta-exported'))
     permissions:
       id-token: write
       contents: read
     uses: ./.github/workflows/_test_cadence.yml
     with:
-      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.sha || github.sha }}
 
   # Cross-compile cadence_executor_runner for each Cadence Xtensa core, one job
   # per backend so they show as separate lines (no matrix grouping). Shared logic
   # lives in _xtensa_build.yml. fusion_g3 is omitted until the upstream fusion_g3
   # <-> nnlib-FusionG3 API skew is fixed (its runner does not link).
   hifi-build:
-    needs: gate
-    if: needs.gate.outputs.run-cadence == 'true'
+    if: >-
+      github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'CLA Signed') && contains(github.event.pull_request.labels.*.name, 'meta-exported'))
     permissions:
       id-token: write
       contents: read
@@ -99,8 +88,11 @@ jobs:
       ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.sha || github.sha }}
 
   vision-build:
-    needs: gate
-    if: needs.gate.outputs.run-cadence == 'true'
+    if: >-
+      github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'CLA Signed') && contains(github.event.pull_request.labels.*.name, 'meta-exported'))
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary

Run the cadence CI (`cpu-build`, `cpu-test`, `hifi-build`, `vision-build`) so the signal is tied to the PR and CI changes are testable pre-merge:

- **Same-repo PRs → `pull_request`.** This reads the PR's *own* workflow and code, so a PR that adds/edits a test job, changes build scripts, or fixes a bug is fully validated **before merge** (one clean graph, all four jobs, credentialed).
- **Meta-exported fork PRs → `pull_request_target`** (gated on `CLA Signed` + `meta-exported`). Forks can't get OIDC on `pull_request`, so the credentialed builds run here.

Drops the `gate` job and the `export-checks` mirror (the mirror produced orphaned checks; native `pull_request_target` checks are already tied to the PR head).

Run condition is inlined per job: `push`/`schedule`/`workflow_dispatch`, or same-repo `pull_request`, or a fork `pull_request_target` labeled `CLA Signed` + `meta-exported`.

## Notes
- On a **fork export** PR you'll see the four jobs skipped on the `pull_request` run plus the real results on the `pull_request_target` run (dual-event). Same-repo PRs are a single clean graph.
- `pull_request_target` always uses `main`'s copy of the workflow, so the fork path is only observable after landing; the same-repo `pull_request` path is testable pre-merge.

Authored with Claude Code.