### PR TITLE
Remove unsupported parametrize cases causing TestX SKIPPING (#20906)

### DIFF
--- a/backends/nxp/tests/generic_tests/test_batch_norm_fusion.py
+++ b/backends/nxp/tests/generic_tests/test_batch_norm_fusion.py
@@ -170,12 +170,14 @@ def test_batch_norm_linear_fusing__full_pipeline(bias: bool):
     [[4, 6, 8], [2, 4, 6, 8], [2, 4, 6, 8, 10]],
     ids=lambda x: f"{len(x)}D",
 )
-@pytest.mark.parametrize("use_qat", [False, True], ids=lambda x: "QAT" if x else "PTQ")
+@pytest.mark.parametrize(
+    "use_qat",
+    [True],
+    ids=["QAT"],
+)  # PTQ excluded: prepare_pt2e fuses here due to a TorchAO bug.
 def test_batch_norm_linear_incompatible__full_pipeline(
     bias: bool, input_shape: list[int], use_qat: bool
 ):
-    if not use_qat:
-        pytest.skip("Fusion done by `prepare_pt2e` itself. This is a bug in TorchAO.")
 
     module = LinearBatchNormModule(
         bias, len(input_shape), input_shape[-1], input_shape[1], input_shape[1]

--- a/backends/nxp/tests/generic_tests/test_quantizer.py
+++ b/backends/nxp/tests/generic_tests/test_quantizer.py
@@ -659,13 +659,15 @@ def test_qat_produces_same_graph_as_ptq():
 
 @pytest.mark.parametrize("input_shape", [(1, 3, 32), (1, 3, 32, 32)])
 @pytest.mark.parametrize("transposed_conv", [True, False])
-@pytest.mark.parametrize("conv_bias", [True, False])
+@pytest.mark.parametrize(
+    "conv_bias",
+    [True],
+    ids=["with_bias"],
+)  # conv_bias=False is not supported by NXP.
 @pytest.mark.parametrize("bn_affine", [True, False])
 def test_torchao_native_conv_bn_qat_fusing(
     input_shape, transposed_conv, conv_bias, bn_affine
 ):
-    if not conv_bias:
-        pytest.skip("Conv without bias is not supported.")
 
     model = models.ConvBatchNormModule(
         bias=conv_bias,


### PR DESCRIPTION
Summary:

Remove parametrize values that always trigger pytest.skip() at runtime, causing
TestX to flag these as SKIPPING issues.

Changes:
1. test_quantizer.py: Remove conv_bias=False from parametrize (always skipped
   because Conv without bias is not supported). Reduces 8 skipping tests.

2. test_batch_norm_fusion.py: Remove use_qat=False from parametrize (always
   skipped because Fusion done by prepare_pt2e itself is a bug in TorchAO).
   Reduces 7 skipping tests.

By not parametrizing unsupported cases, TestX will not see them at all, reducing
noise in test health dashboards.

Differential Revision: D111825058


cc @robert-kalmar @JakeStevens @digantdesai @rascani