### PR TITLE
Install yolo26 requirements before portable export in CI

### DIFF
--- a/.ci/scripts/test_model.sh
+++ b/.ci/scripts/test_model.sh
@@ -127,6 +127,14 @@ test_model() {
       return
   fi
 
+  if [[ "${MODEL_NAME}" == "yolo26" ]]; then
+      # Install yolo26 requirements (ultralytics). torch/torchvision are already
+      # installed and satisfy ultralytics, so only-if-needed leaves them as-is.
+      # No pytorch extra-index-url: it is unused here and would broaden pip's
+      # version resolution across all deps.
+      "${PYTHON_EXECUTABLE}" -m pip install --upgrade-strategy only-if-needed -r examples/models/yolo26/requirements.txt
+  fi
+
   # Export a basic .pte and run the model.
   "${PYTHON_EXECUTABLE}" -m examples.portable.scripts.export --model_name="${MODEL_NAME}" "${STRICT}"
   run_portable_executor_runner


### PR DESCRIPTION
test_model.sh exports yolo26 via examples.portable.scripts.export, but yolo26's model imports ultralytics, which was never installed -- the CI job failed with ModuleNotFoundError: No module named 'ultralytics'.

Install examples/models/yolo26/requirements.txt before the export, matching the per-model dep handling already used for llava/edsr/mb. Use the README's install command (--upgrade-strategy only-if-needed, CPU extra-index) so the ultralytics torch/torchvision deps do not upgrade ExecuTorch's pinned versions.

Authored with Claude assistance.