### PR TITLE
[ET][Windows] Relax -Werror for ExecuTorch CPU kernels on the Windows host

### DIFF
--- a/backends/vulkan/targets.bzl
+++ b/backends/vulkan/targets.bzl
@@ -10,7 +10,13 @@ def get_vulkan_compiler_flags():
             "-Wno-global-constructors",
             "-Wno-missing-prototypes",
         ],
-        "ovr_config//os:windows": [],
+        # The Windows clang host build needs -Werror relaxed for the vendored
+        # VMA headers, but MSVC cl.exe rejects the gcc-style flag, so exclude
+        # pure MSVC. OSS buck2 has no compiler constraint, so guard to non-OSS.
+        "ovr_config//os:windows": select({
+            "DEFAULT": ["-Wno-error"],
+            "ovr_config//compiler:msvc": [],
+        }) if not runtime.is_oss else ["-Wno-error"],
     })
 
 def get_vulkan_preprocessor_flags(no_volk, is_fbcode):

--- a/kernels/optimized/cpu/targets.bzl
+++ b/kernels/optimized/cpu/targets.bzl
@@ -48,6 +48,18 @@ def define_common_targets():
         srcs = ["binary_ops.cpp"],
         exported_headers = ["binary_ops.h"],
         visibility = ["PUBLIC"],
+        # ATen vec headers trip -Werror warnings on the Windows clang host;
+        # MSVC cl.exe rejects the gcc-style flag.
+        compiler_flags = select({
+            "DEFAULT": [],
+            # OSS buck2 has no compiler constraint (ovr_config//compiler:msvc
+            # resolves to the nonexistent prelude//compiler:msvc), so it cannot
+            # appear as a select key there; guard the MSVC branch to non-OSS.
+            "ovr_config//os:windows": select({
+                "DEFAULT": ["-Wno-error"],
+                "ovr_config//compiler:msvc": [],
+            }) if not runtime.is_oss else ["-Wno-error"],
+        }),
         exported_deps = [
             "//executorch/runtime/core/exec_aten:lib",
             "//executorch/runtime/kernel:kernel_includes",

--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -214,6 +214,15 @@ def define_libs(is_fbcode=False):
                 # TODO: replace with get_compiler_optimization_flags from op_registration_util.bzl when that
                 # is re-enabled.
                 "DEFAULT": ["-Os"],
+            }) + select({
+                "DEFAULT": [],
+                # ATen vec headers trip -Werror warnings on the Windows clang
+                # host; MSVC cl.exe rejects the gcc-style flag. OSS buck2 has no
+                # compiler constraint, so guard the MSVC branch to non-OSS.
+                "ovr_config//os:windows": select({
+                    "DEFAULT": ["-Wno-error"],
+                    "ovr_config//compiler:msvc": [],
+                }) if not runtime.is_oss else ["-Wno-error"],
             }),
             header_namespace = "executorch/kernels/optimized",
             visibility = ["PUBLIC"],

--- a/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
@@ -109,6 +109,17 @@ def define_op_library(name, compiler_flags, deps):
             "ovr_config//os:zephyr": [
                 "-Wno-pass-failed",
             ],
+            # The vendored ATen vec headers trip several -Werror warnings on
+            # the Windows (clang) host, so disable warnings-as-errors there.
+            "ovr_config//os:windows": select({
+                "DEFAULT": [
+                    "-Wno-missing-prototypes",
+                    "-Wno-pass-failed",
+                    "-Wno-error",
+                ],
+                # MSVC cl.exe rejects the gcc-style flags above.
+                "ovr_config//compiler:msvc": [],
+            }),
         }) if not runtime.is_oss else [
             "-Wno-missing-prototypes",
             "-Wno-pass-failed",

--- a/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
@@ -124,13 +124,22 @@ def define_op_library(name, deps, android_deps, aten_target, _allow_third_party_
         # Zephyr and Windows builds. OSS bypasses the zephyr branch via
         # runtime.is_oss since ovr_config//os:zephyr is not in the OSS
         # buck2 prelude.
+        # The vendored ATen vec headers pulled in on the Windows host trip
+        # several -Werror warnings (e.g. -Wundef on __GNUC__), so disable
+        # warnings-as-errors for the Windows (clang) kernel compiles.
         compiler_flags = (select({
                 "DEFAULT": ["-Wno-missing-prototypes"],
-                "ovr_config//os:windows": [],
+                "ovr_config//os:windows": select({
+                    "DEFAULT": ["-Wno-error"],
+                    "ovr_config//compiler:msvc": [],
+                }),
                 "ovr_config//os:zephyr": [],
             }) if not runtime.is_oss else select({
                 "DEFAULT": ["-Wno-missing-prototypes"],
-                "ovr_config//os:windows": [],
+                # OSS buck2 has no compiler constraint (ovr_config//compiler:msvc
+                # resolves to the nonexistent prelude//compiler:msvc), so it
+                # cannot appear as a select key. Use the clang flag directly.
+                "ovr_config//os:windows": ["-Wno-error"],
             })) + (
             # For shared library build, we don't want to expose symbols of
             # kernel implementation (ex torch::executor::native::tanh_out)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #20949
* #20948

The arvr Windows clang toolchain enables a stricter `-Werror` warning set than the sanctioned ET build platforms, and vendored third-party headers that ExecuTorch does not own trip it. VMA's `vk_mem_alloc.h` hits `-Werror,-Winconsistent-missing-destructor-override`, and PyTorch's `ATen/cpu/vec/vec_base.h` uses `#if __GNUC__ <= 12` without `defined(__GNUC__)`, hitting `-Werror,-Wundef`. Because the offending code is in vendored headers we cannot patch, this disables warnings-as-errors for the affected compiles, scoped to `ovr_config//os:windows` only, so the clang target compiles are relaxed while the MSVC host tools and all non-Windows platforms are untouched.

`backends/vulkan/targets.bzl` adds `-Wno-error` to the Vulkan targets (VMA header). The CPU-kernel build is split across four independent macros/targets, each of which includes the ATen vec headers and so needs the same relaxation: `kernels/portable/op_registration_util.bzl`, `kernels/optimized/op_registration_util.bzl`, the `binary_ops` support library in `kernels/optimized/cpu/targets.bzl`, and the `libblas` support library in `kernels/optimized/lib_defs.bzl`.

Differential Revision: [D112012049](https://our.internmc.facebook.com/intern/diff/D112012049/)