### PR TITLE
portable: add fast path for contiguous innermost-dim reduction in amax.out and amin.out

### DIFF
--- a/kernels/portable/cpu/op_amax.cpp
+++ b/kernels/portable/cpu/op_amax.cpp
@@ -44,11 +44,39 @@ Tensor& amax_out(
   ET_KERNEL_CHECK(
       ctx, tensors_have_same_dim_order(in, out), InvalidArgument, out);
 
-  ReduceOverDimListPlan plan(in, dim_list);
-
   // @lint-ignore CLANGTIDY facebook-hte-CArray
   static constexpr const char op_name[] = "amax.out";
 
+  // Fast path: contiguous tensor, single innermost dim reduction.
+  // Bypasses the generic ReduceOverDimListPlan (per-element stride/index
+  // recomputation via get_init_index)
+  if (in.numel() > 0 && dim_list.size() == 1 &&
+      !executorch::runtime::isComplexType(in.scalar_type()) &&
+      tensor_is_default_dim_order(in)) {
+    const int64_t d = dim_list[0] < 0 ? dim_list[0] + in.dim() : dim_list[0];
+    if (d >= 0 && d < in.dim() && d == in.dim() - 1 &&
+        tensor_is_contiguous(in)) {
+      const int64_t reduce_size = in.size(d);
+      const int64_t outer_size = in.numel() / reduce_size;
+
+      ET_SWITCH_REALHBBF16_TYPES(in.scalar_type(), ctx, op_name, CTYPE, [&]() {
+        const CTYPE* in_data = in.const_data_ptr<CTYPE>();
+        CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
+        for (int64_t i = 0; i < outer_size; i++) {
+          const CTYPE* row = in_data + i * reduce_size;
+          CTYPE max_v = row[0];
+          for (int64_t j = 1; j < reduce_size; j++) {
+            const CTYPE v = row[j];
+            max_v = utils::isnan_override(v) || v > max_v ? v : max_v;
+          }
+          out_data[i] = max_v;
+        }
+      });
+      return out;
+    }
+  }
+
+  ReduceOverDimListPlan plan(in, dim_list);
   ET_SWITCH_REALHBBF16_TYPES(in.scalar_type(), ctx, op_name, CTYPE, [&]() {
     CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
     const bool success = parallel_for_each_reduce_over_dim_list_output_index(

--- a/kernels/portable/cpu/op_amin.cpp
+++ b/kernels/portable/cpu/op_amin.cpp
@@ -43,11 +43,39 @@ Tensor& amin_out(
   ET_KERNEL_CHECK(
       ctx, tensors_have_same_dim_order(in, out), InvalidArgument, out);
 
-  ReduceOverDimListPlan plan(in, dim_list);
-
   // @lint-ignore CLANGTIDY facebook-hte-CArray
   static constexpr const char op_name[] = "amin.out";
 
+  // Fast path: contiguous tensor, single innermost dim reduction.
+  // Bypasses the generic ReduceOverDimListPlan (per-element stride/index
+  // recomputation via get_init_index) for a tight, directly-indexed loop.
+  if (in.numel() > 0 && dim_list.size() == 1 &&
+      !executorch::runtime::isComplexType(in.scalar_type()) &&
+      tensor_is_default_dim_order(in)) {
+    const int64_t d = dim_list[0] < 0 ? dim_list[0] + in.dim() : dim_list[0];
+    if (d >= 0 && d < in.dim() && d == in.dim() - 1 &&
+        tensor_is_contiguous(in)) {
+      const int64_t reduce_size = in.size(d);
+      const int64_t outer_size = in.numel() / reduce_size;
+
+      ET_SWITCH_REALHBBF16_TYPES(in.scalar_type(), ctx, op_name, CTYPE, [&]() {
+        const CTYPE* in_data = in.const_data_ptr<CTYPE>();
+        CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
+        for (int64_t i = 0; i < outer_size; i++) {
+          const CTYPE* row = in_data + i * reduce_size;
+          CTYPE min_v = row[0];
+          for (int64_t j = 1; j < reduce_size; j++) {
+            const CTYPE v = row[j];
+            min_v = utils::isnan_override(v) || v < min_v ? v : min_v;
+          }
+          out_data[i] = min_v;
+        }
+      });
+      return out;
+    }
+  }
+
+  ReduceOverDimListPlan plan(in, dim_list);
   ET_SWITCH_REALHBBF16_TYPES(in.scalar_type(), ctx, op_name, CTYPE, [&]() {
     CTYPE* out_data = out.mutable_data_ptr<CTYPE>();
     const bool success = parallel_for_each_reduce_over_dim_list_output_index(


### PR DESCRIPTION
### Motivation

`sum`, `mean`, and `var_mean` special-case the contiguous, single innermost-dim reduction shape with a direct pointer loop instead of the generic `ReduceOverDimListPlan`, which recomputes a stride-based starting index per output element via `get_init_index` (#18789, #18790, #18791). `amax.out` and `amin.out` do not have this fast path.

### Tests

No new tests were added. The existing tests already cover both fast and generic paths.
`sum`'s (#18789), `mean`'s (#18790), and `var_mean`'s (#18791) fast-path PRs had no test changes either.

| Test | Shape | `dim` | Fast path? | Dtypes covered |
| --- | --- | --- | --- | --- |
| `AllRealInputOutputPasses` | `{2,3,4}` | `{2}` (innermost) | Yes | `ET_FORALL_REALHBBF16_TYPES` (incl. `Bool`, `Half`, `BFloat16`) |
| `AllRealInputOutputPasses` | `{2,3,4}` | `{-2}` (not innermost) | No, fallback | same |
| `AllRealInputOutputPasses` | `{2,3,4}` | `{0,1}` (multi-dim) | No, fallback | same |
| `AllRealInputOutputPasses` | `{2,2,4}` | null / empty | No, fallback | same |
| `InfinityAndNANTest` | `{2,3,4}` | `{-1}` (innermost) | Yes | `ET_FORALL_FLOATHBF16_TYPES` |

Same coverage in both `op_amax_test.cpp` and `op_amin_test.cpp`.

```
$ ninja -C cmake-out-bench portable_kernels_test -j16
[6/6] Linking CXX executable kernels/test/portable_kernels_test

$ ./cmake-out-bench/kernels/test/portable_kernels_test
[==========] Running 1625 tests from 190 test suites.
[  PASSED  ] 1521 tests.
# 0 FAILED, 209 SKIPPED (pre-existing DISABLED/Aten-only tests, unrelated to this change)

$ ./cmake-out-bench/kernels/test/portable_kernels_test --gtest_filter="OpAmaxOutTest.*:OpAminOutTest.*"
[==========] 10 tests from 2 test suites ran.
[  PASSED  ] 10 tests.

$ lintrunner -a kernels/portable/cpu/op_amax.cpp kernels/portable/cpu/op_amin.cpp
ok No lint issues.
```

cc @larryliu0820 @manuelcandales