### PR TITLE
Arm backend: Add U55 portable fallback ops

### DIFF
--- a/backends/arm/test/ops/test_div_tensor_mode.py
+++ b/backends/arm/test/ops/test_div_tensor_mode.py
@@ -102,6 +102,12 @@ test_data = {
     ),
 }
 
+u55_portable_ops_test_data = {
+    "int8_floor": test_data["int8_floor"],
+    "int8_int_scalar": test_data["int8_int_scalar"],
+    "int32_floor": test_data["int32_floor"],
+}
+
 
 @common.parametrize("data", test_data)
 def test_div_tensor_mode_tosa_FP(data):
@@ -139,11 +145,31 @@ def test_div_tensor_mode_tosa_INT(data):
     test_data,
     xfails={
         "mode_trunc": "CPU op missing in unittests",
+        "int8_floor": "CPU op missing in unittests",
+        "int8_int_scalar": "CPU op missing in unittests",
         "int16_trunc": "CPU op missing in unittests",
+        "int32_floor": "CPU op missing in unittests",
         "int32_trunc": "CPU op missing in unittests",
     },
 )
 def test_div_tensor_mode_u55_INT(data):
+    mode, inputs = data()
+    model = DivTensorModeFloat(mode)
+
+    pipeline = EthosU55PipelineINT[input_tt](
+        model,
+        inputs,
+        aten_ops=[],
+        exir_ops=[],
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.pop_stage("check_count.exir")
+    pipeline.run()
+
+
+@common.XfailIfNoCorstone300
+@common.parametrize("data", u55_portable_ops_test_data)
+def test_div_tensor_mode_u55_INT_portable_ops(data):
     mode, inputs = data()
     model = DivTensorModeFloat(mode)
 

--- a/backends/arm/test/setup_testing.sh
+++ b/backends/arm/test/setup_testing.sh
@@ -11,6 +11,7 @@ et_root_dir=$(realpath "${script_dir}/../../..")
 build_executor_runner=${et_root_dir}/backends/arm/scripts/build_executor_runner.sh
 build_root_test_dir=${et_root_dir}/arm_test/arm_semihosting_executor_runner
 extraflags="-DET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE=83886080"
+portable_extraflags="${extraflags} -DHEAP_SIZE=0x00007000"
 
 # By default tests with an elf without any portable_ops
 # If you supply use_portable_ops=True when creating the ArmTester()
@@ -26,10 +27,21 @@ ${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_confi
 # test setup to make sure models that are not fully delegated can still be tested and run OK
 # To use this you can set use_portable_ops=True when creating ArmTester()
 
-portable_ops_list_u55="aten::permute_copy.out,aten::convolution.out,aten::relu.out,aten::_native_batch_norm_legit_no_training.out,aten::as_strided_copy.out,aten::mean.out,aten::squeeze_copy.dims,dim_order_ops::_clone_dim_order.out,dim_order_ops::_to_dim_order_copy.out"
+# Flow-suite missing-kernel failures covered by portable ops:
+# Ethos-U55/U65
+# aten::avg_pool2d.out                         - test_adaptive_avgpool2d_batch_sizes[arm_ethos_u55]
+# aten::gt.Tensor_out                          - test_divide_f32_trunc[arm_ethos_u55]
+#
+# Ethos-U85:
+# aten::_native_batch_norm_legit_no_training.out - test_swin_v2_t[arm_ethos_u85-static_shapes-float32]
+# dim_order_ops::_to_dim_order_copy.out          - test_argmin_dtype[arm_ethos_u85-float32], test_avgpool3d_input_sizes[arm_ethos_u85]
+# aten::scalar_tensor.out                        - U85 operator-suite aggregate fallback coverage
+# aten::where.self_out                           - U85 operator-suite aggregate fallback coverage
+
+portable_ops_list_u55="aten::permute_copy.out,aten::convolution.out,aten::relu.out,aten::_native_batch_norm_legit_no_training.out,aten::as_strided_copy.out,aten::mean.out,aten::squeeze_copy.dims,aten::avg_pool2d.out,aten::gt.Tensor_out,aten::where.self_out,aten::expand_copy.out,aten::clamp.out,aten::mul.out,aten::index_select.out,aten::fmod.Scalar_out,aten::add.out,aten::arange.start_out,aten::eq.Tensor_out,aten::logical_not.out,dim_order_ops::_clone_dim_order.out,dim_order_ops::_to_dim_order_copy.out"
 portable_ops_list_u65="${portable_ops_list_u55}"
 portable_ops_list_u85="aten::permute_copy.out,aten::convolution.out,aten::relu.out,aten::_native_batch_norm_legit_no_training.out,aten::as_strided_copy.out,aten::mean.out,aten::full_like.out,aten::bmm.out,aten::scalar_tensor.out,aten::index.Tensor_out,aten::where.self_out,dim_order_ops::_to_dim_order_copy.out"
 
-${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --select_ops_list="${portable_ops_list_u55}" --output="${build_root_test_dir}_portable-ops_corstone-300" --extra_build_flags=${extraflags}
-${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --select_ops_list="${portable_ops_list_u65}" --output="${build_root_test_dir}_portable-ops_corstone-300-u65" --extra_build_flags=${extraflags}
+${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --select_ops_list="${portable_ops_list_u55}" --output="${build_root_test_dir}_portable-ops_corstone-300" --extra_build_flags="${portable_extraflags}"
+${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --select_ops_list="${portable_ops_list_u65}" --output="${build_root_test_dir}_portable-ops_corstone-300-u65" --extra_build_flags="${portable_extraflags}"
 ${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="${portable_ops_list_u85}" --output="${build_root_test_dir}_portable-ops_corstone-320" --extra_build_flags=${extraflags}

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -288,13 +288,22 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(COMPILER_PREPROCESSOR_OPTIONS -E -x c -P)
 endif()
 
+set(_arm_runner_linker_preprocessor_options ${COMPILER_PREPROCESSOR_OPTIONS})
+foreach(_arm_runner_linker_define IN ITEMS HEAP_SIZE STACK_SIZE)
+  if(DEFINED ${_arm_runner_linker_define})
+    list(APPEND _arm_runner_linker_preprocessor_options
+         "-D${_arm_runner_linker_define}=${${_arm_runner_linker_define}}"
+    )
+  endif()
+endforeach()
+
 get_filename_component(LINK_FILE_OUT_BASE "${LINK_FILE}" NAME)
 set(LINK_FILE_OUT
     "${CMAKE_CURRENT_BINARY_DIR}/${LINK_FILE_OUT_BASE}.${LINK_FILE_EXT}"
 )
 
 execute_process(
-  COMMAND ${CMAKE_C_COMPILER} ${COMPILER_PREPROCESSOR_OPTIONS} -o
+  COMMAND ${CMAKE_C_COMPILER} ${_arm_runner_linker_preprocessor_options} -o
           ${LINK_FILE_OUT} ${LINK_FILE_IN}
 )
 target_link_options(arm_executor_runner PRIVATE "-T" "${LINK_FILE_OUT}")

--- a/examples/arm/executor_runner/Corstone-300.ld
+++ b/examples/arm/executor_runner/Corstone-300.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Arm Limited and/or its affiliates.
+ * Copyright 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -24,8 +24,16 @@
   #define ETHOSU_ARENA  1
 #endif
 
-__STACK_SIZE = 0x00008000;
-__HEAP_SIZE  = 0x00008000;
+#ifndef STACK_SIZE
+  #define STACK_SIZE 0x00008000
+#endif
+
+#ifndef HEAP_SIZE
+  #define HEAP_SIZE 0x00008000
+#endif
+
+__STACK_SIZE = STACK_SIZE;
+__HEAP_SIZE  = HEAP_SIZE;
 
 MEMORY
 {


### PR DESCRIPTION
Add missing portable CPU fallback kernels to the U55 selected-op runner. U65 inherits the same portable op list, so the U65 portable runner gets the same fallback coverage.

These ops are needed when the partitioner rejects parts of a graph for Ethos-U delegation. The TOSA/Vela delegate segment can still compile successfully, but the model load fails when a non-delegated CPU fallback op is not registered in the portable runner.

Added U55/U65 fallback ops:

  aten::avg_pool2d.out
  aten::gt.Tensor_out
  aten::where.self_out
  aten::expand_copy.out
  aten::clamp.out
  aten::mul.out
  aten::index_select.out
  aten::fmod.Scalar_out
  aten::add.out
  aten::arange.start_out
  aten::eq.Tensor_out
  aten::logical_not.out

Keep the regular U55 div-mode test on the non-portable ELF so it still detects undelegated CPU fallback regions. Add a separate U55 portable-op variant without xfails to verify the mixed delegated and portable fallback runtime path.

Reduce the default Corstone-300 linker heap to keep the portable-op runner linkable with Arm GNU toolchain 15.2 after the additional fallback registrations, while making heap and stack sizes overrideable.

Fixes the flow tests:

  test_adaptive_avgpool2d_batch_sizes[arm_ethos_u55]
  test_divide_f32_trunc[arm_ethos_u55]
  test_swin_v2_t[arm_ethos_u55-static_shapes-float32]
  

cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani