### PR TITLE
All lib installs target CMake install libdir

### DIFF
--- a/devtools/bundled_program/CMakeLists.txt
+++ b/devtools/bundled_program/CMakeLists.txt
@@ -51,7 +51,7 @@ target_include_directories(
 install(
   TARGETS bundled_program
   EXPORT ExecuTorchTargets
-  DESTINATION ${CMAKE_BINARY_DIR}/lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
   INCLUDES
   DESTINATION ${_common_include_directories}
 )

--- a/devtools/etdump/CMakeLists.txt
+++ b/devtools/etdump/CMakeLists.txt
@@ -63,7 +63,7 @@ target_include_directories(
 install(
   TARGETS etdump flatccrt
   EXPORT ExecuTorchTargets
-  DESTINATION ${CMAKE_BINARY_DIR}/lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
   INCLUDES
   DESTINATION ${_common_include_directories}
 )

--- a/extension/evalue_util/CMakeLists.txt
+++ b/extension/evalue_util/CMakeLists.txt
@@ -24,7 +24,7 @@ target_compile_options(extension_evalue_util PUBLIC ${_common_compile_options})
 install(
   TARGETS extension_evalue_util
   EXPORT ExecuTorchTargets
-  DESTINATION ${CMAKE_BINARY_DIR}/lib
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}
   INCLUDES
   DESTINATION ${_common_include_directories}
 )

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -187,4 +187,4 @@ add_dependencies(flatccrt flatcc_cli)
 #
 # Learn more: https://github.com/pytorch/executorch/pull/2467
 set_property(TARGET flatccrt PROPERTY POSITION_INDEPENDENT_CODE ON)
-install(TARGETS flatccrt DESTINATION ${CMAKE_BINARY_DIR}/lib)
+install(TARGETS flatccrt DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
### Summary

4 libraries previously targeted the lib directory in the build directory.  This change modifies target location to match the other 55 libraries in the project.

Fixes #20709 

### Test plan

```bash
# Configure, build, and install
cmake -B cmake-out --preset linux -DCMAKE_BUILD_TYPE=Release -DEXECUTORCH_BUILD_XNNPACK=ON -DCMAKE_INSTALL_PREFIX="et-install" -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DEXECUTORCH_BUILD_EXTENSION_MODULE=ON DEXECUTORCH_BUILD_EXTENSION_DATA_LOADER=ON -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON
cmake --build cmake-out -j15
cmake --install cmake-out --prefix et-install
# Confirm source directory isn't baked into release .cmake file (exit code 1)
grep -n 'cmake-out' et-install/lib/cmake/ExecuTorch/ExecuTorchTargets-release.cmake
# Confirm modified targets appear in installation lib directory
ls -l et-install/lib/libextension_evalue_util.a # exists
ls -l et-install/lib/libflatccrt.a # exists
```

cc @larryliu0820 @GregoryComer