### PR TITLE
Docs: document how to limit build parallelism

### DIFF
--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -272,6 +272,24 @@ cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 
 > **_TIP:_** For faster rebuilds, consider installing ccache (see [Compiler Cache section](#compiler-cache-ccache) below). On first builds, ccache populates its cache. Subsequent builds with the same compiler flags can be significantly faster.
 
+#### Limiting Build Parallelism
+
+The `-j` value above applies only when invoking `cmake --build` directly. The workflow presets (`cmake --workflow --preset llm-release`) and the `Makefile` runner targets that wrap them (`make llama-cpu`, `make whisper-cpu`, and so on) build with unbounded parallelism, so the number of concurrent compiler processes is limited by the build graph rather than by core count.
+
+This matters in `kernels/portable/`, where the operator kernels are templated over every supported dtype. The most expensive of them peak around 400 MiB of resident memory per compiler process, so the risk comes from how many run concurrently rather than from any single one. On a machine with limited RAM, an unbounded build can exhaust memory and trigger the kernel OOM killer, which may terminate unrelated processes such as your editor or terminal.
+
+Set `CMAKE_BUILD_PARALLEL_LEVEL` to cap the job count. It takes precedence over the parallelism configured by a preset, so it works for every build entry point:
+
+```bash
+# Start low on a memory-constrained machine, and raise it if the build
+# stays comfortably within available RAM.
+export CMAKE_BUILD_PARALLEL_LEVEL=2
+
+make llama-cpu
+```
+
+Builds are incremental, so a build that was interrupted by the OOM killer resumes from the objects it already produced.
+
 <hr/>
 
 


### PR DESCRIPTION
### Summary

This PR documents how to limit build parallelism and explains why you might want to.

The existing `-j` guidance in the "Building" documentation only applies when invoking `cmake --build` directly. It doesn't affect the workflow presets or the `Makefile` targets that wrap them (for example, `make llama-cpu` and `make whisper-cpu`). Those presets set `"jobs": 0`, which tells CMake to defer to the native build tool. With the Makefile generator, that becomes `make -j` with no job limit, so the amount of parallelism is effectively determined by the build graph.

On an 8 GB laptop, running `make llama-cpu` launched well over 100 compiler processes at once. Memory was quickly exhausted, and the Linux OOM killer terminated both `cc1plus` processes and unrelated applications, including the editor and the terminal running the build:

```text
kernel: oom-kill:constraint=CONSTRAINT_NONE,...,global_oom,
        task_memcg=/user.slice/.../ptyxis-spawn-....scope,task=cc1plus
kernel: Out of memory: Killed process 12185 (code)
```

From the build output alone, this is difficult to diagnose. All you see is a long stream of

```text
gmake[2]: *** [...] Terminated
```

messages, with nothing to suggest that excessive build parallelism is the underlying cause.

Fortunately, `CMAKE_BUILD_PARALLEL_LEVEL` already solves this problem. It takes precedence over the job count configured by a preset, so it works regardless of whether the build is started through `cmake --build`, a workflow preset, or one of the `Makefile` targets.

Rather than changing the presets, this PR documents that existing mechanism. Simply removing `"jobs": 0` would make these builds run serially by default, which would be a behavior change.

### Test plan

Docs-only change; no build behavior is modified. All measurements were collected on Linux x86-64 with CMake 3.31.10 using the Makefile generator.

**1. Preset semantics.** I created a synthetic project with 20 independent 2-second tasks so that the elapsed time directly reflects the effective level of parallelism.

| Configuration | Elapsed | Effective jobs |
| --- | --- | --- |
| `jobs: 0` | 2.52 s | Unbounded (all 20) |
| `jobs: 0` + `CMAKE_BUILD_PARALLEL_LEVEL=2` | 21.24 s | 2 |
| No `jobs` key | 40.79 s | 1 (serial) |
| No `jobs` key + `CMAKE_BUILD_PARALLEL_LEVEL=4` | 10.40 s | 4 |

I repeated the same experiment through `cmake --workflow --preset` to cover the path used by the `Makefile` targets. The results were consistent: 2.28 s with unbounded parallelism and 20.46 s with `CMAKE_BUILD_PARALLEL_LEVEL=2`.

The first and third rows are also why this PR only updates the documentation. While `"jobs": 0` enables unbounded parallelism, removing the field entirely would change the default behavior to a serial build.

**2. Real ExecuTorch build.** I touched a set of `kernels/portable/cpu/op_*.cpp` files and rebuilt using the `llm-release-install` preset (the one that sets `"jobs": 0`). With `CCACHE_DISABLE=1` to force recompilation, I sampled the number of concurrent `cc1plus` processes every 200 ms.

| `CMAKE_BUILD_PARALLEL_LEVEL` | Max concurrent `cc1plus` | Peak combined RSS |
| --- | ---: | ---: |
| 1 | 1 | 415 MiB |
| 2 | 2 | 823 MiB |

This confirms that `CMAKE_BUILD_PARALLEL_LEVEL` overrides the preset in a real ExecuTorch build, not just in the synthetic example.

**3. Per-process memory.** Sampling peak single-process RSS at `CMAKE_BUILD_PARALLEL_LEVEL=1` showed that the most memory-intensive portable kernels peak at around 415 MiB. The dtype-promoting binary operators (`op_div`, `op_clamp`, and `op_where`) consume the most memory, while the physically largest source files (`op_grid_sampler_2d` and `op_convolution`) peak at only about 190 MiB. This suggests that template instantiation complexity has a larger impact than source file size.

These measurements are the basis for the approximately 400 MiB figure used in the documentation and support framing the failure mode as being driven by the number of concurrent compiler processes rather than by any single compilation.

`lintrunner` reports no issues on the modified file.

cc @mergennachin @nil-is-all @larryliu0820 @GregoryComer