### PR TITLE
Update references to Samsung/Exynos backend in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Deploy **LLMs, vision, speech, and multimodal models** with the same PyTorch API
 - **🔒 Native PyTorch Export** — Direct export from PyTorch. No .onnx, .tflite, or intermediate format conversions. Preserve model semantics.
 - **⚡ Production-Proven** — Powers billions of users at [Meta with real-time on-device inference](https://engineering.fb.com/2025/07/28/android/executorch-on-device-ml-meta-family-of-apps/).
 - **💾 Tiny Runtime** — 50KB base footprint. Runs on microcontrollers to high-end smartphones.
-- **🚀 [12+ Hardware Backends](https://docs.pytorch.org/executorch/main/backends-overview.html)** — Open-source acceleration for Apple, Qualcomm, ARM, MediaTek, Vulkan, and more.
+- **🚀 [12+ Hardware Backends](https://docs.pytorch.org/executorch/main/backends-overview.html)** — Open-source acceleration for Apple, Samsung, Qualcomm, ARM, MediaTek, Vulkan, and more.
 - **🎯 One Export, Multiple Backends** — Switch hardware targets with a single line change. Deploy the same model everywhere.
 
 ## How It Works

--- a/docs/source/backends-overview.md
+++ b/docs/source/backends-overview.md
@@ -33,7 +33,7 @@ Backends are the bridge between your exported model and the hardware it runs on.
 | [OpenVINO](build-run-openvino)                               | Embedded    | CPU/GPU/NPU   | Intel SoCs                      |
 | [NXP](backends/nxp/nxp-overview.md)                          | Embedded    | NPU           | NXP SoCs                        |
 | [Cadence](backends-cadence)                                  | Embedded    | DSP           | DSP-optimized workloads         |
-| [Samsung Exynos](backends/samsung/samsung-overview.md)       | Android     | NPU           | Samsung SoCs                    |
+| [Samsung Exynos](backends/samsung/samsung-overview.md)       | Android     | CPU/GPU/NPU   | Samsung Devices, Samsung SoCs; High Performance |
 
 **Tip:** For best performance, export a `.pte` file for each backend you plan to support.
 


### PR DESCRIPTION

Summary: Refresh the Samsung Exynos backend references in the docs.

- README.md 'Why ExecuTorch?' section: add Samsung to the list of
  hardware backends alongside Apple, Qualcomm, ARM, MediaTek, Vulkan.
- backends-overview.md: update the Samsung Exynos row's Hardware Type
  to CPU/GPU/NPU and Typical Use Case to note Samsung Devices, Samsung
  SoCs, and High Performance.

Test Plan: Docs-only change; rendered tables and README preview verified.

Reviewers:

Subscribers:

Tasks:

Tags:
