### PR TITLE
Allow Python 3.15 / 3.15t builds

### DIFF
--- a/install_utils.py
+++ b/install_utils.py
@@ -273,7 +273,10 @@ def python_is_compatible():
 
         python_version = packaging.version.parse(platform.python_version())
         version_range = packaging.specifiers.SpecifierSet(version_specifier)
-        if python_version not in version_range:
+        # Pass prereleases=True so pre-release interpreters (e.g. 3.15.0b4) are
+        # accepted when they fall within the supported range; SpecifierSet
+        # excludes pre-releases by default.
+        if not version_range.contains(python_version, prereleases=True):
             print(
                 f'ERROR: ExecuTorch does not support python version {python_version}: must satisfy "{version_specifier}"',
                 file=sys.stderr,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.16"
 
 # Runtime dependencies are declared dynamically (see `dynamic` above) and
 # computed in setup.py, so the EXECUTORCH_BUILD_MINIMAL wheel can ship a slimmer


### PR DESCRIPTION
Bumps the supported Python upper bound to `<3.16` so ExecuTorch can be built and installed on Python 3.15 (including free-threaded 3.15t, which reports version 3.15).

Two changes are needed, not just the version bump:
- `pyproject.toml`: `requires-python` `>=3.10,<3.15` -> `>=3.10,<3.16`.
- `install_utils.py`: `python_is_compatible()` used the default `in` operator on the `SpecifierSet`, which excludes pre-releases, so a pre-release interpreter like `3.15.0b4` was rejected even once 3.15 is in range. Switched to `SpecifierSet.contains(..., prereleases=True)` (3.16 pre-releases stay excluded by the `<3.16` bound).

Surfaced while enabling Python 3.15 / 3.15t Linux wheel builds in pytorch/test-infra#8148.

Authored with assistance from Claude Code (AI assistant).