### PR TITLE
Emit std::string_view/std::optional from codegen

### DIFF
--- a/codegen/api/types/types.py
+++ b/codegen/api/types/types.py
@@ -18,14 +18,14 @@ from torchgen.model import BaseTy
 
 halfT = BaseCppType("torch::executor", "Half")
 bfloat16T = BaseCppType("torch::executor", "BFloat16")
-stringT = BaseCppType("torch::executor", "string_view")
+stringT = BaseCppType("std", "string_view")
 scalarTypeT = BaseCppType("torch::executor", "ScalarType")
 tensorT = BaseCppType("torch::executor", "Tensor")
 tensorListT = BaseCppType("torch::executor", "TensorList")
 scalarT = BaseCppType("torch::executor", "Scalar")
 memoryFormatT = BaseCppType("torch::executor", "MemoryFormat")
 intArrayRefT = BaseCppType("torch::executor", "IntArrayRef")
-optionalT = BaseCppType("torch::executor", "optional")
+optionalT = BaseCppType("std", "optional")
 contextT = BaseCppType("torch::executor", "KernelRuntimeContext")
 
 contextExpr = Expr(


### PR DESCRIPTION
Codegen still emitted the deprecated `torch::executor::string_view`/`optional` aliases; emit `std::string_view`/`std::optional` directly. Verified by building `optimized_ops_lib` and `portable_ops_lib` locally.

Authored with Claude.