### PR TITLE
Resolve Operator fallback to method allocator if temp alloc fails (#20981) (#20981)

### DIFF
--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -761,7 +761,10 @@ Error Method::resolve_operator(
   // However, it does not have to be provided, so if it
   // is not provided (or an empty one is provided), we
   // fall back to the method allocator.
-  if (allocator == nullptr || allocator->size() == 0) {
+  if (allocator == nullptr || allocator->size() == 0 ||
+      allocator->size() < (sizeof(TensorMeta) * n_args) +
+              (sizeof(executorch::aten::DimOrderType) * kTensorDimensionLimit *
+               n_args)) {
     allocator = memory_manager_->method_allocator();
   }
   TensorMeta* meta = allocator->allocateList<TensorMeta>(n_args);


### PR DESCRIPTION
Summary:
Currently, the resolve_operator step during method_init will fall back to method allocator if temp allocator is zero or not present.

This change adds logic to fallback to method allocator if temp allocator is present, but insufficient in size for the tensor meta.

Reviewed By: rascani

Differential Revision: D109855815

Pulled By: rstehle
