### PR TITLE
[ET-VK][build] Fix Windows Vulkan/Android build and llama ETDump profiling

### DIFF
--- a/backends/vulkan/runtime/gen_vulkan_spv.py
+++ b/backends/vulkan/runtime/gen_vulkan_spv.py
@@ -641,6 +641,12 @@ def escape(line: str) -> str:
 def preprocess(
     input_text: str, variables: Dict[str, Any], input_path: str = "codegen"
 ) -> str:
+    # Normalize line endings first. Templates checked out with CRLF (common on
+    # Windows) otherwise break the trailing-backslash handling below: in
+    # re.MULTILINE, $ matches immediately before \n, so a CR would sit between a
+    # trailing \ and the line end and defeat the r"\\$" match, leaving a lone
+    # backslash that escape() turns into an unterminated Python string literal.
+    input_text = input_text.replace("\r\n", "\n").replace("\r", "\n")
     # Workaround to handle source files using \ to extend mecros to a new line
     input_text = re.sub(r"\\$", r"\\\\", input_text, flags=re.MULTILINE)
 

--- a/examples/models/llama/CMakeLists.txt
+++ b/examples/models/llama/CMakeLists.txt
@@ -241,7 +241,20 @@ if(ANDROID)
   list(APPEND link_libraries log)
 endif()
 
+# ETDump profiling support (OSS build). The llama runner does not link etdump or
+# define ET_EVENT_TRACER_ENABLED by default. When the core libs are built with
+# EXECUTORCH_BUILD_DEVTOOLS=ON + EXECUTORCH_ENABLE_EVENT_TRACER=ON, find_package
+# imports the etdump target; linking it and defining the macro enables ETDump
+# collection and makes the Vulkan delegate emit per-dispatch GPU timestamps.
+if(TARGET etdump)
+  list(APPEND link_libraries etdump)
+endif()
+
 add_executable(llama_main ${_srcs})
+
+if(TARGET etdump)
+  target_compile_definitions(llama_main PRIVATE ET_EVENT_TRACER_ENABLED)
+endif()
 
 # Copy MLX metallib for runtime if MLX delegate is enabled
 if(TARGET mlxdelegate)

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -46,6 +46,15 @@ else()
   set(_flatbuffers_ep_additional_args)
 endif()
 
+# Allow reusing a prebuilt host flatc instead of building it from source. This is
+# required when cross-compiling with the Ninja generator on Windows: the WIN32
+# branch above only supports the Visual Studio generator (it passes the VS-only
+# CMAKE_GENERATOR_PLATFORM), and the flatbuffers_ep host sub-build otherwise
+# fails under Ninja. Pass -DFLATC_EXECUTABLE=<path to a host flatc(.exe)>.
+if(FLATC_EXECUTABLE)
+  add_executable(flatc IMPORTED GLOBAL)
+  set_target_properties(flatc PROPERTIES IMPORTED_LOCATION "${FLATC_EXECUTABLE}")
+else()
 # We use ExternalProject to build flatc from source to force it target the host.
 # Otherwise, flatc will target the project's toolchain (i.e. iOS, or Android).
 ExternalProject_Add(
@@ -86,6 +95,7 @@ else()
     flatc PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/bin/flatc
   )
 endif()
+endif()
 
 # TODO: re-enable once flatbuffers is added as a subdirectory.
 # set(FLATBUFFERS_BUILD_FLATC OFF) set(FLATBUFFERS_INSTALL OFF)
@@ -104,6 +114,14 @@ else()
   set(_flatcc_extra_cmake_args)
 endif()
 
+# Allow reusing a prebuilt host flatcc (see the flatc note above). Needed for the
+# Ninja-on-Windows cross-compile, where the flatcc_ep host sub-build fails. Pass
+# -DFLATCC_EXECUTABLE=<path to a host flatcc(.exe)>. flatcc_cli is only consumed
+# by devtools/etdump, so this imported target is unused when devtools is off.
+if(FLATCC_EXECUTABLE)
+  add_executable(flatcc_cli IMPORTED GLOBAL)
+  set_target_properties(flatcc_cli PROPERTIES IMPORTED_LOCATION "${FLATCC_EXECUTABLE}")
+else()
 # Similar to flatbuffers, we want to build flatcc for the host. See inline
 # comments in the flatbuffers ExternalProject_Add for more details.
 ExternalProject_Add(
@@ -141,6 +159,7 @@ else()
   set_target_properties(
     flatcc_cli PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/bin/flatcc
   )
+endif()
 endif()
 
 set(FLATCC_RTONLY


### PR DESCRIPTION
Three additive, backward-compatible fixes needed to build the ExecuTorch Vulkan backend and profile the llama runner from a Windows host. Each change is guarded so it is a no-op on non-Windows / non-profiling builds.

### Fixes

- **`backends/vulkan/runtime/gen_vulkan_spv.py`** — normalize CRLF to LF at the top of `preprocess()`, before the trailing-backslash macro-continuation regex runs. GLSL templates checked out with CRLF line endings otherwise leave a lone backslash that `escape()` turns into an unterminated Python string literal (`SyntaxError: unterminated string literal`) during shader codegen.

- **`third-party/CMakeLists.txt`** — allow importing a prebuilt host `flatc`/`flatcc` via `FLATC_EXECUTABLE` / `FLATCC_EXECUTABLE` instead of building them from source. The existing `WIN32` host-tool build only supports the Visual Studio generator (VS-only `CMAKE_GENERATOR_PLATFORM`, `.exe`-less `BUILD_BYPRODUCTS`), which fails under the Ninja generator required by the Android NDK cross-compile.

- **`examples/models/llama/CMakeLists.txt`** — link `etdump` and define `ET_EVENT_TRACER_ENABLED` when the `etdump` target exists (i.e. core libs built with `EXECUTORCH_BUILD_DEVTOOLS=ON` + `EXECUTORCH_ENABLE_EVENT_TRACER=ON`). This enables ETDump collection and makes the Vulkan delegate emit per-dispatch GPU timestamps for per-shader profiling.

All three changes are additive and guarded, so they are no-ops on non-Windows hosts and on non-profiling builds.

### Test plan

Cross-compiled ExecuTorch core libs + `llama_main` for Android arm64 with the Vulkan backend enabled from a Windows host (NDK r29, Ninja generator, imported host `flatc`/`flatcc`). Confirmed `libvulkan_backend.a` is linked and `llama_main` runs on a Galaxy S24 (Adreno 750): Qwen3 0.6B ~80 tok/s decode, Llama 3.2 1B 8da4w ~60 tok/s decode. With DEVTOOLS/EVENT_TRACER on, collected an ETDump containing per-shader Vulkan events and analyzed the prefill/decode breakdown via `custom_inspector.py --mode llm`.

This PR was authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


cc @manuelcandales @digantdesai @cbilgin