### PR TITLE
Fix reasoning routing and cross-turn carry

### DIFF
--- a/examples/llm_server/python/protocol.py
+++ b/examples/llm_server/python/protocol.py
@@ -38,6 +38,11 @@ class ChatMessage(BaseModel):
     role: str
     content: Optional[Union[str, list[dict[str, Any]]]] = None
     name: Optional[str] = None
+    # Optional prior-turn reasoning (chain-of-thought). Mirrors
+    # ResponseMessage.reasoning_content so a multi-turn client can echo an assistant
+    # turn's reasoning back into the request; a chat template that renders prior
+    # reasoning needs it here, and without the field it is dropped at parse.
+    reasoning_content: Optional[str] = None
     tool_calls: Optional[list[ToolCall]] = None
     tool_call_id: Optional[str] = None
 

--- a/examples/llm_server/python/serving_chat.py
+++ b/examples/llm_server/python/serving_chat.py
@@ -189,6 +189,11 @@ class ServingChat:
 
     def _extract_response(self, req: ChatCompletionRequest, text: str):
         """Return tool calls, optional reasoning, and user-visible content."""
+        # Split the reasoning channel out BEFORE tool parsing so the detector only
+        # sees the visible (non-reasoning) text. Parsing the full raw output would let
+        # a tool-call marker the model emitted inside its private reasoning become a
+        # phantom tool call (and drop the real answer).
+        reasoning, text = self._split_reasoning(text)
         tool_calls = None
         if self._tools_active(req):
             parsed = self._tool_detector_cls().detect_and_parse(
@@ -197,7 +202,6 @@ class ServingChat:
             if parsed.calls:
                 tool_calls = [self._to_openai_tool_call(c) for c in parsed.calls]
             text = parsed.normal_text
-        reasoning, text = self._split_reasoning(text)
         if not self._return_reasoning(req):
             reasoning = None
         return tool_calls, reasoning, self._visible_content(text) or None


### PR DESCRIPTION
Summary:
Two fixes to the shared OpenAI chat adapter's reasoning handling, both surfaced by differential parity checks of the control plane against a live reference parser/renderer.

First, `ServingChat._extract_response` ran the tool-call detector on the full raw generation before `_split_reasoning` separated the reasoning channel. Because the detector is not reasoning-aware, a tool-call marker the model emits inside its private reasoning became a phantom tool call (and the real answer was dropped). Split the reasoning channel out first and run the detector only on the visible text.

Second, the input `ChatMessage` schema had no `reasoning_content` field, so a multi-turn client echoing a prior assistant turn's reasoning had it dropped at parse. A reasoning-aware chat template renders prior reasoning from `reasoning_content` (the same key `ResponseMessage` emits), so without the field every prior reasoning turn vanished from the assembled prompt. Add `reasoning_content` to `ChatMessage` so reasoning survives across turns on the re-render path; the warm-resume token-splice path already preserved it via the raw ids, so this also makes the two paths consistent.

This diff was authored with Claude Code.

Reviewed By: Gasoonjia

Differential Revision: D113436993
