### PR TITLE
Guard node.graph.owning_module against None for mypy

### DIFF
--- a/backends/arm/_passes/arm_pass_utils.py
+++ b/backends/arm/_passes/arm_pass_utils.py
@@ -43,8 +43,11 @@ _Dim = int | torch.SymInt
 def is_submodule_node(node: torch.fx.Node):
     if node.op not in ("get_attr", "placeholder"):
         return False
+    owning_module = node.graph.owning_module
+    if owning_module is None or not isinstance(node.target, str):
+        return False
     try:
-        node.graph.owning_module.get_submodule(node.target)
+        owning_module.get_submodule(node.target)
     except AttributeError:
         return False
     return True

--- a/backends/cortex_m/quantizer/pattern_matcher.py
+++ b/backends/cortex_m/quantizer/pattern_matcher.py
@@ -69,7 +69,10 @@ class PatternMatcher:
             return PatternMatchResult(match, False, self.REJECT_PREVIOUSLY_ANNOTATED)
 
         # Reject match if it contains a node that has an input which is too large to be quantized
-        if any(_is_large_scalar(node, node.graph.owning_module) for node in match):
+        owning_module = match[0].graph.owning_module if match else None
+        if owning_module is not None and any(
+            _is_large_scalar(node, owning_module) for node in match
+        ):
             return PatternMatchResult(match, False, self.REJECT_LARGE_SCALAR)
 
         if all(node.op in ("placeholder", "output") for node in match):


### PR DESCRIPTION
### Summary
torch 2.13.0 types torch.fx.Graph.owning_module as Optional[GraphModule], which surfaced two latent lintrunner-mypy errors on unchanged code. The lint job installs torch unpinned, so this began failing on trunk once a run resolved a torchvision compatible with torch 2.13.0 (earlier runs were silently downgraded to 2.12.1, masking the errors).

Guard owning_module for None (and narrow node.target to str in the arm pass) before use. This also hardens both call sites against a genuinely absent owning module at runtime.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell