### PR TITLE
Arm backend: exclude RESCALE from late FuseDuplicateUsersPass

### DIFF
--- a/backends/arm/_passes/fuse_duplicate_users_pass.py
+++ b/backends/arm/_passes/fuse_duplicate_users_pass.py
@@ -8,6 +8,7 @@ from typing import Any, Deque, Dict, Hashable, List, Set, Tuple, Type
 
 import torch
 from executorch.backends.arm._passes.arm_pass import ArmPass
+from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
 from executorch.exir.pass_base import ExportPass, PassResult
 from torch._ops import OpOverload
@@ -29,6 +30,14 @@ class FuseDuplicateUsersPass(ArmPass):
     """
 
     _passes_required_after: Set[Type[ExportPass]] = set()
+
+    # A fused RESCALE feeds its single output tensor to every original consumer.
+    # Later passes and the Vela compiler assume each integer RESCALE feeds one
+    # consumer, so collapsing duplicate RESCALE users onto a shared node corrupts
+    # integer outputs (observed as all-zero results on Ethos-U). Exclude RESCALE
+    # from fusion; the op-count wins this pass targets are on FP graphs, which
+    # carry no rescales.
+    _excluded_targets = frozenset({exir_ops.backend.tosa.RESCALE.default})
 
     def call(self, graph_module: GraphModule) -> PassResult:
         graph = graph_module.graph
@@ -93,6 +102,9 @@ class FuseDuplicateUsersPass(ArmPass):
                 continue
 
             if user.op != "call_function":
+                continue
+
+            if user.target in self._excluded_targets:
                 continue
 
             target_key = self._get_target_key(user.target)

--- a/backends/arm/test/passes/test_fuse_duplicate_users_pass.py
+++ b/backends/arm/test/passes/test_fuse_duplicate_users_pass.py
@@ -163,7 +163,7 @@ def test_fuse_duplicate_users_preserves_graph_order_for_representative():
     assert len(_add_node_names(result.graph_module)) == 1
 
 
-def test_fuse_duplicate_users_removes_identical_rescale_users():
+def test_fuse_duplicate_users_keeps_identical_rescale_users():
     graph_module = _graph_with_duplicate_rescale_users()
 
     with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+INT")):
@@ -172,10 +172,8 @@ def test_fuse_duplicate_users_removes_identical_rescale_users():
     rescale_nodes = _rescale_nodes(result.graph_module)
 
     result.graph_module.graph.lint()
-    assert result.modified
-    assert len(rescale_nodes) == 1
-    output_node = result.graph_module.graph.output_node()
-    assert output_node.args[0] == (rescale_nodes[0], rescale_nodes[0])
+    assert not result.modified
+    assert len(rescale_nodes) == 2
 
 
 class LateDuplicateUsers(torch.nn.Module):


### PR DESCRIPTION
Running `FuseDuplicateUsersPass` after TOSA lowering fuses value-identical `tosa.RESCALE` users of a shared producer onto one node feeding multiple consumers. Later passes and Vela assume each
integer `RESCALE` feeds a single consumer, so this miscompiles quantized graphs — observed as all-zero Ethos-U55 output for `addmm` (`test_addmm_u55_INT[basic]`, `[scalar_bias]`).

The duplicate nodes are structurally and quantization-identical, so no signature refinement can separate them; this excludes `tosa.RESCALE` from fusion instead. The op-count wins this pass
targets are on TOSA-FP graphs, which carry no rescales, so the exclusion preserves the intended benefit.

Also updates the pass test to assert identical `RESCALE` users are kept separate.

Authored with AI assistance (Claude Code).

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani