### PR TITLE
Arm backend: Support sym_size for TOSA shape ext.

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -177,6 +177,7 @@ from .rewrite_slice import RewriteSlicePass  # noqa
 from .rewrite_upsample import RewriteUpsamplePass  # noqa
 from .scalars_to_attribute_pass import ScalarsToAttributePass  # noqa
 from .size_adjust_input_pass import SizeAdjustInputPass  # noqa
+from .symbolic_to_tosa_shape_pass import SymbolicToTosaShapesPass  # noqa
 from .unsqueeze_before_repeat_pass import UnsqueezeBeforeRepeatPass  # noqa
 from .unsqueeze_scalar_placeholders_pass import UnsqueezeScalarPlaceholdersPass  # noqa
 from .replace_inf_and_limit_values_pass import (  # noqa  # usort: skip

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -152,6 +152,7 @@ from executorch.backends.arm._passes import (
     RewriteUpsamplePass,
     ScalarsToAttributePass,
     SizeAdjustInputPass,
+    SymbolicToTosaShapesPass,
     UnsqueezeBeforeRepeatPass,
     UnsqueezeScalarPlaceholdersPass,
 )
@@ -630,6 +631,7 @@ class ArmPassManager(ExportedProgramPassManager):
             [
                 CastInt64BuffersToInt32Pass(exported_program),
                 FuseEqualPlaceholdersPass(exported_program),
+                SymbolicToTosaShapesPass(),
                 FuseConsecutiveConcatShapesPass(),
                 EnsureUniqueOutputNodesPass(),
                 RemoveNoopPass(),

--- a/backends/arm/_passes/symbolic_to_tosa_shape_pass.py
+++ b/backends/arm/_passes/symbolic_to_tosa_shape_pass.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Optional
+
+import torch
+from executorch.backends.arm._passes.arm_pass import ArmPass
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+class SymbolicToTosaShapesPass(ArmPass):
+
+    _passes_required_after = set()
+
+    def call_operator(self, op, args, kwargs, meta, updated: Optional[bool] = False):
+        if op == torch.ops.aten.sym_size.int:
+            return super().call_shape_operator(
+                exir_ops.backend.tosa.DIM.default,
+                (args[0],),
+                {"axis": args[1]},
+                meta,
+            )
+        return super().call_operator(op, args, kwargs, meta, updated)

--- a/backends/arm/operator_support/__init__.py
+++ b/backends/arm/operator_support/__init__.py
@@ -21,6 +21,7 @@ from . import (  # noqa
     reduce_sum_support,
     right_shift_support,
     slice_copy_support,
+    sym_size_int_support,
     to_dim_order_copy_support,
     tosa_supported_operators,
     unfold_copy_support,

--- a/backends/arm/operator_support/sym_size_int_support.py
+++ b/backends/arm/operator_support/sym_size_int_support.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.fx as fx
+from executorch.backends.arm.operator_support.tosa_supported_operators import (
+    register_tosa_support_check,
+    SupportedTOSAOperatorCheck,
+)
+from executorch.backends.arm.tosa.specification import TosaSpecification
+
+
+@register_tosa_support_check
+class SymSizeIntSupport(SupportedTOSAOperatorCheck):
+    """Allow ``aten.sym_size.int`` when the TOSA shape extension is enabled."""
+
+    targets = [torch.ops.aten.sym_size.int]
+    tosa_specs = TosaSpecification.all_profiles_for_version("1.1")
+
+    def is_node_tosa_supported(
+        self, node: fx.Node, tosa_spec: TosaSpecification
+    ) -> bool:
+        return tosa_spec.support_extension("shape")

--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -16,7 +16,6 @@ from typing import final, Optional, Sequence, Type
 
 import torch
 import torch.fx as fx
-
 from executorch.backends.arm._passes.arm_pass_utils import (
     get_first_fake_tensor,
     is_submodule_node,
@@ -84,7 +83,7 @@ class SupportedTOSAOperatorCheck(OperatorSupportBase):
 
     # Class attributes populated by subclasses
     tosa_specs: list[TosaSpecification] = TosaSpecification.all_versions_and_profiles()
-    targets: list[str] = []
+    targets: list[object] = []
 
     @final
     def is_node_supported(
@@ -248,6 +247,115 @@ class MXOpsSupportList(OperatorSupportBase):
         return node.op == "call_function" and node.target in self.targets
 
 
+def _profile_support_check(
+    tosa_spec: TosaSpecification,
+) -> Optional[OperatorSupportBase]:
+    if tosa_spec.support_integer() and tosa_spec.support_float():
+        return TOSAProINTFPSupportList()
+    if tosa_spec.support_integer():
+        return TOSAProINTSupportList()
+    if tosa_spec.support_float():
+        return TOSAProFPSupportList()
+    return None
+
+
+def _registered_support_checks(
+    tosa_spec: TosaSpecification,
+    reporter: WhyNoPartitionReporter,
+) -> list[OperatorSupportBase]:
+    return [
+        check(tosa_spec, reporter)
+        for check in get_registered_tosa_support_checks(tosa_spec)
+    ]
+
+
+def _positive_checks(
+    tosa_spec: TosaSpecification,
+    exported_program: ExportedProgram,
+    reporter: WhyNoPartitionReporter,
+) -> list[OperatorSupportBase]:
+    checks: list[OperatorSupportBase] = [
+        ControlFlowSubmoduleSupported(exported_program, tosa_spec, reporter),
+        ControlFlowOpSupported(exported_program, tosa_spec, reporter),
+    ]
+
+    if profile_check := _profile_support_check(tosa_spec):
+        checks.append(profile_check)
+
+    if tosa_spec.support_extension("mxfp"):
+        checks.append(MXOpsSupportList())
+
+    # TODO: Refactor to use TOSAProSupportLists + negtive checks
+    checks.extend(_registered_support_checks(tosa_spec, reporter))
+
+    return checks
+
+
+def _disallowed_dtypes(tosa_spec: TosaSpecification) -> list[torch.dtype]:
+    dtypes = [torch.float64]
+    if not tosa_spec.support_extension("bf16"):
+        dtypes.append(torch.bfloat16)
+    if not (
+        tosa_spec.support_extension("fp8e4m3") or tosa_spec.support_extension("mxfp")
+    ):
+        dtypes.append(torch.float8_e4m3fn)
+    if not (
+        tosa_spec.support_extension("fp8e5m2") or tosa_spec.support_extension("mxfp")
+    ):
+        dtypes.append(torch.float8_e5m2)
+    if tosa_spec.is_U55_subset:
+        dtypes.append(torch.bool)
+    return dtypes
+
+
+def _wrapped_additional_checks(
+    additional_checks: Optional[Sequence[OperatorSupportBase]],
+    reporter: WhyNoPartitionReporter,
+) -> list[OperatorSupportBase]:
+    if not additional_checks:
+        return []
+    return [
+        reporter.wrap_check(check, f"Rejected by {check.__class__.__name__}")
+        for check in additional_checks
+    ]
+
+
+def _negative_checks(
+    tosa_spec: TosaSpecification,
+    exported_program: ExportedProgram,
+    reporter: WhyNoPartitionReporter,
+    additional_checks: Optional[Sequence[OperatorSupportBase]],
+) -> list[OperatorSupportBase]:
+    checks: list[OperatorSupportBase] = [RankCheck(reporter, MAX_RANK)]
+
+    if not tosa_spec.support_extension("int64"):
+        checks.append(CheckInt64InputsAndOutputs(exported_program, reporter))
+
+    checks.extend(_wrapped_additional_checks(additional_checks, reporter))
+
+    if tosa_spec.support_float():
+        checks.append(CheckMixedFloatingInputs(reporter))
+    else:
+        checks.append(CheckArmQuantized(reporter))
+        checks.append(CheckProperQuantization(reporter))
+
+    checks.append(
+        CheckDtypeInputsAndOutputs(
+            exported_program, reporter, _disallowed_dtypes(tosa_spec), tosa_spec
+        )
+    )
+
+    if tosa_spec.is_U55_subset:
+        checks.append(EthosU55NotSupported(reporter))
+        checks.append(EthosU55DtypeSupport(reporter))
+        checks.append(EthosU55CastCheck(reporter))
+
+    if not tosa_spec.support_extension("shape"):
+        checks.append(SymbolicShapeSupportCheck(reporter))
+
+    return checks
+
+
 def tosa_support_factory(
     tosa_spec: TosaSpecification,
     exported_program: ExportedProgram,
@@ -270,66 +378,10 @@ def tosa_support_factory(
         OperatorSupportBase: Composite checker for the given spec.
 
     """
-    # Postive checks: Add nodes to partitioning
-    positive_checks: list[OperatorSupportBase] = [
-        ControlFlowSubmoduleSupported(exported_program, tosa_spec, reporter),
-        ControlFlowOpSupported(exported_program, tosa_spec, reporter),
-    ]
-
-    if tosa_spec.support_integer() and tosa_spec.support_float():
-        positive_checks.append(TOSAProINTFPSupportList())
-    elif tosa_spec.support_integer():
-        positive_checks.append(TOSAProINTSupportList())
-    elif tosa_spec.support_float():
-        positive_checks.append(TOSAProFPSupportList())
-    if tosa_spec.support_extension("mxfp"):
-        positive_checks.append(MXOpsSupportList())
-    # TODO: Refactor to use TOSAProSupportLists + negtive checks
-    positive_checks += [
-        check(tosa_spec, reporter)
-        for check in get_registered_tosa_support_checks(tosa_spec)
-    ]
-
-    # Negative checks: Remove nodes from partitioning
-    negative_checks: list[OperatorSupportBase] = [
-        CheckInt64InputsAndOutputs(exported_program, reporter),
-        RankCheck(reporter, max_rank=MAX_RANK),
-        *[
-            reporter.wrap_check(check, f"Rejected by {check.__class__.__name__}")
-            for check in (additional_checks if additional_checks else [])
-        ],
-    ]
-
-    if tosa_spec.support_float():
-        negative_checks.append(CheckMixedFloatingInputs(reporter))
-    else:
-        negative_checks.append(CheckArmQuantized(reporter))
-        negative_checks.append(CheckProperQuantization(reporter))
-
-    disallowed_dtypes = [torch.float64]
-    if not tosa_spec.support_extension("bf16"):
-        disallowed_dtypes.append(torch.bfloat16)
-    if not (
-        tosa_spec.support_extension("fp8e4m3") or tosa_spec.support_extension("mxfp")
-    ):
-        disallowed_dtypes.append(torch.float8_e4m3fn)
-    if not (
-        tosa_spec.support_extension("fp8e5m2") or tosa_spec.support_extension("mxfp")
-    ):
-        disallowed_dtypes.append(torch.float8_e5m2)
-    if tosa_spec.is_U55_subset:
-        disallowed_dtypes.append(torch.bool)
-    negative_checks.append(
-        CheckDtypeInputsAndOutputs(
-            exported_program, reporter, disallowed_dtypes, tosa_spec
-        )
+    positive_checks = _positive_checks(tosa_spec, exported_program, reporter)
+    negative_checks = _negative_checks(
+        tosa_spec, exported_program, reporter, additional_checks
     )
-    if tosa_spec.is_U55_subset:
-        negative_checks.append(EthosU55NotSupported(reporter))
-        negative_checks.append(EthosU55DtypeSupport(reporter))
-        negative_checks.append(EthosU55CastCheck(reporter))
-    if not tosa_spec.support_extension("shape"):
-        negative_checks.append(SymbolicShapeSupportCheck(reporter))
 
     return chain(
         reporter.wrap_check(
@@ -368,6 +420,40 @@ class SymbolicShapeSupportCheck(OperatorSupportBase):
 
         return False
 
+    def _partition_dynamic_upmsample_nearest2d(self, node: fx.Node) -> bool:
+        """Check if the node is an upsample_nearest2d with symbolic shapes.
+
+        Args:
+            node (fx.Node): FX node to check.
+
+        Returns:
+            bool: True if the node is an upsample_nearest2d with symbolic
+                shapes; otherwise, False.
+
+        """
+        if node.target != exir_ops.edge.aten.upsample_nearest2d.vec:
+            return False
+
+        try:
+            input_tensor = get_first_fake_tensor(node.all_input_nodes[0])
+            output_tensor = get_first_fake_tensor(node)
+        except Exception as exc:
+            self.reporter.report_reject(
+                node,
+                f"upsample_nearest2d symbolic shapes need tensor metadata: {exc}",
+            )
+            return False
+
+        input_size_xy = input_tensor.shape[2:4]
+        output_size_xy = output_tensor.shape[2:4]
+        if len(input_size_xy) != 2 or len(output_size_xy) != 2:
+            self.reporter.report_reject(
+                node, "upsample_nearest2d expects 2D spatial input/output."
+            )
+            return False
+
+        return True
+
     def is_node_supported(
         self, submodules: typing.Mapping[str, torch.nn.Module], node: fx.Node
     ) -> bool:
@@ -394,14 +480,13 @@ class SymbolicShapeSupportCheck(OperatorSupportBase):
             self._has_symbolic_shape(input_node) for input_node in node.all_input_nodes
         ):
             if node.target == exir_ops.edge.aten.upsample_nearest2d.vec:
-                return True
-
-            self.reporter.report_reject(
-                node,
-                "Node has symbolic shape but the TOSA spec does not support "
-                "the shape extension.",
-            )
-            return False
+                return self._partition_dynamic_upmsample_nearest2d(node)
+            else:
+                self.reporter.report_reject(
+                    node,
+                    "Node has symbolic shape, has the TOSA spec shape extension support?",
+                )
+                return False
 
         return True
 
@@ -562,7 +647,10 @@ class CheckProperQuantization(OperatorSupportBase):
             self.reporter.report_reject(node, "One or more inputs were not quantized.")
             return False
 
-        all_q_users = all((output_node.target in Q_OPS) for output_node in node.users)
+        all_q_users = all(
+            output_node.target in (*Q_OPS, torch.ops.aten.sym_size.int)
+            for output_node in node.users
+        )
         output_dtype = get_first_fake_tensor(node).dtype
         output_quantized = (
             output_quantized or all_q_users or _is_integer_dtype(output_dtype)
@@ -609,6 +697,40 @@ class CheckInt64InputsAndOutputs(OperatorSupportBase):
         min_val, max_val = int(torch.min(data)), int(torch.max(data))
         return min_val >= self.int32_min and max_val <= self.int32_max
 
+    def _check_int64_input_nodes(self, node: torch.fx.Node) -> bool:
+        """Check if all int64 input nodes are constant and will be
+        partitioned.
+        """
+        for input_node in (
+            input_node
+            for input_node in node.all_input_nodes
+            if input_node.op != "get_attr"
+        ):
+            if isinstance(input_node.meta["val"], torch.SymInt):
+                continue
+            tensor_in = get_first_fake_tensor(input_node)
+            if tensor_in.dtype != torch.int64:
+                continue
+            # Constant placeholder
+            if (
+                input_node.op != "call_function"
+                and input_node.name not in self.input_names
+            ):
+                continue
+            # Constant operator
+            if input_node.op == "call_function":
+                if input_node.target in ComputeConstantOpsAOTPass.targeted_ops:
+                    # This is not perfect since the input_node can still be rejected by other checks but
+                    # this should cover the majority of cases.
+                    if self.is_node_supported({}, input_node):
+                        continue
+            self.reporter.report_reject(
+                node, f"Non-constant int64 input {input_node.name}"
+            )
+            return False
+
+        return True
+
     def is_node_supported(
         self, submodules: typing.Mapping[str, torch.nn.Module], node: fx.Node
     ) -> bool:
@@ -618,7 +740,11 @@ class CheckInt64InputsAndOutputs(OperatorSupportBase):
         vals = node.meta["val"]
         tensor_list = vals if isinstance(vals, (list, tuple)) else [vals]
 
-        any_int64 = any(tensor.dtype == torch.int64 for tensor in tensor_list)
+        any_int64 = any(
+            tensor.dtype == torch.int64
+            for tensor in tensor_list
+            if isinstance(tensor, FakeTensor)
+        )
         # Don't partition nodes with int64 output...
         if any_int64:
             # ... Except for constant ops that are directly cast to something non-int64.
@@ -652,35 +778,7 @@ class CheckInt64InputsAndOutputs(OperatorSupportBase):
                 )
                 return False
 
-        # Ops with int64 inputs are only partitioned if input nodes are constant and will be partitioned.
-        # If it is not partitioned, the partition will get an int64 input and fail.
-        for input_node in (
-            input_node
-            for input_node in node.all_input_nodes
-            if input_node.op != "get_attr"
-        ):
-            tensor_in = get_first_fake_tensor(input_node)
-            if tensor_in.dtype != torch.int64:
-                continue
-            # Constant placeholder
-            if (
-                input_node.op != "call_function"
-                and input_node.name not in self.input_names
-            ):
-                continue
-            # Constant operator
-            if input_node.op == "call_function":
-                if input_node.target in ComputeConstantOpsAOTPass.targeted_ops:
-                    # This is not perfect since the input_node can still be rejected by other checks but
-                    # this should cover the majority of cases.
-                    if self.is_node_supported({}, input_node):
-                        continue
-            self.reporter.report_reject(
-                node, f"Non-constant int64 input {input_node.name}"
-            )
-            return False
-
-        return True
+        return self._check_int64_input_nodes(node)
 
 
 class CheckDtypeInputsAndOutputs(OperatorSupportBase):
@@ -712,6 +810,9 @@ class CheckDtypeInputsAndOutputs(OperatorSupportBase):
             for input_node in node.all_input_nodes
             if input_node.op != "get_attr"
         ):
+            if isinstance(input_node.meta["val"], torch.SymInt):
+                continue
+
             tensor = get_first_fake_tensor(input_node)
             if tensor.dtype in self.disallowed_dtypes:
                 self.reporter.report_reject(
@@ -772,6 +873,8 @@ class CheckMixedFloatingInputs(OperatorSupportBase):
             for input_node in node.all_input_nodes
             if input_node.op != "get_attr"
         ):
+            if isinstance(input_node.meta["val"], torch.SymInt):
+                continue
             dtype = get_first_fake_tensor(input_node).dtype
             if dtype.is_floating_point:
                 floating_dtypes.add(dtype)
@@ -809,6 +912,8 @@ class RankCheck(OperatorSupportBase):
         )
         # check if any input node has an unsupported rank
         for input_node in input_nodes:
+            if isinstance(input_node.meta["val"], torch.SymInt):
+                continue
             input_node_shape = get_first_fake_tensor(input_node).shape
             if len(input_node_shape) > self.max_rank:
                 self.reporter.report_reject(

--- a/backends/arm/test/misc/test_tosa_shape_support.py
+++ b/backends/arm/test/misc/test_tosa_shape_support.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import executorch.backends.arm.operator_support.sym_size_int_support  # noqa: F401
+import torch
+
+from executorch.backends.arm.operator_support.tosa_supported_operators import (
+    tosa_support_factory,
+)
+from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
+from executorch.backends.arm.tosa.partitioner import TOSAPartitioner
+from executorch.backends.arm.tosa.specification import TosaSpecification
+from executorch.exir import EdgeCompileConfig, to_edge
+from executorch.exir.backend.utils import WhyNoPartitionReporter
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.export import Dim, export
+
+
+class Add(torch.nn.Module):
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x + y
+
+
+class Atan2(torch.nn.Module):
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return torch.atan2(x, y)
+
+
+class ReturnSymSize(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, int]:
+        return x, x.shape[0]
+
+
+def _exported_program(
+    module: torch.nn.Module,
+    inputs: tuple[torch.Tensor, ...],
+    dynamic_shapes=None,
+):
+    return to_edge(
+        export(module, inputs, dynamic_shapes=dynamic_shapes, strict=True),
+        compile_config=EdgeCompileConfig(_check_ir_validity=False),
+    ).exported_program()
+
+
+def _support(tosa_spec: str, exported_program):
+    reporter = WhyNoPartitionReporter()
+    return (
+        tosa_support_factory(
+            TosaSpecification.create_from_string(tosa_spec),
+            exported_program,
+            reporter,
+        ),
+        reporter,
+    )
+
+
+def _find_node(exported_program, target):
+    return exported_program.graph_module.graph.find_nodes(
+        op="call_function", target=target
+    )[0]
+
+
+def test_shape_extension_does_not_accept_unsupported_static_op():
+    inputs = (torch.randn(2, 3), torch.randn(2, 3))
+    exported_program = _exported_program(Atan2(), inputs)
+    support, reporter = _support("TOSA-1.1+FP+shape", exported_program)
+    atan2_node = _find_node(exported_program, exir_ops.edge.aten.atan2.default)
+
+    assert support.is_node_supported(exported_program.graph_module, atan2_node) is False
+    assert "Not included in BaseTOSASupportList" in reporter.get_table_report()
+
+
+def test_shape_extension_accepts_supported_symbolic_tensor_op():
+    inputs = (torch.randn(2, 3), torch.randn(2, 3))
+    batch = Dim("batch", min=1, max=4)
+    exported_program = _exported_program(
+        Add(),
+        inputs,
+        dynamic_shapes=({0: batch}, {0: batch}),
+    )
+    support, _ = _support("TOSA-1.1+FP+shape", exported_program)
+    add_node = _find_node(exported_program, exir_ops.edge.aten.add.Tensor)
+
+    assert support.is_node_supported(exported_program.graph_module, add_node) is True
+
+
+def test_without_shape_extension_rejects_supported_symbolic_tensor_op():
+    inputs = (torch.randn(2, 3), torch.randn(2, 3))
+    batch = Dim("batch", min=1, max=4)
+    exported_program = _exported_program(
+        Add(),
+        inputs,
+        dynamic_shapes=({0: batch}, {0: batch}),
+    )
+    support, reporter = _support("TOSA-1.0+FP", exported_program)
+    add_node = _find_node(exported_program, exir_ops.edge.aten.add.Tensor)
+
+    assert support.is_node_supported(exported_program.graph_module, add_node) is False
+    assert "Node has symbolic shape" in reporter.get_table_report()
+
+
+def test_without_shape_extension_rejects_sym_size_int():
+    inputs = (torch.randn(2, 3),)
+    batch = Dim("batch", min=1, max=4)
+    exported_program = _exported_program(
+        ReturnSymSize(),
+        inputs,
+        dynamic_shapes=({0: batch},),
+    )
+    support, _ = _support("TOSA-1.1+FP", exported_program)
+    sym_size_node = _find_node(exported_program, torch.ops.aten.sym_size.int)
+
+    assert (
+        support.is_node_supported(exported_program.graph_module, sym_size_node) is False
+    )
+
+
+def test_shape_extension_rejects_sym_size_from_fp32_for_int_spec():
+    inputs = (torch.randn(2, 3),)
+    batch = Dim("batch", min=1, max=4)
+    exported_program = _exported_program(
+        ReturnSymSize(),
+        inputs,
+        dynamic_shapes=({0: batch},),
+    )
+    support, reporter = _support("TOSA-1.1+INT+shape", exported_program)
+    sym_size_node = _find_node(exported_program, torch.ops.aten.sym_size.int)
+
+    assert (
+        support.is_node_supported(exported_program.graph_module, sym_size_node) is False
+    )
+    assert "Node was not marked as quantized" in reporter.get_table_report()
+
+
+def test_shape_extension_rejects_sym_size_from_int64_without_int64_extension():
+    inputs = (torch.ones(2, 3, dtype=torch.int64),)
+    batch = Dim("batch", min=1, max=4)
+    exported_program = _exported_program(
+        ReturnSymSize(),
+        inputs,
+        dynamic_shapes=({0: batch},),
+    )
+    support, reporter = _support("TOSA-1.1+FP+shape", exported_program)
+    sym_size_node = _find_node(exported_program, torch.ops.aten.sym_size.int)
+
+    assert (
+        support.is_node_supported(exported_program.graph_module, sym_size_node) is False
+    )
+    assert "Non-constant int64 input" in reporter.get_table_report()
+
+
+def test_shape_extension_partitions_sym_size_int():
+    inputs = (torch.randn(2, 3),)
+    batch = Dim("batch", min=1, max=4)
+    exported_program = _exported_program(
+        ReturnSymSize(),
+        inputs,
+        dynamic_shapes=({0: batch},),
+    )
+
+    partition_result = TOSAPartitioner(TosaCompileSpec("TOSA-1.1+FP+shape")).partition(
+        exported_program
+    )
+    sym_size_node = _find_node(
+        partition_result.tagged_exported_program, torch.ops.aten.sym_size.int
+    )
+
+    assert sym_size_node.meta.get("delegation_tag") in partition_result.partition_tags

--- a/backends/arm/test/passes/test_symbolic_to_tosa_shape_pass.py
+++ b/backends/arm/test/passes/test_symbolic_to_tosa_shape_pass.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any
+
+import executorch.backends.arm.tosa.dialect  # noqa: F401
+import torch
+from executorch.backends.arm._passes.symbolic_to_tosa_shape_pass import (
+    SymbolicToTosaShapesPass,
+)
+from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
+from executorch.backends.arm.tosa.specification import (
+    TosaLoweringContext,
+    TosaSpecification,
+)
+from executorch.backends.test.graph_builder import GraphBuilder
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import NodeMetadata, PassResult, ProxyValue
+
+
+def _run_symbolic_shape_pass(graph_module: torch.fx.GraphModule) -> PassResult:
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.1+FP+shape")):
+        result = SymbolicToTosaShapesPass()(graph_module)
+    assert result is not None
+    return result
+
+
+def _single_node_with_target(
+    graph_module: torch.fx.GraphModule,
+    target: Any,
+) -> torch.fx.Node:
+    return next(node for node in graph_module.graph.nodes if node.target == target)
+
+
+def _sym_size(
+    builder: GraphBuilder,
+    x: ProxyValue,
+    dim: int,
+    value: int,
+) -> ProxyValue:
+    return builder.call_operator(
+        torch.ops.aten.sym_size.int,
+        (x, dim),
+        meta=NodeMetadata({"val": value}),
+    )
+
+
+def test_symbolic_to_tosa_shapes_rewrites_sym_size_to_dim() -> None:
+    builder = GraphBuilder()
+    x = builder.placeholder("x", torch.randn(2, 18))
+    sym_size = _sym_size(builder, x, 1, 18)
+    builder.output([sym_size])
+
+    result = _run_symbolic_shape_pass(builder.get_graph_module())
+    graph_module = result.graph_module
+    dim_node = _single_node_with_target(graph_module, exir_ops.backend.tosa.DIM.default)
+
+    assert getattr(dim_node.args[0], "target", None) == "x"
+    assert dim_node.kwargs == {"axis": 1}
+    assert torch.ops.aten.sym_size.int not in {
+        node.target for node in graph_module.graph.nodes
+    }
+    assert result.modified is True
+    graph_module.graph.lint()
+
+
+def test_symbolic_to_tosa_shapes_marks_dim_as_shape_dtype() -> None:
+    builder = GraphBuilder()
+    x = builder.placeholder("x", torch.randn(2, 18))
+    sym_size = _sym_size(builder, x, 0, 2)
+    builder.output([sym_size])
+
+    result = _run_symbolic_shape_pass(builder.get_graph_module())
+    dim_node = _single_node_with_target(
+        result.graph_module, exir_ops.backend.tosa.DIM.default
+    )
+
+    assert dim_node.meta[TosaSpecialDtype.meta_key()] == TosaSpecialDtype.SHAPE
+    result.graph_module.graph.lint()
+
+
+def test_symbolic_to_tosa_shapes_leaves_non_sym_size_ops_unchanged() -> None:
+    builder = GraphBuilder()
+    x = builder.placeholder("x", torch.randn(2, 18))
+    add = builder.call_operator(
+        torch.ops.aten.add.Tensor,
+        (x, x),
+        meta=NodeMetadata({"val": torch.empty(2, 18)}),
+    )
+    builder.output([add])
+
+    result = _run_symbolic_shape_pass(builder.get_graph_module())
+    graph_module = result.graph_module
+
+    _single_node_with_target(graph_module, torch.ops.aten.add.Tensor)
+    assert exir_ops.backend.tosa.DIM.default not in {
+        node.target for node in graph_module.graph.nodes
+    }
+    graph_module.graph.lint()

--- a/backends/arm/tosa/partitioner.py
+++ b/backends/arm/tosa/partitioner.py
@@ -309,7 +309,9 @@ class TOSAPartitioner(Partitioner):
             elif detag_first_fp_node and not is_q_node and not is_dq_node:
                 # For non Q/DQ nodes, remove tag from first node in partition if any input has fp dtype
                 for input in node.all_input_nodes:
-                    if is_partitioned(input, tag):
+                    if is_partitioned(input, tag) or isinstance(
+                        input.meta["val"], torch.SymInt
+                    ):
                         continue
                     if get_first_fake_tensor(input).dtype.is_floating_point:
                         reporter.report_reject(
@@ -356,7 +358,13 @@ class TOSAPartitioner(Partitioner):
                 if dtype is None:
                     try:
                         dtype = get_first_fake_tensor(node).dtype
-                    except (AttributeError, KeyError, RuntimeError, ValueError):
+                    except (
+                        AttributeError,
+                        KeyError,
+                        RuntimeError,
+                        ValueError,
+                        TypeError,
+                    ):
                         dtype = None
             if dtype is None:
                 continue


### PR DESCRIPTION
Allow aten.sym_size.int to pass TOSA operator support checks when targeting TOSA-1.1 with the shape extension enabled. Keep the support scoped to shape extension specs so plain TOSA profiles continue to reject symbolic shape operations.

Add coverage for partitioning sym_size.int with TOSA-1.1+FP+shape, and for rejecting sym_size.int when the shape extension is absent or when its input would pull unsupported producer dtypes into the partition.


cc @digantdesai @freddan80 @per @zingo @mansnils @Sebastian-Larsson @robell @rascani