### PR TITLE
Buck fwd-fix: wire up VGF Neural Statistics files

### DIFF
--- a/backends/arm/runtime/targets.bzl
+++ b/backends/arm/runtime/targets.bzl
@@ -37,6 +37,7 @@ def define_common_targets():
         name = "vgf_backend",
         srcs = [
             "VGFBackend.cpp",
+            "VGFNeuralStatistics.cpp",
             "VGFSetup.cpp",
             # Volk must be compiled directly into this target so its global
             # function-pointer variables live in the same linkage unit.
@@ -44,7 +45,10 @@ def define_common_targets():
             # drop the symbols when building a shared library.
             "fbsource//third-party/vulkan-headers-1.4.343/v1.4.343/src:volk_arm_src",
         ],
-        exported_headers = ["VGFSetup.h"],
+        exported_headers = [
+            "VGFNeuralStatistics.h",
+            "VGFSetup.h",
+        ],
         # @lint-ignore BUCKLINT: Avoid `link_whole=True` (https://fburl.com/avoid-link-whole)
         link_whole = True,
         supports_python_dlopen = True,

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -151,3 +151,20 @@ def define_arm_tests():
                 "//executorch/backends/arm:public_api",
             ] if runtime.is_oss else []),
         )
+
+    if not runtime.is_oss and _ENABLE_VGF:
+        runtime.cxx_test(
+            name = "vgf_neural_statistics_test",
+            srcs = ["vgf_neural_statistics_test.cpp"],
+            compiler_flags = [
+                "-DUSE_VULKAN_WRAPPER",
+                "-DUSE_VULKAN_VOLK",
+            ],
+            deps = [
+                "//executorch/backends/arm/runtime:vgf_backend",
+                "//executorch/runtime/core:core",
+                "fbsource//third-party/arm-vgf-library/v0.9.0/src:vgf",
+                "fbsource//third-party/vulkan-headers-1.4.343/v1.4.343/src:volk_arm",
+                "fbsource//third-party/vulkan-headers-1.4.343/v1.4.343/src:vulkan-headers",
+            ],
+        )

--- a/devtools/inspector/TARGETS
+++ b/devtools/inspector/TARGETS
@@ -13,12 +13,20 @@ runtime.python_library(
         "fbsource//third-party/pypi/pandas:pandas",
         "fbsource//third-party/pypi/tabulate:tabulate",
         ":inspector_utils",
+        ":vgf_neural_statistics",
         "//executorch/devtools/debug_format:et_schema",
         "//executorch/devtools/etdump:schema_flatcc",
         "//executorch/devtools/etrecord:etrecord",
         "//executorch/exir:lib",
         "//executorch/devtools/inspector:intermediate_output_capturer",
         "//executorch/devtools/inspector/numerical_comparator:lib",
+    ],
+)
+
+runtime.python_library(
+    name = "vgf_neural_statistics",
+    srcs = [
+        "vgf_neural_statistics.py",
     ],
 )
 
@@ -65,5 +73,6 @@ runtime.python_library(
     deps = [
         ":inspector",
         ":inspector_utils",
+        ":vgf_neural_statistics",
     ],
 )


### PR DESCRIPTION
Summary:
Forward fix for D111929804 (DiffTrain import of pytorch/executorch #20662), which added new source files but only updated the OSS `CMakeLists.txt`; DiffTrain imports don't carry Buck changes, so the new files were never wired into any `TARGETS`/`targets.bzl` and the internal Buck build broke.

New files added by D111929804 with no Buck coverage:
- `backends/arm/runtime/VGFNeuralStatistics.cpp` / `.h`
- `backends/arm/test/vgf_neural_statistics_test.cpp`
- `devtools/inspector/vgf_neural_statistics.py`

This diff:
- Adds `VGFNeuralStatistics.cpp` to the `vgf_backend` `runtime.cxx_library` `srcs` and `VGFNeuralStatistics.h` to its `exported_headers`. `VGFBackend.cpp`/`VGFSetup.h` now include this header, so without it `vgf_backend` fails to compile/link.
- Adds a `runtime.cxx_test` for `vgf_neural_statistics_test.cpp` (gated the same as other VGF Buck usage: non-OSS and `_ENABLE_VGF`). It mirrors `vgf_backend`'s Vulkan setup (`volk_arm` + `vulkan-headers` and the `-DUSE_VULKAN_WRAPPER`/`-DUSE_VULKAN_VOLK` defines) so the ARM data-graph `volk.h` is used; pulling in the standard Vulkan headers instead leaves `VkDataGraphPipelineSessionARM` undefined.
- Adds a `vgf_neural_statistics` `runtime.python_library` for `vgf_neural_statistics.py` and depends on it from the inspector `inspector` and `lib` targets. `inspector/__init__.py` imports this module at top level, so without it every consumer hit `ModuleNotFoundError: No module named 'executorch.devtools.inspector.vgf_neural_statistics'`.

Differential Revision: D112027047




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani