### PR TITLE
Handle scalar tensor shape formatting

### DIFF
--- a/runtime/core/exec_aten/util/tensor_shape_to_c_string.cpp
+++ b/runtime/core/exec_aten/util/tensor_shape_to_c_string.cpp
@@ -28,6 +28,10 @@ std::array<char, kTensorShapeStringSizeLimit> tensor_shape_to_c_string_impl(
     std::strcpy(p, kLimitExceededError);
     return out;
   }
+  if (shape.empty()) {
+    std::strcpy(p, "()");
+    return out;
+  }
   *p++ = '(';
   for (const auto elem : shape) {
     if (elem < 0 ||

--- a/runtime/core/exec_aten/util/test/tensor_shape_to_c_string_test.cpp
+++ b/runtime/core/exec_aten/util/test/tensor_shape_to_c_string_test.cpp
@@ -17,6 +17,12 @@ using executorch::runtime::Span;
 using executorch::runtime::tensor_shape_to_c_string;
 using executorch::runtime::internal::kMaximumPrintableTensorShapeElement;
 
+TEST(TensorShapeToCStringTest, ScalarShape) {
+  Span<const executorch::aten::SizesType> scalar_shape;
+  auto str = tensor_shape_to_c_string(scalar_shape);
+  EXPECT_STREQ(str.data(), "()");
+}
+
 TEST(TensorShapeToCStringTest, Basic) {
   std::array<executorch::aten::SizesType, 3> sizes = {123, 456, 789};
   auto str = tensor_shape_to_c_string(
@@ -27,6 +33,24 @@ TEST(TensorShapeToCStringTest, Basic) {
   str = tensor_shape_to_c_string(Span<const executorch::aten::SizesType>(
       one_size.data(), one_size.size()));
   EXPECT_STREQ(str.data(), "(1234567890)");
+}
+
+TEST(TensorShapeToCStringTest, RankOneShape) {
+  std::array<executorch::aten::SizesType, 1> sizes = {3};
+  auto str = tensor_shape_to_c_string(
+      Span<const executorch::aten::SizesType>(sizes.data(), sizes.size()));
+  EXPECT_STREQ(str.data(), "(3)");
+}
+
+TEST(TensorShapeToCStringTest, InvalidNegativeDimension) {
+  std::array<executorch::aten::SizesType, 1> sizes = {-3};
+  auto str = tensor_shape_to_c_string(
+      Span<const executorch::aten::SizesType>(sizes.data(), sizes.size()));
+  if constexpr (std::numeric_limits<executorch::aten::SizesType>::is_signed) {
+    EXPECT_STREQ(str.data(), "(ERR)");
+  } else {
+    EXPECT_EQ(str.data(), "(" + std::to_string(sizes[0]) + ")");
+  }
 }
 
 TEST(TensorShapeToCStringTest, NegativeItems) {
@@ -76,6 +100,23 @@ TEST(TensorShapeToCStringTest, MaximumLength) {
   auto expected_str = expected.str();
 
   EXPECT_EQ(expected_str, str.data());
+}
+
+TEST(TensorShapeToCStringTest, NearDimensionLimit) {
+  std::array<executorch::aten::SizesType, kTensorDimensionLimit - 1> sizes;
+  std::fill(sizes.begin(), sizes.end(), 3);
+
+  auto str = tensor_shape_to_c_string(
+      Span<const executorch::aten::SizesType>(sizes.data(), sizes.size()));
+
+  std::ostringstream expected;
+  expected << '(' << sizes[0];
+  for (size_t ii = 1; ii < sizes.size(); ++ii) {
+    expected << ", " << sizes[ii];
+  }
+  expected << ')';
+
+  EXPECT_EQ(expected.str(), str.data());
 }
 
 TEST(TensorShapeToCStringTest, ExceedsDimensionLimit) {


### PR DESCRIPTION
## Summary

Fixes scalar tensor shape formatting in `tensor_shape_to_c_string_impl()`.

The helper used to write an opening parenthesis, skip the dimension loop for scalar shapes, then patch `p - 2` and `p - 1`. For an empty shape, `p - 2` points before the output buffer. Scalar shapes now return `"()"` before entering the trailing-comma rewrite path.

Also adds tests for:
- scalar shape `{}`
- rank-1 shape `{3}`
- negative dimensions preserving the existing `ERR` formatting
- a shape near `kTensorDimensionLimit`

## Test Plan

- `git diff --check -- runtime/core/exec_aten/util/tensor_shape_to_c_string.cpp runtime/core/exec_aten/util/test/tensor_shape_to_c_string_test.cpp`
- direct `c++` smoke test against `tensor_shape_to_c_string.cpp` covering scalar, rank-1, negative, and near-limit shapes

I also attempted the CMake/gtest path, but a fresh root configure entered the broader project codegen flow and did not complete promptly in this local checkout.

cc @larryliu0820 @JacobSzwejbka @lucylq