### PR TITLE
Use foreach SGD in QAT example to fix static-analysis lint (#21031)

### DIFF
--- a/examples/arm/QAT_example/qat_loop.py
+++ b/examples/arm/QAT_example/qat_loop.py
@@ -686,7 +686,9 @@ def build_qat_model(
     quantizer = make_quantizer(is_qat=True, io_quantization=io_quantization)
     prepared_model = prepare_qat_pt2e(exported_model, quantizer)
     prepared_model = move_exported_model_to_train(prepared_model)
-    optimizer = torch.optim.SGD(prepared_model.parameters(), lr=lr, momentum=0.9)
+    optimizer = torch.optim.SGD(
+        prepared_model.parameters(), lr=lr, momentum=0.9, foreach=True
+    )
 
     for step in range(steps):
         total_loss = 0.0


### PR DESCRIPTION
Summary:

Follow-up to D112514521. That diff (a diff-train import of the Practical-RIFE
PTQ/QAT accuracy flow) tripped the `missing_for_each_optimizer` CITRINE
static-analysis lint at `qat_loop.py:689`: the QAT training loop constructed
`torch.optim.SGD` without the foreach multi-tensor implementation.

Add `foreach=True` to the `torch.optim.SGD` constructor in `build_qat_model`
so the optimizer uses the multi-tensor path (estimated ~3.3% training speedup
per the lint guidance). Applied to both the `fbcode` and `xplat` copies.

Reviewed By: rascani

Differential Revision: D112638593




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani