### PR TITLE
Fix docs gh-pages publish authentication

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -101,7 +101,6 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     secrets: inherit
     with:
-      secrets-env: DOC_BUILD_GITHUB_TOKEN
       repository: pytorch/executorch
       download-artifact: docs
       ref: gh-pages
@@ -134,9 +133,6 @@ jobs:
         mkdir -p "${TARGET_FOLDER}"
         mv "${RUNNER_ARTIFACT_DIR}"/html/* "${TARGET_FOLDER}"
         git add "${TARGET_FOLDER}" || true
-
-        echo "::add-mask::$SECRET_DOC_BUILD_GITHUB_TOKEN" # Mask the secret in GH logs
-        git remote set-url origin https://x-access-token:$SECRET_DOC_BUILD_GITHUB_TOKEN@github.com/pytorch/executorch.git
 
         git config user.name 'pytorchbot'
         git config user.email 'soumith+bot@pytorch.org'


### PR DESCRIPTION
Summary:
- Stop passing DOC_BUILD_GITHUB_TOKEN into the docs gh-pages publish job.
- Stop overriding `origin` with that token before pushing generated docs.
- Let the checkout credentials use the job's existing `contents: write` permission for the gh-pages push.

Failure fixed:
- https://github.com/pytorch/executorch/actions/runs/29237660083/job/86778638704 failed at `git push -f` with `Permission to pytorch/executorch.git denied to GregoryComer`.

Testing:
- git diff --check

Notes:
- PyYAML/actionlint are not installed in this local environment, so I could not run a workflow syntax parser locally.