### PR TITLE
Qualcomm AI Engine Direct - Remove C++ designated initializers for Windows MSVC

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/qnn_multimodal_runner.cpp
+++ b/examples/qualcomm/oss_scripts/llama/qnn_multimodal_runner.cpp
@@ -175,16 +175,15 @@ void start_multimodal_runner(
       buf.push_back(c);
     }
   };
-  executorch::extension::llm::GenerationConfig config{
-      .echo = true,
-      .ignore_eos = false,
-      .max_new_tokens = -1,
-      .warming = false,
-      .seq_len = FLAGS_seq_len,
-      .temperature = static_cast<float>(FLAGS_temperature),
-      .num_bos = 0,
-      .num_eos = 0,
-  };
+  executorch::extension::llm::GenerationConfig config;
+  config.echo = true;
+  config.ignore_eos = false;
+  config.max_new_tokens = -1;
+  config.warming = false;
+  config.seq_len = FLAGS_seq_len;
+  config.temperature = static_cast<float>(FLAGS_temperature);
+  config.num_bos = 0;
+  config.num_eos = 0;
 
   // 1. [Multimodal] Get raw files from input_list.txt
   std::vector<std::string> audio_raw_files;


### PR DESCRIPTION
### Summary

This PR is a follow-up to https://github.com/pytorch/executorch/pull/19686

Due to the changes in https://github.com/pytorch/executorch/pull/19621, additional adjustments are required for Windows MSVC compatibility. This PR removes remaining C++ designated initializers and aligns the implementation accordingly.

- Designated initializers for C++ aggregates were standardized in C++20.
- GCC and Clang have supported them as a C++11/14/17 extension — they silently accept the syntax even when compiling in `-std=c++17` mode.
- MSVC is strictly conformant: it only accepts designated initializers when `/std:c++20` (or `/std:c++latest`) is active.
