### PR TITLE
Guard ChannelsLastTaggedReshapePass.input_to_nhwc against non-Node input

### DIFF
--- a/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
+++ b/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
@@ -359,6 +359,9 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
         input_node: torch.fx.Node,
         target_node: torch.fx.Node,
     ) -> None:
+        if not isinstance(input_node, torch.fx.Node):
+            return
+
         if is_param_node(self.exported_program, input_node):
             if (
                 ChannelsLastTaggedReshapePass.XNN_NHWC_NODE in input_node.meta


### PR DESCRIPTION
## Summary
`input_to_nhwc` assumes `input_node` is always a `torch.fx.Node` and immediately
calls `is_param_node()` / accesses `.meta` on it. Some traced graphs (e.g. a
MediaPipe hair-segmentation model's activation trace-back path) pass this
function a non-Node value instead — a plain Python constant embedded as a node
argument — which crashes on the first `is_param_node()`/`.meta` access.

Return early when `input_node` isn't a `torch.fx.Node`, instead of assuming it
always is. This mirrors the existing `isinstance(..., torch.fx.Node)` guard a
few lines below in the dynamic-quant trace-back loop.

cc @GregoryComer @digantdesai @cbilgin @JakeStevens