### PR TITLE
Update XNNPACK usage in Vulkan reference tests

### DIFF
--- a/backends/vulkan/test/op_tests/conv2d_gemm_dynamic_test.cpp
+++ b/backends/vulkan/test/op_tests/conv2d_gemm_dynamic_test.cpp
@@ -247,7 +247,6 @@ std::vector<float> conv2d_ref_xnnpack(
       out_min,
       out_max,
       /*flags=*/0,
-      /*code_cache=*/nullptr,
       /*weights_cache=*/nullptr,
       &op);
   if (create_status != xnn_status_success || op == nullptr) {
@@ -258,7 +257,7 @@ std::vector<float> conv2d_ref_xnnpack(
   }
 
   size_t workspace_size = 0;
-  size_t workspace_alignment = 0;
+  const size_t workspace_alignment = 128;
   size_t out_h = 0;
   size_t out_w = 0;
   const xnn_status reshape_status = xnn_reshape_convolution2d_nhwc_f32(
@@ -267,7 +266,6 @@ std::vector<float> conv2d_ref_xnnpack(
       static_cast<size_t>(H_in),
       static_cast<size_t>(W_in),
       &workspace_size,
-      &workspace_alignment,
       &out_h,
       &out_w,
       /*threadpool=*/nullptr);


### PR DESCRIPTION
Summary: Fix an XNNPACK call site in Vulkan tests (used as a reference) that broke when updating the version.

Differential Revision: D111139443




cc @SS-JIA @manuelcandales @digantdesai @cbilgin