### PR TITLE
Allow HF checkpoint cache dir to be overridden via HF_HOME

### DIFF
--- a/examples/models/llama/hf_download.py
+++ b/examples/models/llama/hf_download.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+
 from pathlib import Path
 from typing import Callable
 
@@ -28,7 +30,8 @@ def download_and_convert_hf_checkpoint(
 
     # Build cache path.
     cache_subdir = "meta_checkpoints"
-    cache_dir = Path.home() / ".cache" / cache_subdir
+    home_dir = Path(os.environ.get("HF_HOME", Path.home()))
+    cache_dir = home_dir / ".cache" / cache_subdir
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     # Use repo name to name the converted file.


### PR DESCRIPTION
### **User description**
## Summary

The converted Meta/HF checkpoint cache in `hf_download.py` was always placed under `Path.home()`, which is host-local. This change honors the `HF_HOME` environment variable when building the cache path, so the cache can live on a shared disk that multiple hosts reuse — avoiding redundant downloads and conversions per host.

## Changes

- `examples/models/llama/hf_download.py`: use `HF_HOME` (falling back to `Path.home()`) as the base for the `meta_checkpoints` cache directory.

## Test plan

- With `HF_HOME` unset: cache path resolves to `~/.cache/meta_checkpoints` (unchanged behavior).
- With `HF_HOME=/shared/disk`: cache path resolves to `/shared/disk/.cache/meta_checkpoints`, shareable across hosts.
