### PR TITLE
[ExecuTorch][WebGPU] Test coverage for the f16 KV cache

### DIFF
--- a/backends/webgpu/test/test_webgpu_native.cpp
+++ b/backends/webgpu/test/test_webgpu_native.cpp
@@ -229,6 +229,15 @@ bool sdpa_within_tol(
     int n,
     float* ma,
     float* mr) {
+  float atol = 1e-4f, rtol = 1e-3f;
+#ifdef WGPU_BACKEND_KV_F16
+  // f16 KV opt-in: looser tol for f16 K/V read precision (shader-f16 device).
+  const WebGPUContext* kv_ctx = get_default_webgpu_context();
+  if (kv_ctx != nullptr && kv_ctx->shader_f16_supported) {
+    atol = 2e-3f;
+    rtol = 1e-2f;
+  }
+#endif
   float max_abs = 0.0f, max_rel = 0.0f;
   bool ok = true;
   for (int i = 0; i < n; i++) {
@@ -236,7 +245,7 @@ bool sdpa_within_tol(
     const float re = ae / std::max(std::abs(golden[i]), 1e-6f);
     max_abs = std::max(max_abs, ae);
     max_rel = std::max(max_rel, re);
-    if (ae > 1e-4f && re > 1e-3f) {
+    if (ae > atol && re > rtol) {
       ok = false;
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Tests for the opt-in f16 KV cache (stacked op diff). When built with `EXECUTORCH_WEBGPU_KV_F16` and run on a shader-f16 device, the SDPA op stores the K/V cache as f16, so the entire existing `sdpa_with_kv_cache` golden suite (config sweep + replay + dynamic decode) exercises the f16-KV path with no new goldens needed; this diff loosens the SDPA numeric tolerance to the f16 read-precision floor when — and only when — that path is active.

Key changes:

- `test_webgpu_native.cpp` `sdpa_within_tol` — under `#ifdef WGPU_BACKEND_KV_F16`, compare at abs `2e-3` / rel `1e-2` when the device negotiated shader-f16, else keep the strict f32 abs `1e-4` / rel `1e-3`. Every SDPA config/replay/decode golden then validates the f16-KV output through the existing exemplars.

Constraints: the default (flag-OFF) test build is unchanged; on a non-shader-f16 device (including the CI software adapter) the f16 KV path stays inactive and the strict f32 tolerance applies, so there is no CI behavior change. The f16-KV numeric validation is therefore shader-f16-device-only (Canary/Metal), matching the op's opt-in gating; no CI script change (mirrors the steel-f16 tests).

Co-authored-with: Claude Code.

Differential Revision: [D110919973](https://our.internmc.facebook.com/intern/diff/D110919973/)