### PR TITLE
support MXFP8 (#21146)

### DIFF
--- a/backends/mlx/builder/op_helpers.py
+++ b/backends/mlx/builder/op_helpers.py
@@ -656,6 +656,35 @@ def parse_dequant_nvfp4_node(
     return qdata, scale, per_tensor_scale, output_dtype
 
 
+def parse_dequant_mx_node(
+    node: Node,
+) -> Optional[Tuple[Node, Node, torch.dtype, int, torch.dtype]]:
+    """Parse a torchao.dequantize_mx node.
+
+    Returns (qdata, scale, elem_dtype, block_size, output_dtype) or None if not a
+    dequantize_mx node or the custom op is not registered. MX has no per-tensor
+    scale and no affine zero-point; the block scale is always E8M0.
+    """
+    target = get_aten_target(node.target)
+    try:
+        import executorch.extension.llm.export.mx  # noqa: F401
+    except ImportError:
+        return None
+
+    if target is not torch.ops.torchao.dequantize_mx.default:
+        return None
+
+    qdata, scale, elem_dtype, block_size = node.args[0:4]
+
+    output_dtype = torch.float32
+    if len(node.args) > 4:
+        output_dtype = node.args[4]
+    elif "output_dtype" in node.kwargs:
+        output_dtype = node.kwargs["output_dtype"]
+
+    return qdata, scale, elem_dtype, int(block_size), output_dtype
+
+
 def parse_dequant_int4_node(
     node: Node,
 ) -> Optional[Tuple[Node, Node, Node, int, Optional[torch.dtype]]]:

--- a/backends/mlx/builder/program_builder.py
+++ b/backends/mlx/builder/program_builder.py
@@ -567,6 +567,23 @@ class MLXProgramBuilder:
             if n.op in ("placeholder", "output"):
                 dtype_error = _check_dtype(n)
                 if dtype_error is not None:
+                    # A placeholder consumed entirely by pattern handlers (which
+                    # repack it into new constants -- e.g. an MX fp8/e8m0 weight
+                    # reinterpreted to uint32/uint8) is never emitted as an MLX
+                    # tensor, so its own (unserializable) dtype is irrelevant. Its
+                    # users are the pattern's head/body nodes, which at this point
+                    # have a handler assigned (by _apply_patterns) but are not yet
+                    # marked handled, so check for a claimed handler too.
+                    if (
+                        n.op == "placeholder"
+                        and n.users
+                        and all(
+                            self._is_handled(u) or self.node_info[u].handler is not None
+                            for u in n.users
+                        )
+                    ):
+                        self._mark_supported(n)
+                        continue
                     self._mark_unsupported(n, f"{n.op} {dtype_error}")
                     continue
                 self._mark_supported(n)

--- a/backends/mlx/patterns.py
+++ b/backends/mlx/patterns.py
@@ -23,6 +23,7 @@ from executorch.backends.mlx.builder.op_helpers import (
     emit_quantized_gather,
     emit_stop_position,
     parse_dequant_int4_node,
+    parse_dequant_mx_node,
     parse_dequant_node,
     parse_dequant_nvfp4_node,
     regroup_affine_scales,
@@ -1153,6 +1154,196 @@ class NVFP4QuantizedLinearHandler(PatternHandler):
                     out=P.slot_to_tid(out),
                 )
             )
+
+        if needs_cast:
+            P.emit(
+                AsTypeNode(
+                    x=P.slot_to_tid(out),
+                    out=P.slot_to_tid(out),
+                    scalar_type=torch_dtype_to_scalar_type(self.output_dtype),
+                )
+            )
+
+        return out
+
+
+def _mx_mlx_mode_bits(elem_dtype: torch.dtype):
+    """Map an MX element dtype to the MLX (mode, bits). Rejects unsupported formats.
+
+    MLX's block-scaled kernels only implement E4M3 elements (mxfp8). Other MX
+    element encodings (e5m2, fp4/fp6, ...) are rejected rather than silently
+    mis-lowered.
+    """
+    if elem_dtype == torch.float8_e4m3fn:
+        return "mxfp8", 8
+    raise ValueError(
+        f"MLX backend does not support MX element dtype {elem_dtype}; "
+        "only float8_e4m3fn (mxfp8) is supported."
+    )
+
+
+def _mx_pack_for_mlx(P, qdata_node, scale_node):
+    """Reinterpret ExportableMXTensor's native FP8/E8M0 storage to MLX layout.
+
+    ExportableMXTensor stores ``qdata`` as native FP8 (one value per byte) and
+    ``scale`` as ``float8_e8m0fnu``; MLX's kernel wants ``qdata`` as uint32
+    (4 FP8 codes per word) and ``scale`` as uint8. Both conversions are pure bit
+    reinterpretations (``view``), registered as MLX constants.
+    """
+    qdata_target, qdata = P.get_placeholder_target_and_tensor(qdata_node)
+    scale_target, scale = P.get_placeholder_target_and_tensor(scale_node)
+    w = qdata.contiguous().view(torch.uint8).view(torch.uint32)
+    sc = scale.contiguous().view(torch.uint8)
+    w_slot = P.make_or_get_constant(f"{qdata_target}_mx_packed", w)
+    scale_slot = P.make_or_get_constant(f"{scale_target}_mx_u8", sc)
+    return w_slot, scale_slot
+
+
+@REGISTRY.register_pattern(name="MX_QUANTIZED_LINEAR")
+class MXQuantizedLinearHandler(PatternHandler):
+    """Fuse dequantize_mx + linear into QuantizedMatmulNode for the MX format.
+
+    Matches:
+        linear(x, dequantize_mx(qdata, scale, elem_dtype, block_size), bias)
+
+    Emits:
+        QuantizedMatmulNode [→ AddNode(bias)] [→ AsTypeNode]
+
+    The element dtype is mapped to the MLX ``mode``/``bits`` (rejecting formats
+    MLX can't lower). MX has no per-tensor scale, so no MultiplyNode is emitted.
+    """
+
+    def __init__(self, head, body, qdata, scale, elem_dtype, block_size, output_dtype):
+        super().__init__(head, body)
+        self.qdata = qdata
+        self.scale = scale
+        self.elem_dtype = elem_dtype
+        self.block_size = block_size
+        self.output_dtype = output_dtype
+
+    @classmethod
+    def maybe_create(cls, ep, head):
+        if not match_target(head, torch.ops.aten.linear.default):
+            return None
+        x, dequant = head.args[0:2]
+        if not isinstance(dequant, Node):
+            return None
+        if not has_single_user(dequant):
+            return None
+        parsed = parse_dequant_mx_node(dequant)
+        if parsed is None:
+            return None
+        qdata, scale, elem_dtype, block_size, output_dtype = parsed
+        return cls(head, [dequant], qdata, scale, elem_dtype, block_size, output_dtype)
+
+    def __call__(self, P, n):
+        assert n == self.head
+
+        x_node, w_node = n.args[0:2]
+        b_node = n.args[2] if len(n.args) > 2 else None
+
+        mode, bits = _mx_mlx_mode_bits(self.elem_dtype)
+        needs_cast = x_node.meta["val"].dtype != self.output_dtype
+        has_bias = b_node is not None
+
+        w, scales = _mx_pack_for_mlx(P, self.qdata, self.scale)
+        x, bias = P.slot_map([x_node, b_node])
+
+        out = P.make_or_get_slot(n)
+        P.emit(
+            QuantizedMatmulNode(
+                x=P.slot_to_tid(x),
+                w=P.slot_to_tid(w),
+                scales=P.slot_to_tid(scales),
+                out=P.slot_to_tid(out),
+                biases=None,
+                group_size=self.block_size,
+                bits=bits,
+                mode=mode,
+                transpose=True,
+            )
+        )
+
+        if has_bias:
+            P.emit(
+                AddNode(
+                    a=P.slot_to_tid(out),
+                    b=P.slot_to_tid(bias),
+                    out=P.slot_to_tid(out),
+                )
+            )
+
+        if needs_cast:
+            P.emit(
+                AsTypeNode(
+                    x=P.slot_to_tid(out),
+                    out=P.slot_to_tid(out),
+                    scalar_type=torch_dtype_to_scalar_type(self.output_dtype),
+                )
+            )
+
+        return out
+
+
+@REGISTRY.register_pattern(name="MX_QUANTIZED_EMBEDDING")
+class MXQuantizedEmbeddingHandler(PatternHandler):
+    """Fuse dequantize_mx + embedding into gather + DequantizeNode for the MX format.
+
+    Matches:
+        embedding(dequantize_mx(qdata, scale, elem_dtype, block_size), indices)
+
+    Emits:
+        TakeNode(qdata) → TakeNode(scales) → DequantizeNode [→ AsTypeNode]
+    """
+
+    def __init__(self, head, body, qdata, scale, elem_dtype, block_size, output_dtype):
+        super().__init__(head, body)
+        self.qdata = qdata
+        self.scale = scale
+        self.elem_dtype = elem_dtype
+        self.block_size = block_size
+        self.output_dtype = output_dtype
+
+    @classmethod
+    def maybe_create(cls, ep, head):
+        if not match_target(head, torch.ops.aten.embedding.default):
+            return None
+
+        w, x = head.args[0:2]
+        if not isinstance(w, Node):
+            return None
+        if not has_single_user(w):
+            return None
+        parsed = parse_dequant_mx_node(w)
+        if parsed is None:
+            return None
+        qdata, scale, elem_dtype, block_size, output_dtype = parsed
+        return cls(head, [w], qdata, scale, elem_dtype, block_size, output_dtype)
+
+    def __call__(self, P: MLXProgramBuilder, n: Node) -> Slot:
+        assert n == self.head
+        w_node, x_node = n.args[0:2]
+
+        mode, bits = _mx_mlx_mode_bits(self.elem_dtype)
+        x_dtype = x_node.meta["val"].dtype
+        needs_cast = self.output_dtype != x_dtype
+
+        qdata_slot, scales_slot = _mx_pack_for_mlx(P, self.qdata, self.scale)
+        (x,) = P.slot_map([x_node])
+
+        out = P.make_or_get_slot(n)
+        emit_quantized_gather(
+            P,
+            out,
+            x,
+            qdata_slot,
+            scales_slot,
+            None,
+            group_size=self.block_size,
+            bits=bits,
+            mode=mode,
+            out_dtype=self.output_dtype,
+        )
 
         if needs_cast:
             P.emit(

--- a/backends/mlx/test/test_ops.py
+++ b/backends/mlx/test/test_ops.py
@@ -7556,6 +7556,84 @@ class NVFP4QuantizedLinearTest(OpTestCase):
         return (x,)
 
 
+class MXFP8QuantizedLinearModel(nn.Module):
+    """Simple linear layer that will be quantized with MXFP8."""
+
+    def __init__(
+        self, in_features: int = 64, out_features: int = 128, bias: bool = True
+    ):
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features, bias=bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+@register_test
+class MXFP8QuantizedLinearTest(OpTestCase):
+    """Test case for MXFP8 quantized nn.Linear (mode="mxfp8", group_size 32)."""
+
+    name = "mxfp8_quantized_linear"
+    rtol = 0.1
+    atol = 0.1
+
+    def __init__(
+        self,
+        in_features: int = 64,
+        out_features: int = 128,
+        batch_size: int = 2,
+        seq_len: int = 16,
+        bias: bool = True,
+        dtype: torch.dtype = torch.float32,
+    ):
+        self.in_features = in_features
+        self.out_features = out_features
+        self.batch_size = batch_size
+        self.seq_len = seq_len
+        self.bias = bias
+        self.dtype = dtype
+
+        parts = ["mxfp8_quantized_linear"]
+        if not bias:
+            parts.append("no_bias")
+        if dtype != torch.float32:
+            parts.append(str(dtype).split(".")[-1])
+        self.name = "_".join(parts)
+
+    @classmethod
+    def get_test_configs(cls) -> List["MXFP8QuantizedLinearTest"]:
+        return [
+            cls(),
+            cls(bias=False),
+            cls(dtype=torch.bfloat16),
+            cls(bias=False, dtype=torch.bfloat16),
+        ]
+
+    def get_edge_compile_config(self):
+        from executorch.exir import EdgeCompileConfig
+
+        return EdgeCompileConfig(_check_ir_validity=False)
+
+    def create_model(self) -> nn.Module:
+        model = MXFP8QuantizedLinearModel(
+            self.in_features, self.out_features, bias=self.bias
+        )
+        model = model.to(self.dtype)
+
+        from executorch.extension.llm.export.mx import ExportableMXConfig
+        from torchao.quantization import quantize_
+
+        quantize_(model, ExportableMXConfig())
+
+        return model
+
+    def create_inputs(self) -> Tuple[torch.Tensor, ...]:
+        x = torch.randn(
+            self.batch_size, self.seq_len, self.in_features, dtype=self.dtype
+        )
+        return (x,)
+
+
 def _make_int4_quantized_weight(weight: torch.Tensor, group_size: int) -> torch.Tensor:
     """Groupwise affine 4-bit quantize a ``(N, K)`` weight into an
     ``ExportableInt4Tensor`` (torchao ``Int4Tensor`` packed layout)."""

--- a/extension/llm/export/BUCK
+++ b/extension/llm/export/BUCK
@@ -99,8 +99,45 @@ fbcode_target(_kind = runtime.python_library,
 )
 
 fbcode_target(_kind = runtime.python_library,
+    name = "nvfp4",
+    srcs = [
+        "nvfp4.py",
+    ],
+    _is_external_target = True,
+    base_module = "executorch.extension.llm.export",
+    visibility = [
+        "//executorch/backends/...",
+        "//executorch/examples/...",
+        "//executorch/extension/llm/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//pytorch/ao:torchao",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
+    name = "mx",
+    srcs = [
+        "mx.py",
+    ],
+    _is_external_target = True,
+    base_module = "executorch.extension.llm.export",
+    visibility = [
+        "//executorch/backends/...",
+        "//executorch/examples/...",
+        "//executorch/extension/llm/...",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//pytorch/ao:torchao",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
     name = "quant",
     srcs = [
+        "__init__.py",
         "quant/__init__.py",
         "quant/convert.py",
         "quant/quantize.py",
@@ -116,6 +153,8 @@ fbcode_target(_kind = runtime.python_library,
     deps = [
         ":gguf",
         ":int4",
+        ":mx",
+        ":nvfp4",
         "//caffe2:torch",
         "//executorch/backends/cuda:dp4a_planar_int6_tensor",
         "//pytorch/ao:torchao",

--- a/extension/llm/export/__init__.py
+++ b/extension/llm/export/__init__.py
@@ -4,8 +4,26 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .builder import LLMEdgeManager
+from executorch.extension.llm.export.gguf import ExportableGGUFTensor
+from executorch.extension.llm.export.int4 import ExportableInt4Tensor
+from executorch.extension.llm.export.mx import ExportableMXTensor
+from executorch.extension.llm.export.nvfp4 import ExportableNVFP4Tensor
 
 __all__ = [
+    "ExportableGGUFTensor",
+    "ExportableInt4Tensor",
+    "ExportableMXTensor",
+    "ExportableNVFP4Tensor",
     "LLMEdgeManager",
 ]
+
+
+def __getattr__(name: str):
+    # Lazy: importing the (lightweight) tensor subclasses above must not pull in
+    # builder.py's heavy backend/quantizer dependencies. Consumers that want
+    # ``LLMEdgeManager`` still get it via ``from ...export import LLMEdgeManager``.
+    if name == "LLMEdgeManager":
+        from executorch.extension.llm.export.builder import LLMEdgeManager
+
+        return LLMEdgeManager
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/extension/llm/export/mx.py
+++ b/extension/llm/export/mx.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MX (microscaling) export-compatible quantization.
+
+General OCP Microscaling **MX** block-scaled float tensor (mxfp8, and — once
+their pack/unpack is wired — mxfp4/mxfp6). An MX weight is a block of ``elem_dtype``
+elements sharing one ``float8_e8m0`` (power-of-two) scale per ``block_size``
+group; there is no per-tensor global scale and no affine zero-point.
+
+Storage mirrors torchao's ``MXTensor`` (backend-agnostic), NOT any one backend's
+packing:
+  * ``qdata``  the elements in their native dtype -- e.g. ``float8_e4m3fn`` for
+               mxfp8 (one value per element, unpacked).
+  * ``scale``  ``float8_e8m0fnu`` (biased power-of-two exponent), one per group.
+
+A ``torchao::dequantize_mx`` custom op carries the dequant so the node survives
+``torch.export`` (mirroring ``dequantize_nvfp4`` / ``dequantize_int4_tensor``).
+Backends pattern-match the op and repack ``qdata``/``scale`` into whatever layout
+their kernel wants (e.g. the MLX handler packs FP8 into uint32 words) and reject
+element formats they do not support.
+"""
+
+import types
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torchao.core.config import AOBaseConfig
+from torchao.quantization.quant_api import _quantization_type
+from torchao.quantization.transform_module import register_quantize_module_handler
+from torchao.utils import TorchAOBaseTensor
+
+aten = torch.ops.aten
+
+_MX_DEFAULT_BLOCK_SIZE = 32
+
+# Element encodings this carrier can represent/dequantize. All MX formats share
+# the E8M0 (float8_e8m0fnu) block scale; only the element dtype varies. FP8
+# elements are stored one-per-byte (unpacked); sub-byte formats (fp4) would add
+# their own packing and are intentionally not enabled yet.
+_MX_FP8_ELEM_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
+_MX_SUPPORTED_ELEM_DTYPES = _MX_FP8_ELEM_DTYPES
+
+
+@torch.library.custom_op("torchao::dequantize_mx", mutates_args=())
+def mx_dequantize(
+    qdata: Tensor,
+    scale: Tensor,
+    elem_dtype: torch.dtype,
+    block_size: int,
+    output_dtype: torch.dtype = torch.float32,
+) -> Tensor:
+    """Reference dequant of an MX weight to ``(M, K)``.
+
+    ``qdata`` holds the elements in their native ``elem_dtype`` (FP8, one value
+    per element); ``scale`` is ``float8_e8m0fnu`` (a power-of-two), one per
+    ``block_size`` group along ``K``. This eager body is a portable reference --
+    a backend (e.g. MLX) replaces the op with its fused kernel at lower time.
+    """
+    if elem_dtype not in _MX_FP8_ELEM_DTYPES:
+        raise NotImplementedError(
+            f"dequantize_mx reference only supports FP8 element dtypes "
+            f"{_MX_FP8_ELEM_DTYPES}, got {elem_dtype}"
+        )
+    data_f32 = qdata.to(torch.float32)
+    M = data_f32.shape[0]
+    K = data_f32.shape[1]
+    data_f32 = data_f32.view(M, K // block_size, block_size)
+
+    # float8_e8m0fnu decodes directly to the fp32 power-of-two scale factor.
+    scale_f32 = scale.to(torch.float32).view(M, K // block_size, 1)
+
+    result = (data_f32 * scale_f32).view(M, K)
+    return result.to(output_dtype)
+
+
+@mx_dequantize.register_fake
+def _(qdata, scale, elem_dtype, block_size, output_dtype=torch.float32):
+    # FP8 elements are stored unpacked, so the logical last dim == qdata's.
+    return torch.empty(
+        qdata.shape[0], qdata.shape[1], dtype=output_dtype, device=qdata.device
+    )
+
+
+class ExportableMXTensor(TorchAOBaseTensor):
+    """General MX tensor subclass that dequantizes via a registered custom op.
+
+    Parametrized by ``elem_dtype`` (the block-float element encoding); the block
+    scale is always ``float8_e8m0fnu``. Storage is backend-agnostic (native
+    element dtype for ``qdata``) -- backends repack as needed in their handlers.
+    """
+
+    tensor_data_names = ["qdata", "scale"]
+    tensor_attribute_names = ["elem_dtype", "block_size", "orig_dtype"]
+
+    def __new__(cls, qdata, scale, elem_dtype, block_size, orig_dtype):
+        if elem_dtype not in _MX_SUPPORTED_ELEM_DTYPES:
+            raise NotImplementedError(
+                f"ExportableMXTensor supports element dtypes "
+                f"{_MX_SUPPORTED_ELEM_DTYPES}, got {elem_dtype}"
+            )
+        # FP8 elements: qdata is unpacked (one value per element), so its shape
+        # is already the logical (N, K).
+        shape = (qdata.shape[0], qdata.shape[-1])
+        self = torch.Tensor._make_wrapper_subclass(
+            cls, shape, dtype=orig_dtype, device=qdata.device, requires_grad=False
+        )
+        self.qdata = qdata
+        self.scale = scale
+        self.elem_dtype = elem_dtype
+        self.block_size = block_size
+        self.orig_dtype = orig_dtype
+        return self
+
+    def dequantize(self, output_dtype=None):
+        return torch.ops.torchao.dequantize_mx(
+            self.qdata,
+            self.scale,
+            self.elem_dtype,
+            self.block_size,
+            output_dtype=output_dtype or self.orig_dtype,
+        )
+
+    def to(self, *args, **kwargs) -> "ExportableMXTensor":
+        """Move device and/or set the output dtype *without* dequantizing.
+
+        Mirrors ``ExportableInt4Tensor.to``: ``qdata`` (native FP8) and ``scale``
+        (E8M0) only move across devices -- neither is a floating scale, so
+        casting to the activation dtype must not touch their bit patterns. Only
+        ``orig_dtype`` (the dequantized output dtype) follows ``dtype``.
+        """
+        kwargs = self._get_to_kwargs(*args, **kwargs)
+        device = kwargs.pop("device")
+        dtype = kwargs.pop("dtype")
+        assert dtype.is_floating_point, f"expected a floating dtype; got {dtype}"
+        return ExportableMXTensor(
+            self.qdata.to(device),
+            self.scale.to(device),
+            self.elem_dtype,
+            self.block_size,
+            dtype,
+        )
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+
+implements = ExportableMXTensor.implements
+
+
+@implements([aten.linear.default])
+def _(func, types, args, kwargs):
+    input_tensor = args[0]
+    weight_tensor = args[1]
+    bias = args[2] if len(args) > 2 else None
+    weight_dequant = weight_tensor.dequantize(input_tensor.dtype)
+    return torch.nn.functional.linear(input_tensor, weight_dequant, bias)
+
+
+@implements([aten.embedding.default])
+def _(func, types, args, kwargs):
+    weight_tensor = args[0]
+    indices = args[1]
+    weight_dequant = weight_tensor.dequantize()
+    return torch.nn.functional.embedding(indices, weight_dequant)
+
+
+@implements([aten.t.default])
+def _(func, types, args, kwargs):
+    return args[0].dequantize().t()
+
+
+@implements([aten.detach.default, aten.alias.default])
+def _(func, types, args, kwargs):
+    return args[0]
+
+
+@implements([aten._to_copy.default])
+def _(func, types, args, kwargs):
+    return args[0].dequantize(output_dtype=kwargs.get("dtype", args[0].orig_dtype))
+
+
+@dataclass
+class ExportableMXConfig(AOBaseConfig):
+    """MX weight-only quantization config for torch.export.
+
+    ``elem_dtype`` selects the block-float element encoding (default mxfp8 =
+    ``float8_e4m3fn``); the scale is always E8M0.
+    """
+
+    elem_dtype: torch.dtype = torch.float8_e4m3fn
+    block_size: int = _MX_DEFAULT_BLOCK_SIZE
+
+
+def _linear_extra_repr(self):
+    return (
+        f"in_features={self.weight.shape[1]}, "
+        f"out_features={self.weight.shape[0]}, "
+        f"weight={_quantization_type(self.weight)}"
+    )
+
+
+@register_quantize_module_handler(ExportableMXConfig)
+def _exportable_mx_transform(module: nn.Module, config: ExportableMXConfig):
+    """Quantize a linear/embedding weight to MX via torchao ``to_mx``.
+
+    ``to_mx`` returns the elements in ``elem_dtype`` and an E8M0 block scale --
+    exactly the backend-agnostic form ``ExportableMXTensor`` stores. No backend
+    packing happens here (backends pack in their own handlers).
+    """
+    from torchao.prototype.mx_formats.mx_tensor import to_mx
+
+    weight = module.weight
+    block_size = config.block_size
+    if weight.shape[-1] % block_size != 0:
+        raise RuntimeError(
+            f"MX requires in_features divisible by {block_size}, "
+            f"got {tuple(weight.shape)}"
+        )
+
+    # to_mx supports bf16/fp32 inputs; promote otherwise.
+    hp = weight.contiguous()
+    if hp.dtype not in (torch.bfloat16, torch.float32):
+        hp = hp.to(torch.float32)
+
+    scale_e8m0, data_lp = to_mx(hp, config.elem_dtype, block_size)
+    # data_lp: (N, K) in elem_dtype; scale_e8m0: (N, n_groups) float8_e8m0fnu.
+    # Stored as-is (torchao-native); the backend repacks in its handler.
+    quantized_weight = ExportableMXTensor(
+        data_lp.contiguous(),
+        scale_e8m0.contiguous(),
+        elem_dtype=config.elem_dtype,
+        block_size=block_size,
+        orig_dtype=weight.dtype,
+    )
+    module.weight = nn.Parameter(quantized_weight, requires_grad=False)
+    if isinstance(module, nn.Linear):
+        module.extra_repr = types.MethodType(_linear_extra_repr, module)
+    return module

--- a/extension/llm/export/nvfp4.py
+++ b/extension/llm/export/nvfp4.py
@@ -98,6 +98,28 @@ class ExportableNVFP4Tensor(TorchAOBaseTensor):
             output_dtype=dtype,
         )
 
+    def to(self, *args, **kwargs) -> "ExportableNVFP4Tensor":
+        """Move device and/or set the output dtype *without* dequantizing.
+
+        Mirrors ``ExportableInt4Tensor.to``: the packed ``qdata`` (uint32) and
+        ``scale`` (uint8 E4M3 block scales) only move across devices -- neither
+        is a floating scale, so casting to the activation dtype must not touch
+        their bit patterns. ``per_tensor_scale`` (a float32 scalar) follows the
+        device only, and ``orig_dtype`` (the dequantized output dtype) follows
+        ``dtype``. Use :meth:`dequantize` to materialize a dense tensor.
+        """
+        kwargs = self._get_to_kwargs(*args, **kwargs)
+        device = kwargs.pop("device")
+        dtype = kwargs.pop("dtype")
+        assert dtype.is_floating_point, f"expected a floating dtype; got {dtype}"
+        return ExportableNVFP4Tensor(
+            self.qdata.to(device),
+            self.scale.to(device),
+            self.per_tensor_scale.to(device),
+            self.block_size,
+            dtype,
+        )
+
     __torch_function__ = torch._C._disabled_torch_function_impl
 
 

--- a/extension/llm/export/quant/convert.py
+++ b/extension/llm/export/quant/convert.py
@@ -63,11 +63,21 @@ def maybe_cast(value: torch.Tensor, dtype: Optional[torch.dtype]) -> torch.Tenso
     if type(value) is torch.Tensor:
         return value.to(dtype)
 
-    from executorch.extension.llm.export.gguf import ExportableGGUFTensor
-    from executorch.extension.llm.export.int4 import ExportableInt4Tensor
+    from executorch.extension.llm.export import (
+        ExportableGGUFTensor,
+        ExportableInt4Tensor,
+        ExportableMXTensor,
+        ExportableNVFP4Tensor,
+    )
     from torchao.quantization import IntxUnpackedToInt8Tensor
 
-    castable = (ExportableGGUFTensor, ExportableInt4Tensor, IntxUnpackedToInt8Tensor)
+    castable = (
+        ExportableGGUFTensor,
+        ExportableInt4Tensor,
+        ExportableMXTensor,
+        ExportableNVFP4Tensor,
+        IntxUnpackedToInt8Tensor,
+    )
     return value.to(dtype) if isinstance(value, castable) else value
 
 
@@ -124,15 +134,24 @@ def fuse_along_output(tensors: Sequence[torch.Tensor]) -> torch.Tensor:
             f"{[type(t).__name__ for t in tensors]}"
         )
 
-    from executorch.extension.llm.export.gguf import ExportableGGUFTensor
-    from executorch.extension.llm.export.int4 import ExportableInt4Tensor
+    from executorch.extension.llm.export import (
+        ExportableGGUFTensor,
+        ExportableInt4Tensor,
+        ExportableMXTensor,
+        ExportableNVFP4Tensor,
+    )
     from torchao.quantization import IntxUnpackedToInt8Tensor
 
-    # Per-data-field concat axis (the output-channel dim) by subclass layout.
+    # Per-data-field concat axis (the output-channel dim) by subclass layout. An
+    # axis of ``None`` means the field is not per-output-channel (e.g. NVFP4's
+    # scalar ``per_tensor_scale``): it must match across inputs and is kept as-is.
     axis_by_field = {
         ExportableInt4Tensor: {"qdata": 0, "scale": 1, "zero_point": 1},
         IntxUnpackedToInt8Tensor: {"qdata": 0, "scale": 0, "zero_point": 0},
         ExportableGGUFTensor: {"raw": 0},
+        # NVFP4/MX store qdata (N, ...) and scale (N, K//group) N-major.
+        ExportableNVFP4Tensor: {"qdata": 0, "scale": 0, "per_tensor_scale": None},
+        ExportableMXTensor: {"qdata": 0, "scale": 0},
     }.get(type(first))
     if axis_by_field is None:
         raise TypeError(
@@ -158,10 +177,22 @@ def _fuse_subclass(
                     "fuse_along_output: cannot fuse tensors with different "
                     f"'{name}' ({getattr(t, name)!r} != {ref!r})"
                 )
-    fused_data = [
-        torch.cat([getattr(t, name) for t in tensors], dim=axis_by_field[name])
-        for name in first.tensor_data_names
-    ]
+    fused_data = []
+    for name in first.tensor_data_names:
+        axis = axis_by_field[name]
+        if axis is None:
+            # Not per-output-channel (e.g. a scalar per-tensor scale): must
+            # match across all inputs; keep the first.
+            ref = getattr(first, name)
+            for t in tensors[1:]:
+                if not torch.equal(getattr(t, name), ref):
+                    raise ValueError(
+                        "fuse_along_output: cannot fuse tensors with different "
+                        f"'{name}'"
+                    )
+            fused_data.append(ref)
+        else:
+            fused_data.append(torch.cat([getattr(t, name) for t in tensors], dim=axis))
     return type(first)(*fused_data, *attrs)
 
 
@@ -173,7 +204,7 @@ def _to_exportable_int4(w: torch.Tensor, *, repack_intx: bool) -> torch.Tensor:
     representation (raising if it carries activation quantization, which int4
     export can't represent). Any other tensor is returned unchanged.
     """
-    from executorch.extension.llm.export.int4 import ExportableInt4Tensor
+    from executorch.extension.llm.export import ExportableInt4Tensor
     from torchao.quantization import IntxUnpackedToInt8Tensor
     from torchao.quantization.quantize_.workflows.int4.int4_tensor import Int4Tensor
 


### PR DESCRIPTION
Summary:

Add MXFP8 block-scaled float quantization support to the MLX backend, alongside
the existing NVFP4 path, and unify the MLX safetensors checkpoint loader so it can
load block-scaled (NVFP4 / MXFP8) checkpoints directly.

- New `ExportableMXFP8Tensor` (extension/llm/export/mxfp8.py): a torchao tensor
  subclass carrying MLX-native packed weights (uint32 qdata, uint8 E8M0 block
  scales, group_size 32, 8-bit FP8), with a registered `torchao::dequantize_mxfp8`
  custom op so the dequant survives torch.export, and a payload-preserving `.to()`
  so activation-dtype casts do not dequantize it.
- NVFP4 (extension/llm/export/nvfp4.py): add the same payload-preserving `.to()`
  so block-scaled weights survive `model.to(activation_dtype)` instead of being
  dequantized.
- MLX backend lowering (backends/mlx/patterns.py, backends/mlx/builder/op_helpers.py):
  add `parse_dequant_mxfp8_node` and MXFP8 linear/embedding pattern handlers that
  emit the MLX `mode="mxfp8"` quantized matmul / gather (group_size 32, bits 8).
  The bundled MLX runtime already accepts this mode, so no C++/runtime changes.
- Fusion (extension/llm/export/quant/convert.py): extend `fuse_along_output` and
  `maybe_cast` to handle the NVFP4 / MXFP8 carrier tensors (the per-tensor scale
  is treated as a shared, assert-equal field rather than concatenated).
- Checkpoint loader: unify the MLX reader to resolve each weight's quant mode
  per-tensor from `config.json` (a default mode plus per-module overrides) and
  build the matching representation -- affine -> torchao intx, nvfp4 ->
  ExportableNVFP4Tensor, mxfp8 -> ExportableMXFP8Tensor -- so mixed-format
  checkpoints load correctly from a single path.

Reviewed By: Gasoonjia

Differential Revision: D113113318


