### PR TITLE
Arm backend: Reject unsupported transpose convolutions

### DIFF
--- a/backends/arm/operator_support/convolution_support.py
+++ b/backends/arm/operator_support/convolution_support.py
@@ -31,7 +31,10 @@ from executorch.exir.dialects._ops import ops as exir_ops
 class ConvolutionSupported(SupportedTOSAOperatorCheck):
     """Provide TOSA support check for convolutions."""
 
-    targets = [exir_ops.edge.aten.convolution.default]
+    targets = [
+        exir_ops.edge.aten.convolution.default,
+        torch.ops.aten.conv_transpose2d.input,
+    ]
 
     def is_node_tosa_supported(
         self, node: fx.Node, tosa_spec: TosaSpecification
@@ -42,9 +45,7 @@ class ConvolutionSupported(SupportedTOSAOperatorCheck):
         padding. Apply additional hardware-specific constraints for U55.
 
         """
-        transposed = cast(bool, node.args[6])
-        output_padding = cast(list[int], node.args[7])
-        groups = cast(int, node.args[8])
+        transposed, output_padding, groups = self._get_conv_params(node)
 
         if transposed:
             if not self._check_transposed_support(node, groups, output_padding):
@@ -67,6 +68,13 @@ class ConvolutionSupported(SupportedTOSAOperatorCheck):
             return input_qparams[1]
         return None
 
+    def _has_per_channel_weight(self, node: fx.Node) -> bool:
+        weight_node = cast(fx.Node, node.args[1])
+        return weight_node.target in (
+            torch.ops.quantized_decomposed.dequantize_per_channel.default,
+            exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,
+        )
+
     def _check_output_padding(self, output_padding: list[int], node: fx.Node) -> bool:
         for output_pad in output_padding:
             if output_pad != 0:
@@ -77,22 +85,44 @@ class ConvolutionSupported(SupportedTOSAOperatorCheck):
                 return False
         return True
 
+    def _get_conv_params(self, node: fx.Node) -> tuple[bool, list[int], int]:
+        """Return transposed, output_padding, and groups for supported conv
+        targets.
+        """
+
+        if node.target == torch.ops.aten.conv_transpose2d.input:
+            return True, cast(list[int], node.args[5]), cast(int, node.args[6])
+        return (
+            cast(bool, node.args[6]),
+            cast(list[int], node.args[7]),
+            cast(int, node.args[8]),
+        )
+
+    def _get_transposed_conv_dilation(self, node: fx.Node) -> list[int]:
+        if node.target == torch.ops.aten.conv_transpose2d.input:
+            return cast(list[int], node.args[7])
+        return cast(list[int], node.args[5])
+
     def _check_transposed_support(
         self, node: fx.Node, groups: int, output_padding: list[int]
     ) -> bool:
+        dilation = expand_around_channel(self._get_transposed_conv_dilation(node), 2)
+        if any(d != 1 for d in dilation):
+            self.reporter.report_reject(
+                node, "Transpose convolutions with dilation are not supported."
+            )
+            return False
+
         if groups != 1:
             weight_qargs = self._get_weight_qargs(node)
-            if isinstance(weight_qargs, QuantArgs) and weight_qargs.per_channel:
+            has_per_channel_qargs = (
+                isinstance(weight_qargs, QuantArgs) and weight_qargs.per_channel
+            )
+            if has_per_channel_qargs or self._has_per_channel_weight(node):
                 self.reporter.report_reject(
                     node,
                     "Grouped transpose convolutions with per-channel weight "
                     "quantization are not supported.",
-                )
-                return False
-            dilation = expand_around_channel(cast(list[int], node.args[5]), 2)
-            if any(d != 1 for d in dilation):
-                self.reporter.report_reject(
-                    node, "Transpose convolutions with dilation are not supported."
                 )
                 return False
 

--- a/backends/arm/test/misc/test_convolution_operator_support.py
+++ b/backends/arm/test/misc/test_convolution_operator_support.py
@@ -1,0 +1,218 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.backends.arm._passes.quant_args import QuantArgs
+from executorch.backends.arm.operator_support.convolution_support import (
+    ConvolutionSupported,
+)
+from executorch.backends.arm.tosa import TosaSpecification
+from executorch.exir.backend.utils import WhyNoPartitionReporter
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+# These tests exercise the operator-support predicate directly. Building small
+# FX nodes keeps unsupported cases from reaching the lowering pipeline.
+#
+#     input ─┐
+#            ├─ conv_transpose2d / transposed convolution ──► reject early
+#     weight ┘        │
+#                     ├─ dilation != 1
+#                     └─ grouped + per-channel weight qparams
+#
+# If these cases are incorrectly marked supported, later rewrite/decomposition
+# passes fail with opaque _ExportedProgramGraphPassAdapter errors instead of a
+# clear partition rejection.
+
+
+def _fake_tensor(shape: tuple[int, ...]) -> torch.Tensor:
+    with FakeTensorMode() as mode:
+        return mode.from_tensor(torch.empty(shape))
+
+
+def _make_conv_node(
+    target,
+    args,
+    input_shape=(1, 3, 8, 8),
+    weight_shape=(3, 3, 3, 3),
+    per_channel_weight=False,
+):
+    graph = torch.fx.Graph()
+    input_node = graph.placeholder("input")
+    input_node.meta["val"] = _fake_tensor(input_shape)
+    weight_node = graph.placeholder("weight")
+    weight_node.meta["val"] = _fake_tensor(weight_shape)
+    if per_channel_weight:
+        scale_node = graph.placeholder("scale")
+        scale_node.meta["val"] = _fake_tensor((weight_shape[0],))
+        zero_point_node = graph.placeholder("zero_point")
+        zero_point_node.meta["val"] = _fake_tensor((weight_shape[0],))
+        weight_node = graph.call_function(
+            torch.ops.quantized_decomposed.dequantize_per_channel.default,
+            (weight_node, scale_node, zero_point_node, 0, -127, 127, torch.int8),
+        )
+        weight_node.meta["val"] = _fake_tensor(weight_shape)
+    bias_node = graph.placeholder("bias")
+    bias_node.meta["val"] = _fake_tensor((weight_shape[1],))
+    node_args = {
+        "input": input_node,
+        "weight": weight_node,
+        "bias": bias_node,
+    }
+    resolved_args = tuple(
+        node_args[arg] if isinstance(arg, str) else arg for arg in args
+    )
+    node = graph.call_function(target, resolved_args)
+    node.meta["val"] = _fake_tensor((1, weight_shape[1], 8, 8))
+    return node
+
+
+def _checker() -> ConvolutionSupported:
+    return ConvolutionSupported(
+        TosaSpecification.create_from_string("TOSA-1.0+FP"),
+        WhyNoPartitionReporter(),
+    )
+
+
+def test_rejects_edge_transpose_convolution_with_dilation() -> None:
+    # edge.aten.convolution.default represents transposed convolution via the
+    # boolean transposed argument. Dilation is rejected here because
+    # RewriteConvPass cannot lower dilated TRANSPOSE_CONV2D.
+    node = _make_conv_node(
+        exir_ops.edge.aten.convolution.default,
+        (
+            "input",
+            "weight",
+            "bias",
+            [1, 1],
+            [0, 0],
+            [2, 1],
+            True,
+            [0, 0],
+            1,
+        ),
+    )
+
+    assert not _checker().is_node_supported({}, node)
+
+
+def test_rejects_aten_conv_transpose2d_with_dilation() -> None:
+    # torch.export may also preserve the explicit aten.conv_transpose2d.input
+    # overload. It uses a different argument layout from edge.aten.convolution,
+    # so cover it separately to keep the support-check indexing correct.
+    node = _make_conv_node(
+        torch.ops.aten.conv_transpose2d.input,
+        (
+            "input",
+            "weight",
+            "bias",
+            [1, 1],
+            [0, 0],
+            [0, 0],
+            1,
+            [2, 1],
+        ),
+    )
+
+    assert not _checker().is_node_supported({}, node)
+
+
+def test_rejects_grouped_aten_conv_transpose2d_with_per_channel_weights() -> None:
+    # Grouped transpose convolution is decomposed into per-group convolutions.
+    # Per-channel weight qparams on aten.conv_transpose2d.input do not align with
+    # that decomposition, so the node must be rejected before decomposition.
+    node = _make_conv_node(
+        torch.ops.aten.conv_transpose2d.input,
+        (
+            "input",
+            "weight",
+            "bias",
+            [1, 1],
+            [0, 0],
+            [0, 0],
+            3,
+            [1, 1],
+        ),
+    )
+    node.meta["input_qparams"] = {
+        1: QuantArgs(
+            [1.0, 1.0, 1.0], [0, 0, 0], -127, 127, torch.int8, per_channel=True
+        )
+    }
+
+    assert not _checker().is_node_supported({}, node)
+
+
+def test_rejects_grouped_edge_transpose_convolution_with_per_channel_dq_weight() -> (
+    None
+):
+    # The flow-suite partitioner sees converted quantized models before
+    # FoldAndAnnotateQParamsPass adds input_qparams. At that point per-channel
+    # weight quantization is visible through the dequantize_per_channel weight
+    # input, so reject from that graph shape too.
+    node = _make_conv_node(
+        exir_ops.edge.aten.convolution.default,
+        (
+            "input",
+            "weight",
+            "bias",
+            [1, 1],
+            [0, 0],
+            [1, 1],
+            True,
+            [0, 0],
+            3,
+        ),
+        per_channel_weight=True,
+    )
+
+    assert not _checker().is_node_supported({}, node)
+
+
+def test_rejects_grouped_edge_transpose_convolution_with_per_channel_weights() -> None:
+    # The same grouped/per-channel restriction applies to the edge dialect form
+    # of transposed convolution. This covers the path where export/decomposition
+    # has normalized conv_transpose2d into edge.aten.convolution.default.
+    node = _make_conv_node(
+        exir_ops.edge.aten.convolution.default,
+        (
+            "input",
+            "weight",
+            "bias",
+            [1, 1],
+            [0, 0],
+            [1, 1],
+            True,
+            [0, 0],
+            3,
+        ),
+    )
+    node.meta["input_qparams"] = {
+        1: QuantArgs(
+            [1.0, 1.0, 1.0], [0, 0, 0], -127, 127, torch.int8, per_channel=True
+        )
+    }
+
+    assert not _checker().is_node_supported({}, node)
+
+
+def test_accepts_aten_conv_transpose2d_without_unsupported_options() -> None:
+    # A plain 2D transpose convolution with groups=1 and dilation=1 is still
+    # supported. This guards against the rejection checks becoming too broad.
+    node = _make_conv_node(
+        torch.ops.aten.conv_transpose2d.input,
+        (
+            "input",
+            "weight",
+            "bias",
+            [1, 1],
+            [0, 0],
+            [0, 0],
+            1,
+            [1, 1],
+        ),
+    )
+
+    assert _checker().is_node_supported({}, node)


### PR DESCRIPTION
Reject unsupported transpose convolution cases during TOSA partitioning instead of letting them reach backend lowering.

Grouped transpose convolutions with per-channel weight quantization can appear before qparam metadata is folded, with the per-channel weight visible only through a dequantize_per_channel weight input. Detect and reject that form as well.

Also reject dilated transpose convolutions for both edge convolution and aten conv_transpose2d forms.

This avoids _ExportedProgramGraphPassAdapter failures in the backend test suite for unsupported Arm lowering cases.



cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani