### PR TITLE
Fall back to trace hint when eval_upper_bound returns int_oo

### DIFF
--- a/exir/sym_util.py
+++ b/exir/sym_util.py
@@ -67,7 +67,7 @@ def eval_upper_bound(maybe_symint: Union[int, torch.SymInt]) -> int:
         if hint is not None:
             return hint
         raise RuntimeError(
-            "Cannot evaluate a finite upper bound for symbolic expression "
+            f"Cannot evaluate a finite upper bound for symbolic expression {expr} "
             "(int_oo) and no trace hint is available."
         )
     else:

--- a/exir/sym_util.py
+++ b/exir/sym_util.py
@@ -64,7 +64,7 @@ def eval_upper_bound(maybe_symint: Union[int, torch.SymInt]) -> int:
         return concrete_upper
     elif int_oo is not None and upper_bound is int_oo:
         hint = eval_expr(maybe_symint)
-        if isinstance(hint, int):
+        if hint is not None:
             return hint
         return int_oo
     else:

--- a/exir/sym_util.py
+++ b/exir/sym_util.py
@@ -63,6 +63,9 @@ def eval_upper_bound(maybe_symint: Union[int, torch.SymInt]) -> int:
         ), f"Expect upper bound to be a concrete int but got {concrete_upper}"
         return concrete_upper
     elif int_oo is not None and upper_bound is int_oo:
+        hint = eval_expr(maybe_symint)
+        if isinstance(hint, int):
+            return hint
         return int_oo
     else:
         raise RuntimeError(

--- a/exir/sym_util.py
+++ b/exir/sym_util.py
@@ -66,7 +66,10 @@ def eval_upper_bound(maybe_symint: Union[int, torch.SymInt]) -> int:
         hint = eval_expr(maybe_symint)
         if hint is not None:
             return hint
-        return int_oo
+        raise RuntimeError(
+            "Cannot evaluate a finite upper bound for symbolic expression "
+            "(int_oo) and no trace hint is available."
+        )
     else:
         raise RuntimeError(
             f"Expect upper bound to be sympy.Integer or int_oo. but got {upper_bound}"

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -911,6 +911,16 @@ class TestPasses(unittest.TestCase):
             dynamic_shapes={"x": {0: dim0}},
         )
         edge = to_edge(ep)
+
+        gm = edge.exported_program().graph_module
+        x_node = next(
+            n for n in gm.graph.nodes
+            if n.op == "placeholder" and n.name == "x"
+        )
+        sym_dim = x_node.meta["val"].shape[0]
+        self.assertIsInstance(sym_dim, torch.SymInt)
+        self.assertEqual(eval_upper_bound(sym_dim), 4)
+
         et = edge.to_executorch()
         self.assertIsNotNone(et)
 

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -919,7 +919,10 @@ class TestPasses(unittest.TestCase):
         sym_dim = x_node.meta["val"].shape[0]
         self.assertIsInstance(sym_dim, torch.SymInt)
 
-        from torch.utils._sympy.numbers import int_oo
+        try:
+            from torch.utils._sympy.numbers import int_oo
+        except ImportError:
+            self.skipTest("int_oo not available in this torch version")
         from torch.utils._sympy.value_ranges import bound_sympy
 
         raw_upper = bound_sympy(

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -894,6 +894,26 @@ class TestPasses(unittest.TestCase):
         self.assertEqual(spec[1].shape_dynamism, TensorShapeDynamism.DYNAMIC_BOUND)
         self.assertEqual(spec[1].shape[1], 3)  # Second dim is static
 
+    def test_eval_upper_bound_int_oo_falls_back_to_hint(self) -> None:
+        """When bound_sympy returns int_oo (no finite upper bound from
+        constraints), eval_upper_bound should fall back to the trace hint
+        for backed symbols rather than returning int_oo."""
+
+        class SimpleModel(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        m = SimpleModel()
+        dim0 = torch.export.Dim("batch", min=1)
+        ep = torch.export.export(
+            m,
+            (torch.randn(4, 8),),
+            dynamic_shapes={"x": {0: dim0}},
+        )
+        edge = to_edge(ep)
+        et = edge.to_executorch()
+        self.assertIsNotNone(et)
+
     def test_compile_fix_broken_ops(self) -> None:
         class ExportableLoop(nn.Module):
             def __init__(self, hidden_size, out_channels):

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -905,7 +905,7 @@ class TestPasses(unittest.TestCase):
 
         m = SimpleModel()
         dim0 = torch.export.Dim("batch", min=1)
-        ep = torch.export.export(
+        ep = export(
             m,
             (torch.randn(4, 8),),
             dynamic_shapes={"x": {0: dim0}},
@@ -914,8 +914,7 @@ class TestPasses(unittest.TestCase):
 
         gm = edge.exported_program().graph_module
         x_node = next(
-            n for n in gm.graph.nodes
-            if n.op == "placeholder" and n.name == "x"
+            n for n in gm.graph.nodes if n.op == "placeholder" and n.name == "x"
         )
         sym_dim = x_node.meta["val"].shape[0]
         self.assertIsInstance(sym_dim, torch.SymInt)

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -918,6 +918,15 @@ class TestPasses(unittest.TestCase):
         )
         sym_dim = x_node.meta["val"].shape[0]
         self.assertIsInstance(sym_dim, torch.SymInt)
+
+        from torch.utils._sympy.numbers import int_oo
+        from torch.utils._sympy.value_ranges import bound_sympy
+
+        raw_upper = bound_sympy(
+            sym_dim.node.expr, sym_dim.node.shape_env.var_to_range
+        ).upper
+        self.assertIs(raw_upper, int_oo)
+
         self.assertEqual(eval_upper_bound(sym_dim), 4)
 
         et = edge.to_executorch()


### PR DESCRIPTION
When bound_sympy cannot compute a finite upper bound for a symbolic expression (returns int_oo), fall back to eval_expr for the trace hint before returning int_oo. This allows models with unbounded dynamic shapes (e.g. Dim('batch', min=1) with no max) to pass through ConstraintBasedSymShapeEvalPass without raising.

Previously, int_oo was returned directly, causing
ConstraintBasedSymShapeEvalPass to raise RuntimeError because it requires concrete int upper bounds for memory planning. Downstream exporters had to monkey-patch eval_upper_bound to work around this.