### PR TITLE
migrate is_fbcode-flagged TARGETS files to BUCK with runtime detection (#20404)

### DIFF
--- a/backends/vulkan/test/custom_ops/BUCK
+++ b/backends/vulkan/test/custom_ops/BUCK
@@ -1,8 +1,9 @@
 # Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain xplat-only targets.
+# targets.bzl.
 
+load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_fbcode")
 load(":targets.bzl", "define_common_targets")
 
 oncall("executorch")
 
-define_common_targets()
+define_common_targets(is_fbcode = is_fbcode())

--- a/backends/vulkan/test/custom_ops/TARGETS
+++ b/backends/vulkan/test/custom_ops/TARGETS
@@ -1,5 +1,0 @@
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets(is_fbcode = True)

--- a/backends/vulkan/test/op_tests/BUCK
+++ b/backends/vulkan/test/op_tests/BUCK
@@ -1,8 +1,9 @@
 # Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain xplat-only targets.
+# targets.bzl.
 
+load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_fbcode")
 load(":targets.bzl", "define_common_targets")
 
 oncall("executorch")
 
-define_common_targets()
+define_common_targets(is_fbcode = is_fbcode())

--- a/backends/vulkan/test/op_tests/TARGETS
+++ b/backends/vulkan/test/op_tests/TARGETS
@@ -1,5 +1,0 @@
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets(is_fbcode = True)

--- a/codegen/tools/BUCK
+++ b/codegen/tools/BUCK
@@ -1,8 +1,9 @@
 # Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain xplat-only targets.
+# targets.bzl.
 
+load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_fbcode")
 load(":targets.bzl", "define_common_targets")
 
 oncall("executorch")
 
-define_common_targets()
+define_common_targets(is_fbcode = is_fbcode())

--- a/codegen/tools/TARGETS
+++ b/codegen/tools/TARGETS
@@ -1,5 +1,0 @@
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets(is_fbcode = True)

--- a/extension/runner_util/test/BUCK
+++ b/extension/runner_util/test/BUCK
@@ -1,8 +1,9 @@
 # Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain xplat-only targets.
+# targets.bzl.
 
+load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_fbcode")
 load(":targets.bzl", "define_common_targets")
 
 oncall("executorch")
 
-define_common_targets()
+define_common_targets(is_fbcode = is_fbcode())

--- a/extension/runner_util/test/TARGETS
+++ b/extension/runner_util/test/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain xplat-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets(is_fbcode = True)

--- a/kernels/optimized/BUCK
+++ b/kernels/optimized/BUCK
@@ -1,8 +1,9 @@
 # Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain xplat-only targets.
+# targets.bzl.
 
+load("@fbsource//tools/build_defs:fbsource_utils.bzl", "is_fbcode")
 load(":targets.bzl", "define_common_targets")
 
 oncall("executorch")
 
-define_common_targets()
+define_common_targets(is_fbcode = is_fbcode())

--- a/kernels/optimized/TARGETS
+++ b/kernels/optimized/TARGETS
@@ -1,8 +1,0 @@
-# Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain fbcode-only targets.
-
-load(":targets.bzl", "define_common_targets")
-
-oncall("executorch")
-
-define_common_targets(True)


### PR DESCRIPTION
Summary:

Chunk 2 of fbcode/executorch TARGETS->BUCK migration. 5 directories where
TARGETS called `define_common_targets(is_fbcode = True)` and the sister
BUCK called `define_common_targets()`. The shared targets.bzl actually
branches on is_fbcode, so the flag must be preserved.

Replaces the BUCK call with `define_common_targets(is_fbcode = is_fbcode())`
using `fbsource_utils.is_fbcode()` for runtime cell detection, then deletes
TARGETS. fbcode falls through to BUCK and gets the True branch as before;
xplat keeps getting the False branch.

Directories migrated:
  - backends/vulkan/test/custom_ops
  - backends/vulkan/test/op_tests
  - codegen/tools
  - extension/runner_util/test
  - kernels/optimized

Reviewed By: ndmitchell, mzlee

Differential Revision: D109082061
