### PR TITLE
Arm backend: Relax model test tolerances

### DIFF
--- a/backends/arm/test/models/test_dl3_arm.py
+++ b/backends/arm/test/models/test_dl3_arm.py
@@ -102,7 +102,7 @@ def test_dl3_vgf_quant():
         quantize=True,
     )
     pipeline.change_args(
-        "run_method_and_compare_outputs", rtol=0.1, atol=0.1
+        "run_method_and_compare_outputs", rtol=0.1, atol=0.15
     )  # TODO: MLETORCH-1036 decrease tolerance
     pipeline.run()
 

--- a/backends/arm/test/ops/test_conv3d.py
+++ b/backends/arm/test/ops/test_conv3d.py
@@ -646,7 +646,7 @@ def test_convolution_3d_tosa_INT_a8w4(test_data):
         exir_op,
         tosa_extensions=["int4"],
         qtol=1,
-        frobenius_threshold=0.4,
+        frobenius_threshold=0.5,
     )
     pipeline.quantizer.set_global(
         get_symmetric_a8w4_quantization_config(is_per_channel=per_channel_quantization)


### PR DESCRIPTION
Increase the DL3 VGF quant atol to cover the observed max absolute error while keeping the existing rtol.

Relax the Conv3D A8W4 Frobenius threshold to account for borderline quantization noise in small-output cases where cosine similarity remains high.



cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani