### PR TITLE
Arm backend: Add Jupyter notebook example of MXFP

### DIFF
--- a/backends/arm/ao_ext/ops/mxfp_conv2d_op.py
+++ b/backends/arm/ao_ext/ops/mxfp_conv2d_op.py
@@ -206,11 +206,12 @@ class MXFPConv2dOp(torch.nn.Module):
         padding: tuple[int, int],
         dilation: tuple[int, int],
         groups: int,
-        config: MXFPOpConfig,
+        weight_dtype: MXFPDType,
+        block_size: int,
     ) -> None:
         super().__init__()
-        self.config = config
-        self.weight_dtype = mxfp_dtype_to_str(config.weight_dtype)
+        self.weight_dtype = mxfp_dtype_to_str(weight_dtype)
+        self.block_size = block_size
 
         self.register_buffer("weight_qdata", weight_qdata, persistent=True)
         self.register_buffer("weight_scale", weight_scale, persistent=True)
@@ -241,7 +242,7 @@ class MXFPConv2dOp(torch.nn.Module):
             list(self.padding),
             list(self.dilation),
             self.groups,
-            self.config.block_size,
+            self.block_size,
             self.weight_dtype,
         )
 
@@ -283,5 +284,6 @@ def transform_conv2d_to_mxfp(
         padding,
         dilation,
         module.groups,
-        config,
+        config.weight_dtype,
+        config.block_size,
     )

--- a/backends/arm/ao_ext/ops/mxfp_linear_op.py
+++ b/backends/arm/ao_ext/ops/mxfp_linear_op.py
@@ -137,11 +137,12 @@ class MXFPLinearOp(torch.nn.Module):
         weight_qdata: torch.Tensor,
         weight_scale: torch.Tensor,
         bias: torch.Tensor | None,
-        config: MXFPOpConfig,
+        weight_dtype: MXFPDType,
+        block_size: int,
     ) -> None:
         super().__init__()
-        self.config = config
-        self.weight_dtype = mxfp_dtype_to_str(config.weight_dtype)
+        self.weight_dtype = mxfp_dtype_to_str(weight_dtype)
+        self.block_size = block_size
 
         self.register_buffer("weight_qdata", weight_qdata, persistent=True)
         self.register_buffer("weight_scale", weight_scale, persistent=True)
@@ -163,7 +164,7 @@ class MXFPLinearOp(torch.nn.Module):
             self.weight_qdata,
             self.weight_scale,
             self.bias,
-            self.config.block_size,
+            self.block_size,
             self.weight_dtype,
         )
 
@@ -195,4 +196,10 @@ def transform_linear_to_mxfp(
     weight_scale = weight_scale.unsqueeze(0)
 
     bias = module.bias.detach().to(torch.float32) if module.bias is not None else None
-    return MXFPLinearOp(weight_qdata, weight_scale, bias, config)
+    return MXFPLinearOp(
+        weight_qdata,
+        weight_scale,
+        bias,
+        config.weight_dtype,
+        config.block_size,
+    )

--- a/examples/arm/mxfp_example.ipynb
+++ b/examples/arm/mxfp_example.ipynb
@@ -1,0 +1,247 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "927014ab",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Copyright 2026 Arm Limited and/or its affiliates.\n",
+        "#\n",
+        "# This source code is licensed under the BSD-style license found in the\n",
+        "# LICENSE file in the root directory of this source tree."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "96dd9def",
+      "metadata": {},
+      "source": [
+        "**NOTICE:** *MXFP is not yet fully supported in the VGF backend. This example instead uses the TOSA reference model until VGF has full support.*"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "080aefe7",
+      "metadata": {},
+      "source": [
+        "# Running MXFP on Arm backend\n",
+        "\n",
+        "This guide demonstrates the full flow for quantizing select submodules to MXFP on the Arm backend.\n",
+        "\n",
+        "Before you begin:\n",
+        "1. (In a clean virtual environment with a compatible Python version) Install executorch using `./install_executorch.sh`\n",
+        "2. Install Arm cross-compilation toolchain and simulators using `./examples/arm/setup.sh --i-agree-to-the-contained-eula`\n",
+        "3. Export vulkan environment variables and add MLSDK components to PATH and LD_LIBRARY_PATH using `examples/arm/arm-scratch/setup_path.sh`\n",
+        "\n",
+        "With all commands executed from the base `executorch` folder."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "12b6bd63",
+      "metadata": {},
+      "source": [
+        "### Define the module and quantize it to MXFP\n",
+        "\n",
+        "The following code block shows how to use the `to_mxfp` API to quantize a PyTorch module to an MXFP representation. We start by defining the `torch.nn.Module` we want to quantize, then an `MXFPOpConfig` specifiying how to perform the quantization is created. The config selects which datatype to quantize to, and which exact layers to target. `to_mxfp` then quantizes the module in place."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "05a233cc",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import torch\n",
+        "from torch import nn\n",
+        "\n",
+        "from executorch.backends.arm.ao_ext import MXFPOpConfig, to_mxfp\n",
+        "\n",
+        "torch.manual_seed(0)\n",
+        "\n",
+        "def filter_only_fc1(mod: nn.Module, name: str) -> bool:\n",
+        "    return name == \"fc1\"        \n",
+        "\n",
+        "\n",
+        "class Mod(nn.Module):\n",
+        "    def __init__(self):\n",
+        "        super().__init__()\n",
+        "        self.fc1 = nn.Linear(32, 64)\n",
+        "        self.fc2 = nn.Linear(64, 16)\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        x = self.fc1(x)\n",
+        "        x = torch.relu(x)\n",
+        "        x = self.fc2(x)\n",
+        "        return x\n",
+        "\n",
+        "\n",
+        "module = Mod().eval()\n",
+        "print(f\"Initial module:\\n{module}\\n\")\n",
+        "\n",
+        "# F8E4M3 is used here. See backends/arm/ao_ext/mxfp.py for all supported datatypes.\n",
+        "config = MXFPOpConfig(\n",
+        "    weight_dtype=torch.float8_e4m3fn,\n",
+        ")\n",
+        "# To quantize only module.fc1, add back the commented out filter_fn arg.\n",
+        "to_mxfp(\n",
+        "    module,\n",
+        "    config,\n",
+        "    # filter_fn=filter_only_fc1,\n",
+        ")\n",
+        "print(f\"MXFP-quantized module:\\n{module}\\n\")\n",
+        "\n",
+        "\n",
+        "example_inputs = (torch.randn(1, 32),)\n",
+        "exported_program = torch.export.export(module, example_inputs)\n",
+        "graph_module = exported_program.module(check_guards=False)\n",
+        "print(\"Exported module:\")\n",
+        "_ = graph_module.print_readable()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "48cb1113",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "from executorch.backends.arm.tosa.partitioner import TOSAPartitioner\n",
+        "from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec\n",
+        "from executorch.exir import (\n",
+        "    EdgeCompileConfig,\n",
+        "    ExecutorchBackendConfig,\n",
+        "    to_edge_transform_and_lower,\n",
+        ")\n",
+        "from executorch.extension.export_util.utils import save_pte_program\n",
+        "\n",
+        "\n",
+        "# TODO MLETORCH-2141: MXFP is not fully supported in the VGF toolchain yet.\n",
+        "# Use the TOSA reference model in the mean time and switch to VgfPartitioner\n",
+        "# when full support is in place.\n",
+        "compile_spec = TosaCompileSpec(\"TOSA-1.1+FP+mxfp\")\n",
+        "partitioner = TOSAPartitioner(compile_spec)\n",
+        "\n",
+        "# Lower the exported program to the TOSA backend\n",
+        "edge_program_manager = to_edge_transform_and_lower(\n",
+        "    exported_program,\n",
+        "    partitioner=[partitioner],\n",
+        "    compile_config=EdgeCompileConfig(\n",
+        "        _check_ir_validity=False,\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "# Convert edge program to executorch\n",
+        "executorch_program_manager = edge_program_manager.to_executorch(\n",
+        "    config=ExecutorchBackendConfig(extract_delegate_segments=False)\n",
+        ")\n",
+        "executorch_program_manager.exported_program().module(check_guards=False).print_readable()\n",
+        "\n",
+        "# Save pte file\n",
+        "cwd_dir = os.getcwd()\n",
+        "pte_base_name = \"mxfp_example\"\n",
+        "pte_name = pte_base_name + \".pte\"\n",
+        "pte_path = os.path.join(cwd_dir, pte_name)\n",
+        "save_pte_program(executorch_program_manager, pte_name)\n",
+        "assert os.path.exists(pte_path), \"Build failed; no .pte-file found\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "2c22f2c9",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from executorch.backends.arm.test.runner_utils import TosaReferenceModelDispatch\n",
+        "\n",
+        "# TODO MLETORCH-2141: Run on VGF backend instead when it's supported.\n",
+        "with torch.no_grad():\n",
+        "    lowered_module = executorch_program_manager.exported_program().graph_module\n",
+        "    with TosaReferenceModelDispatch():\n",
+        "        tosa_ref_output = lowered_module(*example_inputs)\n",
+        "\n",
+        "print(\"Model output:\")\n",
+        "print(tosa_ref_output)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "89941ec7",
+      "metadata": {},
+      "source": [
+        "### Porting over already quantized modules\n",
+        "\n",
+        "The flow presented in this notebook shows how to quantize a module to MXFP, but what if we have a module that was quantized outside of the Arm backend's `to_mxfp` flow? Then we need to port this module to the representation that is compatible with the Arm backend. Doing this requires manual work, but it is possible; note that `to_mxfp` simply replaces submodules with corresponding MXFP implementations, e.g., `torch.nn.Linear` is replaced with `executorch.backends.arm.ao_ext.ops.MXFPLinearOp`. With this observation we can replicate this procedure manually by reassigning the module's weights. The code snippet below shows how to replace the model `Mod`'s `self.fc1` with some made-up pretrained MXFP4 weights we could have gotten from somewhere else."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "11b72b86",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import torch\n",
+        "from executorch.backends.arm.ao_ext.ops import MXFPLinearOp\n",
+        "\n",
+        "block_size = 32\n",
+        "in_features = 32\n",
+        "out_features = 64\n",
+        "\n",
+        "# Note: float4_e2m1fn_x2 weights are packed pairwise into uint8 arrays\n",
+        "example_external_w_data = torch.randint(\n",
+        "    0,\n",
+        "    256,\n",
+        "    (1, out_features, in_features // 2),\n",
+        "    dtype=torch.uint8,\n",
+        ")\n",
+        "example_external_w_scale = torch.randint(\n",
+        "    0,\n",
+        "    256,\n",
+        "    (1, out_features, in_features // block_size),\n",
+        "    dtype=torch.float8_e8m0fnu,\n",
+        ")\n",
+        "example_external_bias = torch.randn(out_features, dtype=torch.float32)\n",
+        "\n",
+        "module = Mod().eval()\n",
+        "module.fc1 = MXFPLinearOp(\n",
+        "    example_external_w_data,\n",
+        "    example_external_w_scale,\n",
+        "    example_external_bias,\n",
+        "    torch.float4_e2m1fn_x2,\n",
+        "    block_size,\n",
+        ")\n",
+        "\n",
+        "port_output = module(example_inputs[0])\n",
+        "assert port_output.shape == (1, 16)\n",
+        "print(module)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "env",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.4"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
Add Jupyter notebook example of MXFP workflow on the Arm backend.

Use the weight dtype and block size on MXFP linear and Conv2d directly
instead of accessing them through the config. This will make the last section
of the example simpler.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani