### PR TITLE
Enable Pyrefly in fbcode/executorch (#21045)

### DIFF
--- a/backends/cadence/aot/compiler_funcs.py
+++ b/backends/cadence/aot/compiler_funcs.py
@@ -174,9 +174,13 @@ def extract_output_dequant_params(
                 dtype = args[4]
                 assert isinstance(dtype, torch.dtype)
                 return (
+                    # pyrefly: ignore [bad-argument-type]
                     float(args[0]),  # scale
+                    # pyrefly: ignore [bad-argument-type]
                     int(args[1]),  # zero_point
+                    # pyrefly: ignore [bad-argument-type]
                     int(args[2]),  # qmin
+                    # pyrefly: ignore [bad-argument-type]
                     int(args[3]),  # qmax
                     dtype,
                 )
@@ -249,9 +253,13 @@ def extract_output_dequant_params_through_permute(
                     dtype = args[4]
                     assert isinstance(dtype, torch.dtype)
                     return (
+                        # pyrefly: ignore [bad-argument-type]
                         float(args[0]),  # scale
+                        # pyrefly: ignore [bad-argument-type]
                         int(args[1]),  # zero_point
+                        # pyrefly: ignore [bad-argument-type]
                         int(args[2]),  # qmin
+                        # pyrefly: ignore [bad-argument-type]
                         int(args[3]),  # qmax
                         dtype,
                     )

--- a/backends/cadence/aot/compiler_utils.py
+++ b/backends/cadence/aot/compiler_utils.py
@@ -60,6 +60,7 @@ def get_shape(
             return fake_tensor.shape
         # Case 3. node holds a param
         if node.op == "get_attr":
+            # pyrefly: ignore [bad-argument-type]
             attr_node = getattr(graph_module, node.target)
             return attr_node.shape
         # Default: return None
@@ -134,6 +135,7 @@ def get_tensor_from_attr(
     if node is None:
         return None
     assert node.op == "get_attr"
+    # pyrefly: ignore [bad-argument-type]
     return getattr(graph_module, node.target)
 
 

--- a/backends/cadence/aot/fuse_ops.py
+++ b/backends/cadence/aot/fuse_ops.py
@@ -385,6 +385,7 @@ class FuseQuantizedBatchNormWithConv(RemoveOrReplacePassInterface):
 
     @property
     def targets(self) -> list[EdgeOpOverload]:
+        # pyrefly: ignore [bad-return]
         return self._CONV_TARGETS
 
     def _get_batchnorm_user(self, conv_node: torch.fx.Node) -> Optional[torch.fx.Node]:
@@ -421,6 +422,7 @@ class FuseQuantizedBatchNormWithConv(RemoveOrReplacePassInterface):
         """
         conv_packed_arg_node = get_arg(conv_node, "packed_weight", torch.fx.Node)
         assert conv_packed_arg_node.op == "get_attr"
+        # pyrefly: ignore [bad-argument-type]
         packed_args = getattr(graph_module, conv_packed_arg_node.target)
         weight_tensor, bias_tensor = packed_args.unpack()
 

--- a/backends/cadence/aot/quantizer/patterns.py
+++ b/backends/cadence/aot/quantizer/patterns.py
@@ -120,8 +120,11 @@ class AddmmPattern(QuantizationPattern):
         addmm_node = fused_partition[0].nodes[-1]
 
         bias_qspec = DerivedQuantizationSpec(
+            # pyrefly: ignore [bad-argument-type]
             derived_from=[
+                # pyrefly: ignore [missing-attribute]
                 (addmm_node.args[1], addmm_node),
+                # pyrefly: ignore [missing-attribute]
                 (addmm_node.args[2], addmm_node),
             ],
             derive_qparams_fn=get_bias_qparams,
@@ -131,11 +134,16 @@ class AddmmPattern(QuantizationPattern):
             qscheme=torch.per_tensor_affine,
         )
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(addmm_node, 1)],
+                # pyrefly: ignore [bad-argument-type]
                 weights=[(addmm_node, 2)],
+                # pyrefly: ignore [bad-argument-type]
                 biases=[(addmm_node, 0, bias_qspec)],
+                # pyrefly: ignore [bad-argument-type]
                 output=[(addmm_node,)],
             ),
             addmm_node,
@@ -193,10 +201,13 @@ class AddPattern(QuantizationPattern):
         # Bail if:
         #   - the add node is not a tensor add
         #   - the add node has kwargs (e.g. alpha)
+        # pyrefly: ignore [missing-attribute]
         is_tensor_add = isinstance(add_node.args[0], fx.Node) and isinstance(
-            add_node.args[1], fx.Node
+            add_node.args[1], fx.Node  # pyrefly: ignore [missing-attribute]
         )
+        # pyrefly: ignore [missing-attribute]
         if not is_tensor_add or len(add_node.kwargs) > 0:
+            # pyrefly: ignore [bad-return]
             return (
                 PartitionAnchors(
                     empty=True,
@@ -204,11 +215,14 @@ class AddPattern(QuantizationPattern):
                 add_node,
             )
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(add_node, 0), (add_node, 1)],
                 weights=[],
                 biases=[],
+                # pyrefly: ignore [bad-argument-type]
                 output=[(add_node,)],
             ),
             add_node,
@@ -263,10 +277,13 @@ class AddReluBasePattern(QuantizationPattern):
         # Bail if:
         #   - the add node is not a tensor add
         #   - the add node has kwargs (e.g. alpha)
+        # pyrefly: ignore [missing-attribute]
         is_tensor_add = isinstance(add_node.args[0], fx.Node) and isinstance(
-            add_node.args[1], fx.Node
+            add_node.args[1], fx.Node  # pyrefly: ignore [missing-attribute]
         )
+        # pyrefly: ignore [missing-attribute]
         if not is_tensor_add or len(add_node.kwargs) > 0:
+            # pyrefly: ignore [bad-return]
             return (
                 PartitionAnchors(
                     empty=True,
@@ -274,11 +291,14 @@ class AddReluBasePattern(QuantizationPattern):
                 add_node,
             )
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(add_node, 0), (add_node, 1)],
                 weights=[],
                 biases=[],
+                # pyrefly: ignore [bad-argument-type]
                 output=[(relu_node,)],  # Output is from the relu node
             ),
             relu_node,
@@ -350,11 +370,14 @@ class BmmPattern(QuantizationPattern):
         # pyre-fixme[29]: `Union[BoundMethod[typing.Callable(torch._C.TensorBase.__ge...
         bmm_node = fused_partition[0].nodes[-1]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(bmm_node, 0), (bmm_node, 1)],
                 weights=[],
                 biases=[],
+                # pyrefly: ignore [bad-argument-type]
                 output=[(bmm_node,)],
             ),
             bmm_node,
@@ -401,22 +424,29 @@ class CatPattern(QuantizationPattern):
                     SharedQuantizationSpec,
                 ],
             ]
+        # pyrefly: ignore [bad-assignment]
         ] = [(cat_node, (0, 0))]
+        # pyrefly: ignore [missing-attribute]
         for i in range(1, len(cat_node.args[0])):
             args.append(
+                # pyrefly: ignore [bad-argument-type]
                 (
                     cat_node,
                     (0, i),
+                    # pyrefly: ignore [bad-argument-type, missing-attribute]
                     SharedQuantizationSpec((cat_node.args[0][0], cat_node)),
                 )
             )
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
                 inputs=args,
                 weights=[],
                 biases=[],
+                # pyrefly: ignore [bad-argument-type]
                 output=[
+                    # pyrefly: ignore [bad-argument-type, missing-attribute]
                     (cat_node, SharedQuantizationSpec((cat_node.args[0][0], cat_node)))
                 ],
             ),
@@ -457,8 +487,11 @@ class Conv1dPattern(QuantizationPattern):
         conv1d_node = fused_partition[0].nodes[-1]
 
         bias_qspec = DerivedQuantizationSpec(
+            # pyrefly: ignore [bad-argument-type]
             derived_from=[
+                # pyrefly: ignore [missing-attribute]
                 (conv1d_node.args[0], conv1d_node),
+                # pyrefly: ignore [missing-attribute]
                 (conv1d_node.args[1], conv1d_node),
             ],
             derive_qparams_fn=get_bias_qparams,
@@ -470,15 +503,20 @@ class Conv1dPattern(QuantizationPattern):
 
         # Keep bias empty if not supplied
         bias = []
+        # pyrefly: ignore [bad-index, missing-attribute]
         if len(conv1d_node.args) > 2 and conv1d_node.args[2] is not None:
             bias = [(conv1d_node, 2, bias_qspec)]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(conv1d_node, 0)],
+                # pyrefly: ignore [bad-argument-type]
                 weights=[(conv1d_node, 1)],
                 # pyre-fixme[6]: Incompatible parameter type
                 biases=bias,
+                # pyrefly: ignore [bad-argument-type]
                 output=[(conv1d_node,)],
             ),
             conv1d_node,
@@ -511,8 +549,11 @@ class Conv2dPattern(QuantizationPattern):
         conv2d_node = fused_partition[0].nodes[-1]
 
         bias_qspec = DerivedQuantizationSpec(
+            # pyrefly: ignore [bad-argument-type]
             derived_from=[
+                # pyrefly: ignore [missing-attribute]
                 (conv2d_node.args[0], conv2d_node),
+                # pyrefly: ignore [missing-attribute]
                 (conv2d_node.args[1], conv2d_node),
             ],
             derive_qparams_fn=get_bias_qparams,
@@ -524,15 +565,20 @@ class Conv2dPattern(QuantizationPattern):
 
         # Keep bias empty if not supplied
         bias = []
+        # pyrefly: ignore [bad-index, missing-attribute]
         if len(conv2d_node.args) > 2 and conv2d_node.args[2] is not None:
             bias = [(conv2d_node, 2, bias_qspec)]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(conv2d_node, 0)],
+                # pyrefly: ignore [bad-argument-type]
                 weights=[(conv2d_node, 1)],
                 # pyre-fixme[6]: Incompatible parameter type
                 biases=bias,
+                # pyrefly: ignore [bad-argument-type]
                 output=[(conv2d_node,)],
             ),
             conv2d_node,
@@ -567,22 +613,28 @@ class LayerNormPattern(QuantizationPattern):
         others = [(layer_norm_node, 1)]
 
         # Add weights if supplied
+        # pyrefly: ignore [bad-index, missing-attribute]
         if len(layer_norm_node.args) > 2 and layer_norm_node.args[2]:
             others.append((layer_norm_node, 2))
 
         # Add bias if supplied
+        # pyrefly: ignore [bad-index, missing-attribute]
         if len(layer_norm_node.args) > 3 and layer_norm_node.args[3]:
             others.append((layer_norm_node, 3))
 
         # Weights are used in quantized mode by our kernel, so they are
         # passed in as others here along with the normalized shape.
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(layer_norm_node, 0)],
                 weights=[],
                 biases=[],
                 # Ordering: normalized_shape, weights, bias
+                # pyrefly: ignore [bad-argument-type]
                 others=others,
+                # pyrefly: ignore [bad-argument-type]
                 output=[(layer_norm_node,)],
             ),
             layer_norm_node,
@@ -658,8 +710,11 @@ class LinearPattern(QuantizationPattern):
         linear_node = fused_partition[0].nodes[-1]
 
         bias_qspec = DerivedQuantizationSpec(
+            # pyrefly: ignore [bad-argument-type]
             derived_from=[
+                # pyrefly: ignore [missing-attribute]
                 (linear_node.args[0], linear_node),
+                # pyrefly: ignore [missing-attribute]
                 (linear_node.args[1], linear_node),
             ],
             derive_qparams_fn=get_bias_qparams,
@@ -671,15 +726,20 @@ class LinearPattern(QuantizationPattern):
 
         # Keep bias empty if not supplied
         bias = []
+        # pyrefly: ignore [missing-attribute]
         if len(linear_node.args) > 2:
             bias = [(linear_node, 2, bias_qspec)]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(linear_node, 0)],
+                # pyrefly: ignore [bad-argument-type]
                 weights=[(linear_node, 1)],
                 # pyre-fixme[6]: Incompatible parameter type
                 biases=bias,
+                # pyrefly: ignore [bad-argument-type]
                 output=[(linear_node,)],
             ),
             linear_node,
@@ -724,11 +784,14 @@ class MatmulPattern(QuantizationPattern):
         # pyre-fixme[29]: `Union[BoundMethod[typing.Callable(torch._C.TensorBase.__ge...
         matmul_node = fused_partition[0].nodes[-1]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(matmul_node, 0), (matmul_node, 1)],
                 weights=[],
                 biases=[],
+                # pyrefly: ignore [bad-argument-type]
                 output=[(matmul_node,)],
             ),
             matmul_node,
@@ -777,27 +840,34 @@ class MaxPool2dPattern(QuantizationPattern):
         # prepare_pt2e silently skips it.
         # Expect exactly one user: getitem[0] extracting the values tensor. If indices
         # are also used or the structure is unexpected, bail out.
+        # pyrefly: ignore [missing-attribute]
         users = list(max_pool_node.users)
         if (
             len(users) != 1
             or users[0].target is not operator.getitem
             or users[0].args[1] != 0
         ):
+            # pyrefly: ignore [bad-return]
             return PartitionAnchors(empty=True), max_pool_node
         getitem_0 = users[0]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(max_pool_node, 0)],
                 weights=[],
                 biases=[],
                 # kernel_size, stride, padding, dilation, ceil_mode are literals
+                # pyrefly: ignore [bad-argument-type]
                 literals=[
+                    # pyrefly: ignore [missing-attribute]
                     (max_pool_node, i) for i in range(1, len(max_pool_node.args))
                 ],
                 output=[
                     (
                         getitem_0,
+                        # pyrefly: ignore [bad-argument-type, missing-attribute]
                         SharedQuantizationSpec((max_pool_node.args[0], max_pool_node)),
                     )
                 ],
@@ -860,17 +930,23 @@ class MaxPool2dWithoutIndicesPattern(QuantizationPattern):
         # pyre-fixme[29]: `Union[BoundMethod[typing.Callable(torch._C.TensorBase.__ge...
         max_pool_node = fused_partition[0].nodes[-1]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(max_pool_node, 0)],
                 weights=[],
                 biases=[],
+                # pyrefly: ignore [bad-argument-type]
                 literals=[
+                    # pyrefly: ignore [missing-attribute]
                     (max_pool_node, i) for i in range(1, len(max_pool_node.args))
                 ],
+                # pyrefly: ignore [bad-argument-type]
                 output=[
                     (
                         max_pool_node,
+                        # pyrefly: ignore [bad-argument-type, missing-attribute]
                         SharedQuantizationSpec((max_pool_node.args[0], max_pool_node)),
                     )
                 ],
@@ -897,11 +973,14 @@ class ReluBasePattern(QuantizationPattern):
         # pyre-fixme[29]: `Union[BoundMethod[typing.Callable(torch._C.TensorBase.__ge...
         relu_node = fused_partition[0].nodes[-1]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(relu_node, 0)],
                 weights=[],
                 biases=[],
+                # pyrefly: ignore [bad-argument-type]
                 output=[(relu_node,)],
             ),
             relu_node,
@@ -961,8 +1040,11 @@ class ConvReluBasePattern(QuantizationPattern):
         relu_node = fused_partition[1].nodes[-1]  # Last node
 
         bias_qspec = DerivedQuantizationSpec(
+            # pyrefly: ignore [bad-argument-type]
             derived_from=[
+                # pyrefly: ignore [missing-attribute]
                 (conv_node.args[0], conv_node),
+                # pyrefly: ignore [missing-attribute]
                 (conv_node.args[1], conv_node),
             ],
             derive_qparams_fn=get_bias_qparams,
@@ -974,15 +1056,20 @@ class ConvReluBasePattern(QuantizationPattern):
 
         # Keep bias empty if not supplied
         bias = []
+        # pyrefly: ignore [bad-index, missing-attribute]
         if len(conv_node.args) > 2 and conv_node.args[2] is not None:
             bias = [(conv_node, 2, bias_qspec)]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(conv_node, 0)],
+                # pyrefly: ignore [bad-argument-type]
                 weights=[(conv_node, 1)],
                 # pyre-fixme[6]: Incompatible parameter type
                 biases=bias,
+                # pyrefly: ignore [bad-argument-type]
                 output=[(relu_node,)],  # Output is from the relu node
             ),
             relu_node,
@@ -1076,8 +1163,11 @@ class ConvBNReluBasePattern(QuantizationPattern):
         relu_node = fused_partition[2].nodes[-1]
 
         bias_qspec = DerivedQuantizationSpec(
+            # pyrefly: ignore [bad-argument-type]
             derived_from=[
+                # pyrefly: ignore [missing-attribute]
                 (conv_node.args[0], conv_node),
+                # pyrefly: ignore [missing-attribute]
                 (conv_node.args[1], conv_node),
             ],
             derive_qparams_fn=get_bias_qparams,
@@ -1088,15 +1178,20 @@ class ConvBNReluBasePattern(QuantizationPattern):
         )
 
         bias = []
+        # pyrefly: ignore [bad-index, missing-attribute]
         if len(conv_node.args) > 2 and conv_node.args[2] is not None:
             bias = [(conv_node, 2, bias_qspec)]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(conv_node, 0)],
+                # pyrefly: ignore [bad-argument-type]
                 weights=[(conv_node, 1)],
                 # pyre-fixme[6]: Incompatible parameter type
                 biases=bias,
+                # pyrefly: ignore [bad-argument-type]
                 output=[(relu_node,)],
             ),
             relu_node,
@@ -1177,11 +1272,14 @@ class SoftmaxPattern(QuantizationPattern):
         # pyre-fixme[29]: `Union[BoundMethod[typing.Callable(torch._C.TensorBase.__ge...
         softmax_node = fused_partition[0].nodes[-1]
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
+                # pyrefly: ignore [bad-argument-type]
                 inputs=[(softmax_node, 0)],
                 weights=[],
                 biases=[],
+                # pyrefly: ignore [bad-argument-type]
                 output=[(softmax_node,)],
             ),
             softmax_node,
@@ -1249,7 +1347,9 @@ class MixedW8A32LinearPattern(QuantizationPattern):
         linear_layer = fused_partition[0].nodes[-1]
 
         # Bail if the arguments have different shapes than expected
+        # pyrefly: ignore [missing-attribute]
         if len(linear_layer.args) != 3 or len(linear_layer.kwargs) > 0:
+            # pyrefly: ignore [bad-return]
             return (
                 PartitionAnchors(
                     empty=True,
@@ -1257,11 +1357,13 @@ class MixedW8A32LinearPattern(QuantizationPattern):
                 linear_layer,
             )
 
+        # pyrefly: ignore [bad-index]
         input_node = linear_layer.args[0]
         input_shape = input_node.meta["tensor_meta"].shape
 
         # Bail if the weights are not multiple of 4 (SIMD)
         if input_shape[-1] % 4 != 0:
+            # pyrefly: ignore [bad-return]
             return (
                 PartitionAnchors(
                     empty=True,
@@ -1270,6 +1372,7 @@ class MixedW8A32LinearPattern(QuantizationPattern):
             )
         # Currenly only supporting vector-matrix multiplication
         if len(input_shape) > 0 and input_shape[-2] != 1:
+            # pyrefly: ignore [bad-return]
             return (
                 PartitionAnchors(
                     empty=True,
@@ -1277,12 +1380,16 @@ class MixedW8A32LinearPattern(QuantizationPattern):
                 linear_layer,
             )
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
                 inputs=[],
+                # pyrefly: ignore [bad-argument-type]
                 weights=[(linear_layer, 1)],
+                # pyrefly: ignore [bad-argument-type]
                 biases=[(linear_layer, 2)],
                 output=[],
+                # pyrefly: ignore [bad-argument-type]
                 others=[(linear_layer, 0)],
             ),
             linear_layer,
@@ -1334,7 +1441,9 @@ class MixedW8A32ConvPattern(QuantizationPattern):
 
         # Bail if the arguments have different shapes than expected
         # Stride, padding, dilation and groups are not supported
+        # pyrefly: ignore [missing-attribute]
         if len(conv_layer.args) != 3 or len(conv_layer.kwargs) > 0:
+            # pyrefly: ignore [bad-return]
             return (
                 PartitionAnchors(
                     empty=True,
@@ -1342,11 +1451,13 @@ class MixedW8A32ConvPattern(QuantizationPattern):
                 conv_layer,
             )
 
+        # pyrefly: ignore [bad-index]
         cnn_weights = conv_layer.args[1]
         if "tensor_meta" in cnn_weights.meta:
             cnn_weights_shape = cnn_weights.meta["tensor_meta"].shape
             # Bail if the channels are not multiple of 4 (SIMD)
             if cnn_weights_shape[0] % 4 != 0:
+                # pyrefly: ignore [bad-return]
                 return (
                     PartitionAnchors(
                         empty=True,
@@ -1354,6 +1465,7 @@ class MixedW8A32ConvPattern(QuantizationPattern):
                     conv_layer,
                 )
             if cnn_weights_shape[1] % 4 != 0:
+                # pyrefly: ignore [bad-return]
                 return (
                     PartitionAnchors(
                         empty=True,
@@ -1362,6 +1474,7 @@ class MixedW8A32ConvPattern(QuantizationPattern):
                 )
             # Bail if the kernel size is not 3
             if cnn_weights_shape[2] != 3:
+                # pyrefly: ignore [bad-return]
                 return (
                     PartitionAnchors(
                         empty=True,
@@ -1369,11 +1482,13 @@ class MixedW8A32ConvPattern(QuantizationPattern):
                     conv_layer,
                 )
 
+            # pyrefly: ignore [bad-index]
             inputs = conv_layer.args[0]
             if "tensor_meta" in inputs.meta:
                 inputs_shape = inputs.meta["tensor_meta"].shape
                 # Bail if length != kernel size - Not yet supported
                 if inputs_shape[-1] != cnn_weights_shape[2]:
+                    # pyrefly: ignore [bad-return]
                     return (
                         PartitionAnchors(
                             empty=True,
@@ -1381,12 +1496,16 @@ class MixedW8A32ConvPattern(QuantizationPattern):
                         conv_layer,
                     )
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
                 inputs=[],
+                # pyrefly: ignore [bad-argument-type]
                 weights=[(conv_layer, 1)],
+                # pyrefly: ignore [bad-argument-type]
                 biases=[(conv_layer, 2)],
                 output=[],
+                # pyrefly: ignore [bad-argument-type]
                 others=[(conv_layer, 0)],
             ),
             conv_layer,
@@ -1456,7 +1575,9 @@ class MixedW8A32GruPattern(QuantizationPattern):
     ) -> Tuple[PartitionAnchors, fx.Node]:
         # pyre-fixme[29]: `Union[BoundMethod[typing.Callable(torch._C.TensorBase.__ge...
         gru_layer = fused_partition[0].nodes[-1]
+        # pyrefly: ignore [missing-attribute]
         if len(gru_layer.kwargs) > 0:
+            # pyrefly: ignore [bad-return]
             return (
                 PartitionAnchors(
                     empty=True,
@@ -1465,16 +1586,20 @@ class MixedW8A32GruPattern(QuantizationPattern):
             )
 
         # Bail if input or states are not multiple of 4 (SIMD)
+        # pyrefly: ignore [missing-attribute]
         tensor_meta_0 = gru_layer.args[0].meta.get("tensor_meta", None)
         if tensor_meta_0 is None or tensor_meta_0.shape[-1] % 4 != 0:
+            # pyrefly: ignore [bad-return]
             return (
                 PartitionAnchors(
                     empty=True,
                 ),
                 gru_layer,
             )
+        # pyrefly: ignore [missing-attribute]
         tensor_meta_1 = gru_layer.args[1].meta.get("tensor_meta", None)
         if tensor_meta_1 is None or tensor_meta_1.shape[-1] % 4 != 0:
+            # pyrefly: ignore [bad-return]
             return (
                 PartitionAnchors(
                     empty=True,
@@ -1487,14 +1612,17 @@ class MixedW8A32GruPattern(QuantizationPattern):
                 self.args = args
                 self.meta = meta
 
+        # pyrefly: ignore [missing-attribute]
         wrapper = Wrapper(tuple(gru_layer.args[2]), gru_layer.meta)
 
         # Using SharedQuantizationSpec so that bias_hh has the same observer as bias_ih
         # Both biases get the same quantization scale to match the cpp operator
         bias_ih_node = wrapper.args[2]
         bias_ih_edge = (bias_ih_node, gru_layer)
+        # pyrefly: ignore [bad-argument-type]
         shared_bias_qspec = SharedQuantizationSpec(edge_or_node=bias_ih_edge)
 
+        # pyrefly: ignore [bad-return]
         return (
             PartitionAnchors(
                 inputs=[],
@@ -1510,6 +1638,7 @@ class MixedW8A32GruPattern(QuantizationPattern):
                     ),  # bias_hh shares observer with bias_ih
                 ],
                 output=[],
+                # pyrefly: ignore [bad-argument-type]
                 others=[(gru_layer, 0), (gru_layer, 1)],
             ),
             gru_layer,

--- a/backends/cadence/aot/quantizer/quantizer.py
+++ b/backends/cadence/aot/quantizer/quantizer.py
@@ -196,6 +196,7 @@ class CadenceAtenQuantizer(Quantizer):
             if not no_outside_users(fused_partition):
                 continue
 
+            # pyrefly: ignore [bad-argument-type]
             anchors, _ = self.pattern.get_anchors(model, fused_partition)
             if not anchors or anchors.empty:
                 continue
@@ -435,6 +436,7 @@ class CadenceW8A32MixedQuantizer(CadenceQuantizer):
         quantizers.append(
             CadenceAtenQuantizer(MixedW8A32GruPattern(), qconfig_A32W8sym)
         )
+        # pyrefly: ignore [bad-argument-type]
         super().__init__(quantizers)
 
 

--- a/backends/cadence/aot/replace_ops.py
+++ b/backends/cadence/aot/replace_ops.py
@@ -100,6 +100,7 @@ class ReplaceSafeSoftmaxWithSoftmax(RemoveOrReplacePassInterface):  # keep
 
     @property
     def targets(self) -> list[EdgeOpOverload]:
+        # pyrefly: ignore [bad-return]
         return [torch.ops.aten._safe_softmax.default]
 
     def maybe_remove_or_replace(self, node: torch.fx.Node) -> bool:
@@ -127,6 +128,7 @@ class ReplacePT2QuantWithCadenceQuantPass(RemoveOrReplacePassInterface):
 
     @property
     def targets(self) -> list[EdgeOpOverload]:
+        # pyrefly: ignore [bad-return]
         return [
             torch.ops.quantized_decomposed.quantize_per_tensor.default,
             exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
@@ -155,6 +157,7 @@ class ReplacePT2DequantWithCadenceDequantPass(RemoveOrReplacePassInterface):
 
     @property
     def targets(self) -> list[EdgeOpOverload]:
+        # pyrefly: ignore [bad-return]
         return [
             torch.ops.quantized_decomposed.dequantize_per_tensor.default,
             exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
@@ -360,7 +363,9 @@ class ReplaceAddMMWithLinearPass(RemoveOrReplacePassInterface):
         (bias, mat1, mat2) = node.args[0:3]
 
         # The other two args are optional scale args
+        # pyrefly: ignore [bad-argument-type]
         beta = float(node.kwargs.get("beta", 1.0))
+        # pyrefly: ignore [bad-argument-type]
         alpha = float(node.kwargs.get("alpha", 1.0))
 
         bias, mat1, mat2 = cast(
@@ -1442,6 +1447,7 @@ class ReplaceConvWithIm2RowAndLinear(RemoveOrReplacePassInterface):
         # If the convolution op was quantized, we need the input tensor's
         # zero_point for im2row. Otherwise in_zero_point defaults to a zero
         # tensor.
+        # pyrefly: ignore [bad-index]
         in_zero_point = node.args[7] if quantized_op else 0
 
         # im2row expects every kernel parameter to be 2d. So we extend the
@@ -1719,6 +1725,7 @@ class ReplaceTransposedConvWithLinearPass(RemoveOrReplacePassInterface):
             ) = node.args[8:13]
             # pyre-ignore[58]: Division operands
             requantize_scale = bias_scale / out_scale
+            # pyrefly: ignore [bad-argument-type]
             (out_multiplier, out_shift) = quantize_tensor_multiplier(requantize_scale)
             linear_args = (
                 transposed_im2row,
@@ -1831,6 +1838,7 @@ class ReplaceScalarTensorWithFullPass(RemoveOrReplacePassInterface):
 
     @property
     def targets(self) -> list[EdgeOpOverload]:
+        # pyrefly: ignore [bad-return]
         return [
             torch.ops.aten.scalar_tensor.default,
             exir_ops.edge.aten.scalar_tensor.default,
@@ -2187,6 +2195,7 @@ class ReplaceSplitWithSlicePass(RemoveOrReplacePassInterface):
         # Go over each getitem user, and replace it with slice op
         for user in list(node.users.keys()):
             assert user.target == operator.getitem
+            # pyrefly: ignore [bad-argument-type]
             item_idx = int(user.args[1])
             assert item_idx < len(slice_ops)
             cur_slice = slice_ops[item_idx]
@@ -2225,11 +2234,13 @@ class ReplaceSplitWithSlicePass(RemoveOrReplacePassInterface):
         split_start = 0
         assert isinstance(split_sizes, list)
         for split_size in split_sizes:
+            # pyrefly: ignore [unsupported-operation]
             split_end = split_start + split_size
             slice_args = (split_dim, split_start, split_end)
             slice_ops.append(slice_args)
             split_start = split_end
 
+        # pyrefly: ignore [bad-return]
         return slice_ops
 
 
@@ -2406,6 +2417,7 @@ class ReplaceMulTensorWithMulAndFullOpsPass(RemoveOrReplacePassInterface):
 
     @property
     def targets(self) -> list[EdgeOpOverload]:
+        # pyrefly: ignore [bad-return]
         return [torch.ops.aten.mul.Tensor]
 
     def maybe_remove_or_replace(self, node: torch.fx.Node) -> bool:

--- a/backends/cadence/aot/tests/test_fusion_ops_passes.py
+++ b/backends/cadence/aot/tests/test_fusion_ops_passes.py
@@ -1810,6 +1810,7 @@ class TestFuseSliceSameDimPass(TestFusionPassesBase):
         slices = result.graph_module.graph.find_nodes(
             op="call_function", target=exir_ops.edge.aten.slice_copy.Tensor
         )
+        # pyrefly: ignore [bad-specialization]
         ends = sorted(get_arg(s, "end") for s in slices)
         self.assertEqual(ends, [60, 78])
         validate_numerics(

--- a/backends/cadence/aot/tests/test_memory_passes.py
+++ b/backends/cadence/aot/tests/test_memory_passes.py
@@ -173,13 +173,17 @@ class TestMemTransform(unittest.TestCase):
         dim_offset = 0
         for arg in cast(list[torch.fx.Node], node.args[0]):
             arg_spec = arg.meta.get("spec", None)
+            # pyrefly: ignore [missing-attribute]
             self.assertEqual(arg_spec.mem_id, node_spec.mem_id)
             actual_offset = node_spec.mem_offset + dim_offset * inner_dim_elements
             self.assertEqual(
+                # pyrefly: ignore [missing-attribute]
                 arg_spec.mem_offset,
                 actual_offset,
+                # pyrefly: ignore [missing-attribute]
                 f"{arg=} of node {node=} has wrong memory offset: expected {arg_spec.mem_offset=}, but got {actual_offset=} = {node_spec.mem_offset=} + {dim_offset=} * {inner_dim_elements=}",
             )
+            # pyrefly: ignore [missing-attribute]
             dim_offset += arg_spec.shape[dim]
 
     def _verify_slice_nop_memory_alloc(self, node: torch.fx.Node) -> None:
@@ -200,10 +204,13 @@ class TestMemTransform(unittest.TestCase):
         )
         arg = cast(torch.fx.Node, node.args[0])
         arg_spec = arg.meta.get("spec", None)
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(arg_spec.mem_id, spec.mem_id)
         self.assertEqual(
             spec.mem_offset,
+            # pyrefly: ignore [missing-attribute]
             arg_spec.mem_offset + start * inner_dim_elements,
+            # pyrefly: ignore [missing-attribute]
             f"{arg=} for node {node=} has wrong memory offset: {arg_spec.mem_offset=} {start=} for slice on {dim=}, but output has {spec.mem_offset=}",
         )
 
@@ -225,10 +232,13 @@ class TestMemTransform(unittest.TestCase):
         )
         arg = cast(torch.fx.Node, node.args[0])
         arg_spec = arg.meta.get("spec", None)
+        # pyrefly: ignore [missing-attribute]
         self.assertEqual(arg_spec.mem_id, spec.mem_id)
         self.assertEqual(
             spec.mem_offset,
+            # pyrefly: ignore [missing-attribute]
             arg_spec.mem_offset + index * inner_dim_elements,
+            # pyrefly: ignore [missing-attribute]
             f"{arg=} for node {node=} has wrong memory offset: {arg_spec.mem_offset=} for select on {dim=} {index=}, "
             f"but output has {spec.mem_offset=}"
             f"{spec=} {arg_spec=}",
@@ -1151,6 +1161,7 @@ class TestMemTransform(unittest.TestCase):
             def __init__(self, memory_constraints: MemConstraints):
                 self.memory_constraints = memory_constraints
 
+            # pyrefly: ignore [bad-return]
             def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
                 for node in graph_module.graph.find_nodes(
                     op="call_function", target=torch.ops.aten.add.Scalar

--- a/backends/cadence/aot/tests/test_quantizer_ops.py
+++ b/backends/cadence/aot/tests/test_quantizer_ops.py
@@ -79,6 +79,7 @@ QUANTIZER_ANNOTATION_TEST_CASES: list[
         QuantizationSpec,
         list[QuantizationSpec | None],
     ]
+# pyrefly: ignore [bad-assignment]
 ] = [
     (
         "matmul_A16",

--- a/backends/cadence/aot/tests/test_replace_ops_passes.py
+++ b/backends/cadence/aot/tests/test_replace_ops_passes.py
@@ -3208,6 +3208,7 @@ class TestReplaceEmptyTensorsWithFullPass(unittest.TestCase):
         self.assertTrue(
             op_counts_match(
                 graph_after_passes,
+                # pyrefly: ignore [bad-argument-type]
                 expected_op_counts={
                     torch.ops.aten.mul.Tensor: 1,
                     torch.ops.aten.full.default: 1,

--- a/backends/cadence/aot/type_dispatch.py
+++ b/backends/cadence/aot/type_dispatch.py
@@ -143,6 +143,7 @@ class CompileTimeTypeDispatchPass(ExportPass):
         input_dtype = args[0].to_tensor().dtype
 
         if config.weight_arg_idx is not None:
+            # pyrefly: ignore [missing-attribute]
             weight_dtype = args[config.weight_arg_idx].to_tensor().dtype
             dtype_key = (input_dtype, weight_dtype)
         elif config.is_quant_op:
@@ -164,9 +165,10 @@ class CompileTimeTypeDispatchPass(ExportPass):
         ]:
             groups = cast(int, args[6])
             input_channels = (
+                # pyrefly: ignore [missing-attribute]
                 args[0].to_tensor().shape[1]
                 if op == exir_ops.edge.cadence.quantized_conv2d_nchw.per_tensor
-                else args[0].to_tensor().shape[-1]
+                else args[0].to_tensor().shape[-1]  # pyrefly: ignore [missing-attribute]
             )
             is_depthwise = is_depthwise_conv(groups, input_channels)
             # pyre-ignore[16]: None has no attribute '__iter__'.

--- a/backends/cadence/utils/facto_util.py
+++ b/backends/cadence/utils/facto_util.py
@@ -449,6 +449,7 @@ def apply_tensor_contraints(op_name: str, index: int) -> list[object]:
             )
         case _:
             pass
+    # pyrefly: ignore [bad-return]
     return tensor_constraints
 
 
@@ -503,6 +504,7 @@ def facto_testcase_gen(  # noqa: C901
                     )
                 elif in_spec.name == "max":
                     # max must always be provided (not None), be >= min + 2 (sufficient gap), and bounded
+                    # pyrefly: ignore [bad-assignment]
                     spec.inspec[index].deps = [0, 1]  # deps on input tensor and min
                     spec.inspec[index].constraints.extend(
                         [
@@ -514,6 +516,7 @@ def facto_testcase_gen(  # noqa: C901
                         ]
                     )
             elif in_spec.name == "max_val":  # hardtanh
+                # pyrefly: ignore [bad-assignment]
                 spec.inspec[index].deps = [0, 1]
                 spec.inspec[index].constraints.extend(
                     [cp.Value.Ge(lambda deps, _: deps[1])]
@@ -547,6 +550,7 @@ def facto_testcase_gen(  # noqa: C901
                 )
         elif in_spec.type.is_tensor():
             spec.inspec[index].constraints.extend(
+                # pyrefly: ignore [bad-argument-type]
                 apply_tensor_contraints(op_name, index)
             )
         elif in_spec.type.is_dim_list():

--- a/backends/test/graph_builder.py
+++ b/backends/test/graph_builder.py
@@ -57,9 +57,11 @@ class GraphBuilder(ExportPass):
 
     def __init__(self, fake_tensor_mode: Optional[FakeTensorMode] = None) -> None:
         self.exporter = ExportPass()
+        # pyrefly: ignore [bad-override-mutable-attribute]
         self.tracer: ExportPass.ExportTracer = self.ExportTracer(
             self, torch.fx.graph.CodeGen()
         )
+        # pyrefly: ignore [bad-override-mutable-attribute]
         self.fake_tensor_mode: FakeTensorMode = fake_tensor_mode or FakeTensorMode(
             allow_fallback_kernels=False,
             allow_non_fake_inputs=True,

--- a/backends/test/program_builder.py
+++ b/backends/test/program_builder.py
@@ -95,6 +95,7 @@ class ProgramBuilder(GraphBuilder):
     def get_verifiers(self) -> Optional[list[Verifier]]:
         if self.mode == IrMode.ATEN:
             return None
+        # pyrefly: ignore [bad-return]
         return [
             EXIREdgeDialectVerifier(
                 edge_compile_config=EdgeCompileConfig(

--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -264,6 +264,7 @@ class VulkanSupportedOperators(OperatorSupportBase):
             self.log_skip(node, dtype_reason)
             return False
 
+        # pyrefly: ignore [not-callable]
         if not features.are_node_inputs_supported_fn(node):
             self.log_skip(node, "op args not supported")
             return False

--- a/backends/vulkan/patterns/quantized_binary.py
+++ b/backends/vulkan/patterns/quantized_binary.py
@@ -121,6 +121,7 @@ def find_quantized_binary_patterns(
 ##
 
 
+# pyrefly: ignore [bad-argument-type]
 @register_pattern_replacement("quantized_binary")
 def make_add_q8ta_q8ta_q8to_custom_op(
     ep: ExportedProgram,
@@ -129,6 +130,7 @@ def make_add_q8ta_q8ta_q8to_custom_op(
 ):
     # Determine the operation type based on the anchor node
     op_target = None
+    # pyrefly: ignore [missing-attribute]
     if match.anchor_node.target in {
         exir_ops.edge.aten.add.Tensor,
         exir_ops.edge.aten.add_.Tensor,

--- a/backends/vulkan/patterns/quantized_convolution.py
+++ b/backends/vulkan/patterns/quantized_convolution.py
@@ -107,6 +107,7 @@ class QuantizedConvolutionMatch(PatternMatch):
         # The implementation requires that for non-depthwise grouped convolutions, a
         # group does not cross the texel boundary. The output channels per group must be
         # a multiple of 4. If this is not true, then don't match the pattern.
+        # pyrefly: ignore [unsupported-operation]
         if (self.groups > 1 and self.groups < out_channels) and (
             out_channels / self.groups
         ) % 4 != 0:
@@ -182,6 +183,7 @@ def find_quantized_convolution_patterns(
 ##
 
 
+# pyrefly: ignore [bad-argument-type]
 @register_pattern_replacement("quantized_convolution")
 def make_q8ta_conv2d_custom_op(  # noqa: C901
     ep: ExportedProgram,
@@ -207,7 +209,9 @@ def make_q8ta_conv2d_custom_op(  # noqa: C901
     if match.transposed:
         # Transposed conv weight shape: (IC, OC_per_group, H, W)
         IC, OC_per_group, H, W = weight_tensor.shape
+        # pyrefly: ignore [unsupported-operation]
         OC = OC_per_group * match.groups
+        # pyrefly: ignore [unsupported-operation]
         IC_per_group = IC // match.groups
         # Reshape to (OC, H*W*IC_per_group) matrix format for Im2Col-based
         # transposed convolution.
@@ -216,9 +220,11 @@ def make_q8ta_conv2d_custom_op(  # noqa: C901
         #   (groups, OC_per_group, H, W, IC_per_group) ->
         #   (OC, H*W*IC_per_group)
         weight_tensor = (
+            # pyrefly: ignore [bad-argument-type]
             weight_tensor.reshape(match.groups, IC_per_group, OC_per_group, H, W)
             .permute(0, 2, 3, 4, 1)
             .contiguous()
+            # pyrefly: ignore [bad-argument-type]
             .reshape(OC, H * W * IC_per_group)
             .contiguous()
         )
@@ -230,10 +236,12 @@ def make_q8ta_conv2d_custom_op(  # noqa: C901
     )
 
     if is_depthwise_conv:
+        # pyrefly: ignore [unsupported-operation]
         assert OC % 4 == 0, "depthwise conv requires that OC is divisible by 4"
         # Depthwise convs use a specialized layout; the weight tensor is reshaped to
         # (H, W, OC)
         weight_tensor = (
+            # pyrefly: ignore [bad-argument-type]
             weight_tensor.permute(2, 3, 1, 0).contiguous().view(H, W, OC).contiguous()
         )
     elif not match.transposed:
@@ -242,6 +250,7 @@ def make_q8ta_conv2d_custom_op(  # noqa: C901
         weight_tensor = (
             weight_tensor.permute(0, 2, 3, 1)
             .contiguous()
+            # pyrefly: ignore [bad-argument-type]
             .view(OC, H * W * IC_per_group)
             .contiguous()
         )
@@ -258,6 +267,7 @@ def make_q8ta_conv2d_custom_op(  # noqa: C901
     )
 
     if bias_tensor is not None:
+        # pyrefly: ignore [bad-argument-type]
         utils.align_width_and_update_state_dict(ep, match.bias_node, bias_tensor)
 
     first_graph_node = list(graph_module.graph.nodes)[0]
@@ -300,9 +310,9 @@ def make_q8ta_conv2d_custom_op(  # noqa: C901
     is_pointwise_conv = (
         H == 1
         and W == 1
-        and list(match.stride) == [1, 1]
-        and list(match.dilation) == [1, 1]
-        and list(match.padding) == [0, 0]
+        and list(match.stride) == [1, 1]  # pyrefly: ignore [bad-argument-type]
+        and list(match.dilation) == [1, 1]  # pyrefly: ignore [bad-argument-type]
+        and list(match.padding) == [0, 0]  # pyrefly: ignore [bad-argument-type]
     )
 
     with graph_module.graph.inserting_before(match.output_node):

--- a/backends/vulkan/patterns/quantized_embedding.py
+++ b/backends/vulkan/patterns/quantized_embedding.py
@@ -104,15 +104,18 @@ def find_quantized_embedding_patterns(
     return None
 
 
+# pyrefly: ignore [bad-argument-type]
 @register_pattern_replacement("quantized_embedding")
 def replace_quantized_embedding_patterns(
     ep: ExportedProgram,
     graph_module: torch.fx.GraphModule,
     match: QuantizedEmbeddingMatch,
 ):
+    # pyrefly: ignore [bad-argument-type]
     weight_tensor = get_param_tensor(ep, match.weight_node)
     assert weight_tensor is not None
 
+    # pyrefly: ignore [bad-argument-type]
     scales_tensor = get_param_tensor(ep, match.scales_node)
     assert scales_tensor is not None
 
@@ -125,6 +128,7 @@ def replace_quantized_embedding_patterns(
     # always repack the weight tensor in the format expected by 4 bit linear layers;
     # the runtime shader supports both the original and repacked packing formats
     # for weights.
+    # pyrefly: ignore [bad-argument-type]
     if utils.register_param_mutation(ep, match.weight_node, "4 bit linear weight"):
         # Repack using linear convention (low nibble = even, high nibble = odd)
         vocab_size = weight_tensor.shape[0]
@@ -133,6 +137,7 @@ def replace_quantized_embedding_patterns(
         unpacked = torch.stack([high, low], dim=-1).reshape(vocab_size, -1)
         weight_tensor = pack_4bit_weight_tensor(unpacked)
         utils.align_width_and_update_state_dict(
+            # pyrefly: ignore [bad-argument-type]
             ep, match.weight_node, weight_tensor, align_to=1, force_update=True
         )
 
@@ -154,7 +159,9 @@ def replace_quantized_embedding_patterns(
             ),
         )
 
+    # pyrefly: ignore [missing-attribute]
     embedding_q4gsw_node.meta["val"] = match.anchor_node.meta["val"]
+    # pyrefly: ignore [missing-attribute]
     match.anchor_node.replace_all_uses_with(embedding_q4gsw_node)
 
 
@@ -210,6 +217,7 @@ class TorchAOQuantizedEmbeddingMatch(PatternMatch):
             return
         if block_size[0] != 1:
             return
+        # pyrefly: ignore [bad-argument-type]
         self.group_size = int(block_size[1])
 
         # Trace weight (args[0]) and scales (args[2]) to their placeholders. A
@@ -287,6 +295,7 @@ def find_torchao_quantized_embedding_patterns(
     return None
 
 
+# pyrefly: ignore [bad-argument-type]
 @register_pattern_replacement("torchao_quantized_embedding")
 def replace_torchao_quantized_embedding_patterns(
     ep: ExportedProgram,
@@ -338,5 +347,7 @@ def replace_torchao_quantized_embedding_patterns(
             ),
         )
 
+    # pyrefly: ignore [missing-attribute]
     embedding_q4gsw_node.meta["val"] = match.anchor_node.meta["val"]
+    # pyrefly: ignore [missing-attribute]
     match.anchor_node.replace_all_uses_with(embedding_q4gsw_node)

--- a/backends/vulkan/patterns/quantized_linear.py
+++ b/backends/vulkan/patterns/quantized_linear.py
@@ -125,6 +125,7 @@ class QuantizedLinearMatch(PatternMatch):
             self.dequantize_input_node = anchor_primary_input_node
             self.all_nodes.append(self.dequantize_input_node)
             input_to_dq_node = self.dequantize_input_node.args[0]
+            # pyrefly: ignore [bad-assignment]
             self.pattern_input_node = input_to_dq_node
 
             # torchao dequantize has a slightly different function schema
@@ -140,10 +141,12 @@ class QuantizedLinearMatch(PatternMatch):
 
             # Check for dynamic quantization: input scales are dynamically
             # computed via a choose_qparams op
+            # pyrefly: ignore [bad-argument-type]
             if utils.is_quant_node(input_to_dq_node) and utils.is_dynamic_qscale(
                 self.input_scales_node
             ):
                 self.quantize_input_node = input_to_dq_node
+                # pyrefly: ignore [missing-attribute]
                 self.pattern_input_node = self.quantize_input_node.args[0]
 
         # The implementation has a limitation that input channels must be a
@@ -215,6 +218,7 @@ class QuantizedLinearMatch(PatternMatch):
 
     def is_weight_pergroup_quantized(self) -> bool:
         weight_shape = self.weight_node.meta["val"].shape
+        # pyrefly: ignore [missing-attribute]
         scales_shape = self.weight_scales_node.meta["val"].shape
         if len(scales_shape) != 2:
             return False
@@ -229,6 +233,7 @@ class QuantizedLinearMatch(PatternMatch):
 
     def is_weight_perchannel_quantized(self) -> bool:
         weight_shape = self.weight_node.meta["val"].shape
+        # pyrefly: ignore [missing-attribute]
         scales_shape = self.weight_scales_node.meta["val"].shape
         if len(scales_shape) != 1:
             return False
@@ -257,6 +262,7 @@ class QuantizedLinearMatch(PatternMatch):
             return False
 
         # The getitem node should be retrieving from a choose_qparams op
+        # pyrefly: ignore [bad-argument-type]
         if not utils.is_choose_qparams_node(self.input_scales_node.args[0]):
             return False
 
@@ -347,11 +353,13 @@ def make_linear_q4gsw_op(
 
     # Also transpose the weight scales tensor to shape [num_groups, N]
     if utils.register_param_mutation(
+        # pyrefly: ignore [bad-argument-type]
         ep, match.weight_scales_node, "4 bit linear scales"
     ):
         weight_scales_tensor = weight_scales_tensor.transpose(0, 1).contiguous()
         utils.align_width_and_update_state_dict(
             ep,
+            # pyrefly: ignore [bad-argument-type]
             match.weight_scales_node,
             weight_scales_tensor,
             force_update=True,
@@ -404,11 +412,13 @@ def make_linear_dq8ca_q4gsw_op(
 
     # Also transpose the weight scales tensor to shape [num_groups, N]
     if utils.register_param_mutation(
+        # pyrefly: ignore [bad-argument-type]
         ep, match.weight_scales_node, "4 bit linear scales"
     ):
         weight_scales_tensor = weight_scales_tensor.transpose(0, 1).contiguous()
         utils.align_width_and_update_state_dict(
             ep,
+            # pyrefly: ignore [bad-argument-type]
             match.weight_scales_node,
             weight_scales_tensor,
             force_update=True,
@@ -464,9 +474,11 @@ def make_linear_q8ta_q8csw_custom_op(
     weight_tensor: torch.Tensor,
 ):
     # Pad weight_scales to multiple of 4 so GPU shader reads don't go OOB
+    # pyrefly: ignore [bad-argument-type]
     weight_scales_tensor = get_param_tensor(ep, match.weight_scales_node)
     assert weight_scales_tensor is not None
     utils.align_width_and_update_state_dict(
+        # pyrefly: ignore [bad-argument-type]
         ep, match.weight_scales_node, weight_scales_tensor
     )
 
@@ -529,9 +541,11 @@ def make_q8ta_linear_custom_op(
     weight_tensor: torch.Tensor,
 ):
     # Pad weight_scales to multiple of 4 so GPU shader reads don't go OOB
+    # pyrefly: ignore [bad-argument-type]
     weight_scales_tensor = get_param_tensor(ep, match.weight_scales_node)
     assert weight_scales_tensor is not None
     utils.align_width_and_update_state_dict(
+        # pyrefly: ignore [bad-argument-type]
         ep, match.weight_scales_node, weight_scales_tensor
     )
 
@@ -591,10 +605,13 @@ def make_q8ta_linear_custom_op(
             ),
         )
 
+    # pyrefly: ignore [missing-attribute]
     qlinear_node.meta["val"] = match.quantize_output_node.meta["val"]
+    # pyrefly: ignore [missing-attribute]
     match.quantize_output_node.replace_all_uses_with(qlinear_node)
 
 
+# pyrefly: ignore [bad-argument-type]
 @register_pattern_replacement("quantized_linear")
 def replace_quantized_linear_patterns(
     ep: ExportedProgram,

--- a/backends/vulkan/patterns/quantized_pixel_shuffle.py
+++ b/backends/vulkan/patterns/quantized_pixel_shuffle.py
@@ -71,6 +71,7 @@ class QuantizedPixelShuffleMatch(PatternMatch):
     """
 
     def __init__(self, dequantize_node: torch.fx.Node) -> None:
+        # pyrefly: ignore [bad-override-mutable-attribute]
         self.anchor_node: torch.fx.Node = dequantize_node
         self.match_found: bool = False
         self.all_nodes: List[torch.fx.Node] = [dequantize_node]
@@ -133,6 +134,7 @@ def find_quantized_pixel_shuffle_pattern(
     return None
 
 
+# pyrefly: ignore [bad-argument-type]
 @register_pattern_replacement("quantized_pixel_shuffle")
 def make_quantized_pixel_shuffle_custom_op(
     ep: ExportedProgram,

--- a/backends/vulkan/patterns/quantized_unary.py
+++ b/backends/vulkan/patterns/quantized_unary.py
@@ -90,6 +90,7 @@ def find_quantized_unary_patterns(
 ##
 
 
+# pyrefly: ignore [bad-argument-type]
 @register_pattern_replacement("quantized_unary")
 def make_q8ta_unary_custom_op(
     ep: ExportedProgram,
@@ -97,6 +98,7 @@ def make_q8ta_unary_custom_op(
     match: QuantizedUnaryMatch,
 ):
     op_target = None
+    # pyrefly: ignore [missing-attribute]
     if match.anchor_node.target == exir_ops.edge.aten.relu.default:
         op_target = exir_ops.edge.et_vk.q8ta_relu.default
     else:

--- a/backends/vulkan/patterns/rms_norm.py
+++ b/backends/vulkan/patterns/rms_norm.py
@@ -257,6 +257,7 @@ def _extract_eps_value(eps_node) -> float:
     raise ValueError(f"Cannot extract epsilon value from {eps_node}")
 
 
+# pyrefly: ignore [bad-argument-type]
 @register_pattern_replacement("rms_norm")
 def replace_rms_norm_with_fused_op(
     ep: ExportedProgram,
@@ -276,5 +277,7 @@ def replace_rms_norm_with_fused_op(
             ),
         )
 
+    # pyrefly: ignore [missing-attribute]
     rms_norm_node.meta["val"] = match.anchor_node.meta["val"]
+    # pyrefly: ignore [missing-attribute]
     match.anchor_node.replace_all_uses_with(rms_norm_node)

--- a/backends/vulkan/patterns/sdpa.py
+++ b/backends/vulkan/patterns/sdpa.py
@@ -56,6 +56,7 @@ class CausalSDPAMatch(PatternMatch):
 
         # try to find update key cache node
         self.update_key_cache_node = None
+        # pyrefly: ignore [missing-attribute]
         for user in self.key_cache_node.users:
             if is_update_cache_node(user):
                 self.update_key_cache_node = user
@@ -67,6 +68,7 @@ class CausalSDPAMatch(PatternMatch):
 
         # find update value cache node
         self.update_value_cache_node = None
+        # pyrefly: ignore [missing-attribute]
         for user in self.value_cache_node.users:
             if is_update_cache_node(user):
                 self.update_value_cache_node = user
@@ -114,6 +116,7 @@ def find_singleton_start_pos_node(graph_module: torch.fx.GraphModule):
     )
 
 
+# pyrefly: ignore [bad-argument-type]
 @register_pattern_replacement("causal_sdpa")
 def replace_custom_sdpa_with_causal_sdpa(
     ep: ExportedProgram,
@@ -146,7 +149,9 @@ def replace_custom_sdpa_with_causal_sdpa(
             ),
         )
 
+    # pyrefly: ignore [missing-attribute]
     new_node.meta["val"] = match.anchor_node.meta["val"]
+    # pyrefly: ignore [missing-attribute]
     match.anchor_node.replace_all_uses_with(new_node)
 
     # Manually erase update_cache nodes since DCE will not remove them since they

--- a/backends/vulkan/patterns/select_as_symint.py
+++ b/backends/vulkan/patterns/select_as_symint.py
@@ -47,6 +47,7 @@ class SelectAsSymIntMatch(PatternMatch):
         self.dim_node = select_node.args[1]
         self.index_node = select_node.args[2]
 
+        # pyrefly: ignore [bad-assignment]
         self.all_nodes = [
             self.anchor_node,
             self.select_node,
@@ -77,6 +78,7 @@ def find_select_as_symint_patterns(
 ##
 
 
+# pyrefly: ignore [bad-argument-type]
 @register_pattern_replacement("select_as_symint")
 def replace_select_local_scalar_dense_with_select_as_symint(
     ep: ExportedProgram,
@@ -94,7 +96,9 @@ def replace_select_local_scalar_dense_with_select_as_symint(
             ),
         )
 
+    # pyrefly: ignore [missing-attribute]
     new_node.meta["val"] = match.anchor_node.meta["val"]
+    # pyrefly: ignore [missing-attribute]
     match.anchor_node.replace_all_uses_with(new_node)
 
     # # Remove both the local_scalar_dense and select_copy nodes


### PR DESCRIPTION
Summary:

Automated migration to enable Pyrefly type checking for `fbcode/executorch`.

- Added `python.set_pyrefly(True)` to PACKAGE file
- Suppressed pre-existing type errors

Pyrefly is Meta's next-generation Python type checker, replacing Pyre.

If you encounter issues, you can revert the PACKAGE change by removing
the `python.set_pyrefly(True)` line.
#pyreupgrade

Differential Revision: D112856308
