### PR TITLE
Fix missing cstdint include in memory_buffer.hpp

### DIFF
--- a/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
+++ b/backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <stdio.h>
 #include <string>


### PR DESCRIPTION
### Summary

When I run `install_executorch.sh`, I get a compile error that `uint8_t` in `memory_buffer.hpp` isn't declared. Adding a `cstdint` include to that file makes ExecuTorch build successfully.

### Test plan

`install_executorch.sh --minimal` runs successfully. I didn't have enough time to test without `--minimal`.

cc @kimishpatel @YifanShenSZ @cymbalrush @metascroy