### PR TITLE
Fix QNN llama script Python path

### DIFF
--- a/.ci/scripts/test_llama.sh
+++ b/.ci/scripts/test_llama.sh
@@ -124,9 +124,9 @@ if [[ "${MODE}" =~ .*qnn.* ]]; then
   source "$(dirname "${BASH_SOURCE[0]}")/../../backends/qualcomm/scripts/install_qnn_sdk.sh"
   install_qnn
 
-  export EXECUTORCH_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+  export EXECUTORCH_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
   export LD_LIBRARY_PATH="${QNN_SDK_ROOT}/lib/x86_64-linux-clang"
-  export PYTHONPATH=".."
+  export PYTHONPATH="${EXECUTORCH_ROOT}/..${PYTHONPATH:+:${PYTHONPATH}}"
   cp schema/program.fbs exir/_serialize/program.fbs
   cp schema/scalar_type.fbs exir/_serialize/scalar_type.fbs
   cp -f build-x86/backends/qualcomm/PyQnnManagerAdaptor.cpython-310-x86_64-linux-gnu.so backends/qualcomm/python

--- a/.ci/scripts/test_qnn_static_llama_eval.sh
+++ b/.ci/scripts/test_qnn_static_llama_eval.sh
@@ -15,9 +15,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/../../backends/qualcomm/scripts/install_qnn_sdk.sh"
 install_qnn
 
-export EXECUTORCH_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+export EXECUTORCH_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 export LD_LIBRARY_PATH="${QNN_SDK_ROOT}/lib/x86_64-linux-clang"
-export PYTHONPATH=".."
+export PYTHONPATH="${EXECUTORCH_ROOT}/..${PYTHONPATH:+:${PYTHONPATH}}"
 cp schema/program.fbs exir/_serialize/program.fbs
 cp schema/scalar_type.fbs exir/_serialize/scalar_type.fbs
 cp -f build-x86/backends/qualcomm/PyQnnManagerAdaptor.cpython-310-x86_64-linux-gnu.so backends/qualcomm/python

--- a/.ci/scripts/test_qnn_static_llm.sh
+++ b/.ci/scripts/test_qnn_static_llm.sh
@@ -20,9 +20,9 @@ fi
 source "$(dirname "${BASH_SOURCE[0]}")/../../backends/qualcomm/scripts/install_qnn_sdk.sh"
 install_qnn
 
-export EXECUTORCH_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+export EXECUTORCH_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 export LD_LIBRARY_PATH="${QNN_SDK_ROOT}/lib/x86_64-linux-clang"
-export PYTHONPATH=".."
+export PYTHONPATH="${EXECUTORCH_ROOT}/..${PYTHONPATH:+:${PYTHONPATH}}"
 cp schema/program.fbs exir/_serialize/program.fbs
 cp schema/scalar_type.fbs exir/_serialize/scalar_type.fbs
 cp -f build-x86/backends/qualcomm/PyQnnManagerAdaptor.cpython-310-x86_64-linux-gnu.so backends/qualcomm/python


### PR DESCRIPTION
Summary:

Fix QNN llama CI scripts so they resolve EXECUTORCH_ROOT to the repository root and set PYTHONPATH to the parent of that root. The Qualcomm examples are source-tree modules, so the CI import path needs the repo parent instead of a cwd-relative '..'. This addresses failures such as:

python: No module named executorch.examples.qualcomm.oss_scripts.llama.eval_llama_qnn

Test Plan:

bash -n .ci/scripts/test_llama.sh .ci/scripts/test_qnn_static_llama_eval.sh .ci/scripts/test_qnn_static_llm.sh
git diff --check origin/main
lintrunner -r origin/main
Verified the new EXECUTORCH_ROOT expression resolves to the repo root for all three scripts.

Authored with Claude.