### PR TITLE
Fix channels-last portable fallback by inserting explicit dim-order legalization

### DIFF
--- a/exir/passes/__init__.py
+++ b/exir/passes/__init__.py
@@ -40,6 +40,9 @@ from executorch.exir.passes.executorch_prim_ops_registry import _EXECUTORCH_SYM_
 from executorch.exir.passes.insert_write_back_for_buffers_pass import (
     insert_write_back_for_buffers_pass,
 )
+from executorch.exir.passes.legalize_portable_dim_order_pass import (
+    LegalizePortableDimOrderPass,
+)
 from executorch.exir.passes.memory_format_ops_pass import MemoryFormatOpsPass
 from executorch.exir.passes.memory_planning_pass import MemoryPlanningPass
 from executorch.exir.passes.normalize_transpose_pass import NormalizeTransposePass
@@ -76,6 +79,7 @@ __all__ = [
     "OpReplacePass",
     "ToDevicePass",
     "EdgeToBackendOpsPass",
+    "LegalizePortableDimOrderPass",
     "MemoryFormatOpsPass",
     "MemoryPlanningPass",
     "HintBasedSymShapeEvalPass",

--- a/exir/passes/legalize_portable_dim_order_pass.py
+++ b/exir/passes/legalize_portable_dim_order_pass.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.dim_order_utils import get_dim_order
+from executorch.exir.pass_base import ExportPass, NodeMetadata, ProxyValue
+import executorch.exir.passes.dim_order_ops_registry  # noqa: F401
+
+
+class LegalizePortableDimOrderPass(ExportPass):
+    """Insert contiguous dim-order copies before portable default-layout ops.
+
+    Runs during ``edge -> executorch`` lowering on leftover edge ops whose
+    portable kernels require default dim order on their primary input.
+    """
+
+    _copy_op = exir_ops.edge.dim_order_ops._to_dim_order_copy.default
+    _target_ops = {
+        exir_ops.edge.aten._adaptive_avg_pool2d.default,
+        exir_ops.edge.aten.avg_pool2d.default,
+        exir_ops.edge.aten.expand_copy.default,
+        exir_ops.edge.aten.mean.dim,
+        exir_ops.edge.aten.sum.dim_IntList,
+    }
+
+    def call_operator(self, op, args, kwargs, meta):
+        if op not in self._target_ops:
+            return super().call_operator(op, args, kwargs, meta)
+
+        input_arg = args[0]
+        if isinstance(input_arg, ProxyValue) and input_arg.is_tensor():
+            input_tensor: Optional[torch.Tensor] = input_arg.to_tensor()
+            input_meta = NodeMetadata(input_arg.node.meta)
+        elif isinstance(input_arg, torch.Tensor):
+            input_tensor = input_arg
+            input_meta = meta.copy()
+        else:
+            input_tensor = None
+            input_meta = meta.copy()
+
+        if input_tensor is None or tuple(int(d) for d in input_tensor.dim_order()) == tuple(
+            range(input_tensor.dim())
+        ):
+            return super().call_operator(op, args, kwargs, meta)
+
+        contiguous_dim_order = get_dim_order(
+            torch.contiguous_format, input_tensor.dim()
+        )
+        assert contiguous_dim_order is not None
+
+        legalized_input = super().call_operator(
+            self._copy_op,
+            (input_arg,),
+            {"dim_order": contiguous_dim_order},
+            input_meta,
+        )
+        return super().call_operator(
+            op,
+            (legalized_input, *args[1:]),
+            kwargs,
+            meta,
+        )

--- a/exir/passes/legalize_portable_dim_order_pass.py
+++ b/exir/passes/legalize_portable_dim_order_pass.py
@@ -6,11 +6,12 @@
 
 from typing import Optional
 
+import executorch.exir.passes.dim_order_ops_registry  # noqa: F401
+
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.dim_order_utils import get_dim_order
 from executorch.exir.pass_base import ExportPass, NodeMetadata, ProxyValue
-import executorch.exir.passes.dim_order_ops_registry  # noqa: F401
 
 
 class LegalizePortableDimOrderPass(ExportPass):
@@ -44,9 +45,9 @@ class LegalizePortableDimOrderPass(ExportPass):
             input_tensor = None
             input_meta = meta.copy()
 
-        if input_tensor is None or tuple(int(d) for d in input_tensor.dim_order()) == tuple(
-            range(input_tensor.dim())
-        ):
+        if input_tensor is None or tuple(
+            int(d) for d in input_tensor.dim_order()
+        ) == tuple(range(input_tensor.dim())):
             return super().call_operator(op, args, kwargs, meta)
 
         contiguous_dim_order = get_dim_order(

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -45,6 +45,7 @@ from executorch.exir.passes import (
     convert_constant_dim_order_pass,
     dead_code_elimination_pass,
     EdgeToBackendOpsPass,
+    LegalizePortableDimOrderPass,
     MemoryFormatOpsPass,
     OpReplacePass,
     remove_unused_parameters_pass,
@@ -405,12 +406,14 @@ class ExirExportedProgram:
         self,
         exported_program: ExportedProgram,
         after_to_edge_passes: bool,
+        compile_config: Optional[EdgeCompileConfig] = None,
     ):
         self.exported_program = exported_program
 
         # Add a flag to denote whehter to_edge is called on this program
         # to detect misusage of directly calling to_executorch without to_edge
         self.after_to_edge_passes = after_to_edge_passes
+        self.compile_config = compile_config or EdgeCompileConfig()
 
     def transform(self, *passes: PassType) -> "ExirExportedProgram":
         self.exported_program = _transform(self.exported_program, *passes)
@@ -441,7 +444,9 @@ class ExirExportedProgram:
             raise RuntimeError("Must run to_edge before to_executorch.")
         config = config or ExecutorchBackendConfig()
         new_gm = self.exported_program.graph_module
-        for p in edge_to_executorch_passes(config):
+        for p in edge_to_executorch_passes(
+            config, edge_compile_config=self.compile_config
+        ):
             new_gm_res = p(new_gm)
             assert new_gm_res is not None
             new_gm = new_gm_res.graph_module
@@ -478,6 +483,7 @@ class ExirExportedProgram:
         new_eep = ExirExportedProgram(
             copy.deepcopy(self.exported_program, memo),
             self.after_to_edge_passes,
+            copy.deepcopy(self.compile_config, memo),
         )
         return new_eep
 
@@ -673,6 +679,7 @@ def _to_edge(ep, config: EdgeCompileConfig) -> "ExirExportedProgram":
                 ],
             ),
             False,
+            config,
         )
     pre_op_replace_passes, post_op_replace_passes = _get_aten_to_edge_passes(config)
 
@@ -753,7 +760,9 @@ def pre_memory_planning_passes(
 
 
 def edge_to_executorch_passes(
-    config: ExecutorchBackendConfig, name: Optional[str] = None
+    config: ExecutorchBackendConfig,
+    name: Optional[str] = None,
+    edge_compile_config: Optional[EdgeCompileConfig] = None,
 ) -> List[PassType]:
     """
     Returns a list of passes to lower from edge to executorch.
@@ -766,6 +775,7 @@ def edge_to_executorch_passes(
     else:
         device_cfg = propagate_device_config
 
+    edge_compile_config = edge_compile_config or EdgeCompileConfig()
     passes: List[PassType] = [
         # ExecuTorch backend ops are unable to handle unbacked symints. So after
         # this pass, passes cannot be Interpreter-based, because it will fail if
@@ -780,6 +790,9 @@ def edge_to_executorch_passes(
         EdgeToBackendOpsPass(),
         RemoveGraphAssertsPass(),
     ] + pre_memory_planning_passes(config, name)
+
+    if not edge_compile_config._skip_dim_order:
+        passes.insert(len(config.passes), LegalizePortableDimOrderPass())
 
     return passes
 
@@ -1702,7 +1715,9 @@ class EdgeProgramManager:
             program = unsafe_remove_auto_functionalized_pass(program)
             gm, new_signature = insert_write_back_for_buffers_pass(program)
             new_gm = program.graph_module
-            for p in edge_to_executorch_passes(config, name):
+            for p in edge_to_executorch_passes(
+                config, name, edge_compile_config=self.compile_config
+            ):
                 new_gm_res = p(new_gm)
                 assert new_gm_res is not None
                 new_gm = new_gm_res.graph_module

--- a/exir/tests/test_legalize_portable_dim_order_pass.py
+++ b/exir/tests/test_legalize_portable_dim_order_pass.py
@@ -1,0 +1,233 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.exir import to_edge_transform_and_lower
+from executorch.exir.capture._config import ExecutorchBackendConfig
+from executorch.exir.passes import LegalizePortableDimOrderPass
+from executorch.extension.pybindings.portable_lib import (  # @manual
+    _load_for_executorch_from_buffer,
+)
+from torch.export import export
+from torch.testing import FileCheck
+
+
+class MeanIssueReproModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = torch.mean(x, dim=[2, 3], keepdim=True)
+        return x.reshape([-1, 2])
+
+
+class MeanNoReshapeModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.mean(x, dim=[2, 3], keepdim=True)
+
+
+class MeanKeepdimFalseModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.mean(x, dim=[2, 3], keepdim=False)
+
+
+class MeanSingleDimModule(torch.nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.mean(x, dim=[self.dim], keepdim=True)
+
+
+class LinearIssueReproModule(torch.nn.Module):
+    def __init__(self, out_features: int = 10):
+        super().__init__()
+        self.linear = torch.nn.Linear(10, out_features)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+class TestLegalizePortableDimOrderPass(unittest.TestCase):
+    @staticmethod
+    def _build_edge(module: torch.nn.Module, sample_input):
+        return to_edge_transform_and_lower(
+            export(module, sample_input, strict=True),
+            partitioner=[],
+        )
+
+    @staticmethod
+    def _build_executorch_program(module: torch.nn.Module, sample_input):
+        edge = TestLegalizePortableDimOrderPass._build_edge(module, sample_input)
+        executorch_prog = edge.to_executorch(
+            config=ExecutorchBackendConfig(extract_delegate_segments=False)
+        )
+        return edge, executorch_prog
+
+    @staticmethod
+    def _find_call_function_nodes(graph_module, target_substring: str):
+        return [
+            node
+            for node in graph_module.graph.nodes
+            if node.op == "call_function" and target_substring in str(node.target)
+        ]
+
+    def _assert_runtime_matches_eager(
+        self,
+        module: torch.nn.Module,
+        sample_input,
+        *,
+        atol: float = 1e-5,
+        rtol: float = 1e-5,
+    ):
+        edge, executorch_prog = self._build_executorch_program(module, sample_input)
+        executorch_module = _load_for_executorch_from_buffer(executorch_prog.buffer)
+
+        with torch.no_grad():
+            expected = module(*sample_input)
+        runtime_output = executorch_module.run_method("forward", sample_input)[0]
+
+        torch.testing.assert_close(
+            runtime_output,
+            expected,
+            atol=atol,
+            rtol=rtol,
+        )
+        return edge.exported_program().graph_module
+
+    def test_channels_last_mean_inserts_copy_before_mean(self) -> None:
+        module = MeanIssueReproModule().eval().to(memory_format=torch.channels_last)
+        sample_input = (
+            torch.randn(1, 2, 3, 4).to(memory_format=torch.channels_last),
+        )
+
+        edge = self._build_edge(module, sample_input)
+        updated = edge.transform([LegalizePortableDimOrderPass()])
+        graph_module = updated.exported_program().graph_module
+
+        copy_nodes = self._find_call_function_nodes(graph_module, "_to_dim_order_copy")
+        self.assertEqual(len(copy_nodes), 1)
+        mean_nodes = self._find_call_function_nodes(graph_module, "aten.mean.dim")
+        self.assertEqual(len(mean_nodes), 1)
+
+        copy_arg = mean_nodes[0].args[0]
+        self.assertIsInstance(copy_arg, torch.fx.Node)
+        self.assertIn("_to_dim_order_copy", str(copy_arg.target))
+
+    def test_channels_last_linear_inserts_copy_before_expand_copy(self) -> None:
+        module = LinearIssueReproModule(out_features=8).eval()
+        sample_input = (
+            torch.randn(1, 2, 3, 10).to(memory_format=torch.channels_last),
+        )
+
+        edge = self._build_edge(module, sample_input)
+        updated = edge.transform([LegalizePortableDimOrderPass()])
+        graph_module = updated.exported_program().graph_module
+
+        copy_nodes = self._find_call_function_nodes(graph_module, "_to_dim_order_copy")
+        self.assertEqual(len(copy_nodes), 1)
+        expand_nodes = self._find_call_function_nodes(graph_module, "aten.expand_copy")
+        self.assertTrue(expand_nodes)
+        self.assertTrue(
+            any(
+                isinstance(node.args[0], torch.fx.Node)
+                and "_to_dim_order_copy" in str(node.args[0].target)
+                for node in expand_nodes
+            ),
+            "Expected one expand_copy path to consume a legalized contiguous copy.",
+        )
+
+    def test_contiguous_inputs_skip_copy(self) -> None:
+        mean_module = MeanIssueReproModule().eval().to(memory_format=torch.channels_last)
+        linear_module = LinearIssueReproModule().eval()
+        cases = (
+            ("mean", mean_module, (torch.randn(1, 2, 3, 4).contiguous(),)),
+            ("linear", linear_module, (torch.randn(1, 2, 3, 10).contiguous(),)),
+        )
+
+        for name, module, sample_input in cases:
+            with self.subTest(name=name):
+                edge = self._build_edge(module, sample_input)
+                updated = edge.transform([LegalizePortableDimOrderPass()])
+                FileCheck().check_not("_to_dim_order_copy").run(
+                    updated.exported_program().graph_module.code
+                )
+
+    def test_issue_16507_runtime_regressions(self) -> None:
+        cases = (
+            (
+                "baseline",
+                MeanIssueReproModule().eval().to(memory_format=torch.channels_last),
+                (torch.randn(1, 2, 3, 4).to(memory_format=torch.channels_last),),
+            ),
+            (
+                "no_reshape",
+                MeanNoReshapeModule().eval().to(memory_format=torch.channels_last),
+                (torch.randn(1, 2, 3, 4).to(memory_format=torch.channels_last),),
+            ),
+            (
+                "keepdim_false",
+                MeanKeepdimFalseModule().eval().to(memory_format=torch.channels_last),
+                (torch.randn(1, 2, 3, 4).to(memory_format=torch.channels_last),),
+            ),
+            (
+                "single_dim_h",
+                MeanSingleDimModule(2).eval().to(memory_format=torch.channels_last),
+                (torch.randn(1, 2, 3, 4).to(memory_format=torch.channels_last),),
+            ),
+            (
+                "single_dim_w",
+                MeanSingleDimModule(3).eval().to(memory_format=torch.channels_last),
+                (torch.randn(1, 2, 3, 4).to(memory_format=torch.channels_last),),
+            ),
+        )
+
+        for name, module, sample_input in cases:
+            with self.subTest(name=name):
+                graph_module = self._assert_runtime_matches_eager(module, sample_input)
+                FileCheck().check("_to_dim_order_copy").check("aten.mean.out").run(
+                    graph_module.code
+                )
+
+    def test_issue_11086_runtime_regressions(self) -> None:
+        cases = (
+            (
+                "baseline",
+                LinearIssueReproModule().eval(),
+                (torch.randn(1, 2, 3, 10).to(memory_format=torch.channels_last),),
+            ),
+            (
+                "larger_spatial",
+                LinearIssueReproModule(out_features=6).eval(),
+                (torch.randn(2, 5, 7, 10).to(memory_format=torch.channels_last),),
+            ),
+        )
+
+        for name, module, sample_input in cases:
+            with self.subTest(name=name):
+                graph_module = self._assert_runtime_matches_eager(module, sample_input)
+                FileCheck().check("_to_dim_order_copy").check("aten.expand_copy.out").run(
+                    graph_module.code
+                )
+
+    def test_issue_11086_c1_control_uses_alternate_path(self) -> None:
+        module = LinearIssueReproModule(out_features=8).eval()
+        sample_input = (
+            torch.randn(1, 1, 3, 10).to(memory_format=torch.channels_last),
+        )
+
+        edge = self._build_edge(module, sample_input)
+        graph_module = edge.exported_program().graph_module
+        FileCheck().check_not("aten.expand_copy").run(graph_module.code)
+
+        updated = edge.transform([LegalizePortableDimOrderPass()])
+        FileCheck().check_not("_to_dim_order_copy").run(
+            updated.exported_program().graph_module.code
+        )
+
+        runtime_graph = self._assert_runtime_matches_eager(module, sample_input)
+        FileCheck().check_not("aten.expand_copy.out").run(runtime_graph.code)
+

--- a/exir/tests/test_legalize_portable_dim_order_pass.py
+++ b/exir/tests/test_legalize_portable_dim_order_pass.py
@@ -100,9 +100,7 @@ class TestLegalizePortableDimOrderPass(unittest.TestCase):
 
     def test_channels_last_mean_inserts_copy_before_mean(self) -> None:
         module = MeanIssueReproModule().eval().to(memory_format=torch.channels_last)
-        sample_input = (
-            torch.randn(1, 2, 3, 4).to(memory_format=torch.channels_last),
-        )
+        sample_input = (torch.randn(1, 2, 3, 4).to(memory_format=torch.channels_last),)
 
         edge = self._build_edge(module, sample_input)
         updated = edge.transform([LegalizePortableDimOrderPass()])
@@ -119,9 +117,7 @@ class TestLegalizePortableDimOrderPass(unittest.TestCase):
 
     def test_channels_last_linear_inserts_copy_before_expand_copy(self) -> None:
         module = LinearIssueReproModule(out_features=8).eval()
-        sample_input = (
-            torch.randn(1, 2, 3, 10).to(memory_format=torch.channels_last),
-        )
+        sample_input = (torch.randn(1, 2, 3, 10).to(memory_format=torch.channels_last),)
 
         edge = self._build_edge(module, sample_input)
         updated = edge.transform([LegalizePortableDimOrderPass()])
@@ -141,7 +137,9 @@ class TestLegalizePortableDimOrderPass(unittest.TestCase):
         )
 
     def test_contiguous_inputs_skip_copy(self) -> None:
-        mean_module = MeanIssueReproModule().eval().to(memory_format=torch.channels_last)
+        mean_module = (
+            MeanIssueReproModule().eval().to(memory_format=torch.channels_last)
+        )
         linear_module = LinearIssueReproModule().eval()
         cases = (
             ("mean", mean_module, (torch.randn(1, 2, 3, 4).contiguous(),)),
@@ -209,15 +207,13 @@ class TestLegalizePortableDimOrderPass(unittest.TestCase):
         for name, module, sample_input in cases:
             with self.subTest(name=name):
                 graph_module = self._assert_runtime_matches_eager(module, sample_input)
-                FileCheck().check("_to_dim_order_copy").check("aten.expand_copy.out").run(
-                    graph_module.code
-                )
+                FileCheck().check("_to_dim_order_copy").check(
+                    "aten.expand_copy.out"
+                ).run(graph_module.code)
 
     def test_issue_11086_c1_control_uses_alternate_path(self) -> None:
         module = LinearIssueReproModule(out_features=8).eval()
-        sample_input = (
-            torch.randn(1, 1, 3, 10).to(memory_format=torch.channels_last),
-        )
+        sample_input = (torch.randn(1, 1, 3, 10).to(memory_format=torch.channels_last),)
 
         edge = self._build_edge(module, sample_input)
         graph_module = edge.exported_program().graph_module
@@ -230,4 +226,3 @@ class TestLegalizePortableDimOrderPass(unittest.TestCase):
 
         runtime_graph = self._assert_runtime_matches_eager(module, sample_input)
         FileCheck().check_not("aten.expand_copy.out").run(runtime_graph.code)
-


### PR DESCRIPTION
Fixes #16507 #11086 

I kept the pass and regressions in separate files to keep the change cleaner. A more optimized followup is probably worth doing if more issues like these appear.

Added separate test file `exir/tests/test_legalize_portable_dim_order_pass.py`

cc @JacobSzwejbka @angelayi @larryliu0820 @lucylq