### PR TITLE
Share qparams for aten.concat.default in composable (V2) quantizer (#20999)

### DIFF
--- a/backends/arm/quantizer/arm_quantizer_utils.py
+++ b/backends/arm/quantizer/arm_quantizer_utils.py
@@ -461,6 +461,7 @@ class SharedQspecQuantizer(Quantizer, QuantizerReporterUser):
         torch.ops.aten.pixel_shuffle.default,
         torch.ops.aten.pixel_unshuffle.default,
         torch.ops.aten.cat.default,
+        torch.ops.aten.concat.default,
         torch.ops.aten.concatenate.default,
         torch.ops.aten.stack.default,
         torch.ops.aten.dropout.default,

--- a/backends/cortex_m/test/misc/test_portable_int8.py
+++ b/backends/cortex_m/test/misc/test_portable_int8.py
@@ -365,6 +365,12 @@ OP_CASES = {
         (torch.randn(2, 3, 4, 5), torch.randn(2, 3, 4, 5)),
         None,
     ),
+    "concat": OpCase(
+        torch.ops.aten.concat.default,
+        _build_module(lambda x, y: torch.ops.aten.concat.default([x, y], 1)),
+        (torch.randn(2, 3, 4, 5), torch.randn(2, 3, 4, 5)),
+        None,
+    ),
     "concatenate": OpCase(
         torch.ops.aten.concatenate.default,
         _build_module(lambda x, y: torch.ops.aten.concatenate.default([x, y], 1)),


### PR DESCRIPTION
Summary:

`SharedQspecQuantizer.SHARED_QSPEC_OPS_DEFAULT` (the composable `_TOSAQuantizerV2` path in `arm_quantizer_utils.py`) lists `aten.cat.default`, `aten.concatenate.default`, and `aten.stack.default` but omits `aten.concat.default`. D110085289 fixed the analogous gap only in the legacy V1 annotator (`quantization_annotator.py`) and never touched `SHARED_QSPEC_OPS_DEFAULT`, so the two hardcoded concat-family lists have drifted: the V2 path still gives `aten.concat.default` independent observers. Under dynamic-shape tracing `torch.concat` is captured as `aten.concat.default`, so without shared qparams its inputs get separate scales, blocking a single TOSA CONCAT and splitting the graph into two Ethos-U delegates (the same regression D110085289 fixed for V1).

This adds `aten.concat.default` to `SHARED_QSPEC_OPS_DEFAULT` so the composable quantizer shares qparams across the full concat family, and adds a drift-guard test (`test_shared_qspec_ops_default_covers_concat_family`) that asserts the concat family stays complete so the two lists cannot silently diverge again.

Reviewed By: rascani

Differential Revision: D112236028
