### PR TITLE
Qualcomm AI Engine Direct - Adding QNN backend support for scatter.value core ATen op

### DIFF
--- a/.claude/skills/qualcomm/new_op_development.md
+++ b/.claude/skills/qualcomm/new_op_development.md
@@ -165,6 +165,50 @@ python backends/qualcomm/tests/test_qnn_delegate.py \
 
 Always ask user for `--model`, `--host`, `--device`, `--build_folder` values.
 
+## Step 8b: Add Rework Framework Tests (Emulator-Based)
+
+Emulator-based tests at `backends/qualcomm/tests/rework/` — no device needed, preferred for CI. Read existing ops in `src/op.py` for reference patterns.
+
+**Add op class** to `tests/rework/src/op.py` (alphabetical by *class name* in `src/op.py` and by *function name* in `test.py`
+). All imports (`torch`, `itertools`, `unpack_fixtures`, `export_and_verify`) are file-level — don't add per-class. Class is auto-exported via `from ... import *` in test.py. Use `__class__` (Python idiom for enclosing class in `@staticmethod`):
+```python
+class MyOp(torch.nn.Module):
+    def __init__(self, param):
+        super().__init__()
+        self.param = param
+    def forward(self, x):
+        return torch.my_op(x, self.param)
+
+    @staticmethod
+    @unpack_fixtures
+    def test(subtests, qnn_config, quantizer, compile_spec, expected):
+        for param, inputs in [(1, (torch.randn(3,4),)), (2, (torch.randn(3,4),))]:
+            with subtests.test(msg=f"param:{param}"):
+                with expected as metrics:
+                    export_and_verify(module=__class__(param=param), inputs=inputs,
+                        qnn_config=qnn_config, quantizer=quantizer,
+                        compile_specs=compile_spec, metrics=metrics)
+```
+
+**Register test** in `tests/rework/htp/op/v68/test.py` (alphabetical). Function signature must be exactly `(request, kwargs)`:
+```python
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_my_op(request, kwargs):
+    MyOp.test(request, kwargs)  # noqa: F405
+```
+
+**Expected results** — list of 3: [8a, 16a, fp]. Options: `Tolerance()`, `Tolerance(rtol=1e-1)`, `CosineSimilarity(0.95)`, `pytest.raises(AssertionError)`, `SkipOutputCheck()`.
+
+**Run:** `pytest backends/qualcomm/tests/rework/htp/op/v68/test.py -k "test_my_op" -v`
+
+**Gotchas:**
+- Multi-output ops (sort, topk): only return float tensors — don't expose raw int indices as outputs (causes dtype/memory issues). Use `gather` to consume indices or return only values.
+- `subtests` fixture requires `pytest-subtests` package. Omit for single-case ops (use just `qnn_config, quantizer, compile_spec, expected` params).
+- Some ops fail on x86 emulator but work on-device (TopK/Sort fp, scatter.value quantized). Mark with `pytest.raises(AssertionError)`.
+
+---
+
 ## Step 9: Prevent Decomposition (if needed)
 
 If the ATen op exists in ExecuTorch's decomp table and you have a builder for it:

--- a/backends/qualcomm/_passes/i64_to_i32.py
+++ b/backends/qualcomm/_passes/i64_to_i32.py
@@ -41,6 +41,7 @@ class I64toI32(ExportPass):
     I64_IN_OPS = {
         exir_ops.edge.aten.gather.default: [2],
         exir_ops.edge.aten.scatter.src: [2],
+        exir_ops.edge.aten.scatter.value: [2],
     }
     copy_op = exir_ops.edge.aten._to_copy.default
 

--- a/backends/qualcomm/_passes/layout_transform.py
+++ b/backends/qualcomm/_passes/layout_transform.py
@@ -121,6 +121,7 @@ class LayoutTransform(ExportPass):
         exir_ops.edge.aten.relu.default,
         exir_ops.edge.aten.round.default,
         exir_ops.edge.aten.scatter.src,
+        exir_ops.edge.aten.scatter.value,
         exir_ops.edge.aten.sigmoid.default,
         exir_ops.edge.aten.sign.default,
         exir_ops.edge.aten.slice_copy.Tensor,

--- a/backends/qualcomm/_passes/lift_constant_scalar_operands.py
+++ b/backends/qualcomm/_passes/lift_constant_scalar_operands.py
@@ -76,6 +76,7 @@ SKIP_LIFT_OPS = {
     aten.scalar_tensor.default,
     aten.elu.default,
     aten.hardtanh.default,
+    aten.scatter.value,
 }
 
 

--- a/backends/qualcomm/builders/op_scatter_elements.py
+++ b/backends/qualcomm/builders/op_scatter_elements.py
@@ -9,7 +9,11 @@ import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManager
 
 import numpy as np
 import torch
-from executorch.backends.qualcomm.utils.constants import QCOM_AXIS_ORDER, QCOM_DATA
+from executorch.backends.qualcomm.utils.constants import (
+    QCOM_AXIS_ORDER,
+    QCOM_DATA,
+    QCOM_QUANT_ATTRS,
+)
 
 from .node_visitor import NodeVisitor
 from .node_visitor_manager import register_node_visitor
@@ -18,7 +22,7 @@ from .qnn_constants import OpScatterElements, QNN_OP_PACKAGE_NAME_QTI_AISW
 
 @register_node_visitor
 class ScatterElements(NodeVisitor):
-    target = ["aten.scatter.src"]
+    target = ["aten.scatter.src", "aten.scatter.value"]
 
     def __init__(self, *args) -> None:
         super().__init__(*args)
@@ -48,15 +52,42 @@ class ScatterElements(NodeVisitor):
             nodes_to_wrappers,
         )
 
-        updates_node = self.get_node(node.args[3])
-        updates_tensor = self.get_tensor(updates_node, node)
-        updates_tensor_wrapper = self.define_tensor(
-            updates_node,
-            node,
-            updates_tensor,
-            PyQnnManager.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
-            nodes_to_wrappers,
-        )
+        # Handle both scatter.src (args[3] is a Node/tensor) and
+        # scatter.value (args[3] is a scalar)
+        if isinstance(node.args[3], torch.fx.Node):
+            # scatter.src path: args[3] is a tensor node
+            updates_node = self.get_node(node.args[3])
+            updates_tensor = self.get_tensor(updates_node, node)
+            updates_tensor_wrapper = self.define_tensor(
+                updates_node,
+                node,
+                updates_tensor,
+                PyQnnManager.Qnn_TensorType_t.QNN_TENSOR_TYPE_NATIVE,
+                nodes_to_wrappers,
+            )
+        else:
+            # scatter.value: expand scalar to a float static tensor matching index
+            # shape. For quantized models, use input_node as quant source so
+            # define_tensor derives correct encoding and handles quantization via
+            # get_quant_tensor_value. For fp, use index_node to avoid tensor
+            # aliasing issues with the input at runtime.
+            scalar_val = node.args[3]
+            updates_tensor = torch.full(
+                index_tensor.shape, scalar_val, dtype=input_tensor.dtype
+            )
+            quant_source = (
+                input_node if input_node.meta.get(QCOM_QUANT_ATTRS) else index_node
+            )
+
+            updates_tensor_wrapper = self.define_tensor(
+                quant_source,
+                node,
+                updates_tensor,
+                PyQnnManager.Qnn_TensorType_t.QNN_TENSOR_TYPE_STATIC,
+                nodes_to_wrappers,
+                node_name=f"{node.name}_updates_value",
+                wrapper_idx=2,
+            )
 
         output_tensor = self.get_tensor(node, node)
         output_tensor_wrapper = self.define_tensor(

--- a/backends/qualcomm/quantizer/annotators/htp_rules.py
+++ b/backends/qualcomm/quantizer/annotators/htp_rules.py
@@ -1430,7 +1430,7 @@ class ScaledDotProductAttention(GeneralOpDef):
 
 
 @register_annotator(
-    [torch.ops.aten.scatter.src],
+    [torch.ops.aten.scatter.src, torch.ops.aten.scatter.value],
     qnn_op=None,
 )
 class ScatterElements(GeneralOpDef):

--- a/backends/qualcomm/quantizer/annotators/lpai_rules.py
+++ b/backends/qualcomm/quantizer/annotators/lpai_rules.py
@@ -877,7 +877,7 @@ class ScaledDotProductAttention(GeneralOpDef):
 
 
 @register_annotator(
-    [torch.ops.aten.scatter.src],
+    [torch.ops.aten.scatter.src, torch.ops.aten.scatter.value],
     qnn_op=None,
 )
 class ScatterElements(GeneralOpDef):

--- a/backends/qualcomm/tests/models.py
+++ b/backends/qualcomm/tests/models.py
@@ -2332,6 +2332,16 @@ class ScatterSrc(torch.nn.Module):
         return torch.scatter(data, self.dim, index, src)
 
 
+class ScatterValue(torch.nn.Module):
+    def __init__(self, dim=1, value=0.5):
+        super().__init__()
+        self.dim = dim
+        self.value = value
+
+    def forward(self, data, index):
+        return torch.scatter(data, self.dim, index, self.value)
+
+
 class SelectCopy(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/backends/qualcomm/tests/rework/htp/op/v68/test.py
+++ b/backends/qualcomm/tests/rework/htp/op/v68/test.py
@@ -1267,6 +1267,18 @@ def test_slice_scatter(request, kwargs):
     SliceScatter.test(request, kwargs)  # noqa: F405
 
 
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_scatter_value(request, kwargs):
+    ScatterValue.test(request, kwargs)  # noqa: F405
+
+
 @enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
 @with_htp_context
 def test_softmax(request, kwargs):

--- a/backends/qualcomm/tests/rework/src/op.py
+++ b/backends/qualcomm/tests/rework/src/op.py
@@ -4216,6 +4216,53 @@ class ScaledDotProductAttention(torch.nn.Module):
                     )
 
 
+class ScatterValue(torch.nn.Module):
+    def __init__(self, dim, value):
+        super().__init__()
+        self.dim = dim
+        self.value = value
+
+    def forward(self, data, index):
+        return torch.scatter(data, self.dim, index, self.value)
+
+    @staticmethod
+    @unpack_fixtures
+    def test(subtests, qnn_config, quantizer, compile_spec, expected):
+        cases = [
+            # (dim, value, data_shape, index_tensor)
+            (
+                1,
+                0.5,
+                (3, 5),
+                torch.tensor(
+                    [[0, 1, 2, 3, 4], [4, 3, 2, 1, 0], [1, 0, 3, 4, 2]],
+                    dtype=torch.int64,
+                ),
+            ),
+            (
+                0,
+                1.0,
+                (3, 5),
+                torch.tensor(
+                    [[2, 1, 0, 1, 2], [0, 2, 1, 2, 0], [1, 0, 2, 0, 1]],
+                    dtype=torch.int64,
+                ),
+            ),
+        ]
+        for dim, value, data_shape, index in cases:
+            with subtests.test(msg=f"dim:{dim}, value:{value}"):
+                inputs = (torch.rand(*data_shape), index)
+                with expected as metrics:
+                    export_and_verify(
+                        module=__class__(dim=dim, value=value),
+                        inputs=inputs,
+                        qnn_config=qnn_config,
+                        quantizer=quantizer,
+                        compile_specs=compile_spec,
+                        metrics=metrics,
+                    )
+
+
 class SelectScatter(torch.nn.Module):
     def __init__(self, dim, index):
         super().__init__()

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -2204,6 +2204,42 @@ class TestQNNFloatingPointOperator(TestQNN):
                         index += 1
                         self.lower_module_and_test_output(module, sample_input)
 
+    def test_qnn_backend_scatter_value(self):
+        test_comb = [
+            {
+                QCOM_MODULE: [ScatterValue(dim=1, value=0.5)],  # noqa: F405
+                QCOM_SAMPLE_INPUTS: [
+                    (
+                        torch.rand(3, 5),
+                        torch.tensor(
+                            [[0, 1, 2, 3, 4], [4, 3, 2, 1, 0], [1, 0, 3, 4, 2]],
+                            dtype=torch.int64,
+                        ),
+                    ),
+                ],
+            },
+            {
+                QCOM_MODULE: [ScatterValue(dim=0, value=1.0)],  # noqa: F405
+                QCOM_SAMPLE_INPUTS: [
+                    (
+                        torch.rand(3, 5),
+                        torch.tensor(
+                            [[2, 1, 0, 1, 2], [0, 2, 1, 2, 0], [1, 0, 2, 0, 1]],
+                            dtype=torch.int64,
+                        ),
+                    ),
+                ],
+            },
+        ]
+
+        index = 0
+        for comb in test_comb:
+            for module in comb[QCOM_MODULE]:
+                for sample_input in comb[QCOM_SAMPLE_INPUTS]:
+                    with self.subTest(i=index):
+                        index += 1
+                        self.lower_module_and_test_output(module, sample_input)
+
     def test_qnn_backend_rsqrt(self):
         module = Rsqrt()  # noqa: F405
         sample_input = (torch.abs(torch.randn([3, 4])),)
@@ -5375,6 +5411,43 @@ class TestQNNQuantizedOperator(TestQNN):
                             dtype=torch.int64,
                         ),
                         torch.rand(3, 5),
+                    ),
+                ],
+            },
+        ]
+
+        index = 0
+        for comb in test_comb:
+            for module in comb[QCOM_MODULE]:
+                for sample_input in comb[QCOM_SAMPLE_INPUTS]:
+                    with self.subTest(i=index):
+                        index += 1
+                        qdq_module = self.get_qdq_module(module, sample_input)
+                        self.lower_module_and_test_output(qdq_module, sample_input)
+
+    def test_qnn_backend_scatter_value(self):
+        test_comb = [
+            {
+                QCOM_MODULE: [ScatterValue(dim=1, value=0.5)],  # noqa: F405
+                QCOM_SAMPLE_INPUTS: [
+                    (
+                        torch.rand(3, 5),
+                        torch.tensor(
+                            [[0, 1, 2, 3, 4], [4, 3, 2, 1, 0], [1, 0, 3, 4, 2]],
+                            dtype=torch.int64,
+                        ),
+                    ),
+                ],
+            },
+            {
+                QCOM_MODULE: [ScatterValue(dim=0, value=1.0)],  # noqa: F405
+                QCOM_SAMPLE_INPUTS: [
+                    (
+                        torch.rand(3, 5),
+                        torch.tensor(
+                            [[2, 1, 0, 1, 2], [0, 2, 1, 2, 0], [1, 0, 2, 0, 1]],
+                            dtype=torch.int64,
+                        ),
                     ),
                 ],
             },


### PR DESCRIPTION
### Summary
Adds support for `aten.scatter.value` on the QNN backend by extending the existing `ScatterElements` builder.

`torch.scatter(data, dim, index, value)` scatters a scalar `value` into `data` at positions specified by `index`. Unlike `scatter.src` (which takes a tensor), `scatter.value` takes a scalar which requires special handling in the builder to convert the scalar to a static tensor compatible with QNN's `ScatterElements` op.

Also updated the `new_op_development` Claude skill to include testing information for the new testing framework.

### Test plan
```
pytest backends/qualcomm/tests/rework/htp/op/v68/test.py -k "test_scatter_value" -v


python backends/qualcomm/tests/test_qnn_delegate.py TestQNNQuantizedOperator.test_qnn_backend_scatter_value --soc_model SM8750 --host aisw-vm15-labsd --device 545ee4aa --build_folder build-android

python backends/qualcomm/tests/test_qnn_delegate.py TestQNNFloatingPointOperator.test_qnn_backend_scatter_value --soc_model SM8750 --host aisw-vm15-labsd --device 545ee4aa --build_folder build-android
```