### PR TITLE
Un-skip sum dim=None U55/U85 tests; fix stale addmm xfail reason (#21407)

### DIFF
--- a/backends/arm/test/ops/test_addmm.py
+++ b/backends/arm/test/ops/test_addmm.py
@@ -231,7 +231,7 @@ def test_addmm_16a8w_tosa_INT(test_data: input_t1):
 @common.parametrize("test_data", test_data_suite)
 @common.XfailIfNoCorstone300
 @pytest.mark.xfail(
-    reason="Vela compilation fails with 'Invalid arguments' for int16 addmm operations"
+    reason="int16 addmm fails to load on the Ethos-U55 FVP (method load status 0x14)"
 )
 def test_addmm_16a8w_u55_INT(test_data: input_t1):
     """Test addmm (FC layer) operation with 16A8W quantization on U55 (16-bit

--- a/backends/arm/test/ops/test_sum.py
+++ b/backends/arm/test/ops/test_sum.py
@@ -64,6 +64,18 @@ class Sum(torch.nn.Module):
         return x.sum(dim=dim, keepdim=keepdim)
 
 
+class SumDimNone(torch.nn.Module):
+    # dim=None reduces over all dims. It is baked into the module (rather than
+    # passed as a forward argument) so the FVP bundled program does not need to
+    # serialize None as a model input, which it cannot do.
+    def __init__(self, keepdim: bool):
+        super().__init__()
+        self.keepdim = keepdim
+
+    def forward(self, x: torch.Tensor):
+        return x.sum(dim=None, keepdim=self.keepdim)
+
+
 @common.parametrize(
     "test_data",
     Sum.test_parameters | Sum.test_parameters_bf16 | Sum.test_parameters_fp16,
@@ -98,33 +110,35 @@ def test_sum_dim_intlist_tosa_INT(test_data: input_t1):
     pipeline.run()
 
 
-# dim=None cases skipped: executorch.devtools.bundled_program.config rejects
-# None as a model input (cannot be serialized into the bundled program).
-_DIM_NONE_SKIP_REASON = "bundled_program cannot serialize None as a model input"
-_dim_none_skips = {
-    "dim_None": _DIM_NONE_SKIP_REASON,
-    "dim_None_4d_tensor": _DIM_NONE_SKIP_REASON,
-}
+def _module_and_inputs(test_data: Tuple):
+    # dim=None reduces over all dims; bake it into the module so the FVP bundled
+    # program does not need to serialize None as a model input (which it cannot).
+    x, dim, keepdim = test_data()
+    if dim is None:
+        return SumDimNone(keepdim), (x,)
+    return Sum(), (x, dim, keepdim)
 
 
-@common.parametrize("test_data", Sum.test_parameters, skips=_dim_none_skips)
+@common.parametrize("test_data", Sum.test_parameters)
 @common.XfailIfNoCorstone300
 def test_sum_u55_INT_1_0(test_data: Tuple):
+    module, inputs = _module_and_inputs(test_data)
     pipeline = EthosU55PipelineINT[input_t1](
-        Sum(),
-        test_data(),
+        module,
+        inputs,
         aten_op,
         exir_ops=[],
     )
     pipeline.run()
 
 
-@common.parametrize("test_data", Sum.test_parameters, skips=_dim_none_skips)
+@common.parametrize("test_data", Sum.test_parameters)
 @common.XfailIfNoCorstone320
 def test_sum_u85_INT_1_0(test_data: Tuple):
+    module, inputs = _module_and_inputs(test_data)
     pipeline = EthosU85PipelineINT[input_t1](
-        Sum(),
-        test_data(),
+        module,
+        inputs,
         aten_op,
         exir_ops=[],
     )


### PR DESCRIPTION
Summary:

Two test-hygiene fixes in the Arm backend test suite, both reducing the
`ai_infra_mobile_platform` SKIPPING oncall bucket for `executorch/backends/arm`.

- `test_sum.py`: `test_sum_u55_INT_1_0` / `test_sum_u85_INT_1_0` were skipping
  the `dim_None` and `dim_None_4d_tensor` cases because the FVP bundled program
  cannot serialize `None` as a model input. `dim`/`keepdim` were passed as
  `forward` arguments, so they became model inputs. A new `SumDimNone` module
  bakes `dim=None` into the module, leaving only the tensor as an input, so the
  cases now run and pass on both U55 and U85 instead of being skipped. The
  non-`None` cases are unchanged. (The TOSA path already ran these un-skipped.)

- `test_addmm.py`: the `test_addmm_16a8w_u55_INT` xfail reason claimed "Vela
  compilation fails with 'Invalid arguments'", but the test actually fails at
  runtime on the Corstone-300 U55 FVP (method load status `0x14`); Vela
  compilation succeeds. Corrected the reason string to describe the observed
  failure so the next investigator is not misled. The test still xfails.

Authored with Claude Code.

Reviewed By: rascani

Differential Revision: D113676338


