### PR TITLE
Fix typos and spelling mistakes across docs, comments, and logs

### DIFF
--- a/backends/arm/test/passes/test_fuse_batchnorm_pass.py
+++ b/backends/arm/test/passes/test_fuse_batchnorm_pass.py
@@ -143,7 +143,7 @@ class MergeMultipleUsersBN(torch.nn.Module):
         z = self.conv2d2(x)
         a = self.batch_norm2d(
             y
-        )  # Can be fused despite paramters of conv2d2 having multiple users.
+        )  # Can be fused despite parameters of conv2d2 having multiple users.
 
         return z, a
 

--- a/backends/arm/test/quantizer/test_selective_quantization.py
+++ b/backends/arm/test/quantizer/test_selective_quantization.py
@@ -324,7 +324,7 @@ def test_multiple_folded_get_attr():
     node targets are deleted as soon as there is one get_attr node w/o users
     using the target.
 
-    If there are multiple get_attr nodes refering the same target such as in
+    If there are multiple get_attr nodes referring the same target such as in
     this test, the function crashes if no workaround is present.
 
     """

--- a/backends/cortex_m/passes/clamp_hardswish_pass.py
+++ b/backends/cortex_m/passes/clamp_hardswish_pass.py
@@ -16,7 +16,7 @@ class ClampHardswishPass(ExportPass):
     """
     Adds a clamp operation before hardswish to ensure input is in the range [-3, inf).
 
-    By doing this before quantization the output range of the preceeding op is minimized,
+    By doing this before quantization the output range of the preceding op is minimized,
     potentially improving accuracy.
     """
 

--- a/backends/cuda/triton/replacement_pass.py
+++ b/backends/cuda/triton/replacement_pass.py
@@ -97,7 +97,7 @@ class ReplaceEdgeOpWithTritonOpPass(PassBase):
         allocating partial buffers and running the reduction kernel.
 
         TODO(gasoonjia): Benchmarking to determine the optimal
-        implmentation for each shape.
+        implementation for each shape.
         """
         q_shape = node.args[0].meta["val"].shape
         k_shape = node.args[1].meta["val"].shape

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_bilinear2d_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/upsample_bilinear2d_converter.py
@@ -113,7 +113,7 @@ class UpsampleBilinear2DConverter(NodeConverter):
         x = t_op.tmp_inputs[0]
         y = t_op.tmp_outputs[0]
 
-        # ExecuTorch has 1 paramter (align_corners). NeutronIR has 2 parameters (align_corners, half_pixel_centers).
+        # ExecuTorch has 1 parameter (align_corners). NeutronIR has 2 parameters (align_corners, half_pixel_centers).
         # In ExecuTorch, the pixel compute scale is:
         #  `(input_size - 1) / (output_size - 1)` if align_corners else `input_size / output_size`
         # https://github.com/pytorch/executorch/blob/v1.1.0/kernels/portable/cpu/util/upsample_util.h#L65

--- a/backends/nxp/quantizer/patterns.py
+++ b/backends/nxp/quantizer/patterns.py
@@ -43,11 +43,11 @@ from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 @dataclass
 class NodeArgsIdx:
     """
-    Specifies indexes to args paramater of Node in node input annotation.
+    Specifies indexes to args parameter of Node in node input annotation.
 
 
     Attributes:
-        idx (int): Index to Node's args paramater (list). Selects an input Node or a list of Nodes at the index.
+        idx (int): Index to Node's args parameter (list). Selects an input Node or a list of Nodes at the index.
         inner_idx (int): If specified, index to a list pointed by 'idx' attribute. Selects an input Node at the index.
                          Default: None.
     """

--- a/backends/openvino/README.md
+++ b/backends/openvino/README.md
@@ -126,7 +126,7 @@ Follow the steps below to setup your build environment:
    ```bash
    openvino_build.sh
    ```
-- Optionally, `openvino_build.sh` script can be used to build python package or C++ libraries/binaries seperately.
+- Optionally, `openvino_build.sh` script can be used to build python package or C++ libraries/binaries separately.
 
    **Build OpenVINO Backend Python Package with Pybindings**: To build and install the OpenVINO backend Python package with Python bindings, run the `openvino_build.sh` script with the `--enable_python` argument as shown in the below command. This will compile and install the ExecuTorch Python package with the OpenVINO backend into your Python environment. This option will also enable python bindings required to execute OpenVINO backend tests and `aot_optimize_and_infer.py` script inside `executorch/examples/openvino` folder.
      ```bash

--- a/backends/qualcomm/tests/rework/conftest.py
+++ b/backends/qualcomm/tests/rework/conftest.py
@@ -244,8 +244,8 @@ def temp_attribute(obj, attr, new_value):
         )
 
 
-# No direct depedency between qnn_config and global_setup.
-# Keep following depedency for better practice so global_setup is done first.
+# No direct dependency between qnn_config and global_setup.
+# Keep following dependency for better practice so global_setup is done first.
 @pytest.fixture(autouse=True, scope="session")
 def qnn_config(global_setup, request):
     # generate QnnConfig for on-device test

--- a/backends/test/harness/tester.py
+++ b/backends/test/harness/tester.py
@@ -287,7 +287,7 @@ class Tester:
         return self
 
     def check_node_count(self, input: Dict[Any, int]):
-        # Count the occurances of each target in the graph.
+        # Count the occurrences of each target in the graph.
         target_ops = [
             node.target
             for node in self.stages[self.cur].graph_module.graph.nodes

--- a/backends/test/suite/reporting.py
+++ b/backends/test/suite/reporting.py
@@ -196,10 +196,10 @@ class TestCaseSummary:
     """ The total runtime of the to_edge_transform_and_lower stage, or none, if the test did not run the quantize stage. """
 
     delegated_op_counts: Counter | None = None
-    """ The number of delegated occurances of each operator in the graph. """
+    """ The number of delegated occurrences of each operator in the graph. """
 
     undelegated_op_counts: Counter | None = None
-    """ The number of undelegated occurances of each operator in the graph. """
+    """ The number of undelegated occurrences of each operator in the graph. """
 
     pte_size_bytes: int | None = None
     """ The size of the PTE file in bytes. """

--- a/backends/test/suite/tests/test_reporting.py
+++ b/backends/test/suite/tests/test_reporting.py
@@ -116,7 +116,7 @@ class Reporting(unittest.TestCase):
 
     def test_count_ops(self):
         """
-        Verify that the count_ops function correctly counts operator occurances in the edge graph.
+        Verify that the count_ops function correctly counts operator occurrences in the edge graph.
         """
 
         class Model1(torch.nn.Module):

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -1058,7 +1058,7 @@ TEST_F(VulkanComputeAPITest, vec_test) {
     ASSERT_TRUE(v[2] == 10);
   }
 
-  // Test initalization from temporary vec
+  // Test initialization from temporary vec
   {
     utils::uvec3 v = make_temp_ivec3(4, 5, 10);
     ASSERT_TRUE(v[0] == 4);
@@ -3072,7 +3072,7 @@ void test_to_copy() {
         std::bitset<32>(*reinterpret_cast<uint32_t*>(&input)).to_string() +
         "), expected output = " + std::to_string(expected_output) + "(0b" +
         std::bitset<16>(*expected_bits).to_string() +
-        "), recieved output = " + std::to_string(output) + "(0b" +
+        "), received output = " + std::to_string(output) + "(0b" +
         std::bitset<16>(*output_bits).to_string() + ")";
 
     std::cout << msg << std::endl;

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -201,7 +201,7 @@ class VulkanBackend(BackendDetails):
         # Optionally apply the memory metadata tagging pass, which will insert storage
         # type and memory layout transition nodes to ensure that all tensor arguments
         # to an operator is in a supported or optimal configuration. If this pass is not
-        # applied, there will be a risk that some operators recieve arguments with
+        # applied, there will be a risk that some operators receive arguments with
         # memory settings that are not supported by the implementation.
         if not compile_options.get("skip_tag_memory_metadata", False):
             program = apply_passes(

--- a/backends/xnnpack/operators/quant_params.py
+++ b/backends/xnnpack/operators/quant_params.py
@@ -30,7 +30,7 @@ from torch.export import ExportedProgram
 
 class QuantParams:
     """
-    QuantParams class, to represent the paramaters and meta data needed
+    QuantParams class, to represent the parameters and meta data needed
     to quantize a tensor. The metadata can technically all be encapsulated
     within the quant torch.fx.Node, however, there are some cases in which
     nodes which are meant to be quantized for XNNPACK are not quantized

--- a/backends/xnnpack/runtime/XNNCompiler.cpp
+++ b/backends/xnnpack/runtime/XNNCompiler.cpp
@@ -563,7 +563,7 @@ Error defineTensor(
         uint32_t scale_numel = 0;
 
         // Block scales are preferably serialized as bf16 but can also be
-        // serialized as fp32 for backwards compatability.
+        // serialized as fp32 for backwards compatibility.
         if (qparams->scale_buffer_idx() != 0) {
           auto scale_data_result = getConstantDataPtr(
               qparams->scale_buffer_idx(),

--- a/examples/apple/mps/executor_runner/mps_executor_runner.mm
+++ b/examples/apple/mps/executor_runner/mps_executor_runner.mm
@@ -316,8 +316,8 @@ int main(int argc, char** argv) {
     auto duration = duration_cast<microseconds>(end_exec_time - start_exec_time);
     exec_times.push_back(duration.count());
     if (FLAGS_profile) {
-      const float miliseconds = static_cast<float>(duration.count()) / 1000.f;
-      ET_LOG(Info, "[Run %d] Inference time: %.3f miliseconds", i, miliseconds);
+      const float milliseconds = static_cast<float>(duration.count()) / 1000.f;
+      ET_LOG(Info, "[Run %d] Inference time: %.3f milliseconds", i, milliseconds);
     }
     ET_CHECK_MSG(
         status == Error::Ok,
@@ -331,7 +331,7 @@ int main(int argc, char** argv) {
       itr++;
 
     const float avg_time = (std::reduce(itr, exec_times.end()) / static_cast<float>(FLAGS_num_runs)) / 1000.f;
-    std::cout << "Average inference time: " << std::setprecision(2) << std::fixed << avg_time << " miliseconds\n";
+    std::cout << "Average inference time: " << std::setprecision(2) << std::fixed << avg_time << " milliseconds\n";
   }
   ET_LOG(Info, "Model executed successfully.");
 

--- a/exir/backend/test/test_partitioner.py
+++ b/exir/backend/test/test_partitioner.py
@@ -591,7 +591,7 @@ class TestPartitioner(unittest.TestCase):
                     partition_tags=partition_tags,
                 )
 
-        # Check the edge program inital buffers_to_mutate
+        # Check the edge program initial buffers_to_mutate
         mutate_op = "aten_add_tensor_1"
         self.assertEqual(
             edge.exported_program().graph_signature.buffers_to_mutate[mutate_op],

--- a/exir/passes/external_constants_pass.py
+++ b/exir/passes/external_constants_pass.py
@@ -71,7 +71,7 @@ def external_mutable_weights_pass(
     """
     Move all mutable weights to external file.
     """
-    # pass the gm and the ep seperately as the gm is being mutated by a bunch of passes in to_executorch,
+    # pass the gm and the ep separately as the gm is being mutated by a bunch of passes in to_executorch,
     # so the gm in the ep is lagging the graph signature is still correct.
     # This is really tech debt and all the passes should be refactored to just mutate the ep.
     mutated = False

--- a/extension/training/module/test/training_module_test.cpp
+++ b/extension/training/module/test/training_module_test.cpp
@@ -121,7 +121,7 @@ TEST_F(TrainingModuleTest, NonTrainingModuleTest) {
   ASSERT_EQ(res.error(), Error::InvalidArgument);
 }
 
-TEST_F(TrainingModuleTest, SeperateDataTest) {
+TEST_F(TrainingModuleTest, SeparateDataTest) {
   // Load data map.
   // The eager linear model is defined at:
   // //executorch/test/models/linear_model.py

--- a/schema/program.fbs
+++ b/schema/program.fbs
@@ -349,7 +349,7 @@ table BackendDelegate {
 // abstraction is not currently leveraged, all current programs are 1 chain.
 // We are leaving chains as part of the program definition for future use cases
 // around graph level async where different threads will be represented as
-// seperate chains.
+// separate chains.
 table Chain {
   // Indices of the values that are (non-static) inputs into this Chain.
   inputs: [int];
@@ -518,7 +518,7 @@ table Program {
   // [Optional] Describes the offsets into various segments for each mutable
   // tensor. Only mutable tensors with a meaningful initial state are
   // serialized here (for example weights that will be trained on-device as
-  // opposed to just layer activations). Seperate from the constant_segment to
+  // opposed to just layer activations). Separate from the constant_segment to
   // reduce peak memory usage by letting us read directly from the PTE file
   // into the mutable tensor, as opposed to loading the .pte data into
   // constant memory, copying it over, and then being unable to release the


### PR DESCRIPTION
Fixes multiple typos and spelling mistakes across several files (including program.fbs, external_constants_pass.py, test_partitioner.py, training_module_test.cpp, clamp_hardswish_pass.py, replacement_pass.py, vulkan_preprocess.py, vulkan_compute_api_test.cpp, XNNCompiler.cpp, upsample_bilinear2d_converter.py, test_fuse_batchnorm_pass.py, conftest.py, README.md, tester.py, test_reporting.py, reporting.py) to improve code readability and documentation quality.

cc @mergennachin @nil-is-all @SS-JIA @manuelcandales @digantdesai @cbilgin @GregoryComer @JakeStevens @psiddh @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani @robert-kalmar @AdrianLundell @Gasoonjia