### PR TITLE
Fix Vulkan compute pipeline crash by checking if VK_EXT_subgroup_size_control is enabled

### DIFF
--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -217,15 +217,25 @@ VkDevice create_logical_device(
 #endif /* VK_NV_cooperative_matrix2 */
 
 #ifdef VK_EXT_subgroup_size_control
-  // Only enable the feature struct if the extension was actually requested
-  // and the feature flag is set on the physical device. The extension itself
-  // is filtered into enabled_device_extensions by
-  // find_requested_device_extensions.
+  // Only enable the feature struct if the extension was actually requested,
+  // supported, and successfully enabled.
+  bool subgroup_size_control_extension_enabled = false;
+  for (const auto& ext : enabled_device_extensions) {
+    if (strcmp(ext, VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME) == 0) {
+      subgroup_size_control_extension_enabled = true;
+      break;
+    }
+  }
+
   VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_size_control_features{
       physical_device.subgroup_size_control_features};
-  if (physical_device.supports_subgroup_size_control) {
+  if (physical_device.supports_subgroup_size_control &&
+      subgroup_size_control_extension_enabled) {
     subgroup_size_control_features.pNext = extension_list_top;
     extension_list_top = &subgroup_size_control_features;
+  } else {
+    const_cast<PhysicalDevice&>(physical_device).supports_subgroup_size_control = false;
+    const_cast<PhysicalDevice&>(physical_device).supports_compute_full_subgroups = false;
   }
 #endif /* VK_EXT_subgroup_size_control */
 


### PR DESCRIPTION
This PR fixes a native Vulkan compute pipeline creation crash (-3 VK_ERROR_INITIALIZATION_FAILED) in Android 16 (API 36) system images. The bug occurs because the physical device reports subgroup size control support, but the extension is not enabled on the logical device (due to it being promoted to core Vulkan 1.3, which is not core in Vulkan 1.1 instance/device target). Passing the extension feature struct in pNext of VkDeviceCreateInfo without enabling the extension is invalid usage. This change checks if VK_EXT_subgroup_size_control is successfully enabled before utilizing its features. Fixes #11754.

cc @SS-JIA @manuelcandales @digantdesai @cbilgin