### PR TITLE
drop TARGETS files redundant with fbcode_target-wrapped BUCK siblings

### DIFF
--- a/examples/models/BUCK
+++ b/examples/models/BUCK
@@ -34,8 +34,6 @@ fbcode_target(_kind = python_library,
         "//executorch/examples/models/smollm2:smollm2",  # @manual
         "//executorch/examples/models/smollm3:smollm3",  # @manual
         "//executorch/examples/models/smolvlm:smolvlm",  # @manual
-        "//executorch/examples/models/whisper:whisper",  # @manual
-        "//executorch/examples/models/yolo26:yolo26",  # @manual
     ],
 )
 


### PR DESCRIPTION
Summary:
Chunk 10 of fbcode/executorch TARGETS->BUCK migration. 18 directories
under examples/ where TARGETS defines targets like `python_library(name=X)`
and the sister BUCK defines the same targets via the fbcode_target wrapper:
`fbcode_target(_kind = python_library, name = X)`. Both forms produce the
same logical target in fbcode; the wrapper just adds OSS-migration metadata.

Confirmed every name= in TARGETS is also in BUCK. Deleting TARGETS lets
fbcode fall through to BUCK (via name_v2 = TARGETS,BUCK) with no change in
target inventory.

Directories migrated:
  - examples/models
  - examples/models/{codegen,deeplab_v3,edsr,emformer_rnnt,glm,granite,
    inception_v3,mobilebert,mobilenet_v2,smollm2,smollm3,smolvlm,
    torchvision_vit,toy_model,wav2letter}
  - examples/portable/scripts
  - examples/xnnpack/quantization

Reviewed By: mzlee

Differential Revision: D109082050


