### PR TITLE
Point VGF tests at model-converter 0.9.0

### DIFF
--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -96,7 +96,7 @@ def define_arm_tests():
             typing = False,
             skip_on_mode_mac = True,
             env = {} if runtime.is_oss else ({
-                "MODEL_CONVERTER_PATH": "$(location fbsource//third-party/pypi/ai-ml-sdk-model-converter/0.8.0:model-converter-bin)",
+                "MODEL_CONVERTER_PATH": "$(location fbsource//third-party/pypi/ai-ml-sdk-model-converter/0.9.0:model-converter-bin)",
                 "MODEL_CONVERTER_LIB_DIR": "$(location fbsource//third-party/nvidia-nsight-systems:linux-x86_64)/host-linux-x64",
                 "LAVAPIPE_LIB_PATH": "$(location fbsource//third-party/mesa:vulkan_lvp)",
                 "EMULATION_LAYER_TENSOR_SO": "$(location fbsource//third-party/arm-ml-emulation-layer/v0.9.0/src:libVkLayer_Tensor)",


### PR DESCRIPTION
Summary: `tosa_tools` v2026.5.0 emits TOSA SerLib 2026.5.0 flatbuffers, which the model-converter v0.8.0 cannot deserialize (`ERROR: Tosa file created with newer SerLib version 2026.5.0 is not compatible with current version 1.1.0d`). Repoint the Arm VGF test `MODEL_CONVERTER_PATH` to `ai-ml-sdk-model-converter/0.9.0`, which supports the new spec. Applied to both the fbcode and xplat mirrors.

Differential Revision: D109721412




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell