### PR TITLE
ovr_config | arvr_is_host_or_target_platform | Migrate constraint refs from aliases to subtargets.

### DIFF
--- a/runtime/kernel/targets.bzl
+++ b/runtime/kernel/targets.bzl
@@ -5,7 +5,7 @@ def _operator_registry_preprocessor_flags():
     if max_kernel_num != None:
         return select({
             "DEFAULT": ["-DMAX_KERNEL_NUM=" + max_kernel_num],
-            "ovr_config//build_mode/constraints:arvr_is_host_platform": []
+            "ovr_config//build_mode/constraints:arvr_is_host_or_target_platform[arvr_is_host_platform]": []
         })
     elif not runtime.is_oss:
         return select({


### PR DESCRIPTION
Reviewed By: IanChilds

Differential Revision: D108856354


