### PR TITLE
Bump PyTorch pin to nightly dev20260719

### DIFF
--- a/.ci/docker/ci_commit_pins/pytorch.txt
+++ b/.ci/docker/ci_commit_pins/pytorch.txt
@@ -1,1 +1,1 @@
-release/2.12
+d56735d8ac8cca8062e7c5df10a02f9587d63b98

--- a/runtime/core/portable_type/c10/c10/util/BFloat16-math.h
+++ b/runtime/core/portable_type/c10/c10/util/BFloat16-math.h
@@ -181,7 +181,7 @@ template <
     typename T,
     typename std::enable_if_t<c10::is_reduced_floating_point_v<T>, int> = 0>
 inline T rsqrt(T a) {
-  return 1.0 / std::sqrt(float(a));
+  return 1.0f / std::sqrt(float(a));
 }
 template <
     typename T,

--- a/runtime/core/portable_type/c10/c10/util/complex.h
+++ b/runtime/core/portable_type/c10/c10/util/complex.h
@@ -31,18 +31,10 @@ C10_HOST_DEVICE T abs(const c10::complex<T>& z) {
 #endif
 }
 
-#if defined(USE_ROCM)
-#define ROCm_Bug(x)
-#else
-#define ROCm_Bug(x) x
-#endif
-
 template <typename T>
 C10_HOST_DEVICE T arg(const c10::complex<T>& z) {
-  return ROCm_Bug(std)::atan2(std::imag(z), std::real(z));
+  return std::atan2(std::imag(z), std::real(z));
 }
-
-#undef ROCm_Bug
 
 template <typename T>
 constexpr T norm(const c10::complex<T>& z) {

--- a/runtime/core/portable_type/c10/c10/util/complex_math.h
+++ b/runtime/core/portable_type/c10/c10/util/complex_math.h
@@ -327,7 +327,7 @@ C10_HOST_DEVICE inline c10::complex<T> atanh(const c10::complex<T>& x) {
 template <typename T>
 C10_HOST_DEVICE inline c10::complex<T> log1p(const c10::complex<T>& z) {
 #if defined(__APPLE__) || defined(__MACOSX) || defined(__CUDACC__) || \
-    defined(__HIPCC__)
+    defined(__HIPCC__) || defined(__SYCL_DEVICE_ONLY__)
   // For Mac, the new implementation yielded a high relative error. Falling back
   // to the old version for now.
   // See https://github.com/numpy/numpy/pull/22611#issuecomment-1667945354

--- a/runtime/core/portable_type/c10/torch/headeronly/macros/Macros.h
+++ b/runtime/core/portable_type/c10/torch/headeronly/macros/Macros.h
@@ -123,6 +123,15 @@
 #define C10_HAS_CPP_ATTRIBUTE(x) (0)
 #endif
 
+/// Bind a returned reference/pointer's lifetime to a parameter (or *this) so
+/// Clang can warn when it would dangle. Expands to nothing on compilers that
+/// lack the attribute (e.g. non-clang, older nvcc).
+#if C10_HAS_CPP_ATTRIBUTE(clang::lifetimebound)
+#define C10_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define C10_LIFETIMEBOUND
+#endif
+
 #ifndef FBCODE_CAFFE2
 /// DEPRECATED: Warn if a type or return value is discarded.
 #define C10_NODISCARD [[nodiscard]]

--- a/runtime/core/portable_type/c10/torch/headeronly/util/Half.h
+++ b/runtime/core/portable_type/c10/torch/headeronly/util/Half.h
@@ -213,7 +213,7 @@ C10_HOST_DEVICE inline float fp16_ieee_to_fp32_value(uint16_t h) {
    * Now, remember that denormalized half-precision numbers are represented as:
    *    FP16 = mantissa * 2**(-24).
    * The trick is to construct a normalized single-precision number with the
-   * same mantissa and thehalf-precision input and with an exponent which would
+   * same mantissa and the half-precision input and with an exponent which would
    * scale the corresponding mantissa bits to 2**(-24). A normalized
    * single-precision floating-point number is represented as: FP32 = (1 +
    * mantissa * 2**(-23)) * 2**(exponent - 127) Therefore, when the biased
@@ -236,7 +236,7 @@ C10_HOST_DEVICE inline float fp16_ieee_to_fp32_value(uint16_t h) {
   /*
    * - Choose either results of conversion of input as a normalized number, or
    * as a denormalized number, depending on the input exponent. The variable
-   * two_w contains input exponent in bits 27-31, therefore if its smaller than
+   * two_w contains input exponent in bits 27-31, therefore if it's smaller than
    * 2**27, the input is either a denormal number, or zero.
    * - Combine the result of conversion of exponent and mantissa with the sign
    * of the input number.

--- a/runtime/core/portable_type/c10/torch/headeronly/util/TypeSafeSignMath.h
+++ b/runtime/core/portable_type/c10/torch/headeronly/util/TypeSafeSignMath.h
@@ -14,20 +14,6 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 
 namespace c10 {
 
-/// Returns false since we cannot have x < 0 if x is unsigned.
-template <typename T>
-inline constexpr bool is_negative(
-    const T& /*x*/,
-    std::true_type /*is_unsigned*/) {
-  return false;
-}
-
-/// Returns true if a signed variable x < 0
-template <typename T>
-inline constexpr bool is_negative(const T& x, std::false_type /*is_unsigned*/) {
-  return x < T(0);
-}
-
 /// Returns true if x < 0
 /// NOTE: Will fail on an unsigned custom type
 ///       For the most part it's possible to fix this if
@@ -35,19 +21,12 @@ inline constexpr bool is_negative(const T& x, std::false_type /*is_unsigned*/) {
 ///       However, notably, c10::Half does not :-(
 template <typename T>
 inline constexpr bool is_negative(const T& x) {
-  return is_negative(x, std::is_unsigned<T>());
-}
-
-/// Returns the sign of an unsigned variable x as 0, 1
-template <typename T>
-inline constexpr int signum(const T& x, std::true_type /*is_unsigned*/) {
-  return T(0) < x;
-}
-
-/// Returns the sign of a signed variable x as -1, 0, 1
-template <typename T>
-inline constexpr int signum(const T& x, std::false_type /*is_unsigned*/) {
-  return (T(0) < x) - (x < T(0));
+  if constexpr (std::is_unsigned_v<T>) {
+    // An unsigned value can never be less than zero.
+    return false;
+  } else {
+    return x < T(0);
+  }
 }
 
 /// Returns the sign of x as -1, 0, 1
@@ -57,7 +36,11 @@ inline constexpr int signum(const T& x, std::false_type /*is_unsigned*/) {
 ///       However, notably, c10::Half does not :-(
 template <typename T>
 inline constexpr int signum(const T& x) {
-  return signum(x, std::is_unsigned<T>());
+  if constexpr (std::is_unsigned_v<T>) {
+    return T(0) < x;
+  } else {
+    return (T(0) < x) - (x < T(0));
+  }
 }
 
 /// Returns true if a and b are not both negative
@@ -86,53 +69,22 @@ inline constexpr bool greater_than_max(const T& x) {
 #pragma GCC diagnostic pop
 #endif
 
-/// Returns true if x < lowest(Limit). Standard comparison
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& x,
-    std::false_type /*limit_is_unsigned*/,
-    std::false_type /*x_is_unsigned*/) {
-  return x < std::numeric_limits<Limit>::lowest();
-}
-
-/// Returns false since all the limit is signed and therefore includes
-/// negative values but x cannot be negative because it is unsigned
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& /*x*/,
-    std::false_type /*limit_is_unsigned*/,
-    std::true_type /*x_is_unsigned*/) {
-  return false;
-}
-
-/// Returns true if x < 0, where 0 is constructed from T.
-/// Limit is not signed, so its lower value is zero
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& x,
-    std::true_type /*limit_is_unsigned*/,
-    std::false_type /*x_is_unsigned*/) {
-  return x < T(0);
-}
-
-/// Returns false sign both types are unsigned
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& /*x*/,
-    std::true_type /*limit_is_unsigned*/,
-    std::true_type /*x_is_unsigned*/) {
-  return false;
-}
-
-/// Returns true if x is less than the lowest value of type T
+/// Returns true if x is less than the lowest value of type Limit
 /// NOTE: Will fail on an unsigned custom type
 ///       For the most part it's possible to fix this if
 ///       the custom type has a constexpr constructor.
 ///       However, notably, c10::Half does not :
 template <typename Limit, typename T>
 inline constexpr bool less_than_lowest(const T& x) {
-  return less_than_lowest<Limit>(
-      x, std::is_unsigned<Limit>(), std::is_unsigned<T>());
+  if constexpr (std::is_unsigned_v<T>) {
+    // x is unsigned, so it can never be below the lowest value of any type.
+    return false;
+  } else if constexpr (std::is_unsigned_v<Limit>) {
+    // Limit is unsigned, so its lowest value is zero.
+    return x < T(0);
+  } else {
+    return x < std::numeric_limits<Limit>::lowest();
+  }
 }
 
 } // namespace c10

--- a/torch_pin.py
+++ b/torch_pin.py
@@ -1,2 +1,2 @@
 TORCH_VERSION = "2.12.0"
-# NIGHTLY_VERSION = "dev20260318" Temporarily pinning to stable release candidate. Revert https://github.com/pytorch/executorch/pull/18287
+NIGHTLY_VERSION = "dev20260719"


### PR DESCRIPTION
## Summary

Automated weekly PyTorch pin bump.

- Updates `NIGHTLY_VERSION` in `torch_pin.py` to `dev20260719`
- Updates `.ci/docker/ci_commit_pins/pytorch.txt` to the corresponding nightly commit hash
- Syncs c10 headers from PyTorch into `runtime/core/portable_type/c10/`

This PR was created automatically. If CI fails, Claude will attempt to fix issues (up to 3 attempts). If CI still fails, human review will be requested.

cc @jakeszwe