### PR TITLE
[ET-VK][ez] Fix conv2d_gemm_dynamic_test build against updated XNNPACK API

### DIFF
--- a/backends/vulkan/test/op_tests/conv2d_gemm_dynamic_test.cpp
+++ b/backends/vulkan/test/op_tests/conv2d_gemm_dynamic_test.cpp
@@ -247,6 +247,7 @@ std::vector<float> conv2d_ref_xnnpack(
       out_min,
       out_max,
       /*flags=*/0,
+      /*code_cache=*/nullptr,
       /*weights_cache=*/nullptr,
       &op);
   if (create_status != xnn_status_success || op == nullptr) {
@@ -257,7 +258,7 @@ std::vector<float> conv2d_ref_xnnpack(
   }
 
   size_t workspace_size = 0;
-  const size_t workspace_alignment = 128;
+  size_t workspace_alignment = 128;
   size_t out_h = 0;
   size_t out_w = 0;
   const xnn_status reshape_status = xnn_reshape_convolution2d_nhwc_f32(
@@ -266,6 +267,7 @@ std::vector<float> conv2d_ref_xnnpack(
       static_cast<size_t>(H_in),
       static_cast<size_t>(W_in),
       &workspace_size,
+      &workspace_alignment,
       &out_h,
       &out_w,
       /*threadpool=*/nullptr);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #20910

XNNPACK updated two f32 conv2d entry points and `conv2d_gemm_dynamic_test.cpp` still called the old signatures, breaking the build (and thus the `etvk-eureka-tests` CI workflow). `xnn_create_convolution2d_nhwc_f32` gained an `xnn_code_cache_t code_cache` parameter before `weights_cache` (22 -> 23 args), and `xnn_reshape_convolution2d_nhwc_f32` gained a `size_t* workspace_alignment` out-param after `workspace_size` (8 -> 9 args). Updated both call sites: pass `nullptr` for `code_cache`, and pass `&workspace_alignment` (now written back by XNNPACK).

Differential Revision: [D111934764](https://our.internmc.facebook.com/intern/diff/D111934764/)