### PR TITLE
MLX Q5K/Q6K upgrades

### DIFF
--- a/backends/mlx/builder/op_helpers.py
+++ b/backends/mlx/builder/op_helpers.py
@@ -24,6 +24,12 @@ if TYPE_CHECKING:
 # computing biases = -scales * 2^(bits-1) during the init chain.
 QUANTIZED_SERIALIZE_BIASES = False
 
+# Row-chunk size (in elements) for the int64 bit-packer in ``to_mlx_qparams``.
+# Packing widths that don't divide 32 (5/6-bit) needs int64 scratch; chunking the
+# rows bounds that scratch to ~this many elements instead of the whole weight
+# (a full lm_head would otherwise be tens of GB of int64 -> OOM).
+_PACK_CHUNK_ELEMS = 1 << 24  # ~16M int64 elements (~128 MB per scratch tensor)
+
 
 def get_aten_target(target):
     """
@@ -555,27 +561,43 @@ def to_mlx_qparams(
         Q = q.contiguous().view(torch.uint32).reshape(rows, -1)
     else:
         # Contiguous LSB-first bit-packing for widths that don't divide 32
-        # (e.g. 6-bit), matching MLX's affine pack_and_quantize (ops.cpp).
+        # (e.g. 5/6-bit), matching MLX's affine pack_and_quantize (ops.cpp).
         #
-        # We scatter each column's value directly into its uint32 word(s)
-        # rather than expanding to a per-bit stream, which would materialize an
-        # int64 (rows, cols, bits) tensor (tens of GB for lm_head -> OOM).
-        # Column j occupies global bits [j*bits, (j+1)*bits): word j*bits//32 at
-        # shift j*bits%32, plus a carry into the next word when it straddles the
-        # boundary (at most one carry since bits <= 32). Column bit-ranges within
-        # a word are disjoint, so index_add_ (sum) is equivalent to OR.
+        # We scatter each column's value directly into its uint32 word(s) rather
+        # than expanding to a per-bit stream. Column j occupies global bits
+        # [j*bits, (j+1)*bits): word j*bits//32 at shift j*bits%32, plus a carry
+        # into the next word when it straddles the boundary (at most one carry
+        # since bits <= 32). Column bit-ranges within a word are disjoint, so
+        # index_add_ (sum) is equivalent to OR.
+        #
+        # The scatter needs int64 (a value shifted by up to 31 overflows int32),
+        # so we pack the rows in chunks to bound the peak int64 working set --
+        # packing a full lm_head in one shot would otherwise materialize a
+        # multi-GB int64 tensor.
         n_words = cols * bits // 32
-        q = qdata.to(torch.int64) + offset  # 0 .. 2**bits-1
         pos = torch.arange(cols, dtype=torch.int64) * bits
         word = pos // 32
         shift = pos % 32
-        packed = torch.zeros(rows, n_words, dtype=torch.int64)
-        packed.index_add_(1, word, q << shift)  # low bits (+ overflow)
         straddle = (shift + bits) > 32
-        if bool(straddle.any()):
-            carry = torch.where(straddle, q >> (32 - shift), torch.zeros_like(q))
-            packed.index_add_(1, (word + 1).clamp(max=n_words - 1), carry)
-        Q = (packed & 0xFFFFFFFF).to(torch.int32).contiguous().view(torch.uint32)
+        has_straddle = bool(straddle.any())
+        word_carry = (word + 1).clamp(max=n_words - 1) if has_straddle else None
+
+        rows_per_chunk = max(1, _PACK_CHUNK_ELEMS // cols)
+        chunks = []
+        for r0 in range(0, rows, rows_per_chunk):
+            q = qdata[r0 : r0 + rows_per_chunk].to(torch.int64) + offset
+            packed = torch.zeros(q.shape[0], n_words, dtype=torch.int64)
+            packed.index_add_(1, word, q << shift)  # low bits (+ overflow)
+            if has_straddle:
+                carry = torch.where(straddle, q >> (32 - shift), torch.zeros_like(q))
+                packed.index_add_(1, word_carry, carry)
+                del carry
+            del q
+            chunks.append((packed & 0xFFFFFFFF).to(torch.int32))
+            del packed
+        packed_i32 = chunks[0] if len(chunks) == 1 else torch.cat(chunks, dim=0)
+        del chunks
+        Q = packed_i32.contiguous().view(torch.uint32)
 
     if compute_biases:
         B = -scale * (zero_point.to(scale.dtype) + offset)

--- a/backends/mlx/custom_kernel_ops/gguf/patterns.py
+++ b/backends/mlx/custom_kernel_ops/gguf/patterns.py
@@ -44,7 +44,8 @@ from executorch.backends.mlx.pattern_utils import has_single_user, match_target
 from torch.export.exported_program import ExportedProgram
 from torch.fx.node import Node
 
-# Quant types each pattern can lower (both via fused custom Metal kernels).
+# Quant types each pattern can lower (MLX-native repack by default, or fused
+# custom Metal kernels via ``ET_MLX_EMIT_DIRECT_GGUF=1``).
 _LINEAR_TYPES = {"q4_k", "q5_k", "q6_k"}
 _EMBEDDING_TYPES = {"q4_k", "q5_k", "q6_k"}
 

--- a/backends/mlx/custom_kernel_ops/gguf/patterns.py
+++ b/backends/mlx/custom_kernel_ops/gguf/patterns.py
@@ -17,10 +17,11 @@ linear/embedding to::
 These handlers match that ``dequantize_gguf -> linear/embedding`` subgraph and
 lower it without materializing the dequantized weight:
 
-* **Q6_K** -> fused custom Metal kernels in :mod:`.q6k`.
-* **Q5_K** -> fused custom Metal kernels in :mod:`.q5k`.
-* **Q4_K** -> fused custom Metal kernels in :mod:`.q4k` (default), or the legacy
-  MLX-native repack path when ``ET_MLX_EMIT_DIRECT_GGUF=0``.
+* **Q4_K** / **Q5_K** -> MLX-native repack path by default; the fused custom
+  Metal kernels in :mod:`.q4k` / :mod:`.q5k` when ``ET_MLX_EMIT_DIRECT_GGUF=1``.
+* **Q6_K** -> MLX-native repack path when its sub-blocks merge to an
+  MLX-supported group size (>= 32), else the fused kernels in :mod:`.q6k`;
+  ``ET_MLX_EMIT_DIRECT_GGUF=1`` forces fused.
 
 All cover linear and embedding.
 

--- a/backends/mlx/custom_kernel_ops/gguf/q4k/__init__.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q4k/__init__.py
@@ -12,7 +12,7 @@ See :mod:`.linear` / :mod:`.embedding` for the ``emit_*`` lowerings (called by
 ``custom_kernel_ops.gguf.patterns``); they are not imported here to keep the
 package import light.
 
-By default the legacy export-time repack path
+By default the export-time repack path
 (:mod:`.linear_mlx_native` / :mod:`.embedding_mlx_native`) is used. Set
 ``ET_MLX_EMIT_DIRECT_GGUF=1`` to emit the fused Metal kernels that read raw
 GGUF bytes instead.
@@ -26,7 +26,7 @@ import os
 def emit_direct_gguf() -> bool:
     """Return True to emit fused kernels that read raw GGUF bytes.
 
-    Defaults to False (the legacy MLX-native repack path); set
+    Defaults to False (the MLX-native repack path); set
     ``ET_MLX_EMIT_DIRECT_GGUF=1`` to enable the fused kernels.
     """
     return os.environ.get("ET_MLX_EMIT_DIRECT_GGUF", "0") != "0"

--- a/backends/mlx/custom_kernel_ops/gguf/q4k/embedding.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q4k/embedding.py
@@ -134,7 +134,7 @@ def emit_embedding(
     indices_node: Node,
     output_dtype: torch.dtype,
 ) -> Slot:
-    """Dispatch to fused Metal gather or the legacy MLX-native repack path."""
+    """Dispatch to fused Metal gather or the MLX-native repack path."""
     from executorch.backends.mlx.custom_kernel_ops.gguf.q4k import emit_direct_gguf
 
     if emit_direct_gguf():

--- a/backends/mlx/custom_kernel_ops/gguf/q4k/linear.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q4k/linear.py
@@ -487,7 +487,7 @@ def emit_linear(
     weight_node: Node,
     bias_node: Optional[Node],
 ) -> Slot:
-    """Dispatch to fused Metal kernels or the legacy MLX-native repack path."""
+    """Dispatch to fused Metal kernels or the MLX-native repack path."""
     from executorch.backends.mlx.custom_kernel_ops.gguf.q4k import emit_direct_gguf
 
     if emit_direct_gguf():

--- a/backends/mlx/custom_kernel_ops/gguf/q4k/linear_mlx_native.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q4k/linear_mlx_native.py
@@ -9,8 +9,9 @@
 """GGUF **Q4_K** linear lowering via MLX's native 4-bit quantized matmul.
 
 Lowers a ``dequantize_gguf -> linear`` pattern to a ``QuantizedMatmulNode``
-(mode "affine", group_size 32); the GGUF blob is repacked into MLX qparams at
-export time (see :mod:`.repack_mlx`).
+(mode "affine"); the GGUF blob is repacked into MLX qparams at export time (see
+:mod:`.repack_mlx`). The group size is 32 by default, or the merged 64/128 when
+adjacent sub-blocks are identical.
 """
 
 from __future__ import annotations

--- a/backends/mlx/custom_kernel_ops/gguf/q4k/repack_mlx.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q4k/repack_mlx.py
@@ -39,9 +39,12 @@ def repack_mlx(P: MLXProgramBuilder, weight_node: Node) -> Tuple[Slot, Slot, Slo
         max_group_size=128
     )
     group_size = int(intx.block_size[-1])
-    packed, biases = to_mlx_qparams(intx.qdata, intx.scale, intx.zero_point, _BITS)
+    qdata, scale, zero_point = intx.qdata, intx.scale, intx.zero_point
+    del intx  # drop the tensor-subclass wrapper; keep only the fields we need
+    packed, biases = to_mlx_qparams(qdata, scale, zero_point, _BITS)
+    del qdata  # the (N, K) int8 is no longer needed once packed
 
     packed_slot = P.make_or_get_constant(f"{weight_target}_q4k_packed", packed)
-    scales_slot = P.make_or_get_constant(f"{weight_target}_q4k_scales", intx.scale)
+    scales_slot = P.make_or_get_constant(f"{weight_target}_q4k_scales", scale)
     biases_slot = P.make_or_get_constant(f"{weight_target}_q4k_biases", biases)
     return packed_slot, scales_slot, biases_slot, group_size

--- a/backends/mlx/custom_kernel_ops/gguf/q4k/repack_mlx.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q4k/repack_mlx.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-"""Q4_K -> MLX qparam repack for the legacy MLX-native lowering path.
+"""Q4_K -> MLX qparam repack for the MLX-native lowering path.
 
 Used when ``ET_MLX_EMIT_DIRECT_GGUF=0``: the GGUF blob is unpacked and repacked
 into MLX affine 4-bit qparams at export time instead of being consumed directly

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/__init__.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/__init__.py
@@ -6,16 +6,32 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-"""GGUF Q5_K format implementation (fused custom Metal kernels).
+"""GGUF Q5_K format lowering for the MLX backend.
 
 Re-exports the lightweight constants/header from :mod:`.common` so they can be
 imported without pulling in the MLX builder. The ``emit_*`` lowerings live in
 :mod:`.linear` / :mod:`.embedding` (called by ``custom_kernel_ops.gguf.patterns``)
 and are not imported here.
+
+By default the legacy export-time repack path
+(:mod:`.linear_mlx_native` / :mod:`.embedding_mlx_native`) is used. Set
+``ET_MLX_EMIT_DIRECT_GGUF=1`` to emit the fused Metal kernels that read raw
+GGUF bytes instead.
 """
+
+import os
 
 from executorch.backends.mlx.custom_kernel_ops.gguf.q5k.common import (  # noqa: F401
     _Q5K_HEADER,
     Q5K_BLOCK_BYTES,
     QK_K,
 )
+
+
+def emit_direct_gguf() -> bool:
+    """Return True to emit fused kernels that read raw GGUF bytes.
+
+    Defaults to False (the legacy MLX-native repack path); set
+    ``ET_MLX_EMIT_DIRECT_GGUF=1`` to enable the fused kernels.
+    """
+    return os.environ.get("ET_MLX_EMIT_DIRECT_GGUF", "0") != "0"

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/__init__.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/__init__.py
@@ -13,7 +13,7 @@ imported without pulling in the MLX builder. The ``emit_*`` lowerings live in
 :mod:`.linear` / :mod:`.embedding` (called by ``custom_kernel_ops.gguf.patterns``)
 and are not imported here.
 
-By default the legacy export-time repack path
+By default the export-time repack path
 (:mod:`.linear_mlx_native` / :mod:`.embedding_mlx_native`) is used. Set
 ``ET_MLX_EMIT_DIRECT_GGUF=1`` to emit the fused Metal kernels that read raw
 GGUF bytes instead.
@@ -31,7 +31,7 @@ from executorch.backends.mlx.custom_kernel_ops.gguf.q5k.common import (  # noqa:
 def emit_direct_gguf() -> bool:
     """Return True to emit fused kernels that read raw GGUF bytes.
 
-    Defaults to False (the legacy MLX-native repack path); set
+    Defaults to False (the MLX-native repack path); set
     ``ET_MLX_EMIT_DIRECT_GGUF=1`` to enable the fused kernels.
     """
     return os.environ.get("ET_MLX_EMIT_DIRECT_GGUF", "0") != "0"

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/embedding.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/embedding.py
@@ -55,7 +55,7 @@ _Q5K_EMBED_SOURCE = """
 """
 
 
-def emit_embedding(
+def _emit_embedding_fused(
     P: MLXProgramBuilder,
     head: Node,
     weight_node: Node,
@@ -122,3 +122,23 @@ def emit_embedding(
     )
 
     return out
+
+
+def emit_embedding(
+    P: MLXProgramBuilder,
+    head: Node,
+    weight_node: Node,
+    indices_node: Node,
+    output_dtype: torch.dtype,
+) -> Slot:
+    """Dispatch to fused Metal gather or the legacy MLX-native repack path."""
+    from executorch.backends.mlx.custom_kernel_ops.gguf.q5k import emit_direct_gguf
+
+    if emit_direct_gguf():
+        return _emit_embedding_fused(P, head, weight_node, indices_node, output_dtype)
+
+    from executorch.backends.mlx.custom_kernel_ops.gguf.q5k.embedding_mlx_native import (
+        emit_embedding as emit_embedding_mlx_native,
+    )
+
+    return emit_embedding_mlx_native(P, head, weight_node, indices_node, output_dtype)

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/embedding.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/embedding.py
@@ -131,7 +131,7 @@ def emit_embedding(
     indices_node: Node,
     output_dtype: torch.dtype,
 ) -> Slot:
-    """Dispatch to fused Metal gather or the legacy MLX-native repack path."""
+    """Dispatch to fused Metal gather or the MLX-native repack path."""
     from executorch.backends.mlx.custom_kernel_ops.gguf.q5k import emit_direct_gguf
 
     if emit_direct_gguf():

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/embedding_mlx_native.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/embedding_mlx_native.py
@@ -1,0 +1,58 @@
+#
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+"""GGUF **Q5_K** embedding lowering via MLX's native 5-bit quantized gather.
+
+Lowers a ``dequantize_gguf -> embedding`` pattern to a quantized gather: gather
+the packed quants / scales / biases by index, then dequantize the gathered rows
+(``DequantizeNode``, mode "affine"). The GGUF blob is repacked into MLX qparams
+at export time (see :mod:`.repack_mlx`).
+"""
+
+from __future__ import annotations
+
+from executorch.backends.mlx.builder.op_helpers import emit_quantized_gather
+from executorch.backends.mlx.builder.program_builder import MLXProgramBuilder
+from executorch.backends.mlx.builder.slot_manager import Slot
+from executorch.backends.mlx.custom_kernel_ops.gguf.q5k.repack_mlx import (
+    _BITS,
+    repack_mlx,
+)
+from torch.fx.node import Node
+
+
+def emit_embedding(
+    P: MLXProgramBuilder,
+    head: Node,
+    weight_node: Node,
+    indices_node: Node,
+    output_dtype,
+) -> Slot:
+    """Lower a Q5_K ``dequantize_gguf -> embedding`` pattern to a quantized gather.
+
+    Gathers the packed quants / scales / biases by index, then dequantizes the
+    gathered rows (MLX affine 5-bit) -- the same shape as MLX's generic quantized
+    embedding.
+    """
+    w_slot, scales_slot, biases_slot, group_size = repack_mlx(P, weight_node)
+    (indices_slot,) = P.slot_map([indices_node])
+
+    out = P.make_or_get_slot(head)
+    emit_quantized_gather(
+        P,
+        out,
+        indices_slot,
+        w_slot,
+        scales_slot,
+        biases_slot,
+        group_size=group_size,
+        bits=_BITS,
+        mode="affine",
+        out_dtype=output_dtype,
+    )
+    return out

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/linear.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/linear.py
@@ -454,7 +454,7 @@ def _emit_q5k_matmul(
     )
 
 
-def emit_linear(
+def _emit_linear_fused(
     P: MLXProgramBuilder,
     head: Node,
     x_node: Node,
@@ -512,3 +512,23 @@ def emit_linear(
         ),
     )
     return out
+
+
+def emit_linear(
+    P: MLXProgramBuilder,
+    head: Node,
+    x_node: Node,
+    weight_node: Node,
+    bias_node: Optional[Node],
+) -> Slot:
+    """Dispatch to fused Metal kernels or the legacy MLX-native repack path."""
+    from executorch.backends.mlx.custom_kernel_ops.gguf.q5k import emit_direct_gguf
+
+    if emit_direct_gguf():
+        return _emit_linear_fused(P, head, x_node, weight_node, bias_node)
+
+    from executorch.backends.mlx.custom_kernel_ops.gguf.q5k.linear_mlx_native import (
+        emit_linear as emit_linear_mlx_native,
+    )
+
+    return emit_linear_mlx_native(P, head, x_node, weight_node, bias_node)

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/linear.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/linear.py
@@ -521,7 +521,7 @@ def emit_linear(
     weight_node: Node,
     bias_node: Optional[Node],
 ) -> Slot:
-    """Dispatch to fused Metal kernels or the legacy MLX-native repack path."""
+    """Dispatch to fused Metal kernels or the MLX-native repack path."""
     from executorch.backends.mlx.custom_kernel_ops.gguf.q5k import emit_direct_gguf
 
     if emit_direct_gguf():

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/linear_mlx_native.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/linear_mlx_native.py
@@ -9,8 +9,9 @@
 """GGUF **Q5_K** linear lowering via MLX's native 5-bit quantized matmul.
 
 Lowers a ``dequantize_gguf -> linear`` pattern to a ``QuantizedMatmulNode``
-(mode "affine", group_size 32); the GGUF blob is repacked into MLX qparams at
-export time (see :mod:`.repack_mlx`).
+(mode "affine"); the GGUF blob is repacked into MLX qparams at export time (see
+:mod:`.repack_mlx`). The group size is 32 by default, or the merged 64/128 when
+adjacent sub-blocks are identical.
 """
 
 from __future__ import annotations

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/linear_mlx_native.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/linear_mlx_native.py
@@ -1,0 +1,85 @@
+#
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+"""GGUF **Q5_K** linear lowering via MLX's native 5-bit quantized matmul.
+
+Lowers a ``dequantize_gguf -> linear`` pattern to a ``QuantizedMatmulNode``
+(mode "affine", group_size 32); the GGUF blob is repacked into MLX qparams at
+export time (see :mod:`.repack_mlx`).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from executorch.backends.mlx.builder.op_helpers import torch_dtype_to_scalar_type
+from executorch.backends.mlx.builder.program_builder import MLXProgramBuilder
+from executorch.backends.mlx.builder.slot_manager import Slot
+from executorch.backends.mlx.custom_kernel_ops.gguf.q5k.repack_mlx import (
+    _BITS,
+    repack_mlx,
+)
+from executorch.backends.mlx.serialization.mlx_graph_schema import (
+    AddNode,
+    AsTypeNode,
+    QuantizedMatmulNode,
+)
+from torch.fx.node import Node
+
+
+def emit_linear(
+    P: MLXProgramBuilder,
+    head: Node,
+    x_node: Node,
+    weight_node: Node,
+    bias_node: Optional[Node],
+) -> Slot:
+    """Lower a Q5_K ``dequantize_gguf -> linear`` pattern to MLX 5-bit matmul.
+
+    ``weight_node`` is the raw GGUF blob constant; ``head`` is the ``aten.linear``
+    node. The blob is repacked into MLX qparams at export time, so only the
+    MLX-format constants are serialized.
+    """
+    w_slot, scales_slot, biases_slot, group_size = repack_mlx(P, weight_node)
+    x_slot, bias_slot = P.slot_map([x_node, bias_node])
+
+    out = P.make_or_get_slot(head)
+    P.emit(
+        QuantizedMatmulNode(
+            x=P.slot_to_tid(x_slot),
+            w=P.slot_to_tid(w_slot),
+            scales=P.slot_to_tid(scales_slot),
+            biases=P.slot_to_tid(biases_slot),
+            out=P.slot_to_tid(out),
+            group_size=group_size,
+            bits=_BITS,
+            mode="affine",
+            transpose=True,
+        )
+    )
+
+    if bias_node is not None:
+        P.emit(
+            AddNode(
+                a=P.slot_to_tid(out),
+                b=P.slot_to_tid(bias_slot),
+                out=P.slot_to_tid(out),
+            )
+        )
+
+    out_dtype = head.meta["val"].dtype
+    if out_dtype != x_node.meta["val"].dtype:
+        P.emit(
+            AsTypeNode(
+                x=P.slot_to_tid(out),
+                out=P.slot_to_tid(out),
+                scalar_type=torch_dtype_to_scalar_type(out_dtype),
+            )
+        )
+
+    return out

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/repack_mlx.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/repack_mlx.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-"""Q5_K -> MLX qparam repack for the legacy MLX-native lowering path.
+"""Q5_K -> MLX qparam repack for the MLX-native lowering path.
 
 Used when ``ET_MLX_EMIT_DIRECT_GGUF=0``: the GGUF blob is unpacked and repacked
 into MLX affine 5-bit qparams at export time instead of being consumed directly

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/repack_mlx.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/repack_mlx.py
@@ -6,10 +6,10 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-"""Q4_K -> MLX qparam repack for the legacy MLX-native lowering path.
+"""Q5_K -> MLX qparam repack for the legacy MLX-native lowering path.
 
 Used when ``ET_MLX_EMIT_DIRECT_GGUF=0``: the GGUF blob is unpacked and repacked
-into MLX affine 4-bit qparams at export time instead of being consumed directly
+into MLX affine 5-bit qparams at export time instead of being consumed directly
 by fused Metal kernels.
 """
 
@@ -22,11 +22,11 @@ from executorch.backends.mlx.builder.program_builder import MLXProgramBuilder
 from executorch.backends.mlx.builder.slot_manager import Slot
 from torch.fx.node import Node
 
-_BITS = 4
+_BITS = 5
 
 
 def repack_mlx(P: MLXProgramBuilder, weight_node: Node) -> Tuple[Slot, Slot, Slot, int]:
-    """Unpack a raw Q4_K blob and repack into MLX qparam constants.
+    """Unpack a raw Q5_K blob and repack into MLX qparam constants.
 
     Adjacent sub-blocks with identical scale/min are merged into a larger group
     size (up to 128) when lossless, so ``group_size`` may be 32, 64, or 128.
@@ -35,13 +35,13 @@ def repack_mlx(P: MLXProgramBuilder, weight_node: Node) -> Tuple[Slot, Slot, Slo
     from executorch.extension.llm.export.gguf import ExportableGGUFTensor
 
     weight_target, raw = P.get_placeholder_target_and_tensor(weight_node)
-    intx = ExportableGGUFTensor.from_raw(raw, "q4_k").to_intx_unpacked_to_int8_tensor(
+    intx = ExportableGGUFTensor.from_raw(raw, "q5_k").to_intx_unpacked_to_int8_tensor(
         max_group_size=128
     )
     group_size = int(intx.block_size[-1])
     packed, biases = to_mlx_qparams(intx.qdata, intx.scale, intx.zero_point, _BITS)
 
-    packed_slot = P.make_or_get_constant(f"{weight_target}_q4k_packed", packed)
-    scales_slot = P.make_or_get_constant(f"{weight_target}_q4k_scales", intx.scale)
-    biases_slot = P.make_or_get_constant(f"{weight_target}_q4k_biases", biases)
+    packed_slot = P.make_or_get_constant(f"{weight_target}_q5k_packed", packed)
+    scales_slot = P.make_or_get_constant(f"{weight_target}_q5k_scales", intx.scale)
+    biases_slot = P.make_or_get_constant(f"{weight_target}_q5k_biases", biases)
     return packed_slot, scales_slot, biases_slot, group_size

--- a/backends/mlx/custom_kernel_ops/gguf/q5k/repack_mlx.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q5k/repack_mlx.py
@@ -39,9 +39,12 @@ def repack_mlx(P: MLXProgramBuilder, weight_node: Node) -> Tuple[Slot, Slot, Slo
         max_group_size=128
     )
     group_size = int(intx.block_size[-1])
-    packed, biases = to_mlx_qparams(intx.qdata, intx.scale, intx.zero_point, _BITS)
+    qdata, scale, zero_point = intx.qdata, intx.scale, intx.zero_point
+    del intx  # drop the tensor-subclass wrapper; keep only the fields we need
+    packed, biases = to_mlx_qparams(qdata, scale, zero_point, _BITS)
+    del qdata  # the (N, K) int8 is no longer needed once packed
 
     packed_slot = P.make_or_get_constant(f"{weight_target}_q5k_packed", packed)
-    scales_slot = P.make_or_get_constant(f"{weight_target}_q5k_scales", intx.scale)
+    scales_slot = P.make_or_get_constant(f"{weight_target}_q5k_scales", scale)
     biases_slot = P.make_or_get_constant(f"{weight_target}_q5k_biases", biases)
     return packed_slot, scales_slot, biases_slot, group_size

--- a/backends/mlx/custom_kernel_ops/gguf/q6k/__init__.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q6k/__init__.py
@@ -6,16 +6,35 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-"""GGUF Q6_K format implementation (fused custom Metal kernels).
+"""GGUF Q6_K format lowering for the MLX backend.
 
 Re-exports the lightweight constants/header from :mod:`.common` so they can be
 imported without pulling in the MLX builder. The ``emit_*`` lowerings live in
 :mod:`.linear` / :mod:`.embedding` (called by ``custom_kernel_ops.gguf.patterns``)
 and are not imported here.
+
+Q6_K's native group size is 16, which MLX's affine kernels do not support (only
+32/64/128). The MLX-native repack path (:mod:`.linear_mlx_native` /
+:mod:`.embedding_mlx_native`) is therefore only usable when adjacent sub-blocks
+merge losslessly into a group size >= 32; otherwise lowering falls back to the
+fused Metal kernels. Set ``ET_MLX_EMIT_DIRECT_GGUF=1`` to always use the fused
+kernels.
 """
+
+import os
 
 from executorch.backends.mlx.custom_kernel_ops.gguf.q6k.common import (  # noqa: F401
     _Q6K_HEADER,
     Q6K_BLOCK_BYTES,
     QK_K,
 )
+
+
+def emit_direct_gguf() -> bool:
+    """Return True to emit fused kernels that read raw GGUF bytes.
+
+    Defaults to False (attempt the MLX-native repack path, which itself falls
+    back to fused kernels when the weight does not merge to an MLX-supported
+    group size); set ``ET_MLX_EMIT_DIRECT_GGUF=1`` to force the fused kernels.
+    """
+    return os.environ.get("ET_MLX_EMIT_DIRECT_GGUF", "0") != "0"

--- a/backends/mlx/custom_kernel_ops/gguf/q6k/embedding.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q6k/embedding.py
@@ -53,7 +53,7 @@ _Q6K_EMBED_SOURCE = """
 """
 
 
-def emit_embedding(
+def _emit_embedding_fused(
     P: MLXProgramBuilder,
     head: Node,
     weight_node: Node,
@@ -120,3 +120,32 @@ def emit_embedding(
     )
 
     return out
+
+
+def emit_embedding(
+    P: MLXProgramBuilder,
+    head: Node,
+    weight_node: Node,
+    indices_node: Node,
+    output_dtype: torch.dtype,
+) -> Slot:
+    """Dispatch to the MLX-native repack gather or the fused Metal gather.
+
+    The repack path is only valid when the weight merges to an MLX-supported
+    group size (>= 32); otherwise (and when ``ET_MLX_EMIT_DIRECT_GGUF=1``) the
+    fused gather kernel is used.
+    """
+    from executorch.backends.mlx.custom_kernel_ops.gguf.q6k import emit_direct_gguf
+
+    if not emit_direct_gguf():
+        from executorch.backends.mlx.custom_kernel_ops.gguf.q6k.embedding_mlx_native import (
+            emit_embedding as emit_embedding_mlx_native,
+        )
+
+        out = emit_embedding_mlx_native(
+            P, head, weight_node, indices_node, output_dtype
+        )
+        if out is not None:
+            return out
+
+    return _emit_embedding_fused(P, head, weight_node, indices_node, output_dtype)

--- a/backends/mlx/custom_kernel_ops/gguf/q6k/embedding_mlx_native.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q6k/embedding_mlx_native.py
@@ -1,0 +1,64 @@
+#
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+"""GGUF **Q6_K** embedding lowering via MLX's native 6-bit quantized gather.
+
+Lowers a ``dequantize_gguf -> embedding`` pattern to a quantized gather: gather
+the packed quants / scales / biases by index, then dequantize the gathered rows
+(``DequantizeNode``, mode "affine"). The GGUF blob is repacked into MLX qparams
+at export time (see :mod:`.repack_mlx`). Only usable when the weight merges to an
+MLX-supported group size (>= 32); :func:`emit_embedding` returns ``None``
+otherwise so the caller can fall back to the fused gather kernel.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from executorch.backends.mlx.builder.op_helpers import emit_quantized_gather
+from executorch.backends.mlx.builder.program_builder import MLXProgramBuilder
+from executorch.backends.mlx.builder.slot_manager import Slot
+from executorch.backends.mlx.custom_kernel_ops.gguf.q6k.repack_mlx import (
+    _BITS,
+    repack_mlx,
+)
+from torch.fx.node import Node
+
+
+def emit_embedding(
+    P: MLXProgramBuilder,
+    head: Node,
+    weight_node: Node,
+    indices_node: Node,
+    output_dtype,
+) -> Optional[Slot]:
+    """Lower a Q6_K ``dequantize_gguf -> embedding`` pattern to a quantized gather.
+
+    Returns the output slot, or ``None`` when the weight does not merge to an
+    MLX-supported group size (the caller should fall back to the fused gather).
+    """
+    repacked = repack_mlx(P, weight_node)
+    if repacked is None:
+        return None
+    w_slot, scales_slot, biases_slot, group_size = repacked
+    (indices_slot,) = P.slot_map([indices_node])
+
+    out = P.make_or_get_slot(head)
+    emit_quantized_gather(
+        P,
+        out,
+        indices_slot,
+        w_slot,
+        scales_slot,
+        biases_slot,
+        group_size=group_size,
+        bits=_BITS,
+        mode="affine",
+        out_dtype=output_dtype,
+    )
+    return out

--- a/backends/mlx/custom_kernel_ops/gguf/q6k/linear.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q6k/linear.py
@@ -426,7 +426,7 @@ def _emit_q6k_matmul(
     )
 
 
-def emit_linear(
+def _emit_linear_fused(
     P: MLXProgramBuilder,
     head: Node,
     x_node: Node,
@@ -482,3 +482,30 @@ def emit_linear(
         ),
     )
     return out
+
+
+def emit_linear(
+    P: MLXProgramBuilder,
+    head: Node,
+    x_node: Node,
+    weight_node: Node,
+    bias_node: Optional[Node],
+) -> Slot:
+    """Dispatch to the MLX-native repack path or the fused Metal kernels.
+
+    The repack path is only valid when the weight merges to an MLX-supported
+    group size (>= 32); otherwise (and when ``ET_MLX_EMIT_DIRECT_GGUF=1``) the
+    fused kernels are used.
+    """
+    from executorch.backends.mlx.custom_kernel_ops.gguf.q6k import emit_direct_gguf
+
+    if not emit_direct_gguf():
+        from executorch.backends.mlx.custom_kernel_ops.gguf.q6k.linear_mlx_native import (
+            emit_linear as emit_linear_mlx_native,
+        )
+
+        out = emit_linear_mlx_native(P, head, x_node, weight_node, bias_node)
+        if out is not None:
+            return out
+
+    return _emit_linear_fused(P, head, x_node, weight_node, bias_node)

--- a/backends/mlx/custom_kernel_ops/gguf/q6k/linear_mlx_native.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q6k/linear_mlx_native.py
@@ -1,0 +1,89 @@
+#
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+"""GGUF **Q6_K** linear lowering via MLX's native 6-bit quantized matmul.
+
+Lowers a ``dequantize_gguf -> linear`` pattern to a ``QuantizedMatmulNode``
+(mode "affine"); the GGUF blob is repacked into MLX qparams at export time (see
+:mod:`.repack_mlx`). Only usable when the weight merges to an MLX-supported
+group size (>= 32); :func:`emit_linear` returns ``None`` otherwise so the caller
+can fall back to the fused kernels.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from executorch.backends.mlx.builder.op_helpers import torch_dtype_to_scalar_type
+from executorch.backends.mlx.builder.program_builder import MLXProgramBuilder
+from executorch.backends.mlx.builder.slot_manager import Slot
+from executorch.backends.mlx.custom_kernel_ops.gguf.q6k.repack_mlx import (
+    _BITS,
+    repack_mlx,
+)
+from executorch.backends.mlx.serialization.mlx_graph_schema import (
+    AddNode,
+    AsTypeNode,
+    QuantizedMatmulNode,
+)
+from torch.fx.node import Node
+
+
+def emit_linear(
+    P: MLXProgramBuilder,
+    head: Node,
+    x_node: Node,
+    weight_node: Node,
+    bias_node: Optional[Node],
+) -> Optional[Slot]:
+    """Lower a Q6_K ``dequantize_gguf -> linear`` pattern to MLX 6-bit matmul.
+
+    Returns the output slot, or ``None`` when the weight does not merge to an
+    MLX-supported group size (the caller should fall back to fused kernels).
+    """
+    repacked = repack_mlx(P, weight_node)
+    if repacked is None:
+        return None
+    w_slot, scales_slot, biases_slot, group_size = repacked
+    x_slot, bias_slot = P.slot_map([x_node, bias_node])
+
+    out = P.make_or_get_slot(head)
+    P.emit(
+        QuantizedMatmulNode(
+            x=P.slot_to_tid(x_slot),
+            w=P.slot_to_tid(w_slot),
+            scales=P.slot_to_tid(scales_slot),
+            biases=P.slot_to_tid(biases_slot),
+            out=P.slot_to_tid(out),
+            group_size=group_size,
+            bits=_BITS,
+            mode="affine",
+            transpose=True,
+        )
+    )
+
+    if bias_node is not None:
+        P.emit(
+            AddNode(
+                a=P.slot_to_tid(out),
+                b=P.slot_to_tid(bias_slot),
+                out=P.slot_to_tid(out),
+            )
+        )
+
+    out_dtype = head.meta["val"].dtype
+    if out_dtype != x_node.meta["val"].dtype:
+        P.emit(
+            AsTypeNode(
+                x=P.slot_to_tid(out),
+                out=P.slot_to_tid(out),
+                scalar_type=torch_dtype_to_scalar_type(out_dtype),
+            )
+        )
+
+    return out

--- a/backends/mlx/custom_kernel_ops/gguf/q6k/repack_mlx.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q6k/repack_mlx.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-"""Q6_K -> MLX qparam repack for the legacy MLX-native lowering path.
+"""Q6_K -> MLX qparam repack for the MLX-native lowering path.
 
 Used when ``ET_MLX_EMIT_DIRECT_GGUF=0``: the GGUF blob is unpacked and repacked
 into MLX affine 6-bit qparams at export time instead of being consumed directly

--- a/backends/mlx/custom_kernel_ops/gguf/q6k/repack_mlx.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q6k/repack_mlx.py
@@ -58,17 +58,20 @@ def repack_mlx(
     if group_size < _MIN_MLX_GROUP_SIZE:
         return None
 
-    packed, biases = to_mlx_qparams(intx.qdata, intx.scale, intx.zero_point, _BITS)
+    qdata, scale, zero_point = intx.qdata, intx.scale, intx.zero_point
+    del intx  # drop the tensor-subclass wrapper; keep only the fields we need
+    packed, biases = to_mlx_qparams(qdata, scale, zero_point, _BITS)
+    del qdata  # the (N, K) int8 is no longer needed once packed
 
     packed_slot = P.make_or_get_constant(f"{weight_target}_q6k_packed", packed)
-    scales_slot = P.make_or_get_constant(f"{weight_target}_q6k_scales", intx.scale)
+    scales_slot = P.make_or_get_constant(f"{weight_target}_q6k_scales", scale)
     # Q6_K is symmetric (zero-point 0): emit_quantized_biases computes
     # biases = -scale * 2^(bits-1) in the init chain instead of serializing them.
     biases_slot = emit_quantized_biases(
         P,
         f"{weight_target}_q6k",
-        intx.scale,
-        intx.zero_point,
+        scale,
+        zero_point,
         _BITS,
         biases,
         scales_slot,

--- a/backends/mlx/custom_kernel_ops/gguf/q6k/repack_mlx.py
+++ b/backends/mlx/custom_kernel_ops/gguf/q6k/repack_mlx.py
@@ -1,0 +1,76 @@
+#
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+"""Q6_K -> MLX qparam repack for the legacy MLX-native lowering path.
+
+Used when ``ET_MLX_EMIT_DIRECT_GGUF=0``: the GGUF blob is unpacked and repacked
+into MLX affine 6-bit qparams at export time instead of being consumed directly
+by fused Metal kernels.
+
+Q6_K's native group size is 16, which MLX's affine kernels do not support (only
+32/64/128), so the repack succeeds only when adjacent sub-blocks merge
+losslessly into a group size >= 32 (see
+:func:`...gguf.ExportableGGUFTensor.to_intx_unpacked_to_int8_tensor`). When it
+cannot, :func:`repack_mlx` returns ``None`` so the caller falls back to the
+fused kernels.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from executorch.backends.mlx.builder.op_helpers import (
+    emit_quantized_biases,
+    to_mlx_qparams,
+)
+from executorch.backends.mlx.builder.program_builder import MLXProgramBuilder
+from executorch.backends.mlx.builder.slot_manager import Slot
+from torch.fx.node import Node
+
+_BITS = 6
+
+# MLX affine kernels only support these group sizes; Q6_K's native 16 is not one.
+_MIN_MLX_GROUP_SIZE = 32
+
+
+def repack_mlx(
+    P: MLXProgramBuilder, weight_node: Node
+) -> Optional[Tuple[Slot, Slot, Slot, int]]:
+    """Unpack a raw Q6_K blob and repack into MLX qparam constants.
+
+    Adjacent sub-blocks with identical scale are merged into a larger group size
+    (up to 128) when lossless. Returns ``(packed_slot, scales_slot, biases_slot,
+    group_size)`` when the merged ``group_size`` is MLX-compatible (>= 32), or
+    ``None`` when it is not (so the caller can fall back to fused kernels).
+    """
+    from executorch.extension.llm.export.gguf import ExportableGGUFTensor
+
+    weight_target, raw = P.get_placeholder_target_and_tensor(weight_node)
+    intx = ExportableGGUFTensor.from_raw(raw, "q6_k").to_intx_unpacked_to_int8_tensor(
+        max_group_size=128
+    )
+    group_size = int(intx.block_size[-1])
+    if group_size < _MIN_MLX_GROUP_SIZE:
+        return None
+
+    packed, biases = to_mlx_qparams(intx.qdata, intx.scale, intx.zero_point, _BITS)
+
+    packed_slot = P.make_or_get_constant(f"{weight_target}_q6k_packed", packed)
+    scales_slot = P.make_or_get_constant(f"{weight_target}_q6k_scales", intx.scale)
+    # Q6_K is symmetric (zero-point 0): emit_quantized_biases computes
+    # biases = -scale * 2^(bits-1) in the init chain instead of serializing them.
+    biases_slot = emit_quantized_biases(
+        P,
+        f"{weight_target}_q6k",
+        intx.scale,
+        intx.zero_point,
+        _BITS,
+        biases,
+        scales_slot,
+    )
+    return packed_slot, scales_slot, biases_slot, group_size

--- a/backends/mlx/custom_kernel_ops/gguf/test/test_embedding.py
+++ b/backends/mlx/custom_kernel_ops/gguf/test/test_embedding.py
@@ -29,6 +29,7 @@ import torch.nn as nn
 from executorch.backends.mlx.custom_kernel_ops.gguf.test.test_linear import (
     _BLOB_MAKERS,
     _emit_direct_gguf_env,
+    _mlx_native_dequant,
     _q4k_mlx_native_dequant,
 )
 from executorch.backends.mlx.test.test_utils import OpTestCase
@@ -40,9 +41,10 @@ def _make_gguf_embedding_model(
     K: int,
     ggml_type: str = "q6_k",
     seed: int = 0,
+    uniform: bool = False,
 ) -> nn.Module:
     emb = nn.Embedding(vocab, K)
-    blob = _BLOB_MAKERS[ggml_type](vocab, K, seed=seed)
+    blob = _BLOB_MAKERS[ggml_type](vocab, K, seed=seed, uniform=uniform)
     emb.weight = nn.Parameter(
         ExportableGGUFTensor.from_raw(blob, ggml_type, torch.bfloat16),
         requires_grad=False,
@@ -64,16 +66,20 @@ class GGUFEmbeddingTest(OpTestCase):
         idx_shape: Tuple[int, ...] = (8,),
         ggml_type: str = "q6_k",
         emit_direct_gguf: bool = True,
+        uniform: bool = False,
     ):
         self.vocab = vocab
         self.K = K
         self.idx_shape = idx_shape
         self.ggml_type = ggml_type
         self.emit_direct_gguf = emit_direct_gguf
+        self.uniform = uniform
         shp = "x".join(str(d) for d in idx_shape)
         tag = f"gguf_embedding_{ggml_type}_v{vocab}_k{K}_idx{shp}"
-        if ggml_type == "q4_k" and not emit_direct_gguf:
+        if not emit_direct_gguf:
             tag += "_mlx_native"
+        if uniform:
+            tag += "_merged"
         self.name = tag
 
     @classmethod
@@ -109,6 +115,55 @@ class GGUFEmbeddingTest(OpTestCase):
             cls(vocab=300, K=256, idx_shape=(16,), ggml_type="q5_k"),
             cls(vocab=512, K=256, idx_shape=(2, 3), ggml_type="q5_k"),
             cls(vocab=2048, K=5376, idx_shape=(8,), ggml_type="q5_k"),
+            # Q5_K MLX-native gather (bits=5 affine dequantize).
+            cls(
+                vocab=512,
+                K=256,
+                idx_shape=(8,),
+                ggml_type="q5_k",
+                emit_direct_gguf=False,
+            ),
+            cls(
+                vocab=512,
+                K=256,
+                idx_shape=(2, 3),
+                ggml_type="q5_k",
+                emit_direct_gguf=False,
+            ),
+            # Group-size upgrade: uniform sub-blocks merge to a larger group
+            # size, so the gather runs at gs>32 (and q6_k's native path fires).
+            cls(
+                vocab=512,
+                K=512,
+                idx_shape=(8,),
+                ggml_type="q4_k",
+                emit_direct_gguf=False,
+                uniform=True,
+            ),
+            cls(
+                vocab=512,
+                K=512,
+                idx_shape=(8,),
+                ggml_type="q5_k",
+                emit_direct_gguf=False,
+                uniform=True,
+            ),
+            cls(
+                vocab=512,
+                K=512,
+                idx_shape=(8,),
+                ggml_type="q6_k",
+                emit_direct_gguf=False,
+                uniform=True,
+            ),
+            cls(
+                vocab=512,
+                K=512,
+                idx_shape=(2, 3),
+                ggml_type="q6_k",
+                emit_direct_gguf=False,
+                uniform=True,
+            ),
         ]
 
     def generate_test_files(self, verbose: bool = False):
@@ -122,16 +177,31 @@ class GGUFEmbeddingTest(OpTestCase):
         return EdgeCompileConfig(_check_ir_validity=False)
 
     def create_model(self) -> nn.Module:
-        return _make_gguf_embedding_model(self.vocab, self.K, self.ggml_type)
+        return _make_gguf_embedding_model(
+            self.vocab, self.K, self.ggml_type, uniform=self.uniform
+        )
 
     def create_inputs(self) -> Tuple[torch.Tensor, ...]:
         torch.manual_seed(0)
         indices = torch.randint(0, self.vocab, self.idx_shape, dtype=torch.int64)
         return (indices,)
 
+    def _native_fires(self) -> bool:
+        # MLX-native gather runs when direct emission is off and the weight
+        # merges to an MLX group size: q4_k/q5_k always (native 32); q6_k
+        # (native 16) only when merging reaches >= 32 (uniform fixtures).
+        if self.emit_direct_gguf:
+            return False
+        if self.ggml_type in ("q4_k", "q5_k"):
+            return True
+        return self.uniform
+
     def compute_expected_outputs(self, model, test_inputs):
-        if self.ggml_type == "q4_k" and not self.emit_direct_gguf:
-            weight = _q4k_mlx_native_dequant(model.weight)
+        if self._native_fires():
+            if model.weight.ggml_type == "q4_k":
+                weight = _q4k_mlx_native_dequant(model.weight)
+            else:
+                weight = _mlx_native_dequant(model.weight)
             out = torch.nn.functional.embedding(test_inputs[0], weight)
             return [out.to(model.weight.orig_dtype)]
         return model(*test_inputs)

--- a/backends/mlx/custom_kernel_ops/gguf/test/test_linear.py
+++ b/backends/mlx/custom_kernel_ops/gguf/test/test_linear.py
@@ -328,7 +328,7 @@ class GGUFLinearTest(OpTestCase):
         # fits CI-runner GPU buffer limits; the mat-vec N-tiling path is the
         # same at any N.
         cfgs.append(cls(M=1, N=16384, K=5376, dtype=torch.bfloat16))  # lm_head
-        # Q4_K: exercise both the fused direct path and the legacy MLX-native
+        # Q4_K: exercise both the fused direct path and the MLX-native
         # repack path on each shape. Each path uses its own reference oracle
         # (see compute_expected_outputs).
         q4k_shapes = [
@@ -477,7 +477,7 @@ class GGUFLinearDynamicTest(OpTestCase):
             cls(export_M=4, test_M=1, dtype=torch.float16),
             cls(export_M=4, test_M=40, N=300, K=256, dtype=torch.bfloat16),  # ragged
         ]
-        # Q4_K: exercise both the fused direct path and the legacy MLX-native
+        # Q4_K: exercise both the fused direct path and the MLX-native
         # repack path on each shape. Each path needs its own reference oracle
         # (see compute_expected_outputs).
         for emit_direct in (True, False):

--- a/backends/mlx/custom_kernel_ops/gguf/test/test_linear.py
+++ b/backends/mlx/custom_kernel_ops/gguf/test/test_linear.py
@@ -53,8 +53,14 @@ from executorch.extension.llm.export.gguf import ExportableGGUFTensor
 # ---------------------------------------------------------------------------
 
 
-def make_q6_k_blob(N: int, K: int, seed: int = 0) -> torch.Tensor:
-    """Build a ``(N, (K/256)*210)`` uint8 tensor of valid GGUF Q6_K blocks."""
+def make_q6_k_blob(
+    N: int, K: int, seed: int = 0, uniform: bool = False
+) -> torch.Tensor:
+    """Build a ``(N, (K/256)*210)`` uint8 tensor of valid GGUF Q6_K blocks.
+
+    With ``uniform=True`` every sub-block scale is identical so adjacent groups
+    merge losslessly into a larger (MLX-supported) group size at export time.
+    """
     assert K % QK_K == 0, f"K={K} must be a multiple of {QK_K}"
     nb = K // QK_K
     g = torch.Generator().manual_seed(seed)
@@ -73,11 +79,19 @@ def make_q6_k_blob(N: int, K: int, seed: int = 0) -> torch.Tensor:
     # weights -- the mat-mat kernel stores tiles in half precision (as in
     # llama.cpp), so unrealistically large magnitudes would exceed bf16 tol.
     blocks[..., 208:210] = torch.tensor([7e-4], dtype=torch.float16).view(torch.uint8)
+    if uniform:
+        blocks[..., 192:208] = 8  # identical int8 scale in every sub-block
     return out
 
 
-def make_q4_k_blob(N: int, K: int, seed: int = 0) -> torch.Tensor:
-    """Build a ``(N, (K/256)*144)`` uint8 tensor of valid GGUF Q4_K blocks."""
+def make_q4_k_blob(
+    N: int, K: int, seed: int = 0, uniform: bool = False
+) -> torch.Tensor:
+    """Build a ``(N, (K/256)*144)`` uint8 tensor of valid GGUF Q4_K blocks.
+
+    With ``uniform=True`` the packed sub-block scales/mins are identical so
+    adjacent groups merge losslessly into a larger group size at export time.
+    """
     assert K % QK_K == 0, f"K={K} must be a multiple of {QK_K}"
     nb = K // QK_K
     block_bytes = 144  # Q4_K: d(2) + dmin(2) + scales(12) + qs(128)
@@ -92,11 +106,19 @@ def make_q4_k_blob(N: int, K: int, seed: int = 0) -> torch.Tensor:
     blocks[..., 4:144] = torch.randint(
         0, 256, (N, nb, 140), dtype=torch.uint8, generator=g
     )
+    if uniform:
+        blocks[..., 4:16] = 0x21  # identical packed 6-bit sub-block scales/mins
     return out
 
 
-def make_q5_k_blob(N: int, K: int, seed: int = 0) -> torch.Tensor:
-    """Build a ``(N, (K/256)*176)`` uint8 tensor of valid GGUF Q5_K blocks."""
+def make_q5_k_blob(
+    N: int, K: int, seed: int = 0, uniform: bool = False
+) -> torch.Tensor:
+    """Build a ``(N, (K/256)*176)`` uint8 tensor of valid GGUF Q5_K blocks.
+
+    With ``uniform=True`` the packed sub-block scales/mins are identical so
+    adjacent groups merge losslessly into a larger group size at export time.
+    """
     assert K % QK_K == 0, f"K={K} must be a multiple of {QK_K}"
     nb = K // QK_K
     block_bytes = Q5K_BLOCK_BYTES  # d(2)+dmin(2)+scales(12)+qh(32)+qs(128) = 176
@@ -112,6 +134,8 @@ def make_q5_k_blob(N: int, K: int, seed: int = 0) -> torch.Tensor:
     blocks[..., 4:block_bytes] = torch.randint(
         0, 256, (N, nb, block_bytes - 4), dtype=torch.uint8, generator=g
     )
+    if uniform:
+        blocks[..., 4:16] = 0x21  # identical packed 6-bit sub-block scales/mins
     return out
 
 
@@ -142,10 +166,11 @@ def _make_gguf_linear_model(
     bias: bool,
     ggml_type: str = "q6_k",
     seed: int = 0,
+    uniform: bool = False,
 ) -> nn.Module:
     """An ``nn.Linear`` whose weight is a GGUF ``ExportableGGUFTensor``."""
     linear = nn.Linear(K, N, bias=bias).to(dtype)
-    blob = _BLOB_MAKERS[ggml_type](N, K, seed=seed)
+    blob = _BLOB_MAKERS[ggml_type](N, K, seed=seed, uniform=uniform)
     linear.weight = nn.Parameter(
         ExportableGGUFTensor.from_raw(blob, ggml_type, dtype), requires_grad=False
     )
@@ -198,9 +223,32 @@ def _q4k_mlx_native_dequant(weight) -> torch.Tensor:
     return scale * q_unsigned + bias
 
 
+_GGML_BITS = {"q4_k": 4, "q5_k": 5, "q6_k": 6}
+
+
+def _mlx_native_dequant(weight) -> torch.Tensor:
+    """Reference for the MLX-native repack path (q4_k / q5_k / q6_k).
+
+    Mirrors the export-time repack (``to_intx_unpacked_to_int8_tensor`` with
+    ``max_group_size=128``) and the MLX affine kernel, which computes
+    ``scale*Q + bias == scale*(qdata - zero_point)``. Invariant to lossless
+    group merging, so it validates the group-size upgrade too.
+    """
+    intx = weight.to_intx_unpacked_to_int8_tensor(max_group_size=128)
+    gs = int(intx.block_size[-1])
+    q = intx.qdata.float()
+    scale = intx.scale.float().repeat_interleave(gs, dim=1)
+    zp = intx.zero_point.float().repeat_interleave(gs, dim=1)
+    return scale * (q - zp)
+
+
 def _fp32_linear_mlx_native_reference(model: "GGUFLinearModel", x: torch.Tensor):
     lin = model.linear
-    w = _q4k_mlx_native_dequant(lin.weight)
+    # q4_k keeps its packed-nibble oracle; q5_k/q6_k use the generic one.
+    if lin.weight.ggml_type == "q4_k":
+        w = _q4k_mlx_native_dequant(lin.weight)
+    else:
+        w = _mlx_native_dequant(lin.weight)
     bias = lin.bias.float() if lin.bias is not None else None
     out = torch.nn.functional.linear(x.float(), w, bias)
     return [out.to(x.dtype)]
@@ -235,6 +283,7 @@ class GGUFLinearTest(OpTestCase):
         bias: bool = True,
         ggml_type: str = "q6_k",
         emit_direct_gguf: bool = True,
+        uniform: bool = False,
     ):
         self.M = M
         self.N = N
@@ -243,12 +292,15 @@ class GGUFLinearTest(OpTestCase):
         self.bias = bias
         self.ggml_type = ggml_type
         self.emit_direct_gguf = emit_direct_gguf
+        self.uniform = uniform
         self.rtol, self.atol = _DTYPE_TOL[dtype]
         if ggml_type == "q5_k" and dtype == torch.float16:
             self.rtol, self.atol = 2e-2, 2e-2
         tag = f"gguf_linear_{ggml_type}_m{M}_n{N}_k{K}_{_DTYPE_TAG[dtype]}"
-        if ggml_type == "q4_k" and not emit_direct_gguf:
+        if not emit_direct_gguf:
             tag += "_mlx_native"
+        if uniform:
+            tag += "_merged"
         self.name = tag if bias else tag + "_nobias"
 
     @classmethod
@@ -305,6 +357,43 @@ class GGUFLinearTest(OpTestCase):
         cfgs.append(cls(ggml_type="q5_k", M=40, N=300, K=256, dtype=torch.bfloat16))
         cfgs.append(cls(ggml_type="q5_k", M=1, N=300, K=256, dtype=torch.bfloat16))
         cfgs.append(cls(ggml_type="q5_k", M=1, N=5376, K=5376, dtype=torch.bfloat16))
+        # Q5_K MLX-native repack path (bits=5 affine QuantizedMatmul), decode +
+        # prefill + nobias.
+        cfgs.append(cls(ggml_type="q5_k", emit_direct_gguf=False, M=1, N=512, K=512))
+        cfgs.append(cls(ggml_type="q5_k", emit_direct_gguf=False, M=8, N=512, K=512))
+        cfgs.append(
+            cls(
+                ggml_type="q5_k",
+                emit_direct_gguf=False,
+                M=1,
+                N=512,
+                K=512,
+                bias=False,
+            )
+        )
+        # Group-size upgrade: uniform sub-blocks merge to group_size 128, so the
+        # affine kernels run at gs>32 (and q6_k's native path fires at all).
+        for gt in ("q4_k", "q5_k", "q6_k"):
+            cfgs.append(
+                cls(
+                    ggml_type=gt,
+                    emit_direct_gguf=False,
+                    uniform=True,
+                    M=1,
+                    N=512,
+                    K=512,
+                )
+            )
+        cfgs.append(
+            cls(
+                ggml_type="q6_k",
+                emit_direct_gguf=False,
+                uniform=True,
+                M=8,
+                N=512,
+                K=512,
+            )
+        )
         return cfgs
 
     def generate_test_files(self, verbose: bool = False):
@@ -317,7 +406,12 @@ class GGUFLinearTest(OpTestCase):
     def create_model(self) -> nn.Module:
         return GGUFLinearModel(
             _make_gguf_linear_model(
-                self.N, self.K, self.dtype, self.bias, self.ggml_type
+                self.N,
+                self.K,
+                self.dtype,
+                self.bias,
+                self.ggml_type,
+                uniform=self.uniform,
             )
         )
 
@@ -325,8 +419,18 @@ class GGUFLinearTest(OpTestCase):
         torch.manual_seed(0)
         return (torch.randn(self.M, self.K, dtype=self.dtype),)
 
+    def _native_fires(self) -> bool:
+        # MLX-native repack runs when direct emission is off and the weight
+        # merges to an MLX group size: q4_k/q5_k always (native 32); q6_k
+        # (native 16) only when merging reaches >= 32 (uniform fixtures).
+        if self.emit_direct_gguf:
+            return False
+        if self.ggml_type in ("q4_k", "q5_k"):
+            return True
+        return self.uniform
+
     def compute_expected_outputs(self, model, test_inputs):
-        if self.ggml_type == "q4_k" and not self.emit_direct_gguf:
+        if self._native_fires():
             return _fp32_linear_mlx_native_reference(model, test_inputs[0])
         return _fp32_linear_reference(model, test_inputs[0])
 
@@ -360,7 +464,7 @@ class GGUFLinearDynamicTest(OpTestCase):
             f"gguf_linear_dyn_{ggml_type}_exp{export_M}_test{test_M}_n{N}_k{K}_"
             f"{_DTYPE_TAG[dtype]}"
         )
-        if ggml_type == "q4_k" and not emit_direct_gguf:
+        if not emit_direct_gguf:
             name += "_mlx_native"
         self.name = name
 
@@ -399,6 +503,25 @@ class GGUFLinearDynamicTest(OpTestCase):
         # mat-mat) from a single symbolic-M export.
         cfgs.append(cls(export_M=4, test_M=1, dtype=torch.bfloat16, ggml_type="q5_k"))
         cfgs.append(cls(export_M=4, test_M=8, dtype=torch.bfloat16, ggml_type="q5_k"))
+        # Q5_K dynamic MLX-native repack (single QuantizedMatmul serves both M).
+        cfgs.append(
+            cls(
+                export_M=4,
+                test_M=1,
+                dtype=torch.bfloat16,
+                ggml_type="q5_k",
+                emit_direct_gguf=False,
+            )
+        )
+        cfgs.append(
+            cls(
+                export_M=4,
+                test_M=8,
+                dtype=torch.bfloat16,
+                ggml_type="q5_k",
+                emit_direct_gguf=False,
+            )
+        )
         return cfgs
 
     def get_dynamic_shapes(self):
@@ -429,7 +552,9 @@ class GGUFLinearDynamicTest(OpTestCase):
         return (torch.randn(self.test_M, self.K, dtype=self.dtype),)
 
     def compute_expected_outputs(self, model, test_inputs):
-        if self.ggml_type == "q4_k" and not self.emit_direct_gguf:
+        # Dynamic configs only use the native path for q4_k/q5_k, which always
+        # merges to an MLX group size, so "direct off" implies the native path.
+        if not self.emit_direct_gguf:
             return _fp32_linear_mlx_native_reference(model, test_inputs[0])
         return _fp32_linear_reference(model, test_inputs[0])
 

--- a/extension/llm/export/gguf.py
+++ b/extension/llm/export/gguf.py
@@ -243,6 +243,61 @@ def _q6_k_fields(raw: Tensor, N: int, K: int) -> Tuple[Tensor, Tensor]:
     return q.reshape(N, K).to(torch.int8), eff_scale
 
 
+def _max_uniform_group_size(
+    eff_scale: Tensor,
+    eff_min: Tensor,
+    base_group_size: int,
+    max_group_size: int,
+) -> Tuple[int, Tensor, Tensor]:
+    """Merge adjacent identical sub-block groups into the largest lossless group.
+
+    ``eff_scale`` / ``eff_min`` are ``(N, K // base_group_size)`` per-sub-block
+    affine params. Returns ``(group_size, eff_scale, eff_min)`` where
+    ``group_size`` is the largest power-of-two multiple of ``base_group_size``
+    that is ``<= max_group_size``, divides the per-row group count, and for which
+    every run of ``group_size // base_group_size`` consecutive sub-blocks has an
+    identical scale *and* min across all rows. Because a run is merged only when
+    both params match exactly, ``scale * (q - zero_point)`` is bit-identical, so
+    the upgrade is lossless. The returned params are subsampled to
+    ``(N, K // group_size)``; when no merge applies the inputs are returned
+    unchanged at ``base_group_size``.
+
+    Merging is data-dependent (it inspects the actual scale/min values), so under
+    fake tensors -- e.g. the partitioner's support check, which runs on a fake
+    program -- the values are unknown and the base group size is kept. The real
+    merge happens later during preprocess, when the weight holds real data.
+    """
+    from torch._subclasses.fake_tensor import FakeTensor
+
+    if isinstance(eff_scale, FakeTensor):
+        return base_group_size, eff_scale, eff_min
+
+    n_rows, n_groups = eff_scale.shape
+
+    # Largest power-of-two factor that fits under max_group_size and divides the
+    # group count evenly.
+    factor = 1
+    while (
+        base_group_size * factor * 2 <= max_group_size and n_groups % (factor * 2) == 0
+    ):
+        factor *= 2
+
+    # Step down to the largest factor whose runs are actually uniform (a larger
+    # uniform run implies its sub-runs are too, so the first match is the max).
+    while factor > 1:
+        s = eff_scale.reshape(n_rows, n_groups // factor, factor)
+        m = eff_min.reshape(n_rows, n_groups // factor, factor)
+        if bool((s == s[:, :, :1]).all()) and bool((m == m[:, :, :1]).all()):
+            return (
+                base_group_size * factor,
+                s[:, :, 0].contiguous(),
+                m[:, :, 0].contiguous(),
+            )
+        factor //= 2
+
+    return base_group_size, eff_scale, eff_min
+
+
 # Tensor subclass
 
 
@@ -328,7 +383,9 @@ class ExportableGGUFTensor(TorchAOBaseTensor):
             shape=torch.Size([N, K]),
         )
 
-    def to_intx_unpacked_to_int8_tensor(self) -> Tensor:
+    def to_intx_unpacked_to_int8_tensor(
+        self, max_group_size: Optional[int] = None
+    ) -> Tensor:
         """Convert to a torchao ``IntxUnpackedToInt8Tensor`` (Q4_K, Q5_K or Q6_K).
 
         Q6_K maps to a symmetric int8 tensor (values [-32, 31], zero-point 0).
@@ -336,23 +393,45 @@ class ExportableGGUFTensor(TorchAOBaseTensor):
         affine min is folded into a (float) zero-point, so the rewrite is exact.
         Q5_K maps to a 5-bit tensor: values are centered to [-16, 15] and the
         affine min folded into the zero-point, exactly like Q4_K.
+
+        ``max_group_size``: when set, adjacent sub-blocks whose scale *and* min
+        are identical are merged into the largest lossless group size
+        ``<= max_group_size`` (see :func:`_max_uniform_group_size`). Q6_K is
+        symmetric (no min), so its merge decision is scale-equality only.
+        Defaults to ``None`` (keep the native groups: 32 for Q4_K/Q5_K, 16 for
+        Q6_K).
         """
         from torchao.quantization import IntxUnpackedToInt8Tensor
 
         N, K = int(self.shape[0]), int(self.shape[1])
         if self.ggml_type == "q6_k":
             q, eff_scale = _q6_k_fields(self.raw, N, K)
+            group_size = Q6_K_GROUP_SIZE
+            if max_group_size is not None:
+                # Symmetric (zero-point 0, no min): an all-zeros min always
+                # matches, so the merge reduces to adjacent scale equality.
+                group_size, eff_scale, _ = _max_uniform_group_size(
+                    eff_scale,
+                    torch.zeros_like(eff_scale),
+                    Q6_K_GROUP_SIZE,
+                    max_group_size,
+                )
             return IntxUnpackedToInt8Tensor(
                 qdata=q,
                 scale=eff_scale.to(torch.bfloat16),
                 zero_point=torch.zeros_like(eff_scale, dtype=torch.int8),
                 target_dtype=torch.int8,
-                block_size=(1, Q6_K_GROUP_SIZE),
+                block_size=(1, group_size),
                 dtype=torch.bfloat16,
                 activation_quantization=None,
             )
         if self.ggml_type == "q5_k":
             q, eff_scale, eff_min = _q5_k_fields(self.raw, N, K)
+            group_size = Q5_K_GROUP_SIZE
+            if max_group_size is not None:
+                group_size, eff_scale, eff_min = _max_uniform_group_size(
+                    eff_scale, eff_min, Q5_K_GROUP_SIZE, max_group_size
+                )
             zero = torch.where(
                 eff_scale != 0, eff_min / eff_scale, torch.zeros_like(eff_min)
             )
@@ -363,12 +442,17 @@ class ExportableGGUFTensor(TorchAOBaseTensor):
                 scale=eff_scale.to(torch.bfloat16),
                 zero_point=(zero - 16).to(torch.bfloat16),
                 target_dtype=torch.int5,
-                block_size=(1, Q5_K_GROUP_SIZE),
+                block_size=(1, group_size),
                 dtype=torch.bfloat16,
                 activation_quantization=None,
             )
         if self.ggml_type == "q4_k":
             q, eff_scale, eff_min = _q4_k_fields(self.raw, N, K)
+            group_size = Q4_K_GROUP_SIZE
+            if max_group_size is not None:
+                group_size, eff_scale, eff_min = _max_uniform_group_size(
+                    eff_scale, eff_min, Q4_K_GROUP_SIZE, max_group_size
+                )
             zero = torch.where(
                 eff_scale != 0, eff_min / eff_scale, torch.zeros_like(eff_min)
             )
@@ -379,7 +463,7 @@ class ExportableGGUFTensor(TorchAOBaseTensor):
                 scale=eff_scale.to(torch.bfloat16),
                 zero_point=(zero - 8).to(torch.bfloat16),
                 target_dtype=torch.int4,
-                block_size=(1, Q4_K_GROUP_SIZE),
+                block_size=(1, group_size),
                 dtype=torch.bfloat16,
                 activation_quantization=None,
             )

--- a/extension/llm/export/test/test_gguf.py
+++ b/extension/llm/export/test/test_gguf.py
@@ -125,8 +125,12 @@ class TestExportableGGUFTensor(unittest.TestCase):
 
     def test_to_intx_unpacked_matches_reference(self):
         # Reference is the gguf-package dequant (ExportableGGUFTensor.dequantize);
-        # the Intx tensor's dequantize exercises our unpacking. Covers Q4_K & Q6_K.
-        for ggml_type, make in (("q4_k", _make_q4k_raw), ("q6_k", _make_q6k_raw)):
+        # the Intx tensor's dequantize exercises our unpacking (Q4_K/Q5_K/Q6_K).
+        for ggml_type, make in (
+            ("q4_k", _make_q4k_raw),
+            ("q5_k", _make_q5k_raw),
+            ("q6_k", _make_q6k_raw),
+        ):
             raw = make(N=3, nb=2)
             t = ExportableGGUFTensor.from_raw(raw, ggml_type)
             ix = t.to_intx_unpacked_to_int8_tensor()
@@ -152,6 +156,18 @@ class TestExportableGGUFTensor(unittest.TestCase):
             t = ExportableGGUFTensor.from_raw(make(N=2, nb=2), ggml_type)
             ix = t.to_intx_unpacked_to_int8_tensor()
             self.assertEqual(ix.block_size[1], native_gs, ggml_type)
+
+    def test_group_upgrade_noop_on_nonuniform(self):
+        # Non-uniform sub-block scales must not merge even with max_group_size
+        # set, so Q6_K stays at its native group size 16 (< 32) -- the signal
+        # repack_mlx uses to return None and fall back to the fused kernels.
+        raw = _make_q6k_raw(N=3, nb=2)
+        blk = raw.reshape(3 * 2, _Q6_K_BLOCK_BYTES)
+        # Distinct int8 sub-block scales so adjacent groups differ.
+        blk[:, 192:208] = torch.arange(1, 17, dtype=torch.int8).view(torch.uint8)
+        t = ExportableGGUFTensor.from_raw(raw, "q6_k")
+        ix = t.to_intx_unpacked_to_int8_tensor(max_group_size=128)
+        self.assertEqual(ix.block_size[1], Q6_K_GROUP_SIZE)
 
     def test_group_upgrade_is_lossless(self):
         # The crafted blobs use fixed sub-scales/mins that are uniform within

--- a/extension/llm/export/test/test_gguf.py
+++ b/extension/llm/export/test/test_gguf.py
@@ -36,11 +36,14 @@ except ImportError:
     _HAS_GGUF = False
 
 from executorch.extension.llm.export.gguf import (
+    _max_uniform_group_size,
     _Q4_K_BLOCK_BYTES,
     _Q5_K_BLOCK_BYTES,
     _Q6_K_BLOCK_BYTES,
     ExportableGGUFTensor,
     Q4_K_GROUP_SIZE,
+    Q5_K_GROUP_SIZE,
+    Q6_K_GROUP_SIZE,
 )
 
 
@@ -139,6 +142,48 @@ class TestExportableGGUFTensor(unittest.TestCase):
                 ggml_type,
             )
 
+    def test_group_upgrade_default_keeps_native(self):
+        # Without max_group_size the native group size is preserved.
+        for ggml_type, make, native_gs in (
+            ("q4_k", _make_q4k_raw, Q4_K_GROUP_SIZE),
+            ("q5_k", _make_q5k_raw, Q5_K_GROUP_SIZE),
+            ("q6_k", _make_q6k_raw, Q6_K_GROUP_SIZE),
+        ):
+            t = ExportableGGUFTensor.from_raw(make(N=2, nb=2), ggml_type)
+            ix = t.to_intx_unpacked_to_int8_tensor()
+            self.assertEqual(ix.block_size[1], native_gs, ggml_type)
+
+    def test_group_upgrade_is_lossless(self):
+        # The crafted blobs use fixed sub-scales/mins that are uniform within
+        # each 64-wide run, so max_group_size=64 merges to group_size 64. The
+        # merge must be bit-identical to the native-group unpacking (only equal
+        # groups are merged) and still match the gguf reference.
+        for ggml_type, make, native_gs in (
+            ("q4_k", _make_q4k_raw, Q4_K_GROUP_SIZE),
+            ("q5_k", _make_q5k_raw, Q5_K_GROUP_SIZE),
+            ("q6_k", _make_q6k_raw, Q6_K_GROUP_SIZE),
+        ):
+            raw = make(N=3, nb=2)
+            t = ExportableGGUFTensor.from_raw(raw, ggml_type)
+            base = t.to_intx_unpacked_to_int8_tensor()
+            up = t.to_intx_unpacked_to_int8_tensor(max_group_size=64)
+            self.assertEqual(base.block_size[1], native_gs, ggml_type)
+            self.assertEqual(up.block_size[1], 64, ggml_type)
+            # qdata is untouched by the merge; only scale/zero_point subsample.
+            self.assertTrue(torch.equal(up.qdata, base.qdata), ggml_type)
+            # Bit-identical to the native-group unpacking (lossless).
+            self.assertTrue(torch.equal(up.dequantize(), base.dequantize()), ggml_type)
+            # ...and still matches the gguf reference within bf16 tolerance.
+            self.assertTrue(
+                torch.allclose(
+                    up.dequantize().float(),
+                    t.dequantize(torch.float32),
+                    rtol=1e-2,
+                    atol=5e-2,
+                ),
+                ggml_type,
+            )
+
     def test_to_int4_tensor_matches_reference(self):
         raw = _make_q4k_raw(N=3, nb=2)
         t = ExportableGGUFTensor.from_raw(raw, "q4_k")
@@ -230,6 +275,63 @@ class TestExportableGGUFTensorExport(unittest.TestCase):
             {}
         )
         self.assertIn("torchao.dequantize_gguf.default", self._targets(ep))
+
+
+class TestMaxUniformGroupSize(unittest.TestCase):
+    """Unit tests for the lossless group-size upgrade search.
+
+    Exercises ``_max_uniform_group_size`` directly on synthetic scale/min arrays
+    (no gguf package required).
+    """
+
+    def test_all_equal_upgrades_to_cap(self):
+        gs, s, m = _max_uniform_group_size(torch.ones(3, 8), torch.zeros(3, 8), 32, 128)
+        self.assertEqual(gs, 128)
+        self.assertEqual(tuple(s.shape), (3, 2))
+        self.assertEqual(tuple(m.shape), (3, 2))
+
+    def test_cap_respected(self):
+        gs, _, _ = _max_uniform_group_size(torch.ones(3, 8), torch.zeros(3, 8), 32, 64)
+        self.assertEqual(gs, 64)
+
+    def test_pairs_equal_upgrades_to_64(self):
+        s = torch.tensor([[1, 1, 2, 2, 3, 3, 4, 4]] * 3, dtype=torch.float32)
+        gs, _, _ = _max_uniform_group_size(s, torch.zeros(3, 8), 32, 128)
+        self.assertEqual(gs, 64)
+
+    def test_min_mismatch_blocks_merge(self):
+        # Scales pair up, but a differing min forbids the (lossy) merge.
+        s = torch.tensor([[1, 1, 2, 2, 3, 3, 4, 4]] * 3, dtype=torch.float32)
+        m = torch.tensor([[0, 9, 0, 0, 0, 0, 0, 0]] * 3, dtype=torch.float32)
+        gs, _, _ = _max_uniform_group_size(s, m, 32, 128)
+        self.assertEqual(gs, 32)
+
+    def test_distinct_stays_base_and_returns_inputs(self):
+        s = torch.arange(8, dtype=torch.float32).repeat(2, 1)
+        m = torch.zeros(2, 8)
+        gs, s2, m2 = _max_uniform_group_size(s, m, 32, 128)
+        self.assertEqual(gs, 32)
+        self.assertTrue(torch.equal(s2, s))
+        self.assertTrue(torch.equal(m2, m))
+
+    def test_base16_all_equal(self):
+        # Q6_K-style base group size of 16 can climb 16 -> 128 (factor 8).
+        gs, _, _ = _max_uniform_group_size(
+            torch.ones(2, 16), torch.zeros(2, 16), 16, 128
+        )
+        self.assertEqual(gs, 128)
+
+    def test_subsampled_values(self):
+        s = torch.tensor([[5, 5, 7, 7]] * 2, dtype=torch.float32)
+        m = torch.tensor([[1, 1, 2, 2]] * 2, dtype=torch.float32)
+        gs, s2, m2 = _max_uniform_group_size(s, m, 32, 64)
+        self.assertEqual(gs, 64)
+        self.assertTrue(
+            torch.equal(s2, torch.tensor([[5, 7]] * 2, dtype=torch.float32))
+        )
+        self.assertTrue(
+            torch.equal(m2, torch.tensor([[1, 2]] * 2, dtype=torch.float32))
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds an MLX-native repack lowering path for GGUF Q5_K and Q6_K weights, mirroring the existing Q4_K path: at export time the raw GGUF blob is unpacked and repacked into MLX affine qparams (bits=5 / bits=6) consumed by MLX's native QuantizedMatmul/quantized-gather kernels, gated by ET_MLX_EMIT_DIRECT_GGUF (default = native, falling back to the fused Metal kernels otherwise). It also introduces a lossless group-size upgrade in to_intx_unpacked_to_int8_tensor (_max_uniform_group_size) that merges adjacent sub-blocks with identical scale/min into the largest MLX-supported group size (32→64→128) when bit-exact, which the repack paths request via max_group_size=128; because Q6_K's native group size (16) isn't MLX-compatible, its native path only activates when this merge reaches ≥32 and otherwise transparently falls back to fused kernels. Q6_K's symmetric zero-point lets biases be computed in the init chain via emit_quantized_biases instead of being serialized, and a FakeTensor guard keeps the data-dependent merge from tripping the partitioner's support check. Coverage includes new unit tests for the merge logic in test_gguf.py and native/fused + group-merged op tests across Q4_K/Q5_K/Q6_K in test_linear.py and test_embedding.py.