### PR TITLE
Disable qnn_16a16w Llama runner test (OOM on linux.2xlarge)

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -825,7 +825,8 @@ jobs:
     strategy:
       matrix:
         dtype: [fp32]
-        pt2e_quantize: [qnn_16a16w, qnn_8a8w]
+        # TODO(T12345): re-enable qnn_16a16w once OOM on linux.2xlarge is resolved
+        pt2e_quantize: [qnn_8a8w]
         mode: [qnn]
       fail-fast: false
     with:

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -951,7 +951,8 @@ jobs:
     strategy:
       matrix:
         dtype: [fp32]
-        pt2e_quantize: [qnn_16a16w, qnn_8a8w]
+        # TODO(T12345): re-enable qnn_16a16w once OOM on linux.2xlarge is resolved
+        pt2e_quantize: [qnn_8a8w]
         mode: [qnn]
       fail-fast: false
     with:


### PR DESCRIPTION
The test-llama-runner-qnn-linux (qnn_16a16w) job has been OOM-killed on linux.2xlarge since PR #19660 landed, blocking viable/strict from advancing for 73+ commits. Disable it while the Qualcomm team investigates the memory regression and potential accuracy issue.


