### PR TITLE
Add timeout default in NeutronBackend (#21293)

### DIFF
--- a/backends/nxp/runtime/NeutronBackend.cpp
+++ b/backends/nxp/runtime/NeutronBackend.cpp
@@ -290,6 +290,10 @@ class NeutronBackend final : public PyTorchBackendInterface {
 
     auto* cfg = allocator->allocateInstance<NeutronExecutorchConfig>();
 
+    // allocateInstance returns raw, uninitialized memory (no constructor runs),
+    // so set the driver-config timeout explicitly.
+    cfg->mcfg.timeoutSeconds = 60;
+
     // The following data is read from the "processed" data blob.
     //    cfg->numInputs
     //    cfg->numoutputs


### PR DESCRIPTION
Summary:

The driver header specifies "60" as a default but is never set.

Here, we set the default accordingly.

Without a default, there is a crash in our specific setup.

This may because ET allocates the object, but does not memset or anything so there may be garbage values that negatively impact.

Reviewed By: rascani

Differential Revision: D113453148


