### PR TITLE
[ExecuTorch][WebGPU] Add thin partitioner frontend

### DIFF
--- a/backends/webgpu/README.md
+++ b/backends/webgpu/README.md
@@ -88,7 +88,7 @@ PyTorch model
     │  torch.export
     ▼
 Exported Program
-    │  VulkanPartitioner (tags supported ops)
+    │  WebGPUPartitioner (wraps VulkanPartitioner)
     ▼
 Edge Dialect IR
     │  VulkanBackend.preprocess (builds a Vulkan FlatBuffer)
@@ -110,8 +110,10 @@ Key design choices:
   storage annotations and allocates tensors as buffers.
 - **Built-in WGSL shaders.** Shader source is embedded as C++ string constants,
   with build-time code generation and drift validation.
-- **No Python AOT layer.** The backend directly consumes `.pte` files exported
-  with `VulkanPartitioner`.
+- **Thin Python AOT frontend.** `WebGPUPartitioner` delegates unchanged to
+  `VulkanPartitioner`, preserving Vulkan serialization and the `VulkanBackend`
+  delegate id. It does not independently validate the narrower WebGPU runtime
+  capability set; WebGPU integrations apply that policy separately.
 - **Dynamic shapes.** Tensors allocate at their maximum shape, with SymInt
   arithmetic and per-operator resize hooks for runtime dimensions.
 - **Shape-routed dispatch.** Runtime tensor dimensions select specialized
@@ -140,9 +142,7 @@ of using this script.
 ```python
 import torch
 
-from executorch.backends.vulkan.partitioner.vulkan_partitioner import (
-    VulkanPartitioner,
-)
+from executorch.backends.webgpu.partitioner import WebGPUPartitioner
 from executorch.exir import to_edge_transform_and_lower
 
 
@@ -153,7 +153,7 @@ class AddOne(torch.nn.Module):
 
 ep = torch.export.export(AddOne(), (torch.randn(4, 4),))
 et_program = to_edge_transform_and_lower(
-    ep, partitioner=[VulkanPartitioner()]
+    ep, partitioner=[WebGPUPartitioner()]
 ).to_executorch()
 
 with open("model.pte", "wb") as file:
@@ -178,6 +178,7 @@ output.
 backends/webgpu/
 ├── CMakeLists.txt
 ├── README.md
+├── partitioner/                  # Thin VulkanPartitioner frontend
 ├── runtime/
 │   ├── WebGPUBackend.h/cpp          # BackendInterface (init/execute)
 │   ├── WebGPUGraph.h/cpp            # GPU graph: buffers, pipelines, dispatch

--- a/backends/webgpu/TODO.md
+++ b/backends/webgpu/TODO.md
@@ -2,24 +2,26 @@
 
 ## Current State (Prototype)
 - Single op: `aten.add.Tensor` (fp32, buffer storage)
-- No Python AOT code — directly consumes Vulkan delegate (.pte exported via VulkanPartitioner)
+- Thin `WebGPUPartitioner` Python frontend wrapping `VulkanPartitioner`
 - Reuses Vulkan FlatBuffer format (VH00 header + VK00 payload)
 - Registers as `"VulkanBackend"` at runtime — mutually exclusive with Vulkan backend at link time
 - Built-in WGSL shaders (not embedded in .pte)
 
 ## Architecture
 ```
-VulkanPartitioner (Python) → VkGraphBuilder → VK00 FlatBuffer → .pte
+WebGPUPartitioner → VulkanPartitioner → VkGraphBuilder → VK00 FlatBuffer → .pte
     → WebGPU Runtime: registers as "VulkanBackend", parses VH00/VK00
     → WebGPUGraph::build → GPU buffers/pipelines/bind groups
     → WebGPUGraph::execute → encode + submit compute passes
 ```
 
-Adding a new op requires only C++ runtime work:
+The wrapper preserves Vulkan partitioning behavior and does not validate WebGPU
+runtime capabilities. WebGPU test and export integrations apply their supported-op
+policy separately. Adding a new op requires runtime work plus updating that policy:
 1. WGSL shader + header
 2. C++ op implementation (read args from VkGraph, create pipeline, record dispatch)
 3. Register in CMakeLists.txt
-4. Test with VulkanPartitioner export
+4. Add it to the WebGPU support policy and test with `WebGPUPartitioner` export
 
 ## Performance: Command Encoding Overhead
 WebGPU `GPUCommandBuffer` is single-use (no equivalent to Vulkan's cached command lists).

--- a/backends/webgpu/partitioner/BUCK
+++ b/backends/webgpu/partitioner/BUCK
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+oncall("executorch")
+
+fbcode_target(
+    _kind = runtime.python_library,
+    name = "webgpu_partitioner",
+    srcs = [
+        "__init__.py",
+        "partitioner.py",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/vulkan:op_registry",
+        "//executorch/backends/vulkan/partitioner:vulkan_partitioner",
+        "//executorch/exir/backend:partitioner",
+    ],
+    typing = True,
+)

--- a/backends/webgpu/partitioner/__init__.py
+++ b/backends/webgpu/partitioner/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from executorch.backends.webgpu.partitioner.partitioner import WebGPUPartitioner
+
+__all__ = ["WebGPUPartitioner"]

--- a/backends/webgpu/partitioner/partitioner.py
+++ b/backends/webgpu/partitioner/partitioner.py
@@ -1,0 +1,44 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from typing import Any, Callable, Dict, final, List, Optional, Tuple
+
+import torch
+from executorch.backends.vulkan.op_registry import OpKey
+from executorch.backends.vulkan.partitioner.vulkan_partitioner import VulkanPartitioner
+from executorch.exir.backend.partitioner import Partitioner, PartitionResult
+from torch.export import ExportedProgram
+
+
+@final
+class WebGPUPartitioner(Partitioner):
+    """WebGPU frontend for the Vulkan partitioning and serialization path."""
+
+    def __init__(
+        self,
+        compile_options: Optional[Dict[str, Any]] = None,
+        operator_blocklist: Optional[List[OpKey]] = None,
+        operator_allowlist: Optional[List[OpKey]] = None,
+        nn_module_blocklist: Optional[List[str]] = None,
+        nn_module_allowlist: Optional[List[str]] = None,
+    ) -> None:
+        self._vulkan_partitioner = VulkanPartitioner(
+            compile_options=compile_options,
+            operator_blocklist=operator_blocklist,
+            operator_allowlist=operator_allowlist,
+            nn_module_blocklist=nn_module_blocklist,
+            nn_module_allowlist=nn_module_allowlist,
+        )
+
+    def ops_to_not_decompose(
+        self, ep: ExportedProgram
+    ) -> Tuple[List[torch._ops.OpOverload], Optional[Callable[[torch.fx.Node], bool]]]:
+        return self._vulkan_partitioner.ops_to_not_decompose(ep)
+
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
+        return self._vulkan_partitioner.partition(exported_program)

--- a/backends/webgpu/test/BUCK
+++ b/backends/webgpu/test/BUCK
@@ -34,11 +34,33 @@ fbcode_target(
 )
 
 fbcode_target(
+    _kind = python_unittest,
+    name = "test_webgpu_partitioner",
+    srcs = [
+        "test_webgpu_partitioner.py",
+    ],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/vulkan/partitioner:vulkan_partitioner",
+        "//executorch/backends/vulkan:vulkan_preprocess",
+        "//executorch/backends/webgpu/partitioner:webgpu_partitioner",
+        "//executorch/backends/webgpu/test:tester",
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:partitioner",
+    ],
+)
+
+fbcode_target(
     _kind = runtime.python_library,
     name = "tester",
     srcs = ["tester.py"],
     deps = [
-        "//executorch/backends/vulkan/partitioner:vulkan_partitioner",
-        "//executorch/backends/vulkan:vulkan_preprocess",
+        "//caffe2:torch",
+        "//executorch/backends/test/harness:tester",
+        "//executorch/backends/transforms:duplicate_dynamic_quant_chain",
+        "//executorch/backends/webgpu/partitioner:webgpu_partitioner",
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:partitioner",
+        "//pytorch/ao:torchao",  # @manual
     ],
 )

--- a/backends/webgpu/test/test_webgpu_partitioner.py
+++ b/backends/webgpu/test/test_webgpu_partitioner.py
@@ -1,0 +1,171 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import unittest
+from typing import List
+
+import torch
+from executorch.backends.vulkan.partitioner.vulkan_partitioner import VulkanPartitioner
+from executorch.backends.webgpu.partitioner import WebGPUPartitioner
+from executorch.backends.webgpu.test.tester import Partition, ToEdgeTransformAndLower
+from executorch.exir import (
+    ExecutorchProgramManager,
+    to_edge,
+    to_edge_transform_and_lower,
+)
+from executorch.exir.backend.partitioner import Partitioner, PartitionResult
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.export import ExportedProgram
+
+
+class AddModule(torch.nn.Module):
+    def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        return a + b
+
+
+class TestWebGPUPartitioner(unittest.TestCase):
+    def _export_add(self) -> ExportedProgram:
+        return torch.export.export(
+            AddModule(),
+            (torch.ones(2, 3), torch.full((2, 3), 2.0)),
+        )
+
+    def _partition(self, partitioner: Partitioner) -> PartitionResult:
+        return partitioner.partition(to_edge(self._export_add()).exported_program())
+
+    def _lower(self, partitioner: Partitioner) -> ExecutorchProgramManager:
+        return to_edge_transform_and_lower(
+            self._export_add(), partitioner=[partitioner]
+        ).to_executorch()
+
+    def _delegate_ids(self, program: ExecutorchProgramManager) -> List[str]:
+        return [
+            delegate.id
+            for plan in program.executorch_program.execution_plan
+            for delegate in plan.delegates
+        ]
+
+    def _assert_same_partitioning(
+        self,
+        webgpu_partitioner: WebGPUPartitioner,
+        vulkan_partitioner: VulkanPartitioner,
+    ) -> PartitionResult:
+        webgpu_result = self._partition(webgpu_partitioner)
+        vulkan_result = self._partition(vulkan_partitioner)
+        self.assertEqual(webgpu_result.partition_tags, vulkan_result.partition_tags)
+        return webgpu_result
+
+    def test_lowers_identically_with_vulkan_backend_id(self) -> None:
+        webgpu_program = self._lower(WebGPUPartitioner())
+        vulkan_program = self._lower(VulkanPartitioner())
+
+        self.assertEqual(webgpu_program.buffer, vulkan_program.buffer)
+        self.assertEqual(self._delegate_ids(webgpu_program), ["VulkanBackend"])
+
+    def test_forwards_compile_options(self) -> None:
+        compile_options = {"skip_bool_tensors": True}
+        expected_options = compile_options.copy()
+
+        result = self._assert_same_partitioning(
+            WebGPUPartitioner(compile_options=compile_options),
+            VulkanPartitioner(compile_options=compile_options),
+        )
+
+        self.assertGreater(len(result.partition_tags), 0)
+        self.assertEqual(compile_options, expected_options)
+        for spec in result.partition_tags.values():
+            self.assertEqual(spec.backend_id, "VulkanBackend")
+            self.assertIn(
+                "skip_bool_tensors", [item.key for item in spec.compile_specs]
+            )
+
+    def test_forwards_operator_blocklist(self) -> None:
+        operator_blocklist = [exir_ops.edge.aten.add.Tensor]
+        expected_blocklist = operator_blocklist.copy()
+        self.assertGreater(len(self._partition(WebGPUPartitioner()).partition_tags), 0)
+
+        result = self._assert_same_partitioning(
+            WebGPUPartitioner(operator_blocklist=operator_blocklist),
+            VulkanPartitioner(operator_blocklist=operator_blocklist),
+        )
+
+        self.assertEqual(result.partition_tags, {})
+        self.assertEqual(operator_blocklist, expected_blocklist)
+
+    def test_forwards_operator_allowlist(self) -> None:
+        operator_allowlist = [exir_ops.edge.aten.mul.Tensor]
+        expected_allowlist = operator_allowlist.copy()
+        self.assertGreater(len(self._partition(WebGPUPartitioner()).partition_tags), 0)
+
+        result = self._assert_same_partitioning(
+            WebGPUPartitioner(operator_allowlist=operator_allowlist),
+            VulkanPartitioner(operator_allowlist=operator_allowlist),
+        )
+
+        self.assertEqual(result.partition_tags, {})
+        self.assertEqual(operator_allowlist, expected_allowlist)
+
+    def test_forwards_nn_module_blocklist(self) -> None:
+        nn_module_blocklist = ["AddModule"]
+        expected_blocklist = nn_module_blocklist.copy()
+        self.assertGreater(len(self._partition(WebGPUPartitioner()).partition_tags), 0)
+
+        result = self._assert_same_partitioning(
+            WebGPUPartitioner(nn_module_blocklist=nn_module_blocklist),
+            VulkanPartitioner(nn_module_blocklist=nn_module_blocklist),
+        )
+
+        self.assertEqual(result.partition_tags, {})
+        self.assertEqual(nn_module_blocklist, expected_blocklist)
+
+    def test_forwards_nn_module_allowlist(self) -> None:
+        nn_module_allowlist = ["DoesNotMatch"]
+        expected_allowlist = nn_module_allowlist.copy()
+        self.assertGreater(len(self._partition(WebGPUPartitioner()).partition_tags), 0)
+
+        result = self._assert_same_partitioning(
+            WebGPUPartitioner(nn_module_allowlist=nn_module_allowlist),
+            VulkanPartitioner(nn_module_allowlist=nn_module_allowlist),
+        )
+
+        self.assertEqual(result.partition_tags, {})
+        self.assertEqual(nn_module_allowlist, expected_allowlist)
+
+    def test_forwards_ops_to_not_decompose(self) -> None:
+        exported_program = self._export_add()
+        webgpu_ops, webgpu_filter = WebGPUPartitioner().ops_to_not_decompose(
+            exported_program
+        )
+        vulkan_ops, vulkan_filter = VulkanPartitioner().ops_to_not_decompose(
+            exported_program
+        )
+
+        self.assertEqual(webgpu_ops, vulkan_ops)
+        self.assertIsNotNone(webgpu_filter)
+        self.assertIsNotNone(vulkan_filter)
+        assert webgpu_filter is not None
+        assert vulkan_filter is not None
+        node = next(
+            node
+            for node in exported_program.graph_module.graph.nodes
+            if node.op == "call_function"
+        )
+        self.assertEqual(webgpu_filter(node), vulkan_filter(node))
+
+    def test_webgpu_tester_defaults_to_webgpu_partitioner(self) -> None:
+        self.assertIsInstance(Partition().partitioner, WebGPUPartitioner)
+        self.assertTrue(
+            all(
+                isinstance(partitioner, WebGPUPartitioner)
+                for partitioner in ToEdgeTransformAndLower().partitioners
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/webgpu/test/tester.py
+++ b/backends/webgpu/test/tester.py
@@ -12,7 +12,7 @@ import executorch.backends.test.harness.stages as BaseStages
 import torch
 from executorch.backends.test.harness import Tester as TesterBase
 from executorch.backends.test.harness.stages import StageType
-from executorch.backends.vulkan.partitioner.vulkan_partitioner import VulkanPartitioner
+from executorch.backends.webgpu.partitioner import WebGPUPartitioner
 from executorch.exir import EdgeCompileConfig
 from executorch.exir.backend.partitioner import Partitioner
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -86,13 +86,13 @@ WEBGPU_SUPPORTED_OPS = [
 ]
 
 
-# Lowers via VulkanPartitioner (WebGPU consumes the Vulkan VK00 serialization),
+# Lowers via WebGPUPartitioner (WebGPU consumes the Vulkan VK00 serialization),
 # restricted to the ops the WebGPU runtime implements.
 class Partition(BaseStages.Partition):
     def __init__(self, partitioner: Optional[Partitioner] = None):
         super().__init__(
             partitioner=partitioner
-            or VulkanPartitioner(
+            or WebGPUPartitioner(
                 {"skip_bool_tensors": True},
                 operator_allowlist=WEBGPU_SUPPORTED_OPS,
             ),
@@ -107,14 +107,14 @@ class ToEdgeTransformAndLower(BaseStages.ToEdgeTransformAndLower):
     ):
         if partitioners is None:
             partitioners = [
-                VulkanPartitioner(
+                WebGPUPartitioner(
                     {"skip_bool_tensors": True},
                     operator_allowlist=WEBGPU_SUPPORTED_OPS,
                 )
             ]
 
         super().__init__(
-            default_partitioner_cls=VulkanPartitioner,
+            default_partitioner_cls=WebGPUPartitioner,
             partitioners=partitioners,
             edge_compile_config=edge_compile_config
             or EdgeCompileConfig(_check_ir_validity=False),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #21440

**Give WebGPU a public frontend without changing delegation**

WebGPU exports currently construct `VulkanPartitioner` directly, which obscures the intended frontend even though the runtime deliberately reuses Vulkan partitioning and serialization. This adds a composition-only `WebGPUPartitioner` and migrates the canonical WebGPU tester and documentation. It mirrors `VulkanPartitioner` behavior exactly.

Key changes:

- `WebGPUPartitioner` — forwards all constructor arguments, `partition()`, and `ops_to_not_decompose()` unchanged.
- WebGPU tester — uses the wrapper while preserving `skip_bool_tensors=True` and `WEBGPU_SUPPORTED_OPS`.
- Frontend contract tests — prove byte-identical serialized programs and the unchanged `VulkanBackend` delegate id.
- Documentation — presents the WebGPU-branded entry point and its policy-free boundary.

The invariant is unchanged: no runtime, serialization, backend-id, or capability-policy behavior changes.

Co-authored-with: Claude Code.

Differential Revision: [D113924856](https://our.internmc.facebook.com/intern/diff/D113924856/)