### PR TITLE
docs: fix broken Export IR spec link

### DIFF
--- a/docs/source/ir-exir.md
+++ b/docs/source/ir-exir.md
@@ -2,7 +2,7 @@
 
 Export IR is an intermediate representation (IR) for the result of
 `torch.export`. To read more on the details of Export IR, please read this
-[document](https://pytorch.org/docs/stable/export/ir_spec.html).
+[document](https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/export/ir_spec.html).
 
 The Exported IR is a specification that consists of the following parts:
 


### PR DESCRIPTION
The Export IR Specification page links to `pytorch.org/docs/stable/export/ir_spec.html`, which now dead-ends on a redirect — the page moved under `user_guide/torch_compiler/`. Updated to the current stable URL.

Fixes #20683

cc @mergennachin @nil-is-all @JacobSzwejbka @angelayi