### PR TITLE
rename TARGETS-only fbcode dirs with rules to BUCK (xplat-safe) (#20793)

### DIFF
--- a/backends/aoti/passes/BUCK
+++ b/backends/aoti/passes/BUCK
@@ -1,11 +1,13 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "passes",
     srcs = [
-      "replace_view_copy_with_view.py",
+        "replace_view_copy_with_view.py",
     ],
     visibility = [
         "//executorch/...",

--- a/backends/arm/BUCK
+++ b/backends/arm/BUCK
@@ -4,9 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 
 # @noautodeps
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "constants",
     srcs = [
         "constants.py",
@@ -15,7 +17,8 @@ runtime.python_library(
         "//executorch/exir/dialects:lib",
     ],
 )
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "ao_ext",
     srcs = glob([
         "ao_ext/*.py",
@@ -28,7 +31,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "lib",
     srcs = [
         "__init__.py",
@@ -40,7 +44,8 @@ runtime.python_library(
         "//executorch/backends/arm/quantizer:lib",
     ],
 )
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "common",
     srcs = glob(["common/*.py"]),
     deps = [
@@ -50,7 +55,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "arm_compile_spec",
     srcs = [
         "common/arm_compile_spec.py",
@@ -67,7 +73,8 @@ runtime.python_library(
         "//executorch/backends/arm/_passes:passes",
     ],
 )
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "ethosu",
     srcs = [
         "ethosu/__init__.py",
@@ -83,7 +90,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "vgf",
     srcs = [
         "vgf/__init__.py",
@@ -120,7 +128,8 @@ runtime.python_library(
         "//executorch/exir:lib",
     ],
 )
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "public_api",
     srcs = ["__init__.py"],
     deps = [
@@ -130,7 +139,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "process_node",
     srcs = ["process_node.py"],
     deps = [
@@ -142,7 +152,8 @@ runtime.python_library(
         "//executorch/exir:lib",
     ],
 )
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "arm_vela",
     srcs = [
         "arm_vela.py",
@@ -151,7 +162,8 @@ runtime.python_library(
         "fbsource//third-party/pypi/ethos-u-vela:ethos-u-vela",
     ],
 )
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "arm_model_evaluator",
     srcs = [
         "util/arm_model_evaluator.py",
@@ -160,7 +172,8 @@ runtime.python_library(
         "//caffe2:torch",
     ]
 )
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "_factory",
     srcs = [
         "util/_factory.py"

--- a/backends/arm/_passes/BUCK
+++ b/backends/arm/_passes/BUCK
@@ -1,6 +1,8 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "core",
     srcs = [
         "arm_pass.py",
@@ -17,7 +19,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "arm_pass_manager_base",
     srcs = ["arm_pass_manager.py"],
     deps = [
@@ -32,7 +35,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "arm_pass_manager_fb",
     srcs = [],
     deps = [
@@ -41,7 +45,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "passes",
     srcs = glob(["*.py"], exclude = [
         "arm_pass.py",

--- a/backends/arm/debug/BUCK
+++ b/backends/arm/debug/BUCK
@@ -1,7 +1,9 @@
 # @noautodeps
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "schema",
     srcs = [
         "__init__.py",

--- a/backends/arm/operator_support/BUCK
+++ b/backends/arm/operator_support/BUCK
@@ -1,6 +1,8 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "operator_support",
     srcs = glob(["*.py"]),
     deps = [

--- a/backends/arm/operators/BUCK
+++ b/backends/arm/operators/BUCK
@@ -1,7 +1,9 @@
 # @noautodeps
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "node_visitor",
     srcs = [
         "node_visitor.py",
@@ -15,12 +17,14 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "operator_validation_utils",
     srcs = ["operator_validation_utils.py"],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "ops",
     srcs = glob(["op_*.py", "ops_*.py"]),
     deps = [
@@ -34,7 +38,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "lib",
     srcs = ["__init__.py"],
     deps = [

--- a/backends/arm/quantizer/BUCK
+++ b/backends/arm/quantizer/BUCK
@@ -1,7 +1,9 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 # Exposed through __init__.py
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "quantization_config",
     srcs = ["quantization_config.py"],
     deps = [
@@ -10,7 +12,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "arm_quantizer",
     srcs = ["arm_quantizer.py"],
     deps = [
@@ -29,7 +32,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "quantization_annotator",
     srcs = ["quantization_annotator.py"],
     deps = [
@@ -40,7 +44,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "arm_quantizer_utils",
     srcs = ["arm_quantizer_utils.py"],
     deps = [
@@ -52,7 +57,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "quantizer_support",
     srcs = ["quantizer_support.py"],
     deps = [
@@ -62,7 +68,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "lib",
     srcs = ["__init__.py"],
     deps = [

--- a/backends/cuda/BUCK
+++ b/backends/cuda/BUCK
@@ -1,8 +1,10 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "coalesced_int4_tensor",
     srcs = [
         "coalesced_int4_tensor.py",
@@ -16,7 +18,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "dp4a_planar_int5_tensor",
     srcs = [
         "dp4a_planar_int5_tensor.py",
@@ -30,7 +33,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "dp4a_planar_int6_tensor",
     srcs = [
         "dp4a_planar_int6_tensor.py",
@@ -44,7 +48,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "quantize_op_dispatch",
     srcs = [
         "quantize_op_dispatch/__init__.py",
@@ -66,7 +71,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "cuda_passes",
     srcs = [
         "passes/__init__.py",
@@ -82,7 +88,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "cuda_backend",
     srcs = [
         "cuda_backend.py",
@@ -102,7 +109,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "cuda_partitioner",
     srcs = [
         "cuda_partitioner.py",
@@ -116,7 +124,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "triton_kernels",
     srcs = [
         "triton/kernels/__init__.py",
@@ -134,7 +143,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "triton_replacement_pass",
     srcs = [
         "triton/__init__.py",

--- a/backends/mediatek/quantizer/BUCK
+++ b/backends/mediatek/quantizer/BUCK
@@ -1,6 +1,8 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "quantizer",
     srcs = [
         "__init__.py",

--- a/backends/qualcomm/debugger/BUCK
+++ b/backends/qualcomm/debugger/BUCK
@@ -1,6 +1,8 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "utils",
     srcs = ["utils.py"],
     deps = [
@@ -11,7 +13,8 @@ runtime.python_library(
     ]
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "qnn_intermediate_debugger",
     srcs = [
         "format_outputs.py",

--- a/backends/xnnpack/partition/config/BUCK
+++ b/backends/xnnpack/partition/config/BUCK
@@ -1,8 +1,10 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "xnnpack_partitioner_configs",
     srcs = glob([
         "*.py",

--- a/backends/xnnpack/quantizer/BUCK
+++ b/backends/xnnpack/quantizer/BUCK
@@ -1,6 +1,8 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "xnnpack_quantizer",
     srcs = ["xnnpack_quantizer.py"],
     deps = [
@@ -11,7 +13,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "xnnpack_quantizer_utils",
     srcs = ["xnnpack_quantizer_utils.py"],
     deps = [

--- a/backends/xnnpack/recipes/BUCK
+++ b/backends/xnnpack/recipes/BUCK
@@ -1,8 +1,10 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "xnnpack_recipes",
     srcs = [
         "__init__.py",
@@ -15,7 +17,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "xnnpack_recipe_provider",
     srcs = [
         "xnnpack_recipe_provider.py",
@@ -31,7 +34,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "xnnpack_recipe_types",
     srcs = [
         "xnnpack_recipe_types.py",

--- a/devtools/BUCK
+++ b/devtools/BUCK
@@ -1,8 +1,10 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "lib",
     srcs = ["__init__.py"],
     deps = [

--- a/devtools/backend_debug/BUCK
+++ b/devtools/backend_debug/BUCK
@@ -1,8 +1,10 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "delegation_info",
     srcs = [
         "__init__.py",

--- a/devtools/inspector/numerical_comparator/BUCK
+++ b/devtools/inspector/numerical_comparator/BUCK
@@ -1,15 +1,18 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "numerical_comparator_base",
     srcs = ["numerical_comparator_base.py"],
     deps = [],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "l1_numerical_comparator",
     srcs = ["l1_numerical_comparator.py"],
     deps = [
@@ -18,7 +21,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "mse_numerical_comparator",
     srcs = ["mse_numerical_comparator.py"],
     deps = [
@@ -27,7 +31,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "snr_numerical_comparator",
     srcs = ["snr_numerical_comparator.py"],
     deps = [
@@ -36,7 +41,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "lib",
     srcs = ["__init__.py"],
     deps = [

--- a/devtools/intermediate_output_tap/BUCK
+++ b/devtools/intermediate_output_tap/BUCK
@@ -1,13 +1,16 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "spec",
     srcs = ["_spec.py"],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "custom_ops_lib",
     srcs = ["custom_ops_lib.py"],
     deps = [
@@ -15,7 +18,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "selectors",
     srcs = ["_selectors.py"],
     deps = [
@@ -23,7 +27,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "reducers",
     srcs = ["_reducers.py"],
     deps = [
@@ -32,7 +37,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "tap_pass",
     srcs = ["_tap_pass.py"],
     deps = [
@@ -44,7 +50,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "strip_pass",
     srcs = ["_strip_pass.py"],
     deps = [
@@ -54,7 +61,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "convenience",
     srcs = ["_convenience.py"],
     deps = [
@@ -70,7 +78,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "lib",
     srcs = ["__init__.py"],
     deps = [

--- a/devtools/visualization/BUCK
+++ b/devtools/visualization/BUCK
@@ -1,10 +1,12 @@
 # Any targets that should be shared between fbcode and xplat must be defined in
 # targets.bzl. This file can contain fbcode-only targets.
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "visualization",
     srcs = [
         "__init__.py",
@@ -18,7 +20,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "test",
     srcs = [
         "visualization_utils_test.py",

--- a/examples/models/gemma/BUCK
+++ b/examples/models/gemma/BUCK
@@ -1,0 +1,25 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+oncall("executorch")
+
+fbcode_target(
+    _kind = runtime.python_library,
+    name = "gemma",
+    srcs = [
+        "__init__.py",
+        "convert_weights.py",
+    ],
+    _is_external_target = True,
+    base_module = "executorch.examples.models.gemma",
+    resources = {
+        "config/2b_config.json": "config/2b_config.json",
+    },
+    deps = [
+        "//caffe2:torch",
+        "//executorch/examples/models/llama:llama2_model",
+        "fbcode//pytorch/torchtune:lib",
+        "fbsource//third-party/pypi/safetensors:safetensors",
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/examples/models/gemma2/BUCK
+++ b/examples/models/gemma2/BUCK
@@ -1,0 +1,25 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+oncall("executorch")
+
+fbcode_target(
+    _kind = runtime.python_library,
+    name = "gemma2",
+    srcs = [
+        "__init__.py",
+        "convert_weights.py",
+    ],
+    _is_external_target = True,
+    base_module = "executorch.examples.models.gemma2",
+    resources = {
+        "config/2b_config.json": "config/2b_config.json",
+    },
+    deps = [
+        "//caffe2:torch",
+        "//executorch/examples/models/llama:llama2_model",
+        "fbcode//pytorch/torchtune:lib",
+        "fbsource//third-party/pypi/safetensors:safetensors",
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/examples/models/llama/params/BUCK
+++ b/examples/models/llama/params/BUCK
@@ -1,8 +1,10 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.filegroup(
+fbcode_target(
+    _kind = runtime.filegroup,
     name = "params",
     srcs = [
         "demo_config.json",

--- a/export/BUCK
+++ b/export/BUCK
@@ -1,8 +1,10 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "recipe",
     srcs = [
         "recipe.py",
@@ -16,7 +18,8 @@ runtime.python_library(
     ]
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "export",
     srcs = [
         "export.py",
@@ -31,7 +34,8 @@ runtime.python_library(
 )
 
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "stages",
     srcs = [
         "stages.py",
@@ -49,7 +53,8 @@ runtime.python_library(
 )
 
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "lib",
     srcs = [
         "__init__.py",
@@ -65,7 +70,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "recipe_registry",
     srcs = [
         "recipe_registry.py",
@@ -78,7 +84,8 @@ runtime.python_library(
 )
 
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "recipe_provider",
     srcs = [
         "recipe_provider.py",
@@ -88,14 +95,16 @@ runtime.python_library(
     ]
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "types",
     srcs = [
         "types.py",
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "target_recipes",
     srcs = [
         "target_recipes.py",
@@ -110,7 +119,8 @@ runtime.python_library(
     ]
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "export_utils",
     srcs = ["utils.py"],
     deps = [

--- a/export/tests/BUCK
+++ b/export/tests/BUCK
@@ -1,9 +1,11 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load("@fbsource//xplat/executorch/backends/qualcomm/qnn_version.bzl", "get_qnn_library_version")
 
 oncall("executorch")
 
-runtime.python_test(
+fbcode_target(
+    _kind = runtime.python_test,
     name = "executorch_export",
     srcs = [
         "test_executorch_export.py",
@@ -16,7 +18,8 @@ runtime.python_test(
     ]
 )
 
-runtime.python_test(
+fbcode_target(
+    _kind = runtime.python_test,
     name = "test_executorch_export",
     srcs = [
         "test_recipe_provider.py",
@@ -33,7 +36,8 @@ runtime.python_test(
     ]
 )
 
-runtime.python_test(
+fbcode_target(
+    _kind = runtime.python_test,
     name = "test_target_recipes",
     srcs = [
         "test_target_recipes.py",

--- a/extension/pybindings/test/BUCK
+++ b/extension/pybindings/test/BUCK
@@ -1,8 +1,10 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     # autodeps has a real hard time tracking the owner of the pybindings
     # from portable and the suggested fixes I could find didnt work, so
     # just disabling for now
@@ -30,7 +32,8 @@ runtime.python_library(
     ],
 )
 
-runtime.python_test(
+fbcode_target(
+    _kind = runtime.python_test,
     name = "test_pybindings_portable_lib",
     srcs = ["test_pybindings.py"],
     preload_deps = ["//executorch/kernels/quantized:aot_lib"],
@@ -40,7 +43,8 @@ runtime.python_test(
     ],
 )
 
-runtime.python_test(
+fbcode_target(
+    _kind = runtime.python_test,
     name = "test_pybindings_aten_lib",
     srcs = ["test_pybindings.py"],
     preload_deps = ["//executorch/kernels/quantized:aot_lib"],
@@ -51,7 +55,8 @@ runtime.python_test(
     ],
 )
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "test_pybindings_lib",
     srcs = ["test_pybindings.py"],
     deps = [
@@ -60,7 +65,8 @@ runtime.python_library(
 )
 
 
-runtime.python_test(
+fbcode_target(
+    _kind = runtime.python_test,
     name = "test_backend_pybinding",
     srcs = ["test_backend_pybinding.py"],
     deps = [

--- a/runtime/BUCK
+++ b/runtime/BUCK
@@ -1,8 +1,10 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 oncall("executorch")
 
-runtime.python_library(
+fbcode_target(
+    _kind = runtime.python_library,
     name = "runtime",
     srcs = ["__init__.py"],
     deps = [


### PR DESCRIPTION
Summary:

Chunk 5 of fbcode/executorch TARGETS->BUCK migration. 26 directories that
had only a TARGETS file (no sister BUCK) and define real top-level rules.
Each TARGETS was scanned for fbcode-only constructs (`fbcode_macros`,
`fbcode_target(`, `cpp_unittest(`, `cpp_library(`, `cpp_binary(`,
`re_test_utils`, `keep_gpu_sections`, `buck_genrule`, `//tools/build/buck/`)
and only those without any are migrated here. The `runtime.*` macros they
use are routed by runtime_wrapper.bzl to the right cell-native rule.

Renaming TARGETS -> BUCK exposes these directories to xplat via dirsync.

4 dirs were attempted but reverted because their `runtime.python_binary`
kwargs (e.g. `main_src`) are accepted by fbcode_macros' python_binary but
not by xplat's. They need a small targets.bzl tweak before they can land:
  - devtools/inspector
  - examples/devtools/scripts
  - extension/pybindings/fb/test
  - runtime/test

Reviewed By: mzlee

Differential Revision: D109082056
