### PR TITLE
Deselect tflite-gated quantizer tests in internal CI

### DIFF
--- a/backends/nxp/tests/BUCK
+++ b/backends/nxp/tests/BUCK
@@ -46,6 +46,9 @@ fbcode_target(_kind = python_pytest,
     srcs = [
         "generic_tests/test_quantizer.py",
     ],
+    resources = [
+        "generic_tests/conftest.py",
+    ],
     deps = [
         "//executorch/backends/nxp:quantizer",
         "//caffe2:torch",

--- a/backends/nxp/tests/generic_tests/conftest.py
+++ b/backends/nxp/tests/generic_tests/conftest.py
@@ -1,0 +1,35 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Tests comparing against the TFLite reference are marked `@requires_tflite`
+# (a `skipif` on `tflite is None`). Where the tflite/tensorflow interpreter is
+# not importable, deselect them rather than letting the `skipif` skip them:
+# internal CI (TestX) flags a consistently-skipping test as broken/disabled,
+# while a deselected test produces no signal at all.
+
+# Must stay in sync with the `reason=` of `requires_tflite` in test_quantizer.py.
+_REQUIRES_TFLITE_REASON = "tensorflow/tflite not available"
+
+
+def _is_tflite_gated_and_unavailable(item) -> bool:
+    for marker in item.iter_markers(name="skipif"):
+        condition = marker.args[0] if marker.args else False
+        if condition and marker.kwargs.get("reason") == _REQUIRES_TFLITE_REASON:
+            return True
+    return False
+
+
+def pytest_collection_modifyitems(config, items):
+    selected = []
+    deselected = []
+    for item in items:
+        if _is_tflite_gated_and_unavailable(item):
+            deselected.append(item)
+        else:
+            selected.append(item)
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected


### PR DESCRIPTION
Summary:
Internal CI flags consistently-skipping tests as broken/disabled, generating a backlog of phantom failure issues for the executorch oncall. The 56 NXP quantizer tests that require tflite always skip in fbcode since tflite isn't provisioned in that target.

Following the ARM VGF precedent (D103644035), this adds a pytest collection hook that deselects tflite-gated tests when tflite is unavailable instead of letting them skip. Deselected tests produce no  signal, stopping the phantom issues. The hook is a no-op when tflite is importable, so OSS CI is unaffected.

Differential Revision: D110212311


