### PR TITLE
drop redundant TARGETS files that duplicate sister BUCK files (#20403)

### DIFF
--- a/backends/qualcomm/aot/wrappers/TARGETS
+++ b/backends/qualcomm/aot/wrappers/TARGETS
@@ -1,5 +1,0 @@
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/backends/qualcomm/builders/TARGETS
+++ b/backends/qualcomm/builders/TARGETS
@@ -1,5 +1,0 @@
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/codegen/test/TARGETS
+++ b/codegen/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain xplat-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/configurations/TARGETS
+++ b/configurations/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/examples/devtools/example_runner/TARGETS
+++ b/examples/devtools/example_runner/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/examples/models/gemma4/BUCK
+++ b/examples/models/gemma4/BUCK
@@ -1,4 +1,5 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load(":targets.bzl", "define_common_targets")
 
 oncall("executorch")
@@ -6,3 +7,122 @@ oncall("executorch")
 non_fbcode_target(_kind = define_common_targets,)
 
 fbcode_target(_kind = define_common_targets,)
+
+# Text decoder module
+fbcode_target(_kind = runtime.python_library,
+    name = "text_decoder",
+    srcs = [
+        "text_decoder/__init__.py",
+        "text_decoder/convert_weights.py",
+        "text_decoder/gemma4_attention.py",
+        "text_decoder/gemma4_config.py",
+        "text_decoder/gemma4_cross_decoder.py",
+        "text_decoder/gemma4_decoder_layer.py",
+        "text_decoder/gemma4_model.py",
+        "text_decoder/gemma4_self_decoder.py",
+        "text_decoder/gemma4_transformer.py",
+    ],
+    _is_external_target = True,
+    base_module = "executorch.examples.models.gemma4",
+    resources = {
+        "config/e2b_config.json": "config/e2b_config.json",
+        "config/e4b_config.json": "config/e4b_config.json",
+    },
+    deps = [
+        "//caffe2:torch",
+        "fbsource//third-party/pypi/safetensors:safetensors",
+        "fbsource//third-party/pypi/transformers:transformers",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+# Speech transform module
+fbcode_target(_kind = runtime.python_library,
+    name = "speech_transform",
+    srcs = [
+        "speech_transform.py",
+    ],
+    _is_external_target = True,
+    base_module = "executorch.examples.models.gemma4",
+    deps = [
+        "//caffe2:torch",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+# Export utilities (shared quantization code)
+fbcode_target(_kind = runtime.python_library,
+    name = "quant_utils",
+    srcs = ["quant_utils.py"],
+    _is_external_target = True,
+    base_module = "executorch.examples.models.gemma4",
+    deps = [
+        "//caffe2:torch",
+        "//executorch/examples/models/llama:source_transformation",
+        "//executorch/extension/llm/export:export_lib",
+        "//pytorch/ao:torchao",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+# Single PTE export
+fbcode_target(_kind = runtime.python_binary,
+    name = "export_gemma4",
+    srcs = ["export_gemma4.py"],
+    main_function = "executorch.examples.models.gemma4.export_gemma4.main",
+    preload_deps = [
+        "//pytorch/ao/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight:op_linear_8bit_act_xbit_weight_aten",
+        "//pytorch/ao/torchao/csrc/cpu/shared_kernels/embedding_xbit:op_embedding_xbit_aten",
+        "//executorch/extension/llm/custom_ops:custom_ops_aot_lib",
+        "//executorch/kernels/quantized:aot_lib",
+    ],
+    deps = [
+        ":text_decoder",
+        ":speech_transform",
+        ":quant_utils",
+        "//caffe2:torch",
+        "//executorch/exir:lib",
+        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
+        "//executorch/backends/xnnpack/quantizer:xnnpack_quantizer",
+        "//executorch/extension/llm/export:export_lib",
+        "//executorch/extension/llm/custom_ops:custom_ops_aot_lib",
+        "//executorch/extension/llm/custom_ops:custom_ops_aot_py",
+        "//executorch/kernels/quantized:aot_lib",
+        "//pytorch/ao:torchao",
+        "fbsource//third-party/pypi/safetensors:safetensors",
+        "fbsource//third-party/pypi/transformers:transformers",
+    ],
+)
+
+# Image preprocessing utilities
+fbcode_target(_kind = runtime.python_library,
+    name = "image_utils",
+    srcs = ["image_utils.py"],
+    _is_external_target = True,
+    base_module = "executorch.examples.models.gemma4",
+    deps = [
+        "//caffe2:torch",
+        "fbsource//third-party/pypi/pillow:pillow",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+# Python runner (single PTE, audio + vision + text-only)
+fbcode_target(_kind = runtime.python_binary,
+    name = "run_gemma4",
+    srcs = ["run_gemma4.py"],
+    main_function = "executorch.examples.models.gemma4.run_gemma4.main",
+    preload_deps = [
+        "//executorch/backends/xnnpack:xnnpack_backend",
+        "//executorch/extension/llm/custom_ops:custom_ops_aot_lib",
+        "//executorch/kernels/quantized:aot_lib",
+        "//pytorch/ao/torchao/csrc/cpu/shared_kernels/embedding_xbit:op_embedding_xbit_aten",
+        "//pytorch/ao/torchao/csrc/cpu/shared_kernels/linear_8bit_act_xbit_weight:op_linear_8bit_act_xbit_weight_aten",
+    ],
+    deps = [
+        ":image_utils",
+        "//caffe2:torch",
+        "//executorch/runtime:runtime",
+        "fbsource//third-party/pypi/sentencepiece:sentencepiece",
+    ],
+)

--- a/examples/qualcomm/executor_runner/TARGETS
+++ b/examples/qualcomm/executor_runner/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain xplat-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/aten_util/TARGETS
+++ b/extension/aten_util/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/aten_util/test/TARGETS
+++ b/extension/aten_util/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/cuda/TARGETS
+++ b/extension/cuda/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/image/TARGETS
+++ b/extension/image/TARGETS
@@ -1,5 +1,0 @@
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/image/benchmark/TARGETS
+++ b/extension/image/benchmark/TARGETS
@@ -1,5 +1,0 @@
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/image/test/TARGETS
+++ b/extension/image/test/TARGETS
@@ -1,5 +1,0 @@
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/pytree/aten_util/TARGETS
+++ b/extension/pytree/aten_util/TARGETS
@@ -1,7 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/pytree/aten_util/test/TARGETS
+++ b/extension/pytree/aten_util/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/runner_util/TARGETS
+++ b/extension/runner_util/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain xplat-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/tensor/TARGETS
+++ b/extension/tensor/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/tensor/test/TARGETS
+++ b/extension/tensor/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/testing_util/TARGETS
+++ b/extension/testing_util/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/testing_util/test/TARGETS
+++ b/extension/testing_util/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/threadpool/TARGETS
+++ b/extension/threadpool/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/extension/threadpool/test/TARGETS
+++ b/extension/threadpool/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/kernels/optimized/cpu/TARGETS
+++ b/kernels/optimized/cpu/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/kernels/optimized/test/TARGETS
+++ b/kernels/optimized/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/kernels/portable/cpu/util/TARGETS
+++ b/kernels/portable/cpu/util/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/kernels/portable/cpu/util/test/TARGETS
+++ b/kernels/portable/cpu/util/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/kernels/prim_ops/TARGETS
+++ b/kernels/prim_ops/TARGETS
@@ -1,7 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/runtime/backend/TARGETS
+++ b/runtime/backend/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/runtime/backend/test/TARGETS
+++ b/runtime/backend/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/runtime/core/TARGETS
+++ b/runtime/core/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/runtime/core/exec_aten/TARGETS
+++ b/runtime/core/exec_aten/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/runtime/core/exec_aten/testing_util/TARGETS
+++ b/runtime/core/exec_aten/testing_util/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/runtime/core/exec_aten/testing_util/test/TARGETS
+++ b/runtime/core/exec_aten/testing_util/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/runtime/core/exec_aten/util/TARGETS
+++ b/runtime/core/exec_aten/util/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/runtime/platform/TARGETS
+++ b/runtime/platform/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/runtime/platform/test/TARGETS
+++ b/runtime/platform/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/schema/TARGETS
+++ b/schema/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/schema/test/TARGETS
+++ b/schema/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()

--- a/test/TARGETS
+++ b/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets()


### PR DESCRIPTION
Summary:

Initial chunk of fbcode/executorch TARGETS->BUCK migration. Removes 40
TARGETS files where:

  - 7 are byte-identical to their sister BUCK file, OR
  - 33 contain only a no-arg `define_common_targets()` call matching
    a sister BUCK that also calls `define_common_targets()` with no args

In both cases fbcode falls through to the BUCK file (via
`name_v2 = TARGETS,BUCK`) and evaluates the exact same content it did
before. Any TARGETS that passes any argument to define_common_targets
(positional or keyword) is intentionally excluded — those are the
`is_fbcode = True` cases that need a separate, more careful treatment.

Reviewed By: mzlee

Differential Revision: D109082060
