### PR TITLE
Buck fwd-fix: wire up legalize_portable_dim_order_pass (#20971)

### DIFF
--- a/exir/passes/BUCK
+++ b/exir/passes/BUCK
@@ -15,6 +15,7 @@ fbcode_target(_kind = runtime.python_library,
         ":external_constants_pass",
         ":init_mutable_pass",
         ":insert_write_back_for_buffers_pass",
+        ":legalize_portable_dim_order_pass",
         ":memory_format_ops_pass",
         ":memory_planning_pass",
         ":normalize_transpose_pass",
@@ -48,6 +49,21 @@ fbcode_target(_kind = runtime.python_library,
         "//executorch/exir/dialects/backend:lib",
         "//executorch/exir/dialects/edge:lib",
         "//executorch/exir/operator:convert",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
+    name = "legalize_portable_dim_order_pass",
+    srcs = [
+        "legalize_portable_dim_order_pass.py",
+    ],
+    deps = [
+        ":dim_order_ops_registry",
+        "//caffe2:torch",
+        "//executorch/exir:dim_order_utils",
+        "//executorch/exir:pass_base",
+        "//executorch/exir/dialects:lib",
+        "//executorch/exir/dialects/edge:lib",
     ],
 )
 


### PR DESCRIPTION
Summary:

Forward fix for D111976876 (DiffTrain import of pytorch/executorch #20878). That diff added `executorch/exir/passes/legalize_portable_dim_order_pass.py` and imports `LegalizePortableDimOrderPass` at the top of `exir/passes/__init__.py`, but like every DiffTrain import it carried no Buck changes. Since `exir/passes/BUCK` uses explicit per-file `srcs` lists (no globs), the new module was never wired into any target, so importing `executorch.exir.passes` fails with `ModuleNotFoundError: No module named 'executorch.exir.passes.legalize_portable_dim_order_pass'`. This breaks every fbcode consumer of `//executorch/exir/passes:lib`, including the arm test listing for `fold_scalar_mul_into_conv_pass` (D112075757) and the residual `backends/arm/test:*` listing failures on D112027047.

This adds a `legalize_portable_dim_order_pass` `runtime.python_library` (deps mirror the sibling `memory_format_ops_pass`) and adds it to the `:lib` target `deps`, in both `fbcode` and `xplat` `exir/passes/BUCK`.

Authored with Claude Code.

Differential Revision: D112243998


