### PR TITLE
Re-add recurrent gated delta rule custom op

### DIFF
--- a/examples/models/llama/attention.py
+++ b/examples/models/llama/attention.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Dict, Optional, Tuple, Type, TypedDict
@@ -56,6 +57,8 @@ class Attention(nn.Module, ABC):
 
 
 ATTENTION_REGISTRY: Dict[str, Type[Attention]] = {}
+_RECURRENT_GATED_DELTA_RULE_OP = None
+_TRIED_LOADING_RECURRENT_GATED_DELTA_RULE_OP = False
 
 
 def register_attention(name: str):
@@ -66,6 +69,38 @@ def register_attention(name: str):
         return cls
 
     return decorator
+
+
+def _get_recurrent_gated_delta_rule_op():
+    global _RECURRENT_GATED_DELTA_RULE_OP
+    global _TRIED_LOADING_RECURRENT_GATED_DELTA_RULE_OP
+
+    if _TRIED_LOADING_RECURRENT_GATED_DELTA_RULE_OP:
+        return _RECURRENT_GATED_DELTA_RULE_OP
+
+    _TRIED_LOADING_RECURRENT_GATED_DELTA_RULE_OP = True
+    try:
+        _RECURRENT_GATED_DELTA_RULE_OP = (
+            torch.ops.llama.recurrent_gated_delta_rule.default
+        )
+        return _RECURRENT_GATED_DELTA_RULE_OP
+    except (AttributeError, RuntimeError):
+        pass
+
+    try:
+        from executorch.extension.llm.custom_ops import custom_ops  # noqa: F401
+    except (AttributeError, ImportError, OSError, RuntimeError):
+        logging.debug("Failed to import custom ops library", exc_info=True)
+        return None
+
+    try:
+        _RECURRENT_GATED_DELTA_RULE_OP = (
+            torch.ops.llama.recurrent_gated_delta_rule.default
+        )
+    except (AttributeError, RuntimeError):
+        _RECURRENT_GATED_DELTA_RULE_OP = None
+
+    return _RECURRENT_GATED_DELTA_RULE_OP
 
 
 class KVCache(nn.Module):
@@ -762,7 +797,7 @@ class AttentionGatedDeltaNet(Attention):
         out = F.silu(out[:, :, -seq_len:]).to(mixed_qkv.dtype)
         return out.transpose(1, 2).contiguous()
 
-    def _recurrent_gated_delta_rule(
+    def _gated_delta_rule_op(
         self,
         query: torch.Tensor,
         key: torch.Tensor,
@@ -770,20 +805,29 @@ class AttentionGatedDeltaNet(Attention):
         g: torch.Tensor,
         beta: torch.Tensor,
     ) -> torch.Tensor:
-        # query/key/value: (batch, seq_len, num_heads, head_dim)
-        # g/beta: (batch, seq_len, num_heads)
-        initial_dtype = query.dtype
-        query = _l2norm(query, dim=-1, eps=1e-6)
-        key = _l2norm(key, dim=-1, eps=1e-6)
-        query, key, value, beta, g = [
-            x.transpose(1, 2).contiguous().to(torch.float32)
-            for x in (query, key, value, beta, g)
-        ]
+        batch_size = query.shape[0]
+        recurrent_gated_delta_rule_op = _get_recurrent_gated_delta_rule_op()
+        if recurrent_gated_delta_rule_op is not None:
+            return recurrent_gated_delta_rule_op(
+                query,
+                key,
+                value,
+                g,
+                beta,
+                self.recurrent_state[:batch_size],
+            )
+        return self._naive_gated_delta_rule_op(query, key, value, g, beta)
 
-        batch_size, num_heads, sequence_length, k_head_dim = key.shape
+    def _naive_gated_delta_rule_op(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+    ) -> torch.Tensor:
+        batch_size, num_heads, sequence_length, _ = key.shape
         v_head_dim = value.shape[-1]
-        scale = 1.0 / (query.shape[-1] ** 0.5)
-        query = query * scale
 
         core_attn_out = torch.zeros(
             batch_size,
@@ -817,6 +861,30 @@ class AttentionGatedDeltaNet(Attention):
                 last_recurrent_state.to(self.recurrent_state.dtype)
             )
 
+        return core_attn_out
+
+    def _recurrent_gated_delta_rule(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+    ) -> torch.Tensor:
+        # query/key/value: (batch, seq_len, num_heads, head_dim)
+        # g/beta: (batch, seq_len, num_heads)
+        initial_dtype = query.dtype
+        query = _l2norm(query, dim=-1, eps=1e-6)
+        key = _l2norm(key, dim=-1, eps=1e-6)
+        query, key, value, beta, g = [
+            x.transpose(1, 2).contiguous().to(torch.float32)
+            for x in (query, key, value, beta, g)
+        ]
+
+        scale = 1.0 / (query.shape[-1] ** 0.5)
+        query = query * scale
+
+        core_attn_out = self._gated_delta_rule_op(query, key, value, g, beta)
         return core_attn_out.transpose(1, 2).contiguous().to(initial_dtype)
 
     def forward(

--- a/examples/models/llama/tests/test_qwen3_5_attention.py
+++ b/examples/models/llama/tests/test_qwen3_5_attention.py
@@ -6,6 +6,7 @@
 
 import unittest
 
+import executorch.examples.models.llama.attention as attention_module
 import torch
 from executorch.examples.models.llama.attention import ATTENTION_REGISTRY
 from executorch.examples.models.llama.model_args import ModelArgs
@@ -121,6 +122,109 @@ class Qwen35AttentionTest(unittest.TestCase):
 
         self.assertTrue(
             torch.allclose(state_after_first, state_after_second, atol=1e-5)
+        )
+
+    def test_gated_deltanet_chunked_prefill_matches_full_sequence(self):
+        torch.manual_seed(0)
+        args = self._make_args(
+            use_kv_cache=True,
+            use_q_gate=True,
+            linear_conv_kernel_dim=4,
+            linear_key_head_dim=4,
+            linear_value_head_dim=4,
+            linear_num_key_heads=2,
+            linear_num_value_heads=4,
+        )
+        rope = Rope(args)
+        attn_full = ATTENTION_REGISTRY["gated_deltanet"](args, 0, rope)
+        attn_chunked = ATTENTION_REGISTRY["gated_deltanet"](args, 0, rope)
+        attn_chunked.load_state_dict(attn_full.state_dict())
+
+        x = torch.randn(1, 5, args.dim)
+        dummy_freq = torch.zeros(1, 1)
+
+        full_output, _ = attn_full(
+            x,
+            dummy_freq,
+            dummy_freq,
+            input_pos=torch.tensor([0], dtype=torch.long),
+        )
+
+        chunk_outputs = []
+        for start, end in ((0, 3), (3, 4), (4, 5)):
+            output, _ = attn_chunked(
+                x[:, start:end],
+                dummy_freq,
+                dummy_freq,
+                input_pos=torch.tensor([start], dtype=torch.long),
+            )
+            chunk_outputs.append(output)
+
+        chunked_output = torch.cat(chunk_outputs, dim=1)
+
+        self.assertTrue(torch.allclose(chunked_output, full_output, atol=1e-5))
+        self.assertTrue(
+            torch.allclose(
+                attn_chunked.recurrent_state, attn_full.recurrent_state, atol=1e-5
+            )
+        )
+        self.assertTrue(
+            torch.allclose(attn_chunked.conv_state, attn_full.conv_state, atol=1e-5)
+        )
+
+    def test_gated_deltanet_custom_op_matches_fallback(self):
+        recurrent_op = attention_module._get_recurrent_gated_delta_rule_op()
+        if recurrent_op is None:
+            self.skipTest("llama::recurrent_gated_delta_rule is not available")
+
+        torch.manual_seed(0)
+        args = self._make_args(
+            use_kv_cache=True,
+            use_q_gate=True,
+            linear_conv_kernel_dim=4,
+            linear_key_head_dim=4,
+            linear_value_head_dim=4,
+            linear_num_key_heads=2,
+            linear_num_value_heads=4,
+        )
+        rope = Rope(args)
+        attn_custom = ATTENTION_REGISTRY["gated_deltanet"](args, 0, rope)
+        attn_fallback = ATTENTION_REGISTRY["gated_deltanet"](args, 0, rope)
+        attn_fallback.load_state_dict(attn_custom.state_dict())
+
+        query = torch.randn(1, 3, attn_custom.num_v_heads, attn_custom.head_k_dim)
+        key = torch.randn(1, 3, attn_custom.num_v_heads, attn_custom.head_k_dim)
+        value = torch.randn(1, 3, attn_custom.num_v_heads, attn_custom.head_v_dim)
+        g = torch.randn(1, 3, attn_custom.num_v_heads)
+        beta = torch.sigmoid(torch.randn(1, 3, attn_custom.num_v_heads))
+
+        original_op = attention_module._RECURRENT_GATED_DELTA_RULE_OP
+        original_tried_loading = (
+            attention_module._TRIED_LOADING_RECURRENT_GATED_DELTA_RULE_OP
+        )
+        try:
+            attention_module._RECURRENT_GATED_DELTA_RULE_OP = recurrent_op
+            attention_module._TRIED_LOADING_RECURRENT_GATED_DELTA_RULE_OP = True
+            custom_output = attn_custom._recurrent_gated_delta_rule(
+                query, key, value, g, beta
+            )
+
+            attention_module._RECURRENT_GATED_DELTA_RULE_OP = None
+            attention_module._TRIED_LOADING_RECURRENT_GATED_DELTA_RULE_OP = True
+            fallback_output = attn_fallback._recurrent_gated_delta_rule(
+                query, key, value, g, beta
+            )
+        finally:
+            attention_module._RECURRENT_GATED_DELTA_RULE_OP = original_op
+            attention_module._TRIED_LOADING_RECURRENT_GATED_DELTA_RULE_OP = (
+                original_tried_loading
+            )
+
+        self.assertTrue(torch.allclose(custom_output, fallback_output, atol=1e-5))
+        self.assertTrue(
+            torch.allclose(
+                attn_custom.recurrent_state, attn_fallback.recurrent_state, atol=1e-5
+            )
         )
 
 

--- a/extension/llm/custom_ops/custom_ops.py
+++ b/extension/llm/custom_ops/custom_ops.py
@@ -11,7 +11,8 @@
 # pyre-unsafe
 
 import logging
-
+import os
+from pathlib import Path
 from typing import Tuple
 
 import torch
@@ -27,6 +28,8 @@ try:
     assert op is not None
     op2 = torch.ops.llama.fast_hadamard_transform.default
     assert op2 is not None
+    op3 = torch.ops.llama.recurrent_gated_delta_rule.default
+    assert op3 is not None
 except:
     # This is needed to ensure that custom ops are registered
     from executorch.extension.pybindings import portable_lib  # noqa # usort: skip
@@ -34,12 +37,14 @@ except:
     # Ideally package is installed in only one location but usage of
     # PYATHONPATH can result in multiple locations.
     # ATM this is mainly used in CI for qnn runner. Will need to revisit this
-    from pathlib import Path
-
     package_path = Path(__file__).parent.resolve()
+    override = os.environ.get("EXECUTORCH_CUSTOM_OPS_AOT_LIB")
     logging.info(f"Looking for libcustom_ops_aot_lib.so in {package_path}")
 
-    libs = list(package_path.glob("**/*custom_ops_aot_lib.*"))
+    if override:
+        libs = [Path(override).expanduser().resolve()]
+    else:
+        libs = list(package_path.glob("**/*custom_ops_aot_lib.*"))
 
     assert len(libs) == 1, f"Expected 1 library but got {len(libs)}"
     logging.info(f"Loading custom ops library: {libs[0]}")
@@ -48,6 +53,8 @@ except:
     assert op is not None
     op2 = torch.ops.llama.fast_hadamard_transform.default
     assert op2 is not None
+    op3 = torch.ops.llama.recurrent_gated_delta_rule.default
+    assert op3 is not None
 
 custom_ops_lib = torch.library.Library("llama", "IMPL")
 
@@ -269,6 +276,87 @@ def update_cache_with_indices_meta(
     # workaround. Should we just return cache instead? But I am afraid that
     # will result in extra memory allocation
     return torch.empty((1,), dtype=value.dtype, device="meta")
+
+
+def _validate_recurrent_gated_delta_rule_params(
+    query,
+    key,
+    value,
+    g,
+    beta,
+    recurrent_state,
+):
+    assert (
+        query.dim() == 4
+    ), f"Expected query to be 4 dimensional but got {query.dim()} dimensions."
+    assert (
+        key.dim() == 4
+    ), f"Expected key to be 4 dimensional but got {key.dim()} dimensions."
+    assert (
+        value.dim() == 4
+    ), f"Expected value to be 4 dimensional but got {value.dim()} dimensions."
+    assert g.dim() == 3, f"Expected g to be 3 dimensional but got {g.dim()} dimensions."
+    assert (
+        beta.dim() == 3
+    ), f"Expected beta to be 3 dimensional but got {beta.dim()} dimensions."
+    assert (
+        recurrent_state.dim() == 4
+    ), f"Expected recurrent_state to be 4 dimensional but got {recurrent_state.dim()} dimensions."
+
+    for name, tensor in {
+        "query": query,
+        "key": key,
+        "value": value,
+        "g": g,
+        "beta": beta,
+        "recurrent_state": recurrent_state,
+    }.items():
+        assert (
+            tensor.dtype == torch.float32
+        ), f"Expected {name} to be float32 but got {tensor.dtype}"
+
+    assert (
+        query.shape == key.shape
+    ), f"Expected query and key to have matching shapes but got {query.shape} and {key.shape}"
+    assert (
+        query.shape[:3] == value.shape[:3]
+    ), f"Expected query and value to match in batch/head/sequence dims but got {query.shape} and {value.shape}"
+    assert (
+        g.shape == query.shape[:3]
+    ), f"Expected g to match query batch/head/sequence dims but got {g.shape} and {query.shape}"
+    assert (
+        beta.shape == query.shape[:3]
+    ), f"Expected beta to match query batch/head/sequence dims but got {beta.shape} and {query.shape}"
+    assert recurrent_state.shape == (
+        query.size(0),
+        query.size(1),
+        query.size(3),
+        value.size(3),
+    ), (
+        "Expected recurrent_state to have shape "
+        f"{(query.size(0), query.size(1), query.size(3), value.size(3))} "
+        f"but got {recurrent_state.shape}"
+    )
+
+
+@impl(custom_ops_lib, "recurrent_gated_delta_rule", "Meta")
+def recurrent_gated_delta_rule_meta(
+    query,
+    key,
+    value,
+    g,
+    beta,
+    recurrent_state,
+):
+    _validate_recurrent_gated_delta_rule_params(
+        query,
+        key,
+        value,
+        g,
+        beta,
+        recurrent_state,
+    )
+    return torch.empty_like(value)
 
 
 def _validate_quantized_sdpa_params(

--- a/extension/llm/custom_ops/op_sdpa.cpp
+++ b/extension/llm/custom_ops/op_sdpa.cpp
@@ -15,6 +15,10 @@
 #include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 // @lint-ignore CLANGTIDY facebook-unused-include-check
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+#include <executorch/runtime/kernel/operator_registry.h>
+#include <algorithm>
+#include <cmath>
+#include <vector>
 
 #ifdef ET_USE_THREADPOOL
 #include <executorch/extension/threadpool/threadpool.h>
@@ -174,6 +178,68 @@ bool validate_cache_params(
   ET_CHECK_OR_RETURN_FALSE(
       is_contiguous_dim_order(v_cache.dim_order().data(), v_cache.dim()),
       "value cache must be in contiguous dim order");
+
+  return true;
+}
+
+bool validate_recurrent_gated_delta_rule_args(
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value,
+    const Tensor& g,
+    const Tensor& beta,
+    const Tensor& recurrent_state) {
+  ET_CHECK_OR_RETURN_FALSE(query.dim() == 4, "query must be a 4D tensor");
+  ET_CHECK_OR_RETURN_FALSE(key.dim() == 4, "key must be a 4D tensor");
+  ET_CHECK_OR_RETURN_FALSE(value.dim() == 4, "value must be a 4D tensor");
+  ET_CHECK_OR_RETURN_FALSE(g.dim() == 3, "g must be a 3D tensor");
+  ET_CHECK_OR_RETURN_FALSE(beta.dim() == 3, "beta must be a 3D tensor");
+  ET_CHECK_OR_RETURN_FALSE(
+      recurrent_state.dim() == 4, "recurrent_state must be a 4D tensor");
+
+  ET_CHECK_OR_RETURN_FALSE(
+      query.scalar_type() == ScalarType::Float, "query must be float32");
+  ET_CHECK_OR_RETURN_FALSE(
+      key.scalar_type() == ScalarType::Float, "key must be float32");
+  ET_CHECK_OR_RETURN_FALSE(
+      value.scalar_type() == ScalarType::Float, "value must be float32");
+  ET_CHECK_OR_RETURN_FALSE(
+      g.scalar_type() == ScalarType::Float, "g must be float32");
+  ET_CHECK_OR_RETURN_FALSE(
+      beta.scalar_type() == ScalarType::Float, "beta must be float32");
+  ET_CHECK_OR_RETURN_FALSE(
+      recurrent_state.scalar_type() == ScalarType::Float,
+      "recurrent_state must be float32");
+
+  ET_CHECK_OR_RETURN_FALSE(
+      query.size(0) == key.size(0) && query.size(1) == key.size(1) &&
+          query.size(2) == key.size(2) && query.size(3) == key.size(3),
+      "query and key must have matching shapes");
+  ET_CHECK_OR_RETURN_FALSE(
+      query.size(0) == value.size(0) && query.size(1) == value.size(1) &&
+          query.size(2) == value.size(2),
+      "query and value must match in batch/head/sequence dims");
+  ET_CHECK_OR_RETURN_FALSE(
+      g.size(0) == query.size(0) && g.size(1) == query.size(1) &&
+          g.size(2) == query.size(2),
+      "g must match query batch/head/sequence dims");
+  ET_CHECK_OR_RETURN_FALSE(
+      beta.size(0) == query.size(0) && beta.size(1) == query.size(1) &&
+          beta.size(2) == query.size(2),
+      "beta must match query batch/head/sequence dims");
+  ET_CHECK_OR_RETURN_FALSE(
+      recurrent_state.size(0) == query.size(0) &&
+          recurrent_state.size(1) == query.size(1) &&
+          recurrent_state.size(2) == query.size(3) &&
+          recurrent_state.size(3) == value.size(3),
+      "recurrent_state shape must match [B, H, K, V]");
+
+  for (const Tensor* tensor :
+       {&query, &key, &value, &g, &beta, &recurrent_state}) {
+    ET_CHECK_OR_RETURN_FALSE(
+        is_contiguous_dim_order(tensor->dim_order().data(), tensor->dim()),
+        "recurrent gated delta rule expects contiguous inputs");
+  }
 
   return true;
 }
@@ -610,6 +676,133 @@ Tensor& sdpa_with_kv_cache_out(
 
   return output;
 }
+
+Tensor& recurrent_gated_delta_rule_out(
+    RuntimeContext& ctx,
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value,
+    const Tensor& g,
+    const Tensor& beta,
+    Tensor& recurrent_state,
+    Tensor& output) {
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      resize_tensor(output, value.sizes()) == Error::Ok,
+      InvalidArgument,
+      output,
+      "Failed to resize recurrent_gated_delta_rule output tensor.");
+  ET_KERNEL_CHECK(
+      ctx,
+      validate_recurrent_gated_delta_rule_args(
+          query, key, value, g, beta, recurrent_state),
+      InvalidArgument,
+      output);
+  ET_KERNEL_CHECK(
+      ctx, output.scalar_type() == ScalarType::Float, InvalidArgument, output);
+  ET_KERNEL_CHECK(
+      ctx,
+      is_contiguous_dim_order(output.dim_order().data(), output.dim()),
+      InvalidArgument,
+      output);
+
+  const auto batch_size = query.size(0);
+  const auto num_heads = query.size(1);
+  const auto sequence_length = query.size(2);
+  const auto k_head_dim = query.size(3);
+  const auto v_head_dim = value.size(3);
+
+  const auto q_batch_stride = num_heads * sequence_length * k_head_dim;
+  const auto q_head_stride = sequence_length * k_head_dim;
+  const auto q_seq_stride = k_head_dim;
+
+  const auto value_batch_stride = num_heads * sequence_length * v_head_dim;
+  const auto value_head_stride = sequence_length * v_head_dim;
+  const auto value_seq_stride = v_head_dim;
+
+  const auto gv_batch_stride = num_heads * sequence_length;
+  const auto gv_head_stride = sequence_length;
+
+  const auto state_batch_stride = num_heads * k_head_dim * v_head_dim;
+  const auto state_head_stride = k_head_dim * v_head_dim;
+
+  const auto* query_data = query.const_data_ptr<float>();
+  const auto* key_data = key.const_data_ptr<float>();
+  const auto* value_data = value.const_data_ptr<float>();
+  const auto* g_data = g.const_data_ptr<float>();
+  const auto* beta_data = beta.const_data_ptr<float>();
+  auto* recurrent_state_data = recurrent_state.mutable_data_ptr<float>();
+  auto* output_data = output.mutable_data_ptr<float>();
+  std::vector<float> kv_mem(v_head_dim);
+  std::vector<float> delta(v_head_dim);
+
+  for (int64_t batch = 0; batch < batch_size; ++batch) {
+    for (int64_t head = 0; head < num_heads; ++head) {
+      const auto q_offset = batch * q_batch_stride + head * q_head_stride;
+      const auto value_offset =
+          batch * value_batch_stride + head * value_head_stride;
+      const auto gv_offset = batch * gv_batch_stride + head * gv_head_stride;
+      const auto state_offset =
+          batch * state_batch_stride + head * state_head_stride;
+
+      const auto* q_head = query_data + q_offset;
+      const auto* k_head = key_data + q_offset;
+      const auto* value_head = value_data + value_offset;
+      const auto* g_head = g_data + gv_offset;
+      const auto* beta_head = beta_data + gv_offset;
+      auto* state_head = recurrent_state_data + state_offset;
+      auto* output_head = output_data + value_offset;
+
+      for (int64_t token = 0; token < sequence_length; ++token) {
+        const auto* q_t = q_head + token * q_seq_stride;
+        const auto* k_t = k_head + token * q_seq_stride;
+        const auto* v_t = value_head + token * value_seq_stride;
+        auto* output_t = output_head + token * value_seq_stride;
+
+        const float g_t = std::exp(g_head[token]);
+        const float beta_t = beta_head[token];
+
+        if (g_t != 1.0f) {
+          for (int64_t idx = 0; idx < state_head_stride; ++idx) {
+            state_head[idx] *= g_t;
+          }
+        }
+
+        std::fill(kv_mem.begin(), kv_mem.end(), 0.0f);
+        for (int64_t k_idx = 0; k_idx < k_head_dim; ++k_idx) {
+          const float key_value = k_t[k_idx];
+          const auto* state_row = state_head + k_idx * v_head_dim;
+          for (int64_t v_idx = 0; v_idx < v_head_dim; ++v_idx) {
+            kv_mem[v_idx] += state_row[v_idx] * key_value;
+          }
+        }
+
+        for (int64_t v_idx = 0; v_idx < v_head_dim; ++v_idx) {
+          delta[v_idx] = (v_t[v_idx] - kv_mem[v_idx]) * beta_t;
+        }
+
+        for (int64_t k_idx = 0; k_idx < k_head_dim; ++k_idx) {
+          const float key_value = k_t[k_idx];
+          auto* state_row = state_head + k_idx * v_head_dim;
+          for (int64_t v_idx = 0; v_idx < v_head_dim; ++v_idx) {
+            state_row[v_idx] += key_value * delta[v_idx];
+          }
+        }
+
+        std::fill(output_t, output_t + v_head_dim, 0.0f);
+        for (int64_t k_idx = 0; k_idx < k_head_dim; ++k_idx) {
+          const float query_value = q_t[k_idx];
+          const auto* state_row = state_head + k_idx * v_head_dim;
+          for (int64_t v_idx = 0; v_idx < v_head_dim; ++v_idx) {
+            output_t[v_idx] += state_row[v_idx] * query_value;
+          }
+        }
+      }
+    }
+  }
+
+  return output;
+}
 } // namespace native
 } // namespace executor
 } // namespace torch
@@ -628,3 +821,36 @@ EXECUTORCH_LIBRARY(
     llama,
     "custom_quantized_sdpa.out",
     torch::executor::native::custom_quantized_sdpa_out);
+
+namespace {
+
+void recurrent_gated_delta_rule_out_boxed(
+    executorch::runtime::KernelRuntimeContext& ctx,
+    executorch::runtime::Span<executorch::runtime::EValue*> stack) {
+  ET_KERNEL_CHECK_MSG(
+      ctx,
+      stack.size() == 7,
+      InvalidProgram,
+      /* void */,
+      "Expected %zu args, got %zu",
+      static_cast<size_t>(7),
+      stack.size());
+
+  auto& query = stack[0]->toTensor();
+  auto& key = stack[1]->toTensor();
+  auto& value = stack[2]->toTensor();
+  auto& g = stack[3]->toTensor();
+  auto& beta = stack[4]->toTensor();
+  auto& recurrent_state = stack[5]->toTensor();
+  auto& output = stack[6]->toTensor();
+
+  (void)torch::executor::native::recurrent_gated_delta_rule_out(
+      ctx, query, key, value, g, beta, recurrent_state, output);
+}
+
+const auto recurrent_gated_delta_rule_out_registration =
+    executorch::runtime::register_kernel(executorch::runtime::Kernel(
+        "llama::recurrent_gated_delta_rule.out",
+        recurrent_gated_delta_rule_out_boxed));
+
+} // namespace

--- a/extension/llm/custom_ops/op_sdpa.h
+++ b/extension/llm/custom_ops/op_sdpa.h
@@ -75,6 +75,16 @@ Tensor& custom_quantized_sdpa_out(
     const optional<Tensor>& v_scales,
     const bool is_seq_at_dim_1,
     Tensor& output);
+
+Tensor& recurrent_gated_delta_rule_out(
+    RuntimeContext& ctx,
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value,
+    const Tensor& g,
+    const Tensor& beta,
+    Tensor& recurrent_state,
+    Tensor& output);
 } // namespace native
 } // namespace executor
 } // namespace torch

--- a/extension/llm/custom_ops/op_sdpa_aot.cpp
+++ b/extension/llm/custom_ops/op_sdpa_aot.cpp
@@ -143,6 +143,23 @@ at::Tensor update_cache_with_indices_aten(
     const int64_t start_pos,
     const at::Tensor& indices);
 
+Tensor& recurrent_gated_delta_rule_out_no_context(
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value,
+    const Tensor& g,
+    const Tensor& beta,
+    Tensor& recurrent_state,
+    Tensor& output);
+
+at::Tensor recurrent_gated_delta_rule_aten(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& g,
+    const at::Tensor& beta,
+    at::Tensor& recurrent_state);
+
 Tensor& sdpa_with_kv_cache_out_no_context(
     const Tensor& q_projected,
     const Tensor& k_projected,
@@ -377,6 +394,32 @@ at::Tensor update_cache_with_indices_aten(
   return output;
 }
 
+Tensor& recurrent_gated_delta_rule_out_no_context(
+    const Tensor& query,
+    const Tensor& key,
+    const Tensor& value,
+    const Tensor& g,
+    const Tensor& beta,
+    Tensor& recurrent_state,
+    Tensor& output) {
+  executorch::aten::RuntimeContext context{};
+  return torch::executor::native::recurrent_gated_delta_rule_out(
+      context, query, key, value, g, beta, recurrent_state, output);
+}
+
+at::Tensor recurrent_gated_delta_rule_aten(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value,
+    const at::Tensor& g,
+    const at::Tensor& beta,
+    at::Tensor& recurrent_state) {
+  auto output = at::empty_like(value);
+  WRAP_TO_ATEN(recurrent_gated_delta_rule_out_no_context, 6)
+  (query, key, value, g, beta, recurrent_state, output);
+  return output;
+}
+
 } // namespace native
 } // namespace executor
 } // namespace torch
@@ -410,6 +453,12 @@ TORCH_LIBRARY_FRAGMENT(llama, m) {
   m.def(
       "update_cache_with_indices.out(Tensor value, Tensor(a!) cache, "
       "SymInt start_pos, Tensor indices, *, Tensor(b!) out) -> Tensor(b!)");
+  m.def(
+      "recurrent_gated_delta_rule(Tensor query, Tensor key, Tensor value, Tensor g, "
+      "Tensor beta, Tensor(a!) recurrent_state) -> Tensor");
+  m.def(
+      "recurrent_gated_delta_rule.out(Tensor query, Tensor key, Tensor value, Tensor g, "
+      "Tensor beta, Tensor(a!) recurrent_state, *, Tensor(b!) out) -> Tensor(b!)");
   m.def(
       "custom_quantized_sdpa(Tensor query, Tensor key, Tensor value, SymInt start_pos, "
       "Tensor? attn_mask=None, float drpout_p=0.0, bool is_causal=False, "
@@ -448,6 +497,14 @@ TORCH_LIBRARY_IMPL(llama, CompositeExplicitAutograd, m) {
       WRAP_TO_ATEN(
           torch::executor::native::update_cache_with_indices_out_no_context,
           4));
+  m.impl(
+      "recurrent_gated_delta_rule",
+      torch::executor::native::recurrent_gated_delta_rule_aten);
+  m.impl(
+      "recurrent_gated_delta_rule.out",
+      WRAP_TO_ATEN(
+          torch::executor::native::recurrent_gated_delta_rule_out_no_context,
+          6));
   m.impl(
       "custom_quantized_sdpa",
       torch::executor::native::custom_quantized_sdpa_aten);

--- a/extension/llm/custom_ops/test_update_cache.py
+++ b/extension/llm/custom_ops/test_update_cache.py
@@ -416,6 +416,158 @@ class UpdateQuantizedKVCacheTest(unittest.TestCase):
             k, v, k_scales, v_scales, k_zero_points, v_zero_points, start_pos
         )
 
+
+class RecurrentGatedDeltaRuleTest(unittest.TestCase):
+    def _make_inputs(
+        self,
+        batch_size: int = 2,
+        num_heads: int = 3,
+        seq_len: int = 4,
+        k_head_dim: int = 5,
+        v_head_dim: int = 6,
+    ):
+        query = torch.randn(batch_size, num_heads, seq_len, k_head_dim)
+        key = torch.randn(batch_size, num_heads, seq_len, k_head_dim)
+        value = torch.randn(batch_size, num_heads, seq_len, v_head_dim)
+        g = torch.randn(batch_size, num_heads, seq_len)
+        beta = torch.sigmoid(torch.randn(batch_size, num_heads, seq_len))
+        recurrent_state = torch.randn(batch_size, num_heads, k_head_dim, v_head_dim)
+        return query, key, value, g, beta, recurrent_state
+
+    def _reference_recurrent_gated_delta_rule(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        recurrent_state: torch.Tensor,
+    ):
+        state = recurrent_state.clone()
+        output = torch.zeros_like(value)
+
+        for token in range(query.size(2)):
+            g_t = g[:, :, token].exp().unsqueeze(-1).unsqueeze(-1)
+            beta_t = beta[:, :, token].unsqueeze(-1)
+            k_t = key[:, :, token]
+            v_t = value[:, :, token]
+            q_t = query[:, :, token]
+
+            state = state * g_t
+            kv_mem = (state * k_t.unsqueeze(-1)).sum(dim=-2)
+            delta = (v_t - kv_mem) * beta_t
+            state = state + k_t.unsqueeze(-1) * delta.unsqueeze(-2)
+            output[:, :, token] = (state * q_t.unsqueeze(-1)).sum(dim=-2)
+
+        return output, state
+
+    def test_recurrent_gated_delta_rule_matches_reference(self):
+        torch.manual_seed(0)
+
+        test_cases = (
+            (2, 3, 4, 5, 6),
+            (1, 4, 7, 8, 3),
+        )
+
+        for case in test_cases:
+            with self.subTest(case=case):
+                (
+                    query,
+                    key,
+                    value,
+                    g,
+                    beta,
+                    recurrent_state,
+                ) = self._make_inputs(*case)
+
+                expected_output, expected_state = (
+                    self._reference_recurrent_gated_delta_rule(
+                        query,
+                        key,
+                        value,
+                        g,
+                        beta,
+                        recurrent_state,
+                    )
+                )
+
+                actual_state = recurrent_state.clone()
+                actual_output = torch.ops.llama.recurrent_gated_delta_rule(
+                    query,
+                    key,
+                    value,
+                    g,
+                    beta,
+                    actual_state,
+                )
+
+                self.assertTrue(
+                    torch.allclose(actual_output, expected_output, atol=1e-5)
+                )
+                self.assertTrue(torch.allclose(actual_state, expected_state, atol=1e-5))
+
+    def test_recurrent_gated_delta_rule_out_matches_reference(self):
+        torch.manual_seed(0)
+
+        query, key, value, g, beta, recurrent_state = self._make_inputs()
+        expected_output, expected_state = self._reference_recurrent_gated_delta_rule(
+            query,
+            key,
+            value,
+            g,
+            beta,
+            recurrent_state,
+        )
+
+        actual_state = recurrent_state.clone()
+        actual_output = torch.empty_like(value)
+        returned_output = torch.ops.llama.recurrent_gated_delta_rule.out(
+            query,
+            key,
+            value,
+            g,
+            beta,
+            actual_state,
+            out=actual_output,
+        )
+
+        self.assertEqual(returned_output.data_ptr(), actual_output.data_ptr())
+        self.assertTrue(torch.allclose(actual_output, expected_output, atol=1e-5))
+        self.assertTrue(torch.allclose(actual_state, expected_state, atol=1e-5))
+
+    def test_recurrent_gated_delta_rule_chunked_matches_full_sequence(self):
+        torch.manual_seed(0)
+
+        query, key, value, g, beta, recurrent_state = self._make_inputs(seq_len=6)
+
+        full_state = recurrent_state.clone()
+        full_output = torch.ops.llama.recurrent_gated_delta_rule(
+            query,
+            key,
+            value,
+            g,
+            beta,
+            full_state,
+        )
+
+        chunk_state = recurrent_state.clone()
+        chunk_outputs = []
+        for start, end in ((0, 2), (2, 5), (5, 6)):
+            chunk_outputs.append(
+                torch.ops.llama.recurrent_gated_delta_rule(
+                    query[:, :, start:end, :],
+                    key[:, :, start:end, :],
+                    value[:, :, start:end, :],
+                    g[:, :, start:end],
+                    beta[:, :, start:end],
+                    chunk_state,
+                )
+            )
+
+        chunked_output = torch.cat(chunk_outputs, dim=2)
+        self.assertTrue(torch.allclose(chunked_output, full_output, atol=1e-5))
+        self.assertTrue(torch.allclose(chunk_state, full_state, atol=1e-5))
+
         k = torch.randint(0, 50, (self.batch_size, 1, 8, 4), dtype=torch.int8)
         v = torch.randint(0, 50, (self.batch_size, 1, 8, 4), dtype=torch.int8)
         k_scales = torch.rand((self.batch_size, 1, 8, 1), dtype=torch.float64)


### PR DESCRIPTION
Summary:
- Re-adds `llama::recurrent_gated_delta_rule` runtime and AOT registrations for Qwen3.5 GatedDeltaNet attention.
- Wires Qwen3.5 attention to use the custom op when available, with the Python fallback preserved.
- Adds custom-op reference tests and GatedDeltaNet chunked-prefill/custom-op parity coverage.

Tests:
- `git diff --check -- examples/models/llama/attention.py examples/models/llama/tests/test_qwen3_5_attention.py extension/llm/custom_ops/custom_ops.py extension/llm/custom_ops/op_sdpa.cpp extension/llm/custom_ops/op_sdpa.h extension/llm/custom_ops/op_sdpa_aot.cpp extension/llm/custom_ops/test_update_cache.py`
- `python -m py_compile examples/models/llama/attention.py examples/models/llama/tests/test_qwen3_5_attention.py extension/llm/custom_ops/custom_ops.py extension/llm/custom_ops/test_update_cache.py`
- `python -m pytest examples/models/llama/tests/test_qwen3_5_attention.py -q` -> 6 passed, 1 skipped (`llama::recurrent_gated_delta_rule` library unavailable locally)

Local blockers:
- `cmake --build cmake-out-gdn --target custom_ops_aot_lib --parallel $(sysctl -n hw.ncpu)` fails before compiling this op in existing optimized BLAS code: `runtime/core/array_ref.h` passes `size_t*` to PyTorch 2.9.1 `c10::add_overflows(..., uint64_t*)`.
- `python -m pytest extension/llm/custom_ops/test_update_cache.py::RecurrentGatedDeltaRuleTest -q` cannot collect in this Python environment because importing existing `custom_ops.py` hits `torch._inductor.lowering` -> missing `torch.ops.higher_order.templated_attention`.

Authored with Claude.