### PR TITLE
Arm backend: Add FuseIdenticalInputTransformsPass

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -119,6 +119,9 @@ from .fuse_constant_ops_pass import (  # noqa
 )
 from .fuse_duplicate_users_pass import FuseDuplicateUsersPass  # noqa
 from .fuse_equal_placeholders_pass import FuseEqualPlaceholdersPass  # noqa
+from .fuse_identical_input_transforms_pass import (  # noqa
+    FuseIdenticalInputTransformsPass,
+)
 from .fuse_quantized_activation_pass import FuseQuantizedActivationPass  # noqa
 from .fuse_view_copy_transform_pass import FuseViewCopyTransformPass  # noqa
 from .insert_const_shapes import InsertConstShapesPass  # noqa

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -112,6 +112,7 @@ from executorch.backends.arm._passes import (
     FuseConstantArgsPass,
     FuseDuplicateUsersPass,
     FuseEqualPlaceholdersPass,
+    FuseIdenticalInputTransformsPass,
     FuseQuantizedActivationPass,
     FuseViewCopyTransformPass,
     InsertConstShapesPass,
@@ -500,6 +501,7 @@ class ArmPassManager(ExportedProgramPassManager):
                 # TODO: DecomposeLinearPass should run after InsertRescaleInt32Pass or
                 # before FoldAndAnnotateQParamsPass but is unable to at the moment.
                 # Ticket: MLETORCH-1539
+                FuseIdenticalInputTransformsPass(),
                 DecomposeLinearPass(),
                 InsertRescaleInt32Pass(),
                 FuseConsecutiveRescalesPass(),

--- a/backends/arm/_passes/arm_pass_utils.py
+++ b/backends/arm/_passes/arm_pass_utils.py
@@ -13,6 +13,11 @@ from typing import cast, Optional, Sequence
 
 import torch
 import torch.fx
+
+from executorch.backends.arm._passes.dim_maps import (
+    _normalize_dims,
+    normalize_view_shape,
+)
 from executorch.backends.arm.common.debug import get_node_debug_info
 from executorch.backends.arm.common.type import ensure_type
 from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
@@ -20,7 +25,6 @@ from executorch.exir import ExportedProgram
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
 from executorch.exir.pass_base import NodeMetadata
-
 from torch._export.utils import (
     get_buffer,
     get_lifted_tensor_constant,
@@ -32,6 +36,8 @@ from torch._export.utils import (
 from torch._ops import OpOverload
 from torch._subclasses.fake_tensor import FakeTensor
 from torch.export.graph_signature import InputKind
+
+_Dim = int | torch.SymInt
 
 
 def is_submodule_node(node: torch.fx.Node):
@@ -241,6 +247,43 @@ def meta_without_qparams(meta: NodeMetadata) -> NodeMetadata:
     plain_meta_dict["input_qparams"] = {}
     plain_meta_dict["output_qparams"] = {}
     return NodeMetadata(plain_meta_dict)
+
+
+def refresh_permute_view_meta(node: torch.fx.Node) -> None:
+    """Compute new meta-vals, specifically preserving SymInts for view/permute
+    nodes.
+    """
+    input_node = node.all_input_nodes[0]
+    input_val = input_node.meta.get("val")
+    if input_val is None or node.target not in {
+        exir_ops.edge.aten.view_copy.default,
+        exir_ops.edge.aten.permute_copy.default,
+    }:
+        return
+
+    if not isinstance(input_val, torch.Tensor):
+        node.meta["val"] = node.target(input_val, *node.args[1:])  # type: ignore[operator]
+        return
+
+    # Compute new meta shapes to preserve SymInts.
+    match node.target:
+        case exir_ops.edge.aten.view_copy.default:
+            node.meta["val"] = input_val.new_empty(
+                tuple(
+                    normalize_view_shape(
+                        input_val.shape, cast(Sequence[_Dim], node.args[1])
+                    )
+                )
+            )
+        case exir_ops.edge.aten.permute_copy.default:
+            dims = _normalize_dims(
+                cast(Sequence[int], node.args[1]), len(input_val.shape)
+            )
+            node.meta["val"] = input_val.new_empty(
+                tuple(input_val.shape[dim] for dim in dims)
+            )
+        case _:
+            node.meta["val"] = node.target(input_val, *node.args[1:])  # type: ignore[operator]
 
 
 def insert_scalar(

--- a/backends/arm/_passes/canonicalize_view_copy_permute_pass.py
+++ b/backends/arm/_passes/canonicalize_view_copy_permute_pass.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from typing import cast, Sequence, Set, Type
 
 import torch
+
 from executorch.backends.arm._passes.arm_pass import ArmPass
+from executorch.backends.arm._passes.arm_pass_utils import refresh_permute_view_meta
 from executorch.backends.arm._passes.dim_maps import (
     _dim_equals,
     _is_permutation,
@@ -18,7 +20,6 @@ from executorch.backends.arm._passes.dim_maps import (
 )
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
-
 from torch.fx import GraphModule, Node
 from torch.fx.node import Target
 from torch.fx.passes.infra.pass_base import PassResult
@@ -360,38 +361,11 @@ class CanonicalizeViewCopyPermutePass(ArmPass):
     ) -> None:
         node.target = target
         node.args = (input_node, list(arg))
-        self._refresh_meta(node)
+        refresh_permute_view_meta(node)
 
     def _permute_dims(self, node: Node) -> list[int]:
         assert node.target == self._PERMUTE_TARGET, "Expected permute node"
         return list(cast(Sequence[int], node.args[1]))
-
-    @classmethod
-    def _refresh_meta(cls, node: Node) -> None:
-        input_node = node.args[0]
-        assert isinstance(input_node, Node)
-        input_val = input_node.meta.get("val")
-        if input_val is None or node.target not in cls._TARGETS:
-            return
-
-        # Compute new meta shapes to preserve SymInts.
-        if isinstance(input_val, torch.Tensor):
-            if node.target == cls._VIEW_TARGET:
-                node.meta["val"] = input_val.new_empty(
-                    tuple(cast(Sequence[_Dim], node.args[1]))
-                )
-                return
-
-            if node.target == cls._PERMUTE_TARGET:
-                dims = _normalize_dims(
-                    cast(Sequence[int], node.args[1]), len(input_val.shape)
-                )
-                node.meta["val"] = input_val.new_empty(
-                    tuple(input_val.shape[dim] for dim in dims)
-                )
-                return
-
-        node.meta["val"] = node.target(input_val, *node.args[1:])  # type: ignore[operator]
 
     @staticmethod
     def _shape(node: Node) -> list[_Dim]:

--- a/backends/arm/_passes/dim_maps.py
+++ b/backends/arm/_passes/dim_maps.py
@@ -91,7 +91,21 @@ def _dim_expr(dim: _Dim) -> sympy.Basic:
     return sympy.Integer(dim) if isinstance(dim, int) else dim.node.expr
 
 
+def _simplify_dim(dim: _Dim) -> _Dim:
+    if isinstance(dim, int):
+        return dim
+
+    maybe_int = dim.node.maybe_as_int()
+    return maybe_int if maybe_int is not None else dim
+
+
+def _simplify_shape(shape: Iterable[_Dim]) -> list[_Dim]:
+    return [_simplify_dim(dim) for dim in shape]
+
+
 def _dim_equals(lhs: _Dim, rhs: _Dim) -> bool:
+    lhs = _simplify_dim(lhs)
+    rhs = _simplify_dim(rhs)
     if isinstance(lhs, int) and isinstance(rhs, int):
         return lhs == rhs
     return sympy.simplify(_dim_expr(lhs) - _dim_expr(rhs)) == 0
@@ -113,6 +127,7 @@ def _factor_int(dim: int) -> list[_FactorKey] | None:
 
 
 def _factor_dim(dim: _Dim) -> list[_FactorKey] | None:
+    dim = _simplify_dim(dim)
     if _dim_equals(dim, 1):
         return []
     if isinstance(dim, int):
@@ -143,12 +158,37 @@ def _dedupe(items: Iterable[int]) -> list[int]:
 def numel(shape: Iterable[_Dim]) -> _Dim:
     numel: _Dim = 1
     for dim in shape:
-        numel *= dim
+        numel = _simplify_dim(numel * _simplify_dim(dim))
     return numel
 
 
 def same_numel(first_shape: Iterable[_Dim], second_shape: Iterable[_Dim]) -> bool:
     return _dim_equals(numel(first_shape), numel(second_shape))
+
+
+def normalize_view_shape(
+    source_shape: Sequence[_Dim], target_shape: Sequence[_Dim]
+) -> list[_Dim]:
+    """Normalize a view shape with <=1 unknown dim, indicated by -1."""
+    source_shape = _simplify_shape(source_shape)
+    normalized_shape = _simplify_shape(target_shape)
+    inferred_dims = [
+        index for index, dim in enumerate(normalized_shape) if _dim_equals(dim, -1)
+    ]
+    if not inferred_dims:
+        return normalized_shape
+
+    assert len(inferred_dims) == 1, f"Invalid view shape {target_shape}"
+    inferred_dim = inferred_dims[0]
+    known_shape = [
+        dim for index, dim in enumerate(normalized_shape) if index != inferred_dim
+    ]
+    source_numel = numel(source_shape)
+    known_numel = numel(known_shape)
+    normalized_shape[inferred_dim] = _simplify_dim(
+        source_numel if _dim_equals(known_numel, 1) else source_numel // known_numel
+    )
+    return normalized_shape
 
 
 class _UnionFind:
@@ -210,8 +250,10 @@ class ViewMap:
         input_val = input_node.meta["val"]
         assert isinstance(input_val, torch.Tensor)
 
-        self.source_shape = cast(list[_Dim], list(input_val.shape))
-        self.target_shape = list(cast(Sequence[_Dim], view_node.args[1]))
+        self.source_shape = _simplify_shape(cast(Sequence[_Dim], input_val.shape))
+        self.target_shape = normalize_view_shape(
+            self.source_shape, cast(Sequence[_Dim], view_node.args[1])
+        )
         self._groups = self._build_groups(self.source_shape, self.target_shape)
 
     @classmethod
@@ -220,8 +262,10 @@ class ViewMap:
     ) -> ViewMap:
         """Build a view map directly from source and target shapes."""
         view_map = cls.__new__(cls)
-        view_map.source_shape = list(source_shape)
-        view_map.target_shape = list(target_shape)
+        view_map.source_shape = _simplify_shape(source_shape)
+        view_map.target_shape = normalize_view_shape(
+            view_map.source_shape, target_shape
+        )
         view_map._groups = cls._build_groups(
             view_map.source_shape, view_map.target_shape
         )

--- a/backends/arm/_passes/fuse_identical_input_transforms_pass.py
+++ b/backends/arm/_passes/fuse_identical_input_transforms_pass.py
@@ -1,0 +1,300 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import copy
+from collections.abc import Sequence
+from typing import Any, Callable, cast, Set, Type
+
+import torch
+from executorch.backends.arm._passes.arm_pass import ArmOpTargetedPass
+from executorch.backends.arm._passes.arm_pass_utils import refresh_permute_view_meta
+from executorch.backends.arm._passes.dim_maps import PermuteMap, same_numel, ViewMap
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+from torch.fx import GraphModule, Node
+
+
+class FuseIdenticalInputTransformsPass(ArmOpTargetedPass):
+    """Sink identical input transforms through pointwise ops with multiple
+    inputs. Note that this is only valid for data movement transforms; most
+    operators cannot be swapped in this way while preserving semantics.
+
+    Example:
+        add(permute(x), permute(y))
+    becomes:
+        permute(add(x, y))
+
+    """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    _VIEW_TARGET = exir_ops.edge.aten.view_copy.default
+    _PERMUTE_TARGET = exir_ops.edge.aten.permute_copy.default
+    _TARGETS = {_VIEW_TARGET, _PERMUTE_TARGET}
+    _CONCAT_OPS = {
+        exir_ops.edge.aten.cat.default,
+        exir_ops.edge.aten.concatenate.default,
+    }
+
+    _BINARY_ELEMENTWISE_OPS = {
+        exir_ops.edge.aten.add.Tensor,
+        exir_ops.edge.aten.sub.Tensor,
+        exir_ops.edge.aten.mul.Tensor,
+        exir_ops.edge.aten.div.Tensor,
+        exir_ops.edge.aten.bitwise_right_shift.Tensor,
+        exir_ops.edge.aten.bitwise_left_shift.Tensor,
+        exir_ops.edge.aten.eq.Tensor,
+        exir_ops.edge.aten.gt.Tensor,
+        exir_ops.edge.aten.ge.Tensor,
+        exir_ops.edge.aten.lt.Tensor,
+        exir_ops.edge.aten.le.Tensor,
+        exir_ops.edge.aten.ne.Tensor,
+        exir_ops.edge.aten.bitwise_and.Tensor,
+        exir_ops.edge.aten.bitwise_or.Tensor,
+        exir_ops.edge.aten.bitwise_xor.Tensor,
+        exir_ops.edge.aten.remainder.Tensor,
+    }
+
+    target_ops = _BINARY_ELEMENTWISE_OPS | _CONCAT_OPS
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        modified = False
+
+        while True:
+            iteration_modified = False
+            for node in list(graph_module.graph.nodes):
+                if node.op != "call_function":
+                    continue
+                while self._sink_identical_input_transforms(node):
+                    iteration_modified = True
+
+            if not iteration_modified:
+                break
+            modified = True
+
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.graph.lint()
+            graph_module.recompile()
+            graph_module = super().call(graph_module).graph_module
+
+        return PassResult(graph_module, modified)
+
+    def _sink_identical_input_transforms(self, node: Node) -> bool:
+        if node.target not in self.target_ops:
+            return False
+
+        input_transforms = self._input_transforms(node)
+        if input_transforms is None:
+            return False
+
+        node_val = node.meta.get("val", None)
+        if node_val is None:
+            return False
+
+        transform = input_transforms[0]
+        updated_args = self._updated_node_args(
+            node, transform, node_val, input_transforms
+        )
+        if updated_args is None:
+            return False
+        node_args, node_kwargs, transform_args, node_output_shape = updated_args
+
+        # Remove input transforms
+        producers = [n.all_input_nodes[0] for n in input_transforms]
+
+        node.args = node_args
+        node.kwargs = node_kwargs
+        for input_transform, producer in zip(input_transforms, producers):
+            node.replace_input_with(input_transform, producer)
+        for input_transform in dict.fromkeys(input_transforms):
+            if len(input_transform.users) == 0:
+                node.graph.erase_node(input_transform)
+
+        node.meta = copy.copy(node.meta)
+        node.meta["val"] = node_val.new_empty(node_output_shape)
+
+        # Insert new transform after binary elementwise op
+        with node.graph.inserting_after(node):
+            new_node = node.graph.call_function(
+                cast(Callable[..., Any], transform.target),
+                args=transform_args,
+                kwargs=dict(transform.kwargs),
+            )
+        new_node.meta = copy.copy(transform.meta)
+        refresh_permute_view_meta(new_node)
+
+        for user in list(node.users):
+            if user is not new_node:
+                user.replace_input_with(node, new_node)
+
+        return True
+
+    def _updated_node_args(
+        self, node: Node, transform: Node, node_val: Any, input_transforms: list[Node]
+    ) -> (
+        tuple[tuple[Any, ...], dict[str, Any], tuple[Any, ...], tuple[Any, ...]] | None
+    ):
+        if not self._transforms_are_identical(input_transforms):
+            return None
+        if not self._transforms_only_used_by_node(node, input_transforms):
+            return None
+
+        if node.target in self._BINARY_ELEMENTWISE_OPS:
+            return self._update_node_args_binary(
+                node, transform, node_val, input_transforms
+            )
+
+        if node.target in self._CONCAT_OPS:
+            return self._update_node_args_concat(
+                node, transform, node_val, input_transforms
+            )
+
+        return None
+
+    def _transforms_are_identical(self, input_transforms: list[Node]) -> bool:
+        target = input_transforms[0].target
+        if target not in self._TARGETS:
+            return False
+        if not all(
+            input_transform.target == target for input_transform in input_transforms
+        ):
+            return False
+
+        transform_arg = input_transforms[0].args[1]
+        return all(
+            input_transform.args[1] == transform_arg
+            for input_transform in input_transforms
+        )
+
+    def _transforms_only_used_by_node(
+        self, node: Node, input_transforms: list[Node]
+    ) -> bool:
+        return all(
+            all(user is node for user in input_transform.users)
+            for input_transform in input_transforms
+        )
+
+    def _update_node_args_binary(self, node, transform, node_val, input_transforms):
+        producer_shapes = [
+            tuple(input_node.all_input_nodes[0].meta["val"].shape)
+            for input_node in input_transforms
+        ]
+
+        try:
+            node_output_shape = tuple(torch.broadcast_shapes(*producer_shapes))
+        except RuntimeError:
+            return None
+
+        transform_args = (node, *transform.args[1:])
+        if transform.target == self._VIEW_TARGET:
+            transform_args = (node, list(node_val.shape))
+            if node_output_shape not in producer_shapes:
+                return None
+
+        if transform.target == self._PERMUTE_TARGET:
+            dims = cast(Sequence[int], transform.args[1])
+            rank = len(node_output_shape)
+            normalized_dims = tuple(dim if dim >= 0 else dim + rank for dim in dims)
+            if tuple(node_val.shape) != tuple(
+                node_output_shape[dim] for dim in normalized_dims
+            ):
+                return None
+
+        return node.args, dict(node.kwargs), transform_args, node_output_shape
+
+    def _update_node_args_concat(self, node, transform, node_val, input_transforms):
+        concat_dim = self._concat_dim(node)
+        if concat_dim is None:
+            return None
+
+        new_concat_dim = self._mapped_concat_dim(transform, concat_dim)
+        if new_concat_dim is None:
+            return None
+
+        node_args = (node.args[0], new_concat_dim, *node.args[2:])
+        node_kwargs = dict(node.kwargs)
+        node_kwargs.pop("dim", None)
+
+        producer_shapes = [
+            tuple(input_transform.all_input_nodes[0].meta["val"].shape)
+            for input_transform in input_transforms
+        ]
+        if not self._concat_producer_shapes_match(producer_shapes, new_concat_dim):
+            return None
+
+        node_output_shape = list(producer_shapes[0])
+        node_output_shape[new_concat_dim] = sum(
+            shape[new_concat_dim] for shape in producer_shapes
+        )
+
+        transform_args = (node, *transform.args[1:])
+        if transform.target == self._VIEW_TARGET:
+            if not same_numel(node_output_shape, node_val.shape):
+                return None
+            transform_args = (node, list(node_val.shape))
+
+        if transform.target == self._PERMUTE_TARGET:
+            dims = cast(Sequence[int], transform.args[1])
+            rank = len(node_output_shape)
+            normalized_dims = tuple(dim if dim >= 0 else dim + rank for dim in dims)
+            if tuple(node_val.shape) != tuple(
+                node_output_shape[dim] for dim in normalized_dims
+            ):
+                return None
+
+        return node_args, node_kwargs, transform_args, tuple(node_output_shape)
+
+    def _concat_producer_shapes_match(
+        self, producer_shapes: list[tuple[Any, ...]], concat_dim: int
+    ) -> bool:
+        reference_shape = producer_shapes[0]
+        rank = len(reference_shape)
+        normalized_concat_dim = concat_dim if concat_dim >= 0 else concat_dim + rank
+        if not 0 <= normalized_concat_dim < rank:
+            return False
+
+        return all(
+            len(shape) == rank
+            and all(
+                dim == normalized_concat_dim or shape[dim] == reference_shape[dim]
+                for dim in range(rank)
+            )
+            for shape in producer_shapes
+        )
+
+    def _concat_dim(self, node: Node) -> int | None:
+        dim = node.args[1] if len(node.args) >= 2 else node.kwargs.get("dim", 0)
+        return dim if isinstance(dim, int) else None
+
+    def _mapped_concat_dim(self, transform: Node, concat_dim: int) -> int | None:
+        if transform.target == self._PERMUTE_TARGET:
+            return PermuteMap(transform).map_dims_inverse(concat_dim)[0]
+
+        view_map = ViewMap(transform)
+        if not view_map.is_valid_map:
+            return None
+        mapped_dims = view_map.map_dim_inverse(concat_dim)
+        if mapped_dims is None or len(mapped_dims) != 1:
+            return None
+        return mapped_dims[0]
+
+    def _input_transforms(self, node: Node) -> list[Node] | None:
+        if node.target in self._BINARY_ELEMENTWISE_OPS:
+            input_transforms = list(node.args[:2])
+        elif node.target in self._CONCAT_OPS:
+            if len(node.args) == 0 or not isinstance(node.args[0], Sequence):
+                return None
+            input_transforms = list(node.args[0])
+        else:
+            return None
+
+        if len(input_transforms) < 2 or not all(
+            isinstance(n, Node) for n in input_transforms
+        ):
+            return None
+
+        return cast(list[Node], input_transforms)

--- a/backends/arm/test/passes/test_dim_maps.py
+++ b/backends/arm/test/passes/test_dim_maps.py
@@ -9,7 +9,11 @@ from typing import cast, Sequence, TypeVar
 import sympy  # type: ignore[import-untyped]
 import torch
 
-from executorch.backends.arm._passes.dim_maps import PermuteMap, ViewMap
+from executorch.backends.arm._passes.dim_maps import (
+    normalize_view_shape,
+    PermuteMap,
+    ViewMap,
+)
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
 
@@ -366,6 +370,53 @@ def test_dim_map_preserves_symbolic_dimensions_as_prime_factors() -> None:
     assert view_map.map_dim(0) == [0]
     assert view_map.map_dim(1) == [1, 2]
     assert view_map.map_dim_inverse(0) == [0]
+
+
+def test_normalize_view_shape_infers_concrete_dim_from_symints() -> None:
+    shape_env = ShapeEnv()
+    batch = _make_symint(shape_env, "batch", hint=4)
+
+    normalized_shape = normalize_view_shape([batch, 6], [batch, -1])
+
+    assert normalized_shape[0] is batch
+    assert normalized_shape[1] == 6
+    assert isinstance(normalized_shape[1], int)
+
+
+def test_normalize_view_shape_preserves_symbolic_inferred_dim() -> None:
+    shape_env = ShapeEnv()
+    batch = _make_symint(shape_env, "batch", hint=4)
+
+    normalized_shape = normalize_view_shape([2, batch], [-1])
+
+    assert isinstance(normalized_shape[0], torch.SymInt)
+    assert normalized_shape[0] is not batch
+    assert sympy.simplify(normalized_shape[0].node.expr - 2 * batch.node.expr) == 0
+
+
+def test_view_map_simplifies_constant_symint_dims() -> None:
+    shape_env = ShapeEnv()
+    batch = _make_symint(shape_env, "batch", hint=4)
+    constant = batch * 6 // batch
+
+    view_map = ViewMap.from_shapes([batch, constant], [batch, 2, 3])
+
+    assert view_map.source_shape[1] == 6
+    assert isinstance(view_map.source_shape[1], int)
+    assert view_map.is_valid_map
+    assert view_map.map_dim(1) == [1, 2]
+
+
+def test_view_map_from_shapes_normalizes_symbolic_view_shape() -> None:
+    shape_env = ShapeEnv()
+    batch = _make_symint(shape_env, "batch", hint=4)
+
+    view_map = ViewMap.from_shapes([batch, 6], [batch, -1])
+
+    assert view_map.target_shape[0] is batch
+    assert view_map.target_shape[1] == 6
+    assert isinstance(view_map.target_shape[1], int)
+    assert view_map.is_valid_map
 
 
 def test_dim_map_permute_view_swap_preserves_symbolic_view_shape_dims() -> None:

--- a/backends/arm/test/passes/test_fuse_identical_input_transforms_pass.py
+++ b/backends/arm/test/passes/test_fuse_identical_input_transforms_pass.py
@@ -1,0 +1,432 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+from typing import cast, Sequence
+
+import pytest
+import torch
+from executorch.backends.arm._passes.fuse_identical_input_transforms_pass import (
+    FuseIdenticalInputTransformsPass,
+)
+from executorch.backends.test.graph_builder import GraphBuilder
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import PassResult, ProxyValue
+from torch.utils import _pytree as pytree
+
+
+_ADD = exir_ops.edge.aten.add.Tensor
+_CAT = exir_ops.edge.aten.cat.default
+_VIEW = exir_ops.edge.aten.view_copy.default
+_PERMUTE = exir_ops.edge.aten.permute_copy.default
+
+
+def _count_node(
+    graph_module: torch.fx.GraphModule, target: torch.fx.node.Target
+) -> int:
+    return sum(
+        node.op == "call_function" and node.target == target
+        for node in graph_module.graph.nodes
+    )
+
+
+def _compute_nodes(graph_module: torch.fx.GraphModule) -> list[torch.fx.node.Target]:
+    return [
+        node.target for node in graph_module.graph.nodes if node.op == "call_function"
+    ]
+
+
+def _validate_numerics(
+    original: torch.fx.GraphModule,
+    modified: torch.fx.GraphModule,
+    inputs: tuple[torch.Tensor, ...],
+) -> None:
+    original.eval()
+    modified.eval()
+    with torch.no_grad():
+        original_output = original(*inputs)
+        modified_output = modified(*inputs)
+
+    flat_original, _ = pytree.tree_flatten(original_output)
+    flat_modified, _ = pytree.tree_flatten(modified_output)
+    for original_tensor, modified_tensor in zip(flat_original, flat_modified):
+        torch.testing.assert_close(original_tensor, modified_tensor)
+
+
+def _apply_pass(
+    graph_module: torch.fx.GraphModule,
+) -> tuple[torch.fx.GraphModule, PassResult]:
+    original = copy.deepcopy(graph_module)
+    result = cast(PassResult, FuseIdenticalInputTransformsPass().call(graph_module))
+    return original, result
+
+
+def _binary_transform_graph(
+    x_data: torch.Tensor,
+    y_data: torch.Tensor,
+    x_transforms: Sequence[tuple[torch.fx.node.Target, Sequence[int]]],
+    y_transforms: Sequence[tuple[torch.fx.node.Target, Sequence[int]]],
+) -> torch.fx.GraphModule:
+    builder = GraphBuilder()
+    x = builder.placeholder("x", x_data)
+    y = builder.placeholder("y", y_data)
+
+    x_node = _apply_transforms(builder, x, x_transforms)
+    y_node = _apply_transforms(builder, y, y_transforms)
+    add = builder.call_operator(op=_ADD, args=(x_node, y_node))
+    builder.output([add])
+    return builder.get_graph_module()
+
+
+def _concat_transform_graph(
+    x_data: torch.Tensor,
+    y_data: torch.Tensor,
+    x_transform: tuple[torch.fx.node.Target, Sequence[int]],
+    y_transform: tuple[torch.fx.node.Target, Sequence[int]],
+    dim: int,
+) -> torch.fx.GraphModule:
+    builder = GraphBuilder()
+    x = builder.placeholder("x", x_data)
+    y = builder.placeholder("y", y_data)
+
+    x_node = _apply_transforms(builder, x, [x_transform])
+    y_node = _apply_transforms(builder, y, [y_transform])
+    cat = builder.call_operator(op=_CAT, args=([x_node, y_node], dim))
+    builder.output([cat])
+    return builder.get_graph_module()
+
+
+def _apply_transforms(
+    builder: GraphBuilder,
+    node: ProxyValue,
+    transforms: Sequence[tuple[torch.fx.node.Target, Sequence[int]]],
+) -> ProxyValue:
+    transformed = node
+    for op, arg in transforms:
+        transformed = builder.call_operator(op=op, args=(transformed, list(arg)))
+    return transformed
+
+
+def test_fuse_identical_input_transforms_sinks_view() -> None:
+    x_data = torch.randn(6)
+    y_data = torch.randn(6)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_VIEW, [2, 3])],
+        [(_VIEW, [2, 3])],
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert result.modified
+    assert _count_node(result.graph_module, _VIEW) == 1
+    assert _compute_nodes(result.graph_module) == [_ADD, _VIEW]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_sinks_permute() -> None:
+    x_data = torch.randn(2, 3, 4)
+    y_data = torch.randn(2, 3, 4)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_PERMUTE, [0, 2, 1])],
+        [(_PERMUTE, [0, 2, 1])],
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert result.modified
+    assert _count_node(result.graph_module, _PERMUTE) == 1
+    assert _compute_nodes(result.graph_module) == [_ADD, _PERMUTE]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_sinks_cat_input_views() -> None:
+    x_data = torch.randn(2, 3, 4)
+    y_data = torch.randn(2, 3, 4)
+
+    builder = GraphBuilder()
+    x = builder.placeholder("x", x_data)
+    y = builder.placeholder("y", y_data)
+    x_view = builder.call_operator(op=_VIEW, args=(x, [6, 4]))
+    y_view = builder.call_operator(op=_VIEW, args=(y, [6, 4]))
+    cat = builder.call_operator(op=_CAT, args=([x_view, y_view], 1))
+    builder.output([cat])
+    graph_module = builder.get_graph_module()
+
+    original, result = _apply_pass(graph_module)
+
+    call_nodes = [
+        node for node in result.graph_module.graph.nodes if node.op == "call_function"
+    ]
+    cat_node = next(node for node in call_nodes if node.target == _CAT)
+    view = next(node for node in call_nodes if node.target == _VIEW)
+
+    assert result.modified
+    assert _count_node(result.graph_module, _VIEW) == 1
+    assert _compute_nodes(result.graph_module) == [_CAT, _VIEW]
+    assert [input_node.name for input_node in cat_node.args[0]] == ["x", "y"]
+    assert cat_node.args[1] == 2
+    assert cat_node.meta["val"].shape == torch.Size((2, 3, 8))
+    assert view.args == (cat_node, [6, 8])
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_rejects_cat_mixed_transforms() -> None:
+    x_data = torch.randn(2, 3, 4)
+    y_data = torch.randn(2, 3, 4)
+    graph_module = _concat_transform_graph(
+        x_data,
+        y_data,
+        (_VIEW, [2, 3, 4]),
+        (_PERMUTE, [0, 1, 2]),
+        0,
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert not result.modified
+    assert _count_node(result.graph_module, _VIEW) == 1
+    assert _count_node(result.graph_module, _PERMUTE) == 1
+    assert _compute_nodes(result.graph_module) == [_VIEW, _PERMUTE, _CAT]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_rejects_cat_different_permutes() -> None:
+    x_data = torch.randn(2, 3, 4)
+    y_data = torch.randn(2, 4, 3)
+    graph_module = _concat_transform_graph(
+        x_data,
+        y_data,
+        (_PERMUTE, [0, 1, 2]),
+        (_PERMUTE, [0, 2, 1]),
+        0,
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert not result.modified
+    assert _count_node(result.graph_module, _PERMUTE) == 2
+    assert _compute_nodes(result.graph_module) == [_PERMUTE, _PERMUTE, _CAT]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_rejects_shared_binary_input_transform() -> (
+    None
+):
+    x_data = torch.randn(6)
+    y_data = torch.randn(6)
+
+    builder = GraphBuilder()
+    x = builder.placeholder("x", x_data)
+    y = builder.placeholder("y", y_data)
+    x_view = builder.call_operator(op=_VIEW, args=(x, [2, 3]))
+    y_view = builder.call_operator(op=_VIEW, args=(y, [2, 3]))
+    add = builder.call_operator(op=_ADD, args=(x_view, y_view))
+    builder.output([add, x_view])
+    graph_module = builder.get_graph_module()
+
+    original, result = _apply_pass(graph_module)
+
+    assert not result.modified
+    assert _count_node(result.graph_module, _VIEW) == 2
+    assert _compute_nodes(result.graph_module) == [_VIEW, _VIEW, _ADD]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_rejects_shared_cat_input_transform() -> None:
+    x_data = torch.randn(2, 3, 4)
+    y_data = torch.randn(2, 3, 4)
+
+    builder = GraphBuilder()
+    x = builder.placeholder("x", x_data)
+    y = builder.placeholder("y", y_data)
+    x_view = builder.call_operator(op=_VIEW, args=(x, [6, 4]))
+    y_view = builder.call_operator(op=_VIEW, args=(y, [6, 4]))
+    cat = builder.call_operator(op=_CAT, args=([x_view, y_view], 1))
+    builder.output([cat, x_view])
+    graph_module = builder.get_graph_module()
+
+    original, result = _apply_pass(graph_module)
+
+    assert not result.modified
+    assert _count_node(result.graph_module, _VIEW) == 2
+    assert _compute_nodes(result.graph_module) == [_VIEW, _VIEW, _CAT]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_rejects_different_views() -> None:
+    x_data = torch.randn(6)
+    y_data = torch.randn(6)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_VIEW, [2, 3])],
+        [(_VIEW, [1, 2, 3])],
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert not result.modified
+    assert _count_node(result.graph_module, _VIEW) == 2
+    assert _compute_nodes(result.graph_module) == [_VIEW, _VIEW, _ADD]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_rejects_different_permutes() -> None:
+    x_data = torch.randn(2, 1, 3)
+    y_data = torch.randn(2, 1, 3)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_PERMUTE, [0, 2, 1])],
+        [(_PERMUTE, [0, 1, 2])],
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert not result.modified
+    assert _count_node(result.graph_module, _PERMUTE) == 2
+    assert _compute_nodes(result.graph_module) == [_PERMUTE, _PERMUTE, _ADD]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_sinks_view_permute_chain() -> None:
+    x_data = torch.randn(6, 4)
+    y_data = torch.randn(6, 4)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_VIEW, [2, 3, 4]), (_PERMUTE, [0, 2, 1])],
+        [(_VIEW, [2, 3, 4]), (_PERMUTE, [0, 2, 1])],
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert result.modified
+    assert _count_node(result.graph_module, _VIEW) == 1
+    assert _count_node(result.graph_module, _PERMUTE) == 1
+    assert _compute_nodes(result.graph_module) == [_ADD, _VIEW, _PERMUTE]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_sinks_permute_view_chain() -> None:
+    x_data = torch.randn(2, 3, 4)
+    y_data = torch.randn(2, 3, 4)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_PERMUTE, [0, 2, 1]), (_VIEW, [2, 2, 6])],
+        [(_PERMUTE, [0, 2, 1]), (_VIEW, [2, 2, 6])],
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert result.modified
+    assert _count_node(result.graph_module, _VIEW) == 1
+    assert _count_node(result.graph_module, _PERMUTE) == 1
+    assert _compute_nodes(result.graph_module) == [_ADD, _PERMUTE, _VIEW]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+@pytest.mark.parametrize(
+    "x_shape, y_shape, view_shape",
+    [
+        ((1, 6), (6,), (2, 3)),
+        ((1, 1, 6), (1, 6), (3, 2)),
+    ],
+)
+def test_fuse_identical_input_transforms_sinks_views_through_rank_broadcasts(
+    x_shape: tuple[int, ...],
+    y_shape: tuple[int, ...],
+    view_shape: tuple[int, ...],
+) -> None:
+    x_data = torch.randn(x_shape)
+    y_data = torch.randn(y_shape)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_VIEW, view_shape)],
+        [(_VIEW, view_shape)],
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert result.modified
+    assert _count_node(result.graph_module, _VIEW) == 1
+    assert _compute_nodes(result.graph_module) == [_ADD, _VIEW]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_rejects_views_through_expanding_broadcast() -> (
+    None
+):
+    x_data = torch.randn(1, 6)
+    y_data = torch.randn(6, 1)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_VIEW, [2, 3])],
+        [(_VIEW, [2, 3])],
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert not result.modified
+    assert _count_node(result.graph_module, _VIEW) == 2
+    assert _compute_nodes(result.graph_module) == [_VIEW, _VIEW, _ADD]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+@pytest.mark.parametrize(
+    "x_shape, y_shape",
+    [
+        ((1, 2, 3), (4, 2, 3)),
+        ((4, 1, 3), (1, 2, 3)),
+        ((4, 2, 1), (1, 1, 3)),
+    ],
+)
+def test_fuse_identical_input_transforms_sinks_permutes_through_broadcasts(
+    x_shape: tuple[int, ...],
+    y_shape: tuple[int, ...],
+) -> None:
+    x_data = torch.randn(x_shape)
+    y_data = torch.randn(y_shape)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_PERMUTE, [0, 2, 1])],
+        [(_PERMUTE, [0, 2, 1])],
+    )
+
+    original, result = _apply_pass(graph_module)
+
+    assert result.modified
+    assert _count_node(result.graph_module, _PERMUTE) == 1
+    assert _compute_nodes(result.graph_module) == [_ADD, _PERMUTE]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_cat_rejects_different_view_inputs() -> None:
+    x_data = torch.randn(2, 3, 4)
+    y_data = torch.randn(1, 6, 4)
+
+    builder = GraphBuilder()
+    x = builder.placeholder("x", x_data)
+    y = builder.placeholder("y", y_data)
+    x_view = builder.call_operator(op=_VIEW, args=(x, [6, 4]))
+    y_view = builder.call_operator(op=_VIEW, args=(y, [6, 4]))
+    cat = builder.call_operator(op=_CAT, args=([x_view, y_view], 1))
+    builder.output([cat])
+    graph_module = builder.get_graph_module()
+
+    original, result = _apply_pass(graph_module)
+
+    assert not result.modified
+    assert _count_node(result.graph_module, _VIEW) == 2
+    assert _compute_nodes(result.graph_module) == [_VIEW, _VIEW, _CAT]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))


### PR DESCRIPTION
Sinks identical data movement ops on all inputs
of a binary op, e.g.
   add(permute(x), permute(y))
becomes:
   permute(add(x, y))

Adds support for -1 indexing to view-map using the normalize_view_shape helper, and collapsing of known SymInts using _simplify_dim.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani