### PR TITLE
Update eIQ Neutron SDK to 3.2.0

### DIFF
--- a/backends/nxp/backend/neutron_target_spec.py
+++ b/backends/nxp/backend/neutron_target_spec.py
@@ -122,20 +122,40 @@ class NeutronTargetSpec:
 
     # Whether the target has subsystem (Neutron-S) or not (Neutron-C).
     def is_subsystem(self) -> bool:
-        return self.neutron_target.subsystem
+        return (
+            self.neutron_target.npu.subsystem
+            if hasattr(self.neutron_target, "npu")
+            else self.neutron_target.subsystem
+        )
 
     # Number of compute units.
     def get_num_units(self) -> int:
-        return self.neutron_target.numUnits
+        return (
+            self.neutron_target.npu.numUnits
+            if hasattr(self.neutron_target, "npu")
+            else self.neutron_target.numUnits
+        )
 
     # Number of compute pipelines.
     def get_num_pipes(self) -> int:
-        return self.neutron_target.numPipes
+        return (
+            self.neutron_target.npu.numPipes
+            if hasattr(self.neutron_target, "npu")
+            else self.neutron_target.numPipes
+        )
 
     # Number of compute MACs.
     def get_num_macs(self) -> int:
-        return self.neutron_target.numMacs
+        return (
+            self.neutron_target.npu.numMacs
+            if hasattr(self.neutron_target, "npu")
+            else self.neutron_target.numMacs
+        )
 
     # Neutron compute block hardware version.
     def get_hw_version(self) -> NeutronHWVersion:
-        return NeutronHWVersion(self.neutron_target.hwVersion)
+        return NeutronHWVersion(
+            self.neutron_target.npu.hwVersion
+            if hasattr(self.neutron_target, "npu")
+            else self.neutron_target.hwVersion
+        )

--- a/backends/nxp/requirements-eiq.txt
+++ b/backends/nxp/requirements-eiq.txt
@@ -1,3 +1,3 @@
 --index-url https://eiq.nxp.com/repository
-eiq-neutron-sdk==3.1.3
+eiq-neutron-sdk==3.2.0
 eiq_nsys

--- a/backends/nxp/tests/ir/converter/node_converter/test_conv_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_conv_converter.py
@@ -757,6 +757,10 @@ class TestConv:
                 s := 1,
                 d := 1,
                 id=f"bounds of kernel height: {_conv_id(ins, oc, ks=ks, s=s, d=d)}",
+                marks=pytest.mark.xfail(
+                    reason="AIR-14679",
+                    strict=True,
+                ),
             ),
             pytest.param(
                 ins := (4, 3, 3, 8500),

--- a/backends/nxp/tests/ir/converter/node_converter/test_conv_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_conv_converter.py
@@ -757,10 +757,6 @@ class TestConv:
                 s := 1,
                 d := 1,
                 id=f"bounds of kernel height: {_conv_id(ins, oc, ks=ks, s=s, d=d)}",
-                marks=pytest.mark.xfail(
-                    reason="AIR-14679",
-                    strict=True,
-                ),
             ),
             pytest.param(
                 ins := (4, 3, 3, 8500),

--- a/docs/source/backends/nxp/nxp-overview.md
+++ b/docs/source/backends/nxp/nxp-overview.md
@@ -24,10 +24,10 @@ Among currently supported machine learning models are:
 
 - [MCUXpresso IDE](https://www.nxp.com/design/design-center/software/development-software/mcuxpresso-software-and-tools-/mcuxpresso-integrated-development-environment-ide:MCUXpresso-IDE) or [MCUXpresso Visual Studio Code extension](https://www.nxp.com/design/design-center/software/development-software/mcuxpresso-software-and-tools-/mcuxpresso-for-visual-studio-code:MCUXPRESSO-VSC)
 - [MCUXpresso SDK 26.06](https://mcuxpresso.nxp.com/mcuxsdk/26.06.00/html/index.html)
-- eIQ Neutron SDK version 3.1.3, what you can download from eIQ PyPI:
+- eIQ Neutron SDK version 3.2.0, what you can download from eIQ PyPI:
 
 ```commandline
-$ pip install --index-url https://eiq.nxp.com/repository eiq-neutron-sdk==3.1.3
+$ pip install --index-url https://eiq.nxp.com/repository eiq-neutron-sdk==3.2.0
 ```
 
 Instead of manually installing requirements, except MCUXpresso IDE and SDK, you can use the setup script: 

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -8,7 +8,7 @@ set -u
 EIQ_PYPI_URL="${EIQ_PYPI_URL:-https://eiq.nxp.com/repository}"
 
 # Install eIQ Neutron dependencies - SDK and simulator
-pip install --index-url ${EIQ_PYPI_URL} eiq-neutron-sdk==3.1.3 eiq_nsys
+pip install --index-url ${EIQ_PYPI_URL} eiq-neutron-sdk==3.2.0 eiq_nsys
 
 # Get the directory of the current script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
### Summary
Upgrade the eIQ Neutron SDK to v3.2.0 with backward compatibility.

### Test plan
Tests can be manually run using pytest -c /dev/null backends/nxp/tests/


cc @robert-kalmar @JakeStevens @digantdesai @rascani