### PR TITLE
Fix CUDA CI: HF writes fail on read-only /mnt/hf_cache (HF_TOKEN + writable HF_HOME)

### DIFF
--- a/.github/workflows/cuda-perf.yml
+++ b/.github/workflows/cuda-perf.yml
@@ -145,8 +145,10 @@ jobs:
       script: |
         set -eux
 
-        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect to a writable dir
+        # (RUNNER_TEMP, or /tmp when RUNNER_TEMP isn't writable inside the container).
         export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}" 2>/dev/null || export HF_HOME=/tmp/hf_cache
         mkdir -p "${HF_HOME}"
 
         echo "::group::Setup ExecuTorch"
@@ -224,8 +226,10 @@ jobs:
       script: |
         set -eux
 
-        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect to a writable dir
+        # (RUNNER_TEMP, or /tmp when RUNNER_TEMP isn't writable inside the container).
         export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}" 2>/dev/null || export HF_HOME=/tmp/hf_cache
         mkdir -p "${HF_HOME}"
 
         echo "::group::Setup environment"

--- a/.github/workflows/cuda-perf.yml
+++ b/.github/workflows/cuda-perf.yml
@@ -223,6 +223,11 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         set -eux
+
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}"
+
         echo "::group::Setup environment"
         # OSDC runners can't reach the public PyPI CDN that download.pytorch.org's
         # transitive deps resolve to. Pre-install torch's pure-python deps from the

--- a/.github/workflows/cuda-perf.yml
+++ b/.github/workflows/cuda-perf.yml
@@ -160,8 +160,7 @@ jobs:
 
         echo "::group::Setup Huggingface"
         pip install -U "huggingface_hub[cli]>=1.2.1,<2.0" accelerate "optimum~=2.0.0" "transformers==5.0.0rc1"
-        HF_AUTH_TOKEN="$(printf '%s' "$SECRET_EXECUTORCH_HF_TOKEN" | tr -d '\r\n')"
-        hf auth login --token "$HF_AUTH_TOKEN"
+        export HF_TOKEN="$(printf '%s' "$SECRET_EXECUTORCH_HF_TOKEN" | tr -d '\r\n')"
         OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
         pip install --no-deps git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}
         echo "::endgroup::"

--- a/.github/workflows/cuda-perf.yml
+++ b/.github/workflows/cuda-perf.yml
@@ -144,6 +144,11 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         set -eux
+
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}"
+
         echo "::group::Setup ExecuTorch"
         # OSDC runners can't reach the public PyPI CDN that download.pytorch.org's
         # transitive deps resolve to. Pre-install torch's pure-python deps from the

--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -126,8 +126,7 @@ jobs:
         if [ "${{ matrix.model_name }}" != "dinov2-small-imagenet1k-1-layer" ]; then
           echo "::group::Setup Huggingface"
           pip install -U "huggingface_hub[cli]>=1.2.1,<2.0" accelerate "optimum~=2.0.0" "transformers==5.0.0rc1"
-          HF_AUTH_TOKEN="$(printf '%s' "$SECRET_EXECUTORCH_HF_TOKEN" | tr -d '\r\n')"
-          hf auth login --token "$HF_AUTH_TOKEN"
+          export HF_TOKEN="$(printf '%s' "$SECRET_EXECUTORCH_HF_TOKEN" | tr -d '\r\n')"
           OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
           pip install --no-deps git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}
           echo "::endgroup::"

--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -99,6 +99,10 @@ jobs:
       script: |
         set -eux
 
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}"
+
         echo "::group::Fix libstdc++ GLIBCXX version"
         # The executorch pybindings require GLIBCXX_3.4.30 which conda's libstdc++ doesn't have.
         # Replace conda's libstdc++ with the system version to fix ImportError.

--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -99,8 +99,10 @@ jobs:
       script: |
         set -eux
 
-        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect to a writable dir
+        # (RUNNER_TEMP, or /tmp when RUNNER_TEMP isn't writable inside the container).
         export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}" 2>/dev/null || export HF_HOME=/tmp/hf_cache
         mkdir -p "${HF_HOME}"
 
         echo "::group::Fix libstdc++ GLIBCXX version"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -557,6 +557,9 @@ jobs:
         # fsspec is pinned to satisfy datasets' fsspec[http]<=2025.3.0 so the later
         # examples install doesn't try to downgrade it from the public CDN.
         pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 "fsspec[http]<=2025.3.0" numpy pillow
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}"
         source .ci/scripts/test_model_e2e.sh cuda "${{ matrix.model.repo }}/${{ matrix.model.name }}" "${{ matrix.quant }}" "${RUNNER_ARTIFACT_DIR}"
 
   test-cuda-pybind:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -388,8 +388,10 @@ jobs:
       script: |
         set -eux
 
-        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect to a writable dir
+        # (RUNNER_TEMP, or /tmp when RUNNER_TEMP isn't writable inside the container).
         export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}" 2>/dev/null || export HF_HOME=/tmp/hf_cache
         mkdir -p "${HF_HOME}"
 
         echo "::group::Setup ExecuTorch"
@@ -557,8 +559,10 @@ jobs:
         # fsspec is pinned to satisfy datasets' fsspec[http]<=2025.3.0 so the later
         # examples install doesn't try to downgrade it from the public CDN.
         pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 "fsspec[http]<=2025.3.0" numpy pillow
-        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect to a writable dir
+        # (RUNNER_TEMP, or /tmp when RUNNER_TEMP isn't writable inside the container).
         export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}" 2>/dev/null || export HF_HOME=/tmp/hf_cache
         mkdir -p "${HF_HOME}"
         source .ci/scripts/test_model_e2e.sh cuda "${{ matrix.model.repo }}/${{ matrix.model.name }}" "${{ matrix.quant }}" "${RUNNER_ARTIFACT_DIR}"
 
@@ -611,8 +615,10 @@ jobs:
       script: |
         set -eux
 
-        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect to a writable dir
+        # (RUNNER_TEMP, or /tmp when RUNNER_TEMP isn't writable inside the container).
         export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}" 2>/dev/null || export HF_HOME=/tmp/hf_cache
         mkdir -p "${HF_HOME}"
 
         echo "::group::Setup ExecuTorch"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -406,8 +406,7 @@ jobs:
         if [ "${{ matrix.model.name }}" != "parakeet-tdt" ] && [ "${{ matrix.model.name }}" != "dinov2-small-imagenet1k-1-layer" ]; then
           echo "::group::Setup Huggingface"
           pip install -U "huggingface_hub[cli]>=1.2.1,<2.0" accelerate "optimum~=2.0.0" "transformers==5.0.0rc1"
-          HF_AUTH_TOKEN="$(printf '%s' "$SECRET_EXECUTORCH_HF_TOKEN" | tr -d '\r\n')"
-          hf auth login --token "$HF_AUTH_TOKEN"
+          export HF_TOKEN="$(printf '%s' "$SECRET_EXECUTORCH_HF_TOKEN" | tr -d '\r\n')"
           OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
           pip install --no-deps git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}
           echo "::endgroup::"
@@ -626,8 +625,7 @@ jobs:
 
         echo "::group::Setup Huggingface"
         pip install -U "huggingface_hub[cli]>=1.2.1,<2.0"
-        HF_AUTH_TOKEN="$(printf '%s' "$SECRET_EXECUTORCH_HF_TOKEN" | tr -d '\r\n')"
-        hf auth login --token "$HF_AUTH_TOKEN"
+        export HF_TOKEN="$(printf '%s' "$SECRET_EXECUTORCH_HF_TOKEN" | tr -d '\r\n')"
         echo "::endgroup::"
 
         echo "::group::Install optimum-executorch"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -388,6 +388,10 @@ jobs:
       script: |
         set -eux
 
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}"
+
         echo "::group::Setup ExecuTorch"
         # OSDC runners can't reach the public PyPI CDN that download.pytorch.org's
         # transitive deps resolve to. Pre-install torch's pure-python deps from the
@@ -603,6 +607,10 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         set -eux
+
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect it to a writable dir.
+        export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}"
 
         echo "::group::Setup ExecuTorch"
         # Disable MKL to avoid duplicate target error when conda has multiple MKL installations


### PR DESCRIPTION
## Summary
Since **pytorch/pytorch#188654** (landed **2026-07-03**), the OSDC runner fleet mounts a shared, **read-only** HuggingFace cache at `/mnt/hf_cache` and defaults `HF_HOME` to it (to share a pre-seeded, S3-backed model cache). executorch's CUDA jobs were never adapted, so every HF **write** now lands on the read-only mount and fails:

```
OSError: [Errno 30] Read-only file system: '/mnt/hf_cache/...'
```

This broke the CUDA CI (`export-model-cuda-artifact`, `benchmark-cuda`, `export-model-cuda-windows-artifact`, `test-cuda-pybind`) starting Jul 3. pytorch/pytorch updated its own workflows in the same PR (use the read-only mount only in `TRANSFORMERS_OFFLINE` mode, otherwise download into a writable `${RUNNER_TEMP}/hf_cache`); this PR does the equivalent for executorch.

