### PR TITLE
Replace c10:: types with std and drop redundant optional boxing in tests

### DIFF
--- a/backends/vulkan/test/op_tests/quantize_affine_test.cpp
+++ b/backends/vulkan/test/op_tests/quantize_affine_test.cpp
@@ -21,7 +21,7 @@
 #include <limits>
 
 static inline void
-_check_dims(c10::string_view name, int64_t expected, int64_t actual) {
+_check_dims(std::string_view name, int64_t expected, int64_t actual) {
   VK_CHECK_COND(
       expected == actual,
       name,
@@ -35,11 +35,11 @@ at::Tensor quantize_affine_reference_impl(
     const at::Tensor& input_,
     const std::vector<int64_t>& block_size,
     const at::Tensor& scale,
-    const c10::optional<at::Tensor>& zero_point_opt,
+    const std::optional<at::Tensor>& zero_point_opt,
     int64_t quant_min,
     int64_t quant_max,
     at::ScalarType out_dtype,
-    c10::optional<std::string> zero_point_domain_opt = std::string("INT")) {
+    std::optional<std::string> zero_point_domain_opt = std::string("INT")) {
   constexpr float kEps = 1e-7f;
 
   const int64_t ndim = input_.dim();
@@ -138,11 +138,11 @@ at::Tensor dequantize_affine_reference_impl(
     const at::Tensor& input_,
     const std::vector<int64_t>& block_size,
     const at::Tensor& scale,
-    const c10::optional<at::Tensor>& zero_point_opt,
+    const std::optional<at::Tensor>& zero_point_opt,
     int64_t quant_min,
     int64_t quant_max,
     at::ScalarType out_dtype,
-    c10::optional<std::string> zero_point_domain_opt = std::string("INT")) {
+    std::optional<std::string> zero_point_domain_opt = std::string("INT")) {
   const int64_t ndim = input_.dim();
   _check_dims("input", block_size.size(), ndim);
 
@@ -236,47 +236,6 @@ at::Tensor dequantize_affine_reference_impl(
   dq = dq.view(in_sizes);
 
   return dq;
-}
-
-// Wrapper function to maintain compatibility with existing test code (above is
-// a good reference for how the python implementation works)
-at::Tensor quantize_affine_reference_impl(
-    const at::Tensor& input,
-    const std::vector<int64_t>& block_size,
-    const at::Tensor& scale,
-    const at::Tensor& zero_point,
-    int64_t quant_min,
-    int64_t quant_max,
-    at::ScalarType dtype) {
-  return quantize_affine_reference_impl(
-      input,
-      block_size,
-      scale,
-      c10::optional<at::Tensor>(zero_point),
-      quant_min,
-      quant_max,
-      dtype,
-      std::string("INT"));
-}
-
-// Wrapper function for dequantize_affine
-at::Tensor dequantize_affine_reference_impl(
-    const at::Tensor& input,
-    const std::vector<int64_t>& block_size,
-    const at::Tensor& scale,
-    const at::Tensor& zero_point,
-    int64_t quant_min,
-    int64_t quant_max,
-    at::ScalarType dtype) {
-  return dequantize_affine_reference_impl(
-      input,
-      block_size,
-      scale,
-      c10::optional<at::Tensor>(zero_point),
-      quant_min,
-      quant_max,
-      dtype,
-      std::string("INT"));
 }
 
 void test_vulkan_quantize_affine_impl(

--- a/extension/aten_util/test/make_aten_functor_from_et_functor_test.cpp
+++ b/extension/aten_util/test/make_aten_functor_from_et_functor_test.cpp
@@ -280,7 +280,7 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestConvert_OptionalTensor) {
 
   // Convert optional et to at.
   torch::executor::testing::TensorFactory<ScalarType::Int> tf;
-  auto et_in = std::optional<torch::executor::Tensor>(tf.ones({3}));
+  std::optional<torch::executor::Tensor> et_in = tf.ones({3});
   auto optional_at_out = type_convert<
                              std::optional<torch::executor::Tensor>,
                              std::optional<at::Tensor>>(optional_et)
@@ -403,7 +403,7 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestWrap_EmbeddingByte) {
 }
 
 TEST_F(MakeATenFunctorFromETFunctorTest, TestWrap_OptionalScalarAdd) {
-  std::optional<int64_t> a = std::optional<int64_t>(3);
+  std::optional<int64_t> a = 3;
   std::optional<int64_t> b = std::optional<int64_t>();
   at::Tensor out = torch::tensor({0});
 
@@ -418,7 +418,7 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestWrap_OptionalScalarAdd) {
 }
 
 TEST_F(MakeATenFunctorFromETFunctorTest, TestWrap_OptionalTensorAdd) {
-  std::optional<at::Tensor> a = std::optional<at::Tensor>(torch::tensor({8}));
+  std::optional<at::Tensor> a = torch::tensor({8});
   std::optional<at::Tensor> b = std::optional<at::Tensor>();
   at::Tensor out = torch::tensor({0});
 
@@ -465,9 +465,7 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestWrap_ArrayRefTensorAdd) {
 
 TEST_F(MakeATenFunctorFromETFunctorTest, TestWrap_ArrayRefOptional) {
   std::vector<std::optional<at::Tensor>> vec{
-      std::optional<at::Tensor>(torch::tensor({1})),
-      std::optional<at::Tensor>(),
-      std::optional<at::Tensor>(torch::tensor({3}))};
+      torch::tensor({1}), std::optional<at::Tensor>(), torch::tensor({3})};
   at::Tensor out = torch::tensor({0});
 
   at::ArrayRef arrayref = at::ArrayRef(vec.data(), vec.size());
@@ -512,8 +510,7 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestWrap_TupleOut) {
 
 TEST_F(MakeATenFunctorFromETFunctorTest, TestConvert_ConstRefOptionals) {
   // Test const optional scalar conversion
-  const std::optional<int64_t> const_optional_at_in =
-      std::optional<int64_t>(42);
+  const std::optional<int64_t> const_optional_at_in = 42;
   auto const_optional_et =
       type_convert<const std::optional<int64_t>, std::optional<int64_t>>(
           const_optional_at_in)
@@ -522,7 +519,7 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestConvert_ConstRefOptionals) {
   EXPECT_EQ(const_optional_et.value(), 42);
 
   // Test optional scalar reference conversion
-  std::optional<int64_t> optional_at_ref_in = std::optional<int64_t>(24);
+  std::optional<int64_t> optional_at_ref_in = 24;
   auto optional_et_from_ref =
       type_convert<std::optional<int64_t>&, std::optional<int64_t>>(
           optional_at_ref_in)
@@ -531,8 +528,7 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestConvert_ConstRefOptionals) {
   EXPECT_EQ(optional_et_from_ref.value(), 24);
 
   // Test const optional scalar reference conversion
-  const std::optional<int64_t> const_optional_at_ref_in =
-      std::optional<int64_t>(84);
+  const std::optional<int64_t> const_optional_at_ref_in = 84;
   auto const_optional_et_from_ref =
       type_convert<const std::optional<int64_t>&, std::optional<int64_t>>(
           const_optional_at_ref_in)
@@ -542,7 +538,7 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestConvert_ConstRefOptionals) {
 
   // Test const optional tensor conversion
   const std::optional<at::Tensor> const_optional_tensor_at_in =
-      std::optional<at::Tensor>(torch::tensor({5}));
+      torch::tensor({5});
   auto const_optional_tensor_converter = type_convert<
       const std::optional<at::Tensor>,
       std::optional<torch::executor::Tensor>>(const_optional_tensor_at_in);
@@ -551,8 +547,7 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestConvert_ConstRefOptionals) {
   EXPECT_EQ(const_optional_tensor_et.value().const_data_ptr<int64_t>()[0], 5);
 
   // Test optional tensor reference conversion
-  std::optional<at::Tensor> optional_tensor_at_ref_in =
-      std::optional<at::Tensor>(torch::tensor({7}));
+  std::optional<at::Tensor> optional_tensor_at_ref_in = torch::tensor({7});
   auto optional_tensor_converter_from_ref = type_convert<
       std::optional<at::Tensor>&,
       std::optional<torch::executor::Tensor>>(optional_tensor_at_ref_in);
@@ -563,7 +558,7 @@ TEST_F(MakeATenFunctorFromETFunctorTest, TestConvert_ConstRefOptionals) {
 
   // Test const optional tensor reference conversion
   const std::optional<at::Tensor> const_optional_tensor_at_ref_in =
-      std::optional<at::Tensor>(torch::tensor({9}));
+      torch::tensor({9});
   auto const_optional_tensor_converter_from_ref = type_convert<
       const std::optional<at::Tensor>&,
       std::optional<torch::executor::Tensor>>(const_optional_tensor_at_ref_in);

--- a/extension/llm/custom_ops/op_sdpa_test.cpp
+++ b/extension/llm/custom_ops/op_sdpa_test.cpp
@@ -135,9 +135,8 @@ TEST(OpScaledDotProductAttentionTest, CorrectnessTest_11) {
   executorch::aten::Tensor value = tfFloat.make(
       {1, 1, 1, 8},
       {99.375, 80.125, -81.0, 8.5, -70.375, -54.25, -80.25, 34.125});
-  std::optional<executorch::aten::Tensor> attn_mask =
-      std::optional<executorch::aten::Tensor>(
-          tfFloat.full({1, 1}, std::numeric_limits<float>::infinity()));
+  executorch::aten::Tensor attn_mask =
+      tfFloat.full({1, 1}, std::numeric_limits<float>::infinity());
   double dropout_p = 0.0;
   bool is_causal = false;
   std::optional<double> scale;
@@ -314,7 +313,7 @@ TEST(OpScaledDotProductAttentionTest, CorrectnessTest_18) {
   std::optional<executorch::aten::Tensor> attn_mask;
   double dropout_p = 0.0;
   bool is_causal = false;
-  std::optional<double> scale = std::optional<double>(-INFINITY);
+  double scale = -INFINITY;
   executorch::aten::Tensor ret_expected = tfFloat.make(
       {3, 2, 2, 6},
       {NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN,
@@ -387,15 +386,14 @@ TEST(OpScaledDotProductAttentionTest, CorrectnessTest_19) {
        15.25,   53.75,   44.625,  -22.0,   -84.0,   -7.25,   22.0,    25.875,
        17.625,  -86.875, 22.75,   -74.0,   -79.875, -68.0,   -71.125, -81.625,
        -4.125,  65.875,  1.875,   76.125,  -43.75,  -15.25,  -4.625,  -66.125});
-  std::optional<executorch::aten::Tensor> attn_mask =
-      std::optional<executorch::aten::Tensor>(tfFloat.make(
+  executorch::aten::Tensor attn_mask = tfFloat.make(
           {3, 1, 2, 2, 4},
           {39.0,  49.375,  -87.125, -99.125, 49.375,  -41.125, 26.25,   79.75,
            91.0,  -3.125,  65.75,   63.5,    -48.375, 43.375,  22.5,    -53.625,
            -70.0, 2.125,   21.875,  6.375,   -6.375,  75.25,   -35.875, 86.375,
            71.5,  -35.875, 19.75,   11.625,  -87.25,  49.0,    -6.0,    62.875,
            7.125, 87.375,  -14.75,  55.5,    59.125,  24.75,   -66.5,   72.375,
-           2.25,  81.375,  -87.125, 35.125,  -39.125, 43.5,    52.875,  39.5}));
+           2.25,  81.375,  -87.125, 35.125,  -39.125, 43.5,    52.875,  39.5});
   double dropout_p = 0.0;
   bool is_causal = false;
   std::optional<double> scale;
@@ -593,12 +591,10 @@ TEST(OpScaledDotProductAttentionTest, CorrectnessTest_51) {
   executorch::aten::Tensor value = tfFloat.make(
       {1, 1, 3, 3},
       {70.375, 30.875, 72.125, 53.0, 39.125, -4.625, 26.5, 79.5, 88.625});
-  std::optional<executorch::aten::Tensor> attn_mask =
-      std::optional<executorch::aten::Tensor>(tfFloat.make(
-          {8, 3},
-          {-59.25, -26.25, -3.0,  -24.125, 47.75,  92.375,  87.5,    21.5,
-           64.5,   45.0,   -54.0, 17.375,  -67.75, 14.625,  88.75,   36.0,
-           88.375, 25.75,  42.5,  -13.375, -82.75, -59.625, -21.125, 6.5}));
+  executorch::aten::Tensor attn_mask = tfFloat.make(
+      {8, 3}, {-59.25, -26.25, -3.0,  -24.125, 47.75,  92.375,  87.5,    21.5,
+               64.5,   45.0,   -54.0, 17.375,  -67.75, 14.625,  88.75,   36.0,
+               88.375, 25.75,  42.5,  -13.375, -82.75, -59.625, -21.125, 6.5});
   double dropout_p = 0.0;
   bool is_causal = false;
   std::optional<double> scale;

--- a/kernels/portable/test/op_div_test.cpp
+++ b/kernels/portable/test/op_div_test.cpp
@@ -60,7 +60,7 @@ TEST_F(OpDivScalarOutKernelTest, SanityCheckModeTrunc) {
   op_div_out_mode(
       tf_a.make(sizes, {1, 2, 4, -9}),
       tf_a.make(sizes, {2, 2, 2, 2}),
-      std::optional<std::string_view>("trunc"),
+      "trunc",
       out);
 
   // Check that it matches the expected output.
@@ -78,7 +78,7 @@ TEST_F(OpDivScalarOutKernelTest, SanityCheckModeFloor) {
   op_div_out_mode(
       tf_a.make(sizes, {1, 2, 4, -9}),
       tf_a.make(sizes, {2, 2, 2, 2}),
-      std::optional<std::string_view>("floor"),
+      "floor",
       out);
 
   // Check that it matches the expected output.
@@ -92,11 +92,7 @@ TEST_F(OpDivScalarModeOutKernelTest, SanityCheckModeTrunc) {
 
   Tensor out = tf.zeros(sizes);
 
-  op_div_scalar_mode_out(
-      tf.make(sizes, {1, 2, 4, -9}),
-      2,
-      std::optional<std::string_view>("trunc"),
-      out);
+  op_div_scalar_mode_out(tf.make(sizes, {1, 2, 4, -9}), 2, "trunc", out);
 
   // Check that it matches the expected output.
   EXPECT_TENSOR_EQ(out, tf.make(sizes, {0, 1, 2, -4}));
@@ -109,11 +105,7 @@ TEST_F(OpDivScalarModeOutKernelTest, SanityCheckModeFloor) {
 
   Tensor out = tf.zeros(sizes);
 
-  op_div_scalar_mode_out(
-      tf.make(sizes, {1, 2, 4, -9}),
-      2,
-      std::optional<std::string_view>("floor"),
-      out);
+  op_div_scalar_mode_out(tf.make(sizes, {1, 2, 4, -9}), 2, "floor", out);
 
   // Check that it matches the expected output.
   EXPECT_TENSOR_EQ(out, tf.make(sizes, {0, 1, 2, -5}));

--- a/kernels/test/op_avg_pool2d_test.cpp
+++ b/kernels/test/op_avg_pool2d_test.cpp
@@ -282,7 +282,7 @@ class OpAvgPool2DOutTest : public OperatorTest {
             padding_vec.data(), padding_vec.size());
     bool ceil_mode = false;
     bool count_include_pad = true;
-    std::optional<int64_t> divisor_override = std::optional<int64_t>(10);
+    int64_t divisor_override = 10;
     executorch::aten::Tensor out = tfFloat.zeros({2, 3, 3, 4});
     executorch::aten::Tensor out_expected = tfFloat.make(
         {2, 3, 3, 4},

--- a/kernels/test/op_convolution_test.cpp
+++ b/kernels/test/op_convolution_test.cpp
@@ -165,7 +165,7 @@ TEST_F(OpConvCorrectnessTest, GenericSmokeTest) {
   op_convolution_out(
       input,
       weight,
-      std::optional<Tensor>(bias),
+      bias,
       executorch::aten::ArrayRef<int64_t>{stride, 1},
       executorch::aten::ArrayRef<int64_t>{padding, 1},
       executorch::aten::ArrayRef<int64_t>{dilation, 1},
@@ -493,7 +493,7 @@ TEST_F(OpConvCorrectnessTest, InvalidInputShape) {
       op_convolution_out(
           input,
           weight,
-          std::optional<Tensor>(bias),
+          bias,
           executorch::aten::ArrayRef<int64_t>{stride, 1},
           executorch::aten::ArrayRef<int64_t>{padding, 1},
           executorch::aten::ArrayRef<int64_t>{dilation, 1},
@@ -507,7 +507,7 @@ TEST_F(OpConvCorrectnessTest, InvalidInputShape) {
       op_convolution_out(
           input,
           weight,
-          std::optional<Tensor>(bias),
+          bias,
           executorch::aten::ArrayRef<int64_t>{stride, 1},
           executorch::aten::ArrayRef<int64_t>{padding, 1},
           executorch::aten::ArrayRef<int64_t>{dilation, 1},
@@ -539,7 +539,7 @@ TEST_F(OpConvCorrectnessTest, TransposedDefaultParams) {
   op_convolution_out(
       input,
       weight,
-      std::optional<Tensor>(bias),
+      bias,
       executorch::aten::ArrayRef<int64_t>{stride, 1},
       executorch::aten::ArrayRef<int64_t>{padding, 1},
       executorch::aten::ArrayRef<int64_t>{dilation, 1},
@@ -576,7 +576,7 @@ TEST_F(OpConvCorrectnessTest, TransposedNonDefaultParams) {
   op_convolution_out(
       input,
       weight,
-      std::optional<Tensor>(bias),
+      bias,
       executorch::aten::ArrayRef<int64_t>{stride, 1},
       executorch::aten::ArrayRef<int64_t>{padding, 1},
       executorch::aten::ArrayRef<int64_t>{dilation, 1},
@@ -644,7 +644,7 @@ TEST_F(OpConvCorrectnessTest, TransposedDefaultParamsChannelsLast) {
   op_convolution_out(
       input,
       weight,
-      std::optional<Tensor>(bias),
+      bias,
       executorch::aten::ArrayRef<int64_t>{stride, 1},
       executorch::aten::ArrayRef<int64_t>{padding, 1},
       executorch::aten::ArrayRef<int64_t>{dilation, 1},
@@ -688,7 +688,7 @@ TEST_F(OpConvCorrectnessTest, TransposedNonDefaultParamsChannelsLast) {
   op_convolution_out(
       input,
       weight,
-      std::optional<Tensor>(bias),
+      bias,
       executorch::aten::ArrayRef<int64_t>{stride, 1},
       executorch::aten::ArrayRef<int64_t>{padding, 1},
       executorch::aten::ArrayRef<int64_t>{dilation, 1},
@@ -720,7 +720,7 @@ TEST_F(OpConvCorrectnessTest, InvalidOutputPadding) {
       op_convolution_out(
           input,
           weight,
-          std::optional<Tensor>(bias),
+          bias,
           executorch::aten::ArrayRef<int64_t>{stride, 1},
           executorch::aten::ArrayRef<int64_t>{padding, 1},
           executorch::aten::ArrayRef<int64_t>{dilation, 1},

--- a/kernels/test/op_native_batch_norm_test.cpp
+++ b/kernels/test/op_native_batch_norm_test.cpp
@@ -63,26 +63,24 @@ class OpNativeBatchNormLegitNoTrainingOutTest : public OperatorTest {
                  9.971039772033691,  3.5423521995544434, 7.452159881591797,
                  9.93700122833252,   1.8560808897018433, 1.524025797843933,
                  7.3222975730896});
-    std::optional<executorch::aten::Tensor> weight =
-        std::optional<executorch::aten::Tensor>(tf.make(
-            {7},
-            {8.287437438964844,
-             8.227645874023438,
-             6.65926456451416,
-             9.436124801635742,
-             4.119281768798828,
-             8.593960762023926,
-             2.3760855197906494}));
-    std::optional<executorch::aten::Tensor> bias =
-        std::optional<executorch::aten::Tensor>(tf.make(
-            {7},
-            {7.824275970458984,
-             6.84327507019043,
-             8.354326248168945,
-             8.773970603942871,
-             3.89609694480896,
-             3.0753469467163086,
-             3.1105971336364746}));
+    executorch::aten::Tensor weight = tf.make(
+        {7},
+        {8.287437438964844,
+         8.227645874023438,
+         6.65926456451416,
+         9.436124801635742,
+         4.119281768798828,
+         8.593960762023926,
+         2.3760855197906494});
+    executorch::aten::Tensor bias = tf.make(
+        {7},
+        {7.824275970458984,
+         6.84327507019043,
+         8.354326248168945,
+         8.773970603942871,
+         3.89609694480896,
+         3.0753469467163086,
+         3.1105971336364746});
     executorch::aten::Tensor running_mean = tf.make(
         {7},
         {9.700226783752441,
@@ -339,26 +337,24 @@ TEST_F(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest3D) {
                   3.887125253677368,  9.278786659240723,    6.742891311645508,
                   5.01821756362915,   2.326876640319824,    7.939553737640381,
                   3.2622408866882324, 3.829448699951172});
-  std::optional<executorch::aten::Tensor> weight =
-      std::optional<executorch::aten::Tensor>(tfFloat.make(
-          {7},
-          {0.5193436145782471,
-           4.531304836273193,
-           8.960723876953125,
-           8.598731994628906,
-           2.6848177909851074,
-           7.309220314025879,
-           2.2476916313171387}));
-  std::optional<executorch::aten::Tensor> bias =
-      std::optional<executorch::aten::Tensor>(tfFloat.make(
-          {7},
-          {4.643010139465332,
-           0.2791440486907959,
-           3.6721653938293457,
-           3.918765068054199,
-           2.6499342918395996,
-           5.721188545227051,
-           5.901060104370117}));
+  executorch::aten::Tensor weight = tfFloat.make(
+      {7},
+      {0.5193436145782471,
+       4.531304836273193,
+       8.960723876953125,
+       8.598731994628906,
+       2.6848177909851074,
+       7.309220314025879,
+       2.2476916313171387});
+  executorch::aten::Tensor bias = tfFloat.make(
+      {7},
+      {4.643010139465332,
+       0.2791440486907959,
+       3.6721653938293457,
+       3.918765068054199,
+       2.6499342918395996,
+       5.721188545227051,
+       5.901060104370117});
   executorch::aten::Tensor running_mean = tfFloat.make(
       {7},
       {5.818909645080566,
@@ -521,20 +517,18 @@ TEST_F(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTest4D) {
        9.173870086669922,   3.781676769256592,   5.6734232902526855,
        3.301741600036621,   1.3799077272415161,  8.990988731384277,
        2.2520315647125244,  2.483280897140503});
-  std::optional<executorch::aten::Tensor> weight =
-      std::optional<executorch::aten::Tensor>(tfFloat.make(
-          {4},
-          {1.8311285972595215,
-           5.851841926574707,
-           6.108979225158691,
-           5.1755266189575195}));
-  std::optional<executorch::aten::Tensor> bias =
-      std::optional<executorch::aten::Tensor>(tfFloat.make(
-          {4},
-          {5.1375732421875,
-           3.7950849533081055,
-           2.406358242034912,
-           5.785604476928711}));
+  executorch::aten::Tensor weight = tfFloat.make(
+      {4},
+      {1.8311285972595215,
+       5.851841926574707,
+       6.108979225158691,
+       5.1755266189575195});
+  executorch::aten::Tensor bias = tfFloat.make(
+      {4},
+      {5.1375732421875,
+       3.7950849533081055,
+       2.406358242034912,
+       5.785604476928711});
   executorch::aten::Tensor running_mean = tfFloat.make(
       {4},
       {2.8203158378601074,
@@ -681,20 +675,18 @@ TEST_F(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTestDouble) {
        1.7936384677886963,  1.8733304738998413,  9.386192321777344,
        2.442445755004883,   2.2374587059020996,  1.6268903017044067,
        1.9272565841674805,  0.04978537559509277, 5.165012359619141});
-  std::optional<executorch::aten::Tensor> weight =
-      std::optional<executorch::aten::Tensor>(tfDouble.make(
-          {4},
-          {5.4100823402404785,
-           3.3440847396850586,
-           0.9714162349700928,
-           0.6811875104904175}));
-  std::optional<executorch::aten::Tensor> bias =
-      std::optional<executorch::aten::Tensor>(tfDouble.make(
-          {4},
-          {6.839208126068115,
-           6.471728801727295,
-           3.077871799468994,
-           4.0067667961120605}));
+  executorch::aten::Tensor weight = tfDouble.make(
+      {4},
+      {5.4100823402404785,
+       3.3440847396850586,
+       0.9714162349700928,
+       0.6811875104904175});
+  executorch::aten::Tensor bias = tfDouble.make(
+      {4},
+      {6.839208126068115,
+       6.471728801727295,
+       3.077871799468994,
+       4.0067667961120605});
   executorch::aten::Tensor running_mean = tfDouble.make(
       {4},
       {8.781468391418457,
@@ -821,16 +813,15 @@ TEST_F(OpNativeBatchNormLegitNoTrainingOutTest, SampleAtomicTestNoWeight) {
                   5.87992000579834,    2.196932315826416,  8.085456848144531,
                   7.774395942687988,   8.86058235168457});
   std::optional<executorch::aten::Tensor> weight;
-  std::optional<executorch::aten::Tensor> bias =
-      std::optional<executorch::aten::Tensor>(tfFloat.make(
-          {7},
-          {3.2798612117767334,
-           7.070205211639404,
-           0.8457618951797485,
-           8.21817684173584,
-           4.158933162689209,
-           9.13807201385498,
-           5.7105536460876465}));
+  executorch::aten::Tensor bias = tfFloat.make(
+      {7},
+      {3.2798612117767334,
+       7.070205211639404,
+       0.8457618951797485,
+       8.21817684173584,
+       4.158933162689209,
+       9.13807201385498,
+       5.7105536460876465});
   executorch::aten::Tensor running_mean = tfFloat.make(
       {7},
       {8.596701622009277,
@@ -1004,26 +995,24 @@ TEST_F(OpNativeBatchNormLegitOutTest, SampleAtomicTest2D) {
                9.971039772033691,  3.5423521995544434, 7.452159881591797,
                9.93700122833252,   1.8560808897018433, 1.524025797843933,
                7.3222975730896});
-  std::optional<executorch::aten::Tensor> weight =
-      std::optional<executorch::aten::Tensor>(tfFloat.make(
-          {7},
-          {8.287437438964844,
-           8.227645874023438,
-           6.65926456451416,
-           9.436124801635742,
-           4.119281768798828,
-           8.593960762023926,
-           2.3760855197906494}));
-  std::optional<executorch::aten::Tensor> bias =
-      std::optional<executorch::aten::Tensor>(tfFloat.make(
-          {7},
-          {7.824275970458984,
-           6.84327507019043,
-           8.354326248168945,
-           8.773970603942871,
-           3.89609694480896,
-           3.0753469467163086,
-           3.1105971336364746}));
+  executorch::aten::Tensor weight = tfFloat.make(
+      {7},
+      {8.287437438964844,
+       8.227645874023438,
+       6.65926456451416,
+       9.436124801635742,
+       4.119281768798828,
+       8.593960762023926,
+       2.3760855197906494});
+  executorch::aten::Tensor bias = tfFloat.make(
+      {7},
+      {7.824275970458984,
+       6.84327507019043,
+       8.354326248168945,
+       8.773970603942871,
+       3.89609694480896,
+       3.0753469467163086,
+       3.1105971336364746});
   executorch::aten::Tensor running_mean = tfFloat.make(
       {7},
       {9.700226783752441,
@@ -1128,12 +1117,8 @@ TEST_F(OpNativeBatchNormLegitNoStatsOutTest, SampleAtomicTest4D) {
       tfFloat.make({2, 3, 2, 2}, {0,   1,   4,   9,   16,  25,  36,  49,
                                   64,  81,  100, 121, 144, 169, 196, 225,
                                   256, 289, 324, 361, 400, 441, 484, 529});
-  std::optional<executorch::aten::Tensor> weight =
-      std::optional<executorch::aten::Tensor>(
-          tfFloat.make({3}, {1.1, 0.7, 0.3}));
-  std::optional<executorch::aten::Tensor> bias =
-      std::optional<executorch::aten::Tensor>(
-          tfFloat.make({3}, {1.7, 2.2, 3.3}));
+  executorch::aten::Tensor weight = tfFloat.make({3}, {1.1, 0.7, 0.3});
+  executorch::aten::Tensor bias = tfFloat.make({3}, {1.7, 2.2, 3.3});
   bool training = true;
   double momentum = 1e-3;
   double eps = 1e-5;


### PR DESCRIPTION
Use std::optional/std::string_view instead of c10:: in tests, and remove redundant std::optional boxing (plain types + implicit conversion where the target is already optional).

cc @SS-JIA @manuelcandales @digantdesai @cbilgin @larryliu0820 @mergennachin @cccclai @helunwencser @jackzhxng