### PR TITLE
Arm backend: Relax Qwen3 VL BF16 tolerance on Arm64

### DIFF
--- a/backends/arm/test/models/Qwen3_VL/test_qwen3_vl_model.py
+++ b/backends/arm/test/models/Qwen3_VL/test_qwen3_vl_model.py
@@ -246,6 +246,13 @@ def test_qwen3_vl_full_models_tosa_FP(test_case: Qwen3VLModelTestCase):
 def test_qwen3_vl_full_models_tosa_FP_bf16(test_case: Qwen3VLModelTestCase):
     model, inputs = test_case.model_cls.prepare_model_and_inputs()
     model, inputs = _to_bfloat16_model_and_floating_inputs(model, inputs)
+    # Slightly higher atol for TOSA BF16 on aarch64 (MLETORCH-2048: numeric mismatch)
+    atol = (
+        0.4
+        if common.is_aarch64_host()
+        and test_case.model_cls is LowerableVisionModelWrapper
+        else 0.1
+    )
     with torch.no_grad():
         pipeline = TosaPipelineFP[input_t](
             model,
@@ -253,8 +260,8 @@ def test_qwen3_vl_full_models_tosa_FP_bf16(test_case: Qwen3VLModelTestCase):
             aten_op=[],
             exir_op=[],
             tosa_extensions=["bf16"],
-            atol=1e-1,
-            rtol=1e-1,
+            atol=atol,
+            rtol=0.1,
         )
         pipeline.run()
 


### PR DESCRIPTION
Increase the TOSA BF16 atol for the Qwen3 VL full vision-model test on aarch64 only.


cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani