### PR TITLE
Qualcomm AI Engine Direct - Add QNN Windows MSVC Build to CI

### DIFF
--- a/.ci/scripts/build-qnn-windows-msvc.ps1
+++ b/.ci/scripts/build-qnn-windows-msvc.ps1
@@ -1,0 +1,70 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+$ErrorActionPreference = "Stop"
+
+conda create --yes --quiet -n et python=3.12
+conda activate et
+
+# Install CI requirements
+pip install -r .ci/docker/requirements-ci.txt
+
+# Provision the QNN SDK
+if ($env:QNN_SDK_ROOT -and (Test-Path -Path $env:QNN_SDK_ROOT)) {
+    Write-Host "Using existing QNN SDK at $env:QNN_SDK_ROOT"
+} else {
+    # Resolve the QNN_VERSION and QNN_ZIP_URL
+    $qnnInfo = python -c "import sys; sys.path.insert(0, r'backends\qualcomm\scripts'); import download_qnn_sdk as d; print(d.QNN_VERSION); print(d.QNN_ZIP_URL)"
+    if ($LASTEXITCODE -ne 0 -or $qnnInfo.Count -lt 2) {
+        Write-Error "Failed to read QNN_VERSION and QNN_ZIP_URL from download_qnn_sdk.py."
+        exit 1
+    }
+    $qnnVersion = $qnnInfo[0].Trim()
+    $qnnZipUrl  = $qnnInfo[1].Trim()
+
+    $qnnInstallDir = Join-Path $env:TEMP "qnn"
+    New-Item -Path $qnnInstallDir -ItemType Directory -Force | Out-Null
+    $qnnZip = Join-Path $env:TEMP "qnn_sdk.zip"
+    Write-Host "Downloading QNN SDK v$qnnVersion ..."
+    $ProgressPreference = "SilentlyContinue"
+    Invoke-WebRequest -Uri $qnnZipUrl -OutFile $qnnZip
+    Write-Host "Extracting QNN SDK ..."
+    Expand-Archive -Path $qnnZip -DestinationPath $qnnInstallDir -Force
+    Remove-Item -Path $qnnZip -Force
+
+    $env:QNN_SDK_ROOT = Join-Path $qnnInstallDir "qairt\$qnnVersion"
+    Write-Host "Set QNN_SDK_ROOT=$env:QNN_SDK_ROOT"
+}
+
+if (-not (Test-Path -Path (Join-Path $env:QNN_SDK_ROOT "include\QNN"))) {
+    Write-Error "QNN SDK layout unexpected: missing include\QNN under $env:QNN_SDK_ROOT"
+    exit 1
+}
+
+# Test x86_64 Windows host build
+.\backends\qualcomm\scripts\build.ps1 -SkipArm64Windows -Release
+
+$x86Artifacts = @(
+    "build-x86_64-windows\backends\qualcomm\Release\PyQnnManagerAdaptor*.pyd",
+    "build-x86_64-windows\backends\qualcomm\Release\qnn_executorch_backend.dll",
+    "build-x86_64-windows\examples\qualcomm\executor_runner\Release\qnn_executor_runner.exe"
+)
+foreach ($artifact in $x86Artifacts) {
+    if (-not (Get-ChildItem -Path $artifact -ErrorAction SilentlyContinue)) {
+        Write-Error "ERROR: x86_64 artifact not found: $artifact"
+        exit 1
+    }
+}
+
+# The ARM64 MSVC toolchain is currently not installed in the Windows CI
+# environment. Enabling this build configuration results in build failures
+# due to the missing ARM64 platform definition.
+# `.\backends\qualcomm\scripts\build.ps1 -SkipX86Windows -Release`
+#
+# Temporarily disable this build option until ARM64 MSVC support is available
+# in CI. The configuration can be re-enabled in a future update.
+
+Write-Host "PASSED: QNN backend Windows MSVC build completed"

--- a/.github/workflows/qnn-windows-msvc.yml
+++ b/.github/workflows/qnn-windows-msvc.yml
@@ -1,0 +1,74 @@
+name: Test QNN Windows MSVC build
+
+# Changes to backends/qualcomm/, top-level CMake files, extension/,
+# examples/, runtime/, and other shared infrastructure can affect
+# the QNN Windows MSVC build. Rather than maintaining a fragile list
+# of relevant path filters, this workflow runs on every PR to ensure
+# build coverage.
+#
+# Reasons for keeping qnn-windows-msvc.yml separate from test-backend-qnn.yml:
+#
+# - Two workflows are triggered by different tags.
+#   - test-backend-qnn.yml runs under ciflow/nightly/*.
+#   - qnn-windows-msvc.yml runs under ciflow/trunk/*.
+#   Merging them would introduce the behavior change to the existing flow.
+#
+# - Workflow reruns are more efficient when they remain separate.
+#   A Windows-only failure would still require rerunning jobs in test-backend-qnn.yml
+#   if they are combined into a single workflow, resulting in unnecessary CI
+#   resource consumption (and vice versa).
+#
+# - Failure signals are clearer when the workflows are isolated.
+#   With a combined workflow, additional inspection of the job list would be required to
+#   identify the root cause of a failing status. Keeping the workflows separate provides
+#   distinct top-level CI statuses, making the failure domain immediately obvious.
+#
+# For now, qnn-windows-msvc.yml should remain separate from trunk.yml and pull.yml:
+#
+# - trunk.yml is only triggered for PRs that modify files matching:
+#     - .ci/docker/ci_commit_pins/pytorch.txt
+#     - .ci/scripts/**
+#     - zephyr/**
+#   As a result, trunk.yml would not run for PRs that touch backends/qualcomm/**.
+#
+# - pull.yml runs on every PR without path filters, but currently contains only
+#   Linux jobs. Keeping qnn-windows-msvc.yml as a standalone workflow provides
+#   independent status visibility and more efficient reruns for QNN Windows build.
+#
+# Once the QNN Windows CI path has demonstrated sufficient stability, we can revisit
+# whether it makes sense to consolidate qnn-windows-msvc.yml into pull.yml.
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+    tags:
+      - ciflow/trunk/*
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-qnn-windows-msvc:
+    name: build-qnn-windows-msvc
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    with:
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        git config --global http.sslBackend openssl
+        git submodule update --init --recursive
+        conda init powershell
+        powershell -Command "& {
+          Set-PSDebug -Trace 1
+          \$ErrorActionPreference = 'Stop'
+          \$PSNativeCommandUseErrorActionPreference = \$true
+          .ci/scripts/build-qnn-windows-msvc.ps1
+        }"

--- a/backends/qualcomm/runtime/backends/QnnBackendUnifiedRegistry.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendUnifiedRegistry.cpp
@@ -16,6 +16,8 @@
 #include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiBackend.h>
 #include <executorch/backends/qualcomm/runtime/backends/lpai/LpaiDevice.h>
 
+#include <pal/Path.h>
+
 #include <string>
 
 namespace executorch {
@@ -154,7 +156,8 @@ Error QnnBackendUnifiedRegistry::GetOrCreateBackendBundle(
   }
   // 5. Create QnnSystemImplementation and load qnn library
   std::unique_ptr<QnnSystemImplementation> system_implementation =
-      std::make_unique<QnnSystemImplementation>("libQnnSystem.so");
+      std::make_unique<QnnSystemImplementation>(
+          pal::path::GetLibraryName("QnnSystem"));
   ret = system_implementation->Load();
   ET_CHECK_OR_RETURN_ERROR(
       ret == Error::Ok, Internal, "Fail to load Qnn system library");

--- a/backends/qualcomm/scripts/build.ps1
+++ b/backends/qualcomm/scripts/build.ps1
@@ -72,8 +72,22 @@ $CmakeX86    = 'build-x86_64-windows'
 $CmakeArm64  = 'build-arm64-windows'
 $CmakeHexagon = 'build-hexagon'
 
-# Use the Python that is active in the current environment.
-$PythonExe = if ($env:PYTHON_EXECUTABLE) { $env:PYTHON_EXECUTABLE } else { 'python' }
+# Preserve the current Python executable path before launching the Visual
+# Studio developer shell (Launch-VsDevShell.ps1)
+#
+# When launching, it rewrites the $env:PATH to inject the MSVC toolchain.
+# Depending on the Visual Studio version, these changes can override or remove
+# the Python entry from $env:PATH
+#
+# To ensure the Python interpreter remains accessible, capture and store its
+# absolute path before invoking Launch-VsDevShell.ps1.
+$PyCmd = Get-Command python -ErrorAction SilentlyContinue
+if (-not $PyCmd) {
+    Write-Error "No 'python' found on PATH. Requires 'python' to continue the QNN Windows MSVC build."
+    exit 1
+}
+$PythonExe = $PyCmd.Source
+Write-Host "Using Python: $PythonExe" -ForegroundColor Cyan
 
 # ---------------------------------------------------------------------------
 # Helper: clean or prepare a build directory
@@ -116,6 +130,46 @@ function Run-CMake([string[]]$ConfigArgs, [string]$BuildDir, [string]$Target = '
 }
 
 # ---------------------------------------------------------------------------
+# Helper: locate an installed Visual Studio and its matching CMake generator
+# ---------------------------------------------------------------------------
+function Get-InstalledVsGenerator() {
+    $ProgramRoots = @(${env:ProgramFiles(x86)}, $env:ProgramFiles) | Where-Object { $_ }
+    $VsInstalls = @(
+        @{ Dir = "18"; Generator = "Visual Studio 18 2026" },
+        @{ Dir = "2022"; Generator = "Visual Studio 17 2022" }
+    )
+    $Editions = @("Enterprise", "Professional", "Community", "Preview", "BuildTools")
+    foreach ($root in $ProgramRoots) {
+        foreach ($vs in $VsInstalls) {
+            foreach ($edition in $Editions) {
+                $DevShell = "$root\Microsoft Visual Studio\$($vs.Dir)\$edition\Common7\Tools\Launch-VsDevShell.ps1"
+                if (Test-Path $DevShell) {
+                    Write-Host "Using VS dev shell: $DevShell" -ForegroundColor Cyan
+                    return [PSCustomObject]@{ Generator = $vs.Generator; DevShell = $DevShell }
+                }
+            }
+        }
+    }
+    throw "No supported Visual Studio installation found (2026 or 2022)."
+}
+
+# ---------------------------------------------------------------------------
+# Helper: validate that the active CMake supports the selected generator
+#
+# Must be executed after activating the Visual Studio Developer Shell so the
+# `cmake` resolved from PATH matches the build environment.
+# ---------------------------------------------------------------------------
+function Assert-GeneratorSupported([string]$Generator) {
+    if ($Generator -eq "Visual Studio 18 2026") {
+        $cmakeVersion = [version](& cmake --version |
+            Select-String -Pattern '(\d+\.\d+\.\d+)').Matches[0].Value
+        if ($cmakeVersion.Major -lt 4) {
+            throw "'Visual Studio 18 2026' requires CMake >= 4, but found CMake version $cmakeVersion"
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Block 1: ARM64 Windows cross-compiled build  (build-arm64-windows/)
 #
 # Cross-compiles the ExecuTorch runtime + QNN backend for arm64-windows using
@@ -131,15 +185,24 @@ function Run-CMake([string[]]$ConfigArgs, [string]$BuildDir, [string]$Target = '
 # ---------------------------------------------------------------------------
 if (-not $SkipArm64Windows) {
     $BuildRoot = Join-Path $PrjRoot $CmakeArm64
+
+    # Activate the VS environment for ARM64 MSVC toolchain
+    $VsGenerator = Get-InstalledVsGenerator
+    & $VsGenerator.DevShell -Arch arm64
+    Assert-GeneratorSupported $VsGenerator.Generator
+
     Prepare-BuildDir $BuildRoot
 
     $ConfigArgs = @(
         $PrjRoot,
-        "-DCMAKE_INSTALL_PREFIX=$BuildRoot",
-        "-DCMAKE_BUILD_TYPE=$BuildType",
+        "-G", $VsGenerator.Generator,
+        "-A", "ARM64",
         "-DCMAKE_SYSTEM_NAME=Windows",
         "-DCMAKE_SYSTEM_PROCESSOR=ARM64",
-        "-A", "ARM64",
+        "-DCMAKE_BUILD_TYPE=$BuildType",
+        "-DCMAKE_INSTALL_PREFIX=$BuildRoot",
+        "-DPYTHON_EXECUTABLE=$PythonExe",
+        "-DQNN_SDK_ROOT=$env:QNN_SDK_ROOT",
         "-DEXECUTORCH_BUILD_QNN=ON",
         "-DEXECUTORCH_BUILD_DEVTOOLS=ON",
         "-DEXECUTORCH_BUILD_EXTENSION_LLM=ON",
@@ -149,11 +212,9 @@ if (-not $SkipArm64Windows) {
         "-DEXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR=ON",
         "-DEXECUTORCH_BUILD_EXTENSION_NAMED_DATA_MAP=ON",
         "-DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON",
+        "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON",
         "-DEXECUTORCH_ENABLE_EVENT_TRACER=ON",
         "-DEXECUTORCH_ENABLE_LOGGING=ON",
-        "-DQNN_SDK_ROOT=$env:QNN_SDK_ROOT",
-        "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON",
-        "-DPYTHON_EXECUTABLE=$PythonExe",
         "-B$BuildRoot"
     )
     Run-CMake -ConfigArgs $ConfigArgs -BuildDir $BuildRoot
@@ -167,17 +228,18 @@ if (-not $SkipArm64Windows) {
 
     $ExampleArgs = @(
         $ExampleRoot,
+        "-G", $VsGenerator.Generator,
+        "-A", "ARM64",
         "-DCMAKE_SYSTEM_NAME=Windows",
         "-DCMAKE_SYSTEM_PROCESSOR=ARM64",
-        "-A", "ARM64",
         "-DCMAKE_BUILD_TYPE=$BuildType",
         "-DCMAKE_PREFIX_PATH=$CmakePrefixPath",
-        "-DSUPPORT_REGEX_LOOKAHEAD=ON",
-        "-DBUILD_TESTING=OFF",
-        "-DEXECUTORCH_ENABLE_LOGGING=ON",
-        "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON",
         "-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH",
         "-DPYTHON_EXECUTABLE=$PythonExe",
+        "-DEXECUTORCH_ENABLE_LOGGING=ON",
+        "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON",
+        "-DSUPPORT_REGEX_LOOKAHEAD=ON",
+        "-DBUILD_TESTING=OFF",
         "-DDSP_TYPE=$DspType",
         $DirectModeFlag,
         "-B$ExampleBuild"
@@ -194,15 +256,16 @@ if (-not $SkipArm64Windows) {
 
     $LlamaArgs = @(
         $LlamaRoot,
-        "-DBUILD_TESTING=OFF",
+        "-G", $VsGenerator.Generator,
+        "-A", "ARM64",
         "-DCMAKE_SYSTEM_NAME=Windows",
         "-DCMAKE_SYSTEM_PROCESSOR=ARM64",
-        "-A", "ARM64",
         "-DCMAKE_BUILD_TYPE=$BuildType",
         "-DCMAKE_PREFIX_PATH=$CmakePrefixPath",
-        "-DEXECUTORCH_ENABLE_LOGGING=ON",
         "-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH",
         "-DPYTHON_EXECUTABLE=$PythonExe",
+        "-DEXECUTORCH_ENABLE_LOGGING=ON",
+        "-DBUILD_TESTING=OFF",
         "-B$LlamaBuild"
     )
     Write-Host "`n=== cmake configure (examples/models/llama arm64-windows) ===" -ForegroundColor Cyan
@@ -226,8 +289,15 @@ if ($EnableHexagon) {
 
     $ConfigArgs = @(
         $PrjRoot,
-        "-DCMAKE_INSTALL_PREFIX=$BuildRoot",
+        "-DCMAKE_TOOLCHAIN_FILE=$env:HEXAGON_SDK_ROOT\build\cmake\hexagon_toolchain.cmake",
         "-DCMAKE_BUILD_TYPE=$BuildType",
+        "-DCMAKE_INSTALL_PREFIX=$BuildRoot",
+        "-DPYTHON_EXECUTABLE=$PythonExe",
+        "-DQNN_SDK_ROOT=$env:QNN_SDK_ROOT",
+        "-DHEXAGON_SDK_ROOT=$env:HEXAGON_SDK_ROOT",
+        "-DHEXAGON_TOOLS_ROOT=$env:HEXAGON_TOOLS_ROOT",
+        "-DDSP_VERSION=$env:DSP_VERSION",
+        "-DDSP_TYPE=$DspType",
         "-DEXECUTORCH_BUILD_QNN=ON",
         "-DEXECUTORCH_BUILD_XNNPACK=OFF",
         "-DEXECUTORCH_BUILD_DEVTOOLS=ON",
@@ -236,19 +306,12 @@ if ($EnableHexagon) {
         "-DEXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR=ON",
         "-DEXECUTORCH_BUILD_EXTENSION_NAMED_DATA_MAP=ON",
         "-DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON",
-        "-DEXECUTORCH_ENABLE_EVENT_TRACER=ON",
-        "-DEXECUTORCH_ENABLE_LOGGING=ON",
+        "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON",
         "-DEXECUTORCH_BUILD_PTHREADPOOL=OFF",
         "-DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF",
+        "-DEXECUTORCH_ENABLE_EVENT_TRACER=ON",
+        "-DEXECUTORCH_ENABLE_LOGGING=ON",
         "-DFLATCC_ALLOW_WERROR=OFF",
-        "-DQNN_SDK_ROOT=$env:QNN_SDK_ROOT",
-        "-DHEXAGON_SDK_ROOT=$env:HEXAGON_SDK_ROOT",
-        "-DHEXAGON_TOOLS_ROOT=$env:HEXAGON_TOOLS_ROOT",
-        "-DDSP_VERSION=$env:DSP_VERSION",
-        "-DCMAKE_TOOLCHAIN_FILE=$env:HEXAGON_SDK_ROOT\build\cmake\hexagon_toolchain.cmake",
-        "-DDSP_TYPE=$DspType",
-        "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON",
-        "-DPYTHON_EXECUTABLE=$PythonExe",
         "-B$BuildRoot"
     )
     Run-CMake -ConfigArgs $ConfigArgs -BuildDir $BuildRoot
@@ -270,11 +333,22 @@ if ($EnableHexagon) {
 if (-not $SkipX86Windows) {
     $BuildRoot = Join-Path $PrjRoot $CmakeX86
 
+    # Activate the VS environment for AMD64 MSVC toolchain
+    $VsGenerator = Get-InstalledVsGenerator
+    & $VsGenerator.DevShell -Arch amd64
+    Assert-GeneratorSupported $VsGenerator.Generator
+
     Prepare-BuildDir $BuildRoot
 
     $ConfigArgs = @(
+        $PrjRoot,
+        "-G", $VsGenerator.Generator,
+        "-A", "x64",
+        "-DCMAKE_SYSTEM_NAME=Windows",
+        "-DCMAKE_SYSTEM_PROCESSOR=AMD64",
         "-DCMAKE_BUILD_TYPE=$BuildType",
         "-DCMAKE_INSTALL_PREFIX=$BuildRoot",
+        "-DPYTHON_EXECUTABLE=$PythonExe",
         "-DQNN_SDK_ROOT=$env:QNN_SDK_ROOT",
         "-DEXECUTORCH_BUILD_QNN=ON",
         "-DEXECUTORCH_BUILD_DEVTOOLS=ON",
@@ -284,12 +358,10 @@ if (-not $SkipX86Windows) {
         "-DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON",
         "-DEXECUTORCH_BUILD_EXTENSION_FLAT_TENSOR=ON",
         "-DEXECUTORCH_BUILD_EXTENSION_NAMED_DATA_MAP=ON",
-        "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON",
         "-DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON",
+        "-DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON",
         "-DEXECUTORCH_ENABLE_EVENT_TRACER=ON",
         "-DEXECUTORCH_ENABLE_LOGGING=ON",
-        "-DPYTHON_EXECUTABLE=$PythonExe",
-        "-S$PrjRoot",
         "-B$BuildRoot"
     )
     Run-CMake -ConfigArgs $ConfigArgs -BuildDir $BuildRoot
@@ -342,13 +414,17 @@ if (-not $SkipX86Windows) {
 
     $ExampleArgs = @(
         $ExampleRoot,
+        "-G", $VsGenerator.Generator,
+        "-A", "x64",
+        "-DCMAKE_SYSTEM_NAME=Windows",
+        "-DCMAKE_SYSTEM_PROCESSOR=AMD64",
         "-DCMAKE_BUILD_TYPE=$BuildType",
         "-DCMAKE_PREFIX_PATH=$CmakePrefixPath",
         "-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH",
         "-DPYTHON_EXECUTABLE=$PythonExe",
+        "-DEXECUTORCH_ENABLE_LOGGING=ON",
         "-DSUPPORT_REGEX_LOOKAHEAD=ON",
         "-DBUILD_TESTING=OFF",
-        "-DEXECUTORCH_ENABLE_LOGGING=ON",
         "-B$ExampleBuild"
     )
     Write-Host "`n=== cmake configure (examples/qualcomm x86-64 Windows) ===" -ForegroundColor Cyan
@@ -366,12 +442,16 @@ if (-not $SkipX86Windows) {
 
     $LlamaArgs = @(
         $LlamaRoot,
-        "-DBUILD_TESTING=OFF",
+        "-G", $VsGenerator.Generator,
+        "-A", "x64",
+        "-DCMAKE_SYSTEM_NAME=Windows",
+        "-DCMAKE_SYSTEM_PROCESSOR=AMD64",
         "-DCMAKE_BUILD_TYPE=$BuildType",
         "-DCMAKE_PREFIX_PATH=$CmakePrefixPath",
-        "-DEXECUTORCH_ENABLE_LOGGING=ON",
         "-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH",
         "-DPYTHON_EXECUTABLE=$PythonExe",
+        "-DEXECUTORCH_ENABLE_LOGGING=ON",
+        "-DBUILD_TESTING=OFF",
         "-B$LlamaBuild"
     )
     Write-Host "`n=== cmake configure (examples/models/llama x86-64 Windows) ===" -ForegroundColor Cyan


### PR DESCRIPTION
### Summary
- This PR adds a CI workflow that validates the QNN Windows MSVC build.
- Fix Linux-specific file path to Windows-compatible.
- Add helper function in `backends/qualcomm/scripts/build.ps1` to validate the CMake version after dev-shell activation.

### Test plan
Passing `.github/workflows/qnn-windows-msvc.yml`.
