### PR TITLE
Arm backend: Skip irrelevant lowering passes

### DIFF
--- a/backends/arm/_passes/broadcast_args_pass.py
+++ b/backends/arm/_passes/broadcast_args_pass.py
@@ -28,20 +28,35 @@ class BroadcastArgsPass(ArmPass):
 
     _passes_required_after: Set[Type[ExportPass]] = set()
 
-    targeted_ops = {
+    target_ops = {
         exir_ops.edge.aten.add.Tensor,
         exir_ops.edge.aten.sub.Tensor,
         # mul is indirectly targeting div as div is decompsed to reciprocal + mul
         exir_ops.edge.aten.mul.Tensor,
     }
 
-    def call(self, graph_module: GraphModule) -> PassResult:
+    def should_run_pass(self, graph_module: GraphModule) -> bool:
         tosa_spec = get_context_spec()
         if not tosa_spec.is_U55_subset:
-            return PassResult(graph_module, False)
+            return False
+        for node in graph_module.graph.nodes:
+            if node.op != "call_function" or node.target not in self.target_ops:
+                continue
+            output_shape = get_first_fake_tensor(node).shape
+            broadcasts = 0
+            for arg in node.args:
+                if not isinstance(arg, Node):
+                    continue
+                if get_first_fake_tensor(arg).shape != output_shape:
+                    broadcasts += 1
+                if broadcasts > 1:
+                    return True
+        return False
+
+    def call(self, graph_module: GraphModule) -> PassResult:
         modified = False
         for node in graph_module.graph.nodes:
-            if node.op != "call_function" or node.target not in self.targeted_ops:
+            if node.op != "call_function" or node.target not in self.target_ops:
                 continue
 
             output_shape = get_first_fake_tensor(node).shape

--- a/backends/arm/_passes/cast_int64_pass.py
+++ b/backends/arm/_passes/cast_int64_pass.py
@@ -25,6 +25,19 @@ class CastInt64BuffersToInt32Pass(ArmPass):
         super().__init__(*args, **kwargs)
         self.exported_program = exported_program
 
+    def should_run_pass(self, graph_module: torch.fx.GraphModule) -> bool:
+        for node in graph_module.graph.nodes:
+            if len(node.users) == 0:
+                continue
+            fake_tensor = node.meta.get("val")
+            if not isinstance(fake_tensor, torch._subclasses.fake_tensor.FakeTensor):
+                continue
+            if fake_tensor.dtype == torch.int64 and is_buffer(
+                self.exported_program, node
+            ):
+                return True
+        return False
+
     def _assert_within_int32(self, tensor: torch.Tensor, node: torch.fx.Node):
         if torch.min(tensor) < torch.iinfo(torch.int32).min:
             raise RuntimeError(

--- a/backends/arm/_passes/cast_to_int32_pass.py
+++ b/backends/arm/_passes/cast_to_int32_pass.py
@@ -7,33 +7,33 @@ from typing import Set, Type
 
 import torch
 
-from executorch.backends.arm._passes.arm_pass import ArmPass
+from executorch.backends.arm._passes.arm_pass import ArmOpTargetedPass
 
 from executorch.backends.arm.tosa.specification import get_context_spec
 from executorch.exir.dialects._ops import ops as exir_ops
-from executorch.exir.pass_base import ExportPass, PassResult
+from executorch.exir.pass_base import ExportPass
 
 
-class CastToInt32Pass(ArmPass):
+class CastToInt32Pass(ArmOpTargetedPass):
     """Casts the input to int32 if it is not already and casts back the output
     to the original input dtype.
     """
 
     _passes_required_after: Set[Type[ExportPass]] = set()
 
-    targeted_ops = {
+    target_ops = {
         exir_ops.edge.aten.bitwise_left_shift.Tensor,
         exir_ops.edge.aten.bitwise_right_shift.Tensor,
     }
 
-    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+    def should_run_pass(self, graph_module: torch.fx.GraphModule) -> bool:
         tosa_spec = get_context_spec()
         if not tosa_spec.is_U55_subset:
-            return PassResult(graph_module, False)
-        return super().call(graph_module)
+            return False
+        return super().should_run_pass(graph_module)
 
     def call_operator(self, op, args, kwargs, meta):
-        if op not in self.targeted_ops:
+        if op not in self.target_ops:
             return super().call_operator(op, args, kwargs, meta)
 
         new_args: list = []

--- a/backends/arm/_passes/conv1d_unsqueeze_pass.py
+++ b/backends/arm/_passes/conv1d_unsqueeze_pass.py
@@ -15,6 +15,7 @@ from executorch.backends.arm._passes.size_adjust_input_pass import SizeAdjustInp
 
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
+from torch.fx import GraphModule
 
 
 class Conv1dUnsqueezePass(ArmOpTargetedPass):
@@ -35,6 +36,17 @@ class Conv1dUnsqueezePass(ArmOpTargetedPass):
         SizeAdjustInputPass,
     }
     target_ops = (exir_ops.edge.aten.convolution.default,)
+
+    def should_run_pass(self, graph_module: GraphModule) -> bool:
+        for node in graph_module.graph.nodes:
+            if node.op != "call_function" or node.target not in self.target_ops:
+                continue
+            if len(node.args) > 3 and len(node.args[3]) == 1:
+                return True
+        return any(
+            isinstance(child, GraphModule) and self.should_run_pass(child)
+            for child in graph_module.children()
+        )
 
     def call_operator(self, op, args, kwargs, meta):
         if op not in self.target_ops:

--- a/backends/arm/_passes/convert_split_to_slice.py
+++ b/backends/arm/_passes/convert_split_to_slice.py
@@ -7,7 +7,7 @@
 from typing import Set, Type
 
 import torch.fx
-from executorch.backends.arm._passes import ArmPass
+from executorch.backends.arm._passes import ArmOpTargetedPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
@@ -16,7 +16,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class ConvertSplitToSlicePass(ArmPass):
+class ConvertSplitToSlicePass(ArmOpTargetedPass):
     """Replace a split operation with many slice operations."""
 
     _passes_required_after: Set[Type[ExportPass]] = set()
@@ -25,6 +25,7 @@ class ConvertSplitToSlicePass(ArmPass):
         exir_ops.edge.aten.split_with_sizes_copy.default,
         exir_ops.edge.aten.split_copy.Tensor,
     )
+    target_ops = split_ops
     slice = exir_ops.edge.aten.slice_copy.Tensor
 
     def call(self, graph_module: torch.fx.GraphModule):

--- a/backends/arm/_passes/decompose_add_sub_alpha_pass.py
+++ b/backends/arm/_passes/decompose_add_sub_alpha_pass.py
@@ -12,6 +12,7 @@ import torch
 from executorch.backends.arm._passes import ArmOpTargetedPass
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
+from torch.fx import GraphModule
 
 
 _ADD_OPS = (
@@ -60,6 +61,19 @@ class DecomposeAddSubAlphaPass(ArmOpTargetedPass):
 
     _passes_required_after: Set[Type[ExportPass]] = set()
     target_ops = _ADD_OPS + _SUB_OPS
+
+    def should_run_pass(self, graph_module: GraphModule) -> bool:
+        for node in graph_module.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target in self.target_ops
+                and _should_decompose(node.kwargs.get("alpha", 1))
+            ):
+                return True
+        return any(
+            isinstance(child, GraphModule) and self.should_run_pass(child)
+            for child in graph_module.children()
+        )
 
     def call_operator(self, op, args, kwargs, meta, updated: bool | None = False):
         if op not in self.target_ops:

--- a/backends/arm/_passes/decompose_batch_norm_no_stats.py
+++ b/backends/arm/_passes/decompose_batch_norm_no_stats.py
@@ -8,7 +8,7 @@ import operator
 from typing import Set, Type
 
 import torch
-from executorch.backends.arm._passes import ArmPass
+from executorch.backends.arm._passes import ArmOpTargetedPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node
 from executorch.backends.arm._passes.fuse_constant_ops_pass import (
     ComputeConstantOpsAOTPass,
@@ -19,7 +19,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class DecomposeBatchNormNoStatsPass(ArmPass):
+class DecomposeBatchNormNoStatsPass(ArmOpTargetedPass):
     """
     Decompose BatchNorm2d(track_running_stats=False) (aten._native_batch_norm_legit_no_training)
     into a sequence of elementwise operations:
@@ -42,21 +42,21 @@ class DecomposeBatchNormNoStatsPass(ArmPass):
         ComputeConstantOpsAOTPass,
         InsertTableOpsPass,
     }
+    target_ops = (
+        exir_ops.edge.aten._native_batch_norm_legit.no_stats,
+        exir_ops.edge.aten._native_batch_norm_legit_no_training.default,
+        torch.ops.aten._native_batch_norm_legit_no_training.default,
+        torch.ops.aten.batch_norm.default,
+        torch.ops.aten.native_batch_norm.default,
+    )
+    check_allowed_to_transform = True
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:  # noqa: C901
-        bn_ops = (
-            exir_ops.edge.aten._native_batch_norm_legit.no_stats,
-            exir_ops.edge.aten._native_batch_norm_legit_no_training.default,
-            torch.ops.aten._native_batch_norm_legit_no_training.default,
-            torch.ops.aten.batch_norm.default,
-            torch.ops.aten.native_batch_norm.default,
-        )
-
         modified = False
         for node in graph_module.graph.nodes:
             if (
                 node.op != "call_function"
-                or node.target not in bn_ops
+                or node.target not in self.target_ops
                 or not self.allowed_to_transform(node.meta)
             ):
                 continue

--- a/backends/arm/_passes/decompose_dynamic_full_pass.py
+++ b/backends/arm/_passes/decompose_dynamic_full_pass.py
@@ -6,7 +6,7 @@
 from typing import Any, Set, Type
 
 import torch
-from executorch.backends.arm._passes.arm_pass import ArmPass
+from executorch.backends.arm._passes.arm_pass import ArmOpTargetedPass
 from executorch.backends.arm._passes.unsqueeze_before_repeat_pass import (
     UnsqueezeBeforeRepeatPass,
 )
@@ -14,7 +14,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
 
-class DecomposeDynamicFullPass(ArmPass):
+class DecomposeDynamicFullPass(ArmOpTargetedPass):
     """Rewrite dynamic-shape `full` into scalar `full` plus `repeat`."""
 
     _passes_required_after: Set[Type[ExportPass]] = {UnsqueezeBeforeRepeatPass}
@@ -23,6 +23,7 @@ class DecomposeDynamicFullPass(ArmPass):
         torch.ops.aten.full.default,
         exir_ops.edge.aten.full.default,
     }
+    target_ops = full_targets
     repeat = exir_ops.edge.aten.repeat.default
 
     @staticmethod

--- a/backends/arm/_passes/decompose_layernorm_pass.py
+++ b/backends/arm/_passes/decompose_layernorm_pass.py
@@ -8,7 +8,7 @@ import operator
 from typing import Set, Type
 
 import torch
-from executorch.backends.arm._passes import ArmPass
+from executorch.backends.arm._passes import ArmOpTargetedPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node, insert_scalar
 from executorch.backends.arm._passes.decompose_meandim_pass import DecomposeMeanDimPass
 from executorch.backends.arm._passes.decompose_var_pass import DecomposeVarPass
@@ -46,7 +46,7 @@ def get_layer_norm_decomposition(op) -> tuple:
     raise RuntimeError(f"Can't get layer_norm composition for op {op}")
 
 
-class DecomposeLayerNormPass(ArmPass):
+class DecomposeLayerNormPass(ArmOpTargetedPass):
     """
     layernorm is defined as: ((x - E[x]) / sqrt(Var[x] + eps)) * weights + bias
     Decompose layernorm(x, normalized_shape, weights, bias, eps) to a sequence of:
@@ -73,6 +73,8 @@ class DecomposeLayerNormPass(ArmPass):
         exir_ops.edge.aten.native_layer_norm.default,
         torch.ops.aten.layer_norm.default,
     }
+    target_ops = _TARGET_OPS
+    check_allowed_to_transform = True
 
     def call(self, graph_module: torch.fx.GraphModule):
         modified = False

--- a/backends/arm/_passes/decompose_linear_pass.py
+++ b/backends/arm/_passes/decompose_linear_pass.py
@@ -8,7 +8,7 @@ from typing import Set, Type
 
 import torch
 
-from executorch.backends.arm._passes import ArmPass
+from executorch.backends.arm._passes import ArmOpTargetedPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
@@ -18,7 +18,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class DecomposeLinearPass(ArmPass):
+class DecomposeLinearPass(ArmOpTargetedPass):
     """This pass decomposes linear into a Conv2D with view operations.
 
     Example:
@@ -31,6 +31,7 @@ class DecomposeLinearPass(ArmPass):
     """
 
     _passes_required_after: Set[Type[ExportPass]] = {InsertRescaleInt32Pass}
+    target_ops = (exir_ops.edge.aten.linear.default,)
 
     def call(self, graph_module):
         modified = False

--- a/backends/arm/_passes/decompose_permute_for_u55_pass.py
+++ b/backends/arm/_passes/decompose_permute_for_u55_pass.py
@@ -18,6 +18,7 @@ from executorch.backends.arm.tosa.mapping import map_dtype
 from executorch.backends.arm.tosa.specification import get_context_spec
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
+from torch.fx import GraphModule
 
 
 class DecomposePermuteForU55Pass(ArmOpTargetedPass):
@@ -41,6 +42,11 @@ class DecomposePermuteForU55Pass(ArmOpTargetedPass):
     _CAT_OP = exir_ops.edge.aten.cat.default
     _MAX_PRODUCT = 2**16
     _VELA_TARGET = "ethos-u55-128"
+
+    def should_run_pass(self, graph_module: GraphModule) -> bool:
+        if not get_context_spec().is_U55_subset:
+            return False
+        return super().should_run_pass(graph_module)
 
     @classmethod
     def _violates_u55_worst_case_constraint(cls, shape: Sequence[int]) -> bool:

--- a/backends/arm/_passes/decompose_select.py
+++ b/backends/arm/_passes/decompose_select.py
@@ -8,7 +8,7 @@
 from typing import Set, Type
 
 import torch
-from executorch.backends.arm._passes import ArmPass
+from executorch.backends.arm._passes import ArmOpTargetedPass
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
     get_first_fake_tensor,
@@ -20,12 +20,16 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 
 
-class DecomposeSelectPass(ArmPass):
+class DecomposeSelectPass(ArmOpTargetedPass):
     """This pass decomposes select into slice + squeeze to ensure that Aten and
     TOSA outputs has the same rank (input rank -1)
     """
 
     _passes_required_after: Set[Type[ExportPass]] = {ConvertSqueezesToViewPass}
+    target_ops = (
+        exir_ops.edge.aten.select.int,
+        exir_ops.edge.aten.select_copy.int,
+    )
 
     def call(self, graph_module: torch.fx.GraphModule):
         modified = False
@@ -34,10 +38,7 @@ class DecomposeSelectPass(ArmPass):
             if node.op != "call_function":
                 continue
 
-            if node.target in (
-                exir_ops.edge.aten.select.int,
-                exir_ops.edge.aten.select_copy.int,
-            ):
+            if node.target in self.target_ops:
                 slice_op = exir_ops.edge.aten.slice_copy.Tensor
                 squeeze_op = exir_ops.edge.aten.squeeze_copy.dims
             else:

--- a/backends/arm/_passes/fuse_equal_placeholders_pass.py
+++ b/backends/arm/_passes/fuse_equal_placeholders_pass.py
@@ -36,31 +36,53 @@ class FuseEqualPlaceholdersPass(ArmPass):
         super().__init__(*args, **kwargs)
         self.exported_program = exported_program
 
+    def _get_param_key(
+        self, node: torch.fx.Node, include_data_hash: bool
+    ) -> tuple[tuple[object, ...], torch.Tensor] | None:
+        if not is_param_node(self.exported_program, node):
+            return None
+
+        tensor = get_param_tensor(self.exported_program, node)
+        if tensor is None:
+            return None
+
+        key: tuple[object, ...] = (
+            node.meta.get(TosaSpecialDtype.meta_key(), None),
+            str(tensor.dtype),
+            tuple(tensor.shape),
+        )
+        if include_data_hash:
+            t_cpu = tensor.cpu().contiguous().flatten().view(dtype=torch.uint8)
+            data_hash = hashlib.sha1(
+                t_cpu.numpy().tobytes(), usedforsecurity=False
+            ).hexdigest()
+            key = (*key, data_hash)
+        return key, tensor
+
+    def should_run_pass(self, graph_module: torch.fx.GraphModule) -> bool:
+        seen: set[tuple[object, ...]] = set()
+        for node in graph_module.graph.nodes:
+            param_key = self._get_param_key(node, include_data_hash=False)
+            if param_key is None:
+                continue
+            key, _ = param_key
+            if key in seen:
+                # Metadata matches are only a cheap pre-scan; call() hashes the
+                # tensor bytes before actually fusing placeholders.
+                return True
+            seen.add(key)
+        return False
+
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
         modified = False
 
         # Build a cache of params: mapping hash_key -> list of (node, tensor)
         hash_buckets = defaultdict(list)
         for node in graph_module.graph.nodes:
-            if not is_param_node(self.exported_program, node):
+            param_key = self._get_param_key(node, include_data_hash=True)
+            if param_key is None:
                 continue
-            tensor = get_param_tensor(self.exported_program, node)
-            if tensor is None:
-                continue
-            # Create a lightweight fingerprint: dtype + shape + SHA1 of raw bytes
-            # Ensure tensor is on CPU and contiguous
-
-            # ensure we don't merge any special case int48_t tensors with int32_t tensors
-            # since int48_t tensors needs to be instantiated separately.
-            is_special_dtype = node.meta.get(TosaSpecialDtype.meta_key(), None)
-            t_cpu = tensor.cpu().contiguous().flatten().view(dtype=torch.uint8)
-            data_bytes = t_cpu.numpy().tobytes()
-            key = (
-                is_special_dtype,
-                str(tensor.dtype),
-                tuple(tensor.shape),
-                hashlib.sha1(data_bytes, usedforsecurity=False).hexdigest(),
-            )
+            key, tensor = param_key
             hash_buckets[key].append((node, tensor))
 
         # For each bucket with more than one entry, fuse:

--- a/backends/arm/_passes/match_arg_dtype_pass.py
+++ b/backends/arm/_passes/match_arg_dtype_pass.py
@@ -6,7 +6,7 @@
 from typing import Set, Type
 
 import torch
-from executorch.backends.arm._passes import ArmPass
+from executorch.backends.arm._passes import ArmOpTargetedPass
 from executorch.backends.arm._passes.arm_pass_utils import create_node, get_node_arg
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -30,7 +30,7 @@ def get_largest_dtype(dtype_1, dtype_2):
     return dtype_1 if DTYPE_RANK[dtype_1] > DTYPE_RANK[dtype_2] else dtype_2
 
 
-class MatchArgDtypePass(ArmPass):
+class MatchArgDtypePass(ArmOpTargetedPass):
     """Pass to match data types of non-condition input tensors.
 
     Edge dialect allows different data types for non-condition tensors, while TOSA
@@ -44,14 +44,14 @@ class MatchArgDtypePass(ArmPass):
 
     _passes_required_after: Set[Type[ExportPass]] = set()
 
-    targeted_ops = {exir_ops.edge.aten.sub.Tensor, exir_ops.edge.aten.where.self}
+    target_ops = {exir_ops.edge.aten.sub.Tensor, exir_ops.edge.aten.where.self}
 
     def call(self, graph_module: torch.fx.GraphModule):
         modified_graph = False
         graph = graph_module.graph
 
         for node in list(graph.nodes):
-            if node.op != "call_function" or node.target not in self.targeted_ops:
+            if node.op != "call_function" or node.target not in self.target_ops:
                 continue
 
             input_ = get_node_arg(node.args, 0)

--- a/backends/arm/_passes/match_arg_ranks_pass.py
+++ b/backends/arm/_passes/match_arg_ranks_pass.py
@@ -8,7 +8,7 @@
 
 from typing import cast, Set, Type
 
-from executorch.backends.arm._passes import ArmPass
+from executorch.backends.arm._passes import ArmOpTargetedPass
 
 from executorch.backends.arm._passes.arm_pass_utils import (
     create_node,
@@ -22,8 +22,8 @@ from executorch.exir.pass_base import ExportPass, PassResult
 from torch.fx import GraphModule, Node
 
 
-class MatchArgRanksPass(ArmPass):
-    """For ops in 'targeted_ops', make sure that the inputs share the same rank.
+class MatchArgRanksPass(ArmOpTargetedPass):
+    """For ops in 'target_ops', make sure that the inputs share the same rank.
     New dimensions are inserted from the beginning of the inputs that have a
     lower rank to match the input with the highest rank.
 
@@ -44,7 +44,7 @@ class MatchArgRanksPass(ArmPass):
         super().__init__(*args, **kwargs)
         self.exported_program = exported_program
 
-    targeted_ops = [
+    target_ops = [
         exir_ops.edge.aten.add.Tensor,
         exir_ops.edge.aten.sub.Tensor,
         exir_ops.edge.aten.mul.Tensor,
@@ -89,7 +89,7 @@ class MatchArgRanksPass(ArmPass):
         for node in graph_module.graph.nodes:
             node = cast(Node, node)
 
-            if node.op != "call_function" or node.target not in self.targeted_ops:
+            if node.op != "call_function" or node.target not in self.target_ops:
                 continue
 
             # Calculate max rank of all inputs to node

--- a/backends/arm/_passes/replace_scalar_with_tensor_pass.py
+++ b/backends/arm/_passes/replace_scalar_with_tensor_pass.py
@@ -98,6 +98,16 @@ class ReplaceScalarWithTensorByProfilePass(ArmPass, ReplaceScalarWithTensorArgPa
         # Actual selection is done per-call in call_operator.
         super().__init__(tfa_pass, _all_ops, *args, **kwargs)
 
+    def should_run_pass(self, graph_module: torch.fx.GraphModule) -> bool:
+        for node in graph_module.graph.nodes:
+            if node.op == "call_function" and node.target in _all_ops:
+                return True
+
+        return any(
+            isinstance(child, torch.fx.GraphModule) and self.should_run_pass(child)
+            for child in graph_module.children()
+        )
+
     def call_operator(self, op, args, kwargs, meta):
         if self.is_tfa_pass and op in _preserve_in_tfa:
             return ExportPass.call_operator(self, op, args, kwargs, meta)

--- a/backends/arm/_passes/rewrite_adaptive_avg_pool2d.py
+++ b/backends/arm/_passes/rewrite_adaptive_avg_pool2d.py
@@ -6,7 +6,7 @@
 from typing import Set, Type
 
 import torch
-from executorch.backends.arm._passes import ArmPass
+from executorch.backends.arm._passes import ArmOpTargetedPass
 
 from executorch.backends.arm._passes.fuse_constant_ops_pass import (
     ComputeConstantOpsAOTPass,
@@ -20,7 +20,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
 
-class RewriteAdaptiveAvgPool2dPass(ArmPass):
+class RewriteAdaptiveAvgPool2dPass(ArmOpTargetedPass):
     """Rewrite dynamic adaptive average pooling to tosa.avg_pool2d_adaptive when
     possible.
 
@@ -31,7 +31,7 @@ class RewriteAdaptiveAvgPool2dPass(ArmPass):
 
     """
 
-    targeted_ops = {exir_ops.edge.aten._adaptive_avg_pool2d.default}
+    target_ops = {exir_ops.edge.aten._adaptive_avg_pool2d.default}
     _passes_required_after: Set[Type[ExportPass]] = {
         ComputeConstantOpsAOTPass,
     }
@@ -81,7 +81,7 @@ class RewriteAdaptiveAvgPool2dPass(ArmPass):
         return stride + remainder, stride
 
     def call_operator(self, op, args, kwargs, meta, updated=False):
-        if op not in self.targeted_ops:
+        if op not in self.target_ops:
             return super().call_operator(op, args, kwargs, meta, updated)
 
         x = args[0]

--- a/backends/arm/_passes/scalars_to_attribute_pass.py
+++ b/backends/arm/_passes/scalars_to_attribute_pass.py
@@ -13,6 +13,7 @@ from executorch.backends.arm._passes.match_arg_ranks_pass import MatchArgRanksPa
 from executorch.exir.graph_module import get_cond_while_submodules
 from executorch.exir.pass_base import ExportPass, PassResult
 from torch.fx import GraphModule, Node
+from torch.fx.node import Argument
 from torchao.quantization.pt2e.utils import get_new_attr_name_with_prefix
 
 
@@ -33,6 +34,29 @@ class ScalarsToAttributePass(ArmPass):
         torch.ops.aten.div.Tensor_mode,
     ]
 
+    @staticmethod
+    def _is_scalar_arg(arg: object) -> bool:
+        return isinstance(arg, (int, float))
+
+    def _has_scalar_arg(self, node: Node) -> bool:
+        return (
+            node.op == "call_function"
+            and node.target in self.targeted_ops
+            and any(self._is_scalar_arg(arg) for arg in node.args)
+        )
+
+    def should_run_pass(self, graph_module: GraphModule) -> bool:
+        if any(
+            self._has_scalar_arg(cast(Node, node)) for node in graph_module.graph.nodes
+        ):
+            return True
+        return any(
+            any(
+                self._has_scalar_arg(cast(Node, node)) for node in submodule.graph.nodes
+            )
+            for _, submodule, _ in get_cond_while_submodules(graph_module)
+        )
+
     def _convert_scalar_args(
         self,
         graph_module: GraphModule,
@@ -52,9 +76,12 @@ class ScalarsToAttributePass(ArmPass):
 
         modified = False
         output_fake_tensor = get_first_fake_tensor(n)
-        new_args: list[Node | int] = []
+        new_args: list[Argument] = []
         for arg in n.args:
             if isinstance(arg, Node):
+                new_args.append(arg)
+                continue
+            if not self._is_scalar_arg(arg):
                 new_args.append(arg)
                 continue
             if isinstance(arg, int) and not torch.is_floating_point(output_fake_tensor):

--- a/backends/arm/_passes/unsqueeze_scalar_placeholders_pass.py
+++ b/backends/arm/_passes/unsqueeze_scalar_placeholders_pass.py
@@ -28,6 +28,18 @@ class UnsqueezeScalarPlaceholdersPass(ArmPass):
         super().__init__(*args, **kwargs)
         self.exported_program = exported_program
 
+    def should_run_pass(self, graph_module: torch.fx.GraphModule) -> bool:
+        for node in graph_module.graph.nodes:
+            if node.op != "placeholder":
+                continue
+            if node.meta["val"].dim() != 0:
+                continue
+            if is_buffer(self.exported_program, node) or is_param(
+                self.exported_program, node
+            ):
+                return True
+        return False
+
     def call(self, graph_module: torch.fx.GraphModule):
         modified = False
         for node in graph_module.graph.nodes:


### PR DESCRIPTION
Add custom should_run_pass() pre-scans for Arm passes whose full ExportPass retracing path is only useful for specific graph patterns. The pre-scan keeps existing transforms unchanged when a relevant node is present, but returns an unmodified PassResult when the graph cannot be affected by the pass.

This avoids rebuilding graphs for placeholder, rank, dtype, buffer, layout, no-op, and decomposition passes that would otherwise scan the whole graph in call() and make no changes.

| Model       | Improvement |
|-------------|------------:|
| DeepLabV3   | +10.9%      |
| Wav2Letter  | +5.0%       |
| InceptionV3 | +3.2%       |
| MobileNetV2 | +12.8%      |
| MobileNetV3 | +12.1%      |


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell @rascani