### PR TITLE
Arm backend: Add xlarge pytest decorator

### DIFF
--- a/backends/arm/test/models/Qwen3_VL/test_qwen3_vl_model.py
+++ b/backends/arm/test/models/Qwen3_VL/test_qwen3_vl_model.py
@@ -88,7 +88,7 @@ def _make_pixel_values(config, device: torch.device) -> torch.Tensor:
 
 class Qwen3VLModelTestModule(torch.nn.Module):
     @classmethod
-    def prepare_model_and_inputs(cls):
+    def prepare_model_and_inputs(cls, config_factory=_make_qwen3_vl_e2e_test_config):
         raise NotImplementedError
 
 
@@ -130,9 +130,9 @@ class TextModelWrapper(Qwen3VLModelTestModule):
         return outputs.last_hidden_state
 
     @classmethod
-    def prepare_model_and_inputs(cls):
+    def prepare_model_and_inputs(cls, config_factory=_make_qwen3_vl_e2e_test_config):
         torch.manual_seed(0)
-        config = _make_qwen3_vl_e2e_test_config()
+        config = config_factory()
         model = cls(config).eval()
         input_ids = torch.randint(0, 128, (2, 8), dtype=torch.long)
         attention_mask = torch.ones_like(input_ids)
@@ -193,9 +193,9 @@ class LowerableVisionModelWrapper(Qwen3VLModelTestModule):
         return hidden_states + deepstack_residual
 
     @classmethod
-    def prepare_model_and_inputs(cls):
+    def prepare_model_and_inputs(cls, config_factory=_make_qwen3_vl_e2e_test_config):
         torch.manual_seed(0)
-        config = _make_qwen3_vl_e2e_test_config()
+        config = config_factory()
         model = cls(config).eval()
         pixel_values = _make_pixel_values(config, torch.device("cpu"))
         return model, (pixel_values,)
@@ -232,10 +232,11 @@ VGF_NO_QUANT_TEST_CASES: dict[str, Qwen3VLModelTestCase] = {
 }
 
 
-@pytest.mark.slow
-@common.parametrize("test_case", TOSA_FP_TEST_CASES)
-def test_qwen3_vl_full_models_tosa_FP(test_case: Qwen3VLModelTestCase):
-    model, inputs = test_case.model_cls.prepare_model_and_inputs()
+def _test_qwen3_vl_full_models_tosa_FP(
+    test_case: Qwen3VLModelTestCase,
+    config_factory=_make_qwen3_vl_e2e_test_config,
+):
+    model, inputs = test_case.model_cls.prepare_model_and_inputs(config_factory)
     with torch.no_grad():
         pipeline = TosaPipelineFP[input_t](
             model,
@@ -248,10 +249,11 @@ def test_qwen3_vl_full_models_tosa_FP(test_case: Qwen3VLModelTestCase):
         pipeline.run()
 
 
-@pytest.mark.slow
-@common.parametrize("test_case", TOSA_FP_TEST_CASES)
-def test_qwen3_vl_full_models_tosa_FP_bf16(test_case: Qwen3VLModelTestCase):
-    model, inputs = test_case.model_cls.prepare_model_and_inputs()
+def _test_qwen3_vl_full_models_tosa_FP_bf16(
+    test_case: Qwen3VLModelTestCase,
+    config_factory=_make_qwen3_vl_e2e_test_config,
+):
+    model, inputs = test_case.model_cls.prepare_model_and_inputs(config_factory)
     model, inputs = _to_bfloat16_model_and_floating_inputs(model, inputs)
     # Slightly higher atol for TOSA BF16 on aarch64 (MLETORCH-2048: numeric mismatch)
     atol = (
@@ -273,11 +275,11 @@ def test_qwen3_vl_full_models_tosa_FP_bf16(test_case: Qwen3VLModelTestCase):
         pipeline.run()
 
 
-@pytest.mark.slow
-@common.SkipIfNoModelConverter
-@common.parametrize("test_case", VGF_NO_QUANT_TEST_CASES)
-def test_qwen3_vl_full_models_vgf_no_quant(test_case: Qwen3VLModelTestCase):
-    model, inputs = test_case.model_cls.prepare_model_and_inputs()
+def _test_qwen3_vl_full_models_vgf_no_quant(
+    test_case: Qwen3VLModelTestCase,
+    config_factory=_make_qwen3_vl_e2e_test_config,
+):
+    model, inputs = test_case.model_cls.prepare_model_and_inputs(config_factory)
     with torch.no_grad():
         pipeline = VgfPipeline[input_t](
             model,
@@ -290,11 +292,11 @@ def test_qwen3_vl_full_models_vgf_no_quant(test_case: Qwen3VLModelTestCase):
         pipeline.run()
 
 
-@pytest.mark.slow
-@common.SkipIfNoModelConverter
-@common.parametrize("test_case", VGF_NO_QUANT_TEST_CASES)
-def test_qwen3_vl_full_models_vgf_no_quant_bf16(test_case: Qwen3VLModelTestCase):
-    model, inputs = test_case.model_cls.prepare_model_and_inputs()
+def _test_qwen3_vl_full_models_vgf_no_quant_bf16(
+    test_case: Qwen3VLModelTestCase,
+    config_factory=_make_qwen3_vl_e2e_test_config,
+):
+    model, inputs = test_case.model_cls.prepare_model_and_inputs(config_factory)
     model, inputs = _to_bfloat16_model_and_floating_inputs(model, inputs)
     with torch.no_grad():
         pipeline = VgfPipeline[input_t](
@@ -309,10 +311,11 @@ def test_qwen3_vl_full_models_vgf_no_quant_bf16(test_case: Qwen3VLModelTestCase)
         pipeline.run()
 
 
-@pytest.mark.slow
-def test_qwen3_vl_text_model_tosa_mxfp8_bf16():
+def _test_qwen3_vl_text_model_tosa_mxfp8_bf16(
+    config_factory=_make_qwen3_vl_e2e_test_config,
+):
     # The Qwen 3 VL FP8 model only quantizes the TextModel
-    model, inputs = TextModelWrapper.prepare_model_and_inputs()
+    model, inputs = TextModelWrapper.prepare_model_and_inputs(config_factory)
     model, inputs = _to_bfloat16_model_and_floating_inputs(model, inputs)
     mxfp_config = MXFPOpConfig(weight_dtype=torch.float8_e4m3fn)
     with torch.no_grad():
@@ -339,3 +342,63 @@ def test_qwen3_vl_text_model_tosa_mxfp8_bf16():
             suffix="mxfp_linear",
         )
         pipeline.run()
+
+
+@pytest.mark.slow
+@common.parametrize("test_case", TOSA_FP_TEST_CASES)
+def test_qwen3_vl_full_models_tosa_FP(test_case: Qwen3VLModelTestCase):
+    _test_qwen3_vl_full_models_tosa_FP(test_case)
+
+
+@pytest.mark.slow
+@common.parametrize("test_case", TOSA_FP_TEST_CASES)
+def test_qwen3_vl_full_models_tosa_FP_bf16(test_case: Qwen3VLModelTestCase):
+    _test_qwen3_vl_full_models_tosa_FP_bf16(test_case)
+
+
+@pytest.mark.slow
+@common.SkipIfNoModelConverter
+@common.parametrize("test_case", VGF_NO_QUANT_TEST_CASES)
+def test_qwen3_vl_full_models_vgf_no_quant(test_case: Qwen3VLModelTestCase):
+    _test_qwen3_vl_full_models_vgf_no_quant(test_case)
+
+
+@pytest.mark.slow
+@common.SkipIfNoModelConverter
+@common.parametrize("test_case", VGF_NO_QUANT_TEST_CASES)
+def test_qwen3_vl_full_models_vgf_no_quant_bf16(test_case: Qwen3VLModelTestCase):
+    _test_qwen3_vl_full_models_vgf_no_quant_bf16(test_case)
+
+
+@pytest.mark.slow
+def test_qwen3_vl_text_model_tosa_mxfp8_bf16():
+    _test_qwen3_vl_text_model_tosa_mxfp8_bf16()
+
+
+@pytest.mark.slow
+@pytest.mark.xlarge
+@common.parametrize("test_case", TOSA_FP_TEST_CASES)
+def test_qwen3_vl_2b_instruct_full_models_tosa_FP_bf16(
+    test_case: Qwen3VLModelTestCase,
+):
+    _test_qwen3_vl_full_models_tosa_FP_bf16(
+        test_case, _make_qwen3_vl_2b_instruct_layer_config
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.xlarge
+@common.SkipIfNoModelConverter
+@common.parametrize("test_case", VGF_NO_QUANT_TEST_CASES)
+def test_qwen3_vl_2b_instruct_full_models_vgf_no_quant_bf16(
+    test_case: Qwen3VLModelTestCase,
+):
+    _test_qwen3_vl_full_models_vgf_no_quant_bf16(
+        test_case, _make_qwen3_vl_2b_instruct_layer_config
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.xlarge
+def test_qwen3_vl_2b_instruct_text_model_tosa_mxfp8_bf16():
+    _test_qwen3_vl_text_model_tosa_mxfp8_bf16(_make_qwen3_vl_2b_instruct_layer_config)

--- a/backends/arm/test/pytest.ini
+++ b/backends/arm/test/pytest.ini
@@ -3,5 +3,6 @@ timeout = 1800
 addopts = --strict-markers
 markers =
     slow: Tests that take long time
+    xlarge: Tests that are known to use a lot of memory
     flaky: Tests that are known to be flaky/intermittent
     tosa_ref_model: Tests that use TOSA reference model # Temporary!

--- a/backends/arm/test/test_arm_backend.sh
+++ b/backends/arm/test/test_arm_backend.sh
@@ -90,7 +90,7 @@ test_pytest_models_no_target() {
     source backends/arm/scripts/install_models_for_test.sh
 
     # Run arm baremetal pytest tests without FVP
-    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k "${EXCLUDE_TARGET_EXPR}"
+    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k "${EXCLUDE_TARGET_EXPR}" -m "not xlarge"
     echo "${TEST_SUITE_NAME}: PASS"
 }
 
@@ -110,7 +110,7 @@ test_pytest_models_tosa() {
     # Install model dependencies for pytest
     source backends/arm/scripts/install_models_for_test.sh
 
-    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k tosa
+    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k tosa -m "not xlarge"
     echo "${TEST_SUITE_NAME}: PASS"
 }
 
@@ -146,7 +146,7 @@ test_pytest_models_ethos_u55() {
     # Install model dependencies for pytest
     source backends/arm/scripts/install_models_for_test.sh
 
-    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k u55
+    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k u55 -m "not xlarge"
     echo "${TEST_SUITE_NAME}: PASS"
 }
 
@@ -204,7 +204,7 @@ test_pytest_models_ethos_u85() {
     # Install model dependencies for pytest
     source backends/arm/scripts/install_models_for_test.sh
 
-    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k u85
+    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k u85 -m "not xlarge"
     echo "${TEST_SUITE_NAME}: PASS"
 }
 
@@ -251,7 +251,7 @@ test_pytest_models_vkml() {
     # Install model dependencies for pytest
     source backends/arm/scripts/install_models_for_test.sh
 
-    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k _vgf_
+    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k _vgf_ -m "not xlarge"
     echo "${TEST_SUITE_NAME}: PASS"
 }
 


### PR DESCRIPTION
* Add xlarge decorator for tests that use a lot of memory
* Add full Qwen 3 VL model tests

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani