### PR TITLE
Arm backend: Add PReLU decomposition pass

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -81,6 +81,7 @@ from .decompose_maxpool2d_with_dilation_pass import DecomposeMaxPool2dPass  # no
 from .decompose_meandim_pass import DecomposeMeanDimPass  # noqa
 from .decompose_ne_pass import DecomposeNotEqualPass  # noqa
 from .decompose_permute_for_u55_pass import DecomposePermuteForU55Pass  # noqa
+from .decompose_prelu_pass import DecomposePReLUPass  # noqa
 from .decompose_quant_nodes import DecomposeQuantNodesPass  # noqa
 from .decompose_remainder_pass import DecomposeRemainderPass  # noqa
 from .decompose_rnn_pass import DecomposeRnnPass  # noqa

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -81,6 +81,7 @@ from executorch.backends.arm._passes import (
     DecomposeMeanDimPass,
     DecomposeNotEqualPass,
     DecomposePermuteForU55Pass,
+    DecomposePReLUPass,
     DecomposeQuantNodesPass,
     DecomposeRemainderPass,
     DecomposeRnnPass,
@@ -578,6 +579,7 @@ class ArmPassManager(ExportedProgramPassManager):
                 ReplaceScalarWithTensorByProfilePass(),
                 RewriteLeLtToGeGtPass(),
                 DecomposeLeakyReLUPass(),  # Emits full_like so before ConvertFullLikeToFullPass
+                DecomposePReLUPass(),
                 ConvertFullLikeToFullPass(),
                 MatchArgDtypePass(),
                 UnsqueezeScalarPlaceholdersPass(exported_program),
@@ -729,6 +731,7 @@ class ArmPassManager(ExportedProgramPassManager):
                     DecomposeMeanDimPass(graph_module, self.tosa_spec, tfa_pass=True),
                     DecomposeAdaptiveAvgPool2dPass(tfa_pass=True),
                     DecomposeAvgPool2dPass(tfa_pass=True),
+                    DecomposePReLUPass(tfa_pass=True),
                 ]
             )
 

--- a/backends/arm/_passes/decompose_prelu_pass.py
+++ b/backends/arm/_passes/decompose_prelu_pass.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Set, Type
+
+import torch
+from executorch.backends.arm._passes import ArmOpTargetedPass
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass
+
+edge_ops = (exir_ops.edge.aten.prelu.default,)
+torch_ops = (torch.ops.aten.prelu.default,)
+
+
+def _get_prelu_ops(op) -> tuple:
+    if op in edge_ops:
+        return (
+            exir_ops.edge.aten.clamp.default,
+            exir_ops.edge.aten.mul.Tensor,
+            exir_ops.edge.aten.add.Tensor,
+            exir_ops.edge.aten.view_copy.default,
+        )
+    if op in torch_ops:
+        return (
+            torch.ops.aten.clamp.default,
+            torch.ops.aten.mul.Tensor,
+            torch.ops.aten.add.Tensor,
+            torch.ops.aten.view_copy.default,
+        )
+    raise RuntimeError(f"Can't get decomposition ops for op {op}")
+
+
+def _weight_shape(input_rank: int, weight_shape: torch.Size) -> tuple[int, ...] | None:
+    weight_dims = tuple(int(dim) for dim in weight_shape)
+    if len(weight_dims) == 0 or weight_dims == (1,):
+        return None
+    if len(weight_dims) != 1:
+        raise RuntimeError(f"Unsupported PReLU weight shape: {weight_dims}")
+    if input_rank < 2:
+        raise RuntimeError(
+            f"Per-channel PReLU weight requires input rank >= 2, got {input_rank}"
+        )
+    return (1, weight_dims[0], *([1] * (input_rank - 2)))
+
+
+class DecomposePReLUPass(ArmOpTargetedPass):
+    """Decompose PReLU into primitive TOSA-supported operations.
+
+    PReLU(x, weight) = max(0, x) + weight * min(0, x)
+
+    Example:
+        %op1 = clamp(x,0,None) (equivalent to max(0,x))
+        %op2 = clamp(x,None,0) (equivalent to min(0,x))
+        %op3 = weight
+        %op4 = mul(%op3,%op2)
+        %op5 = add(%op1,%op4)
+
+    """
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+    target_ops = edge_ops + torch_ops
+    check_allowed_to_transform = True
+
+    def call_operator(self, op, args, kwargs, meta):
+        if (
+            op not in self.target_ops
+            or not self.allowed_to_transform(meta)
+            or self._is_quantized_meta(meta)
+        ):
+            return super().call_operator(op, args, kwargs, meta)
+
+        x, weight = args
+        clamp, mul, add, view = _get_prelu_ops(op)
+
+        positive = super().call_operator(
+            op=clamp, args=(x, 0, None), kwargs=kwargs, meta=meta, updated=True
+        )
+        negative = super().call_operator(
+            op=clamp, args=(x, None, 0), kwargs=kwargs, meta=meta, updated=True
+        )
+
+        input_rank = len(x.data.shape)
+        reshape_shape = _weight_shape(input_rank, weight.data.shape)
+        if reshape_shape is not None:
+            weight = super().call_operator(
+                op=view,
+                args=(weight, reshape_shape),
+                kwargs={},
+                meta=meta,
+            )
+
+        scaled_negative = super().call_operator(
+            op=mul,
+            args=(negative, weight),
+            kwargs=kwargs,
+            meta=meta,
+            updated=True,
+        )
+        return super().call_operator(
+            op=add,
+            args=(positive, scaled_negative),
+            kwargs=kwargs,
+            meta=meta,
+            updated=True,
+        )

--- a/backends/arm/quantizer/quantizer_support.py
+++ b/backends/arm/quantizer/quantizer_support.py
@@ -185,6 +185,7 @@ ALL_QPARAM_OP_PATTERNS = (
         (torch.ops.aten.var.correction,),
         (torch.ops.aten.leaky_relu.default,),
         (torch.ops.aten.leaky_relu_.default,),
+        (torch.ops.aten.prelu.default,),
         (torch.ops.aten.linalg_vector_norm.default,),
         (torch.ops.aten.log_softmax.int,),
         (torch.ops.aten.round.default,),

--- a/backends/arm/test/ops/test_prelu.py
+++ b/backends/arm/test/ops/test_prelu.py
@@ -1,0 +1,97 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import torch
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
+    EthosU85PipelineINT,
+    TosaPipelineFP,
+    TosaPipelineINT,
+)
+
+aten_op = "torch.ops.aten.prelu.default"
+exir_op = "executorch_exir_dialects_edge__ops_aten_prelu_default"
+input_t1 = Tuple[torch.Tensor]
+
+
+class PReLU(torch.nn.Module):
+    def __init__(self, num_parameters: int = 1):
+        super().__init__()
+        self.activation = torch.nn.PReLU(num_parameters=num_parameters)
+
+    def forward(self, x: torch.Tensor):
+        return self.activation(x)
+
+    test_data: dict[str, tuple[input_t1, int]] = {
+        "scalar_2d": ((torch.randn(4, 5),), 1),
+        "scalar_4d": ((torch.randn(1, 3, 8, 8),), 1),
+        "per_channel_3d": ((torch.randn(2, 4, 5),), 4),
+        "per_channel_4d": ((torch.randn(1, 3, 8, 8),), 3),
+    }
+
+
+@common.parametrize("test_data", PReLU.test_data)
+def test_prelu_tosa_FP(test_data):
+    data, num_parameters = test_data
+    pipeline = TosaPipelineFP[input_t1](
+        PReLU(num_parameters),
+        data,
+        [],
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.add_stage_after(
+        "to_edge_transform_and_lower", pipeline.tester.check_not, [exir_op]
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", PReLU.test_data)
+def test_prelu_tosa_INT(test_data):
+    data, num_parameters = test_data
+    pipeline = TosaPipelineINT[input_t1](
+        PReLU(num_parameters),
+        data,
+        [],
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.add_stage_after(
+        "to_edge_transform_and_lower", pipeline.tester.check_not, [exir_op]
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", PReLU.test_data)
+@common.XfailIfNoCorstone300
+def test_prelu_u55_INT(test_data):
+    data, num_parameters = test_data
+    pipeline = EthosU55PipelineINT[input_t1](
+        PReLU(num_parameters),
+        data,
+        [],
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.add_stage_after(
+        "to_edge_transform_and_lower", pipeline.tester.check_not, [exir_op]
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", PReLU.test_data)
+@common.XfailIfNoCorstone320
+def test_prelu_u85_INT(test_data):
+    data, num_parameters = test_data
+    pipeline = EthosU85PipelineINT[input_t1](
+        PReLU(num_parameters),
+        data,
+        [],
+        use_to_edge_transform_and_lower=True,
+    )
+    pipeline.add_stage_after(
+        "to_edge_transform_and_lower", pipeline.tester.check_not, [exir_op]
+    )
+    pipeline.run()


### PR DESCRIPTION
Decompose aten.prelu.default into clamp, mul, and add so the Arm backend can lower it through existing TOSA-supported primitives.

Scalar PReLU weights are used directly; 1D per-channel weights are reshaped for broadcasting over the channel dimension.

This intentionally uses the same lowering for U55 and U85 instead of a U85-specific where/select path.

The pass only supports scalar or 1D PReLU weights, assumes per-channel weights apply to dim 1, and relies on the existing clamp/mul/add/view_copy backend and quantizer support for dtype and shape coverage.

Signed-off-by: Per Held <per.held@arm.com>

Change-Id: Ib3889c27eb51b7aa21c99439b8edadffc57e0e13


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani