### PR TITLE
Build public API manifest tests in OSS buck only

### DIFF
--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -61,8 +61,6 @@ def define_arm_tests():
         "misc/tosa_dialect/test_tosa_dialect_mxfp_conv2d.py",
         "misc/tosa_dialect/test_tosa_dialect_mxfp_linear.py",
         "misc/tosa_dialect/test_tosa_resize.py",
-        "misc/test_public_api_manifest.py",
-        "misc/test_validate_public_api_manifest.py",
         "misc/test_tosa_spec.py",
         "misc/test_bn_relu_folding_qat.py",
         "misc/test_custom_partition.py",
@@ -80,6 +78,16 @@ def define_arm_tests():
     test_files += [
         "deprecation/test_arm_compile_spec_deprecation.py",
     ]
+
+    # These import the top-level executorch.backends.arm package, whose
+    # __init__ eagerly imports torch. Pulling that into pytest collection fails
+    # in the packaged (non-OSS) build, so build them in OSS only; the public API
+    # surface is covered by a dedicated backward-compatibility CI job.
+    if runtime.is_oss:
+        test_files += [
+            "misc/test_public_api_manifest.py",
+            "misc/test_validate_public_api_manifest.py",
+        ]
 
     TESTS = {}
 
@@ -116,8 +124,6 @@ def define_arm_tests():
                 "//executorch/backends/arm/test:mxfp_test_common",
                 "//executorch/backends/arm/test/misc:dw_convs_shared_weights_module",
                 "//executorch/backends/arm:ao_ext",
-                "//executorch/backends/arm/scripts/public_api_manifest:public_api_manifest",
-                "//executorch/backends/arm:public_api",
                 "//executorch/backends/arm:ethosu",
                 "//executorch/backends/arm/tosa:compile_spec",
                 "//executorch/backends/arm/tosa:partitioner",
@@ -129,5 +135,11 @@ def define_arm_tests():
                 "fbsource//third-party/pypi/pytest:pytest",
                 "fbsource//third-party/pypi/parameterized:parameterized",
                 "fbsource//third-party/tosa_tools:tosa_reference_model",
-            ],
+            ] + ([
+                # Needed only by the OSS-only public API manifest tests above.
+                # Depending on them everywhere drags the top-level package
+                # __init__ (and its torch import) into pytest collection.
+                "//executorch/backends/arm/scripts/public_api_manifest:public_api_manifest",
+                "//executorch/backends/arm:public_api",
+            ] if runtime.is_oss else []),
         )


### PR DESCRIPTION
Summary:
The Arm public API manifest / backward-compatibility feature added two unit tests (`misc/test_public_api_manifest.py`, `misc/test_validate_public_api_manifest.py`) and wired the `:public_api` / `public_api_manifest` libraries into the shared `deps` of every Arm op/pass test in `define_arm_tests`. `:public_api` is the top-level `executorch/backends/arm/__init__.py`, which eagerly imports torch, so pytest now imports it while collecting every test — and that import fails in the packaged buck build, breaking test listing for the whole Arm test suite.

Build the two manifest unit tests and those deps only in OSS (`runtime.is_oss`), where they are covered by the dedicated public-API backward-compatibility CI job. Op/pass tests no longer pull in the top-level package `__init__`.

Authored with Claude.

Reviewed By: Gasoonjia

Differential Revision: D109918480




cc @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani