### PR TITLE
Fix Windows unittest CI: force CPU-only build (CUDA 13.2 toolkit on runner breaks _portable_lib load)

### DIFF
--- a/.ci/scripts/setup-windows.ps1
+++ b/.ci/scripts/setup-windows.ps1
@@ -1,5 +1,6 @@
 param (
-    [string]$editable = "false"
+    [string]$editable = "false",
+    [string]$cpuOnly = "false"
 )
 
 conda create --yes --quiet -n et python=3.12
@@ -12,6 +13,16 @@ conda activate et
 
 # Install test dependencies
 pip install -r .ci/docker/requirements-ci.txt
+
+# The Windows CI image ships CUDA toolkits on PATH, so install_executorch
+# (setup.py) auto-enables EXECUTORCH_BUILD_CUDA whenever the detected nvcc
+# version is in SUPPORTED_CUDA_VERSIONS. CPU-only jobs install CPU torch, so a
+# CUDA build of _portable_lib then fails to load its CUDA DLLs at import time
+# ("DLL load failed while importing _portable_lib"). Force a CPU-only build
+# when the caller asks for it.
+if ($cpuOnly -eq 'true') {
+    $env:CMAKE_ARGS = "$env:CMAKE_ARGS -DEXECUTORCH_BUILD_CUDA=OFF"
+}
 
 if ($editable -eq 'true') {
     install_executorch.bat --editable

--- a/.ci/scripts/wheel/pre_build_script.sh
+++ b/.ci/scripts/wheel/pre_build_script.sh
@@ -50,6 +50,15 @@ if [[ $UNAME_S == *"MINGW"* || $UNAME_S == *"MSYS"* ]]; then
     echo "Enabling symlinks on Windows"
     git config core.symlinks true
     git checkout -f HEAD
+
+    # Windows wheels are CPU-only (build-wheels-windows.yml sets
+    # with-cuda: disabled), but the Windows CI image ships a CUDA toolkit on
+    # PATH, which makes setup.py auto-enable EXECUTORCH_BUILD_CUDA. That bakes a
+    # CUDA _portable_lib into the CPU wheel, which then fails its DLL load in the
+    # smoke test ("DLL load failed while importing _portable_lib"). Force a
+    # CPU-only build.
+    export CMAKE_ARGS="${CMAKE_ARGS:-} -DEXECUTORCH_BUILD_CUDA=OFF"
+    echo "CMAKE_ARGS=${CMAKE_ARGS}" >> "${GITHUB_ENV}"
 fi
 
 # Manually install build requirements because `python setup.py bdist_wheel` does

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -72,7 +72,7 @@ jobs:
           \$ErrorActionPreference = 'Stop'
           \$PSNativeCommandUseErrorActionPreference = \$true
 
-          .ci/scripts/setup-windows.ps1 -editable "${{ inputs.editable }}"
+          .ci/scripts/setup-windows.ps1 -editable "${{ inputs.editable }}" -cpuOnly true
           if (\$LASTEXITCODE -ne 0) {
               Write-Host "Setup failed. Exit code: \$LASTEXITCODE."
               exit \$LASTEXITCODE


### PR DESCRIPTION
## Summary
Fixes the Windows unittest CI breakage introduced by #20440 (`Add CUDA 13.2 support and drop unsupported 12.8/12.9`).

`unittest / windows`, `unittest-editable / windows`, and `unittest-release / windows` have been red on `main` since c0643f5 (parent was green).

## Root cause
The Windows CI image ships CUDA toolkits on `PATH` (it has both `v13.2` and `v13.0`; `nvcc` resolves to **13.2.78**).

`install_executorch` auto-enables the CUDA backend when `install_utils.is_cuda_available()` returns True (`setup.py` ~L882-889), and that check is driven purely by the `nvcc` version being in `SUPPORTED_CUDA_VERSIONS`.

- **Before #20440:** `13.2 ∉ SUPPORTED_CUDA_VERSIONS` → `is_cuda_available()` = False → CPU-only build → green.
- **After #20440:** adding `(13, 2)` makes `is_cuda_available()` = **True** on the Windows runner → `setup.py` flips `-DEXECUTORCH_BUILD_CUDA=ON`. But the unittest jobs install **CPU** torch, so the CUDA build of `_portable_lib` can't find its CUDA DLLs:

```
ImportError: DLL load failed while importing _portable_lib: The specified module could not be found.
```

That aborts pytest collection (`24 errors during collection`) and fails the job.

## Fix
Add a `-cpuOnly` switch to the shared `.ci/scripts/setup-windows.ps1` that forces `-DEXECUTORCH_BUILD_CUDA=OFF` via `CMAKE_ARGS`, and pass it from the CPU unittest workflow (`_unittest.yml`). This restores the pre-#20440 CPU-only behavior for these jobs.

The CUDA Windows jobs (`cuda-windows.yml`) call the same script **without** `-cpuOnly`, so they are unaffected and keep building CUDA.

## Note / follow-up
The deeper issue is that the auto-detection keys off `nvcc` presence rather than whether the installed torch is actually a CUDA build. A more general fix would be to only enable `EXECUTORCH_BUILD_CUDA` when `torch.version.cuda` is set. Left out here to keep the unblock low-risk; happy to follow up.
