### PR TITLE
Add adapter_quant field to LoraConfig

### DIFF
--- a/extension/llm/export/config/llm_config.py
+++ b/extension/llm/export/config/llm_config.py
@@ -96,6 +96,9 @@ class LoraConfig:
     lora_rank: int = 0
     lora_alpha: int = 0
     target_modules: List[str] = field(default_factory=list)
+    # Per-adapter quantization/precision: "int8" | "fp16" | "fp32" | None.
+    # Overrides the global --lora_precision flag for this adapter only.
+    adapter_quant: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
Summary:
Split out from D105388759. Adds a per-adapter quantization/precision field `adapter_quant` to `LoraConfig` so each LoRA adapter can independently select `int8`/`fp16`/`fp32`, overriding the global `--lora_precision` flag for that adapter only.

This is a standalone, behavior-preserving dataclass field addition (defaults to `None`) that the per-adapter quant logic in `export_llm_backbone.py` builds on. Landed separately so the config schema change can be reviewed and merged independently. Changes are mirrored in both the `fbcode` and `xplat` copies of `llm_config.py`.

This diff was authored with Claude Code.

Differential Revision: D109642451


