### PR TITLE
fix(cadence): fix or-precedence bug in check_out_zero_point_is_min_range

### DIFF
--- a/backends/cadence/aot/quantizer/utils.py
+++ b/backends/cadence/aot/quantizer/utils.py
@@ -281,6 +281,6 @@ def check_out_zero_point_is_min_range(
         return out_zero_point == -128
     elif out_dtype == torch.int16:
         return out_zero_point == -32768
-    elif out_dtype == torch.uint8 or torch.uint16:
+    elif out_dtype == torch.uint8 or out_dtype == torch.uint16:
         return out_zero_point == 0
     return False

--- a/backends/cadence/aot/tests/test_quantizer_utils.py
+++ b/backends/cadence/aot/tests/test_quantizer_utils.py
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+
+import torch
+from executorch.backends.cadence.aot.quantizer.utils import (
+    check_out_zero_point_is_min_range,
+)
+
+
+class TestCheckOutZeroPointIsMinRange(unittest.TestCase):
+    def test_signed_types(self) -> None:
+        self.assertTrue(check_out_zero_point_is_min_range(-128, torch.int8))
+        self.assertFalse(check_out_zero_point_is_min_range(0, torch.int8))
+        self.assertTrue(check_out_zero_point_is_min_range(-32768, torch.int16))
+        self.assertFalse(check_out_zero_point_is_min_range(0, torch.int16))
+
+    def test_unsigned_types(self) -> None:
+        self.assertTrue(check_out_zero_point_is_min_range(0, torch.uint8))
+        self.assertFalse(check_out_zero_point_is_min_range(5, torch.uint8))
+        self.assertTrue(check_out_zero_point_is_min_range(0, torch.uint16))
+
+    def test_non_quant_dtype_is_false(self) -> None:
+        # Dtypes that are not one of the handled quant types must return False,
+        # regardless of the zero point value (regression for an `or` precedence
+        # bug that made the unsigned branch always match).
+        self.assertFalse(check_out_zero_point_is_min_range(0, torch.float32))
+        self.assertFalse(check_out_zero_point_is_min_range(0, torch.int32))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`check_out_zero_point_is_min_range` (backends/cadence/aot/quantizer/utils.py) contained an operator-precedence bug:

```python
elif out_dtype == torch.uint8 or torch.uint16:
    return out_zero_point == 0
return False
```

Python parses this as `(out_dtype == torch.uint8) or (torch.uint16)`. Since `torch.uint16` is a (truthy) dtype object, the `elif` is effectively always `True` for any dtype that isn't `int8`/`int16`, and the trailing `return False` is dead code.

Effect: for unrelated dtypes such as `float32` or `int32`, the function returned `out_zero_point == 0` instead of `False`.

```
check_out_zero_point_is_min_range(0, torch.float32)  # was True, should be False
check_out_zero_point_is_min_range(0, torch.int32)    # was True, should be False
```

The function gates Add+ReLU fusion in `quantizer/patterns.py` (`AddReluPattern.get_anchors`), so an output whose dtype is not a supported quant type but whose zero point happens to be 0 would wrongly pass the check.

Fix: compare `out_dtype` against each dtype explicitly:

```python
elif out_dtype == torch.uint8 or out_dtype == torch.uint16:
```

## Test plan

Adds `backends/cadence/aot/tests/test_quantizer_utils.py` covering signed (int8/int16), unsigned (uint8/uint16), and non-quant (float32/int32) dtypes.

- Before the fix, `test_non_quant_dtype_is_false` fails (`float32`/`int32` with zero point 0 return `True`).
- After the fix, all tests pass.

Run:
```
python -m unittest backends.cadence.aot.tests.test_quantizer_utils -v
```

cc @mcremon-meta