### PR TITLE
prevent AOTI library collisions between delegates

### DIFF
--- a/backends/cuda/runtime/cuda_backend.cpp
+++ b/backends/cuda/runtime/cuda_backend.cpp
@@ -330,10 +330,18 @@ class ET_EXPERIMENTAL CudaBackend final
         so_blob_key.c_str(),
         static_cast<uint32_t>(aoti_dso_buffer.error()));
 
-    // Generate dynamic temporary file path
+    // Generate a unique temporary file path. so_blob_key already selected the
+    // blob above and is deliberately kept out of the filename: it can be an
+    // untrusted, variable-length payload key, so embedding it risks path
+    // traversal and cross-key collisions. Uniqueness comes from the pid
+    // (across processes) and an atomic counter (within a process, since two
+    // identical CUDA partitions would otherwise clobber each other's .so).
+    static std::atomic<uint64_t> so_file_counter{0};
     filesystem::path temp_dir = filesystem::temp_directory_path();
-    filesystem::path so_path =
-        temp_dir / (so_blob_key + to_string(get_process_id()) + ".so");
+    filesystem::path so_path = temp_dir /
+        ("executorch_cuda_" + to_string(get_process_id()) + "_" +
+         to_string(so_file_counter.fetch_add(1, std::memory_order_relaxed)) +
+         ".so");
 
     // Create a temporary file
     ofstream outfile(so_path, ios::binary);


### PR DESCRIPTION
Summary:
The CUDA backend writes each compiled AOTInductor library to a temporary file,
named from its content key plus the process id, before loading it. Two identical
CUDA partitions can share the same content key, so both delegates computed the
same path; loading the second library overwrote the first while it was still in
use, and symbol lookup could then crash.

Append a per-process atomic counter to the temporary file name so every delegate
in a process gets a distinct path. The file is still removed when the delegate is
destroyed, as before; only the name changes.

Differential Revision: D113322459


