### PR TITLE
Fix variable type mismatch build failure

### DIFF
--- a/runtime/core/array_ref.h
+++ b/runtime/core/array_ref.h
@@ -162,7 +162,7 @@ class ArrayRef final {
   /// slice(n, m) - Take M elements of the array starting at element N
   ArrayRef<T> slice(size_t N, size_t M) const {
     // cant slice longer then the array
-    size_t end = 0;
+    uint64_t end = 0;
     ET_CHECK(!c10::add_overflows(N, M, &end) && end <= size());
     return ArrayRef<T>(data() + N, M);
   }

--- a/runtime/core/hierarchical_allocator.h
+++ b/runtime/core/hierarchical_allocator.h
@@ -84,7 +84,7 @@ class HierarchicalAllocator final {
       size_t offset_bytes,
       size_t size_bytes) {
     // Check for integer overflow in offset_bytes + size_bytes.
-    size_t end_bytes = 0;
+    uint64_t end_bytes = 0;
     ET_CHECK_OR_RETURN_ERROR(
         !c10::add_overflows(offset_bytes, size_bytes, &end_bytes),
         InvalidArgument,


### PR DESCRIPTION
### Summary
Fix a variable type mismatch in two locations - it should be uint64_t, not size_t. This appears to be a regression introduced when adding overflow checks. It compiles on some platforms, but breaks on platforms where uint64_t != size_t. For example, on mac w/ clang, size_t is unsigned long whereas uint64_t is unsigned long long. Both are 64 bits, but it nonetheless fails to compile due to the mismatch.