### PR TITLE
Revert black bump to unbreak lintrunner on main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,10 @@ first_party_detection = false
 # Emit syntax compatible with older versions of python instead of only the range
 # specified by `requires-python`. TODO: Remove this once we support these older
 # versions of python and can expand the `requires-python` range.
-target-version = ["py38", "py39", "py310", "py311", "py312", "py313", "py314"]
+# py314 is intentionally omitted: black 24.4.2 does not recognize it, and the
+# newer black that does (>=26) reformats the whole repo. Add py314 here when the
+# tree is reformatted to the newer black stable style.
+target-version = ["py38", "py39", "py310", "py311", "py312", "py313"]
 
 [tool.docformatter]
 black = true

--- a/requirements-lintrunner.txt
+++ b/requirements-lintrunner.txt
@@ -9,7 +9,7 @@ pycodestyle==2.11.1
 torchfix==0.6.0
 
 # UFMT
-black==26.3.0
+black==24.4.2
 ufmt==2.8.0
 usort==1.0.8.post1
 


### PR DESCRIPTION
### Summary
#20452 raised black from 24.4.2 to 26.3.0 so it would accept "py314" in [tool.black] target-version. That two-year jump in black's stable style would reformat ~1900 tracked files, so lintrunner --all-files fails on main under the newer style.

Revert black to 24.4.2 and drop py314 from target-version, which is a formatting-only setting and does not affect running executorch on 3.14. The rest of #20452's 3.14 support (requires-python, classifiers, wheel matrices, setup.py) is unchanged.