### PR TITLE
fix(transforms): convert view_copy to unsqueeze when the added dim is 0

### DIFF
--- a/backends/transforms/test/test_view_copy_to_squeeze_unsqueeze.py
+++ b/backends/transforms/test/test_view_copy_to_squeeze_unsqueeze.py
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.transforms.view_copy_to_squeeze_unsqueeze import (
+    ViewCopyToSqueezeUnsqueezePass,
+)
+from executorch.exir import to_edge
+
+
+def _call_function_targets(graph_module: torch.fx.GraphModule):
+    return [n.target for n in graph_module.graph.nodes if n.op == "call_function"]
+
+
+class TestViewCopyToSqueezeUnsqueezePass(unittest.TestCase):
+    def _run(self, model, example_inputs):
+        aten = torch.export.export(model, example_inputs, strict=True)
+        edge = to_edge(aten).transform([ViewCopyToSqueezeUnsqueezePass()])
+        return _call_function_targets(edge.exported_program().graph_module)
+
+    def test_unsqueeze_at_dim_0(self):
+        # Adding a size-1 dim at the front (dim 0). The added dim index is 0,
+        # which must not be treated as "no match" by a falsy check.
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x.view(1, 3, 4)
+
+        targets = self._run(Model().eval(), (torch.randn(3, 4),))
+        unsqueeze_op = torch.ops.aten.unsqueeze_copy.default
+        view_op = torch.ops.aten.view_copy.default
+        self.assertTrue(
+            any(t.name() == unsqueeze_op.name() for t in targets),
+            f"view_copy was not converted to unsqueeze_copy: {targets}",
+        )
+        self.assertFalse(any(t.name() == view_op.name() for t in targets))
+
+    def test_unsqueeze_at_dim_1(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x.view(3, 1, 4)
+
+        targets = self._run(Model().eval(), (torch.randn(3, 4),))
+        unsqueeze_op = torch.ops.aten.unsqueeze_copy.default
+        self.assertTrue(any(t.name() == unsqueeze_op.name() for t in targets))
+
+    def test_squeeze(self):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x.view(3, 4)
+
+        targets = self._run(Model().eval(), (torch.randn(1, 3, 4),))
+        squeeze_op = torch.ops.aten.squeeze_copy.dims
+        self.assertTrue(any(t.name() == squeeze_op.name() for t in targets))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/transforms/view_copy_to_squeeze_unsqueeze.py
+++ b/backends/transforms/view_copy_to_squeeze_unsqueeze.py
@@ -122,7 +122,7 @@ class ViewCopyToSqueezeUnsqueezePass(ExportPass):
                     modified = True
                     continue
                 unsqueeze_dim = self.find_unsqueeze_dim(input_shape, view_shape)
-                if unsqueeze_dim:
+                if unsqueeze_dim is not None:
                     self.replace_view_copy_node(
                         graph_module, node, self.unsqueeze_op, unsqueeze_dim
                     )


### PR DESCRIPTION
## Summary

`ViewCopyToSqueezeUnsqueezePass` rewrites a `view_copy` that adds a size-1 dimension into an `unsqueeze_copy`. It decides whether to do the rewrite with:

```python
unsqueeze_dim = self.find_unsqueeze_dim(input_shape, view_shape)
if unsqueeze_dim:
    ...
```

`find_unsqueeze_dim` returns the **index** of the added size-1 dimension, and `None` when the shapes don't match an unsqueeze. When the size-1 dim is added at the **front**, the returned index is `0` — which is falsy — so `if unsqueeze_dim:` skips the rewrite and the `view_copy` is left in place for that case (e.g. `[3, 4] -> [1, 3, 4]`).

The fix is to guard on `is not None`:

```python
if unsqueeze_dim is not None:
```

(The squeeze branch is unaffected: `find_squeeze_dims` returns a non-empty list or `None`, so its `if squeeze_dims:` check is correct.)

## Test plan

Adds `backends/transforms/test/test_view_copy_to_squeeze_unsqueeze.py` with three cases: unsqueeze at dim 0 (regression for this bug), unsqueeze at dim 1, and squeeze.

- Before the fix, `test_unsqueeze_at_dim_0` fails — the `view_copy` is not converted (graph still contains `aten.view_copy`).
- After the fix, all three tests pass.

Run:
```
python -m unittest backends.transforms.test.test_view_copy_to_squeeze_unsqueeze -v
```