### PR TITLE
Forward fix for broken update and attend test

### DIFF
--- a/extension/llm/cache/targets.bzl
+++ b/extension/llm/cache/targets.bzl
@@ -11,5 +11,6 @@ def define_common_targets():
         visibility = ["PUBLIC"],
         deps = [
             "//caffe2:torch",
+            "//executorch/exir:_warnings",
         ],
     )


### PR DESCRIPTION
Summary:
[executorch] Add missing exir:_warnings dep to llm cache library

The `cache` python_library sources `reference_cache.py`, which imports
`from executorch.exir._warnings import experimental` for the `experimental` decorators on `CacheConfig` and `ContiguousReferenceCache`. The target only
depended on `//caffe2:torch`, so `executorch.exir` was absent at runtime and every test in `test_update_and_attend` failed at import with
`ModuleNotFoundError: No module named 'executorch.exir'`.

Add `//executorch/exir:_warnings` to the `cache` library's deps.

Reviewed By: metascroy

Differential Revision: D113428489


