### PR TITLE
Qualcomm AI Engine Direct - Fix sliding window attention

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/runner/kv_manager.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/kv_manager.cpp
@@ -260,7 +260,7 @@ void KVManager::update_attention_mask(
       fill_mask(
           attention_mask_dtype_,
           cur_ptr - n_past * getDtypeSize(attention_mask_dtype_),
-          n_past + n_update,
+          n_past + n_update - available_cache_len,
           /*use_pos_value=*/false);
     }
     cur_ptr += metadata_.context_len * getDtypeSize(attention_mask_dtype_);


### PR DESCRIPTION
### Summary
When `n_past + n_update` exceeds the `available_cache_len`
it should mask only the remain part.

### Test plan
gemma3 CI in `TestExampleLLMScript.test_static_llm_model`