### PR TITLE
Fix TOSA serialization install in Linux unittest

### DIFF
--- a/.ci/scripts/unittest-linux-cmake.sh
+++ b/.ci/scripts/unittest-linux-cmake.sh
@@ -11,19 +11,18 @@ set -eux
 # Install from a local tosa-tools checkout when available. If absent in this
 # checkout layout, clone the pinned upstream tag and install from there.
 if ! python -c "import tosa_serializer" >/dev/null 2>&1; then
-  TOSA_SERIALIZATION_DIR="./examples/arm/arm-scratch/tosa-tools/serialization"
-  if [[ ! -d "${TOSA_SERIALIZATION_DIR}" ]]; then
+  TOSA_TOOLS_DIR="./examples/arm/arm-scratch/tosa-tools"
+  if [[ ! -d "${TOSA_TOOLS_DIR}" ]]; then
     TOSA_TOOLS_DIR="$(mktemp -d /tmp/tosa-tools.XXXXXX)"
-    git clone --depth 1 --branch v2025.11.2 \
+    git clone --depth 1 --branch v2026.05.0 \
       https://git.gitlab.arm.com/tosa/tosa-tools.git "${TOSA_TOOLS_DIR}"
-    TOSA_SERIALIZATION_DIR="${TOSA_TOOLS_DIR}/serialization"
   fi
 
   # NOTE: Will be removed when tosa-tools is installed via pypi
   python -m pip install pybind11==2.10.4
   CMAKE_POLICY_VERSION_MINIMUM=3.5 BUILD_PYBIND=1 \
     python -m pip install --no-dependencies \
-    "${TOSA_SERIALIZATION_DIR}"
+    "${TOSA_TOOLS_DIR}"
   python -c "import tosa_serializer"
 fi
 


### PR DESCRIPTION
Summary:

Fix the Linux unittest TOSA serializer install by moving the fallback clone to tosa-tools v2026.05.0 and installing from the tosa-tools repo root. Upstream moved packaging to the root pyproject in this release; installing from serialization/ is now intentionally unsupported.

This avoids patching pyproject.toml in CI and uses the current upstream packaging layout instead.


Authored with Claude.