### PR TITLE
Cortex-M backend: Make pytest collection seeding deterministic

### DIFF
--- a/backends/cortex_m/test/TARGETS
+++ b/backends/cortex_m/test/TARGETS
@@ -1,15 +1,20 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("targets.bzl", "define_common_targets")
 
 oncall("executorch")
 python_unittest(
     name="test_replace_quant_nodes",
+    env={
+        "TEST_RUNTIME_IS_NOT_OSS": "1" if not runtime.is_oss else "0",
+    },
     srcs=[
         "test_helpers_passes_utils.py",
         "test_replace_quant_nodes.py",

--- a/backends/cortex_m/test/conftest.py
+++ b/backends/cortex_m/test/conftest.py
@@ -1,8 +1,12 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+import os
+import random
 
 import pytest
 from executorch.backends.cortex_m.target_config import CortexMTargetConfig
@@ -29,7 +33,10 @@ def _selected_targets(config) -> list[str]:
 
 
 def pytest_report_header(config):
-    return f"cortex-m op-test targets: {', '.join(_selected_targets(config))}"
+    return (
+        f"cortex-m op-test targets: {', '.join(_selected_targets(config))} "
+        f"{config._test_seed_label}"
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -46,3 +53,45 @@ def cortex_m_target(request) -> CortexMTargetConfig:
     the AoT target config (and, for implementation tests, the matching prebuilt
     FVP runner)."""
     return CortexMTargetConfig.from_target_string(request.param)
+
+
+def pytest_configure(config):
+    seed, seed_label = _setup_random_seed()
+    config._test_seed = seed
+    config._test_seed_label = seed_label
+
+    if os.environ.get("TEST_RUNTIME_IS_NOT_OSS", "0") != "1":
+        _set_random_seed(seed)
+
+
+@pytest.fixture(autouse=True)
+def set_random_seed(request):
+    """Control random numbers in the Cortex-M test suite.
+
+    By default this uses a fixed seed (0) for reproducible tests. Use
+    TEST_SEED to set a custom session seed, or set it to RANDOM to choose a
+    random session seed.
+    """
+    _set_random_seed(request.config._test_seed)
+
+
+def _setup_random_seed():
+    seed_env = os.environ.get("TEST_SEED", "0")
+    if seed_env == "RANDOM":
+        random.seed()  # reset seed, in case any other test has fiddled with it
+        seed = random.randint(0, 2**32 - 1)  # nosec B311 - test seed
+        seed_label = f"TEST_SEED=RANDOM using:{seed}"
+    elif str.isdigit(seed_env):
+        seed = int(seed_env)
+        seed_label = f"TEST_SEED={seed}"
+    else:
+        raise TypeError("TEST_SEED env variable must be integers or the string RANDOM")
+
+    return seed, seed_label
+
+
+def _set_random_seed(seed):
+    import torch
+
+    random.seed(seed)
+    torch.manual_seed(seed)


### PR DESCRIPTION
### Summary
Seed the Cortex-M test RNG during pytest configuration in OSS/local test runs so module-level random inputs are deterministic before collection imports test modules.

Use TEST_SEED for the Cortex-M test session seed, matching the Arm backend test behavior.

Keep packaged non-OSS Buck behavior unchanged by skipping that early torch import there, while preserving the per-test seeding fixture.


cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani @psiddh @AdrianLundell