### PR TITLE
Fix yolo26 generic model test dependencies

### DIFF
--- a/.ci/scripts/test_model.sh
+++ b/.ci/scripts/test_model.sh
@@ -108,6 +108,11 @@ test_model() {
     bash examples/models/llava/install_requirements.sh
     STRICT="--no-strict"
   fi
+  if [[ "${MODEL_NAME}" == "yolo26" ]]; then
+    "${PYTHON_EXECUTABLE}" -m pip install --upgrade-strategy only-if-needed \
+      --extra-index-url https://download.pytorch.org/whl/cpu \
+      -r examples/models/yolo26/requirements.txt
+  fi
   if [[ "${MODEL_NAME}" == "qwen2_5_1_5b" ]]; then
       # Install requirements for export_llama
       bash examples/models/llama/install_requirements.sh


### PR DESCRIPTION
Summary:
- keep yolo26 in the generic periodic model matrix
- install examples/models/yolo26/requirements.txt before exporting yolo26 through .ci/scripts/test_model.sh

Root cause:
- the trunk failure imports examples.models.yolo26.model during generic portable export, but the job environment does not include ultralytics

Validation:
- bash -n .ci/scripts/test_model.sh
- python3 -m py_compile .ci/scripts/gather_test_models.py
- periodic PR run 29110868143: test-models-linux (cmake, yolo26, portable, linux.2xlarge, 90) / linux-job passed