### PR TITLE
Remove _use_edge_ops=False (#20909)

### DIFF
--- a/devtools/etrecord/tests/etrecord_test.py
+++ b/devtools/etrecord/tests/etrecord_test.py
@@ -1201,7 +1201,7 @@ class TestETRecord(unittest.TestCase):
         edge_output2 = to_edge(
             export(f2, f2.get_random_inputs(), strict=True),
             compile_config=exir.EdgeCompileConfig(
-                _check_ir_validity=False, _use_edge_ops=False
+                _check_ir_validity=False,
             ),
         )
 

--- a/exir/capture/_config.py
+++ b/exir/capture/_config.py
@@ -38,8 +38,6 @@ class CaptureConfig:
 class EdgeCompileConfig:
     # TODO(qihan): remove ability to opt out
     _check_ir_validity: bool = True
-    # TODO(larryliu): remove this
-    _use_edge_ops: bool = True
     # TODO(gasoonjia): remove this
     _skip_dim_order: bool = False
     # Allow core ATen ops check to be skipped for certain ops, but continue with the rest of the checks.

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -688,14 +688,13 @@ def _to_edge(ep, config: EdgeCompileConfig) -> "ExirExportedProgram":
         new_ep.exported_program = lift_constant_tensor_pass(new_ep.exported_program)
 
     new_gm = new_ep.exported_program.graph_module
-    if config._use_edge_ops:
-        new_gm_res = OpReplacePass()(new_gm)
+    new_gm_res = OpReplacePass()(new_gm)
+    assert new_gm_res is not None
+    new_gm = new_gm_res.graph_module
+    if not config._skip_dim_order:
+        new_gm_res = MemoryFormatOpsPass()(new_gm)
         assert new_gm_res is not None
         new_gm = new_gm_res.graph_module
-        if not config._skip_dim_order:
-            new_gm_res = MemoryFormatOpsPass()(new_gm)
-            assert new_gm_res is not None
-            new_gm = new_gm_res.graph_module
 
     for p in post_op_replace_passes:
         new_gm_res = p(new_gm)
@@ -824,10 +823,9 @@ def _generate_edge_program(
         ReplaceViewOpsWithViewCopyOpsPass(),
     ]
     passes.extend(pre_op_replace_passes)
-    if config._use_edge_ops:
-        passes.append(OpReplacePass())
-        if not config._skip_dim_order:
-            passes.append(MemoryFormatOpsPass())
+    passes.append(OpReplacePass())
+    if not config._skip_dim_order:
+        passes.append(MemoryFormatOpsPass())
 
     gm = program.graph_module
     for p in passes:

--- a/exir/verification/test/test_verifier.py
+++ b/exir/verification/test/test_verifier.py
@@ -38,46 +38,6 @@ class TestEdgeDialectVerifier(unittest.TestCase):
             verifier.check_valid_edge_op(edge_op)
             verifier.check_valid_op(edge_op)
 
-    def test_edge_verifier_check_edge_op(self) -> None:
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
-            def forward(self, x: torch.Tensor) -> torch.Tensor:
-                return x.transpose(0, 1)
-
-        m = Model().eval()
-
-        example_input = (torch.zeros([2, 2]),)
-
-        export_model = export(m, example_input, strict=True)
-
-        compile_config_without_edge_op = EdgeCompileConfig(
-            _use_edge_ops=False, _skip_dim_order=False
-        )
-
-        edge_manager = to_edge(
-            export_model, compile_config=compile_config_without_edge_op
-        )
-
-        normal_verifier = EXIREdgeDialectVerifier()
-        disable_edge_op_check_verifier = EXIREdgeDialectVerifier(
-            compile_config_without_edge_op
-        )
-
-        # exported model can not pass normal verifier due to
-        # incontiguous memory layout tensor is not supported in ET
-        with self.assertRaises(SpecViolationError):
-            normal_verifier(edge_manager.exported_program())
-
-        # exported model can pass disable_edge_op_check_verifier due to the
-        # incontiguous memory layout tensor verification is disabled by
-        # compile_config_without_edge_op (_use_edge_ops=False). Noted that this
-        # verifation has been done when calling `to_edge`. Explicitly calling
-        # verifier here just for better demonstration and is unnecessary
-        # in real world for ir verification.
-        disable_edge_op_check_verifier(edge_manager.exported_program())
-
     def test_edge_verifier_check_valid_dim_order_graph(self) -> None:
         class Model(torch.nn.Module):
             def __init__(self):

--- a/exir/verification/verifier.py
+++ b/exir/verification/verifier.py
@@ -263,7 +263,6 @@ def EXIREdgeDialectVerifier(  # noqa: C901
             _edge_compile_config = edge_compile_config or EdgeCompileConfig()
 
             self.enable = _edge_compile_config._check_ir_validity
-            self.check_edge_ops = _edge_compile_config._use_edge_ops
             self.use_dim_order = not _edge_compile_config._skip_dim_order
 
             self._core_aten_ops_exception_list = _core_aten_ops_exception_list
@@ -274,11 +273,7 @@ def EXIREdgeDialectVerifier(  # noqa: C901
                 preserve_ops=_preserve_ops,
             )
             self.check_valid_aten_op = self.aten_op_verifier.check_valid_op
-
-            if self.check_edge_ops:
-                self.check_valid_op = self.check_valid_edge_op
-            else:
-                self.check_valid_op = self.check_valid_aten_op
+            self.check_valid_op = self.check_valid_edge_op
 
         def allowed_getattr_types(self) -> Tuple[Type[Any], ...]:
             return (
@@ -319,9 +314,8 @@ def EXIREdgeDialectVerifier(  # noqa: C901
         def check_additional(self, gm: GraphModule) -> None:
             if not self.enable:
                 return
-            if self.check_edge_ops:
-                _check_tensors_are_contiguous(gm)
-                _check_tensor_args_matching_op_allowed_dtype(gm)
+            _check_tensors_are_contiguous(gm)
+            _check_tensor_args_matching_op_allowed_dtype(gm)
 
         def is_valid(self, gm: GraphModule) -> bool:
             try:


### PR DESCRIPTION
Summary:

Support for _use_edge_ops=False has been marked for removal for awhile.

This PR finalizes it. Preceeding PRs have removed all OSS usages of it in-tree.

Reviewed By: rascani

Differential Revision: D111926304


