### PR TITLE
Qualcomm AI Engine Direct - Pass migration - part 1

### DIFF
--- a/backends/qualcomm/_passes/__init__.py
+++ b/backends/qualcomm/_passes/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .annotate_avg_pool1d import AnnotateAvgPool1D
+from .annotate_get_attr import AnnotateGetAttr
 from .annotate_quant_attrs import AnnotateQuantAttrs
 from .annotate_stack import AnnotateStack
 from .annotate_unbind import AnnotateUnbind
@@ -70,6 +71,7 @@ from .tag_quant_io import TagQuantIO
 
 __all__ = [
     AnnotateAvgPool1D,
+    AnnotateGetAttr,
     AnnotateQuantAttrs,
     AnnotateStack,
     AnnotateUnbind,

--- a/backends/qualcomm/_passes/__init__.py
+++ b/backends/qualcomm/_passes/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .annotate_avg_pool1d import AnnotateAvgPool1D
+from .annotate_get_attr import AnnotateGetAttr
 from .annotate_quant_attrs import AnnotateQuantAttrs
 from .annotate_stack import AnnotateStack
 from .annotate_unbind import AnnotateUnbind
@@ -73,6 +74,7 @@ from .tag_quant_io import TagQuantIO
 
 __all__ = [
     AnnotateAvgPool1D,
+    AnnotateGetAttr,
     AnnotateQuantAttrs,
     AnnotateStack,
     AnnotateUnbind,

--- a/backends/qualcomm/_passes/annotate_get_attr.py
+++ b/backends/qualcomm/_passes/annotate_get_attr.py
@@ -1,0 +1,52 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.backends.qualcomm.builders.node_visitor import dq_ops
+from executorch.backends.qualcomm.utils.constants import QCOM_QUANT_ATTRS
+from executorch.exir.pass_base import ExportPass, PassResult
+
+from .utils import get_quant_attrs
+
+
+class AnnotateGetAttr(ExportPass):
+    """
+    Annotates quantization attributes for `get_attr` nodes.
+
+    In passes such as `CanonicalizeConv`, `ConvertLinearToConv2d`,
+    `LiftConstantScalarOperands`, and others, `get_attr` nodes and the
+    corresponding quantization attributes are inserted into the GraphModule
+    to store modified constant values.
+
+    However, the quantization attributes associated with `get_attr` nodes will
+    be discarded in certain passes, such as `I64toI32` and `LayoutTransform`.
+    This happens due to the following line:
+    `graph_module = super().call(graph_module).graph_module`
+
+    which reconstructs the GraphModule and drops any existing quantization
+    attributes stored in the metadata of `get_attr` nodes.
+
+    To guarantee correctness, this pass repopulates the quantization attributes
+    for `get_attr` nodes and ensures to be scheduled after the `I64toI32` and
+    `LayoutTransform` passes.
+    """
+
+    def __init__(self, edge_program: torch.export.ExportedProgram):
+        self.edge_program = edge_program
+
+    def _annotate_get_attr(
+        self, graph_module: torch.fx.GraphModule
+    ) -> torch.fx.GraphModule:
+        for node in graph_module.graph.nodes:
+            if node.op == "get_attr" and list(node.users)[0].target in dq_ops:
+                dq_op = list(node.users)[0]
+                quant_attrs = get_quant_attrs(self.edge_program, dq_op)
+                node.meta[QCOM_QUANT_ATTRS] = quant_attrs
+
+    def call(self, graph_module: torch.fx.GraphModule):
+        self._annotate_get_attr(graph_module)
+        graph_module.recompile()
+        return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/annotate_get_attr.py
+++ b/backends/qualcomm/_passes/annotate_get_attr.py
@@ -1,0 +1,54 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.backends.qualcomm.builders.node_visitor import dq_ops
+from executorch.backends.qualcomm.utils.constants import QCOM_QUANT_ATTRS
+from executorch.exir.pass_base import ExportPass, PassResult
+
+from .utils import get_quant_attrs
+
+
+class AnnotateGetAttr(ExportPass):
+    """
+    Annotates quantization attributes for `get_attr` nodes.
+
+    In passes such as `CanonicalizeConv`, `ConvertLinearToConv2d`,
+    `LiftConstantScalarOperands`, and others, `get_attr` nodes and the
+    corresponding quantization attributes are inserted into the GraphModule
+    to store modified constant values.
+
+    However, the quantization attributes associated with `get_attr` nodes will
+    be discarded in certain passes, such as `I64toI32` and `LayoutTransform`.
+    This happens due to the following line:
+    `graph_module = super().call(graph_module).graph_module`
+
+    which reconstructs the GraphModule and drops any existing quantization
+    attributes stored in the metadata of `get_attr` nodes.
+
+    To guarantee correctness, this pass repopulates the quantization attributes
+    for `get_attr` nodes and ensures to be scheduled after the `I64toI32` and
+    `LayoutTransform` passes.
+    """
+
+    def __init__(self, edge_program: torch.export.ExportedProgram):
+        self.edge_program = edge_program
+
+    def _annotate_get_attr(
+        self, graph_module: torch.fx.GraphModule
+    ) -> torch.fx.GraphModule:
+        for node in graph_module.graph.nodes:
+            if node.op == "get_attr":
+                for op in list(node.users):
+                    if op.target in dq_ops:
+                        quant_attrs = get_quant_attrs(self.edge_program, op)
+                        node.meta[QCOM_QUANT_ATTRS] = quant_attrs
+                        break
+
+    def call(self, graph_module: torch.fx.GraphModule):
+        self._annotate_get_attr(graph_module)
+        graph_module.recompile()
+        return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/annotate_quant_attrs.py
+++ b/backends/qualcomm/_passes/annotate_quant_attrs.py
@@ -55,12 +55,6 @@ class AnnotateQuantAttrs(ExportPass):
             source_n = quant_node.args[0]
         source_n.meta[QCOM_QUANT_ATTRS] = quant_attrs
 
-    def _expand(self, tensor, dim, axis) -> torch.Tensor:
-        tensor = tensor[(...,) + (None,) * (dim - 1)]
-        order = torch.arange(dim).tolist()
-        order[axis], order[0] = order[0], order[axis]
-        return tensor.permute(order)
-
     # Find the the last dq nodes between regular op nodes
     # Return dq2 in example below when q1 is given as node parameter:
     # ... -> n1 -> q1 -> dq1 -> q2 -> dq2 -> n2 -> ...

--- a/backends/qualcomm/_passes/backends/gpu/qnn_gpu_pass_manager.py
+++ b/backends/qualcomm/_passes/backends/gpu/qnn_gpu_pass_manager.py
@@ -38,12 +38,9 @@ class QnnGpuPassManager(QnnPassManager):
         return []
 
     @classmethod
-    def get_export_passes(
-        cls,
-        convert_linear_to_conv2d: bool = False,
-    ):
+    def get_export_passes(cls):
         # DecomposeReciprocal should be placed in the export pipeline, as it depends on
         # LiftConstantScalarOperands to lift the scalar operand.
         passes = [DecomposeReciprocal]
-        passes.extend(super().get_export_passes(convert_linear_to_conv2d))
+        passes.extend(super().get_export_passes())
         return passes

--- a/backends/qualcomm/_passes/backends/htp/qnn_htp_pass_manager.py
+++ b/backends/qualcomm/_passes/backends/htp/qnn_htp_pass_manager.py
@@ -38,12 +38,9 @@ class QnnHtpPassManager(QnnPassManager):
         return passes
 
     @classmethod
-    def get_export_passes(
-        cls,
-        convert_linear_to_conv2d: bool = False,
-    ):
+    def get_export_passes(cls):
         # DecomposeReciprocal should be placed in the export pipeline, as it depends on
         # LiftConstantScalarOperands to lift the scalar operand.
         passes = [DecomposeReciprocal]
-        passes.extend(super().get_export_passes(convert_linear_to_conv2d))
+        passes.extend(super().get_export_passes())
         return passes

--- a/backends/qualcomm/_passes/backends/htp/qnn_htp_pass_manager.py
+++ b/backends/qualcomm/_passes/backends/htp/qnn_htp_pass_manager.py
@@ -42,12 +42,9 @@ class QnnHtpPassManager(QnnPassManager):
         return passes
 
     @classmethod
-    def get_export_passes(
-        cls,
-        convert_linear_to_conv2d: bool = False,
-    ):
+    def get_export_passes(cls):
         # DecomposeReciprocal should be placed in the export pipeline, as it depends on
         # LiftConstantScalarOperands to lift the scalar operand.
         passes = [DecomposeReciprocal]
-        passes.extend(super().get_export_passes(convert_linear_to_conv2d))
+        passes.extend(super().get_export_passes())
         return passes

--- a/backends/qualcomm/_passes/backends/lpai/qnn_lpai_pass_manager.py
+++ b/backends/qualcomm/_passes/backends/lpai/qnn_lpai_pass_manager.py
@@ -70,14 +70,11 @@ class QnnLpaiPassManager(QnnPassManager):
         return passes
 
     @classmethod
-    def get_export_passes(
-        cls,
-        convert_linear_to_conv2d: bool = False,
-    ):
+    def get_export_passes(cls):
         # Both DecomposeHardSigmoid and DecomposeReciprocal should be placed in the export
         # pipeline, as they rely on LiftConstantScalarOperands to lift the scalar operand.
         passes = [DecomposeHardsigmoid, DecomposeReciprocal]
-        passes.extend(super().get_export_passes(convert_linear_to_conv2d))
+        passes.extend(super().get_export_passes())
         return passes
 
     @classmethod

--- a/backends/qualcomm/_passes/canonicalize_conv.py
+++ b/backends/qualcomm/_passes/canonicalize_conv.py
@@ -4,16 +4,38 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from enum import IntEnum
 from typing import cast, Tuple
 
 import torch
 
-from executorch.backends.qualcomm.builders.utils import get_parameter, set_parameter
+from executorch.backends.qualcomm.builders.node_visitor import dq_ops
+from executorch.backends.qualcomm.builders.utils import get_parameter
+from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 from executorch.exir.passes import dead_code_elimination_pass
 from torch._guards import detect_fake_mode
+from torchao.quantization.pt2e.utils import get_new_attr_name_with_prefix
 
-from .utils import append_qdq, copy_meta
+from .utils import copy_meta
+
+
+class ConvParamIdx(IntEnum):
+    """
+    Spec for `aten.convolution` (https://docs.pytorch.org/docs/stable/torch.compiler_ir.html)
+    convolution(Tensor input, Tensor weight, Tensor? bias, SymInt[] stride, SymInt[] padding,
+                SymInt[] dilation, bool transposed, SymInt[] output_padding, SymInt groups) -> Tensor
+    """
+
+    INPUT = 0
+    WEIGHT = 1
+    BIAS = 2
+    STRIDE = 3
+    PADDING = 4
+    DILATION = 5
+    TRANSPOSED = 6
+    OUTPUT_PADDING = 7
+    GROUPS = 8
 
 
 class CanonicalizeConv(ExportPass):
@@ -27,17 +49,8 @@ class CanonicalizeConv(ExportPass):
     def __init__(self, edge_program: torch.export.ExportedProgram):
         super(CanonicalizeConv, self).__init__()
         self.edge_program = edge_program
-        self.conv1d_op_map = {
-            torch.ops.aten.conv1d.default: torch.ops.aten.conv2d.default,
-            torch.ops.aten.conv_transpose1d.default: torch.ops.aten.conv_transpose2d.input,
-        }
-        self.transpose_conv_set = {
-            torch.ops.aten.conv_transpose1d.default,
-            torch.ops.aten.conv_transpose2d.input,
-            torch.ops.aten.conv_transpose3d.input,
-        }
 
-    def dilate(self, tensor, dilation):
+    def _dilate(self, tensor, dilation):
         # e.g.
         # for 3x3 kernel with dilation == (2, 3)
         #             1, 0, 0, 2, 0, 0, 3
@@ -52,165 +65,135 @@ class CanonicalizeConv(ExportPass):
         new_tensor[indexing] = tensor
         return new_tensor
 
-    def call(self, graph_module: torch.fx.GraphModule):
+    def _replace_1d_conv(
+        self,
+        graph_module: torch.fx.GraphModule,
+        node: torch.fx.Node,
+        input_node: torch.fx.Node,
+    ):
         graph = graph_module.graph
-        # condition 1
-        for node in graph.nodes:
-            # arg order (https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.conv_transpose2d.html)
-            # > input, weight, bias, stride, padding, output_padding, groups, dilation
-            if node.target in self.transpose_conv_set and len(node.args) > 7:
-                dilation = cast(Tuple[int], node.args[7])
-                # dilate kernel in advance
-                filter_arg = node.args[1]
-                filter_node = (
-                    # fp graph
-                    filter_arg
-                    if filter_arg.op == "placeholder"
-                    # qdq graph
-                    else node.args[1].args[0]
-                )
-                filter_tensor = self.dilate(
-                    get_parameter(filter_node, self.edge_program),
-                    dilation,
-                )
-                # update tensor meta for kernel node
-                fake_mode = detect_fake_mode(filter_node.meta["val"])
-                converter = fake_mode.fake_tensor_converter
-                filter_node.meta["val"] = converter.from_real_tensor(
-                    fake_mode, filter_tensor
-                )
-                # update kernel
-                set_parameter(
-                    (
-                        torch.nn.Parameter(filter_tensor)
-                        if filter_tensor.dtype == torch.float
-                        else filter_tensor
-                    ),
-                    filter_node,
-                    self.edge_program,
-                )
-                # pop dilation for graph in cpu
-                node.args = node.args[0:-1]
+        with graph_module.graph.inserting_after(node):
+            unsqueeze_op = exir_ops.edge.aten.unsqueeze_copy.default
+            unsqueeze_node = graph.create_node(
+                "call_function",
+                unsqueeze_op,
+                (
+                    input_node,
+                    2,
+                ),
+            )
+            # This pass is scheduled after the `FoldQDQ` pass. After copying the metadata
+            # from the input node, the quantization attributes are also propagated to
+            # the corresponding `unsqueeze` node.
+            unsqueeze_node.meta = copy_meta(
+                input_node.meta, lambda m: {**m, "val": m["val"].unsqueeze(2)}
+            )
 
-        # condition 2
-        for node in graph.nodes:
-            if node.target in self.conv1d_op_map:
-                input_node = node.args[0]
-                with graph_module.graph.inserting_after(input_node):
-                    unsqueeze_op = torch.ops.aten.unsqueeze_copy.default
-                    unsqueeze_node = graph.create_node(
+            with graph_module.graph.inserting_after(unsqueeze_node):
+                conv_args = (
+                    unsqueeze_node,
+                    node.args[ConvParamIdx.WEIGHT],
+                    node.args[ConvParamIdx.BIAS],
+                    [1] + node.args[ConvParamIdx.STRIDE],
+                    [0] + node.args[ConvParamIdx.PADDING],
+                    [1] + node.args[ConvParamIdx.DILATION],
+                    node.args[ConvParamIdx.TRANSPOSED],
+                    [0] + node.args[ConvParamIdx.OUTPUT_PADDING],
+                    node.args[ConvParamIdx.GROUPS],
+                )
+                conv2d_node = graph.create_node(
+                    "call_function",
+                    exir_ops.edge.aten.convolution.default,
+                    conv_args,
+                )
+                conv2d_node.meta = copy_meta(
+                    node.meta, lambda m: {**m, "val": m["val"].unsqueeze(2)}
+                )
+
+                with graph_module.graph.inserting_after(conv2d_node):
+                    squeeze_op = exir_ops.edge.aten.squeeze_copy.dims
+                    squeeze_node = graph.create_node(
                         "call_function",
-                        unsqueeze_op,
+                        squeeze_op,
                         (
-                            input_node,
-                            2,
+                            conv2d_node,
+                            [2],
                         ),
                     )
-                    unsqueeze_node.meta = copy_meta(
-                        input_node.meta, lambda m: {**m, "val": m["val"].unsqueeze(2)}
+                    squeeze_node.meta = copy_meta(node.meta)
+
+        for user in node.users.copy():
+            user.replace_input_with(node, squeeze_node)
+
+    def call(self, graph_module: torch.fx.GraphModule):
+        graph = graph_module.graph
+        for node in graph.nodes:
+            # After decomposition to Core ATen, all variants within the conv and conv_transpose family
+            # are lowered to `aten.convolution`.
+            if node.target is exir_ops.edge.aten.convolution.default:
+                stride = cast(Tuple[int], node.args[ConvParamIdx.STRIDE])
+                dilation = cast(Tuple[int], node.args[ConvParamIdx.DILATION])
+                is_conv_transpose = node.args[ConvParamIdx.TRANSPOSED]
+                is_1d_op = len(stride) == 1
+                has_conv_transpose_dilation = is_conv_transpose and any(
+                    val != 1 for val in dilation
+                )
+                has_filter_update = is_1d_op or has_conv_transpose_dilation
+                if not has_filter_update:
+                    continue
+
+                input_node = node.args[ConvParamIdx.INPUT]
+                filter_placeholder_node = (
+                    # FP graph
+                    node.args[ConvParamIdx.WEIGHT]
+                    if node.args[ConvParamIdx.WEIGHT].op == "placeholder"
+                    # QDQ graph
+                    else node.args[ConvParamIdx.WEIGHT].args[0]
+                )
+                filter_tensor = (
+                    get_parameter(filter_placeholder_node, self.edge_program)
+                    .contiguous()
+                    .detach()
+                )
+
+                if has_conv_transpose_dilation:
+                    filter_tensor = self._dilate(filter_tensor, dilation)
+                    node.args = (
+                        *node.args[: ConvParamIdx.DILATION],
+                        [1] * len(dilation),
+                        *node.args[ConvParamIdx.TRANSPOSED :],
                     )
-                    qdq_node_after_unsqueeze = append_qdq(
-                        graph_module=graph_module,
-                        node=unsqueeze_node,
-                        qdq_node=input_node,
-                    )
+                if is_1d_op:
+                    filter_tensor = filter_tensor.unsqueeze(2)
 
-                    with graph_module.graph.inserting_after(qdq_node_after_unsqueeze):
-                        # conv2d must be inserted before conv1d in the graph to preserve correct
-                        # topological ordering. This is required due to conv-bn fusion: when conv1d
-                        # has no bias, the fused bias (from batchnorm) is introduced as a new node,
-                        # and its corresponding dq (dequantize) node must appear before conv2d in
-                        # the execution order.
-                        with graph_module.graph.inserting_before(node):
-                            filter_arg = node.args[1]
-                            filter_node = (
-                                filter_arg
-                                if filter_arg.op == "placeholder"
-                                else node.args[1].args[0]
+                if has_filter_update:
+                    buffer_name = get_new_attr_name_with_prefix(node.name)(graph_module)
+                    graph_module.register_buffer(buffer_name, filter_tensor)
+
+                    with graph_module.graph.inserting_after(filter_placeholder_node):
+                        get_attr_node = graph_module.graph.get_attr(buffer_name)
+                        fake_mode = detect_fake_mode(
+                            filter_placeholder_node.meta["val"]
+                        )
+                        converter = fake_mode.fake_tensor_converter
+                        get_attr_node.meta["val"] = converter.from_real_tensor(
+                            fake_mode, filter_tensor
+                        )
+
+                        if node.args[ConvParamIdx.WEIGHT].target in dq_ops:
+                            filter_dequant_node = node.args[ConvParamIdx.WEIGHT]
+                            # Reuse the dequant node and replace its input with the get_attr node.
+                            # The quant attrs of the get_attr node are populated by the `AnnotateGetAttr` pass.
+                            filter_dequant_node.replace_input_with(
+                                filter_placeholder_node, get_attr_node
                             )
-                            filter_node.meta["val"] = filter_node.meta["val"].unsqueeze(
-                                2
-                            )
-                            filter_tensor = get_parameter(
-                                filter_node, self.edge_program
-                            ).unsqueeze(2)
-                            set_parameter(
-                                (
-                                    torch.nn.Parameter(filter_tensor)
-                                    if filter_tensor.dtype == torch.float
-                                    else filter_tensor
-                                ),
-                                filter_node,
-                                self.edge_program,
+                        else:
+                            node.replace_input_with(
+                                filter_placeholder_node, get_attr_node
                             )
 
-                            num_args = len(node.args)
-
-                            bias_node = node.args[2] if num_args > 2 else None
-                            stride = [1] + node.args[3] if num_args > 3 else [1, 1]
-                            padding = [0] + node.args[4] if num_args > 4 else [0, 0]
-                            if node.target == torch.ops.aten.conv1d.default:
-                                dilation = (
-                                    [1] + node.args[5] if num_args > 5 else [1, 1]
-                                )
-                                groups = node.args[6] if num_args > 6 else 1
-                                conv_args = (
-                                    qdq_node_after_unsqueeze,
-                                    node.args[1],
-                                    bias_node,
-                                    stride,
-                                    padding,
-                                    dilation,
-                                    groups,
-                                )
-                            else:
-                                output_padding = (
-                                    [0] + node.args[5] if num_args > 5 else [0, 0]
-                                )
-                                groups = node.args[6] if num_args > 6 else 1
-                                dilation = (
-                                    [1] + node.args[7] if num_args > 7 else [1, 1]
-                                )
-                                conv_args = (
-                                    qdq_node_after_unsqueeze,
-                                    node.args[1],
-                                    bias_node,
-                                    stride,
-                                    padding,
-                                    output_padding,
-                                    groups,
-                                    dilation,
-                                )
-                            conv2d_node = graph.create_node(
-                                "call_function",
-                                self.conv1d_op_map[node.target],
-                                conv_args,
-                            )
-                            conv2d_node.meta = copy_meta(
-                                node.meta, lambda m: {**m, "val": m["val"].unsqueeze(2)}
-                            )
-                            qdq_node_after_conv2d = append_qdq(
-                                graph_module=graph_module,
-                                node=conv2d_node,
-                                qdq_node=list(node.users)[0],
-                            )
-
-                            with graph_module.graph.inserting_after(
-                                qdq_node_after_conv2d
-                            ):
-                                squeeze_op = torch.ops.aten.squeeze_copy.dims
-                                squeeze_node = graph.create_node(
-                                    "call_function",
-                                    squeeze_op,
-                                    (
-                                        qdq_node_after_conv2d,
-                                        [2],
-                                    ),
-                                )
-                                squeeze_node.meta = copy_meta(node.meta)
-
-                for user in node.users.copy():
-                    user.replace_input_with(node, squeeze_node)
+                if is_1d_op:
+                    self._replace_1d_conv(graph_module, node, input_node)
 
         dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/convert_linear_to_conv2d.py
+++ b/backends/qualcomm/_passes/convert_linear_to_conv2d.py
@@ -5,10 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from executorch.backends.qualcomm._passes.utils import append_qdq, copy_meta
-from executorch.backends.qualcomm.builders.utils import get_parameter, set_parameter
+
+from executorch.backends.qualcomm._passes.utils import copy_meta
+from executorch.backends.qualcomm.builders.node_visitor import dq_ops
+from executorch.backends.qualcomm.builders.utils import get_parameter
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.dialects.edge._ops import EdgeOpOverload
 from executorch.exir.pass_base import ExportPass, PassResult
 from executorch.exir.passes import dead_code_elimination_pass
+from torch._guards import detect_fake_mode
+from torch._subclasses.fake_tensor import FakeTensor
 from torch.fx import GraphModule
 from torchao.quantization.pt2e.utils import get_new_attr_name_with_prefix
 
@@ -25,208 +31,228 @@ class ConvertLinearToConv2d(ExportPass):
     def __init__(self, edge_program: torch.export.ExportedProgram):
         super().__init__()
         self.edge_program = edge_program
-        self.per_block_dq = torch.ops.torchao.dequantize_affine.default
 
     def _register_tensor(
         self,
-        gm: torch.fx.GraphModule,
-        node: torch.fx.Node,
-        tensor_constant: torch.Tensor,
-    ) -> torch.fx.Node:
-        new_node_name = get_new_attr_name_with_prefix(node.name)(gm)
-        gm.register_buffer(new_node_name, tensor_constant)
-
-        with gm.graph.inserting_before(node):
-            get_attr_node = gm.graph.get_attr(new_node_name)
-            get_attr_node.meta["val"] = tensor_constant
-        return get_attr_node
-
-    def _append_dq(
-        self,
         graph_module: torch.fx.GraphModule,
-        node: torch.fx.Node,
-        qdq_node: torch.fx.Node,
-    ):
-        q_op = torch.ops.quantized_decomposed.quantize_per_tensor.default
-        dq_op = torch.ops.quantized_decomposed.dequantize_per_tensor.default
-
-        if qdq_node.target not in {q_op, dq_op}:
-            return node
-
-        with graph_module.graph.inserting_after(node):
-            dq_args = (node, *qdq_node.args[1:])
-            dq_node = graph_module.graph.create_node("call_function", dq_op, dq_args)
-            dq_node.meta = copy_meta(node.meta)
-        return dq_node
-
-    def _create_node(
-        self, graph_module, target, args, meta_node, new_meta_val, qdq_node
-    ):
-        new_node = graph_module.graph.call_function(target, args)
-        new_node.meta = copy_meta(
-            meta_node.meta,
-            lambda m, new_meta_val=new_meta_val: {
-                **m,
-                "val": new_meta_val,
-            },
+        weight_placeholder_node: torch.fx.Node,
+        weight_val: torch.Tensor,
+    ) -> torch.fx.Node:
+        buffer_name = get_new_attr_name_with_prefix(weight_placeholder_node.name)(
+            graph_module
         )
-        dq_node = append_qdq(
-            graph_module=graph_module,
-            node=new_node,
-            qdq_node=qdq_node,
-        )
-        return dq_node
+        graph_module.register_buffer(buffer_name, weight_val)
 
-    def _reshape_weight(self, graph_module, weight_node, dq_node):
-        # After export, constant node will be placeholder from edge_program
-        weight_val = get_parameter(weight_node, self.edge_program)
-        assert weight_val is not None, "Cannot get the weight in linear node."
-
-        weight_val = weight_val.reshape(*weight_val.shape, 1, 1)
-        # Create the new weight node when several node share the same weight
-        # such as embedding and lm_head in LLM.
-        if len(list(weight_node.users)) > 1:
-            weight_node = self._register_tensor(graph_module, weight_node, weight_val)
-            dq_node = self._append_dq(graph_module, weight_node, dq_node)
-        else:
-            set_parameter(
-                (
-                    torch.nn.Parameter(weight_val)
-                    if weight_val.dtype == torch.float
-                    else weight_val
-                ),
-                weight_node,
-                self.edge_program,
+        with graph_module.graph.inserting_after(weight_placeholder_node):
+            get_attr_node = graph_module.graph.get_attr(buffer_name)
+            get_attr_node.meta = copy_meta(weight_placeholder_node.meta)
+            fake_mode = detect_fake_mode(weight_placeholder_node.meta["val"])
+            converter = fake_mode.fake_tensor_converter
+            get_attr_node.meta["val"] = converter.from_real_tensor(
+                fake_mode, weight_val
             )
 
-        # Update node meta val
-        weight_node.meta["val"] = weight_node.meta["val"].reshape(weight_val.shape)
-        dq_node.meta["val"] = dq_node.meta["val"].reshape(weight_val.shape)
-        # Update block size for per-block quant
-        if dq_node.target == self.per_block_dq:
-            new_args = list(dq_node.args)
-            # pad block size
-            new_args[1] = _pad_list_to_4(list(new_args[1]))
-            dq_node.args = tuple(new_args)
+        return get_attr_node
 
-        return dq_node
+    def _create_node(
+        self,
+        graph_module: torch.fx.GraphModule,
+        target: EdgeOpOverload,
+        args: tuple,
+        node_meta_val: FakeTensor,
+        meta_source_node: torch.fx.Node = None,
+    ) -> torch.fx.Node:
+        anchor_node = meta_source_node if meta_source_node else args[0]
+        with graph_module.graph.inserting_after(anchor_node):
+            inserted_node = graph_module.graph.create_node(
+                "call_function",
+                target,
+                args,
+            )
+            inserted_node.meta = copy_meta(
+                anchor_node.meta, lambda m: {**m, "val": node_meta_val}
+            )
+
+        return inserted_node
+
+    def _reshape_weight_for_all_users(
+        self,
+        graph_module: torch.fx.GraphModule,
+        weight_placeholder_node: torch.fx.Node,
+    ) -> torch.fx.Node:
+        weight_val = get_parameter(weight_placeholder_node, self.edge_program)
+        assert weight_val is not None, "Cannot get the weight in linear node."
+
+        weight_val = weight_val.reshape(*weight_val.shape, 1, 1).contiguous().detach()
+        get_attr_node = self._register_tensor(
+            graph_module, weight_placeholder_node, weight_val
+        )
+        if list(weight_placeholder_node.users)[0].target in dq_ops:
+            # Scenarios where multiple linear nodes share the same weights, such as the embedding and lm_head in LLM.
+            for dq_node in list(weight_placeholder_node.users):
+                if (
+                    list(dq_node.users)[0].target
+                    is not exir_ops.edge.aten.linear.default
+                ):
+                    # Add a safety check to prevent replacing weights of non-linear nodes with updated weights.
+                    continue
+                # For shared weights, a dequantize node is inserted per user after quantization.
+                # Reuse the dequantize node after weight updates by replacing its input with the corresponding `get_attr` node.
+                dq_node.replace_input_with(weight_placeholder_node, get_attr_node)
+
+                fake_mode = detect_fake_mode(get_attr_node.meta["val"])
+                converter = fake_mode.fake_tensor_converter
+                dq_node.meta["val"] = converter.from_real_tensor(fake_mode, weight_val)
+
+                # Update block size for per-block quant
+                if dq_node.target is exir_ops.edge.torchao.dequantize_affine.default:
+                    new_args = list(dq_node.args)
+                    # pad block size
+                    new_args[1] = _pad_list_to_4(list(new_args[1]))
+                    dq_node.args = tuple(new_args)
+
+            return dq_node
+        else:
+            for user in list(weight_placeholder_node.users):
+                if user.target is not exir_ops.edge.aten.linear.default:
+                    # Add a safety check to prevent replacing weights of non-linear nodes with updated weights.
+                    continue
+                user.replace_input_with(weight_placeholder_node, get_attr_node)
+
+            return get_attr_node
 
     def call(self, graph_module: GraphModule):
         graph = graph_module.graph
+        # The set tracks whether the weights associated with a linear node have been preprocessed,
+        # and is used in cases where multiple linear nodes share the same weights.
+        preprocessed_linear_weights_set = set()
 
-        for node in list(graph.nodes):
-            if node.target == torch.ops.aten.linear.default:
+        for node in graph.nodes:
+            if node.target is exir_ops.edge.aten.linear.default:
                 input_node = node.args[0]
-                # In quantization flow, weight_arg will be dq node.
-                weight_arg = node.args[1]
-                weight_node = (
-                    weight_arg if weight_arg.op == "placeholder" else weight_arg.args[0]
+                weight_placeholder_node = (
+                    # QDQ graph
+                    node.args[1].args[0]
+                    if node.args[1].target in dq_ops
+                    # FP graph
+                    else node.args[1]
                 )
                 bias_arg = node.args[2] if len(node.args) > 2 else None
 
                 input_meta_val = input_node.meta["val"]
                 output_meta_val = node.meta["val"]
-                if bias_arg:
-                    bias_meta_val = bias_arg.meta["val"]
-
+                bias_meta_val = bias_arg.meta["val"] if bias_arg else None
                 rank = input_meta_val.ndim
-                with graph.inserting_before(node):
-                    # Step 1: reshape input
-                    # rank = 2: (dim, C) -> (1, C, 1, dim)
-                    # rank = 3: (N, dim, C) -> (N, C, 1, dim)
-                    # rank = 4: (N, H, W, C) -> (N, C, H, W)
-                    order = (0, 3, 1, 2)
-                    if rank <= 3:
-                        # (dim, C) -> (1, C, 1, dim)
-                        # (N, dim, C) -> (N, C, 1, dim)
-                        shape = (
-                            (1, *input_meta_val.shape, 1)
-                            if rank == 2
-                            else (*input_meta_val.shape, 1)
-                        )
-                        x_meta_val = input_meta_val.reshape(shape)
-                        input_node = self._create_node(
-                            graph_module,
-                            torch.ops.aten.reshape.default,
-                            (input_node, shape),
-                            node,
-                            x_meta_val,
-                            input_node,
-                        )
-                        order = (0, 2, 3, 1)
+                cur_meta_val = input_meta_val
 
-                    x_meta_val = x_meta_val.permute(order)
-                    x = self._create_node(
+                # Step 1: calibrate input
+                # rank = 2: Reshape (dim, C) to (1, dim, C, 1), and permute to (1, C, 1, dim)
+                # rank = 3: Reshape (N, dim, C) to (N, dim, C, 1), and permute to (N, C, 1, dim)
+                # rank = 4: Permute (N, H, W, C) to (N, C, H, W)
+                if rank <= 3:
+                    shape = (
+                        (1, *input_meta_val.shape, 1)
+                        if rank == 2
+                        else (*input_meta_val.shape, 1)
+                    )
+                    cur_meta_val = cur_meta_val.reshape(shape)
+                    reshape_node = self._create_node(
                         graph_module,
-                        torch.ops.aten.permute.default,
-                        (input_node, order),
-                        node,
-                        x_meta_val,
-                        input_node,
+                        exir_ops.edge.aten.view_copy.default,
+                        (input_node, shape),
+                        cur_meta_val,
                     )
 
-                    # Step 2: reshape weight
-                    weight_arg = self._reshape_weight(
-                        graph_module, weight_node, weight_arg
-                    )
-                    weight_meta_val = weight_arg.meta["val"]
+                # This pass is scheduled after the `FoldQDQ` pass. After copying the metadata,
+                # the quantization attributes are also propagated to the target node.
+                order = (0, 3, 1, 2) if rank == 4 else (0, 2, 3, 1)
+                cur_meta_val = cur_meta_val.permute(order)
+                permute_node = self._create_node(
+                    graph_module,
+                    exir_ops.edge.aten.permute_copy.default,
+                    (reshape_node, order) if rank <= 3 else (input_node, order),
+                    cur_meta_val,
+                )
 
-                    conv_args = [x, weight_arg]
-                    conv_args_meta_val = [x_meta_val, weight_meta_val]
-                    if bias_arg:
-                        conv_args.append(bias_arg)
-                        conv_args_meta_val.append(bias_meta_val)
-                    else:
-                        conv_args.append(None)
-                        conv_args_meta_val.append(None)
-
-                    conv_args.extend(
-                        [[1, 1], [0, 0], [1, 1], 1]
-                    )  # stride, padding, dilation, groups
-                    conv_node_val = torch.nn.functional.conv2d(
-                        *conv_args_meta_val,
-                        stride=(1, 1),
-                        padding=(0, 0),
-                        dilation=(1, 1),
-                        groups=1,
+                # Step 2: reshape weight
+                if weight_placeholder_node.name not in preprocessed_linear_weights_set:
+                    weight_arg = self._reshape_weight_for_all_users(
+                        graph_module, weight_placeholder_node
                     )
-                    conv_node = self._create_node(
+                    # Add the name of the preprocessed weights to the list.
+                    preprocessed_linear_weights_set.add(
+                        weight_arg.args[0].name
+                        if weight_arg.target in dq_ops
+                        else weight_arg.name
+                    )
+                else:
+                    # Skip preprocessing as the weights have already been processed due to shared weights.
+                    weight_arg = node.args[1]
+
+                weight_meta_val = weight_arg.meta["val"]
+
+                stride = [1, 1]
+                padding = [0, 0]
+                dilation = [1, 1]
+                transposed = False
+                output_padding = [0, 0]
+                groups = 1
+                """
+                Spec for `aten.convolution` (https://docs.pytorch.org/docs/stable/torch.compiler_ir.html)
+                convolution(Tensor input, Tensor weight, Tensor? bias, SymInt[] stride, SymInt[] padding,
+                            SymInt[] dilation, bool transposed, SymInt[] output_padding, SymInt groups) -> Tensor
+                """
+                conv_args = (
+                    permute_node,
+                    weight_arg,
+                    bias_arg,
+                    stride,
+                    padding,
+                    dilation,
+                    transposed,
+                    output_padding,
+                    groups,
+                )
+                cur_meta_val = exir_ops.edge.aten.convolution.default(
+                    cur_meta_val,
+                    weight_meta_val,
+                    bias_meta_val,
+                    *conv_args[3:],
+                )
+                conv_node = self._create_node(
+                    graph_module,
+                    exir_ops.edge.aten.convolution.default,
+                    conv_args,
+                    cur_meta_val,
+                    meta_source_node=node,
+                )
+
+                # Step 3: restore original output of linear node
+                # rank = 2: Permute (1, C, 1, dim) to (1, dim, C, 1), and reshape to (dim, C)
+                # rank = 3: Permute (N, C, 1, dim) to (N, dim, C, 1), and reshape to (N, dim, C)
+                # rank = 4: Permute (N, C, H, W) to (N, H, W, C)
+                order = (0, 2, 3, 1) if rank == 4 else (0, 3, 1, 2)
+                cur_meta_val = cur_meta_val.permute(order)
+                permute_node = self._create_node(
+                    graph_module,
+                    exir_ops.edge.aten.permute_copy.default,
+                    (conv_node, order),
+                    cur_meta_val,
+                )
+                if rank <= 3:
+                    target_shape = output_meta_val.shape
+                    cur_meta_val = cur_meta_val.reshape(target_shape)
+                    reshape_node = self._create_node(
                         graph_module,
-                        torch.ops.aten.conv2d.default,
-                        tuple(conv_args),
-                        node,
-                        conv_node_val,
-                        list(node.users)[0],
+                        exir_ops.edge.aten.view_copy.default,
+                        (permute_node, target_shape),
+                        cur_meta_val,
                     )
+                    node.replace_all_uses_with(reshape_node)
+                else:
+                    node.replace_all_uses_with(permute_node)
 
-                    # Step 3: restore shape
-                    # rank = 2: (1, C, 1, dim) -> (dim, C)
-                    # rank = 3: (N, C, 1, dim) -> (N, dim C)
-                    # rank = 4: (N, C, H, W) -> (N, H, W, C)
-                    order = (0, 2, 3, 1) if rank == 4 else (0, 3, 1, 2)
-                    y_meta_val = conv_node_val.permute(order)
-                    y = self._create_node(
-                        graph_module,
-                        torch.ops.aten.permute.default,
-                        (conv_node, order),
-                        node,
-                        y_meta_val,
-                        list(node.users)[0],
-                    )
-                    if rank <= 3:
-                        target_shape = output_meta_val.shape
-                        y_meta_val = y_meta_val.reshape(target_shape)
-                        y = self._create_node(
-                            graph_module,
-                            torch.ops.aten.reshape.default,
-                            (y, target_shape),
-                            node,
-                            y_meta_val,
-                            list(node.users)[0],
-                        )
-
-                    node.replace_all_uses_with(y)
-                    graph.erase_node(node)
+                graph.erase_node(node)
 
         dead_code_elimination_pass(graph_module)
         return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/fold_qdq.py
+++ b/backends/qualcomm/_passes/fold_qdq.py
@@ -39,8 +39,10 @@ class FoldQDQ(ExportPass):
             if n.target not in dq_ops:
                 continue
 
-            # skip parameters & buffers
-            if not self.force_fold and is_parameter(n.args[0], self.edge_program):
+            # skip parameters & buffers & get_attr
+            if not self.force_fold and (
+                is_parameter(n.args[0], self.edge_program) or n.args[0].op == "get_attr"
+            ):
                 self._annotate_bypass(n)
             else:
                 for user_n in user_list:

--- a/backends/qualcomm/_passes/i64_to_i32.py
+++ b/backends/qualcomm/_passes/i64_to_i32.py
@@ -135,7 +135,9 @@ class I64toI32(ExportPass):
                 if param.dtype == torch.int64:
                     # QNN does not support int64
                     self._update_meta(n)
-            elif n.op == "placeholder":
+            elif n.op == "placeholder" or n.op == "get_attr":
+                # A `get_attr` node may be introduced after the `LiftConstantScalarOperands` pass.
+                # If the scalar operand has an int64 data type, it should be explicitly cast to int32.
                 node_val = n.meta["val"]
                 if self._is_tensor_of_dtype(node_val, torch.int64):
                     with graph_module.graph.inserting_after(n):

--- a/backends/qualcomm/_passes/i64_to_i32.py
+++ b/backends/qualcomm/_passes/i64_to_i32.py
@@ -136,7 +136,9 @@ class I64toI32(ExportPass):
                 if param.dtype == torch.int64:
                     # QNN does not support int64
                     self._update_meta(n)
-            elif n.op == "placeholder":
+            elif n.op == "placeholder" or n.op == "get_attr":
+                # A `get_attr` node may be introduced after the `LiftConstantScalarOperands` pass.
+                # If the scalar operand has an int64 data type, it should be explicitly cast to int32.
                 node_val = n.meta["val"]
                 if self._is_tensor_of_dtype(node_val, torch.int64):
                     with graph_module.graph.inserting_after(n):

--- a/backends/qualcomm/_passes/qnn_pass_manager.py
+++ b/backends/qualcomm/_passes/qnn_pass_manager.py
@@ -11,6 +11,7 @@ from typing import Dict
 
 from executorch.backends.qualcomm._passes import (
     AnnotateAvgPool1D,
+    AnnotateGetAttr,
     AnnotateQuantAttrs,
     AnnotateStack,
     AnnotateUnbind,
@@ -120,10 +121,13 @@ class QnnPassManager(PassManager):
         """
         return [
             (AnnotateAvgPool1D, True),
+            (AnnotateGetAttr, True),
             (AnnotateQuantAttrs, True),
             (AnnotateStack, True),
             (AnnotateUnbind, True),
+            (CanonicalizeConv, True),
             (ConvertBmmToMatmul, False),
+            (ConvertLinearToConv2d, False),
             (DecomposeAcos, True),
             (DecomposeAddmm, True),
             (DecomposeAny, True),
@@ -197,10 +201,7 @@ class QnnPassManager(PassManager):
         ]
 
     @classmethod
-    def get_export_passes(
-        cls,
-        convert_linear_to_conv2d: bool = False,
-    ):
+    def get_export_passes(cls):
         """Return export pipeline pass classes. Override in subclasses to add backend-specific passes."""
         passes = [
             DecomposeBinaryAlpha,
@@ -221,16 +222,10 @@ class QnnPassManager(PassManager):
             # This pass is needed before to_edge pipeline to avoid mixed type for div operator with RemoveMixedTypeOperators pass.
             DecomposeFloorDivide,
             DecomposeWrapWithAutocast,
-            # this pass will rewrite state_dict, it needs to be accomplished before
-            # to_edge_transform_and_lower
-            CanonicalizeConv,
-            ConvertLinearToConv2d,
             ConvertSquareToPow,
             LiftConstantScalarOperands,
             InsertReshapeForReduceOps,
         ]
-        if not convert_linear_to_conv2d:
-            passes.remove(ConvertLinearToConv2d)
         return passes
 
     @classmethod
@@ -275,6 +270,12 @@ class QnnPassManager(PassManager):
         """
         return {
             AnnotateAvgPool1D: [RemoveRedundancy],
+            AnnotateGetAttr: [
+                CanonicalizeConv,
+                ConvertLinearToConv2d,
+                I64toI32,
+                LayoutTransform,
+            ],
             AnnotateQuantAttrs: [
                 ConvertBmmToMatmul,
                 RecomposePixelUnshuffle,
@@ -282,7 +283,9 @@ class QnnPassManager(PassManager):
             ],
             AnnotateStack: [RemoveRedundancy],
             AnnotateUnbind: [RemoveRedundancy],
+            CanonicalizeConv: [FoldQDQ],
             ConvertBmmToMatmul: [RecomposePixelUnshuffle],
+            ConvertLinearToConv2d: [FoldQDQ],
             DecomposeAcos: [RemoveRedundancy],
             DecomposeAddmm: [RemoveRedundancy],
             DecomposeAny: [RemoveRedundancy],
@@ -304,7 +307,10 @@ class QnnPassManager(PassManager):
             ExpandBroadcastTensorShape: [FoldQDQ],
             FixedLinearKeepDim: [FoldQDQ],
             FoldQDQ: [AnnotateQuantAttrs, AnnotateStack, AnnotateUnbind],
-            I64toI32: [RemoveRedundancy],
+            I64toI32: [
+                LiftConstantScalarOperands,
+                RemoveRedundancy,
+            ],
             InsertCastForFpActQuantizedWeight: [FoldQDQ, LayoutTransform],
             LayoutTransform: [
                 AnnotateQuantAttrs,
@@ -363,18 +369,14 @@ class QnnPassManager(PassManager):
         compiler_specs=None,
         skip_node_id_set: set = None,
         skip_node_op_set: set = None,
+        convert_linear_to_conv2d: bool = False,
     ):
-        # TODO: remove this workaround when target could be correctly detected
-        from executorch.backends.qualcomm.builders import node_visitor
-        from executorch.exir.dialects._ops import ops as exir_ops
-
-        node_visitor.q_ops.add(exir_ops.edge.torchao.quantize_affine.default)
-        node_visitor.dq_ops.add(exir_ops.edge.torchao.dequantize_affine.default)
-
         self._reset()
         passes_job = (
             passes_job if passes_job is not None else self.get_capture_program_passes()
         )
+        if ConvertLinearToConv2d in passes_job and convert_linear_to_conv2d:
+            passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
         dep_table = (
             dep_table
             if dep_table is not None
@@ -432,10 +434,9 @@ class QnnPassManager(PassManager):
     def transform_for_export_pipeline(
         self,
         exported_program: ExportedProgram,
-        convert_linear_to_conv2d: bool = False,
     ):
         self._instantiate_passes(
-            self.get_export_passes(convert_linear_to_conv2d),
+            self.get_export_passes(),
             edge_program=exported_program,
             quantization_capture=True,
         )
@@ -448,12 +449,17 @@ class QnnPassManager(PassManager):
         exported_program: ExportedProgram,
         passes_job: OrderedDict = None,
         dep_table: Dict = None,
+        convert_linear_to_conv2d: bool = False,
     ):
         transform_passes = self.get_to_edge_transform_passes(
-            exported_program, passes_job=passes_job, dep_table=dep_table
+            exported_program,
+            passes_job=passes_job,
+            dep_table=dep_table,
+            convert_linear_to_conv2d=convert_linear_to_conv2d,
         )
         for p in transform_passes:
             p(exported_program.graph_module)
+        lift_constant_tensor_pass(exported_program)
         exported_program._graph_signature = _get_updated_graph_signature(
             exported_program.graph_signature,
             exported_program.graph_module,

--- a/backends/qualcomm/_passes/qnn_pass_manager.py
+++ b/backends/qualcomm/_passes/qnn_pass_manager.py
@@ -11,6 +11,7 @@ from typing import Dict
 
 from executorch.backends.qualcomm._passes import (
     AnnotateAvgPool1D,
+    AnnotateGetAttr,
     AnnotateQuantAttrs,
     AnnotateStack,
     AnnotateUnbind,
@@ -121,10 +122,13 @@ class QnnPassManager(PassManager):
         """
         return [
             (AnnotateAvgPool1D, True),
+            (AnnotateGetAttr, True),
             (AnnotateQuantAttrs, True),
             (AnnotateStack, True),
             (AnnotateUnbind, True),
+            (CanonicalizeConv, True),
             (ConvertBmmToMatmul, False),
+            (ConvertLinearToConv2d, False),
             (DecomposeAcos, True),
             (DecomposeAddmm, True),
             (DecomposeAny, True),
@@ -197,10 +201,7 @@ class QnnPassManager(PassManager):
         ]
 
     @classmethod
-    def get_export_passes(
-        cls,
-        convert_linear_to_conv2d: bool = False,
-    ):
+    def get_export_passes(cls):
         """Return export pipeline pass classes. Override in subclasses to add backend-specific passes."""
         passes = [
             DecomposeBinaryAlpha,
@@ -222,16 +223,10 @@ class QnnPassManager(PassManager):
             # This pass is needed before to_edge pipeline to avoid mixed type for div operator with RemoveMixedTypeOperators pass.
             DecomposeFloorDivide,
             DecomposeWrapWithAutocast,
-            # this pass will rewrite state_dict, it needs to be accomplished before
-            # to_edge_transform_and_lower
-            CanonicalizeConv,
-            ConvertLinearToConv2d,
             ConvertSquareToPow,
             LiftConstantScalarOperands,
             InsertReshapeForReduceOps,
         ]
-        if not convert_linear_to_conv2d:
-            passes.remove(ConvertLinearToConv2d)
         return passes
 
     @classmethod
@@ -276,6 +271,12 @@ class QnnPassManager(PassManager):
         """
         return {
             AnnotateAvgPool1D: [RemoveRedundancy],
+            AnnotateGetAttr: [
+                CanonicalizeConv,
+                ConvertLinearToConv2d,
+                I64toI32,
+                LayoutTransform,
+            ],
             AnnotateQuantAttrs: [
                 ConvertBmmToMatmul,
                 RecomposePixelUnshuffle,
@@ -283,7 +284,9 @@ class QnnPassManager(PassManager):
             ],
             AnnotateStack: [RemoveRedundancy],
             AnnotateUnbind: [RemoveRedundancy],
+            CanonicalizeConv: [FoldQDQ],
             ConvertBmmToMatmul: [RecomposePixelUnshuffle],
+            ConvertLinearToConv2d: [FoldQDQ],
             DecomposeAcos: [RemoveRedundancy],
             DecomposeAddmm: [RemoveRedundancy],
             DecomposeAny: [RemoveRedundancy],
@@ -303,7 +306,10 @@ class QnnPassManager(PassManager):
             ExpandBroadcastTensorShape: [FoldQDQ],
             FixedLinearKeepDim: [FoldQDQ],
             FoldQDQ: [AnnotateQuantAttrs, AnnotateStack, AnnotateUnbind],
-            I64toI32: [RemoveRedundancy],
+            I64toI32: [
+                LiftConstantScalarOperands,
+                RemoveRedundancy,
+            ],
             InsertCastForFpActQuantizedWeight: [FoldQDQ, LayoutTransform],
             LayoutTransform: [
                 AnnotateQuantAttrs,
@@ -362,18 +368,14 @@ class QnnPassManager(PassManager):
         compiler_specs=None,
         skip_node_id_set: set = None,
         skip_node_op_set: set = None,
+        convert_linear_to_conv2d: bool = False,
     ):
-        # TODO: remove this workaround when target could be correctly detected
-        from executorch.backends.qualcomm.builders import node_visitor
-        from executorch.exir.dialects._ops import ops as exir_ops
-
-        node_visitor.q_ops.add(exir_ops.edge.torchao.quantize_affine.default)
-        node_visitor.dq_ops.add(exir_ops.edge.torchao.dequantize_affine.default)
-
         self._reset()
         passes_job = (
             passes_job if passes_job is not None else self.get_capture_program_passes()
         )
+        if ConvertLinearToConv2d in passes_job and convert_linear_to_conv2d:
+            passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
         dep_table = (
             dep_table
             if dep_table is not None
@@ -431,10 +433,9 @@ class QnnPassManager(PassManager):
     def transform_for_export_pipeline(
         self,
         exported_program: ExportedProgram,
-        convert_linear_to_conv2d: bool = False,
     ):
         self._instantiate_passes(
-            self.get_export_passes(convert_linear_to_conv2d),
+            self.get_export_passes(),
             edge_program=exported_program,
             quantization_capture=True,
         )
@@ -447,12 +448,17 @@ class QnnPassManager(PassManager):
         exported_program: ExportedProgram,
         passes_job: OrderedDict = None,
         dep_table: Dict = None,
+        convert_linear_to_conv2d: bool = False,
     ):
         transform_passes = self.get_to_edge_transform_passes(
-            exported_program, passes_job=passes_job, dep_table=dep_table
+            exported_program,
+            passes_job=passes_job,
+            dep_table=dep_table,
+            convert_linear_to_conv2d=convert_linear_to_conv2d,
         )
         for p in transform_passes:
             p(exported_program.graph_module)
+        lift_constant_tensor_pass(exported_program)
         exported_program._graph_signature = _get_updated_graph_signature(
             exported_program.graph_signature,
             exported_program.graph_module,

--- a/backends/qualcomm/builders/node_visitor.py
+++ b/backends/qualcomm/builders/node_visitor.py
@@ -90,12 +90,14 @@ q_ops = {
     exir_ops.edge.quantized_decomposed.quantize_per_channel.default,
     exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
     exir_ops.edge.quantized_decomposed.quantize_per_tensor.tensor,
+    exir_ops.edge.torchao.quantize_affine.default,
 }
 
 dq_ops = {
     exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
     exir_ops.edge.quantized_decomposed.dequantize_per_tensor.tensor,
     exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,
+    exir_ops.edge.torchao.dequantize_affine.default,
 }
 
 q_dq_map = {

--- a/backends/qualcomm/tests/models.py
+++ b/backends/qualcomm/tests/models.py
@@ -943,15 +943,26 @@ class ConvFullLike(torch.nn.Module):
 
 
 class ConvTranspose1dSingle(torch.nn.Module):
-    def __init__(self, bias=True, dilation=1):
+    def __init__(
+        self,
+        bias=True,
+        in_channels=1,
+        out_channels=3,
+        kernel_size=3,
+        stride=2,
+        padding=1,
+        dilation=1,
+        groups=1,
+    ):
         super().__init__()
         self.conv_transpose = torch.nn.ConvTranspose1d(
-            in_channels=1,
-            out_channels=3,
-            kernel_size=3,
-            stride=2,
-            padding=1,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
             dilation=dilation,
+            groups=groups,
             bias=bias,
         )
 
@@ -1682,6 +1693,26 @@ class LinearNonConstantWeight(torch.nn.Module):
         k = torch.nn.functional.linear(x, w_k, b_k)
         v = torch.nn.functional.linear(x, w_v, b_v)
         return q * k * v
+
+
+class LinearSharedWeight(torch.nn.Module):
+    def __init__(self, in_features, out_features):
+        super().__init__()
+        self.shared_weight_0 = torch.nn.Parameter(
+            torch.randn(out_features, in_features)
+        )
+        self.shared_weight_1 = torch.nn.Parameter(
+            torch.randn(out_features, in_features)
+        )
+
+    def forward(self, x, y):
+        x_0 = torch.nn.functional.linear(x, self.shared_weight_0)
+        y_0 = torch.nn.functional.linear(y, self.shared_weight_0)
+
+        x_1 = torch.nn.functional.linear(x, self.shared_weight_1)
+        y_1 = torch.nn.functional.linear(y, self.shared_weight_1)
+
+        return (x_0 + y_0) + (x_1 + y_1)
 
 
 class Log(torch.nn.Module):

--- a/backends/qualcomm/tests/models.py
+++ b/backends/qualcomm/tests/models.py
@@ -974,15 +974,26 @@ class ConvFullLike(torch.nn.Module):
 
 
 class ConvTranspose1dSingle(torch.nn.Module):
-    def __init__(self, bias=True, dilation=1):
+    def __init__(
+        self,
+        bias=True,
+        in_channels=1,
+        out_channels=3,
+        kernel_size=3,
+        stride=2,
+        padding=1,
+        dilation=1,
+        groups=1,
+    ):
         super().__init__()
         self.conv_transpose = torch.nn.ConvTranspose1d(
-            in_channels=1,
-            out_channels=3,
-            kernel_size=3,
-            stride=2,
-            padding=1,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
             dilation=dilation,
+            groups=groups,
             bias=bias,
         )
 
@@ -1751,6 +1762,26 @@ class LinearNonConstantWeight(torch.nn.Module):
         k = torch.nn.functional.linear(x, w_k, b_k)
         v = torch.nn.functional.linear(x, w_v, b_v)
         return q * k * v
+
+
+class LinearSharedWeight(torch.nn.Module):
+    def __init__(self, in_features, out_features):
+        super().__init__()
+        self.shared_weight_0 = torch.nn.Parameter(
+            torch.randn(out_features, in_features)
+        )
+        self.shared_weight_1 = torch.nn.Parameter(
+            torch.randn(out_features, in_features)
+        )
+
+    def forward(self, x, y):
+        x_0 = torch.nn.functional.linear(x, self.shared_weight_0)
+        y_0 = torch.nn.functional.linear(y, self.shared_weight_0)
+
+        x_1 = torch.nn.functional.linear(x, self.shared_weight_1)
+        y_1 = torch.nn.functional.linear(y, self.shared_weight_1)
+
+        return (x_0 + y_0) + (x_1 + y_1)
 
 
 class Log(torch.nn.Module):

--- a/backends/qualcomm/tests/rework/htp/op/v68/test.py
+++ b/backends/qualcomm/tests/rework/htp/op/v68/test.py
@@ -958,6 +958,37 @@ def test_linear_non_constant_weight(request, kwargs):
     LinearNonConstantWeight.test(request, kwargs)  # noqa: F405
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": CosineSimilarity(0.95)},
+            id="8a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 4, "pcq": True, "expected": CosineSimilarity(0.95)},
+            id="16a4w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="16a8w_pcq",
+        ),
+        pytest.param(
+            {
+                "act": "fp16",
+                "param": 8,
+                "pcq": True,
+                "expected": CosineSimilarity(0.95),
+            },
+            id="fp16a8w_pcq",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_shared_weights(request, kwargs):
+    LinearSharedWeight.test(request, kwargs)  # noqa: F405
+
+
 @enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
 @with_htp_context
 def test_log(request, kwargs):

--- a/backends/qualcomm/tests/rework/passes/passes_helper.py
+++ b/backends/qualcomm/tests/rework/passes/passes_helper.py
@@ -20,7 +20,10 @@ from executorch.backends.qualcomm.utils.qnn_manager_lifecycle import QnnManagerC
 from executorch.backends.qualcomm.utils.utils import qnn_edge_config
 from executorch.exir.backend.backend_details import CompileSpec
 from executorch.exir.pass_base import ExportPass
-from executorch.exir.program._program import _gen_edge_manager_for_partitioners
+from executorch.exir.program._program import (
+    _gen_edge_manager_for_partitioners,
+    lift_constant_tensor_pass,
+)
 from torchao.quantization.pt2e.quantizer import Quantizer
 
 NodeTarget = object | set[object]
@@ -194,7 +197,6 @@ class PassPipeline:
         target_pass: type[ExportPass],
         backend_type: QnnExecuTorchBackendType = QnnExecuTorchBackendType.kHtpBackend,
         quantizer: Quantizer = None,
-        convert_linear_to_conv2d: bool = False,
     ) -> torch.fx.GraphModule:
         with calibrate(module, [sample_input], quantizer) as quantized:
             module = quantized
@@ -202,7 +204,7 @@ class PassPipeline:
         gm = ep.graph_module
         pm_cls = get_qnn_pass_manager_cls(backend_type)
         pass_classes = PassPipeline._slice_to_target(
-            pm_cls.get_export_passes(convert_linear_to_conv2d=convert_linear_to_conv2d),
+            pm_cls.get_export_passes(),
             target_pass,
             "export",
         )
@@ -226,6 +228,7 @@ class PassPipeline:
         passes_job: OrderedDict = None,
         skip_node_id_set: set | None = None,
         skip_node_op_set: set | None = None,
+        convert_linear_to_conv2d: bool = False,
     ):
         """
         If target_pass is None, runs all edge passes.
@@ -242,6 +245,7 @@ class PassPipeline:
             passes_job=passes_job,
             skip_node_id_set=skip_node_id_set,
             skip_node_op_set=skip_node_op_set,
+            convert_linear_to_conv2d=convert_linear_to_conv2d,
         )
         if target_pass is not None:
             edge_passes = PassPipeline._slice_to_target(
@@ -266,6 +270,10 @@ class PassPipeline:
                 constant_methods=None,
             )
             edge_manager = edge_manager.transform(edge_passes)
+        # Passes like CanonicalizeConv/ConvertLinearToConv2d create new `get_attr`
+        # nodes to store modified weights; lift_constant_tensor_pass converts them
+        # into `placeholder` nodes.
+        lift_constant_tensor_pass(edge_manager.exported_program())
         return edge_manager.exported_program()
 
     @staticmethod

--- a/backends/qualcomm/tests/rework/passes/test.py
+++ b/backends/qualcomm/tests/rework/passes/test.py
@@ -25,6 +25,12 @@ def test_annotate_avg_pool1d(request, kwargs):
 
 @enumerate_backends_quantized()
 @repack_pass_fixtures
+def test_annotate_get_attr(request, kwargs):
+    AnnotateGetAttr.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_backends_quantized()
+@repack_pass_fixtures
 def test_annotate_quant_attrs(request, kwargs):
     AnnotateQuantAttrs.test(request, kwargs)  # noqa: F405
 

--- a/backends/qualcomm/tests/rework/src/op.py
+++ b/backends/qualcomm/tests/rework/src/op.py
@@ -2902,19 +2902,20 @@ class Linear(torch.nn.Module):
     @staticmethod
     @unpack_fixtures
     def test(subtests, qnn_config, quantizer, compile_spec, expected):
-        inputs = (torch.randn(3, 512),)
+        input_shapes = [(3, 512), (3, 3, 512), (3, 3, 3, 512)]
         biases = [True, False]
-        for use_bias in biases:
-            with subtests.test(msg=f"use_bias:{use_bias}"):
-                with expected as metrics:
-                    export_and_verify(
-                        module=__class__(use_bias=use_bias),
-                        inputs=inputs,
-                        qnn_config=qnn_config,
-                        quantizer=quantizer,
-                        compile_specs=compile_spec,
-                        metrics=metrics,
-                    )
+        for input_shape in input_shapes:
+            for use_bias in biases:
+                with subtests.test(msg=f"rank:{len(input_shape)}, use_bias:{use_bias}"):
+                    with expected as metrics:
+                        export_and_verify(
+                            module=__class__(use_bias=use_bias),
+                            inputs=(torch.randn(input_shape),),
+                            qnn_config=qnn_config,
+                            quantizer=quantizer,
+                            compile_specs=compile_spec,
+                            metrics=metrics,
+                        )
 
 
 class LinearNonConstantWeight(torch.nn.Module):
@@ -2942,19 +2943,48 @@ class LinearNonConstantWeight(torch.nn.Module):
     @staticmethod
     @unpack_fixtures
     def test(subtests, qnn_config, quantizer, compile_spec, expected):
-        inputs = (torch.randn(3, 512),)
+        input_shapes = [(3, 512), (3, 3, 512), (3, 3, 3, 512)]
         biases = [True, False]
-        for use_bias in biases:
-            with subtests.test(msg=f"use_bias:{use_bias}"):
-                with expected as metrics:
-                    export_and_verify(
-                        module=__class__(use_bias=use_bias),
-                        inputs=inputs,
-                        qnn_config=qnn_config,
-                        quantizer=quantizer,
-                        compile_specs=compile_spec,
-                        metrics=metrics,
-                    )
+        for input_shape in input_shapes:
+            for use_bias in biases:
+                with subtests.test(msg=f"rank:{len(input_shape)}, use_bias:{use_bias}"):
+                    with expected as metrics:
+                        export_and_verify(
+                            module=__class__(use_bias=use_bias),
+                            inputs=(torch.randn(input_shape),),
+                            qnn_config=qnn_config,
+                            quantizer=quantizer,
+                            compile_specs=compile_spec,
+                            metrics=metrics,
+                        )
+
+
+class LinearSharedWeight(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.shared_weight_0 = torch.nn.Parameter(torch.randn(32, 512))
+        self.shared_weight_1 = torch.nn.Parameter(torch.randn(32, 512))
+
+    def forward(self, x, y):
+        x_0 = torch.nn.functional.linear(x, self.shared_weight_0)
+        y_0 = torch.nn.functional.linear(y, self.shared_weight_0)
+        x_1 = torch.nn.functional.linear(x, self.shared_weight_1)
+        y_1 = torch.nn.functional.linear(y, self.shared_weight_1)
+        return (x_0 + y_0) + (x_1 + y_1)
+
+    @staticmethod
+    @unpack_fixtures
+    def test(qnn_config, quantizer, compile_spec, expected):
+        inputs = (torch.randn(3, 512), torch.randn(3, 512))
+        with expected as metrics:
+            export_and_verify(
+                module=__class__(),
+                inputs=inputs,
+                qnn_config=qnn_config,
+                quantizer=quantizer,
+                compile_specs=compile_spec,
+                metrics=metrics,
+            )
 
 
 class Log(torch.nn.Module):

--- a/backends/qualcomm/tests/rework/src/pattern.py
+++ b/backends/qualcomm/tests/rework/src/pattern.py
@@ -142,6 +142,59 @@ class AnnotateAvgPool1D:
         ), "avg_pool1d partition nodes should have QCOM_QUANT_ATTRS"
 
 
+class AnnotateGetAttr:
+    class _Conv1d(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv1d(4, 8, kernel_size=3, padding=1)
+
+        def forward(self, x):
+            return self.conv(x)
+
+    @staticmethod
+    @unpack_pass_fixtures
+    def test(
+        quantizer,
+        compile_spec,
+        backend_type: QnnExecuTorchBackendType,
+        assertions: Assertions,
+        pass_pipeline: PassPipeline,
+    ):
+        # Workflow:
+        # 1. CanonicalizeConv rewrites the conv1d weight into a new get_attr node
+        #    (dq_ops-consuming, in the quantized flow) with QCOM_QUANT_ATTRS set.
+        # 2. LayoutTransform rebuilds the GraphModule and drops the quant metadata.
+        # 3. AnnotateGetAttr repopulates it on the corresponding get_attr node.
+        # 4. lift_constant_tensor_pass converts get_attr node into a
+        #    "_lifted_tensor_constant*" placeholder while preserving its metadata.
+        module = AnnotateGetAttr._Conv1d()
+        inputs = (torch.randn(1, 4, 16),)
+        target_pass = _passes.AnnotateGetAttr
+        _ = assertions
+        gm = pass_pipeline.lower_edge_ep(
+            module=module,
+            sample_input=inputs,
+            backend_type=backend_type,
+            compile_spec=compile_spec,
+            target_pass=target_pass,
+            quantizer=quantizer,
+        ).graph_module
+
+        lifted_constant_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "placeholder"
+            and n.name.startswith("_lifted_tensor_constant")
+            and list(n.users)[0].target in dq_ops
+        ]
+        assert (
+            len(lifted_constant_nodes) > 0
+        ), "expected at least one lifted tensor constant feeding a dequantize op"
+        assert all(
+            QCOM_QUANT_ATTRS in n.meta for n in lifted_constant_nodes
+        ), "lifted tensor constants feeding a dequantize op should have QCOM_QUANT_ATTRS after AnnotateGetAttr"
+
+
 class AnnotateQuantAttrs:
     class _Basic(torch.nn.Module):
         def forward(self, x):
@@ -313,7 +366,7 @@ class CanonicalizeConv:
         def forward(self, x):
             return self.conv(x)
 
-    # --- Group 2: transpose conv dilation (kernel dilated manually, dilation arg removed) ---
+    # --- Group 2: transpose conv dilation (kernel dilated manually, dilation arg calibrated) ---
     class _ConvTranspose1dDilation(torch.nn.Module):
         def __init__(self):
             super().__init__()
@@ -339,13 +392,14 @@ class CanonicalizeConv:
             return self.conv(x)
 
     @staticmethod
-    def _assert_no_dilation(gm, targets):
-        """Assert dilation arg has been removed from all matching nodes."""
+    def _assert_no_dilation(gm):
+        """Assert dilation arg has been calibrated from edge convolution op."""
         for node in gm.graph.nodes:
-            if node.target in targets:
-                assert len(node.args) <= 7 or all(
-                    d == 1 for d in node.args[7]
-                ), f"{node.target} dilation arg (index 7) should be all ones"
+            if node.target is exir_ops.edge.aten.convolution.default:
+                dilation = node.args[5]
+                assert all(
+                    d == 1 for d in dilation
+                ), f"{node.target} dilation arg (index 5) should be all ones"
 
     @staticmethod
     @unpack_pass_fixtures
@@ -358,79 +412,77 @@ class CanonicalizeConv:
         pass_pipeline: PassPipeline,
     ):
         target_pass = _passes.CanonicalizeConv
-        _ = compile_spec
+        conv = exir_ops.edge.aten.convolution.default
 
         # --- Group 1: conv1d → unsqueeze_copy + conv2d + squeeze_copy ---
         with subtests.test(msg="conv1d"):
-            gm = pass_pipeline.lower_export_gm(
+            gm = pass_pipeline.lower_edge_ep(
                 module=CanonicalizeConv._Conv1d(),
                 sample_input=(torch.randn(1, 4, 16),),
                 target_pass=target_pass,
                 backend_type=backend_type,
+                compile_spec=compile_spec,
                 quantizer=quantizer,
+            ).graph_module
+            assertions.assert_target_count(gm, conv, 1)
+            assertions.assert_target_count(
+                gm, exir_ops.edge.aten.unsqueeze_copy.default, 1
             )
-            assertions.assert_no_target(gm, torch.ops.aten.conv1d.default)
-            assertions.assert_target_count(gm, torch.ops.aten.conv2d.default, 1)
-            assertions.assert_target_count(gm, torch.ops.aten.unsqueeze_copy.default, 1)
-            assertions.assert_target_count(gm, torch.ops.aten.squeeze_copy.dims, 1)
+            assertions.assert_target_count(gm, exir_ops.edge.aten.squeeze_copy.dims, 1)
 
         with subtests.test(msg="conv1d_transpose"):
-            gm = pass_pipeline.lower_export_gm(
+            gm = pass_pipeline.lower_edge_ep(
                 module=CanonicalizeConv._ConvTranspose1d(),
                 sample_input=(torch.randn(1, 4, 8),),
                 target_pass=target_pass,
                 backend_type=backend_type,
+                compile_spec=compile_spec,
                 quantizer=quantizer,
+            ).graph_module
+            assertions.assert_target_count(gm, conv, 1)
+            assertions.assert_target_count(
+                gm, exir_ops.edge.aten.unsqueeze_copy.default, 1
             )
-            assertions.assert_no_target(gm, torch.ops.aten.conv_transpose1d.default)
-            assertions.assert_target_count(gm, torch.ops.aten.conv_transpose2d.input, 1)
-            assertions.assert_target_count(gm, torch.ops.aten.unsqueeze_copy.default, 1)
-            assertions.assert_target_count(gm, torch.ops.aten.squeeze_copy.dims, 1)
+            assertions.assert_target_count(gm, exir_ops.edge.aten.squeeze_copy.dims, 1)
 
-        # --- Group 2: transpose conv dilation — kernel dilated, dilation arg removed ---
+        # --- Group 2: transpose conv dilation — kernel dilated, dilation arg calibrated ---
         with subtests.test(msg="conv_transpose1d_dilation"):
-            gm = pass_pipeline.lower_export_gm(
+            gm = pass_pipeline.lower_edge_ep(
                 module=CanonicalizeConv._ConvTranspose1dDilation(),
                 sample_input=(torch.randn(1, 4, 8),),
                 target_pass=target_pass,
                 backend_type=backend_type,
+                compile_spec=compile_spec,
                 quantizer=quantizer,
-            )
-            assertions.assert_no_target(gm, torch.ops.aten.conv_transpose1d.default)
-            assertions.assert_target_count(gm, torch.ops.aten.conv_transpose2d.input, 1)
-            CanonicalizeConv._assert_no_dilation(
-                gm, {torch.ops.aten.conv_transpose2d.input}
-            )
+            ).graph_module
+            assertions.assert_target_count(gm, conv, 1)
+            CanonicalizeConv._assert_no_dilation(gm)
 
         with subtests.test(msg="conv_transpose2d_dilation"):
-            gm = pass_pipeline.lower_export_gm(
+            gm = pass_pipeline.lower_edge_ep(
                 module=CanonicalizeConv._ConvTranspose2dDilation(),
                 sample_input=(torch.randn(1, 4, 8, 8),),
                 target_pass=target_pass,
                 backend_type=backend_type,
+                compile_spec=compile_spec,
                 quantizer=quantizer,
-            )
-            assertions.assert_target_count(gm, torch.ops.aten.conv_transpose2d.input, 1)
-            CanonicalizeConv._assert_no_dilation(
-                gm, {torch.ops.aten.conv_transpose2d.input}
-            )
+            ).graph_module
+            assertions.assert_target_count(gm, conv, 1)
+            CanonicalizeConv._assert_no_dilation(gm)
 
         # TODO: update this once lpai starts to support transpose_conv3d
         if backend_type != QnnExecuTorchBackendType.kLpaiBackend:
             with subtests.test(msg="conv_transpose3d_dilation"):
-                gm = pass_pipeline.lower_export_gm(
+                gm = pass_pipeline.lower_edge_ep(
                     module=CanonicalizeConv._ConvTranspose3dDilation(),
                     sample_input=(torch.randn(1, 4, 4, 4, 4),),
                     target_pass=target_pass,
                     backend_type=backend_type,
+                    compile_spec=compile_spec,
                     quantizer=quantizer,
-                )
-                assertions.assert_target_count(
-                    gm, torch.ops.aten.conv_transpose3d.input, 1
-                )
-                CanonicalizeConv._assert_no_dilation(
-                    gm, {torch.ops.aten.conv_transpose3d.input}
-                )
+                ).graph_module
+                assertions.assert_target_count(gm, conv, 1)
+                CanonicalizeConv._assert_no_dilation(gm)
 
 
 class ConvertBmmToMatmul:
@@ -478,32 +530,71 @@ class ConvertLinearToConv2d:
         def forward(self, x):
             return self.linear(x)
 
+    class _SharedWeight(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.randn(4, 8))
+
+        def forward(self, x, y):
+            return torch.nn.functional.linear(
+                x, self.weight
+            ) + torch.nn.functional.linear(y, self.weight)
+
     @staticmethod
     @unpack_pass_fixtures
     def test(
+        subtests,
         quantizer,
         compile_spec,
         backend_type: QnnExecuTorchBackendType,
         assertions: Assertions,
         pass_pipeline: PassPipeline,
     ):
-        module = ConvertLinearToConv2d._Basic()
-        inputs = (torch.randn(2, 8),)
         target_pass = _passes.ConvertLinearToConv2d
-        _ = compile_spec
-        gm = pass_pipeline.lower_export_gm(
-            module=module,
-            sample_input=inputs,
-            target_pass=target_pass,
-            backend_type=backend_type,
-            quantizer=quantizer,
-            convert_linear_to_conv2d=True,
-        )
-        assertions.assert_no_target(gm, torch.ops.aten.linear.default)
-        assertions.assert_target_count(gm, torch.ops.aten.conv2d.default, 1)
-        # rank-2 input: reshape×2 (input + output restore) + permute×2 (pre/post conv)
-        assertions.assert_target_count(gm, torch.ops.aten.reshape.default, 2)
-        assertions.assert_target_count(gm, torch.ops.aten.permute.default, 2)
+        conv = exir_ops.edge.aten.convolution.default
+
+        with subtests.test(msg="basic"):
+            gm = pass_pipeline.lower_edge_ep(
+                module=ConvertLinearToConv2d._Basic(),
+                sample_input=(torch.randn(2, 8),),
+                backend_type=backend_type,
+                compile_spec=compile_spec,
+                target_pass=target_pass,
+                quantizer=quantizer,
+                convert_linear_to_conv2d=True,
+            ).graph_module
+            assertions.assert_no_target(gm, exir_ops.edge.aten.linear.default)
+            assertions.assert_target_count(gm, conv, 1)
+            # rank-2 input: reshape×2 (input + output restore) + permute×2 (pre/post conv)
+            assertions.assert_target_count(gm, exir_ops.edge.aten.view_copy.default, 2)
+            assertions.assert_target_count(
+                gm, exir_ops.edge.aten.permute_copy.default, 2
+            )
+
+        with subtests.test(msg="shared_weight"):
+            gm = pass_pipeline.lower_edge_ep(
+                module=ConvertLinearToConv2d._SharedWeight(),
+                sample_input=(torch.randn(2, 8), torch.randn(2, 8)),
+                backend_type=backend_type,
+                compile_spec=compile_spec,
+                target_pass=target_pass,
+                quantizer=quantizer,
+                convert_linear_to_conv2d=True,
+            ).graph_module
+            assertions.assert_no_target(gm, exir_ops.edge.aten.linear.default)
+            assertions.assert_target_count(gm, conv, 2)
+            conv_weight_sources = set()
+            for node in gm.graph.nodes:
+                if node.target is conv:
+                    weight_arg = node.args[1]
+                    conv_weight_sources.add(
+                        weight_arg.args[0]
+                        if weight_arg.target in dq_ops
+                        else weight_arg
+                    )
+            assert (
+                len(conv_weight_sources) == 1
+            ), f"expected both convolution nodes to share one weight source, got {conv_weight_sources}"
 
 
 class ConvertMhaToSha:

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -537,8 +537,20 @@ class TestQNNFloatingPointOperator(TestQNN):
             ConvTranspose1dSingle(),  # noqa: F405
             ConvTranspose1dSingle(bias=False),  # noqa: F405
             ConvTranspose1dSingle(dilation=2),  # noqa: F405
+            ConvTranspose1dSingle(  # noqa: F405
+                bias=False,
+                kernel_size=2,
+                stride=1,
+                padding=2,
+                dilation=2,
+            ),
+            ConvTranspose1dSingle(  # noqa: F405
+                kernel_size=2,
+                stride=1,
+                padding=2,
+            ),
         ]
-        sample_input = (torch.randn([1, 1, 33]),)
+        sample_input = (torch.randn([1, 1, 16]),)
         for i, module in enumerate(modules):
             with self.subTest(i=i):
                 self.lower_module_and_test_output(module, sample_input)
@@ -1731,14 +1743,97 @@ class TestQNNFloatingPointOperator(TestQNN):
                 self.lower_module_and_test_output(module, sample_input)
 
     def test_qnn_backend_linear(self):
-        modules = [
-            Linear(),  # noqa: F405
-            LinearNonConstantWeight(),  # noqa: F405
+        test_comb = [
+            {
+                QCOM_MODULE: [
+                    Linear(),  # noqa: F405
+                    Linear(use_bias=False),  # noqa: F405
+                    LinearNonConstantWeight(),  # noqa: F405
+                ],
+                QCOM_SAMPLE_INPUTS: [
+                    (torch.randn([3, 512]),),
+                    (torch.randn([3, 3, 512]),),
+                    (torch.randn([3, 3, 3, 512]),),
+                ],
+            },
         ]
-        sample_input = (torch.randn([3, 512]),)
+
+        index = 0
+        for comb in test_comb:
+            for module in comb[QCOM_MODULE]:
+                for sample_input in comb[QCOM_SAMPLE_INPUTS]:
+                    with self.subTest(i=index):
+                        index += 1
+                        self.lower_module_and_test_output(module, sample_input)
+
+    def test_qnn_backend_linear_to_conv2d(self):
+        from executorch.backends.qualcomm._passes import ConvertLinearToConv2d
+
+        test_comb = [
+            {
+                QCOM_MODULE: [
+                    Linear(),  # noqa: F405
+                    Linear(use_bias=False),  # noqa: F405
+                ],
+                QCOM_SAMPLE_INPUTS: [
+                    (torch.randn([3, 512]),),
+                    (torch.randn([3, 3, 512]),),
+                    (torch.randn([3, 3, 3, 512]),),
+                ],
+            },
+        ]
+
+        passes_job = get_qnn_pass_manager_cls().get_capture_program_passes()
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY][
+            "edge_program"
+        ] = None
+
+        index = 0
+        for comb in test_comb:
+            for module in comb[QCOM_MODULE]:
+                for sample_input in comb[QCOM_SAMPLE_INPUTS]:
+                    with self.subTest(i=index):
+                        index += 1
+                        self.lower_module_and_test_output(
+                            module, sample_input, passes_job=passes_job
+                        )
+
+    def test_qnn_backend_linear_shared_weights(self):
+        modules = [
+            LinearSharedWeight(512, 32),  # noqa: F405
+        ]
+
+        sample_input = (
+            torch.randn([3, 512]),
+            torch.randn([3, 512]),
+        )
         for i, module in enumerate(modules):
             with self.subTest(i=i):
                 self.lower_module_and_test_output(module, sample_input)
+
+    def test_qnn_backend_linear_to_conv2d_shared_weights(self):
+        from executorch.backends.qualcomm._passes import ConvertLinearToConv2d
+
+        modules = [
+            LinearSharedWeight(512, 32),  # noqa: F405
+        ]
+
+        passes_job = get_qnn_pass_manager_cls().get_capture_program_passes()
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY][
+            "edge_program"
+        ] = None
+
+        sample_input = (
+            torch.randn([3, 512]),
+            torch.randn([3, 512]),
+        )
+        for i, module in enumerate(modules):
+            with self.subTest(i=i):
+                self.lower_module_and_test_output(
+                    module, sample_input, passes_job=passes_job
+                )
 
     def test_qnn_backend_log(self):
         module = Log()  # noqa: F405
@@ -3455,8 +3550,20 @@ class TestQNNQuantizedOperator(TestQNN):
             ConvTranspose1dSingle(),  # noqa: F405
             ConvTranspose1dSingle(bias=False),  # noqa: F405
             ConvTranspose1dSingle(dilation=2),  # noqa: F405
+            ConvTranspose1dSingle(  # noqa: F405
+                bias=False,
+                kernel_size=2,
+                stride=1,
+                padding=2,
+                dilation=2,
+            ),
+            ConvTranspose1dSingle(  # noqa: F405
+                kernel_size=2,
+                stride=1,
+                padding=2,
+            ),
         ]
-        sample_input = (torch.randn([1, 1, 3]),)
+        sample_input = (torch.randn([1, 1, 16]),)
         for i, module in enumerate(modules):
             with self.subTest(i=i):
                 module = self.get_qdq_module(module, sample_input)
@@ -4600,15 +4707,101 @@ class TestQNNQuantizedOperator(TestQNN):
                 self.lower_module_and_test_output(module, sample_input)
 
     def test_qnn_backend_linear(self):
-        modules = [
-            Linear(),  # noqa: F405
-            LinearNonConstantWeight(),  # noqa: F405
+        test_comb = [
+            {
+                QCOM_MODULE: [
+                    Linear(),  # noqa: F405
+                    Linear(use_bias=False),  # noqa: F405
+                    LinearNonConstantWeight(),  # noqa: F405
+                ],
+                QCOM_SAMPLE_INPUTS: [
+                    (torch.randn([3, 512]),),
+                    (torch.randn([3, 3, 512]),),
+                    (torch.randn([3, 3, 3, 512]),),
+                ],
+            },
         ]
-        sample_input = (torch.randn([3, 512]),)
+
+        index = 0
+        for comb in test_comb:
+            for module in comb[QCOM_MODULE]:
+                for sample_input in comb[QCOM_SAMPLE_INPUTS]:
+                    with self.subTest(i=index):
+                        index += 1
+                        qdq_module = self.get_qdq_module(module, sample_input)
+                        self.lower_module_and_test_output(qdq_module, sample_input)
+
+    def test_qnn_backend_linear_to_conv2d(self):
+        from executorch.backends.qualcomm._passes import ConvertLinearToConv2d
+
+        test_comb = [
+            {
+                QCOM_MODULE: [
+                    Linear(),  # noqa: F405
+                    Linear(use_bias=False),  # noqa: F405
+                ],
+                QCOM_SAMPLE_INPUTS: [
+                    (torch.randn([3, 512]),),
+                    (torch.randn([3, 3, 512]),),
+                    (torch.randn([3, 3, 3, 512]),),
+                ],
+            },
+        ]
+
+        passes_job = get_qnn_pass_manager_cls().get_capture_program_passes()
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY][
+            "edge_program"
+        ] = None
+
+        index = 0
+        for comb in test_comb:
+            for module in comb[QCOM_MODULE]:
+                for sample_input in comb[QCOM_SAMPLE_INPUTS]:
+                    with self.subTest(i=index):
+                        index += 1
+                        qdq_module = self.get_qdq_module(module, sample_input)
+                        self.lower_module_and_test_output(
+                            qdq_module, sample_input, passes_job=passes_job
+                        )
+
+    def test_qnn_backend_linear_shared_weights(self):
+        modules = [
+            LinearSharedWeight(512, 32),  # noqa: F405
+        ]
+
+        sample_input = (
+            torch.randn([3, 512]),
+            torch.randn([3, 512]),
+        )
         for i, module in enumerate(modules):
             with self.subTest(i=i):
-                module = self.get_qdq_module(module, sample_input)
-                self.lower_module_and_test_output(module, sample_input)
+                qdq_module = self.get_qdq_module(module, sample_input)
+                self.lower_module_and_test_output(qdq_module, sample_input)
+
+    def test_qnn_backend_linear_to_conv2d_shared_weights(self):
+        from executorch.backends.qualcomm._passes import ConvertLinearToConv2d
+
+        modules = [
+            LinearSharedWeight(512, 32),  # noqa: F405
+        ]
+
+        passes_job = get_qnn_pass_manager_cls().get_capture_program_passes()
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY][
+            "edge_program"
+        ] = None
+
+        sample_input = (
+            torch.randn([3, 512]),
+            torch.randn([3, 512]),
+        )
+        for i, module in enumerate(modules):
+            with self.subTest(i=i):
+                qdq_module = self.get_qdq_module(module, sample_input)
+                self.lower_module_and_test_output(
+                    qdq_module, sample_input, passes_job=passes_job
+                )
 
     @unittest.skipIf(is_qnn_sdk_version_less_than("2.30"), "UT pass after QNN 2.30")
     def test_qnn_backend_linear_block(self):
@@ -4630,6 +4823,37 @@ class TestQNNQuantizedOperator(TestQNN):
                     block_size_map={"linear": (1, 32)},
                 )
                 self.lower_module_and_test_output(module, sample_input)
+
+    @unittest.skipIf(is_qnn_sdk_version_less_than("2.30"), "UT pass after QNN 2.30")
+    def test_qnn_backend_linear_to_conv2d_block(self):
+        from executorch.backends.qualcomm._passes import ConvertLinearToConv2d
+
+        modules = [
+            Linear(use_bias=False),  # noqa: F405
+            Linear(use_bias=True),  # noqa: F405
+        ]
+
+        passes_job = get_qnn_pass_manager_cls().get_capture_program_passes()
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY][
+            "edge_program"
+        ] = None
+
+        sample_input = (torch.randn([3, 512]),)
+        for i, module in enumerate(modules):
+            with self.subTest(i=i):
+                # update block size for linear weight (OI)
+                # channel dimension(O) is defaultly sliced in QNN
+                # divide dimension(I) into 16 groups
+                module = self.get_qdq_module(
+                    module,
+                    sample_input,
+                    quant_dtype=QuantDtype.use_16a4w_block,
+                    block_size_map={"linear": (1, 32)},
+                )
+                self.lower_module_and_test_output(
+                    module, sample_input, passes_job=passes_job
+                )
 
     def test_qnn_backend_linear_qat(self):
         """

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -547,8 +547,20 @@ class TestQNNFloatingPointOperator(TestQNN):
             ConvTranspose1dSingle(),  # noqa: F405
             ConvTranspose1dSingle(bias=False),  # noqa: F405
             ConvTranspose1dSingle(dilation=2),  # noqa: F405
+            ConvTranspose1dSingle(  # noqa: F405
+                bias=False,
+                kernel_size=2,
+                stride=1,
+                padding=2,
+                dilation=2,
+            ),
+            ConvTranspose1dSingle(  # noqa: F405
+                kernel_size=2,
+                stride=1,
+                padding=2,
+            ),
         ]
-        sample_input = (torch.randn([1, 1, 33]),)
+        sample_input = (torch.randn([1, 1, 16]),)
         for i, module in enumerate(modules):
             with self.subTest(i=i):
                 self.lower_module_and_test_output(module, sample_input)
@@ -1741,14 +1753,97 @@ class TestQNNFloatingPointOperator(TestQNN):
                 self.lower_module_and_test_output(module, sample_input)
 
     def test_qnn_backend_linear(self):
-        modules = [
-            Linear(),  # noqa: F405
-            LinearNonConstantWeight(),  # noqa: F405
+        test_comb = [
+            {
+                QCOM_MODULE: [
+                    Linear(),  # noqa: F405
+                    Linear(use_bias=False),  # noqa: F405
+                    LinearNonConstantWeight(),  # noqa: F405
+                ],
+                QCOM_SAMPLE_INPUTS: [
+                    (torch.randn([3, 512]),),
+                    (torch.randn([3, 3, 512]),),
+                    (torch.randn([3, 3, 3, 512]),),
+                ],
+            },
         ]
-        sample_input = (torch.randn([3, 512]),)
+
+        index = 0
+        for comb in test_comb:
+            for module in comb[QCOM_MODULE]:
+                for sample_input in comb[QCOM_SAMPLE_INPUTS]:
+                    with self.subTest(i=index):
+                        index += 1
+                        self.lower_module_and_test_output(module, sample_input)
+
+    def test_qnn_backend_linear_to_conv2d(self):
+        from executorch.backends.qualcomm._passes import ConvertLinearToConv2d
+
+        test_comb = [
+            {
+                QCOM_MODULE: [
+                    Linear(),  # noqa: F405
+                    Linear(use_bias=False),  # noqa: F405
+                ],
+                QCOM_SAMPLE_INPUTS: [
+                    (torch.randn([3, 512]),),
+                    (torch.randn([3, 3, 512]),),
+                    (torch.randn([3, 3, 3, 512]),),
+                ],
+            },
+        ]
+
+        passes_job = get_qnn_pass_manager_cls().get_capture_program_passes()
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY][
+            "edge_program"
+        ] = None
+
+        index = 0
+        for comb in test_comb:
+            for module in comb[QCOM_MODULE]:
+                for sample_input in comb[QCOM_SAMPLE_INPUTS]:
+                    with self.subTest(i=index):
+                        index += 1
+                        self.lower_module_and_test_output(
+                            module, sample_input, passes_job=passes_job
+                        )
+
+    def test_qnn_backend_linear_shared_weights(self):
+        modules = [
+            LinearSharedWeight(512, 32),  # noqa: F405
+        ]
+
+        sample_input = (
+            torch.randn([3, 512]),
+            torch.randn([3, 512]),
+        )
         for i, module in enumerate(modules):
             with self.subTest(i=i):
                 self.lower_module_and_test_output(module, sample_input)
+
+    def test_qnn_backend_linear_to_conv2d_shared_weights(self):
+        from executorch.backends.qualcomm._passes import ConvertLinearToConv2d
+
+        modules = [
+            LinearSharedWeight(512, 32),  # noqa: F405
+        ]
+
+        passes_job = get_qnn_pass_manager_cls().get_capture_program_passes()
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY][
+            "edge_program"
+        ] = None
+
+        sample_input = (
+            torch.randn([3, 512]),
+            torch.randn([3, 512]),
+        )
+        for i, module in enumerate(modules):
+            with self.subTest(i=i):
+                self.lower_module_and_test_output(
+                    module, sample_input, passes_job=passes_job
+                )
 
     def test_qnn_backend_log(self):
         module = Log()  # noqa: F405
@@ -3571,8 +3666,20 @@ class TestQNNQuantizedOperator(TestQNN):
             ConvTranspose1dSingle(),  # noqa: F405
             ConvTranspose1dSingle(bias=False),  # noqa: F405
             ConvTranspose1dSingle(dilation=2),  # noqa: F405
+            ConvTranspose1dSingle(  # noqa: F405
+                bias=False,
+                kernel_size=2,
+                stride=1,
+                padding=2,
+                dilation=2,
+            ),
+            ConvTranspose1dSingle(  # noqa: F405
+                kernel_size=2,
+                stride=1,
+                padding=2,
+            ),
         ]
-        sample_input = (torch.randn([1, 1, 3]),)
+        sample_input = (torch.randn([1, 1, 16]),)
         for i, module in enumerate(modules):
             with self.subTest(i=i):
                 module = self.get_qdq_module(module, sample_input)
@@ -4898,15 +5005,101 @@ class TestQNNQuantizedOperator(TestQNN):
                 self.lower_module_and_test_output(module, sample_input)
 
     def test_qnn_backend_linear(self):
-        modules = [
-            Linear(),  # noqa: F405
-            LinearNonConstantWeight(),  # noqa: F405
+        test_comb = [
+            {
+                QCOM_MODULE: [
+                    Linear(),  # noqa: F405
+                    Linear(use_bias=False),  # noqa: F405
+                    LinearNonConstantWeight(),  # noqa: F405
+                ],
+                QCOM_SAMPLE_INPUTS: [
+                    (torch.randn([3, 512]),),
+                    (torch.randn([3, 3, 512]),),
+                    (torch.randn([3, 3, 3, 512]),),
+                ],
+            },
         ]
-        sample_input = (torch.randn([3, 512]),)
+
+        index = 0
+        for comb in test_comb:
+            for module in comb[QCOM_MODULE]:
+                for sample_input in comb[QCOM_SAMPLE_INPUTS]:
+                    with self.subTest(i=index):
+                        index += 1
+                        qdq_module = self.get_qdq_module(module, sample_input)
+                        self.lower_module_and_test_output(qdq_module, sample_input)
+
+    def test_qnn_backend_linear_to_conv2d(self):
+        from executorch.backends.qualcomm._passes import ConvertLinearToConv2d
+
+        test_comb = [
+            {
+                QCOM_MODULE: [
+                    Linear(),  # noqa: F405
+                    Linear(use_bias=False),  # noqa: F405
+                ],
+                QCOM_SAMPLE_INPUTS: [
+                    (torch.randn([3, 512]),),
+                    (torch.randn([3, 3, 512]),),
+                    (torch.randn([3, 3, 3, 512]),),
+                ],
+            },
+        ]
+
+        passes_job = get_qnn_pass_manager_cls().get_capture_program_passes()
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY][
+            "edge_program"
+        ] = None
+
+        index = 0
+        for comb in test_comb:
+            for module in comb[QCOM_MODULE]:
+                for sample_input in comb[QCOM_SAMPLE_INPUTS]:
+                    with self.subTest(i=index):
+                        index += 1
+                        qdq_module = self.get_qdq_module(module, sample_input)
+                        self.lower_module_and_test_output(
+                            qdq_module, sample_input, passes_job=passes_job
+                        )
+
+    def test_qnn_backend_linear_shared_weights(self):
+        modules = [
+            LinearSharedWeight(512, 32),  # noqa: F405
+        ]
+
+        sample_input = (
+            torch.randn([3, 512]),
+            torch.randn([3, 512]),
+        )
         for i, module in enumerate(modules):
             with self.subTest(i=i):
-                module = self.get_qdq_module(module, sample_input)
-                self.lower_module_and_test_output(module, sample_input)
+                qdq_module = self.get_qdq_module(module, sample_input)
+                self.lower_module_and_test_output(qdq_module, sample_input)
+
+    def test_qnn_backend_linear_to_conv2d_shared_weights(self):
+        from executorch.backends.qualcomm._passes import ConvertLinearToConv2d
+
+        modules = [
+            LinearSharedWeight(512, 32),  # noqa: F405
+        ]
+
+        passes_job = get_qnn_pass_manager_cls().get_capture_program_passes()
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY][
+            "edge_program"
+        ] = None
+
+        sample_input = (
+            torch.randn([3, 512]),
+            torch.randn([3, 512]),
+        )
+        for i, module in enumerate(modules):
+            with self.subTest(i=i):
+                qdq_module = self.get_qdq_module(module, sample_input)
+                self.lower_module_and_test_output(
+                    qdq_module, sample_input, passes_job=passes_job
+                )
 
     @unittest.skipIf(is_qnn_sdk_version_less_than("2.30"), "UT pass after QNN 2.30")
     def test_qnn_backend_linear_block(self):
@@ -4928,6 +5121,37 @@ class TestQNNQuantizedOperator(TestQNN):
                     block_size_map={"linear": (1, 32)},
                 )
                 self.lower_module_and_test_output(module, sample_input)
+
+    @unittest.skipIf(is_qnn_sdk_version_less_than("2.30"), "UT pass after QNN 2.30")
+    def test_qnn_backend_linear_to_conv2d_block(self):
+        from executorch.backends.qualcomm._passes import ConvertLinearToConv2d
+
+        modules = [
+            Linear(use_bias=False),  # noqa: F405
+            Linear(use_bias=True),  # noqa: F405
+        ]
+
+        passes_job = get_qnn_pass_manager_cls().get_capture_program_passes()
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ACTIVATE_KEY] = True
+        passes_job[ConvertLinearToConv2d][QCOM_PASS_ARGS_KWARGS_DEFAULTS_KEY][
+            "edge_program"
+        ] = None
+
+        sample_input = (torch.randn([3, 512]),)
+        for i, module in enumerate(modules):
+            with self.subTest(i=i):
+                # update block size for linear weight (OI)
+                # channel dimension(O) is defaultly sliced in QNN
+                # divide dimension(I) into 16 groups
+                module = self.get_qdq_module(
+                    module,
+                    sample_input,
+                    quant_dtype=QuantDtype.use_16a4w_block,
+                    block_size_map={"linear": (1, 32)},
+                )
+                self.lower_module_and_test_output(
+                    module, sample_input, passes_job=passes_job
+                )
 
     def test_qnn_backend_linear_qat(self):
         """

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -464,10 +464,7 @@ def to_edge_transform_and_lower_to_qnn(
         # If placed in the to_edge_transform_passes, it will be executed
         # after the lift_constant_tensor_pass, causing the operation builder
         # to fail to correctly retrieve the parameter by the get_parameter.
-        aten_programs[graph_name] = pass_manager.transform_for_export_pipeline(
-            ep,
-            convert_linear_to_conv2d=convert_linear_to_conv2d,
-        )
+        aten_programs[graph_name] = pass_manager.transform_for_export_pipeline(ep)
         transform_passes[graph_name] = pass_manager.get_to_edge_transform_passes(
             ep,
             passes_job=passes_job[graph_name],
@@ -475,6 +472,7 @@ def to_edge_transform_and_lower_to_qnn(
             compiler_specs=compiler_specs[graph_name],
             skip_node_id_set=skip_node_id_set,
             skip_node_op_set=skip_node_op_set,
+            convert_linear_to_conv2d=convert_linear_to_conv2d,
         )
     with QnnManagerContext(compiler_specs):
         return to_edge_transform_and_lower(

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -473,10 +473,7 @@ def to_edge_transform_and_lower_to_qnn(
         # If placed in the to_edge_transform_passes, it will be executed
         # after the lift_constant_tensor_pass, causing the operation builder
         # to fail to correctly retrieve the parameter by the get_parameter.
-        aten_programs[graph_name] = pass_manager.transform_for_export_pipeline(
-            ep,
-            convert_linear_to_conv2d=convert_linear_to_conv2d,
-        )
+        aten_programs[graph_name] = pass_manager.transform_for_export_pipeline(ep)
         transform_passes[graph_name] = pass_manager.get_to_edge_transform_passes(
             ep,
             passes_job=passes_job[graph_name],
@@ -484,6 +481,7 @@ def to_edge_transform_and_lower_to_qnn(
             compiler_specs=compiler_specs[graph_name],
             skip_node_id_set=skip_node_id_set,
             skip_node_op_set=skip_node_op_set,
+            convert_linear_to_conv2d=convert_linear_to_conv2d,
         )
     with QnnManagerContext(compiler_specs):
         return to_edge_transform_and_lower(

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -1344,6 +1344,8 @@ def to_edge_transform_and_lower(  # noqa: C901
 
     if transform_passes is not None:
         edge_manager = edge_manager.transform(transform_passes)
+        for method in edge_manager.methods:
+            lift_constant_tensor_pass(edge_manager.exported_program(method))
 
         if generate_etrecord:
             edge_manager._etrecord.add_extra_export_modules(

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -1342,6 +1342,8 @@ def to_edge_transform_and_lower(  # noqa: C901
 
     if transform_passes is not None:
         edge_manager = edge_manager.transform(transform_passes)
+        for method in edge_manager.methods:
+            lift_constant_tensor_pass(edge_manager.exported_program(method))
 
         if generate_etrecord:
             edge_manager._etrecord.add_extra_export_modules(


### PR DESCRIPTION
## Summary

This is **part 1** of a series whose goal is to deprecate `to_edge_transform_and_lower_to_qnn` and migrate Qualcomm-specific passes from the export pipeline into `to_edge_transform_and_lower`.

The core change is in `exir/program/_program.py`: after the `EdgeProgramManager` finishes running `transform_passes`, we now invoke `lift_constant_tensor_pass` on each method's `ExportedProgram`. Several QNN passes (`CanonicalizeConv`, `ConvertLinearToConv2d`, etc.) rewrite constant values and insert new `get_attr` nodes to store them. Without lifting, these mutated constants are not reflected back into the `ExportedProgram`; `lift_constant_tensor_pass` promotes the `get_attr` nodes into placeholders so the modified constants are correctly propagated.

## Changes
- `exir/program/_program.py`: run `lift_constant_tensor_pass` over every method after `edge_manager.transform(transform_passes)` completes.
- Move `CanonicalizeConv` and `ConvertLinearToConv2d` out of the export pipeline (`get_export_passes`) and into the to-edge transform pipeline.
- Add new pass `AnnotateGetAttr` to repopulate `QCOM_QUANT_ATTRS` for `get_attr` nodes. Passes such as `I64toI32` and `LayoutTransform` reconstruct the `GraphModule` (`graph_module = super().call(graph_module).graph_module`), which drops the quant attributes previously stored on `get_attr` node metadata.

## Test plan
- `CanonicalizeConv`
Test cases:
`TEST_MATRIX = {TestQNNFloatingPointOperator.test_qnn_backend_conv1d TestQNNFloatingPointOperator.test_qnn_conv1d_batch_norm TestQNNFloatingPointOperator.test_qnn_backend_conv2d TestQNNFloatingPointOperator.test_qnn_backend_conv3d_sequential TestQNNFloatingPointOperator.test_qnn_backend_conv_transpose1d TestQNNFloatingPointOperator.test_qnn_backend_conv_transpose2d TestQNNFloatingPointOperator.test_qnn_backend_conv_transpose3d TestQNNFloatingPointModel.test_qnn_backend_conv1d_relu_log_softmax TestQNNQuantizedOperator.test_qnn_backend_conv1d TestQNNQuantizedOperator.test_qnn_conv1d_batch_norm TestQNNQuantizedOperator.test_qnn_backend_conv2d TestQNNQuantizedOperator.test_qnn_backend_conv3d_sequential TestQNNQuantizedOperator.test_qnn_backend_conv_transpose1d TestQNNQuantizedOperator.test_qnn_backend_conv_transpose2d TestQNNQuantizedOperator.test_qnn_backend_conv_transpose3d TestQNNQuantizedModel.test_qnn_backend_conv1d_relu_log_softmax}`
Command:
`python backends/qualcomm/tests/test_qnn_delegate.py ${TEST_MATRIX} --build_folder build-android/ --host ${HOST_NAME} --device ${DEVICE_ID} --soc_model ${SOC_ID} --seed 1126 --backend htp`
`python -m pytest "backends/qualcomm/tests/rework/passes/test.py::test_canonicalize_conv[htp]" -v`
`python -m pytest "backends/qualcomm/tests/rework/passes/test.py::test_canonicalize_conv[lpai]" -v`

- `ConvertLinearToConv2d`
Test cases:
`TEST_MATRIX = {TestQNNFloatingPointOperator.test_qnn_backend_linear TestQNNFloatingPointOperator.test_qnn_backend_linear_to_conv2d TestQNNFloatingPointOperator.test_qnn_backend_linear_shared_weights TestQNNFloatingPointOperator.test_qnn_backend_linear_to_conv2d_shared_weights  TestQNNQuantizedOperator.test_qnn_backend_linear TestQNNQuantizedOperator.test_qnn_backend_linear_to_conv2d TestQNNQuantizedOperator.test_qnn_backend_linear_shared_weights TestQNNQuantizedOperator.test_qnn_backend_linear_to_conv2d_shared_weights TestQNNQuantizedOperator.test_qnn_backend_linear_block TestQNNQuantizedOperator.test_qnn_backend_linear_to_conv2d_block TestQNNQuantizedOperator.test_qnn_backend_linear_qat}`
Command:
`python backends/qualcomm/tests/test_qnn_delegate.py ${TEST_MATRIX} --build_folder build-android/ --host ${HOST_NAME} --device ${DEVICE_ID} --soc_model ${SOC_ID} --seed 1126 --backend htp`
`python -m pytest "backends/qualcomm/tests/rework/passes/test.py::test_convert_linear_to_conv2d[htp]" -v`
`python -m pytest "backends/qualcomm/tests/rework/passes/test.py::test_convert_linear_to_conv2d[lpai]" -v`
`python -m pytest "backends/qualcomm/tests/rework/htp/op/v68/test.py::test_linear_shared_weights" -v`

- `AnnotateGetAttr`
Command:
`python -m pytest "backends/qualcomm/tests/rework/passes/test.py::test_annotate_get_attr" -v`