### PR TITLE
[ET][OSS] Remove _use_edge_ops=True

### DIFF
--- a/exir/backend/test/hta_partitioner_demo.py
+++ b/exir/backend/test/hta_partitioner_demo.py
@@ -81,7 +81,7 @@ class HTAPartitionerMultiplePatternsDemo(Partitioner):
         pattern_sub = (
             to_edge(
                 export(SubModule(), (input_x, input_h), strict=True),
-                compile_config=exir.EdgeCompileConfig(_use_edge_ops=True),
+                compile_config=exir.EdgeCompileConfig(),
             )
             .exported_program()
             .graph_module

--- a/exir/backend/test/test_backends_lifted.py
+++ b/exir/backend/test/test_backends_lifted.py
@@ -627,9 +627,7 @@ class TestBackends(unittest.TestCase):
 
         traced = to_edge(
             export(composite_m, inputs, strict=True),
-            compile_config=exir.EdgeCompileConfig(
-                _check_ir_validity=False, _use_edge_ops=True
-            ),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
         )
 
         program_without_delegates = to_edge(
@@ -748,9 +746,7 @@ class TestBackends(unittest.TestCase):
 
         traced = to_edge(
             export(composite_m, inputs, strict=True),
-            compile_config=exir.EdgeCompileConfig(
-                _check_ir_validity=False, _use_edge_ops=True
-            ),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
         )
 
         program_without_delegates = to_edge(

--- a/exir/backend/test/test_debug_handle_map.py
+++ b/exir/backend/test/test_debug_handle_map.py
@@ -66,9 +66,7 @@ class TestBackendDebugHandle(unittest.TestCase):
             models.ModelWithUnusedArg(),
         ]
 
-        edge_compile_config = exir.EdgeCompileConfig(
-            _check_ir_validity=False, _use_edge_ops=True
-        )
+        edge_compile_config = exir.EdgeCompileConfig(_check_ir_validity=False)
 
         for model in module_list:
             model_inputs = model.get_random_inputs()

--- a/exir/backend/test/test_lowered_backend_module.py
+++ b/exir/backend/test/test_lowered_backend_module.py
@@ -78,9 +78,7 @@ class TestBackendAPI(unittest.TestCase):
         expected_res = sin_module(*model_inputs)
         edgeir_m = to_edge(
             export(sin_module, model_inputs, strict=True),
-            compile_config=exir.EdgeCompileConfig(
-                _check_ir_validity=False, _use_edge_ops=True
-            ),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
         )
         max_value = model_inputs[0].shape[0]
         compile_specs = [CompileSpec("max_value", bytes([max_value]))]
@@ -117,9 +115,7 @@ class TestBackendAPI(unittest.TestCase):
             models.ModelWithUnusedArg(),
         ]
 
-        edge_compile_config = exir.EdgeCompileConfig(
-            _check_ir_validity=False, _use_edge_ops=True
-        )
+        edge_compile_config = exir.EdgeCompileConfig(_check_ir_validity=False)
 
         for model in module_list:
             model_inputs = model.get_random_inputs()
@@ -170,9 +166,7 @@ class TestBackendAPI(unittest.TestCase):
             models.ModelWithUnusedArg(),
         ]
 
-        edge_compile_config = exir.EdgeCompileConfig(
-            _check_ir_validity=False, _use_edge_ops=True
-        )
+        edge_compile_config = exir.EdgeCompileConfig(_check_ir_validity=False)
 
         for model in module_list:
             model_inputs = model.get_random_inputs()

--- a/exir/emit/test/test_emit.py
+++ b/exir/emit/test/test_emit.py
@@ -2176,9 +2176,7 @@ class TestEmit(unittest.TestCase):
 
         edge_program_manager = exir.to_edge(
             {"forward1": ep1, "forward2": ep2},
-            compile_config=exir.EdgeCompileConfig(
-                _check_ir_validity=False, _use_edge_ops=True
-            ),
+            compile_config=exir.EdgeCompileConfig(_check_ir_validity=False),
         )
 
         edge_program_manager = edge_program_manager.to_backend(

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -1758,9 +1758,7 @@ class TestPasses(unittest.TestCase):
         # lower to edge dialect
         edge_prog = to_edge(
             aten_prog,
-            compile_config=EdgeCompileConfig(
-                _check_ir_validity=False, _use_edge_ops=True
-            ),
+            compile_config=EdgeCompileConfig(_check_ir_validity=False),
         )
         edge_prog = edge_prog.to_backend(XnnpackPartitioner())
 

--- a/exir/tests/test_quant_fusion_pass.py
+++ b/exir/tests/test_quant_fusion_pass.py
@@ -300,7 +300,6 @@ class TestQuantFusionPass(unittest.TestCase):
             m = _convert_to_reference_decomposed_fx(m)
             compile_config = EdgeCompileConfig(
                 _check_ir_validity=False,
-                _use_edge_ops=True,
             )
             m = to_edge(
                 export(m, example_inputs, strict=True), compile_config=compile_config
@@ -358,7 +357,6 @@ class TestQuantFusionPass(unittest.TestCase):
             m = _convert_to_reference_decomposed_fx(m)
             compile_config = EdgeCompileConfig(
                 _check_ir_validity=False,
-                _use_edge_ops=True,
             )
             m = to_edge(
                 export(m, example_inputs, strict=True), compile_config=compile_config
@@ -431,7 +429,6 @@ class TestQuantFusionPass(unittest.TestCase):
 
         compile_config = EdgeCompileConfig(
             _check_ir_validity=False,
-            _use_edge_ops=True,
         )
         m = to_edge(
             export(model, example_inputs, strict=True), compile_config=compile_config


### PR DESCRIPTION

In preparation for removing `_use_edge_ops` (see the TODO in `_config.py` for `EdgeCompileConfig`), this removes all explicit usages where `_use_edge_ops=True`, since that is already the default.


cc @larryliu0820 @JacobSzwejbka @lucylq