### PR TITLE
Cortex-M backend: Remove cmsis_nn check in passes/__init__

### DIFF
--- a/backends/cortex_m/passes/__init__.py
+++ b/backends/cortex_m/passes/__init__.py
@@ -3,36 +3,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from importlib.util import find_spec
-
-
-def _missing_dependencies_error(missing: str) -> ModuleNotFoundError:
-    return ModuleNotFoundError(
-        "Cortex-M backend dependencies are not installed "
-        f"(missing: {missing}). Install ExecuTorch with "
-        "`pip install executorch[cortex_m]`, or if building from source run "
-        "`examples/arm/setup.sh --i-agree-to-the-contained-eula`."
-    )
-
-
-def _ensure_cortex_m_dependencies() -> None:
-    required_modules = {
-        "cmsis_nn": "cmsis_nn",
-    }
-    missing_packages = []
-    for module_name, package_name in required_modules.items():
-        try:
-            if find_spec(module_name) is None:
-                missing_packages.append(package_name)
-        except (ImportError, ValueError):
-            missing_packages.append(package_name)
-
-    if missing_packages:
-        raise _missing_dependencies_error(", ".join(missing_packages))
-
-
-_ensure_cortex_m_dependencies()
-
 from .cortex_m_pass import CortexMPass  # noqa  # usort: skip
 from .activation_fusion_pass import ActivationFusionPass  # noqa
 from .aten_to_cortex_m_pass import AtenToCortexMPass  # noqa


### PR DESCRIPTION
https://github.com/pytorch/executorch/pull/20371 removed the need for it, but missed actually removing it.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani