### PR TITLE
Default to C++20, pin embedded backends to C++17

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -23,7 +23,7 @@
   gh_facebook_buck2_shims_meta = shim
 
 [cxx]
-  cxxflags = -g -std=c++17
+  cxxflags = -g -std=c++20
 
 [parser]
   target_platform_detector_spec = target:root//...->prelude//platforms:default target:shim//...->prelude//platforms:default

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,8 @@ announce_configured_options(ET_ENABLE_VGF_INPUT_DUMP)
 # they can be properly gc'd. -s: strip symbol.
 if(WIN32)
   set(CMAKE_CXX_FLAGS_RELEASE "/Gy /Gw ${CMAKE_CXX_FLAGS_RELEASE}")
+  # C++20 headers pull in <windows.h>; suppress its min/max macros.
+  add_compile_definitions(NOMINMAX)
 else()
   set(CMAKE_CXX_FLAGS_RELEASE
       "-ffunction-sections -fdata-sections ${CMAKE_CXX_FLAGS_RELEASE}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ include(ExternalProject)
 include(GNUInstallDirs)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
 endif()
 announce_configured_options(CMAKE_CXX_STANDARD)
 

--- a/backends/arm/CMakeLists.txt
+++ b/backends/arm/CMakeLists.txt
@@ -7,6 +7,9 @@ project(arm_backend)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Pin to C++17 for embedded toolchain compatibility (not all support C++20).
+set(CMAKE_CXX_STANDARD 17)
+
 # Source root directory for executorch.
 if(NOT EXECUTORCH_ROOT)
   set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)

--- a/backends/cadence/CMakeLists.txt
+++ b/backends/cadence/CMakeLists.txt
@@ -7,9 +7,8 @@
 # Set the minimum required version of CMake for this project.
 cmake_minimum_required(VERSION 3.10)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+# Pin to C++17 for embedded toolchain compatibility (not all support C++20).
+set(CMAKE_CXX_STANDARD 17)
 
 # Set the project name.
 project(cadence_backend)

--- a/backends/cadence/fusion_g3/operators/CMakeLists.txt
+++ b/backends/cadence/fusion_g3/operators/CMakeLists.txt
@@ -7,9 +7,8 @@
 cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+# Pin to C++17 for embedded toolchain compatibility (not all support C++20).
+set(CMAKE_CXX_STANDARD 17)
 
 include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 include(${EXECUTORCH_ROOT}/tools/cmake/Codegen.cmake)

--- a/backends/cadence/generic/operators/CMakeLists.txt
+++ b/backends/cadence/generic/operators/CMakeLists.txt
@@ -7,9 +7,8 @@
 cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+# Pin to C++17 for embedded toolchain compatibility (not all support C++20).
+set(CMAKE_CXX_STANDARD 17)
 
 include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 include(${EXECUTORCH_ROOT}/tools/cmake/Codegen.cmake)

--- a/backends/cadence/hifi/operators/CMakeLists.txt
+++ b/backends/cadence/hifi/operators/CMakeLists.txt
@@ -7,9 +7,8 @@
 cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+# Pin to C++17 for embedded toolchain compatibility (not all support C++20).
+set(CMAKE_CXX_STANDARD 17)
 
 include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 include(${EXECUTORCH_ROOT}/tools/cmake/Codegen.cmake)

--- a/backends/cadence/vision/operators/CMakeLists.txt
+++ b/backends/cadence/vision/operators/CMakeLists.txt
@@ -7,9 +7,8 @@
 cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+# Pin to C++17 for embedded toolchain compatibility (not all support C++20).
+set(CMAKE_CXX_STANDARD 17)
 
 include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 include(${EXECUTORCH_ROOT}/tools/cmake/Codegen.cmake)

--- a/backends/cortex_m/CMakeLists.txt
+++ b/backends/cortex_m/CMakeLists.txt
@@ -8,9 +8,8 @@
 cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+# Pin to C++17 for embedded toolchain compatibility (not all support C++20).
+set(CMAKE_CXX_STANDARD 17)
 
 # Source root directory for executorch
 if(NOT EXECUTORCH_ROOT)

--- a/backends/mediatek/CMakeLists.txt
+++ b/backends/mediatek/CMakeLists.txt
@@ -8,6 +8,9 @@
 */
 ]]
 
+# Pin to C++17 for embedded toolchain compatibility (not all support C++20).
+set(CMAKE_CXX_STANDARD 17)
+
 # Let include directory as "executorch/..."
 set(_common_include_directories ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 

--- a/backends/nxp/CMakeLists.txt
+++ b/backends/nxp/CMakeLists.txt
@@ -3,6 +3,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Pin to C++17 for embedded toolchain compatibility (not all support C++20).
+set(CMAKE_CXX_STANDARD 17)
+
 set(_common_include_directories ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 add_compile_definitions(C10_USING_CUSTOM_GENERATED_MACROS)
 


### PR DESCRIPTION


### Summary

PyTorch has moved to C++20 and ExecuTorch's PyTorch-facing targets (_portable_lib, util, wheel config) are already built as C++20. Raise the repo-wide default in the top-level CMakeLists and .buckconfig to match.

The embedded backends build the portable runtime without PyTorch, so their constraint is the cross-toolchain, not the standard the host uses. Pin cadence, cortex_m, arm, nxp, and mediatek to C++17 so they keep building on toolchains (e.g. Xtensa) that lack full C++20 support, regardless of the new default.


### Test plan
No new test is required.

cc @mcremon-meta @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani @robert-kalmar @JakeStevens