### PR TITLE
Fix buck dep for test_permute_optimization_passes (#20497)

### DIFF
--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -397,6 +397,7 @@ def define_common_targets():
         deps = [
             "//caffe2:torch",
             "//executorch/backends/test:graph_builder",
+            "//executorch/exir:lib",
             "//executorch/exir:pass_base",
             "//executorch/exir/dialects:lib",
             ":fuse_cascaded_transpose_or_permute_ops",


### PR DESCRIPTION
Summary:

D109300695 (GitHub PR #19873) added a new test `test_postpone_permute_with_symbolic_shapes` that imports `to_edge` and `EdgeCompileConfig` from `executorch.exir`, but the `test_permute_optimization_passes` buck test target was never updated to depend on `//executorch/exir:lib` (the owner of `executorch/exir/__init__.py`). As a result the entire test module failed to import (`Failed to import test module: test_permute_optimization_passes`), turning every test in the module into a land-blocking CRITICAL signal on the diff train.

Add the missing `//executorch/exir:lib` dep to both the `fbcode` and `xplat` copies of `backends/transforms/targets.bzl` so the two mirrors stay in sync.

Reviewed By: Gasoonjia

Differential Revision: D109619313
