### PR TITLE
Fix nullptr dereference segfault in QNN runtime when op_package_options is null

### DIFF
--- a/backends/qualcomm/runtime/QnnManager.cpp
+++ b/backends/qualcomm/runtime/QnnManager.cpp
@@ -84,7 +84,10 @@ QnnManager::QnnManager(
         "Enable shared buffer: %d", options->shared_buffer());
     QNN_EXECUTORCH_LOG_INFO(
         "The number of op packages: %d",
-        options_->op_package_options()->op_package_infos()->size());
+        options_->op_package_options() &&
+                options_->op_package_options()->op_package_infos()
+            ? options_->op_package_options()->op_package_infos()->size()
+            : 0);
   }
 
   backend_params_ptr_ = std::make_unique<BackendConfigParameters>();

--- a/backends/qualcomm/runtime/backends/QnnBackendCommon.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendCommon.cpp
@@ -94,7 +94,8 @@ Error QnnBackend::Configure(
     return Error::Internal;
   }
 
-  if (op_package_options->op_package_infos()->size() > 0) {
+  if (op_package_options && op_package_options->op_package_infos() &&
+      op_package_options->op_package_infos()->size() > 0) {
     BackendRegisterOpPackage(op_package_options->op_package_infos());
   }
 


### PR DESCRIPTION
This PR fixes a nullptr dereference segmentation fault in Qualcomm QNN backend's runtime when 'op_package_options' is not present in the serialized metadata (which is common for standard models). It adds null-safety checks before dereferencing options in QnnManager.cpp and QnnBackendCommon.cpp. Fixes #20619.

cc @cbilgin @psiddh