### PR TITLE
Arm backend: Fix fuse_identical_input_transforms for user inputs

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -122,6 +122,7 @@ from .fuse_duplicate_users_pass import FuseDuplicateUsersPass  # noqa
 from .fuse_equal_placeholders_pass import FuseEqualPlaceholdersPass  # noqa
 from .fuse_identical_input_transforms_pass import (  # noqa
     FuseIdenticalInputTransformsPass,
+    NormalizeTransformInputPlaceholdersPass,
 )
 from .fuse_quantized_activation_pass import FuseQuantizedActivationPass  # noqa
 from .fuse_view_copy_transform_pass import FuseViewCopyTransformPass  # noqa

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -129,6 +129,7 @@ from executorch.backends.arm._passes import (
     NormalizeDelegateIOLayoutPass,
     NormalizeIndexPutBoolIndexTensorPass,
     NormalizeIndexPutNoneIndicesPass,
+    NormalizeTransformInputPlaceholdersPass,
     NormalizeWhileInitialArgsPass,
     PromoteBoolOperandsPass,
     QuantizeClampArgumentsPass,
@@ -502,7 +503,7 @@ class ArmPassManager(ExportedProgramPassManager):
                 # TODO: DecomposeLinearPass should run after InsertRescaleInt32Pass or
                 # before FoldAndAnnotateQParamsPass but is unable to at the moment.
                 # Ticket: MLETORCH-1539
-                FuseIdenticalInputTransformsPass(),
+                FuseIdenticalInputTransformsPass(exported_program),
                 DecomposeLinearPass(),
                 InsertRescaleInt32Pass(),
                 FuseConsecutiveRescalesPass(),
@@ -638,6 +639,7 @@ class ArmPassManager(ExportedProgramPassManager):
             [
                 CastInt64BuffersToInt32Pass(exported_program),
                 FuseEqualPlaceholdersPass(exported_program),
+                NormalizeTransformInputPlaceholdersPass(exported_program),
                 ExirToTosaPass(exported_program),
                 SymbolicToTosaShapesPass(),
                 InsertDynamicPaddingPass(),

--- a/backends/arm/_passes/fuse_identical_input_transforms_pass.py
+++ b/backends/arm/_passes/fuse_identical_input_transforms_pass.py
@@ -14,7 +14,92 @@ from executorch.backends.arm._passes.arm_pass_utils import refresh_permute_view_
 from executorch.backends.arm._passes.dim_maps import PermuteMap, same_numel, ViewMap
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
+from torch.export.exported_program import ExportedProgram
+from torch.export.graph_signature import InputSpec, TensorArgument
 from torch.fx import GraphModule, Node
+
+
+class NormalizeTransformInputPlaceholdersPass(ExportPass):
+    """Normalize placeholder names for lifted transform inputs."""
+
+    def __init__(self, exported_program: ExportedProgram | None = None) -> None:
+        super().__init__()
+        self.exported_program = exported_program
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        return PassResult(
+            graph_module,
+            self._normalize_transform_user_input_placeholders(graph_module),
+        )
+
+    def _normalize_transform_user_input_placeholders(
+        self, graph_module: GraphModule
+    ) -> bool:
+        if self.exported_program is None:
+            return False
+
+        signature = self.exported_program.graph_signature
+        placeholder_names = {
+            node.name for node in graph_module.graph.nodes if node.op == "placeholder"
+        }
+        name_updates: dict[str, str] = {}
+        modified = False
+        for node in graph_module.graph.nodes:
+            if node.op != "placeholder":
+                continue
+            if not self._placeholder_represents_transform(node):
+                continue
+            old_target = str(node.target)
+
+            if node.target != node.name:
+                node.target = node.name
+                modified = True
+                if old_target not in placeholder_names:
+                    name_updates[old_target] = node.name
+
+        if not modified:
+            return False
+
+        if name_updates:
+            signature.input_specs = [
+                self._renamed_input_spec(spec, name_updates)
+                for spec in signature.input_specs
+            ]
+        graph_module.graph.lint()
+        graph_module.recompile()
+        return True
+
+    def _placeholder_represents_transform(self, node: Node) -> bool:
+        return any(
+            self._matches_transform_placeholder_name(node.name, target)
+            or self._matches_transform_placeholder_name(str(node.target), target)
+            for target in FuseIdenticalInputTransformsPass._TARGETS
+        )
+
+    def _matches_transform_placeholder_name(
+        self, name: str, target: torch.fx.node.Target
+    ) -> bool:
+        base_name = self._target_placeholder_name(target)
+        if name == base_name:
+            return True
+
+        suffix = name.removeprefix(f"{base_name}_")
+        return suffix != name and suffix.isdecimal()
+
+    def _target_placeholder_name(self, target: torch.fx.node.Target) -> str:
+        return target.__name__.replace(".", "_")  # type: ignore[union-attr]
+
+    def _renamed_input_spec(
+        self, spec: InputSpec, name_updates: dict[str, str]
+    ) -> InputSpec:
+        if isinstance(spec.arg, TensorArgument) and spec.arg.name in name_updates:
+            return InputSpec(
+                kind=spec.kind,
+                arg=TensorArgument(name=name_updates[spec.arg.name]),
+                target=spec.target,
+                persistent=spec.persistent,
+            )
+        return spec
 
 
 class FuseIdenticalInputTransformsPass(ArmOpTargetedPass):
@@ -60,8 +145,16 @@ class FuseIdenticalInputTransformsPass(ArmOpTargetedPass):
 
     target_ops = _BINARY_ELEMENTWISE_OPS | _CONCAT_OPS
 
+    def __init__(self, exported_program: ExportedProgram | None = None) -> None:
+        super().__init__()
+        self.exported_program = exported_program
+
     def call(self, graph_module: GraphModule) -> PassResult:
-        modified = False
+        modified = (
+            NormalizeTransformInputPlaceholdersPass(self.exported_program)
+            .call(graph_module)
+            .modified
+        )
 
         while True:
             iteration_modified = False
@@ -124,7 +217,7 @@ class FuseIdenticalInputTransformsPass(ArmOpTargetedPass):
                 args=transform_args,
                 kwargs=dict(transform.kwargs),
             )
-        new_node.meta = copy.copy(transform.meta)
+        new_node.meta = self._new_transform_meta(node, transform)
         refresh_permute_view_meta(new_node)
 
         for user in list(node.users):
@@ -132,6 +225,14 @@ class FuseIdenticalInputTransformsPass(ArmOpTargetedPass):
                 user.replace_input_with(node, new_node)
 
         return True
+
+    def _new_transform_meta(self, node: Node, transform: Node) -> dict[str, Any]:
+        meta = copy.copy(transform.meta)
+        if "delegation_tag" in node.meta:
+            meta["delegation_tag"] = node.meta["delegation_tag"]
+        else:
+            meta.pop("delegation_tag", None)
+        return meta
 
     def _updated_node_args(
         self, node: Node, transform: Node, node_val: Any, input_transforms: list[Node]

--- a/backends/arm/test/passes/test_fuse_identical_input_transforms_pass.py
+++ b/backends/arm/test/passes/test_fuse_identical_input_transforms_pass.py
@@ -4,16 +4,29 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+from types import SimpleNamespace
 from typing import cast, Sequence
 
 import pytest
 import torch
+from executorch.backends.arm import process_node
 from executorch.backends.arm._passes.fuse_identical_input_transforms_pass import (
     FuseIdenticalInputTransformsPass,
+    NormalizeTransformInputPlaceholdersPass,
 )
+from executorch.backends.arm.tosa.specification import TosaSpecification
 from executorch.backends.test.graph_builder import GraphBuilder
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import PassResult, ProxyValue
+from torch.export.exported_program import ExportedProgram
+from torch.export.graph_signature import (
+    ExportGraphSignature,
+    InputKind,
+    InputSpec,
+    OutputKind,
+    OutputSpec,
+    TensorArgument,
+)
 from torch.utils import _pytree as pytree
 
 
@@ -38,6 +51,10 @@ def _compute_nodes(graph_module: torch.fx.GraphModule) -> list[torch.fx.node.Tar
     ]
 
 
+def _call_function_nodes(graph_module: torch.fx.GraphModule) -> list[torch.fx.Node]:
+    return [node for node in graph_module.graph.nodes if node.op == "call_function"]
+
+
 def _validate_numerics(
     original: torch.fx.GraphModule,
     modified: torch.fx.GraphModule,
@@ -57,9 +74,13 @@ def _validate_numerics(
 
 def _apply_pass(
     graph_module: torch.fx.GraphModule,
+    exported_program: ExportedProgram | None = None,
 ) -> tuple[torch.fx.GraphModule, PassResult]:
     original = copy.deepcopy(graph_module)
-    result = cast(PassResult, FuseIdenticalInputTransformsPass().call(graph_module))
+    result = cast(
+        PassResult,
+        FuseIdenticalInputTransformsPass(exported_program).call(graph_module),
+    )
     return original, result
 
 
@@ -127,6 +148,34 @@ def test_fuse_identical_input_transforms_sinks_view() -> None:
     _validate_numerics(original, result.graph_module, (x_data, y_data))
 
 
+def test_fuse_identical_input_transforms_sunk_view_keeps_delegation_tag() -> None:
+    x_data = torch.randn(6)
+    y_data = torch.randn(6)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_VIEW, [2, 3])],
+        [(_VIEW, [2, 3])],
+    )
+    add = next(
+        node for node in _call_function_nodes(graph_module) if node.target == _ADD
+    )
+    add.meta["delegation_tag"] = "tag0"
+
+    original, result = _apply_pass(graph_module)
+
+    call_nodes = _call_function_nodes(result.graph_module)
+    add = next(node for node in call_nodes if node.target == _ADD)
+    view = next(node for node in call_nodes if node.target == _VIEW)
+
+    assert result.modified
+    assert _count_node(result.graph_module, _VIEW) == 1
+    assert _compute_nodes(result.graph_module) == [_ADD, _VIEW]
+    assert add.meta["delegation_tag"] == "tag0"
+    assert view.meta["delegation_tag"] == "tag0"
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
 def test_fuse_identical_input_transforms_sinks_permute() -> None:
     x_data = torch.randn(2, 3, 4)
     y_data = torch.randn(2, 3, 4)
@@ -142,6 +191,33 @@ def test_fuse_identical_input_transforms_sinks_permute() -> None:
     assert result.modified
     assert _count_node(result.graph_module, _PERMUTE) == 1
     assert _compute_nodes(result.graph_module) == [_ADD, _PERMUTE]
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_sunk_permute_replaces_stale_tag() -> None:
+    x_data = torch.randn(2, 3, 4)
+    y_data = torch.randn(2, 3, 4)
+    graph_module = _binary_transform_graph(
+        x_data,
+        y_data,
+        [(_PERMUTE, [0, 2, 1])],
+        [(_PERMUTE, [0, 2, 1])],
+    )
+    for node in _call_function_nodes(graph_module):
+        if node.target == _PERMUTE:
+            node.meta["delegation_tag"] = "old_tag"
+        if node.target == _ADD:
+            node.meta["delegation_tag"] = "tag0"
+
+    original, result = _apply_pass(graph_module)
+
+    call_nodes = _call_function_nodes(result.graph_module)
+    permute = next(node for node in call_nodes if node.target == _PERMUTE)
+
+    assert result.modified
+    assert _count_node(result.graph_module, _PERMUTE) == 1
+    assert _compute_nodes(result.graph_module) == [_ADD, _PERMUTE]
+    assert permute.meta["delegation_tag"] == "tag0"
     _validate_numerics(original, result.graph_module, (x_data, y_data))
 
 
@@ -174,6 +250,358 @@ def test_fuse_identical_input_transforms_sinks_cat_input_views() -> None:
     assert cat_node.meta["val"].shape == torch.Size((2, 3, 8))
     assert view.args == (cat_node, [6, 8])
     _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_sunk_cat_view_keeps_delegation_tag() -> None:
+    x_data = torch.randn(2, 3, 4)
+    y_data = torch.randn(2, 3, 4)
+
+    builder = GraphBuilder()
+    x = builder.placeholder("x", x_data)
+    y = builder.placeholder("y", y_data)
+    x_view = builder.call_operator(op=_VIEW, args=(x, [6, 4]))
+    y_view = builder.call_operator(op=_VIEW, args=(y, [6, 4]))
+    cat = builder.call_operator(op=_CAT, args=([x_view, y_view], 1))
+    cat.node.meta["delegation_tag"] = "tag0"
+    builder.output([cat])
+    graph_module = builder.get_graph_module()
+
+    original, result = _apply_pass(graph_module)
+
+    call_nodes = _call_function_nodes(result.graph_module)
+    view = next(node for node in call_nodes if node.target == _VIEW)
+
+    assert result.modified
+    assert _count_node(result.graph_module, _VIEW) == 1
+    assert _compute_nodes(result.graph_module) == [_CAT, _VIEW]
+    assert view.meta["delegation_tag"] == "tag0"
+    _validate_numerics(original, result.graph_module, (x_data, y_data))
+
+
+def test_fuse_identical_input_transforms_preserves_transform_user_input_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+    x.meta["val"] = torch.randn(2, 3)
+    y.meta["val"] = torch.randn(2, 3)
+    add = graph.call_function(_ADD, args=(x, y))
+    add.meta["val"] = torch.randn(2, 3)
+    graph.output((add,))
+    graph_module = torch.fx.GraphModule({}, graph)
+    x.name = "aten_view_copy_default"
+    x.target = "aten_view_copy_default"
+    y.name = "aten_view_copy_default_1"
+    y.target = "aten_view_copy_default"
+    exported_program = cast(
+        ExportedProgram,
+        SimpleNamespace(
+            graph_signature=ExportGraphSignature(
+                input_specs=[
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name=x.name),
+                        target=None,
+                    ),
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name=y.name),
+                        target=None,
+                    ),
+                ],
+                output_specs=[
+                    OutputSpec(
+                        kind=OutputKind.USER_OUTPUT,
+                        arg=TensorArgument(name=add.name),
+                        target=None,
+                    )
+                ],
+            )
+        ),
+    )
+
+    fuse_pass = FuseIdenticalInputTransformsPass()
+    fuse_pass.exported_program = exported_program
+    result = cast(
+        PassResult,
+        fuse_pass.call(graph_module),
+    )
+
+    placeholders = [
+        node for node in result.graph_module.graph.nodes if node.op == "placeholder"
+    ]
+    input_spec_names = [
+        spec.arg.name for spec in exported_program.graph_signature.input_specs
+    ]
+
+    monkeypatch.setattr(process_node, "process_inputs", lambda *args: None)
+    for node in placeholders:
+        process_node.process_placeholder(
+            node,
+            None,
+            exported_program,
+            None,
+            cast(TosaSpecification, None),
+        )
+
+    assert result.modified
+    assert [node.name for node in placeholders] == [
+        "aten_view_copy_default",
+        "aten_view_copy_default_1",
+    ]
+    assert [node.target for node in placeholders] == [
+        "aten_view_copy_default",
+        "aten_view_copy_default_1",
+    ]
+    assert input_spec_names == [
+        "aten_view_copy_default",
+        "aten_view_copy_default_1",
+    ]
+
+
+def test_fuse_identical_input_transforms_normalizes_multi_user_transform_input() -> (
+    None
+):
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+    x.meta["val"] = torch.randn(2, 3)
+    y.meta["val"] = torch.randn(2, 3)
+    add = graph.call_function(_ADD, args=(x, y))
+    sub = graph.call_function(exir_ops.edge.aten.sub.Tensor, args=(x, y))
+    add.meta["val"] = torch.randn(2, 3)
+    sub.meta["val"] = torch.randn(2, 3)
+    graph.output((add, sub))
+    graph_module = torch.fx.GraphModule({}, graph)
+    x.name = "aten_view_copy_default_2"
+    x.target = "aten_view_copy_default"
+    exported_program = cast(
+        ExportedProgram,
+        SimpleNamespace(
+            graph_signature=ExportGraphSignature(
+                input_specs=[
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name=x.name),
+                        target=None,
+                    ),
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name=y.name),
+                        target=None,
+                    ),
+                ],
+                output_specs=[
+                    OutputSpec(
+                        kind=OutputKind.USER_OUTPUT,
+                        arg=TensorArgument(name=add.name),
+                        target=None,
+                    ),
+                    OutputSpec(
+                        kind=OutputKind.USER_OUTPUT,
+                        arg=TensorArgument(name=sub.name),
+                        target=None,
+                    ),
+                ],
+            )
+        ),
+    )
+
+    _, result = _apply_pass(graph_module, exported_program)
+
+    input_spec_names = [
+        spec.arg.name for spec in exported_program.graph_signature.input_specs
+    ]
+    assert result.modified
+    assert x.name == "aten_view_copy_default_2"
+    assert x.target == "aten_view_copy_default_2"
+    assert input_spec_names == ["aten_view_copy_default_2", "y"]
+
+
+def test_normalize_transform_input_placeholders_does_not_sink_transforms() -> None:
+    graph_module = _binary_transform_graph(
+        torch.randn(6),
+        torch.randn(6),
+        [(_VIEW, [2, 3])],
+        [(_VIEW, [2, 3])],
+    )
+    placeholder = next(
+        node for node in graph_module.graph.nodes if node.op == "placeholder"
+    )
+    placeholder.name = "aten_view_copy_default_2"
+    placeholder.target = "aten_view_copy_default"
+    exported_program = cast(
+        ExportedProgram,
+        SimpleNamespace(
+            graph_signature=ExportGraphSignature(
+                input_specs=[
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name="aten_view_copy_default"),
+                        target=None,
+                    )
+                ],
+                output_specs=[],
+            )
+        ),
+    )
+
+    result = NormalizeTransformInputPlaceholdersPass(exported_program).call(
+        graph_module
+    )
+
+    input_spec_names = [
+        spec.arg.name for spec in exported_program.graph_signature.input_specs
+    ]
+    assert result.modified
+    assert placeholder.target == "aten_view_copy_default_2"
+    assert input_spec_names == ["aten_view_copy_default_2"]
+    assert _count_node(result.graph_module, _VIEW) == 2
+    assert _compute_nodes(result.graph_module) == [_VIEW, _VIEW, _ADD]
+
+
+def test_fuse_identical_input_transforms_normalizes_transform_input_signature() -> None:
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+    x.meta["val"] = torch.randn(2, 3)
+    y.meta["val"] = torch.randn(2, 3)
+    add = graph.call_function(_ADD, args=(x, y))
+    add.meta["val"] = torch.randn(2, 3)
+    graph.output((add,))
+    graph_module = torch.fx.GraphModule({}, graph)
+    x.name = "aten_view_copy_default_2"
+    x.target = "aten_view_copy_default"
+    exported_program = cast(
+        ExportedProgram,
+        SimpleNamespace(
+            graph_signature=ExportGraphSignature(
+                input_specs=[
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name="aten_view_copy_default"),
+                        target=None,
+                    ),
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name=y.name),
+                        target=None,
+                    ),
+                ],
+                output_specs=[
+                    OutputSpec(
+                        kind=OutputKind.USER_OUTPUT,
+                        arg=TensorArgument(name=add.name),
+                        target=None,
+                    )
+                ],
+            )
+        ),
+    )
+
+    _, result = _apply_pass(graph_module, exported_program)
+
+    input_spec_names = [
+        spec.arg.name for spec in exported_program.graph_signature.input_specs
+    ]
+    assert result.modified
+    assert x.target == "aten_view_copy_default_2"
+    assert input_spec_names == ["aten_view_copy_default_2", "y"]
+
+
+def test_fuse_identical_input_transforms_normalizes_non_user_transform_placeholder() -> (
+    None
+):
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+    x.meta["val"] = torch.randn(2, 3)
+    y.meta["val"] = torch.randn(2, 3)
+    add = graph.call_function(_ADD, args=(x, y))
+    add.meta["val"] = torch.randn(2, 3)
+    graph.output((add,))
+    graph_module = torch.fx.GraphModule({}, graph)
+    x.name = "aten_view_copy_default_2"
+    x.target = "aten_view_copy_default"
+    exported_program = cast(
+        ExportedProgram,
+        SimpleNamespace(
+            graph_signature=ExportGraphSignature(
+                input_specs=[
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name=y.name),
+                        target=None,
+                    ),
+                ],
+                output_specs=[
+                    OutputSpec(
+                        kind=OutputKind.USER_OUTPUT,
+                        arg=TensorArgument(name=add.name),
+                        target=None,
+                    )
+                ],
+            )
+        ),
+    )
+
+    _, result = _apply_pass(graph_module, exported_program)
+
+    input_spec_names = [
+        spec.arg.name for spec in exported_program.graph_signature.input_specs
+    ]
+    assert result.modified
+    assert x.target == "aten_view_copy_default_2"
+    assert input_spec_names == ["y"]
+
+
+def test_fuse_identical_input_transforms_ignores_non_transform_placeholder_names() -> (
+    None
+):
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    y = graph.placeholder("y")
+    x.meta["val"] = torch.randn(2, 3)
+    y.meta["val"] = torch.randn(2, 3)
+    add = graph.call_function(_ADD, args=(x, y))
+    add.meta["val"] = torch.randn(2, 3)
+    graph.output((add,))
+    graph_module = torch.fx.GraphModule({}, graph)
+    x.name = "custom_view_copy_default"
+    x.target = "custom_view_copy_default_base"
+    exported_program = cast(
+        ExportedProgram,
+        SimpleNamespace(
+            graph_signature=ExportGraphSignature(
+                input_specs=[
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name=x.name),
+                        target=None,
+                    ),
+                    InputSpec(
+                        kind=InputKind.USER_INPUT,
+                        arg=TensorArgument(name=y.name),
+                        target=None,
+                    ),
+                ],
+                output_specs=[
+                    OutputSpec(
+                        kind=OutputKind.USER_OUTPUT,
+                        arg=TensorArgument(name=add.name),
+                        target=None,
+                    )
+                ],
+            )
+        ),
+    )
+
+    _, result = _apply_pass(graph_module, exported_program)
+
+    assert not result.modified
+    assert x.name == "custom_view_copy_default"
+    assert x.target == "custom_view_copy_default_base"
 
 
 def test_fuse_identical_input_transforms_rejects_cat_mixed_transforms() -> None:


### PR DESCRIPTION
### Summary
Sink identical view_copy and permute_copy inputs through supported elementwise and concat ops. This removes redundant transform nodes and normalizes lifted transform input placeholders so graph signatures stay consistent.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani