### PR TITLE
Fix printf format specifier mismatches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,10 +443,8 @@ list(APPEND _common_compile_options $<$<CXX_COMPILER_ID:MSVC>:/wd4996>
      $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
 )
 # GCC checks no format strings by default; enforce them as errors.
-list(
-  APPEND
-  _common_compile_options
-  $<$<CXX_COMPILER_ID:GNU>:-Wformat;-Wformat-signedness;-Werror=format;-Werror=format-signedness>
+list(APPEND _common_compile_options
+     $<$<CXX_COMPILER_ID:GNU>:-Wformat;-Werror=format>
 )
 # Set default CMAKE_POSITION_INDEPENDENT_CODE behavior if ON or not set
 # (default) (and not for MSVC compiler)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,12 @@ endif()
 list(APPEND _common_compile_options $<$<CXX_COMPILER_ID:MSVC>:/wd4996>
      $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wno-deprecated-declarations>
 )
+# GCC checks no format strings by default; enforce them as errors.
+list(
+  APPEND
+  _common_compile_options
+  $<$<CXX_COMPILER_ID:GNU>:-Wformat;-Wformat-signedness;-Werror=format;-Werror=format-signedness>
+)
 # Set default CMAKE_POSITION_INDEPENDENT_CODE behavior if ON or not set
 # (default) (and not for MSVC compiler)
 if(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE

--- a/backends/apple/metal/runtime/metal_backend.cpp
+++ b/backends/apple/metal/runtime/metal_backend.cpp
@@ -463,7 +463,7 @@ class ET_EXPERIMENTAL MetalBackend final
         !c10::add_overflows(n_inputs, n_outputs, &n_io_sum) &&
             n_io_sum == args.size(),
         InvalidArgument,
-        "number of user input %zd and output %zd generated from AOT Inductor does not match ET runner's %zd. Exit.",
+        "number of user input %zu and output %zu generated from AOT Inductor does not match ET runner's %zu. Exit.",
         n_inputs,
         n_outputs,
         args.size())

--- a/backends/cadence/cadence_executor_runner.cpp
+++ b/backends/cadence/cadence_executor_runner.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
     ET_LOG(Error, "Program::load failed: 0x%" PRIx32, program.error());
     return 1;
   }
-  ET_LOG(Info, "Model buffer loaded, has %u methods", program->num_methods());
+  ET_LOG(Info, "Model buffer loaded, has %zu methods", program->num_methods());
 
   const char* method_name = nullptr;
   {

--- a/backends/cortex_m/ops/op_transpose.cpp
+++ b/backends/cortex_m/ops/op_transpose.cpp
@@ -53,7 +53,7 @@ Tensor& transpose_out(
   if (perm.size() != static_cast<int64_t>(rank)) {
     ET_LOG(
         Error,
-        "transpose_out: permutation length %zd does not match tensor rank %zu",
+        "transpose_out: permutation length %zu does not match tensor rank %zu",
         perm.size(),
         rank);
     context.fail(Error::InvalidArgument);

--- a/backends/cuda/runtime/cuda_backend.cpp
+++ b/backends/cuda/runtime/cuda_backend.cpp
@@ -493,7 +493,7 @@ class ET_EXPERIMENTAL CudaBackend final
         !c10::add_overflows(n_inputs, n_outputs, &n_io_sum) &&
             n_io_sum == args.size(),
         InvalidArgument,
-        "number of user input %zd and output %zd generated from AOT Inductor does not match ET runner's %zd. Exit.",
+        "number of user input %zu and output %zu generated from AOT Inductor does not match ET runner's %zu. Exit.",
         n_inputs,
         n_outputs,
         args.size())

--- a/backends/cuda/runtime/cuda_backend.cpp
+++ b/backends/cuda/runtime/cuda_backend.cpp
@@ -718,7 +718,7 @@ class ET_EXPERIMENTAL CudaBackend final
         error == Error::Ok,
         Internal,
         "AOTInductorModelContainerRun failed with error code %d",
-        error);
+        static_cast<int>(error));
 
     if (is_capture_step) {
       // End capture → instantiate graph

--- a/backends/nxp/runtime/NeutronBackend.cpp
+++ b/backends/nxp/runtime/NeutronBackend.cpp
@@ -7,6 +7,8 @@
  * Implementation of the backend for the NXP Neutron NPU.
  */
 
+#include <cinttypes>
+
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/evalue.h>
@@ -382,7 +384,7 @@ class NeutronBackend final : public PyTorchBackendInterface {
     if (neutronRC != ENONE) {
       ET_LOG(
           Error,
-          "Neutron model preparation failed with error code %ld",
+          "Neutron model preparation failed with error code %" PRId32,
           neutronRC);
       return Error::InvalidProgram;
     }
@@ -390,7 +392,10 @@ class NeutronBackend final : public PyTorchBackendInterface {
 #ifdef EXTERNAL_MEM
     neutronRC = neutronSetConfig(&neutronMemCopyConfig);
     if (neutronRC != ENONE) {
-      ET_LOG(Error, "Neutron set config failed with error code %ld", neutronRC);
+      ET_LOG(
+          Error,
+          "Neutron set config failed with error code %" PRId32,
+          neutronRC);
       return Error::InvalidProgram;
     }
 #endif
@@ -558,7 +563,7 @@ class NeutronBackend final : public PyTorchBackendInterface {
     if (neutronRC != ENONE) {
       ET_LOG(
           Error,
-          "Neutron model evaluation failed with error code %ld",
+          "Neutron model evaluation failed with error code %" PRId32,
           neutronRC);
       return Error::InvalidProgram;
     }

--- a/backends/samsung/runtime/enn_backend.cpp
+++ b/backends/samsung/runtime/enn_backend.cpp
@@ -63,7 +63,7 @@ class EnnBackend final : public PyTorchBackendInterface {
       ET_CHECK_OR_RETURN_ERROR(
           args[index]->isTensor(),
           InvalidArgument,
-          "Expected argument to delegate at index %u to be a Tensor, but got %" PRIu32,
+          "Expected argument to delegate at index %d to be a Tensor, but got %" PRIu32,
           index,
           static_cast<uint32_t>(args[index]->tag));
       Tensor* tensor = &args[index]->toTensor();

--- a/backends/samsung/runtime/enn_executor.cpp
+++ b/backends/samsung/runtime/enn_executor.cpp
@@ -26,7 +26,7 @@ Error EnnExecutor::initialize(const char* binary_buf_addr, size_t buf_size) {
   ET_CHECK_OR_RETURN_ERROR(
       ret == ENN_RET_SUCCESS, Internal, "Enn initialize failed.");
 
-  ET_LOG(Info, "Start to open model %p, %ld", binary_buf_addr, buf_size);
+  ET_LOG(Info, "Start to open model %p, %zu", binary_buf_addr, buf_size);
   ret = enn_api_inst->EnnOpenModelFromMemory(
       binary_buf_addr, buf_size, &model_id_);
 
@@ -58,13 +58,13 @@ Error EnnExecutor::eval(
   ET_CHECK_OR_RETURN_ERROR(
       inputs.size() == getInputSize(),
       InvalidArgument,
-      "Invalid number of inputs, expect %" PRIu32 " while get %ld",
+      "Invalid number of inputs, expect %" PRId32 " while get %zu",
       getInputSize(),
       inputs.size());
   ET_CHECK_OR_RETURN_ERROR(
       outputs.size() == getOutputSize(),
       InvalidArgument,
-      "Invalid number of outputs, expected %" PRIu32 " while get %ld",
+      "Invalid number of outputs, expected %" PRId32 " while get %zu",
       getOutputSize(),
       outputs.size());
 

--- a/examples/arm/executor_runner/arm_perf_monitor.cpp
+++ b/examples/arm/executor_runner/arm_perf_monitor.cpp
@@ -235,8 +235,10 @@ void StopMeasurements(int num_inferences) {
 }
 
 #else
+// cppcheck-suppress unusedFunction
 void StartMeasurements() {}
 
+// cppcheck-suppress unusedFunction
 void StopMeasurements(int num_inferences) {
   (void)num_inferences;
 }

--- a/examples/arm/executor_runner/arm_perf_monitor.cpp
+++ b/examples/arm/executor_runner/arm_perf_monitor.cpp
@@ -209,7 +209,7 @@ void StopMeasurements(int num_inferences) {
   ET_LOG(Info, "Ethos-U PMU report:");
   ET_LOG(
       Info,
-      "ethosu_pmu_cycle_cntr : % " PRIu64 " (%.2f per inference)",
+      "ethosu_pmu_cycle_cntr : %" PRIu64 " (%.2f per inference)",
       ethosu_pmuCycleCount,
       (double)ethosu_pmuCycleCount / num_inferences);
 

--- a/examples/portable/executor_runner/executor_runner.cpp
+++ b/examples/portable/executor_runner/executor_runner.cpp
@@ -376,7 +376,7 @@ int main(int argc, char** argv) {
 
     ET_CHECK_MSG(
         status == Error::Ok,
-        "get_program_data() from bundle PTE failed: 0x%x" PRIx32,
+        "get_program_data() from bundle PTE failed: 0x%" PRIx32,
         static_cast<uint32_t>(status));
   } else {
     ET_LOG(Debug, "PTE Model has no bundled IO");
@@ -888,8 +888,7 @@ int main(int argc, char** argv) {
     } else {
       ET_LOG(
           Info,
-          "=== Error calculating stats for testset %zu ERROR: 0x%x" PRIx32
-          "===",
+          "=== Error calculating stats for testset %zu ERROR: 0x%" PRIx32 "===",
           testset_idx,
           static_cast<uint32_t>(stats.status));
     }

--- a/examples/portable/executor_runner/executor_runner.cpp
+++ b/examples/portable/executor_runner/executor_runner.cpp
@@ -848,7 +848,8 @@ int main(int argc, char** argv) {
                 i,
                 j,
                 tensor.const_data_ptr<int8_t>()[j] ? "true " : "false",
-                tensor.const_data_ptr<int8_t>()[j]);
+                static_cast<unsigned int>(
+                    static_cast<uint8_t>(tensor.const_data_ptr<int8_t>()[j])));
           }
         }
       } else {

--- a/examples/qualcomm/oss_scripts/llama/runner/multimodal_runner/encoder.cpp
+++ b/examples/qualcomm/oss_scripts/llama/runner/multimodal_runner/encoder.cpp
@@ -50,7 +50,7 @@ Result<Tensor> EncoderRunner::encode(TensorPtr& image_tensor) {
   ET_CHECK_MSG(is_method_loaded(), "Encoder method not loaded");
 
   auto tensor_ptr = image_tensor.get();
-  ET_LOG(Info, "Encoding tensor with numel: %zu", tensor_ptr->numel());
+  ET_LOG(Info, "Encoding tensor with numel: %zd", tensor_ptr->numel());
 
   std::vector<executorch::runtime::EValue> encoder_inputs;
   encoder_inputs.emplace_back(*tensor_ptr);

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -20,6 +20,7 @@
 #include <executorch/runtime/platform/runtime.h>
 #include <cassert>
 #include <chrono>
+#include <cinttypes>
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -417,7 +418,7 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
     auto duration =
         std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
             .count();
-    ET_LOG(Debug, "Execution time: %lld ms.", duration);
+    ET_LOG(Debug, "Execution time: %" PRId64 " ms.", duration);
 
 #else
     auto result = module_->execute(method, evalues);

--- a/extension/data_loader/mmap_data_loader.cpp
+++ b/extension/data_loader/mmap_data_loader.cpp
@@ -79,7 +79,7 @@ Result<MmapDataLoader> MmapDataLoader::from(
     return Error::AccessFailed;
   }
   if ((page_size & ~(page_size - 1)) != page_size) {
-    ET_LOG(Error, "Page size 0x%ld is not a power of 2", page_size);
+    ET_LOG(Error, "Page size 0x%lx is not a power of 2", page_size);
     return Error::InvalidState;
   }
 
@@ -211,7 +211,7 @@ Result<FreeableBuffer> MmapDataLoader::load(
   ET_CHECK_OR_RETURN_ERROR(
       pages != MAP_FAILED,
       AccessFailed,
-      "Failed to map %s: mmap(..., size=%zd, ..., fd=%d, offset=0x%zx)",
+      "Failed to map %s: mmap(..., size=%zu, ..., fd=%d, offset=0x%zx)",
       file_name_,
       range.size,
       fd_,
@@ -224,7 +224,7 @@ Result<FreeableBuffer> MmapDataLoader::load(
       if (mlock_config_ == MlockConfig::UseMlockIgnoreErrors) {
         ET_LOG(
             Debug,
-            "Ignoring mlock error for file %s (off=0x%zd): "
+            "Ignoring mlock error for file %s (off=0x%zx): "
             "mlock(%p, %zu) failed: %s (%d)",
             file_name_,
             offset,
@@ -235,7 +235,7 @@ Result<FreeableBuffer> MmapDataLoader::load(
       } else {
         ET_LOG(
             Error,
-            "File %s (off=0x%zd): mlock(%p, %zu) failed: %s (%d)",
+            "File %s (off=0x%zx): mlock(%p, %zu) failed: %s (%d)",
             file_name_,
             offset,
             pages,
@@ -321,7 +321,7 @@ Error MmapDataLoader::load_into(
   ET_CHECK_OR_RETURN_ERROR(
       pages != MAP_FAILED,
       AccessFailed,
-      "Failed to map %s: mmap(..., size=%zd, ..., fd=%d, offset=0x%zx)",
+      "Failed to map %s: mmap(..., size=%zu, ..., fd=%d, offset=0x%zx)",
       file_name_,
       range.size,
       fd_,

--- a/extension/flat_tensor/flat_tensor_data_map.cpp
+++ b/extension/flat_tensor/flat_tensor_data_map.cpp
@@ -71,7 +71,7 @@ Result<const flat_tensor_flatbuffer::NamedData*> get_named_data(
       ET_CHECK_OR_RETURN_ERROR(
           segment_index >= 0 && segment_index < segments->size(),
           InvalidExternalData,
-          "Segment index %zu for key %.*s is out of bounds for segment size %d. Malformed PTD file.",
+          "Segment index %zu for key %.*s is out of bounds for segment size %u. Malformed PTD file.",
           segment_index,
           static_cast<int>(key.size()),
           key.data(),

--- a/extension/llm/runner/multimodal_prefiller.cpp
+++ b/extension/llm/runner/multimodal_prefiller.cpp
@@ -104,7 +104,7 @@ Result<uint64_t> MultimodalPrefiller::prefill(
 
     ET_LOG(
         Info,
-        "Image tensor dim: %zu, dtype: %s",
+        "Image tensor dim: %zd, dtype: %s",
         image_tensor->dim(),
         ::executorch::runtime::toString(image_tensor->scalar_type()));
     // Run image encoder
@@ -161,7 +161,7 @@ Result<uint64_t> MultimodalPrefiller::prefill(
 
     ET_LOG(
         Info,
-        "Audio tensor dim: %zu, dtype: %s",
+        "Audio tensor dim: %zd, dtype: %s",
         audio_tensor->dim(),
         ::executorch::runtime::toString(audio_tensor->scalar_type()));
 

--- a/extension/llm/runner/stats.h
+++ b/extension/llm/runner/stats.h
@@ -174,7 +174,7 @@ inline void print_report(const Stats& stats) {
 
   ET_LOG(
       Info,
-      "\tPrompt Tokens: %" PRIu64 "    Generated Tokens: %" PRIu64,
+      "\tPrompt Tokens: %" PRId64 "    Generated Tokens: %" PRId64,
       stats.num_prompt_tokens,
       stats.num_generated_tokens);
 
@@ -206,7 +206,7 @@ inline void print_report(const Stats& stats) {
       (double)(stats.inference_end_ms - stats.prompt_eval_end_ms);
   ET_LOG(
       Info,
-      "\t\tGenerated %" PRIu64
+      "\t\tGenerated %" PRId64
       " tokens:\t%f (seconds)\t\t Rate: \t%f (tokens/second)",
       stats.num_generated_tokens,
       eval_time / stats.SCALING_FACTOR_UNITS_PER_SECOND,
@@ -224,7 +224,7 @@ inline void print_report(const Stats& stats) {
 
   ET_LOG(
       Info,
-      "\tSampling time over %" PRIu64 " tokens:\t%f (seconds)",
+      "\tSampling time over %" PRId64 " tokens:\t%f (seconds)",
       stats.num_prompt_tokens + stats.num_generated_tokens,
       (double)stats.aggregate_sampling_time_ms /
           stats.SCALING_FACTOR_UNITS_PER_SECOND);

--- a/extension/llm/runner/text_prefiller.cpp
+++ b/extension/llm/runner/text_prefiller.cpp
@@ -119,7 +119,7 @@ TextPrefiller::TextPrefiller(
 
     ET_CHECK_OK_OR_RETURN_ERROR(outputs_res.error());
     ET_LOG(
-        Info, "Prefill token result numel(): %zu", outputs_res.get().numel());
+        Info, "Prefill token result numel(): %zd", outputs_res.get().numel());
 
     start_pos += num_prompt_tokens;
     cur_token =

--- a/extension/llm/runner/wav_loader.h
+++ b/extension/llm/runner/wav_loader.h
@@ -179,7 +179,7 @@ inline std::unique_ptr<WavHeader> load_wav_header(
       header->RIFF[1],
       header->RIFF[2],
       header->RIFF[3]);
-  ET_LOG(Info, "Chunk Size: %d", header->ChunkSize);
+  ET_LOG(Info, "Chunk Size: %u", header->ChunkSize);
   ET_LOG(
       Info,
       "WAVE Header: %c%c%c%c",
@@ -194,14 +194,14 @@ inline std::unique_ptr<WavHeader> load_wav_header(
       header->fmt[1],
       header->fmt[2],
       header->fmt[3]);
-  ET_LOG(Info, "Format Chunk Size: %d", header->Subchunk1Size);
+  ET_LOG(Info, "Format Chunk Size: %u", header->Subchunk1Size);
   ET_LOG(Info, "Audio Format: %d", header->AudioFormat);
   ET_LOG(Info, "Number of Channels: %d", header->NumOfChan);
-  ET_LOG(Info, "Sample Rate: %d", header->SamplesPerSec);
-  ET_LOG(Info, "Byte Rate: %d", header->bytesPerSec);
+  ET_LOG(Info, "Sample Rate: %u", header->SamplesPerSec);
+  ET_LOG(Info, "Byte Rate: %u", header->bytesPerSec);
   ET_LOG(Info, "Block Align: %d", header->blockAlign);
   ET_LOG(Info, "Bits per Sample: %d", header->bitsPerSample);
-  ET_LOG(Info, "Subchunk2Size: %d", header->Subchunk2Size);
+  ET_LOG(Info, "Subchunk2Size: %u", header->Subchunk2Size);
 
   return header;
 }

--- a/extension/runner_util/inputs.cpp
+++ b/extension/runner_util/inputs.cpp
@@ -56,7 +56,7 @@ Result<BufferCleanup> prepare_input_tensors(
   ET_CHECK_OR_RETURN_ERROR(
       inputs != nullptr,
       MemoryAllocationFailed,
-      "malloc(%zd) failed",
+      "malloc(%zu) failed",
       num_inputs * sizeof(void*));
 
   // Allocate memory for each input tensor.

--- a/extension/wasm/wasm_bindings.cpp
+++ b/extension/wasm/wasm_bindings.cpp
@@ -97,7 +97,7 @@ inline void assert_valid_numel(
       computed_numel.error(), "Invalid tensor sizes: numel computation failed");
   THROW_IF_FALSE(
       data.size() >= static_cast<size_t>(computed_numel.get()),
-      "Required %ld elements, given %ld",
+      "Required %zd elements, given %zu",
       computed_numel.get(),
       data.size());
 }

--- a/kernels/portable/cpu/op_view_as_real_copy.cpp
+++ b/kernels/portable/cpu/op_view_as_real_copy.cpp
@@ -46,7 +46,7 @@ Tensor& view_as_real_copy_out(
       static_cast<size_t>(self.dim()) < kTensorDimensionLimit,
       InvalidArgument,
       out,
-      "Output size buffer is too small. Expected at least %zu, got %zu",
+      "Output size buffer is too small. Expected at least %zd, got %zu",
       self.dim() + 1,
       kTensorDimensionLimit);
   get_view_as_real_copy_out_target_size(self, expected_output_size);

--- a/kernels/portable/cpu/util/copy_ops_util.cpp
+++ b/kernels/portable/cpu/util/copy_ops_util.cpp
@@ -265,7 +265,7 @@ bool check_unbind_copy_args(const Tensor& in, int64_t dim, TensorList out) {
   const ssize_t dim_size = in.size(dim);
   ET_CHECK_OR_RETURN_FALSE(
       dim_size == static_cast<ssize_t>(out.size()),
-      "out tensorlist's length %zd must equal unbind dim %" PRId64
+      "out tensorlist's length %zu must equal unbind dim %" PRId64
       " size = %zd.",
       out.size(),
       dim,

--- a/kernels/portable/cpu/util/index_util.cpp
+++ b/kernels/portable/cpu/util/index_util.cpp
@@ -46,7 +46,7 @@ bool check_gather_args(
           "size of dimension %zd of index should be smaller than the size of that dimension of input if dimension %zd != dim %zd",
           d,
           d,
-          (size_t)dim);
+          dim);
     }
   }
   const long* index_data = index.const_data_ptr<long>();
@@ -54,7 +54,7 @@ bool check_gather_args(
     ET_CHECK_OR_RETURN_FALSE(
         index_data[i] >= 0 && index_data[i] < nonempty_size(in, dim),
         "Index is out of bounds for dimension %zd with size %zd",
-        (size_t)dim,
+        dim,
         nonempty_size(index, dim));
   }
 
@@ -96,7 +96,7 @@ bool check_index_select_args(
           "index[%zu] = %" PRId64 " is out of range [0, %zd)",
           i,
           index_ptr[i],
-          static_cast<size_t>(nonempty_size(in, dim)));
+          nonempty_size(in, dim));
     }
   } else {
     const int32_t* const index_ptr = index.const_data_ptr<int32_t>();
@@ -106,7 +106,7 @@ bool check_index_select_args(
           "index[%zu] = %" PRId32 " is out of range [0, %zd)",
           i,
           index_ptr[i],
-          static_cast<size_t>(nonempty_size(in, dim)));
+          nonempty_size(in, dim));
     }
   }
 
@@ -138,9 +138,7 @@ bool check_nonzero_args(const Tensor& in, const Tensor& out) {
       toString(out.scalar_type()));
 
   ET_CHECK_OR_RETURN_FALSE(
-      out.dim() == 2,
-      "Expected out to be a 2d tensor received %zd",
-      ssize_t(out.dim()));
+      out.dim() == 2, "Expected out to be a 2d tensor received %zd", out.dim());
 
   return true;
 }
@@ -187,7 +185,7 @@ bool check_scatter_add_args(
           "size of dimension %zd of index should be smaller than the size of that dimension of self if dimension %zd != dim %zd",
           d,
           d,
-          (size_t)dim);
+          dim);
     }
   }
   const long* index_data = index.const_data_ptr<long>();
@@ -195,7 +193,7 @@ bool check_scatter_add_args(
     ET_CHECK_OR_RETURN_FALSE(
         index_data[i] >= 0 && index_data[i] < nonempty_size(self, dim),
         "Index is out of bounds for dimension %zd with size %zd",
-        (size_t)dim,
+        dim,
         nonempty_size(self, dim));
   }
   return true;

--- a/kernels/portable/cpu/util/kernel_ops_util.cpp
+++ b/kernels/portable/cpu/util/kernel_ops_util.cpp
@@ -249,7 +249,7 @@ void calculate_kernel_output_sizes(
 bool check_arange_args(double start, double end, double step, Tensor& out) {
   ET_CHECK_OR_RETURN_FALSE(
       out.dim() == 1,
-      "out should be a 1-d tensor, but got a %zu-d tensor",
+      "out should be a 1-d tensor, but got a %zd-d tensor",
       out.dim());
 
   ET_CHECK_OR_RETURN_FALSE(

--- a/kernels/portable/cpu/util/reduce_util.h
+++ b/kernels/portable/cpu/util/reduce_util.h
@@ -278,7 +278,7 @@ void apply_over_dim(
   }
   ET_CHECK_MSG(
       out_ix < get_out_numel(in, dim),
-      "Out index %zd is out of bounds",
+      "Out index %zu is out of bounds",
       out_ix);
 
   if (in.numel() == 0) {
@@ -358,7 +358,7 @@ class ApplyOverDimListPlan {
 
   template <typename Fn>
   void execute(const Fn& fn, const size_t out_ix) const {
-    ET_CHECK_MSG(out_ix < out_numel_, "Out index %zd is out of bounds", out_ix);
+    ET_CHECK_MSG(out_ix < out_numel_, "Out index %zu is out of bounds", out_ix);
 
     switch (mode_) {
       case ExecutionMode::NothingToDo:
@@ -489,7 +489,7 @@ std::tuple<CTYPE_OUT, long> map_reduce_over_dim(
 
   ET_CHECK_MSG(
       out_ix < get_out_numel(in, dim),
-      "Out index %zd is out of bounds",
+      "Out index %zu is out of bounds",
       out_ix);
 
   ET_CHECK_MSG(in.numel() > 0, "Input tensor must be nonempty");

--- a/runtime/core/exec_aten/testing_util/tensor_factory.h
+++ b/runtime/core/exec_aten/testing_util/tensor_factory.h
@@ -265,8 +265,8 @@ class TensorFactory {
     auto expected_numel = internal::sizes_to_numel(sizes);
     ET_CHECK_MSG(
         expected_numel == data.size(),
-        "Number of data elements %zd "
-        "does not match expected number of elements %zd",
+        "Number of data elements %zu "
+        "does not match expected number of elements %zu",
         data.size(),
         expected_numel);
 
@@ -310,8 +310,8 @@ class TensorFactory {
     auto expected_numel = internal::sizes_to_numel(sizes);
     ET_CHECK_MSG(
         expected_numel == data.size(),
-        "Number of data elements %zd "
-        "does not match expected number of elements %zd",
+        "Number of data elements %zu "
+        "does not match expected number of elements %zu",
         data.size(),
         expected_numel);
 
@@ -795,8 +795,8 @@ class TensorFactory {
     auto expected_numel = internal::sizes_to_numel(sizes);
     ET_CHECK_MSG(
         expected_numel == data.size(),
-        "Number of data elements %zd "
-        "does not match expected number of elements %zd",
+        "Number of data elements %zu "
+        "does not match expected number of elements %zu",
         data.size(),
         expected_numel);
 
@@ -843,8 +843,8 @@ class TensorFactory {
     auto expected_numel = internal::sizes_to_numel(sizes);
     ET_CHECK_MSG(
         expected_numel == data.size(),
-        "Number of data elements %zd "
-        "does not match expected number of elements %zd",
+        "Number of data elements %zu "
+        "does not match expected number of elements %zu",
         data.size(),
         expected_numel);
 

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -57,7 +57,7 @@
 #define ET_CHECK_NON_ZERO_DIM_SIZE(DIM, T)           \
   const size_t udim = ET_NORMALIZE_IX(DIM, T.dim()); \
   ET_CHECK_MSG(                                      \
-      T.size(udim) != 0, "Expected dim %zd to have non-zero size.", udim);
+      T.size(udim) != 0, "Expected dim %zu to have non-zero size.", udim);
 
 /**
  * Asserts that all tensors have the same shape.
@@ -272,7 +272,7 @@
   do {                                                                         \
     ET_CHECK_MSG(                                                              \
         a__.dim() == b__.dim(),                                                \
-        "Two tensors shall have same number of strides, but not %zu and %zu.", \
+        "Two tensors shall have same number of strides, but not %zd and %zd.", \
         a__.dim(),                                                             \
         b__.dim());                                                            \
     const ::executorch::aten::ArrayRef<executorch::aten::StridesType>          \
@@ -301,7 +301,7 @@
     ET_CHECK_MSG(                                                       \
         a__.dim() == b__.dim() && b__.dim() == c__.dim(),               \
         "Three tensors shall have same number of strides, "             \
-        "but not %zu, %zu and %zu.",                                    \
+        "but not %zd, %zd and %zd.",                                    \
         a__.dim(),                                                      \
         b__.dim(),                                                      \
         c__.dim());                                                     \

--- a/runtime/core/exec_aten/util/tensor_util_aten.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_aten.cpp
@@ -101,7 +101,7 @@ bool tensors_have_same_dim_order(
     ET_CHECK_OR_RETURN_FALSE(
         get_dim_order(tensor_list[i], other_dim_order, tensor_list[i].dim()) ==
             Error::Ok,
-        "Failed to retrieve dim order from %zd-th input tensor!",
+        "Failed to retrieve dim order from %zu-th input tensor!",
         i);
 
     all_contiguous = all_contiguous &&
@@ -112,7 +112,7 @@ bool tensors_have_same_dim_order(
 
   ET_CHECK_OR_RETURN_FALSE(
       all_contiguous || all_channels_last,
-      "%zd input tensors have different dim orders",
+      "%zu input tensors have different dim orders",
       tensor_list.size());
 
   return all_contiguous || all_channels_last;

--- a/runtime/core/exec_aten/util/tensor_util_portable.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_portable.cpp
@@ -46,7 +46,7 @@ bool tensor_has_valid_dim_order(torch::executor::Tensor t) {
     for ([[maybe_unused]] const auto d : c10::irange(t.dim())) {
       ET_LOG(
           Error,
-          "    dim_order(%zu): %zu",
+          "    dim_order(%zd): %zu",
           d,
           static_cast<size_t>(t.dim_order()[d]));
     }
@@ -67,7 +67,7 @@ bool tensor_is_default_or_channels_last_dim_order(torch::executor::Tensor t) {
     for ([[maybe_unused]] const auto d : c10::irange(t.dim())) {
       ET_LOG(
           Error,
-          "    dim_order(%zu): %zu",
+          "    dim_order(%zd): %zu",
           d,
           static_cast<size_t>(t.dim_order()[d]));
     }
@@ -84,7 +84,7 @@ bool tensor_is_default_dim_order(torch::executor::Tensor t) {
     for ([[maybe_unused]] const auto d : c10::irange(t.dim())) {
       ET_LOG(
           Error,
-          "    dim_order(%zu): %zu",
+          "    dim_order(%zd): %zu",
           d,
           static_cast<size_t>(t.dim_order()[d]));
     }
@@ -101,7 +101,7 @@ bool tensor_is_channels_last_dim_order(torch::executor::Tensor t) {
     for ([[maybe_unused]] const auto d : c10::irange(t.dim())) {
       ET_LOG(
           Error,
-          "    dim_order(%zu): %zu",
+          "    dim_order(%zd): %zu",
           d,
           static_cast<size_t>(t.dim_order()[d]));
     }
@@ -129,7 +129,7 @@ bool tensors_have_same_dim_order(
 
   ET_CHECK_OR_RETURN_FALSE(
       all_contiguous || all_channels_last,
-      "%zd input tensors have different dim orders",
+      "%zu input tensors have different dim orders",
       tensor_list.size());
 
   return true;

--- a/runtime/core/portable_type/tensor_impl.cpp
+++ b/runtime/core/portable_type/tensor_impl.cpp
@@ -108,7 +108,7 @@ Error TensorImpl::internal_resize_contiguous(ArrayRef<SizesType> new_sizes) {
   ET_CHECK_OR_RETURN_ERROR(
       static_cast<ssize_t>(new_sizes.size()) == dim_,
       NotSupported,
-      "Attempted to change the tensor rank which is immutable: old=%zu, new=%zu",
+      "Attempted to change the tensor rank which is immutable: old=%zd, new=%zu",
       dim_,
       new_sizes.size());
 
@@ -156,7 +156,7 @@ Error TensorImpl::internal_resize_contiguous(ArrayRef<SizesType> new_sizes) {
       ET_CHECK_OR_RETURN_ERROR(
           static_cast<size_t>(new_numel) <= numel_bound_,
           NotSupported,
-          "Attempted to resize a bounded tensor with a maximum capacity of %zu elements to %zu elements.",
+          "Attempted to resize a bounded tensor with a maximum capacity of %zu elements to %zd elements.",
           numel_bound_,
           new_numel);
 

--- a/runtime/executor/method.cpp
+++ b/runtime/executor/method.cpp
@@ -1217,7 +1217,7 @@ Method::set_input(const EValue& input_evalue, size_t input_idx) {
           !overflow,
           InvalidArgument,
           "Input %" ET_PRIsize_t
-          ": numel overflowed at dimension %zd with size %zd",
+          ": numel overflowed at dimension %zu with size %zu",
           input_idx,
           (size_t)i,
           (size_t)t_src.size(i));

--- a/runtime/executor/program.cpp
+++ b/runtime/executor/program.cpp
@@ -219,7 +219,7 @@ Result<executorch_flatbuffer::ExecutionPlan*> get_execution_plan(
                 program_data->size() - sizeof(flatbuffers::soffset_t),
         InvalidProgram,
         "Root table offset %u is invalid for program size %zu",
-        root_offset,
+        static_cast<unsigned>(root_offset),
         program_data->size());
   }
   // Get the pointer to the root flatbuffer table.

--- a/runtime/executor/program_validation.cpp
+++ b/runtime/executor/program_validation.cpp
@@ -41,7 +41,7 @@ validate_tensor(const executorch_flatbuffer::Tensor* tensor) {
       ET_LOG(
           Error,
           "Size must be non-negative, got %d at dimension %u",
-          size,
+          static_cast<int>(size),
           static_cast<unsigned>(i));
       return Error::InvalidProgram;
     }
@@ -199,7 +199,7 @@ validate_program(const executorch_flatbuffer::Program* program) {
                 "TensorList item %u has out-of-bounds index %d (values size "
                 "%u) in execution plan %u",
                 static_cast<unsigned>(item_idx),
-                evalue_index,
+                static_cast<int>(evalue_index),
                 static_cast<unsigned>(values->size()),
                 static_cast<unsigned>(plan_idx));
             return Error::InvalidProgram;
@@ -213,7 +213,7 @@ validate_program(const executorch_flatbuffer::Program* program) {
                 "TensorList item %u references null evalue at index %d in "
                 "execution plan %u",
                 static_cast<unsigned>(item_idx),
-                evalue_index,
+                static_cast<int>(evalue_index),
                 static_cast<unsigned>(plan_idx));
             return Error::InvalidProgram;
           }
@@ -226,7 +226,7 @@ validate_program(const executorch_flatbuffer::Program* program) {
                 "index %d in execution plan %u",
                 static_cast<unsigned>(item_idx),
                 static_cast<int>(referenced_value->val_type()),
-                evalue_index,
+                static_cast<int>(evalue_index),
                 static_cast<unsigned>(plan_idx));
             return Error::InvalidProgram;
           }

--- a/runtime/executor/pte_data_map.cpp
+++ b/runtime/executor/pte_data_map.cpp
@@ -35,7 +35,7 @@ Result<FreeableBuffer> PteDataMap::get_data(std::string_view key) const {
         "Searching for key %.*s: NamedData at index %d is null",
         static_cast<int>(key.size()),
         key.data(),
-        i);
+        static_cast<int>(i));
     const auto* named_data_key = named_data_item->key();
     if (named_data_key->size() == key.size() &&
         memcmp(named_data_key->data(), key.data(), key.size()) == 0) {
@@ -50,7 +50,7 @@ Result<FreeableBuffer> PteDataMap::get_data(std::string_view key) const {
           segment_index,
           static_cast<int>(key.size()),
           key.data(),
-          segments_->size());
+          static_cast<unsigned>(segments_->size()));
       size_t segment_offset = segments_->Get(segment_index)->offset();
       size_t segment_size = segments_->Get(segment_index)->size();
       return loader_->load(
@@ -71,15 +71,15 @@ ET_NODISCARD Result<const char*> PteDataMap::get_key(uint32_t index) const {
       index < named_data_->size(),
       InvalidArgument,
       "Index out of range: named_data size is %u, received index %u",
-      named_data_->size(),
-      index);
+      static_cast<unsigned>(named_data_->size()),
+      static_cast<unsigned>(index));
 
   const auto* item = named_data_->Get(index);
   ET_CHECK_OR_RETURN_ERROR(
       item != nullptr && item->key() != nullptr,
       InvalidArgument,
       "NamedData at index %u is null",
-      index);
+      static_cast<unsigned>(index));
   return item->key()->c_str();
 }
 

--- a/runtime/executor/tensor_parser_exec_aten.cpp
+++ b/runtime/executor/tensor_parser_exec_aten.cpp
@@ -149,14 +149,14 @@ ET_NODISCARD Error validateTensorLayout(
       InvalidExternalData,
       "Dim order size mismatch. Expected %d, got %u.",
       dim,
-      s_tensor->dim_order()->size());
+      static_cast<unsigned>(s_tensor->dim_order()->size()));
   for (int i = 0; i < dim; i++) {
     ET_CHECK_OR_RETURN_ERROR(
         s_tensor->sizes()->Get(i) == expected_layout.sizes()[i],
         InvalidExternalData,
         "Sizes mismatch. Expected %d, got %d for size at index %d.",
-        s_tensor->sizes()->Get(i),
-        expected_layout.sizes()[i],
+        static_cast<int>(s_tensor->sizes()->Get(i)),
+        static_cast<int>(expected_layout.sizes()[i]),
         i);
     ET_CHECK_OR_RETURN_ERROR(
         s_tensor->dim_order()->Get(i) == expected_layout.dim_order()[i],

--- a/runtime/kernel/operator_registry.h
+++ b/runtime/kernel/operator_registry.h
@@ -24,11 +24,11 @@
 #include <ostream>
 #endif
 
-#define ET_LOG_KERNEL_KEY(k)      \
-  ET_LOG(                         \
-      Info,                       \
-      "key: %s, is_fallback: %s", \
-      k.data(),                   \
+#define ET_LOG_KERNEL_KEY(k)          \
+  ET_LOG(                             \
+      Info,                           \
+      "key: %s, is_fallback: %s",     \
+      k.data() ? k.data() : "(null)", \
       k.is_fallback() ? "true" : "false");
 #define ET_LOG_TENSOR_META(meta_list)                                \
   for (const auto& meta : meta_list) {                               \

--- a/runtime/kernel/operator_registry.h
+++ b/runtime/kernel/operator_registry.h
@@ -34,7 +34,7 @@
   for (const auto& meta : meta_list) {                               \
     ET_LOG(Info, "dtype: %d | dim order: [", int(meta.dtype_));      \
     for (size_t i = 0; i < meta.dim_order_.size(); i++) {            \
-      ET_LOG(Info, "%d,", static_cast<int32_t>(meta.dim_order_[i])); \
+      ET_LOG(Info, "%d,", static_cast<int>(meta.dim_order_[i])); \
     }                                                                \
     ET_LOG(Info, "]");                                               \
   }


### PR DESCRIPTION
Fix printf format specifier mismatches (sign/size errors like PRIu64 for int64_t, %zd for size_t; malformed literals like `0x%x" PRIx32`) across runtime, kernels, extensions, backends, and examples. Then enforce format checks as errors under GCC via _common_compile_options, since GCC checks no format strings by default. Verified by rebuilding with clang -Wformat=2 and syntax-checking all 255 first-party TUs with GCC's -Wformat-signedness — both clean.

Authored with Claude.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani