### PR TITLE
Quantize aten.concat like aten.cat for Ethos-U

### DIFF
--- a/backends/arm/quantizer/quantization_annotator.py
+++ b/backends/arm/quantizer/quantization_annotator.py
@@ -859,6 +859,7 @@ def get_quant_properties(  # noqa: C901
         )
     elif node.target in (
         torch.ops.aten.cat.default,
+        torch.ops.aten.concat.default,
         torch.ops.aten.concatenate.default,
         torch.ops.aten.stack.default,
     ):


### PR DESCRIPTION
Summary:
The ARM PT2E quantization annotator gives a `SharedQuantizationSpec` to `aten.cat.default`, `aten.concatenate.default`, and `aten.stack.default`, so every concat input and the output share one scale/zero-point. That shared annotation is what lets a quantized concat lower to a single TOSA `CONCAT` and stay inside one Ethos-U delegate.

`aten.concat.default` was missing from that tuple. `torch.concat` is captured as `aten.concat.default` under dynamic-shape tracing (the path the EMG cascade detector PTQ uses for its `emg_features`/`imu_features` fusion at `networks.py:251`), so that concat received independent observers for each input and the output. The three distinct scales cannot be expressed as one TOSA `CONCAT` — the ARM backend has no rescale-before-concat — so the partitioner strands the op on CPU as dequantize/cat/quantize and the detector splits into two Ethos-U delegates instead of one. Under static-shape tracing the same source op is captured as `aten.cat.default`, which is why this only reproduces on the production (dynamic-shape) lowering path.

Add `aten.concat.default` next to the existing aliases so it gets the same shared spec. Applied to both the `fbcode` and `xplat` mirrors.

Differential Revision: D110085289




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani