### PR TITLE
Run docs gh-pages publish outside Docker

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -104,6 +104,9 @@ jobs:
       repository: pytorch/executorch
       download-artifact: docs
       ref: gh-pages
+      # Publish on the host so actions/checkout's persisted credentials are
+      # available to git push.
+      run-with-docker: false
       timeout: 90
       script: |
         set -euo pipefail


### PR DESCRIPTION
Summary:
- Run the docs gh-pages publish script on the host instead of inside Docker.
- Keep using actions/checkout persisted credentials for the GITHUB_TOKEN-backed push.

Failure fixed:
- Post-#20890 docs publish jobs still fail at git push -f with fatal: could not read Username for https://github.com: terminal prompts disabled because the Dockerized script cannot see checkout credentials from the host.

Testing:
- git diff --check
- Ruby YAML parse of .github/workflows/doc-build.yml

Notes:
- actionlint is not installed in this local environment.