### PR TITLE
executorch: make CUDA backend and partitioner targets PUBLIC

### DIFF
--- a/backends/cuda/BUCK
+++ b/backends/cuda/BUCK
@@ -94,9 +94,7 @@ fbcode_target(
     srcs = [
         "cuda_backend.py",
     ],
-    visibility = [
-        "//executorch/...",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         ":cuda_passes",
         ":triton_replacement_pass",
@@ -115,9 +113,7 @@ fbcode_target(
     srcs = [
         "cuda_partitioner.py",
     ],
-    visibility = [
-        "//executorch/...",
-    ],
+    visibility = ["PUBLIC"],
     deps = [
         "//caffe2:torch",
         "//executorch/backends/aoti:aoti_partitioner",


### PR DESCRIPTION
## Summary

Make the ExecuTorch CUDA backend's Python export targets publicly visible.

`backends/cuda/BUCK` now sets `cuda_backend` and `cuda_partitioner` to `visibility = ["PUBLIC"]` (previously `["//executorch/..."]`). These are the Python export-side targets: the `CudaBackend` delegate and the `CudaPartitioner` used at `.pte` export time.

## Motivation

A consumer outside `//executorch/...` (the Torch-TensorRT ExecuTorch composition test, which builds a coalesced TensorRT + CUDA `.pte` via `CudaPartitioner`) needs to depend on these targets. `PUBLIC` is how ExecuTorch already exposes this kind of target: the CoreML `backend`/`partitioner`, the MPS and MediaTek backends, and the CUDA runtime targets (`cuda_platform`, `runtime_shims`, `cuda_allocator`, and the C++ `cuda_backend`) are all `PUBLIC`. Using it here avoids ad-hoc per-consumer visibility grants that would need editing every time a new consumer appears.

## Test plan

Visibility-only change; no code behavior is affected. `buck2 cquery` on the consuming composition test resolves its dependencies on `cuda_backend` and `cuda_partitioner` with no visibility violation.
