### PR TITLE
[ET][Windows] Fix ExecuTorch Windows host build portability defects

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.h
+++ b/backends/vulkan/runtime/api/containers/Tensor.h
@@ -549,11 +549,11 @@ class vTensor final {
     return sizes_;
   }
 
-  inline const int64_t size(size_t dim) const {
+  inline int64_t size(size_t dim) const {
     return sizes().at(dim);
   }
 
-  inline const int64_t dim() const {
+  inline int64_t dim() const {
     return sizes_.size();
   }
 

--- a/extension/data_loader/mman.h
+++ b/extension/data_loader/mman.h
@@ -81,9 +81,13 @@ ET_INLINE void fcntl_rdadvise_apple(int fd, size_t file_size) {
 
 #else
 
+#ifndef NOMINMAX
 #define NOMINMAX
 #include <windows.h>
 #undef NOMINMAX
+#else
+#include <windows.h>
+#endif
 #include <io.h>
 
 #include <executorch/extension/data_loader/mman_windows.h>

--- a/extension/data_loader/mman_windows.cpp
+++ b/extension/data_loader/mman_windows.cpp
@@ -23,9 +23,13 @@
 #include <io.h>
 #include <cstdint>
 #include <limits>
+#ifndef NOMINMAX
 #define NOMINMAX
 #include <windows.h>
 #undef NOMINMAX
+#else
+#include <windows.h>
+#endif
 
 #ifndef STATUS_SECTION_TOO_BIG
 #define STATUS_SECTION_TOO_BIG 0xC0000040L

--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -81,9 +81,10 @@ def define_common_targets():
             "ovr_config//build_mode:arvr_mode[enabled]": select({
                 "DEFAULT": ["fbsource//xplat/caffe2:ovrsource_aten_Config.h"],
                 # ovrsource_aten_Config.h is an oxx_static_library that only
-                # works on OVR-native platforms. On Android, it produces no
-                # outputs, so use the xplat variant instead.
+                # works on OVR-native platforms. On Android and the Windows
+                # host, it produces no outputs, so use the xplat variant.
                 "ovr_config//os:android": ["fbsource//xplat/caffe2:generated_aten_config_header"],
+                "ovr_config//os:windows": ["fbsource//xplat/caffe2:generated_aten_config_header"],
             }),
         }) + get_sleef_deps(),
         fbcode_exported_deps = ([


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #20949
* __->__ #20948

Building ExecuTorch (Vulkan backend plus core runtime) for a Windows x86_64 host with the arvr clang toolchain surfaced three genuine portability defects that fail under its strict `-Werror` set and generated-header wiring. These are correct fixes independent of any warning-suppression workaround.

In `runtime/core/portable_type/c10/c10/targets.bzl`, the arvr-mode `select` that supplies the generated `ATen/Config.h` routed every non-Android OS to `ovrsource_aten_Config.h`, an OVR-native-only `oxx_static_library` that produces no output on the Windows host. The result was `fatal error: 'ATen/Config.h' file not found` in every CPU kernel that includes ATen vec headers. This adds an `ovr_config//os:windows` branch pointing at the working `generated_aten_config_header`, mirroring the existing Android fallback.

In `backends/vulkan/runtime/api/containers/Tensor.h`, `size()` and `dim()` returned `const int64_t` by value; the meaningless top-level `const` on a scalar return trips `-Werror,-Wignored-qualifiers`. This header is included throughout the Vulkan backend, so it blocked `vulkan_graph_runtime`. The `const` qualifier is dropped.

In `extension/data_loader/mman.h` and `mman_windows.cpp`, `#define NOMINMAX` was unconditional while the toolchain already predefines it, tripping `-Werror,-Wmacro-redefined` when compiling `mmap_data_loader` (pulled in by `Module`). Both sites are now guarded with `#ifndef NOMINMAX`.

Differential Revision: [D112012051](https://our.internmc.facebook.com/intern/diff/D112012051/)