### PR TITLE
Proper implementation for VulkanBackend::is_available()

### DIFF
--- a/backends/vulkan/cmake/ShaderLibrary.cmake
+++ b/backends/vulkan/cmake/ShaderLibrary.cmake
@@ -25,8 +25,9 @@ if(NOT EXECUTORCH_ROOT)
 endif()
 
 # find_program already searches the PATH environment variable and appends the
-# platform executable suffix (.exe on Windows). Add the Vulkan SDK bin dir as a
-# hint so glslc is found on Windows even when only VULKAN_SDK is set.
+# platform executable suffix (.exe on Windows). Prefer the Vulkan SDK bin dir so
+# an explicitly configured SDK takes precedence, including on Windows where the
+# installer may not add it to PATH.
 find_program(GLSLC_PATH glslc HINTS $ENV{VULKAN_SDK}/bin $ENV{VULKAN_SDK}/Bin)
 
 if(NOT GLSLC_PATH AND EXECUTORCH_BUILD_VULKAN)

--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -10,6 +10,7 @@
 #include <executorch/backends/vulkan/runtime/VulkanDelegateHeader.h>
 #include <executorch/backends/vulkan/serialization/schema_generated.h>
 
+#include <executorch/backends/vulkan/runtime/api/Context.h>
 #include <executorch/backends/vulkan/runtime/graph/ComputeGraph.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
@@ -614,8 +615,7 @@ class VulkanBackend final : public ::executorch::runtime::BackendInterface {
   ~VulkanBackend() override = default;
 
   bool is_available() const override {
-    // TODO(ssjia): replace with an actual Vulkan runtime availability check
-    return true;
+    return vkapi::set_and_get_external_adapter() != nullptr || api::available();
   }
 
   ET_NODISCARD Error compileModel(

--- a/backends/vulkan/runtime/vk_api/Runtime.cpp
+++ b/backends/vulkan/runtime/vk_api/Runtime.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <mutex>
 #include <sstream>
 
 namespace vkcompute {
@@ -474,13 +475,18 @@ Adapter* set_and_get_external_adapter(
     const VkInstance instance,
     const VkPhysicalDevice physical_device,
     const VkDevice logical_device) {
-  static const std::unique_ptr<Adapter> p_external_adapter =
-      init_external_adapter(
-          instance,
-          physical_device,
-          logical_device,
-          1,
-          set_and_get_pipeline_cache_data_path(""));
+  static std::mutex external_adapter_mutex;
+  static std::unique_ptr<Adapter> p_external_adapter;
+
+  const std::lock_guard<std::mutex> lock(external_adapter_mutex);
+  if (!p_external_adapter) {
+    p_external_adapter = init_external_adapter(
+        instance,
+        physical_device,
+        logical_device,
+        1,
+        set_and_get_pipeline_cache_data_path(""));
+  }
 
   return p_external_adapter.get();
 }

--- a/install_utils.py
+++ b/install_utils.py
@@ -65,10 +65,9 @@ def is_vulkan_available() -> bool:
     Windows, the desktop GPU platforms the backend supports (macOS would require
     MoltenVK).
 
-    glslc is looked up on PATH and, failing that, under $VULKAN_SDK/{bin,Bin} to
-    match the find_program() HINTS the build uses (see pybind.cmake and
-    ShaderLibrary.cmake): the Windows Vulkan SDK sets VULKAN_SDK but does not add
-    its bin directory to PATH, so a PATH-only probe would miss it there.
+    glslc is accepted from PATH or under $VULKAN_SDK/{bin,Bin}. The Windows
+    Vulkan SDK sets VULKAN_SDK but does not add its bin directory to PATH, so a
+    PATH-only probe would miss it there.
 
     Returns:
         True if glslc is available on a supported platform, False otherwise.


### PR DESCRIPTION
### Summary
- Implemented real runtime checks in `VulkanBackend::is_available()`
- Fixed lazy external Vulkan adapter initialization and thread safety (since the availability check may query the external adapter before valid handles are registered)
- Preserved `$VULKAN_SDK` priority when there's a conflict with the path

Fixes #20140

### Test plan
Tested on Linux with an A100. I'm relying on the CI for Windows testing.


cc @SS-JIA @manuelcandales @digantdesai @cbilgin