### PR TITLE
Add missing Buck deps for TOSA dialect real_impl

### DIFF
--- a/backends/arm/tosa/dialect/BUCK
+++ b/backends/arm/tosa/dialect/BUCK
@@ -10,6 +10,8 @@ fbcode_target(_kind = runtime.python_library,
         "shape.py",
     ],
     deps = [
+        "fbsource//third-party/tosa_tools:serializer",
+        "fbsource//third-party/tosa_tools:tosa_reference_model",
         "//caffe2:torch",
         "//executorch/backends/arm/tosa:mapping",
         "//executorch/backends/arm/tosa:tosa",


### PR DESCRIPTION
Summary:
Adds the two missing third-party Buck deps to the `//executorch/backends/arm/tosa/dialect:core` target so the Arm TOSA dialect imports under Buck again. This is a stacked follow-up fix for D110150349.

D110150349 added `real_impl.py` to the `srcs` of the `core` target. `real_impl.py` imports `tosa_reference_model` and `tosa_serializer` at module top level, but the target `deps` were not updated to provide them. Because `ops_registration.py` now imports `real_impl` unconditionally, and every TOSA op module imports from `ops_registration`, the entire Arm TOSA dialect fails to import under Buck. This cascades into every downstream consumer that touches the Arm lowering path.

The import works in OSS (where the deps come from pip/CMake) but breaks under Buck, where third-party deps must be declared explicitly. The fix adds them to the `core` target:
- `fbsource//third-party/tosa_tools:serializer`
- `fbsource//third-party/tosa_tools:tosa_reference_model`

Differential Revision: D110214945




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell