### PR TITLE
Bump PyTorch pin to 2.13

### DIFF
--- a/.ci/docker/ci_commit_pins/pytorch.txt
+++ b/.ci/docker/ci_commit_pins/pytorch.txt
@@ -1,1 +1,1 @@
-release/2.12
+release/2.13

--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -16,6 +16,37 @@ install_domains() {
   pip_install --no-build-isolation --user "git+https://github.com/pytorch/vision.git@${TORCHVISION_VERSION}"
 }
 
+select_pytorch_source_build_compiler() {
+  local cxx_version
+  local clang_major
+
+  if ! command -v c++ >/dev/null 2>&1; then
+    return
+  fi
+
+  cxx_version="$(c++ --version 2>/dev/null | head -n 1 || true)"
+  if [[ "${cxx_version}" != *clang* && "${cxx_version}" != *Clang* ]]; then
+    return
+  fi
+
+  clang_major="$(sed -nE 's/.*clang version ([0-9]+).*/\1/p' <<<"${cxx_version}" | head -n 1)"
+  if [[ -z "${clang_major}" ]]; then
+    clang_major="$(sed -nE 's/.*Apple clang version ([0-9]+).*/\1/p' <<<"${cxx_version}" | head -n 1)"
+  fi
+
+  if [[ -n "${clang_major}" && "${clang_major}" -lt 16 ]]; then
+    if command -v gcc >/dev/null 2>&1 && command -v g++ >/dev/null 2>&1; then
+      echo "Using gcc/g++ for PyTorch source build because ${cxx_version} is too old"
+      export CC=gcc
+      export CXX=g++
+      export CMAKE_C_COMPILER=gcc
+      export CMAKE_CXX_COMPILER=g++
+    else
+      echo "gcc/g++ not found; continuing PyTorch source build with ${cxx_version}"
+    fi
+  fi
+}
+
 install_pytorch_and_domains() {
   git clone https://github.com/pytorch/pytorch.git
 
@@ -33,6 +64,7 @@ install_pytorch_and_domains() {
   if [[ -n "${PYTORCH_BUILD_MAX_JOBS:-}" ]]; then
     export MAX_JOBS="${PYTORCH_BUILD_MAX_JOBS}"
   fi
+  select_pytorch_source_build_compiler
   # Then build and install PyTorch
   conda_run python setup.py bdist_wheel
   pip_install "$(echo dist/*.whl)"
@@ -40,7 +72,7 @@ install_pytorch_and_domains() {
   # Grab the pinned audio and vision commits from PyTorch
   TORCHAUDIO_VERSION=release/2.11
   export TORCHAUDIO_VERSION
-  TORCHVISION_VERSION=release/0.27
+  TORCHVISION_VERSION=release/0.28
   export TORCHVISION_VERSION
 
   install_domains

--- a/.ci/scripts/utils.sh
+++ b/.ci/scripts/utils.sh
@@ -107,7 +107,7 @@ install_pytorch_and_domains() {
   local torch_release=$(cat version.txt)
   # Download key must match the upload key below (basename of dist/*.whl,
   # which always carries setup.py's resolved +gitHASH). Branch-ref pins
-  # like `release/2.12` would otherwise produce `+gitrelease` here and
+  # like `release/2.13` would otherwise produce `+gitrelease` here and
   # never hit the cache.
   local torch_short_hash=$(git rev-parse --short=7 HEAD)
   local torch_wheel_path="cached_artifacts/pytorch/executorch/pytorch_wheels/${system_name}/${python_version}"
@@ -178,7 +178,7 @@ install_pytorch_and_domains() {
   # Grab the pinned audio and vision commits from PyTorch
   TORCHAUDIO_VERSION=release/2.11
   export TORCHAUDIO_VERSION
-  TORCHVISION_VERSION=release/0.27
+  TORCHVISION_VERSION=release/0.28
   export TORCHVISION_VERSION
 
   install_domains

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -49,7 +49,7 @@ def install_requirements(use_pytorch_nightly):
         # Setting use_pytorch_nightly to false to test the pinned PyTorch commit. Note
         # that we don't need to set any version number there because they have already
         # been installed on CI before this step, so pip won't reinstall them
-        ("torch==2.12.0" if use_pytorch_nightly else "torch"),
+        ("torch==2.13.0" if use_pytorch_nightly else "torch"),
     ]
 
     # Install the requirements for core ExecuTorch package.
@@ -112,7 +112,7 @@ def install_optional_example_requirements(use_pytorch_nightly):
 
     print("Installing torch domain libraries")
     DOMAIN_LIBRARIES = [
-        ("torchvision==0.27.0" if use_pytorch_nightly else "torchvision"),
+        ("torchvision==0.28.0" if use_pytorch_nightly else "torchvision"),
         ("torchaudio==2.11.0" if use_pytorch_nightly else "torchaudio"),
     ]
     # Then install domain libraries

--- a/runtime/core/portable_type/c10/c10/util/BFloat16-math.h
+++ b/runtime/core/portable_type/c10/c10/util/BFloat16-math.h
@@ -181,7 +181,7 @@ template <
     typename T,
     typename std::enable_if_t<c10::is_reduced_floating_point_v<T>, int> = 0>
 inline T rsqrt(T a) {
-  return 1.0 / std::sqrt(float(a));
+  return 1.0f / std::sqrt(float(a));
 }
 template <
     typename T,

--- a/runtime/core/portable_type/c10/c10/util/complex_math.h
+++ b/runtime/core/portable_type/c10/c10/util/complex_math.h
@@ -327,7 +327,7 @@ C10_HOST_DEVICE inline c10::complex<T> atanh(const c10::complex<T>& x) {
 template <typename T>
 C10_HOST_DEVICE inline c10::complex<T> log1p(const c10::complex<T>& z) {
 #if defined(__APPLE__) || defined(__MACOSX) || defined(__CUDACC__) || \
-    defined(__HIPCC__)
+    defined(__HIPCC__) || defined(__SYCL_DEVICE_ONLY__)
   // For Mac, the new implementation yielded a high relative error. Falling back
   // to the old version for now.
   // See https://github.com/numpy/numpy/pull/22611#issuecomment-1667945354

--- a/runtime/core/portable_type/c10/torch/headeronly/util/Half.h
+++ b/runtime/core/portable_type/c10/torch/headeronly/util/Half.h
@@ -236,7 +236,7 @@ C10_HOST_DEVICE inline float fp16_ieee_to_fp32_value(uint16_t h) {
   /*
    * - Choose either results of conversion of input as a normalized number, or
    * as a denormalized number, depending on the input exponent. The variable
-   * two_w contains input exponent in bits 27-31, therefore if its smaller than
+   * two_w contains input exponent in bits 27-31, therefore if it's smaller than
    * 2**27, the input is either a denormal number, or zero.
    * - Combine the result of conversion of exponent and mantissa with the sign
    * of the input number.

--- a/torch_pin.py
+++ b/torch_pin.py
@@ -1,2 +1,2 @@
-TORCH_VERSION = "2.12.0"
+TORCH_VERSION = "2.13.0"
 # NIGHTLY_VERSION = "dev20260318" Temporarily pinning to stable release candidate. Revert https://github.com/pytorch/executorch/pull/18287


### PR DESCRIPTION
Summary:
- bump the CI/source PyTorch pin from release/2.12 to release/2.13
- bump install-time torch from 2.12.0 to 2.13.0 and torchvision from 0.27.0 to 0.28.0
- sync copied c10 headers with PyTorch release/2.13
- bump the torchao submodule to include the upstream PyTorch 2.13 `aten.transpose.Dimname` fix
- build PyTorch with gcc/g++ inside clang<16 Docker images, since PyTorch 2.13 now requires clang 16+

Notes:
- torchaudio remains on 2.11.0 / release/2.11 because pytorch/audio does not currently publish a 2.13.0 tag or release/2.13 branch.

Validation:
- /usr/bin/python3 -m py_compile install_requirements.py torch_pin.py
- bash -n .ci/docker/common/install_pytorch.sh .ci/scripts/utils.sh
- .ci/scripts/check_c10_sync.sh
- checked failed PR logs for the repeated torchao `Dimname` and clang-12 PyTorch source-build failures