### PR TITLE
Add shim_et nlohmann-json shim for OSS buck2 build

### DIFF
--- a/shim_et/third-party/nlohmann-json/BUCK
+++ b/shim_et/third-party/nlohmann-json/BUCK
@@ -1,0 +1,3 @@
+load(":targets.bzl", "define_common_targets")
+
+define_common_targets()

--- a/shim_et/third-party/nlohmann-json/targets.bzl
+++ b/shim_et/third-party/nlohmann-json/targets.bzl
@@ -1,0 +1,10 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    # Only for OSS
+    if runtime.is_oss:
+        native.cxx_library(
+            name = "nlohmann-json",
+            exported_deps = ["root//extension/llm/tokenizers/third-party:nlohmann_json"],
+            visibility = ["PUBLIC"],
+        )

--- a/shim_et/xplat/executorch/build/env_interface.bzl
+++ b/shim_et/xplat/executorch/build/env_interface.bzl
@@ -45,7 +45,7 @@ _EXTERNAL_DEPS = {
     "libtorch_python": "//third-party:libtorch_python",
     "log": [], # Intentionally not supporting OSS buck build log
     # Huggingface Tokenizer
-    "nlohmann_json": [], # Intentionally not supporting OSS buck build HF tokenizer.
+    "nlohmann_json": "//extension/llm/tokenizers/third-party:nlohmann_json",
     "prettytable": "//third-party:prettytable",
     "pybind11": "//third-party:pybind11",
     "pcre2": "//extension/llm/tokenizers/third-party:pcre2",


### PR DESCRIPTION
The tokenizers submodule bump moved the
fbsource//third-party/nlohmann-json dependency onto the tokenizers :headers target, which is reachable from the OSS buck2 CI build (multimodal_runner_lib -> text_token_generator -> tokenizers:headers). Since fbsource aliases to shim_et, this requires a shim_et//third-party/nlohmann-json package, which did not exist (only re2 had one).

Add the shim, mirroring shim_et//third-party/re2, aliasing nlohmann-json to the header-only nlohmann_json target added to the tokenizers submodule (meta-pytorch/tokenizers#201), and bump the submodule pin to include it.
