### PR TITLE
Reland "Use const_data_ptr/mutable_data_ptr instead of deprecated data_ptr"

### DIFF
--- a/backends/cortex_m/ops/op_quantized_add.cpp
+++ b/backends/cortex_m/ops/op_quantized_add.cpp
@@ -66,8 +66,8 @@ Tensor& quantized_add_out(
   int32_t out_zp = static_cast<int32_t>(output_zero_point);
   int32_t output_mult = static_cast<int32_t>(output_multiplier);
   int output_shift_val = static_cast<int>(output_shift);
-  int8_t* input1_ptr = input1_int8.data_ptr<int8_t>();
-  int8_t* input2_ptr = input2_int8.data_ptr<int8_t>();
+  const int8_t* input1_ptr = input1_int8.const_data_ptr<int8_t>();
+  const int8_t* input2_ptr = input2_int8.const_data_ptr<int8_t>();
 
   // Left shift to maximize precision
   const int32_t left_shift = 20;
@@ -99,7 +99,7 @@ Tensor& quantized_add_out(
       std::swap<int32_t>(zp1, zp2);
       std::swap<int32_t>(input1_mult, input2_mult);
       std::swap<int>(input1_shift_val, input2_shift_val);
-      std::swap<int8_t*>(input1_ptr, input2_ptr);
+      std::swap(input1_ptr, input2_ptr);
     }
     adds_per_loop = input1_int8.size(1);
   } else {

--- a/backends/cortex_m/ops/op_quantized_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_conv2d.cpp
@@ -173,8 +173,8 @@ Tensor& quantized_conv2d_out(
   conv_params.activation.max = activation_max_val;
 
   cmsis_nn_per_channel_quant_params quant_params;
-  quant_params.multiplier = requantize_multipliers.data_ptr<int32_t>();
-  quant_params.shift = requantize_shifts.data_ptr<int32_t>();
+  quant_params.multiplier = requantize_multipliers.mutable_data_ptr<int32_t>();
+  quant_params.shift = requantize_shifts.mutable_data_ptr<int32_t>();
 
   const int8_t* input_data = input.const_data_ptr<int8_t>();
   const int8_t* weight_data = weight.const_data_ptr<int8_t>();

--- a/backends/cortex_m/ops/op_quantized_depthwise_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_depthwise_conv2d.cpp
@@ -211,8 +211,8 @@ Tensor& quantized_depthwise_conv2d_out(
   dw_conv_params.activation.max = activation_max_val;
 
   cmsis_nn_per_channel_quant_params quant_params;
-  quant_params.multiplier = requantize_multipliers.data_ptr<int32_t>();
-  quant_params.shift = requantize_shifts.data_ptr<int32_t>();
+  quant_params.multiplier = requantize_multipliers.mutable_data_ptr<int32_t>();
+  quant_params.shift = requantize_shifts.mutable_data_ptr<int32_t>();
 
   const int8_t* input_data = input.const_data_ptr<int8_t>();
   const int8_t* weight_data = weight.const_data_ptr<int8_t>();

--- a/backends/cortex_m/ops/op_quantized_linear.cpp
+++ b/backends/cortex_m/ops/op_quantized_linear.cpp
@@ -34,8 +34,9 @@ Tensor& quantized_linear_out(
   const int8_t* weight_data = weights.const_data_ptr<int8_t>();
   const int32_t* bias_data =
       bias.has_value() ? bias.value().const_data_ptr<int32_t>() : nullptr;
-  int32_t* kernel_sum_data =
-      kernel_sum.has_value() ? kernel_sum.value().data_ptr<int32_t>() : nullptr;
+  int32_t* kernel_sum_data = kernel_sum.has_value()
+      ? kernel_sum.value().mutable_data_ptr<int32_t>()
+      : nullptr;
   int8_t* output_data = out.mutable_data_ptr<int8_t>();
 
   cmsis_nn_context ctx;

--- a/backends/cortex_m/ops/op_quantized_mul.cpp
+++ b/backends/cortex_m/ops/op_quantized_mul.cpp
@@ -54,8 +54,8 @@ Tensor& quantized_mul_out(
       output_shift);
 
   // Extract quantization parameters
-  int8_t* input1_ptr = input1_int8.data_ptr<int8_t>();
-  int8_t* input2_ptr = input2_int8.data_ptr<int8_t>();
+  const int8_t* input1_ptr = input1_int8.const_data_ptr<int8_t>();
+  const int8_t* input2_ptr = input2_int8.const_data_ptr<int8_t>();
   int32_t zp1 = static_cast<int32_t>(input1_zero_point);
   int32_t zp2 = static_cast<int32_t>(input2_zero_point);
   const int32_t out_zp = static_cast<int32_t>(output_zero_point);
@@ -67,7 +67,7 @@ Tensor& quantized_mul_out(
   if (channel_broadcast) {
     if (input1_int8.numel() < input2_int8.numel()) {
       std::swap<int32_t>(zp1, zp2);
-      std::swap<int8_t*>(input1_ptr, input2_ptr);
+      std::swap(input1_ptr, input2_ptr);
     }
 
     muls_per_loop = input1_int8.size(1);

--- a/backends/cortex_m/ops/op_quantized_transpose_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_transpose_conv2d.cpp
@@ -172,8 +172,8 @@ Tensor& quantized_transpose_conv2d_out(
   transpose_conv_params.activation.max = activation_max_val;
 
   cmsis_nn_per_channel_quant_params quant_params;
-  quant_params.multiplier = requantize_multipliers.data_ptr<int32_t>();
-  quant_params.shift = requantize_shifts.data_ptr<int32_t>();
+  quant_params.multiplier = requantize_multipliers.mutable_data_ptr<int32_t>();
+  quant_params.shift = requantize_shifts.mutable_data_ptr<int32_t>();
 
   const int8_t* input_data = input.const_data_ptr<int8_t>();
   const int8_t* weight_data = weight.const_data_ptr<int8_t>();

--- a/backends/mediatek/runtime/NeuronBackend.cpp
+++ b/backends/mediatek/runtime/NeuronBackend.cpp
@@ -218,7 +218,7 @@ int NeuronExecuTorchDelegate::HintNeuronBackend(Span<EValue*> args) const {
     auto& allocator = GET_NEURON_ALLOCATOR;
     size_t inputCount = mInputSizes.size(), outputCount = mOutputSizes.size();
     for (int i = 0; i < inputCount; i++) {
-      auto data_ptr = args[i]->toTensor().data_ptr();
+      auto data_ptr = args[i]->toTensor().mutable_data_ptr();
       if (mHasImported.count(data_ptr)) {
         continue;
       }
@@ -230,7 +230,7 @@ int NeuronExecuTorchDelegate::HintNeuronBackend(Span<EValue*> args) const {
       }
     }
     for (int o = inputCount; o < inputCount + outputCount; o++) {
-      auto data_ptr = args[o]->toTensor().data_ptr();
+      auto data_ptr = args[o]->toTensor().mutable_data_ptr();
       if (mHasImported.count(data_ptr)) {
         continue;
       }

--- a/backends/mediatek/runtime/include/NeuronBackend.h
+++ b/backends/mediatek/runtime/include/NeuronBackend.h
@@ -241,7 +241,7 @@ class NeuronExecuTorchDelegate {
     // Prepare input data
     for (int i = 0; i < data_input_count; i++) {
       auto tensor_in = args[i]->toTensor();
-      auto data_ptr = tensor_in.data_ptr();
+      auto data_ptr = tensor_in.mutable_data_ptr();
       auto data_size = tensor_in.nbytes();
       mPreparedInputs.push_back(InputOutputInfo{data_ptr, data_size});
     }
@@ -258,7 +258,7 @@ class NeuronExecuTorchDelegate {
     for (int o = data_input_count; o < data_input_count + data_output_count;
          o++) {
       auto tensor_out = args[o]->toTensor();
-      auto data_ptr = tensor_out.data_ptr();
+      auto data_ptr = tensor_out.mutable_data_ptr();
       auto data_size = tensor_out.nbytes();
       mPreparedOutputs.push_back(InputOutputInfo{data_ptr, data_size});
     }

--- a/devtools/bundled_program/bundled_program.cpp
+++ b/devtools/bundled_program/bundled_program.cpp
@@ -426,8 +426,8 @@ ET_NODISCARD ErrorStats compute_method_output_error_stats(
         }
 
         // we assume float32 here; adapt for other dtypes as needed
-        const float* e_data = expected.data_ptr<float>();
-        const float* a_data = method_output_tensor.data_ptr<float>();
+        const float* e_data = expected.const_data_ptr<float>();
+        const float* a_data = method_output_tensor.const_data_ptr<float>();
 
         for (int64_t k = 0; k < nelem; ++k) {
           double abs_err = std::abs(a_data[k] - e_data[k]);

--- a/examples/llm_manual/main.cpp
+++ b/examples/llm_manual/main.cpp
@@ -54,8 +54,8 @@ std::string generate(
     // sampler expects.
     Tensor logits_tensor = logits_evalue.get()[0].toTensor();
     std::vector<float> logits(
-        logits_tensor.data_ptr<float>(),
-        logits_tensor.data_ptr<float>() + logits_tensor.numel());
+        logits_tensor.const_data_ptr<float>(),
+        logits_tensor.const_data_ptr<float>() + logits_tensor.numel());
 
     // Sample the next token from the logits.
     int64_t next_token = sampler.sample(logits);

--- a/examples/nxp/executor_runner/nxp_executor_runner.cpp
+++ b/examples/nxp/executor_runner/nxp_executor_runner.cpp
@@ -196,7 +196,7 @@ Error saveOutputs(
       return Error::AccessFailed;
     }
     fwrite(
-        values[i].toTensor().data_ptr(),
+        values[i].toTensor().const_data_ptr(),
         1,
         values[i].toTensor().nbytes(),
         datasetFile);

--- a/examples/qualcomm/oss_scripts/t5/runner/runner.cpp
+++ b/examples/qualcomm/oss_scripts/t5/runner/runner.cpp
@@ -116,7 +116,7 @@ Error Runner::load() {
 
 uint64_t Runner::logits_to_token(
     const executorch::aten::Tensor& logits_tensor) {
-  return sampler_->sample(logits_tensor.data_ptr<float>());
+  return sampler_->sample(logits_tensor.mutable_data_ptr<float>());
 }
 
 Error Runner::generate(

--- a/examples/qualcomm/oss_scripts/whisper/runner/runner.cpp
+++ b/examples/qualcomm/oss_scripts/whisper/runner/runner.cpp
@@ -110,7 +110,7 @@ Error Runner::load() {
 }
 uint64_t Runner::logits_to_token(
     const executorch::aten::Tensor& logits_tensor) {
-  return sampler_->sample(logits_tensor.data_ptr<float>());
+  return sampler_->sample(logits_tensor.mutable_data_ptr<float>());
 }
 /**
  * @param inputs: A vector containing one element: a vector of bytes that

--- a/examples/qualcomm/qaihub_scripts/llama/runner/runner.cpp
+++ b/examples/qualcomm/qaihub_scripts/llama/runner/runner.cpp
@@ -134,7 +134,7 @@ Error Runner::load() {
 
 int32_t Runner::logitsToToken(const Tensor& logits_tensor) {
   static std::vector<float> logits_f(vocab_size_);
-  const uint16_t* logits = logits_tensor.data_ptr<uint16_t>();
+  const uint16_t* logits = logits_tensor.const_data_ptr<uint16_t>();
 
 #if defined(__aarch64__)
   static int32x4_t offset = vmovq_n_s32(logits_offset_);

--- a/extension/android/jni/jni_layer.cpp
+++ b/extension/android/jni/jni_layer.cpp
@@ -88,7 +88,7 @@ class TensorHybrid : public facebook::jni::HybridClass<TensorHybrid> {
     // value immediately so the data is valid.
     facebook::jni::local_ref<facebook::jni::JByteBuffer> jTensorBuffer =
         facebook::jni::JByteBuffer::wrapBytes(
-            (uint8_t*)tensor.data_ptr(), tensor.nbytes());
+            (uint8_t*)tensor.mutable_data_ptr(), tensor.nbytes());
     jTensorBuffer->order(facebook::jni::JByteOrder::nativeOrder());
 
     static const auto jMethodNewTensor =

--- a/extension/flat_tensor/serialize/serialize.cpp
+++ b/extension/flat_tensor/serialize/serialize.cpp
@@ -191,7 +191,8 @@ runtime::Error save_ptd(
   i = tensor_map.size();
   for (const auto& [name, tensor] : tensor_map) {
     out.write(
-        reinterpret_cast<const char*>(tensor.data_ptr()), tensor.nbytes());
+        reinterpret_cast<const char*>(tensor.const_data_ptr()),
+        tensor.nbytes());
     // Don't pad last entry.
     if (i != 1) {
       write_nulls(out, padding_required(tensor.nbytes(), tensor_alignment));

--- a/extension/llm/runner/pybindings.cpp
+++ b/extension/llm/runner/pybindings.cpp
@@ -610,7 +610,7 @@ PYBIND11_MODULE(_llm_runner, m) {
 
         image_tensor = image_tensor.contiguous();
         if (image_tensor.scalar_type() == torch::kUInt8) {
-          uint8_t* data = image_tensor.data_ptr<uint8_t>();
+          const uint8_t* data = image_tensor.const_data_ptr<uint8_t>();
           std::vector<uint8_t> image_data(data, data + image_tensor.numel());
           return MultimodalInput(Image(
               std::move(image_data),
@@ -618,7 +618,7 @@ PYBIND11_MODULE(_llm_runner, m) {
               static_cast<int32_t>(height),
               static_cast<int32_t>(channels)));
         } else if (image_tensor.scalar_type() == torch::kFloat) {
-          float* data = image_tensor.data_ptr<float>();
+          const float* data = image_tensor.const_data_ptr<float>();
           std::vector<float> image_data(data, data + image_tensor.numel());
           return MultimodalInput(Image(
               std::move(image_data),
@@ -647,7 +647,7 @@ PYBIND11_MODULE(_llm_runner, m) {
 
         audio_tensor = audio_tensor.contiguous();
         if (audio_tensor.scalar_type() == torch::kUInt8) {
-          uint8_t* data = audio_tensor.data_ptr<uint8_t>();
+          const uint8_t* data = audio_tensor.const_data_ptr<uint8_t>();
           std::vector<uint8_t> audio_data(data, data + audio_tensor.numel());
           return MultimodalInput(Audio(
               std::move(audio_data),
@@ -655,7 +655,7 @@ PYBIND11_MODULE(_llm_runner, m) {
               static_cast<int32_t>(n_bins),
               static_cast<int32_t>(n_frames)));
         } else if (audio_tensor.scalar_type() == torch::kFloat) {
-          float* data = audio_tensor.data_ptr<float>();
+          const float* data = audio_tensor.const_data_ptr<float>();
           std::vector<float> audio_data(data, data + audio_tensor.numel());
           return MultimodalInput(Audio(
               std::move(audio_data),
@@ -684,7 +684,7 @@ PYBIND11_MODULE(_llm_runner, m) {
 
         audio_tensor = audio_tensor.contiguous();
         if (audio_tensor.scalar_type() == torch::kUInt8) {
-          uint8_t* data = audio_tensor.data_ptr<uint8_t>();
+          const uint8_t* data = audio_tensor.const_data_ptr<uint8_t>();
           std::vector<uint8_t> audio_data(data, data + audio_tensor.numel());
           return MultimodalInput(RawAudio{
               std::move(audio_data),

--- a/extension/llm/sampler/test/test_sampler.cpp
+++ b/extension/llm/sampler/test/test_sampler.cpp
@@ -26,7 +26,7 @@ TEST(SamplerTest, TestArgMax) {
   // -7.5863]]])
   torch::Tensor input = torch::rand({1, 1, 32000}, at::kFloat);
   input[0][0][396] = 1.0f;
-  EXPECT_EQ(sampler.sample(input.data_ptr<float>()), 396);
+  EXPECT_EQ(sampler.sample(input.mutable_data_ptr<float>()), 396);
 }
 
 TEST(SamplerTest, TestArgMaxWithFP16) {
@@ -39,7 +39,7 @@ TEST(SamplerTest, TestArgMaxWithFP16) {
   // -7.5863]]])
   torch::Tensor input = torch::rand({1, 1, 32000}, at::kHalf);
   input[0][0][396] = 1.0f;
-  EXPECT_EQ(sampler.sample(input.data_ptr<c10::Half>()), 396);
+  EXPECT_EQ(sampler.sample(input.mutable_data_ptr<c10::Half>()), 396);
 }
 
 TEST(SamplerTest, TestTopKRestrictsToCandidates) {
@@ -62,7 +62,7 @@ TEST(SamplerTest, TestTopKRestrictsToCandidates) {
   for (int trial = 0; trial < 50; ++trial) {
     // Re-fill logits each trial because sample() mutates them in place.
     torch::Tensor logits = input.clone();
-    int32_t out = sampler.sample(logits.data_ptr<float>());
+    int32_t out = sampler.sample(logits.mutable_data_ptr<float>());
     EXPECT_TRUE(allowed.count(out)) << "trial " << trial << " got " << out;
   }
 }
@@ -84,7 +84,7 @@ TEST(SamplerTest, TestTopKDisabledByZero) {
   int hits = 0;
   for (int trial = 0; trial < 20; ++trial) {
     torch::Tensor logits = input.clone();
-    if (sampler.sample(logits.data_ptr<float>()) == 11) {
+    if (sampler.sample(logits.mutable_data_ptr<float>()) == 11) {
       hits++;
     }
   }
@@ -107,7 +107,7 @@ TEST(SamplerTest, TestTopKWithFP16) {
   std::set<int32_t> allowed = {3, 8};
   for (int trial = 0; trial < 30; ++trial) {
     torch::Tensor logits = input.clone();
-    int32_t out = sampler.sample(logits.data_ptr<c10::Half>());
+    int32_t out = sampler.sample(logits.mutable_data_ptr<c10::Half>());
     EXPECT_TRUE(allowed.count(out)) << "trial " << trial << " got " << out;
   }
 }
@@ -126,7 +126,7 @@ TEST(SamplerTest, TestTopKEqualsOneIsArgmax) {
 
   for (int trial = 0; trial < 10; ++trial) {
     torch::Tensor logits = input.clone();
-    EXPECT_EQ(sampler.sample(logits.data_ptr<float>()), 57);
+    EXPECT_EQ(sampler.sample(logits.mutable_data_ptr<float>()), 57);
   }
 }
 
@@ -148,7 +148,7 @@ TEST(SamplerTest, TestTopKTakesPrecedenceOverTopP) {
   std::set<int32_t> allowed = {3, 8};
   for (int trial = 0; trial < 50; ++trial) {
     torch::Tensor logits = input.clone();
-    int32_t out = sampler.sample(logits.data_ptr<float>());
+    int32_t out = sampler.sample(logits.mutable_data_ptr<float>());
     EXPECT_TRUE(allowed.count(out)) << "trial " << trial << " got " << out;
   }
 }

--- a/extension/training/test/training_loop_test.cpp
+++ b/extension/training/test/training_loop_test.cpp
@@ -58,7 +58,8 @@ TEST_F(TrainingLoopTest, OptimizerSteps) {
   auto param_res = mod.named_parameters("forward");
   ASSERT_EQ(param_res.error(), Error::Ok);
 
-  float orig_data = param_res.get().at("linear.weight").data_ptr<float>()[0];
+  float orig_data =
+      param_res.get().at("linear.weight").const_data_ptr<float>()[0];
 
   SGDOptions options{0.1};
   SGD optimizer(param_res.get(), options);
@@ -77,5 +78,6 @@ TEST_F(TrainingLoopTest, OptimizerSteps) {
 
   // Check that the data has changed.
   ASSERT_NE(
-      param_res.get().at("linear.weight").data_ptr<float>()[0], orig_data);
+      param_res.get().at("linear.weight").const_data_ptr<float>()[0],
+      orig_data);
 }

--- a/kernels/portable/test/op_allclose_test.cpp
+++ b/kernels/portable/test/op_allclose_test.cpp
@@ -38,8 +38,8 @@ class OpAllCloseTest : public OperatorTest {
     Tensor a = tf.ones(/*sizes=*/{2, 2});
     Tensor b = tf.ones(/*sizes=*/{2, 2});
 
-    auto a_data = a.data_ptr<CTYPE>();
-    auto b_data = b.data_ptr<CTYPE>();
+    auto a_data = a.const_data_ptr<CTYPE>();
+    auto b_data = b.mutable_data_ptr<CTYPE>();
     b_data[0] = a_data[0] + adiff + a_data[0] * rdiff;
 
     TensorFactory<ScalarType::Bool> tf_bool;
@@ -54,7 +54,7 @@ class OpAllCloseTest : public OperatorTest {
         /*dummy_param=*/false,
         out);
 
-    auto out_data = out.data_ptr<bool>();
+    auto out_data = out.const_data_ptr<bool>();
     EXPECT_EQ(out_data[0], should_match)
         << a_data[0] << " doesn't match " << b_data[0] << "; dtype " << DTYPE;
   }
@@ -76,7 +76,7 @@ TEST_F(OpAllCloseTest, IdenticalFloatTensors) {
       /*dummy_param=*/false,
       out);
 
-  auto out_data = out.data_ptr<bool>();
+  auto out_data = out.const_data_ptr<bool>();
   EXPECT_EQ(out_data[0], true);
 }
 
@@ -96,7 +96,7 @@ TEST_F(OpAllCloseTest, IdenticalDoubleTensors) {
       /*dummy_param=*/false,
       out);
 
-  auto out_data = out.data_ptr<bool>();
+  auto out_data = out.const_data_ptr<bool>();
   EXPECT_EQ(out_data[0], true);
 }
 
@@ -116,7 +116,7 @@ TEST_F(OpAllCloseTest, NonEqualFloatTensors) {
       /*dummy_param=*/false,
       out);
 
-  auto out_data = out.data_ptr<bool>();
+  auto out_data = out.const_data_ptr<bool>();
   EXPECT_EQ(out_data[0], false);
 }
 
@@ -136,7 +136,7 @@ TEST_F(OpAllCloseTest, NonEqualDoubleTensors) {
       /*dummy_param=*/false,
       out);
 
-  auto out_data = out.data_ptr<bool>();
+  auto out_data = out.const_data_ptr<bool>();
   EXPECT_EQ(out_data[0], false);
 }
 
@@ -155,7 +155,7 @@ TEST_F(OpAllCloseTest, IdenticalIntTensors) {
       /*dummy_param=*/false,
       out);
 
-  auto out_data = out.data_ptr<bool>();
+  auto out_data = out.const_data_ptr<bool>();
   EXPECT_EQ(out_data[0], true);
 }
 
@@ -174,7 +174,7 @@ TEST_F(OpAllCloseTest, NonEqualIntTensors) {
       /*dummy_param=*/false,
       out);
 
-  auto out_data = out.data_ptr<bool>();
+  auto out_data = out.const_data_ptr<bool>();
   EXPECT_EQ(out_data[0], false);
 }
 
@@ -192,7 +192,7 @@ TEST_F(OpAllCloseTest, IdenticalBoolTensors) {
       /*equal_nan=*/false,
       /*dummy_param=*/false,
       out);
-  auto out_data = out.data_ptr<bool>();
+  auto out_data = out.const_data_ptr<bool>();
   EXPECT_EQ(out_data[0], true);
 }
 
@@ -200,7 +200,7 @@ TEST_F(OpAllCloseTest, NonEqualBoolTensors) {
   TensorFactory<ScalarType::Bool> tf_bool;
   Tensor a = tf_bool.ones(/*sizes=*/{2, 2});
   Tensor b = tf_bool.ones(/*sizes=*/{2, 2});
-  auto b_data = b.data_ptr<bool>();
+  auto b_data = b.mutable_data_ptr<bool>();
   b_data[0] = false;
   Tensor out = tf_bool.zeros(/*sizes=*/{1});
 
@@ -212,7 +212,7 @@ TEST_F(OpAllCloseTest, NonEqualBoolTensors) {
       /*equal_nan=*/false,
       /*dummy_param=*/false,
       out);
-  auto out_data = out.data_ptr<bool>();
+  auto out_data = out.const_data_ptr<bool>();
   EXPECT_EQ(out_data[0], false);
 }
 

--- a/kernels/test/custom_kernel_example/op_relu.cpp
+++ b/kernels/test/custom_kernel_example/op_relu.cpp
@@ -34,8 +34,8 @@ namespace {
  */
 template <typename CTYPE>
 void relu(const Tensor& input, Tensor& output) {
-  const CTYPE* in_data = input.data_ptr<CTYPE>();
-  CTYPE* out_data = output.data_ptr<CTYPE>();
+  const CTYPE* in_data = input.const_data_ptr<CTYPE>();
+  CTYPE* out_data = output.mutable_data_ptr<CTYPE>();
   size_t lim = input.numel();
   Tensor::SizesType expected_output_size[16];
   for (size_t i = 0; i < output.dim(); ++i) {

--- a/runtime/core/exec_aten/testing_util/tensor_factory.h
+++ b/runtime/core/exec_aten/testing_util/tensor_factory.h
@@ -391,7 +391,8 @@ class TensorFactory {
     int32_t W = sizes[3];
 
     std::vector<ctype> contiguous_data(
-        input.data_ptr<ctype>(), input.data_ptr<ctype>() + input.numel());
+        input.const_data_ptr<ctype>(),
+        input.const_data_ptr<ctype>() + input.numel());
     std::vector<ctype> channels_last_data(
         N * C * H * W); // Create a new blob with the same total size to contain
                         // channels_last data
@@ -901,7 +902,8 @@ class TensorFactory {
     int32_t W = sizes[3];
 
     std::vector<ctype> contiguous_data(
-        input.data_ptr<ctype>(), input.data_ptr<ctype>() + input.numel());
+        input.const_data_ptr<ctype>(),
+        input.const_data_ptr<ctype>() + input.numel());
     std::vector<ctype> channels_last_data(
         N * C * H * W); // Create a new blob with the same total size to contain
                         // channels_last data


### PR DESCRIPTION
Relands #20958. Reverted in b3d69a98ed because `op_allclose_test` broke the internal (non-OSS) build: `b_data` was `const_data_ptr` but written on the next line. Now `mutable_data_ptr`; grepped the other test files for the same const/mutable slip, found none.

