### PR TITLE
Add Module.load overload with per-backend options (#21413)

### DIFF
--- a/extension/android/BUCK
+++ b/extension/android/BUCK
@@ -8,6 +8,7 @@ non_fbcode_target(_kind = fb_android_library,
     warnings_as_errors = False,
     required_for_source_only_abi = True,
     srcs = [
+        "executorch_android/src/main/java/org/pytorch/executorch/BackendOptionsMap.kt",
         "executorch_android/src/main/java/org/pytorch/executorch/DType.kt",
         "executorch_android/src/main/java/org/pytorch/executorch/EValue.kt",
         "executorch_android/src/main/java/org/pytorch/executorch/ExecuTorchRuntime.kt",

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/BackendOptionsMap.kt
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/BackendOptionsMap.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package org.pytorch.executorch
+
+import org.pytorch.executorch.annotations.Experimental
+
+/** A single backend option: an integer [value] for [key]. */
+@Experimental class BackendOption(val key: String, val value: Int)
+
+/**
+ * A map of backend name -> backend options, passed to [Module.load] to configure ExecuTorch
+ * backends at model-load (delegate-init) time. Mirrors the iOS `BackendOptionsMap`.
+ *
+ * Because the options travel with the load, this is per-model and ordering-safe (no process-global
+ * setter to sequence before the load). Example:
+ * ```
+ * val options = BackendOptionsMap().setInt("XnnpackBackend", "workspace_sharing_mode", 2)
+ * val module = Module.load(path, options)
+ * ```
+ *
+ * Warning: These APIs are experimental and subject to change without notice.
+ */
+@Experimental
+class BackendOptionsMap {
+
+  private val options = mutableMapOf<String, MutableList<BackendOption>>()
+
+  /** Set an integer-valued option [key] on [backendName]. */
+  fun setInt(backendName: String, key: String, value: Int): BackendOptionsMap {
+    options.getOrPut(backendName) { mutableListOf() }.add(BackendOption(key, value))
+    return this
+  }
+
+  /** True if no options have been set. */
+  fun isEmpty(): Boolean = options.isEmpty()
+
+  // Flatten to parallel (backend, key, value) arrays for the JNI boundary in a single pass, so the
+  // three arrays are element-aligned by construction (the native side regroups them by backend).
+  internal fun toJniArrays(): Triple<Array<String>, Array<String>, IntArray> {
+    val backends = mutableListOf<String>()
+    val keys = mutableListOf<String>()
+    val values = mutableListOf<Int>()
+    for ((backend, opts) in options) {
+      for (opt in opts) {
+        backends.add(backend)
+        keys.add(opt.key)
+        values.add(opt.value)
+      }
+    }
+    return Triple(backends.toTypedArray(), keys.toTypedArray(), values.toIntArray())
+  }
+}

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.kt
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/Module.kt
@@ -22,8 +22,13 @@ import org.pytorch.executorch.annotations.Experimental
  * Warning: These APIs are experimental and subject to change without notice
  */
 @Experimental
-open class Module private constructor(moduleAbsolutePath: String, loadMode: Int, numThreads: Int) :
-    Closeable {
+open class Module
+private constructor(
+    moduleAbsolutePath: String,
+    loadMode: Int,
+    numThreads: Int,
+    backendOptions: BackendOptionsMap?,
+) : Closeable {
 
   private val mHybridData: HybridData
   private val mMethodMetadata: Map<String, MethodMetadata>
@@ -33,7 +38,20 @@ open class Module private constructor(moduleAbsolutePath: String, loadMode: Int,
 
   init {
     ExecuTorchRuntime.getRuntime()
-    mHybridData = initHybrid(moduleAbsolutePath, loadMode, numThreads)
+    mHybridData =
+        if (backendOptions == null || backendOptions.isEmpty()) {
+          initHybrid(moduleAbsolutePath, loadMode, numThreads)
+        } else {
+          val (backendNames, optionKeys, optionValues) = backendOptions.toJniArrays()
+          initHybridWithOptions(
+              moduleAbsolutePath,
+              loadMode,
+              numThreads,
+              backendNames,
+              optionKeys,
+              optionValues,
+          )
+        }
     mMethodMetadata = populateMethodMeta()
   }
 
@@ -252,7 +270,33 @@ open class Module private constructor(moduleAbsolutePath: String, loadMode: Int,
     @JvmOverloads
     fun load(modelPath: String?, loadMode: Int = LOAD_MODE_FILE, numThreads: Int = 0): Module {
       ExecuTorchRuntime.validateFilePath(modelPath, "model path")
-      return Module(modelPath!!, loadMode, numThreads)
+      return Module(modelPath!!, loadMode, numThreads, null)
+    }
+
+    /**
+     * Loads a serialized ExecuTorch module and applies per-backend options at delegate-init (load)
+     * time. Prefer this over a process-global setter: the options travel with the load, so there is
+     * no ordering or thread-safety hazard to manage.
+     *
+     * @param modelPath path to file that contains the serialized ExecuTorch module.
+     * @param options backend options to apply at load, e.g.
+     *   `BackendOptionsMap().setInt("XnnpackBackend", "workspace_sharing_mode", 2)`.
+     * @param loadMode load mode for the module. See constants in [Module].
+     * @param numThreads the number of threads to use for inference. A value of 0 defaults to a
+     *   hardware-specific default.
+     * @return new [Module] object which owns the model module.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun load(
+        modelPath: String?,
+        options: BackendOptionsMap,
+        loadMode: Int = LOAD_MODE_FILE,
+        numThreads: Int = 0,
+    ): Module {
+      ExecuTorchRuntime.validateFilePath(modelPath, "model path")
+      // Non-null already guaranteed by validateFilePath above.
+      return Module(checkNotNull(modelPath), loadMode, numThreads, options)
     }
 
     @DoNotStrip
@@ -261,6 +305,17 @@ open class Module private constructor(moduleAbsolutePath: String, loadMode: Int,
         moduleAbsolutePath: String,
         loadMode: Int,
         numThreads: Int,
+    ): HybridData
+
+    @DoNotStrip
+    @JvmStatic
+    private external fun initHybridWithOptions(
+        moduleAbsolutePath: String,
+        loadMode: Int,
+        numThreads: Int,
+        backendNames: Array<String>,
+        optionKeys: Array<String>,
+        optionValues: IntArray,
     ): HybridData
 
     @DoNotStrip @JvmStatic fun readLogBufferStatic(): Array<String>? = readLogBufferStaticNative()

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -13,6 +13,7 @@
 #include <executorch/extension/module/module.h>
 #include <executorch/extension/runner_util/inputs.h>
 #include <executorch/extension/tensor/tensor.h>
+#include <executorch/runtime/backend/backend_options_map.h>
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 #include <executorch/runtime/core/portable_type/tensor_impl.h>
 #include <executorch/runtime/platform/log.h>
@@ -21,6 +22,7 @@
 #include <cassert>
 #include <chrono>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -265,6 +267,24 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
     return makeCxxInstance(modelPath, loadMode, numThreads);
   }
 
+  static facebook::jni::local_ref<jhybriddata> initHybridWithOptions(
+      facebook::jni::alias_ref<jclass>,
+      facebook::jni::alias_ref<jstring> modelPath,
+      jint loadMode,
+      jint numThreads,
+      facebook::jni::alias_ref<facebook::jni::JArrayClass<jstring>>
+          backendNames,
+      facebook::jni::alias_ref<facebook::jni::JArrayClass<jstring>> optionKeys,
+      facebook::jni::alias_ref<facebook::jni::JArrayInt> optionValues) {
+    return makeCxxInstance(
+        modelPath,
+        loadMode,
+        numThreads,
+        backendNames,
+        optionKeys,
+        optionValues);
+  }
+
   ExecuTorchJni(
       facebook::jni::alias_ref<jstring> modelPath,
       jint loadMode,
@@ -318,6 +338,70 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
     }
 #endif
 #endif
+  }
+
+  // Loads with the backend options after base construction, so the real load
+  // error surfaces here instead of being masked by the base ctor's "Failed to
+  // create Module".
+  ExecuTorchJni(
+      facebook::jni::alias_ref<jstring> modelPath,
+      jint loadMode,
+      jint numThreads,
+      facebook::jni::alias_ref<facebook::jni::JArrayClass<jstring>>
+          backendNames,
+      facebook::jni::alias_ref<facebook::jni::JArrayClass<jstring>> optionKeys,
+      facebook::jni::alias_ref<facebook::jni::JArrayInt> optionValues)
+      : ExecuTorchJni(modelPath, loadMode, numThreads) {
+    // Group entries by backend; the grouped vectors back the map's Spans, so
+    // they must outlive the load() call (which deep-copies).
+    std::map<std::string, std::vector<executorch::runtime::BackendOption>>
+        grouped;
+    const size_t count = backendNames->size();
+    if (optionKeys->size() != count || optionValues->size() != count) {
+      executorch::jni_helper::throwExecutorchException(
+          static_cast<uint32_t>(Error::InvalidArgument),
+          "backend option arrays must have equal length");
+      return;
+    }
+    auto values = optionValues->pin();
+    for (size_t i = 0; i < count; ++i) {
+      executorch::runtime::BackendOption option{};
+      const std::string key = optionKeys->getElement(i)->toStdString();
+      if (key.size() >= executorch::runtime::kMaxOptionKeyLength) {
+        executorch::jni_helper::throwExecutorchException(
+            static_cast<uint32_t>(Error::InvalidArgument),
+            "backend option key too long: " + key);
+        return;
+      }
+      std::strncpy(
+          option.key,
+          key.c_str(),
+          executorch::runtime::kMaxOptionKeyLength - 1);
+      option.key[executorch::runtime::kMaxOptionKeyLength - 1] = '\0';
+      option.value = static_cast<int>(values[i]);
+      grouped[backendNames->getElement(i)->toStdString()].push_back(option);
+    }
+
+    executorch::runtime::LoadBackendOptionsMap options_map;
+    for (auto& entry : grouped) {
+      const auto set_error = options_map.set_options(
+          entry.first.c_str(),
+          executorch::runtime::Span<executorch::runtime::BackendOption>(
+              entry.second.data(), entry.second.size()));
+      if (set_error != Error::Ok) {
+        executorch::jni_helper::throwExecutorchException(
+            static_cast<uint32_t>(set_error),
+            "Failed to set backend options for " + entry.first);
+        return;
+      }
+    }
+
+    const auto load_error = module_->load(options_map);
+    if (load_error != Error::Ok) {
+      executorch::jni_helper::throwExecutorchException(
+          static_cast<uint32_t>(load_error),
+          "Failed to load Module with backend options");
+    }
   }
 
   facebook::jni::local_ref<facebook::jni::JArrayClass<JEValue>> execute(
@@ -556,6 +640,8 @@ class ExecuTorchJni : public facebook::jni::HybridClass<ExecuTorchJni> {
   static void registerNatives() {
     registerHybrid({
         makeNativeMethod("initHybrid", ExecuTorchJni::initHybrid),
+        makeNativeMethod(
+            "initHybridWithOptions", ExecuTorchJni::initHybridWithOptions),
         makeNativeMethod("executeNative", ExecuTorchJni::execute),
         makeNativeMethod("loadMethodNative", ExecuTorchJni::load_method),
         makeNativeMethod("readLogBufferNative", ExecuTorchJni::readLogBuffer),


### PR DESCRIPTION
Summary:

Adds a per-model way to pass backend options at load (delegate-init) time on
Android, mirroring the iOS `loadWithOptions:` / `BackendOptionsMap` API. This
replaces an earlier attempt that used a process-global `set_option` setter (which
had ordering and per-model-scoping concerns raised in review).

API:
- `BackendOptionsMap` (Kotlin): a minimal builder — `setInt(backendName, key, value)`
  — backed by `mutableMapOf<String, MutableList<BackendOption>>`. Int-only for now
  (all current callers need); extensible to bool/string later for full iOS parity.
- `Module.load(path, options, ...)`: new overload. When options are non-empty the
  Module is constructed and eagerly loaded with them.

Implementation:
- The new JNI entry `initHybridWithOptions` is a *delegating* constructor: it
  delegates to the existing constructor (left byte-for-byte unchanged — which only
  CONSTRUCTS the Module; `is_loaded()` is false, no program load yet), then regroups
  the flattened (backend, key, int-value) arrays into a C++ `LoadBackendOptionsMap`
  and calls `module_->load(map)`. That is the single program load (`load_internal`
  is guarded by `is_loaded()`), so there is no double-load; the options are
  deep-copied onto the Module instance and applied per-delegate at method init via
  `BackendInitContext` — i.e. scoped to this model, not the process-global backend
  option store.
- The load error is surfaced directly (outside the base ctor's try) so the real
  error code/message reaches Java instead of being masked.
- Input validation: option-key length is checked against `kMaxOptionKeyLength`
  (throws `InvalidArgument` rather than silently truncating), the three parallel
  JNI arrays are asserted equal-length, and the `set_options` return value is
  checked and surfaced.

Because the options travel with the load, there is no process-global setter to
sequence before `Module.load` — ordering-safe and thread-safe by construction.

Reviewed By: psiddh

Differential Revision: D113100694


