### PR TITLE
Make extension/cuda:caller_stream fbcode-only

### DIFF
--- a/extension/cuda/BUCK
+++ b/extension/cuda/BUCK
@@ -1,8 +1,14 @@
 # Any targets that should be shared between fbcode and xplat must be defined in
-# targets.bzl. This file can contain xplat-only targets.
+# targets.bzl. This file can contain fbcode-only targets.
+#
+# caller_stream unconditionally includes <cuda_runtime.h>, whose headers only
+# resolve through the fbcode cell's CUDA third-party. Like the other executorch
+# CUDA targets, it must therefore be defined fbcode-only; defining it in the
+# xplat cell produces a target that cannot compile ("cuda_runtime.h not found").
 
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 load(":targets.bzl", "define_common_targets")
 
 oncall("executorch")
 
-define_common_targets()
+fbcode_target(_kind = define_common_targets,)


### PR DESCRIPTION
Summary:
`buck build --flagfile fbcode//mode/dev fbsource//xplat/executorch/extension/cuda:caller_stream_static`
(and the non-static variant) failed to compile with:

  caller_stream.h:11:10: fatal error: 'cuda_runtime.h' file not found

Root cause: `caller_stream.h` unconditionally includes `<cuda_runtime.h>`,
whose headers only resolve through the fbcode cell's CUDA third-party
(`("cuda", None, "cuda-lazy")`). The BUCK file called
`define_common_targets()` unconditionally, so the target was also defined
in the xplat cell, where the CUDA external_dep does not resolve into the
dependency graph (confirmed via `buck2 cquery deps(...)` — only the cuda
toolchain `cuda_path`/`nvcc` appear, not the `:cuda-lazy` library). The
result is an xplat target that can never compile.

Every other executorch CUDA target (e.g. backends/aoti/slim/cuda,
backends/cuda/runtime) is defined fbcode-only via
`fbcode_target(_kind = define_common_targets,)`. This change makes
extension/cuda follow the same convention.

Consumers of `//executorch/extension/cuda:caller_stream`
(backends/cuda/runtime, backends/aoti/slim/*) are all fbcode-only CUDA
targets, so nothing that previously built is affected.

Build the fbcode-cell target instead:
`buck build fbcode//mode/dev fbcode//executorch/extension/cuda:caller_stream_static`

Differential Revision: D112930632


