### PR TITLE
Add oncall to all executorch build files missing one (#20496)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,1 @@
+oncall("executorch")

--- a/backends/aoti/BUCK
+++ b/backends/aoti/BUCK
@@ -1,3 +1,5 @@
 load("targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/backends/aoti/TARGETS
+++ b/backends/aoti/TARGETS
@@ -1,3 +1,5 @@
 load("targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/backends/aoti/slim/c10/core/BUCK
+++ b/backends/aoti/slim/c10/core/BUCK
@@ -1,3 +1,5 @@
 load("targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/backends/aoti/slim/c10/core/test/BUCK
+++ b/backends/aoti/slim/c10/core/test/BUCK
@@ -1,4 +1,6 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 fbcode_target(_kind = define_common_targets,)

--- a/backends/aoti/slim/c10/macros/BUCK
+++ b/backends/aoti/slim/c10/macros/BUCK
@@ -1,4 +1,6 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 fbcode_target(_kind = define_common_targets,)

--- a/backends/aoti/slim/core/BUCK
+++ b/backends/aoti/slim/core/BUCK
@@ -1,4 +1,6 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 fbcode_target(_kind = define_common_targets,)

--- a/backends/aoti/slim/core/test/BUCK
+++ b/backends/aoti/slim/core/test/BUCK
@@ -1,4 +1,6 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 fbcode_target(_kind = define_common_targets,)

--- a/backends/aoti/slim/factory/BUCK
+++ b/backends/aoti/slim/factory/BUCK
@@ -1,4 +1,6 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 fbcode_target(_kind = define_common_targets,)

--- a/backends/aoti/slim/util/BUCK
+++ b/backends/aoti/slim/util/BUCK
@@ -1,3 +1,5 @@
 load("targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/backends/aoti/slim/util/test/BUCK
+++ b/backends/aoti/slim/util/test/BUCK
@@ -1,3 +1,5 @@
 load("targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/backends/arm/BUCK
+++ b/backends/arm/BUCK
@@ -9,6 +9,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(
     _kind = runtime.python_library,
     name = "constants",

--- a/backends/arm/_passes/BUCK
+++ b/backends/arm/_passes/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(
     _kind = runtime.python_library,
     name = "core",

--- a/backends/arm/debug/BUCK
+++ b/backends/arm/debug/BUCK
@@ -2,6 +2,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(
     _kind = runtime.python_library,
     name = "schema",

--- a/backends/arm/operator_support/BUCK
+++ b/backends/arm/operator_support/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(
     _kind = runtime.python_library,
     name = "operator_support",

--- a/backends/arm/operators/BUCK
+++ b/backends/arm/operators/BUCK
@@ -2,6 +2,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(
     _kind = runtime.python_library,
     name = "node_visitor",

--- a/backends/arm/quantizer/BUCK
+++ b/backends/arm/quantizer/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 # Exposed through __init__.py
 fbcode_target(
     _kind = runtime.python_library,

--- a/backends/arm/tosa/BUCK
+++ b/backends/arm/tosa/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(_kind = runtime.python_library,
     name = "schemas",
     srcs = ["schemas/__init__.py"],

--- a/backends/arm/tosa/dialect/BUCK
+++ b/backends/arm/tosa/dialect/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(_kind = runtime.python_library,
     name = "core",
     srcs = [

--- a/backends/mediatek/BUCK
+++ b/backends/mediatek/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(_kind = runtime.python_library,
     name = "preprocess",
     srcs = [

--- a/backends/mediatek/_passes/BUCK
+++ b/backends/mediatek/_passes/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(_kind = runtime.python_library,
     name = "passes",
     srcs = [

--- a/backends/mediatek/quantizer/BUCK
+++ b/backends/mediatek/quantizer/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(
     _kind = runtime.python_library,
     name = "quantizer",

--- a/backends/qualcomm/debugger/BUCK
+++ b/backends/qualcomm/debugger/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(
     _kind = runtime.python_library,
     name = "utils",

--- a/backends/xnnpack/quantizer/BUCK
+++ b/backends/xnnpack/quantizer/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(
     _kind = runtime.python_library,
     name = "xnnpack_quantizer",

--- a/examples/apple/coreml/llama/BUCK
+++ b/examples/apple/coreml/llama/BUCK
@@ -4,6 +4,8 @@ load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "no
 
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
+oncall("executorch")
+
 fbcode_target(_kind = runtime.python_library,
     name = "llama_transformer",
     srcs = [

--- a/examples/apple/coreml/scripts/BUCK
+++ b/examples/apple/coreml/scripts/BUCK
@@ -3,6 +3,8 @@ load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "no
 # targets.bzl. This file can contain fbcode-only targets.
 load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
 
+oncall("executorch")
+
 fbcode_target(_kind = python_binary,
     name = "extract_coreml_models",
     srcs = [

--- a/exir/backend/test/demos/BUCK
+++ b/exir/backend/test/demos/BUCK
@@ -1,6 +1,8 @@
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 
+oncall("executorch")
+
 fbcode_target(_kind = python_unittest,
     name = "test_delegate_aten_mode",
     srcs = [

--- a/shim_et/BUCK
+++ b/shim_et/BUCK
@@ -5,6 +5,8 @@ load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain", "system_python_toolchain")
 load("@prelude//toolchains:remote_test_execution.bzl", "remote_test_execution_toolchain")
 
+oncall("executorch")
+
 # Although the non-Android toolchains below are present in shim/BUCK, it appears that we
 # have to duplicate them here or builds won't work.
 system_cxx_toolchain(

--- a/shim_et/third-party/nlohmann-json/BUCK
+++ b/shim_et/third-party/nlohmann-json/BUCK
@@ -1,3 +1,5 @@
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()

--- a/shim_et/third-party/re2/BUCK
+++ b/shim_et/third-party/re2/BUCK
@@ -1,3 +1,5 @@
 load(":targets.bzl", "define_common_targets")
 
+oncall("executorch")
+
 define_common_targets()


### PR DESCRIPTION
Summary:

Adds `oncall("executorch")` to every executorch build file that lacked one, and adds a top-level `executorch/BUCK` that declares only the oncall.

Every build file needs an `oncall()` annotation so build and test failures have an owning team. This expands the original `backends/aoti` change to cover the remaining 28 build files per cell (56 files total), applied identically to `fbcode/` and `xplat/`, whose executorch trees mirror each other file-for-file.

`executorch` is the right oncall for all of them: every missing file's own subtree is already dominated by `oncall("executorch")`. The only competing signals anywhere in the set are one `odai_jarvis` (`backends/arm/runtime`) and one `bolt_team` (`backends/arm/runtime/fb`) against 9 pre-existing `executorch` under `backends/arm`.

This PR was authored with AI assistance (Claude Code).

Reviewed By: mzlee

Differential Revision: D109546129


