### PR TITLE
Import `torch` before `torch` submodules in `tosa/specification.py` (#20594)

### DIFF
--- a/backends/arm/tosa/specification.py
+++ b/backends/arm/tosa/specification.py
@@ -13,6 +13,10 @@ import contextvars
 import re
 from typing import Dict, Generic, List, Set, TypeVar
 
+# Import torch before any torch submodule so torch.SymInt is defined; importing
+# torch.fx first triggers a torch.distributed circular import during collection.
+import torch  # noqa: F401
+
 from packaging.version import Version
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 


### PR DESCRIPTION
Summary:

Adding `FuseIdenticalInputTransformsPass` (D109873690) creates a new test target `fbcode//executorch/backends/arm/test:fuse_identical_input_transforms_pass` whose pytest collection fails to list any tests with `AttributeError: partially initialized module 'torch' has no attribute 'SymInt' (most likely due to a circular import)`.

The crash originates in `executorch/backends/arm/tosa/specification.py`, which does `from torch.fx.experimental.symbolic_shapes import ShapeEnv` without first importing `torch`. When that submodule import is the first time `torch` is touched in the process, it pulls in `torch.distributed`, whose module-level `RankType = int | torch.SymInt` evaluates before `torch.SymInt` is defined, leaving `torch` half-initialized. Import order varies by target, which is why the new target hits it while siblings such as `test_dim_maps` (which `import torch` early) do not.

Adding a bare `import torch` ahead of the submodule import forces `torch` to fully initialize first, breaking the circular dependency deterministically.

This is a separate change from D109873690, which has already landed in OSS and cannot be amended.

Authored with Claude Code.

Reviewed By: metascroy

Differential Revision: D110066026


