### PR TITLE
Fix nullable-to-nonnull conversions for Xcode 26.6 (#20466)

### DIFF
--- a/extension/llm/apple/ExecuTorchLLM/Exported/ExecuTorchLLMMultimodalRunner.mm
+++ b/extension/llm/apple/ExecuTorchLLM/Exported/ExecuTorchLLMMultimodalRunner.mm
@@ -170,8 +170,8 @@ using namespace executorch::runtime;
 - (BOOL)loadWithError:(NSError**)error {
   if (![self isLoaded]) {
     _runner = llm::create_multimodal_runner(
-      _modelPath.UTF8String,
-      llm::load_tokenizer(_tokenizerPath.UTF8String)
+      _modelPath.UTF8String ?: "",
+      llm::load_tokenizer(_tokenizerPath.UTF8String ?: "")
     );
     if (!_runner) {
       if (error) {
@@ -206,7 +206,7 @@ using namespace executorch::runtime;
   for (ExecuTorchLLMMultimodalInput *input in inputs) {
     switch (input.type) {
       case ExecuTorchLLMMultimodalInputTypeText:
-        nativeInputs.emplace_back(llm::MultimodalInput(input.text.UTF8String));
+        nativeInputs.emplace_back(llm::MultimodalInput(input.text.UTF8String ?: ""));
         break;
       case ExecuTorchLLMMultimodalInputTypeImage: {
         ExecuTorchLLMImage *image = input.image;

--- a/extension/llm/apple/ExecuTorchLLM/Exported/ExecuTorchLLMTextRunner.mm
+++ b/extension/llm/apple/ExecuTorchLLM/Exported/ExecuTorchLLMTextRunner.mm
@@ -44,7 +44,7 @@ using namespace executorch::runtime;
     _tokenizerPath = [tokenizerPath copy];
     _specialTokens = std::make_unique<std::vector<std::string>>();
     for (NSString *token in specialTokens) {
-      _specialTokens->emplace_back(token.UTF8String);
+      _specialTokens->emplace_back(token.UTF8String ?: "");
     }
   }
   return self;
@@ -57,8 +57,8 @@ using namespace executorch::runtime;
 - (BOOL)loadWithError:(NSError**)error {
   if (![self isLoaded]) {
     _runner = llm::create_text_llm_runner(
-      _modelPath.UTF8String,
-      llm::load_tokenizer(_tokenizerPath.UTF8String, std::move(_specialTokens))
+      _modelPath.UTF8String ?: "",
+      llm::load_tokenizer(_tokenizerPath.UTF8String ?: "", std::move(_specialTokens))
     );
     if (!_runner) {
       if (error) {
@@ -89,7 +89,7 @@ using namespace executorch::runtime;
     return NO;
   }
   auto status = _runner->generate(
-    prompt.UTF8String,
+    prompt.UTF8String ?: "",
     config.nativeConfig,
     [callback](const std::string& token) {
       if (callback) {


### PR DESCRIPTION
Summary:

X-link: https://github.com/pytorch/pytorch/pull/187979

Xcode 26.x errors under `-Werror` on implicit conversions from nullable `NSString.UTF8String` results to non-nullable `const char *` / `std::string` parameters. Guard each affected site with a `?: ""` fallback (these paths are non-null in practice, so behavior is unchanged). Fixed sites (both the `fbcode` and `xplat` mirror copies):

- `caffe2/.../mpscnn/tests/MPSCNNTests.mm`: the `sf.UTF8String` append in the tensor-printing helper.
- `executorch/.../ExecuTorchLLMTextRunner.mm`: `token.UTF8String` (special tokens), `_modelPath`/`_tokenizerPath` (runner creation), and `prompt.UTF8String` (generate).
- `executorch/.../ExecuTorchLLMMultimodalRunner.mm`: `_modelPath`/`_tokenizerPath` (runner creation) and `input.text.UTF8String` (text input).

___

Differential Revision: D109459540


