### PR TITLE
NXP backend: Remove broadcasting restrictions

### DIFF
--- a/backends/nxp/backend/ir/converter/node_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converter.py
@@ -437,11 +437,3 @@ class NodeConverter(ABC):
             input_tensor.meta["val"].shape == output_shape
             for input_tensor in node.all_input_nodes
         )
-
-    @staticmethod
-    def _node_inputs_ranks_not_equal(node) -> bool:
-        first_input_shape = node.all_input_nodes[0].meta["val"].shape
-        return not all(
-            len(input_node.meta["val"].shape) == len(first_input_shape)
-            for input_node in node.all_input_nodes[1:]
-        )

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/add_tensor_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/add_tensor_converter.py
@@ -5,7 +5,7 @@
 
 import torch
 
-from executorch.backends.nxp.backend.data_format import NXP_NODE_FORMAT
+from executorch.backends.nxp.backend.ir.converter.conversion.common import OpsList
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
     NodeConverter,
@@ -27,14 +27,6 @@ class AddTensorConverter(NodeConverter):
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
         if not NodeConverter.at_least_one_input_shape_matches_the_output_shape(node):
-            return False
-
-        # If one input is in channel first and ranks of input tensors are not equal, we need to add Transposes
-        # Transpose is currently not supported for new flow
-        if any(
-            input_node.meta[NXP_NODE_FORMAT].is_channels_first()
-            for input_node in node.all_input_nodes
-        ) and NodeConverter._node_inputs_ranks_not_equal(node):
             return False
 
         supported_types = [torch.int8, torch.uint8]
@@ -68,4 +60,7 @@ class AddTensorConverter(NodeConverter):
         t_op = self._create_tflite_op_with_io_tensors(node)
         t_op.builtin_options = add_options.Add()
 
-        self.builder.append_operators([t_op])
+        ops = OpsList(middle_op=t_op)
+        # Create additional ops in case of shape broadcasting
+        ops.add_pre(self.builder.ensure_correct_broadcasting(t_op, t_op.tmp_outputs[0]))
+        self.builder.append_operators(ops.flatten())

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/mul_tensor_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/mul_tensor_converter.py
@@ -4,7 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from executorch.backends.nxp.backend.data_format import NXP_NODE_FORMAT
+
+from executorch.backends.nxp.backend.ir.converter.conversion.common import OpsList
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
     NodeConverter,
@@ -26,14 +27,6 @@ class MulTensorConverter(NodeConverter):
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
         if not NodeConverter.at_least_one_input_shape_matches_the_output_shape(node):
-            return False
-
-        # If one input is in channel first and ranks of input tensors are not equal, we need to add Transposes
-        # Transpose is currently not supported for new flow
-        if any(
-            input_node.meta[NXP_NODE_FORMAT].is_channels_first()
-            for input_node in node.all_input_nodes
-        ) and NodeConverter._node_inputs_ranks_not_equal(node):
             return False
 
         supported_types = [torch.int8, torch.uint8]
@@ -64,4 +57,7 @@ class MulTensorConverter(NodeConverter):
         t_op = self._create_tflite_op_with_io_tensors(node)
         t_op.builtin_options = mul_options.Mul()
 
-        self.builder.append_operators([t_op])
+        ops = OpsList(middle_op=t_op)
+        # Create additional ops in case of shape broadcasting
+        ops.add_pre(self.builder.ensure_correct_broadcasting(t_op, t_op.tmp_outputs[0]))
+        self.builder.append_operators(ops.flatten())

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/sub_tensor_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/sub_tensor_converter.py
@@ -5,7 +5,7 @@
 
 import torch
 
-from executorch.backends.nxp.backend.data_format import NXP_NODE_FORMAT
+from executorch.backends.nxp.backend.ir.converter.conversion.common import OpsList
 from executorch.backends.nxp.backend.ir.converter.node_converter import (
     CustomDelegationOptions,
     NodeConverter,
@@ -27,14 +27,6 @@ class SubTensorConverter(NodeConverter):
         custom_delegation_options: CustomDelegationOptions,
     ) -> bool:
         if not NodeConverter.at_least_one_input_shape_matches_the_output_shape(node):
-            return False
-
-        # If one input is in channel first and ranks of input tensors are not equal, we need to add Transposes
-        # Transpose is currently not supported for new flow
-        if any(
-            input_node.meta[NXP_NODE_FORMAT].is_channels_first()
-            for input_node in node.all_input_nodes
-        ) and NodeConverter._node_inputs_ranks_not_equal(node):
             return False
 
         supported_types = [torch.int8, torch.uint8]
@@ -72,4 +64,8 @@ class SubTensorConverter(NodeConverter):
         t_op = self._create_tflite_op_with_io_tensors(node)
 
         t_op.builtin_options = sub_options.Sub()
-        self.builder.append_operators([t_op])
+
+        ops = OpsList(middle_op=t_op)
+        # Create additional ops in case of shape broadcasting
+        ops.add_pre(self.builder.ensure_correct_broadcasting(t_op, t_op.tmp_outputs[0]))
+        self.builder.append_operators(ops.flatten())

--- a/backends/nxp/quantizer/patterns.py
+++ b/backends/nxp/quantizer/patterns.py
@@ -917,7 +917,6 @@ class MulTensorPattern(QuantizationPattern):
         self, gm: fx.GraphModule, fused_partition: list[fx.GraphModule]
     ) -> PartitionAnchors | None:
         node = fused_partition[0].nodes[-1]
-        input_nodes = node.all_input_nodes
 
         qspec = FixedQParamsQuantizationSpec(
             dtype=torch.int8,
@@ -927,15 +926,6 @@ class MulTensorPattern(QuantizationPattern):
             quant_max=127,
             qscheme=torch.per_tensor_affine,
         )
-
-        # The "Mul" operator in Neutron IR requires a specific scale and zero_point
-        # (defined above) for its inputs.
-        # Since these input nodes have already been annotated by their own patterns
-        # which didn't take the requirements of "Mul" into account, we need to overwrite
-        # the existing "quantization_annotation".
-        for input_node in input_nodes:
-            if "quantization_annotation" in input_node.meta:
-                input_node.meta["quantization_annotation"].output_qspec = qspec
 
         return PartitionAnchors(
             inputs=[(node, NodeArgsIdx(0), qspec), (node, NodeArgsIdx(1), qspec)],

--- a/backends/nxp/tests/ir/converter/node_converter/test_add_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_add_tensor_converter.py
@@ -19,12 +19,13 @@ from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
-from executorch.backends.nxp.tests.models import AddTensorConvModule, AddTensorModule
+from executorch.backends.nxp.tests.models import AddTensorModule, MaxPoolAddTensorModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 from executorch.backends.nxp.tests.ops_aliases import (
     AddTensor,
-    Convolution,
     ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
 )
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
@@ -104,6 +105,10 @@ class TestAddTensor:
             pytest.param(
                 [ModelInputSpec((4,)), ModelInputSpec((4, 4))], id="2 inputs 1D + 2D."
             ),
+            pytest.param(
+                [ModelInputSpec((1, 4, 8, 8)), ModelInputSpec((8, 8))],
+                id="2 inputs 4D + 2D.",
+            ),
         ],
     )
     def test__broadcast(self, mocker, request, input_spec):
@@ -153,30 +158,27 @@ class TestAddTensor:
         assert graph_contains_any_of_ops(delegated_ep.graph, [AddTensor])
 
     @pytest.mark.parametrize(
-        "x_input_shape",
+        "input_spec",
         [
             pytest.param(
-                (1, 4, 5, 5), id="4D, product of dims is not a multiple of 8."
+                ModelInputSpec((1, 4, 5, 5)),
+                id="4D, product of dims is not a multiple of 8.",
             ),
         ],
     )
-    def test__w_conv(self, mocker, request, x_input_shape):
-        model = AddTensorConvModule()
-
-        n, c, h, w = x_input_shape
-        y_input_spec = ModelInputSpec((n, 8, h, w))
-        x_input_spec = ModelInputSpec(x_input_shape)
+    def test__channels_first_input(self, mocker, request, input_spec):
+        model = MaxPoolAddTensorModule()
 
         graph_verifier = DetailedGraphVerifier(
             mocker,
-            expected_delegated_ops={AddTensor: 1, Convolution: 1},
+            expected_delegated_ops={AddTensor: 1, MaxPool2DWithIndices: 1, GetItem: 1},
             expected_non_delegated_ops={},
         )
         dataset_creator = RandomDatasetCreator(low=-1.0, high=1.0)
 
         lower_run_compare(
             model,
-            [x_input_spec, y_input_spec],
+            [input_spec, input_spec],
             graph_verifier,
             request,
             dataset_creator,
@@ -186,21 +188,45 @@ class TestAddTensor:
         "input_spec",
         [
             pytest.param(
-                [ModelInputSpec((1, 4, 5, 5)), ModelInputSpec((1, 8, 5, 1))],
+                [ModelInputSpec((1, 8, 5, 5)), ModelInputSpec((1, 8, 5, 1))],
                 id="2 inputs 4D + 4D.",
             ),
             pytest.param(
-                [ModelInputSpec((1, 4, 1, 67)), ModelInputSpec((1, 8, 5, 67))],
+                [ModelInputSpec((1, 8, 1, 67)), ModelInputSpec((1, 8, 5, 67))],
                 id="2 inputs 4D + 4D same width.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 5, 5)), ModelInputSpec((1, 1))],
+                id="2 inputs 4D + 2D ones tensor.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 8, 8)), ModelInputSpec((8, 8))],
+                id="2 inputs 4D + 2D both dims 8.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 5, 5)), ModelInputSpec((1, 5))],
+                id="2 inputs 4D + 2D one dim 5.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 12, 10)), ModelInputSpec((8, 1, 10))],
+                id="2 inputs 4D + 3D channels dim 1.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 4, 10)), ModelInputSpec((1, 4, 1))],
+                id="2 inputs 4D + 3D channels dim 4.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 25, 18)), ModelInputSpec((4, 1, 8, 25, 18))],
+                id="2 inputs 4D + 5D.",
             ),
         ],
     )
-    def test__w_conv_broadcast(self, mocker, request, input_spec):
-        model = AddTensorConvModule()
+    def test__broadcast__channels_first_input(self, mocker, request, input_spec):
+        model = MaxPoolAddTensorModule()
 
         graph_verifier = DetailedGraphVerifier(
             mocker,
-            expected_delegated_ops={AddTensor: 1, Convolution: 1},
+            expected_delegated_ops={AddTensor: 1, MaxPool2DWithIndices: 1, GetItem: 1},
             expected_non_delegated_ops={},
         )
         dataset_creator = RandomDatasetCreator(low=-1.0, high=1.0)
@@ -215,25 +241,3 @@ class TestAddTensor:
             comparator,
             remove_quant_io_ops=True,
         )
-
-    @pytest.mark.parametrize(
-        "input_spec",
-        [
-            pytest.param(
-                [ModelInputSpec((1, 4, 5, 5)), ModelInputSpec((1, 5))],
-                id="2 inputs 4D + 2D.",
-            ),
-            pytest.param(
-                [ModelInputSpec((1, 4, 4, 10)), ModelInputSpec((1, 4, 1))],
-                id="2 inputs 4D + 3D.",
-            ),
-        ],
-    )
-    def test__w_conv_unsupported(self, input_spec):
-        model = AddTensorConvModule()
-
-        delegated_ep = to_quantized_edge_program(model, input_spec).exported_program()
-
-        # Make sure the `add.Tensor` was NOT delegated.
-        assert graph_contains_any_of_ops(delegated_ep.graph, [ExecutorchDelegateCall])
-        assert graph_contains_any_of_ops(delegated_ep.graph, [AddTensor])

--- a/backends/nxp/tests/ir/converter/node_converter/test_mul_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_mul_tensor_converter.py
@@ -9,17 +9,22 @@ import numpy as np
 import pytest
 import torch
 
+from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import (
     ModelInputSpec,
     to_quantized_edge_program,
 )
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
-from executorch.backends.nxp.tests.models import MulTensorConvModule, MulTensorModule
+from executorch.backends.nxp.tests.model_output_comparator import (
+    AllCloseOutputComparator,
+)
+from executorch.backends.nxp.tests.models import MaxPoolMulTensorModule, MulTensorModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 from executorch.backends.nxp.tests.ops_aliases import (
-    Convolution,
     ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
     MulTensor,
 )
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
@@ -39,6 +44,7 @@ class TestMulTensor:
             pytest.param((6, 8), id="2D."),
             pytest.param((1, 4, 8), id="3D."),
             pytest.param((1, 4, 8, 8), id="4D."),
+            pytest.param((1, 4, 9, 11, 4), id="5D."),
         ],
     )
     def test__basic_nsys_inference(self, mocker, request, x_input_shape):
@@ -92,7 +98,7 @@ class TestMulTensor:
             ),
         ],
     )
-    def test__correct_broadcast(self, input_spec, mocker, request):
+    def test__broadcast(self, input_spec, mocker, request):
         model = MulTensorModule()
         graph_verifier = DetailedGraphVerifier(
             mocker, expected_delegated_ops={MulTensor: 1}, expected_non_delegated_ops={}
@@ -116,7 +122,7 @@ class TestMulTensor:
             ),
         ],
     )
-    def test__incorrect_broadcast(self, input_spec):
+    def test__broadcast_unsupported(self, input_spec):
         # Broadcast where at least one of the inputs is not equal to output is not supported
         model = MulTensorModule()
 
@@ -129,29 +135,26 @@ class TestMulTensor:
         assert graph_contains_any_of_ops(delegated_ep.graph, [MulTensor])
 
     @pytest.mark.parametrize(
-        "x_input_shape",
+        "input_spec",
         [
             pytest.param(
-                (1, 4, 5, 5), id="4D, product of dims is not a multiple of 8."
+                ModelInputSpec((1, 4, 5, 5)),
+                id="4D, product of dims is not a multiple of 8.",
             ),
         ],
     )
-    def test__w_conv(self, mocker, request, x_input_shape):
-        model = MulTensorConvModule()
-
-        n, c, h, w = x_input_shape
-        y_input_spec = ModelInputSpec((n, 8, h, w))
-        x_input_spec = ModelInputSpec(x_input_shape)
+    def test__channels_first_input(self, mocker, request, input_spec):
+        model = MaxPoolMulTensorModule()
 
         graph_verifier = DetailedGraphVerifier(
             mocker,
-            expected_delegated_ops={MulTensor: 1, Convolution: 1},
+            expected_delegated_ops={MulTensor: 1, MaxPool2DWithIndices: 1, GetItem: 1},
             expected_non_delegated_ops={},
         )
 
         lower_run_compare(
             model,
-            [x_input_spec, y_input_spec],
+            [input_spec, input_spec],
             graph_verifier,
             request,
         )
@@ -160,20 +163,55 @@ class TestMulTensor:
         "input_spec",
         [
             pytest.param(
-                [ModelInputSpec((1, 4, 5, 5)), ModelInputSpec((1, 5))],
-                id="2 inputs 4D + 2D.",
+                [ModelInputSpec((1, 8, 7, 1)), ModelInputSpec((1, 8, 1, 1))],
+                id="2 inputs 4D + 4D.",
             ),
             pytest.param(
-                [ModelInputSpec((1, 4, 4, 10)), ModelInputSpec((1, 4, 1))],
-                id="2 inputs 4D + 3D.",
+                [ModelInputSpec((1, 8, 5, 5)), ModelInputSpec((1, 8, 5, 1))],
+                id="2 inputs 4D + 4D same height.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 5, 5)), ModelInputSpec((1, 1))],
+                id="2 inputs 4D + 2D ones tensor.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 8, 8)), ModelInputSpec((8, 8))],
+                id="2 inputs 4D + 2D both dims 8.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 5, 5)), ModelInputSpec((1, 5))],
+                id="2 inputs 4D + 2D one dim 5.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 12, 10)), ModelInputSpec((8, 1, 10))],
+                id="2 inputs 4D + 3D channels dim 1.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 4, 10)), ModelInputSpec((1, 4, 1))],
+                id="2 inputs 4D + 3D channels dim 4.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 25, 18)), ModelInputSpec((4, 1, 8, 25, 18))],
+                id="2 inputs 4D + 5D.",
             ),
         ],
     )
-    def test__w_conv_unsupported(self, input_spec):
-        model = MulTensorConvModule()
+    def test__broadcast__channels_first_input(self, mocker, request, input_spec):
+        model = MaxPoolMulTensorModule()
+        graph_verifier = DetailedGraphVerifier(
+            mocker,
+            expected_delegated_ops={MulTensor: 1, MaxPool2DWithIndices: 1, GetItem: 1},
+            expected_non_delegated_ops={},
+        )
+        dataset_creator = RandomDatasetCreator(low=-1.0, high=1.0)
+        comparator = AllCloseOutputComparator(atol=1)
 
-        delegated_ep = to_quantized_edge_program(model, input_spec).exported_program()
-
-        # Make sure the `mul.Tensor` was NOT delegated.
-        assert graph_contains_any_of_ops(delegated_ep.graph, [ExecutorchDelegateCall])
-        assert graph_contains_any_of_ops(delegated_ep.graph, [MulTensor])
+        lower_run_compare(
+            model,
+            input_spec,
+            graph_verifier,
+            request,
+            dataset_creator,
+            comparator,
+            remove_quant_io_ops=True,
+        )

--- a/backends/nxp/tests/ir/converter/node_converter/test_sub_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_sub_tensor_converter.py
@@ -19,11 +19,12 @@ from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
-from executorch.backends.nxp.tests.models import SubTensorConvModule, SubTensorModule
+from executorch.backends.nxp.tests.models import MaxPoolSubTensorModule, SubTensorModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 from executorch.backends.nxp.tests.ops_aliases import (
-    Convolution,
     ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
     SubTensor,
 )
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
@@ -153,30 +154,27 @@ class TestSubTensor:
         assert graph_contains_any_of_ops(delegated_ep.graph, [SubTensor])
 
     @pytest.mark.parametrize(
-        "x_input_shape",
+        "input_spec",
         [
             pytest.param(
-                (1, 4, 5, 5), id="4D, product of dims is not a multiple of 8."
+                ModelInputSpec((1, 4, 5, 5)),
+                id="4D, product of dims is not a multiple of 8.",
             ),
         ],
     )
-    def test__w_conv(self, mocker, request, x_input_shape):
-        model = SubTensorConvModule()
-
-        n, c, h, w = x_input_shape
-        y_input_spec = ModelInputSpec((n, 8, h, w))
-        x_input_spec = ModelInputSpec(x_input_shape)
+    def test__channels_first_input(self, mocker, request, input_spec):
+        model = MaxPoolSubTensorModule()
 
         graph_verifier = DetailedGraphVerifier(
             mocker,
-            expected_delegated_ops={SubTensor: 1, Convolution: 1},
+            expected_delegated_ops={SubTensor: 1, MaxPool2DWithIndices: 1, GetItem: 1},
             expected_non_delegated_ops={},
         )
         dataset_creator = RandomDatasetCreator(low=-1.0, high=1.0)
 
         lower_run_compare(
             model,
-            [x_input_spec, y_input_spec],
+            [input_spec, input_spec],
             graph_verifier,
             request,
             dataset_creator,
@@ -186,20 +184,44 @@ class TestSubTensor:
         "input_spec",
         [
             pytest.param(
-                [ModelInputSpec((1, 4, 7, 1)), ModelInputSpec((1, 8, 1, 1))],
+                [ModelInputSpec((1, 8, 7, 1)), ModelInputSpec((1, 8, 1, 1))],
                 id="2 inputs 4D + 4D.",
             ),
             pytest.param(
-                [ModelInputSpec((1, 4, 5, 5)), ModelInputSpec((1, 8, 5, 1))],
+                [ModelInputSpec((1, 8, 5, 5)), ModelInputSpec((1, 8, 5, 1))],
                 id="2 inputs 4D + 4D same height.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 5, 5)), ModelInputSpec((1, 1))],
+                id="2 inputs 4D + 2D ones tensor.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 8, 8)), ModelInputSpec((8, 8))],
+                id="2 inputs 4D + 2D both dims 8.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 5, 5)), ModelInputSpec((1, 5))],
+                id="2 inputs 4D + 2D one dim 5.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 12, 10)), ModelInputSpec((8, 1, 10))],
+                id="2 inputs 4D + 3D channels dim 1.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 4, 10)), ModelInputSpec((1, 4, 1))],
+                id="2 inputs 4D + 3D channels dim 4.",
+            ),
+            pytest.param(
+                [ModelInputSpec((1, 8, 25, 18)), ModelInputSpec((4, 1, 8, 25, 18))],
+                id="2 inputs 4D + 5D.",
             ),
         ],
     )
-    def test__w_conv_broadcast(self, mocker, request, input_spec):
-        model = SubTensorConvModule()
+    def test__broadcast_channels_first_input(self, mocker, request, input_spec):
+        model = MaxPoolSubTensorModule()
         graph_verifier = DetailedGraphVerifier(
             mocker,
-            expected_delegated_ops={SubTensor: 1, Convolution: 1},
+            expected_delegated_ops={SubTensor: 1, MaxPool2DWithIndices: 1, GetItem: 1},
             expected_non_delegated_ops={},
         )
         dataset_creator = RandomDatasetCreator(low=-1.0, high=1.0)
@@ -214,25 +236,3 @@ class TestSubTensor:
             comparator,
             remove_quant_io_ops=True,
         )
-
-    @pytest.mark.parametrize(
-        "input_spec",
-        [
-            pytest.param(
-                [ModelInputSpec((1, 4, 5, 5)), ModelInputSpec((1, 5))],
-                id="2 inputs 4D + 2D.",
-            ),
-            pytest.param(
-                [ModelInputSpec((1, 4, 4, 10)), ModelInputSpec((1, 4, 1))],
-                id="2 inputs 4D + 3D.",
-            ),
-        ],
-    )
-    def test__w_conv_unsupported(self, input_spec):
-        model = SubTensorConvModule()
-
-        delegated_ep = to_quantized_edge_program(model, input_spec).exported_program()
-
-        # Make sure the `sub.Tensor` was NOT delegated.
-        assert graph_contains_any_of_ops(delegated_ep.graph, [ExecutorchDelegateCall])
-        assert graph_contains_any_of_ops(delegated_ep.graph, [SubTensor])

--- a/backends/nxp/tests/models.py
+++ b/backends/nxp/tests/models.py
@@ -628,13 +628,15 @@ class MulTensorModule(torch.nn.Module):
         return x * y
 
 
-class MulTensorConvModule(torch.nn.Module):
+class MaxPoolMulTensorModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.conv = Conv2dModule(padding=1, stride=1)
+        self.max_pool2d = torch.nn.MaxPool2d(
+            kernel_size=1
+        )  # No-op, but it enforces the channels first format.
 
     def forward(self, x, y):
-        x = self.conv(x)
+        x = self.max_pool2d(x)
         return x * y
 
 
@@ -656,13 +658,15 @@ class AddTensorModule(torch.nn.Module):
         return x + y
 
 
-class AddTensorConvModule(torch.nn.Module):
+class MaxPoolAddTensorModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.conv = Conv2dModule(padding=1, stride=1)
+        self.max_pool2d = torch.nn.MaxPool2d(
+            kernel_size=1
+        )  # No-op, but it enforces the channels first format.
 
     def forward(self, x, y):
-        x = self.conv(x)
+        x = self.max_pool2d(x)
         return x + y
 
 
@@ -684,13 +688,15 @@ class SubTensorModule(torch.nn.Module):
         return x - y
 
 
-class SubTensorConvModule(torch.nn.Module):
+class MaxPoolSubTensorModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
-        self.conv = Conv2dModule(padding=1, stride=1)
+        self.max_pool2d = torch.nn.MaxPool2d(
+            kernel_size=1
+        )  # No-op, but it enforces the channels first format.
 
     def forward(self, x, y):
-        x = self.conv(x)
+        x = self.max_pool2d(x)
         return x - y
 
 


### PR DESCRIPTION
### Summary
Removes broadcasting restrictions. After full Permute_copy/Transpose support full broadcast can be enabled. Transpose is required for broadcasting ops with inputs with different dim order. Small refactoring of tests.

### Test plan
Tests provided.


cc @robert-kalmar