### PR TITLE
Prevent packed weight cache file from growing on reload

### DIFF
--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -340,8 +340,10 @@ size_t XNNWeightsCache::look_up(
   const void* unpacked_bias_ptr = cache_key->bias;
   auto entry = context->unpacked_data_to_name_.find(unpacked_weights_ptr);
   if (entry == context->unpacked_data_to_name_.end()) {
+    context->last_lookup_unnamed_ = true;
     return SIZE_MAX;
   }
+  context->last_lookup_unnamed_ = false;
   std::string weight_bias_name = entry->second;
 
   if (unpacked_bias_ptr != nullptr) {
@@ -375,6 +377,9 @@ size_t XNNWeightsCache::look_up(
 
 void* XNNWeightsCache::reserve_space(XNNWeightsCache* context, size_t n) {
 #ifndef _WIN32
+  if (context->last_lookup_unnamed_ || context->loaded_from_disk_) {
+    return context->reserve_space_heap(n);
+  }
   if (context->packed_file_fd_ >= 0) {
     size_t page_size = sysconf(_SC_PAGESIZE);
     size_t file_offset =
@@ -753,6 +758,8 @@ bool XNNWeightsCache::load_packed_cache() {
   // a no-op until new packs arrive. Initialize watermark so
   // save_packed_index short-circuits.
   mmap_regions_at_last_save_ = mmap_regions_.size();
+  mmap_regions_synced_ = mmap_regions_.size();
+  loaded_from_disk_ = true;
   return true;
 #else
   return false;

--- a/backends/xnnpack/runtime/XNNWeightsCache.h
+++ b/backends/xnnpack/runtime/XNNWeightsCache.h
@@ -223,6 +223,19 @@ class XNNWeightsCache {
   // in mmap_regions_, so delete_packed_data() can munmap when ref_count==0.
   std::unordered_map<void*, size_t> file_ptr_to_region_index_;
 
+  // Set by look_up when the kernel pointer is not in unpacked_data_to_name_
+  // (i.e., the constant is unnamed / embedded in the delegate blob). Checked
+  // by reserve_space to route unnamed constants to heap instead of the
+  // file-backed mmap — unnamed entries can never be found by name on reload,
+  // so persisting them to disk wastes space and triggers spurious saves.
+  bool last_lookup_unnamed_{false};
+
+  // True after load_packed_cache succeeds. When set, reserve_space routes
+  // to heap — all named entries are already in the file, so any new
+  // reserve_space is a re-pack (e.g., XNNPACK internal re-pack for a
+  // different runtime context) that doesn't need to persist.
+  bool loaded_from_disk_{false};
+
   // See mutex() for the locking contract — caller-owned, no internal
   // use within this class.
   std::mutex instance_mutex_;


### PR DESCRIPTION
Summary:
On each NGTTS model reload, the cache file grew by ~24KB and the timestamp updated, even though all named entries were cache hits. Three independent causes:

1. Unnamed constants (not registered in `NamedDataMap`) always miss `look_up` and go through `reserve_space` file-backed path, extending the file with data that can never be found by name on subsequent loads.

2. After `load_packed_cache`, `mmap_regions_synced_` was 0 while `mmap_regions_` was 1, causing `finalize_for_runtime` to msync the read-only loaded region on every reload — updating the file mtime.

3. XNNPACK internally re-packs certain weights (e.g., for different runtime contexts) by calling `reserve_space` without going through `look_up` first. On a warm cache this extends the file with data already present in the loaded cache.

Fix:
- `last_lookup_unnamed_`: set in `look_up` when the kernel pointer is not in the name map. `reserve_space` checks this flag and routes to heap.
- `mmap_regions_synced_`: initialized in `load_packed_cache` to match `mmap_regions_.size()`, preventing spurious msync on loaded regions.
- `loaded_from_disk_`: set after `load_packed_cache` succeeds. `reserve_space` routes to heap when the cache is warm — all named entries are already in the file, so any new `reserve_space` call is a re-pack that does not need to persist.

Differential Revision: D111354375


