### PR TITLE
Use dynamic CPU count for cmake --build -j in docs and test scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,7 +325,7 @@ To build C++ tests manually with CMake, run the following from the repository ro
 
 ```bash
 cmake . -Bcmake-out -DCMAKE_INSTALL_PREFIX=cmake-out -DEXECUTORCH_BUILD_TESTS=ON
-cmake --build cmake-out -j9 --target install
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install
 ```
 
 You can then use `ctest` to list or run individual C++ tests directly:

--- a/backends/xnnpack/README.md
+++ b/backends/xnnpack/README.md
@@ -117,7 +117,7 @@ cmake \
 Then you can build the runtime componenets with
 
 ```bash
-cmake --build cmake-out -j9 --target install --config Release
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 ```
 
 Now you should be able to find the executable built at `./cmake-out/executor_runner` you can run the executable with the model you generated as such

--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -143,7 +143,7 @@ When building as a submodule as part of a user CMake build, ExecuTorch CMake opt
 CMake configuration for standalone runtime build:
 ```bash
 cmake -B cmake-out --preset [preset] [options]
-cmake --build cmake-out -j10
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ```
 
 #### Build Presets
@@ -265,8 +265,9 @@ cd executorch
 #
 # NOTE: The `-j` argument specifies how many jobs/processes to use when
 # building, and tends to speed up the build significantly. It's typical to use
-# "core count + 1" as the `-j` value.
-cmake --build cmake-out -j9
+# "core count + 1" as the `-j` value; the command below derives that
+# dynamically (`nproc` on Linux, `sysctl -n hw.ncpu` on macOS).
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ```
 
 > **_TIP:_** For faster rebuilds, consider installing ccache (see [Compiler Cache section](#compiler-cache-ccache) below). On first builds, ccache populates its cache. Subsequent builds with the same compiler flags can be significantly faster.

--- a/examples/xnnpack/README.md
+++ b/examples/xnnpack/README.md
@@ -51,7 +51,7 @@ cmake \
 Then you can build the runtime components with
 
 ```bash
-cmake --build cmake-out -j9 --target install --config Release
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 ```
 
 Now finally you should be able to run this model with the following command
@@ -105,7 +105,7 @@ cmake \
 Then you can build the runtime componenets with
 
 ```bash
-cmake --build cmake-out -j9 --target install --config Release
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 ```
 
 Now you should be able to find the executable built at `./cmake-out/executor_runner` you can run the executable with the model you generated as such

--- a/extension/training/README.md
+++ b/extension/training/README.md
@@ -247,7 +247,7 @@ cmake \
 Then you can build the runtime componenets with
 
 ```bash
-cmake --build cmake-out -j9 --target install --config Release
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 ```
 
 Now you should be able to find the executable built at `./cmake-out/extension/training/train_xor` you can run the executable with the model you generated as such

--- a/kernels/README.md
+++ b/kernels/README.md
@@ -257,7 +257,7 @@ cmake -DCMAKE_INSTALL_PREFIX=cmake-out \
           -DCMAKE_BUILD_TYPE=Release \
           -DPYTHON_EXECUTABLE=python \
           -Bcmake-out .
-cmake --build cmake-out -j9 --target install --config Release
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 ```
 2. The generated `NativeFunctions.h` file is located in
 ```
@@ -367,7 +367,7 @@ cmake . \
   -DEXECUTORCH_BUILD_TESTS=ON \
   -Bcmake-out
 
-cmake --build cmake-out -j9 --target install
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install
 ```
 2. Run tests. You should see your test here.
 ```

--- a/test/build_optimized_size_test.sh
+++ b/test/build_optimized_size_test.sh
@@ -30,14 +30,14 @@ cmake_install_executorch_lib() {
           -DEXECUTORCH_OPTIMIZE_SIZE=ON \
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           -Bcmake-out .
-  cmake --build cmake-out -j9 --target install --config MinSizeRel
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config MinSizeRel
 }
 
 test_cmake_size_test() {
     CXXFLAGS="-g" retry cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DEXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON -DCMAKE_INSTALL_PREFIX=cmake-out -Bcmake-out/test test
 
     echo "Build size test"
-    cmake --build cmake-out/test -j9 --config MinSizeRel
+    cmake --build cmake-out/test -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config MinSizeRel
 
     echo 'ExecuTorch with no ops binary size, unstripped:'
     ls -al cmake-out/test/size_test

--- a/test/build_size_test.sh
+++ b/test/build_size_test.sh
@@ -33,7 +33,7 @@ cmake_install_executorch_lib() {
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           ${EXTRA_BUILD_ARGS} \
           -Bcmake-out .
-  cmake --build cmake-out -j9 --target install --config Release
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 }
 
 test_cmake_size_test() {
@@ -43,7 +43,7 @@ test_cmake_size_test() {
         -Bcmake-out/test test
 
     echo "Build size test"
-    cmake --build cmake-out/test -j9 --config Release
+    cmake --build cmake-out/test -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 
     echo 'ExecuTorch with no ops binary size, unstripped:'
     ls -al cmake-out/test/size_test

--- a/test/run_oss_cpp_tests.sh
+++ b/test/run_oss_cpp_tests.sh
@@ -59,7 +59,7 @@ build_executorch() {
     -DEXECUTORCH_BUILD_XNNPACK=ON \
     -DEXECUTORCH_BUILD_TESTS=ON \
     -Bcmake-out
-  cmake --build cmake-out -j9 --target install
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install
 }
 
 build_and_run_test() {


### PR DESCRIPTION
### Summary
Several build docs and `test/` scripts hardcode the `cmake --build -j`
parallelism (`-j9`, `-j10`), which assumes a fixed machine. This replaces
them with a portable expression that derives "core count + 1" at runtime —
`nproc` on Linux, `sysctl -n hw.ncpu` on macOS:

    -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))

"core count + 1" matches the guidance already documented in
`docs/source/using-executorch-building-from-source.md`. The `nproc → sysctl`
fallback keeps the commands working on both Linux and macOS, and the
arithmetic degrades gracefully to `-j1` if neither tool is available.

Partial fix for #10887. Scope is limited to general (non-vendor) docs and
contributor-facing `test/` build scripts (9 files). Vendor-backend scripts
(cadence, vulkan, coreml, qualcomm, mediatek, samsung, mps, nxp), CI scripts
under `.ci/`, and non-cmake `-j` flags are intentionally left for follow-ups.

### Test plan
- `lintrunner` passes on all changed files.
- `bash -n` passes on the three modified shell scripts.
- Verified the expression evaluates to a valid integer on Linux, e.g. `17`
  on a 16-core machine.

cc @GregoryComer @digantdesai @cbilgin @JakeStevens @larryliu0820