### PR TITLE
Bump vendored XNNPACK to include qd8_bf16_qb4w subgraph FC

### DIFF
--- a/backends/xnnpack/cmake/Dependencies.cmake
+++ b/backends/xnnpack/cmake/Dependencies.cmake
@@ -66,6 +66,10 @@ if(WIN32)
   set_overridable_option(XNNPACK_ENABLE_AVX256VNNI OFF)
   set_overridable_option(XNNPACK_ENABLE_AVX256VNNIGFNI OFF)
   set_overridable_option(XNNPACK_ENABLE_AVX512BF16 OFF)
+  # clang-cl (reported by CMake as Clang, not MSVC, so XNNPACK's own MSVC gate
+  # does not catch it) crashes with an internal codegen error compiling some of
+  # the AVX512-FP16 micro-kernels, so disable them on Windows.
+  set_overridable_option(XNNPACK_ENABLE_AVX512FP16 OFF)
 endif()
 
 set(XNNPACK_BUILD_ALL_MICROKERNELS

--- a/backends/xnnpack/third-party/xnnpack.buck.bzl
+++ b/backends/xnnpack/third-party/xnnpack.buck.bzl
@@ -70,7 +70,10 @@ def define_xnnpack():
     # @lint-ignore BUCKLINT: native and fb_native are explicitly forbidden in fbcode.
     native.cxx_library(
         name = "subgraph",
-        srcs = SUBGRAPH_SRCS + ["XNNPACK/src/datatype.c"],
+        srcs = SUBGRAPH_SRCS + [
+            "XNNPACK/src/datatype.c",
+            "XNNPACK/src/subgraph/rewrites/cvt_to_fp32.cc",
+        ],
         compiler_flags = [
             "-Wno-error=missing-braces",  # required since the SGX toolchain does not have this by default
         ],
@@ -1150,6 +1153,7 @@ def define_xnnpack():
             "XNNPACK/src/init.c",
             "XNNPACK/src/params.c",
             "XNNPACK/src/configs/hardware-config.c",
+            "XNNPACK/src/xnnpack/init-once.c",
             "XNNPACK/src/microparams-init.c",
             "XNNPACK/src/microkernel-utils.c",
             "XNNPACK/src/reference/binary-elementwise.cc",


### PR DESCRIPTION
## Summary

Bumps the vendored XNNPACK submodule (`backends/xnnpack/third-party/XNNPACK`) from `1adaa7c` to `92a7ad5` (current `google/XNNPACK` master).

The key change picked up in this range is [google/XNNPACK#10818](https://github.com/google/XNNPACK/pull/10818), which adds the **`qd8_bf16_qb4w` fully-connected path to the subgraph layer**. Before this, XNNPACK's subgraph layer could build `qd8_f32_qb4w` and `qd8_f16_qb4w` dynamic-quant FC subgraphs but had no bf16-scale variant, so a bf16 activation feeding an `8da4w` (int8-dynamic-activation / int4-weight, blockwise) linear could not be lowered/run through XNNPACK.

This bump is a prerequisite for bf16 dynamic-quant (`8da4w`) delegation to XNNPACK; the ExecuTorch-side backend changes that consume it are in a follow-up PR.

## Test plan

- Built ExecuTorch with the bumped submodule (x86, XNNPACK backend).
- Exported `google/gemma-3-1b-it` with `--dtype bfloat16 --qlinear 8da4w --qembedding 8w` via `optimum-executorch` (XNNPACK recipe, custom SDPA + KV cache) — lowering succeeds and the FC nodes delegate as `qd8_bf16_qb4w`.
- Runtime forward on the resulting `.pte` produces finite `bfloat16` logits with argmax matching the fp32 and bf16-no-quant baselines.

cc @GregoryComer @digantdesai @cbilgin