### PR TITLE
Add partitioner, preprocess, and default passes (#21442)

### DIFF
--- a/backends/native/BUCK
+++ b/backends/native/BUCK
@@ -15,6 +15,10 @@ fbcode_target(
     name = "lib",
     typing = True,
     srcs = [
+        "__init__.py",
+        "partitioner.py",
+        "passes/__init__.py",
+        "preprocess.py",
         "serialization/__init__.py",
         "serialization/graph_serialize.py",
         "serialization/schema.py",
@@ -24,8 +28,14 @@ fbcode_target(
     },
     visibility = ["PUBLIC"],
     deps = [
+        "fbsource//third-party/pypi/flatbuffers:flatbuffers",
         "//caffe2:torch",
         "//executorch/exir:lib",
         "//executorch/exir/_serialize:lib",
+        "//executorch/exir/backend:backend_details",
+        "//executorch/exir/backend:partitioner",
+        "//executorch/exir/backend:utils",
+        "//executorch/exir/passes:cse_pass",
+        "//executorch/exir/passes:lib",
     ],
 )

--- a/backends/native/__init__.py
+++ b/backends/native/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from executorch.backends.native.passes import get_default_passes
+from executorch.exir import EdgeCompileConfig
+
+__all__ = [
+    "get_default_compile_config",
+    "get_default_passes",
+]
+
+
+# pyre-ignore[11]: EdgeCompileConfig is defined in a pyre-unsafe exir module.
+def get_default_compile_config() -> EdgeCompileConfig:
+    """EdgeCompileConfig shared by the native export and ET lowering paths.
+
+    IR validity checking is off and dim order is skipped: the native backend's
+    passes emit non-core ops and it serializes dim_order itself.
+    """
+    return EdgeCompileConfig(_check_ir_validity=False, _skip_dim_order=True)

--- a/backends/native/partitioner.py
+++ b/backends/native/partitioner.py
@@ -1,0 +1,211 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Native backend partitioner.
+
+Claims core ATen ops (torch.Tag.core) plus an explicit opt-in set, and delegates
+whole torch.cond control-flow ops whose branches are fully supported. Graph
+cleanup (CSE) runs before lowering via transform_passes, since ExecuTorch forbids
+a partitioner from mutating the graph module.
+"""
+
+from typing import Callable, final, List, Mapping, Optional, Tuple
+
+import torch
+
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.backend.partitioner import (
+    DelegationSpec,
+    Partitioner,
+    PartitionResult,
+)
+from executorch.exir.backend.utils import tag_constant_data, tag_mutated_buffer
+
+from torch.export.exported_program import ExportedProgram
+from torch.fx import GraphModule, Node
+from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
+from torch.fx.passes.operator_support import OperatorSupportBase
+
+# Non-core ops the native backend supports. Also preserved (not decomposed).
+_SUPPORTED_NON_CORE_OPS = [
+    torch.ops.aten.matmul.default,
+    torch.ops.aten.linear.default,
+    torch.ops.aten.addmm.default,
+    torch.ops.aten.scaled_dot_product_attention.default,
+]
+
+# Maps a control-flow higher-order op to the arg indices of its branch submodule
+# get_attr nodes (cond's true and false fns).
+_HOP_SUBMODULE_ARG_INDICES = {
+    torch.ops.higher_order.cond: (1, 2),
+}
+
+EXTERNAL_CONSTANTS_TAG_KEY = "external_constants_tag"
+
+
+class NativeSupportedOperators(OperatorSupportBase):
+    _NON_CORE = set(_SUPPORTED_NON_CORE_OPS)
+
+    def is_node_supported(
+        self, submodules: Mapping[str, torch.nn.Module], node: Node
+    ) -> bool:
+        if node.op in ("placeholder", "output", "get_attr"):
+            return False
+        if node.op != "call_function":
+            return False
+        if isinstance(node.target, torch._ops.HigherOrderOperator):
+            return False
+
+        from executorch.exir.dialects.edge._ops import EdgeOpOverload
+
+        target = node.target
+        if isinstance(target, EdgeOpOverload):
+            target = target._op
+        if isinstance(target, torch._ops.OpOverload):
+            if target in self._NON_CORE:
+                return True
+            return torch.Tag.core in target.tags or torch.Tag.view_copy in target.tags
+        return False
+
+
+def _branch_graph_module(gm: GraphModule, node: Node) -> Optional[GraphModule]:
+    """Resolve a get_attr node to the branch/body GraphModule it names."""
+    if node.op != "get_attr":
+        return None
+    try:
+        sub = gm.get_submodule(str(node.target))
+    except AttributeError:
+        return None
+    return sub if isinstance(sub, GraphModule) else None
+
+
+def _hop_branch_nodes(node: Node) -> List[Node]:
+    """The get_attr arg nodes carrying a control-flow HOP's branch submodules."""
+    indices = _HOP_SUBMODULE_ARG_INDICES.get(node.target)
+    if indices is None:
+        return []
+    out: List[Node] = []
+    for i in indices:
+        if i < len(node.args):
+            arg = node.args[i]
+            if isinstance(arg, Node) and arg.op == "get_attr":
+                out.append(arg)
+    return out
+
+
+def _submodule_fully_supported(
+    gm: GraphModule, op_support: OperatorSupportBase
+) -> bool:
+    """True if every op in a branch (recursing into nested HOPs) is supported."""
+    for node in gm.graph.nodes:
+        if node.op != "call_function":
+            continue
+        if isinstance(node.target, torch._ops.HigherOrderOperator):
+            branch_nodes = _hop_branch_nodes(node)
+            if not branch_nodes:
+                return False
+            for b in branch_nodes:
+                sub = _branch_graph_module(gm, b)
+                if sub is None or not _submodule_fully_supported(sub, op_support):
+                    return False
+        elif not op_support.is_node_supported({}, node):
+            return False
+    return True
+
+
+@final
+class NativePartitioner(Partitioner):
+    def __init__(
+        self, external_constants_tag: Optional[str] = "native_weights"
+    ) -> None:
+        from executorch.backends.native.preprocess import NativeBackend
+
+        compile_specs: List[CompileSpec] = []
+        if external_constants_tag is not None:
+            compile_specs.append(
+                CompileSpec(
+                    EXTERNAL_CONSTANTS_TAG_KEY,
+                    external_constants_tag.encode("utf-8"),
+                )
+            )
+        self.delegation_spec = DelegationSpec(NativeBackend.__name__, compile_specs)
+
+    def ops_to_not_decompose(
+        self, ep: ExportedProgram
+    ) -> Tuple[List[torch._ops.OpOverload], Optional[Callable[[Node], bool]]]:
+        # Already-partitioned graph -> nothing to preserve.
+        from executorch.exir.lowered_backend_module import executorch_call_delegate
+
+        for node in ep.graph.nodes:
+            if node.op == "call_function" and node.target is executorch_call_delegate:
+                return ([], None)
+
+        present: List[torch._ops.OpOverload] = []
+        seen = set()
+        for node in ep.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if not isinstance(node.target, torch._ops.OpOverload):
+                continue
+            if node.target in _SUPPORTED_NON_CORE_OPS and node.target not in seen:
+                present.append(node.target)
+                seen.add(node.target)
+
+        return (present, None)
+
+    def partition(self, exported_program: ExportedProgram) -> PartitionResult:
+        partition_tags = {}
+        op_support = NativeSupportedOperators()
+
+        capability_partitioner = CapabilityBasedPartitioner(
+            exported_program.graph_module,
+            op_support,
+            allows_single_node_partition=True,
+        )
+
+        partition_list = capability_partitioner.propose_partitions()
+
+        for partition in partition_list:
+            for node in partition.nodes:
+                tag = f"tag{partition.id}"
+                node.meta["delegation_tag"] = tag
+                partition_tags[tag] = self.delegation_spec
+
+        # Delegate each control-flow HOP whose branches are fully supported. HOPs
+        # are unsupported by is_node_supported (so the capability partitioner skips
+        # them); tagging the HOP node and its branch get_attr args together makes
+        # the fuser pull the branch submodules into one delegated subgraph.
+        gm = exported_program.graph_module
+        hop_id = 0
+        for node in gm.graph.nodes:
+            if node.op != "call_function":
+                continue
+            if node.target not in _HOP_SUBMODULE_ARG_INDICES:
+                continue
+            branch_nodes = _hop_branch_nodes(node)
+            if not branch_nodes:
+                continue
+            if not all(
+                (sub := _branch_graph_module(gm, b)) is not None
+                and _submodule_fully_supported(sub, op_support)
+                for b in branch_nodes
+            ):
+                continue
+            tag = f"hop_tag{hop_id}"
+            hop_id += 1
+            node.meta["delegation_tag"] = tag
+            for b in branch_nodes:
+                b.meta["delegation_tag"] = tag
+            partition_tags[tag] = self.delegation_spec
+
+        tag_constant_data(exported_program)
+        tag_mutated_buffer(exported_program)
+
+        return PartitionResult(
+            tagged_exported_program=exported_program,
+            partition_tags=partition_tags,
+        )

--- a/backends/native/passes/__init__.py
+++ b/backends/native/passes/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Graph transformation passes for the native backend.
+
+Passed to ``to_edge_transform_and_lower`` via its ``transform_passes`` argument so
+they run on the edge-dialect graph before partitioning/delegation. Each pass lives
+in its own module; this package aggregates them and exposes the default pass list.
+"""
+
+from typing import List, Union
+
+from executorch.exir.pass_base import ExportedProgramPassBase, ExportPass
+from executorch.exir.passes.cse_pass import CSEPass
+
+__all__ = [
+    "get_default_passes",
+]
+
+
+def get_default_passes() -> List[Union[ExportPass, ExportedProgramPassBase]]:
+    """Passes enabled by default for the native backend."""
+    return [
+        CSEPass(),
+    ]

--- a/backends/native/preprocess.py
+++ b/backends/native/preprocess.py
@@ -1,0 +1,68 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+NativeBackend — AOT preprocess for the native portable runtime.
+
+Serializes the delegated fx subgraph into the native backend's generic
+flatbuffer format (a topological list of fx nodes; see serialization/).
+Constant tensor data is shipped via the NamedDataStore, referenced by
+fully-qualified name -- never embedded in the graph flatbuffer.
+
+Graph cleanup (CSE, reinplace, view_copy collapsing) is expected to run before
+lowering via the ``transform_passes`` argument of
+``to_edge_transform_and_lower`` (see ``passes.get_default_passes``).
+"""
+
+from typing import final, List
+
+from executorch.backends.native.serialization import serialize_graph
+
+from executorch.exir._serialize._named_data_store import NamedDataStore
+
+from executorch.exir.backend.backend_details import (
+    BackendDetails,
+    CompileSpec,
+    ExportedProgram,
+    PreprocessResult,
+)
+
+from torch._subclasses.fake_tensor import FakeTensor
+
+
+@final
+class NativeBackend(BackendDetails):
+    @staticmethod
+    def preprocess(
+        edge_program: ExportedProgram,
+        module_compile_spec: List[CompileSpec],
+    ) -> PreprocessResult:
+        flatbuffer_bytes, constant_data = serialize_graph(
+            edge_program.graph_module,
+            edge_program.graph_signature,
+            edge_program.state_dict,
+            edge_program.constants,
+        )
+
+        external_tag = None
+        for spec in module_compile_spec:
+            if spec.key == "external_constants_tag":
+                external_tag = bytes(spec.value).decode("utf-8")
+
+        named_data_store = NamedDataStore()
+        for fqn, tensor in constant_data.items():
+            if isinstance(tensor, FakeTensor):
+                continue
+            named_data_store.add_named_data(
+                fqn,
+                tensor.detach().contiguous(),
+                external_tag=external_tag,
+            )
+
+        return PreprocessResult(
+            processed_bytes=flatbuffer_bytes,
+            data_store_output=named_data_store.get_named_data_store_output(),
+        )

--- a/backends/native/test/BUCK
+++ b/backends/native/test/BUCK
@@ -13,3 +13,36 @@ fbcode_target(
         "//executorch/exir:lib",
     ],
 )
+
+fbcode_target(
+    _kind = runtime.python_test,
+    name = "test_preprocess",
+    srcs = ["test_preprocess.py"],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/native:lib",
+        "//executorch/exir:lib",
+    ],
+)
+
+fbcode_target(
+    _kind = runtime.python_test,
+    name = "test_passes",
+    srcs = ["test_passes.py"],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/native:lib",
+        "//executorch/exir:lib",
+    ],
+)
+
+fbcode_target(
+    _kind = runtime.python_test,
+    name = "test_partitioner",
+    srcs = ["test_partitioner.py"],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/native:lib",
+        "//executorch/exir:lib",
+    ],
+)

--- a/backends/native/test/test_partitioner.py
+++ b/backends/native/test/test_partitioner.py
@@ -1,0 +1,202 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+import torch.nn as nn
+
+from executorch.backends.native import get_default_compile_config
+from executorch.backends.native.partitioner import (
+    _SUPPORTED_NON_CORE_OPS,
+    NativePartitioner,
+    NativeSupportedOperators,
+)
+from executorch.backends.native.passes import get_default_passes
+from executorch.backends.native.serialization import deserialize_graph
+from executorch.backends.native.serialization.schema import GraphArg
+from executorch.exir import to_edge_transform_and_lower
+from executorch.exir.dialects._ops import ops as _edge_ops
+from executorch.exir.lowered_backend_module import (
+    executorch_call_delegate,
+    get_lowered_submodules,
+)
+
+
+def _make_node(op, target):
+    node = MagicMock()
+    node.op = op
+    node.target = target
+    return node
+
+
+class NativeSupportedOperatorsTest(unittest.TestCase):
+    def setUp(self):
+        self.sup = NativeSupportedOperators()
+
+    def test_rejects_non_call_function_nodes(self):
+        # placeholder/output/get_attr and any other non call_function op are
+        # never claimed by the delegate.
+        for op in ("placeholder", "output", "get_attr", "call_module", "call_method"):
+            with self.subTest(op=op):
+                self.assertFalse(self.sup.is_node_supported({}, _make_node(op, None)))
+
+    def test_rejects_higher_order_operator(self):
+        node = _make_node("call_function", torch.ops.higher_order.cond)
+        self.assertFalse(self.sup.is_node_supported({}, node))
+
+    def test_rejects_non_opoverload_callable(self):
+        node = _make_node("call_function", lambda x: x)
+        self.assertFalse(self.sup.is_node_supported({}, node))
+
+    def test_accepts_core_aten_op(self):
+        op = torch.ops.aten.add.Tensor
+        self.assertIn(torch.Tag.core, op.tags)
+        self.assertTrue(self.sup.is_node_supported({}, _make_node("call_function", op)))
+
+    def test_accepts_opt_in_ops(self):
+        # Every op in the explicit opt-in set is claimed.
+        for op in _SUPPORTED_NON_CORE_OPS:
+            with self.subTest(op=str(op)):
+                self.assertTrue(
+                    self.sup.is_node_supported({}, _make_node("call_function", op))
+                )
+
+    def test_accepts_view_copy_tagged_op(self):
+        op = torch.ops.aten.view_copy.default
+        self.assertIn(torch.Tag.view_copy, op.tags)
+        self.assertTrue(self.sup.is_node_supported({}, _make_node("call_function", op)))
+
+    def test_rejects_non_core_unsupported_op(self):
+        op = torch.ops.aten.linalg_solve_triangular.default
+        self.assertNotIn(torch.Tag.core, op.tags)
+        self.assertFalse(
+            self.sup.is_node_supported({}, _make_node("call_function", op))
+        )
+
+    def test_accepts_edge_op_overlay(self):
+        # EdgeOpOverload wraps OpOverload; the partitioner unwraps and accepts it.
+        node = _make_node("call_function", _edge_ops.edge.aten.add.Tensor)
+        self.assertTrue(self.sup.is_node_supported({}, node))
+
+    def test_rejects_non_core_edge_op(self):
+        edge_op = _edge_ops.edge.aten.linalg_solve_triangular.default
+        self.assertNotIn(torch.Tag.core, edge_op._op.tags)
+        node = _make_node("call_function", edge_op)
+        self.assertFalse(self.sup.is_node_supported({}, node))
+
+
+class NativePartitionerOpsToNotDecomposeTest(unittest.TestCase):
+    def test_collects_supported_non_core_ops(self):
+        ep = torch.export.export(nn.Linear(4, 4), (torch.randn(1, 4),))
+        ops, filt = NativePartitioner().ops_to_not_decompose(ep)
+        self.assertIsNone(filt)
+        self.assertTrue(ops, "a linear model should preserve a non-core op")
+        for op in ops:
+            self.assertIn(op, _SUPPORTED_NON_CORE_OPS)
+
+    def test_deduplicates_preserved_ops(self):
+        class TwoLinears(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.a = nn.Linear(4, 4)
+                self.b = nn.Linear(4, 4)
+
+            def forward(self, x):
+                return self.b(self.a(x))
+
+        ep = torch.export.export(TwoLinears(), (torch.randn(1, 4),))
+        ops, _ = NativePartitioner().ops_to_not_decompose(ep)
+        self.assertTrue(ops)
+        self.assertEqual(len(ops), len(set(ops)), "preserved ops must be deduped")
+
+    def test_already_partitioned_graph_preserves_nothing(self):
+        lowered = to_edge_transform_and_lower(
+            torch.export.export(nn.Linear(4, 4), (torch.randn(1, 4),)),
+            partitioner=[NativePartitioner()],
+        )
+        ep = lowered._edge_programs["forward"]
+        self.assertTrue(
+            any(
+                n.op == "call_function" and n.target is executorch_call_delegate
+                for n in ep.graph.nodes
+            ),
+            "expected an already-partitioned graph with a delegate call",
+        )
+        ops, filt = NativePartitioner().ops_to_not_decompose(ep)
+        self.assertEqual(ops, [])
+        self.assertIsNone(filt)
+
+
+class NativePartitionerE2ETest(unittest.TestCase):
+    def test_linear_delegates_all_ops(self):
+        model = nn.Linear(4, 4)
+        ep = torch.export.export(model, (torch.randn(1, 4),))
+        lowered = to_edge_transform_and_lower(ep, partitioner=[NativePartitioner()])
+        graph = lowered._edge_programs["forward"].graph
+        delegate_calls = [
+            n
+            for n in graph.nodes
+            if n.op == "call_function" and "executorch_call_delegate" in str(n.target)
+        ]
+        non_delegate_ops = [
+            n
+            for n in graph.nodes
+            if n.op == "call_function"
+            and "executorch_call_delegate" not in str(n.target)
+            and "getitem" not in str(n.target)
+        ]
+        self.assertGreater(
+            len(delegate_calls), 0, "Expected at least one delegate call"
+        )
+        self.assertEqual(
+            len(non_delegate_ops),
+            0,
+            "All ops should be delegated, but found: "
+            f"{[str(n.target) for n in non_delegate_ops]}",
+        )
+
+
+class _CondModel(nn.Module):
+    def forward(self, pred, x):
+        def true_fn(x):
+            return x + x
+
+        def false_fn(x):
+            return x * x
+
+        return torch.cond(pred, true_fn, false_fn, (x,))
+
+
+class NativePartitionerHOPTest(unittest.TestCase):
+    def test_cond_delegated_as_single_native_program(self):
+        # A whole torch.cond plus its branch subgraphs is delegated into one
+        # native program; the serialized graph inlines each branch as a GraphArg.
+        ep = torch.export.export(_CondModel(), (torch.tensor(True), torch.randn(3)))
+        lowered = to_edge_transform_and_lower(
+            ep,
+            transform_passes=get_default_passes(),
+            partitioner=[NativePartitioner()],
+            compile_config=get_default_compile_config(),
+        )
+        edge_ep = lowered._edge_programs["forward"]
+        subs = get_lowered_submodules(edge_ep.graph_module)
+        self.assertEqual(len(subs), 1, "cond should lower to one native delegate")
+
+        graph = deserialize_graph(subs[0][1].processed_bytes)
+        graphargs = [
+            na.arg.value
+            for n in graph.nodes
+            for na in (n.inputs or [])
+            if isinstance(na.arg.value, GraphArg)
+        ]
+        # cond has a true and a false branch, each an inlined subgraph.
+        self.assertEqual(len(graphargs), 2)
+        self.assertTrue(all(ga.graph.nodes for ga in graphargs))
+        self.assertTrue(
+            any(n.target and n.target.endswith("cond") for n in graph.nodes)
+        )

--- a/backends/native/test/test_passes.py
+++ b/backends/native/test/test_passes.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.nn as nn
+
+from executorch.backends.native import get_default_compile_config
+from executorch.exir import to_edge
+from executorch.exir.passes.cse_pass import CSEPass
+
+
+def _transformed(model, example_inputs, passes):
+    edge = to_edge(
+        torch.export.export(model, example_inputs),
+        compile_config=get_default_compile_config(),
+    )
+    return edge.transform(passes).exported_program()
+
+
+class CSEPassTest(unittest.TestCase):
+    def test_dedupes_identical_subexprs(self):
+        class DupModel(nn.Module):
+            def forward(self, x):
+                a = x + x
+                b = x + x
+                return a * b
+
+        ep = _transformed(DupModel(), (torch.randn(4, 4),), [CSEPass()])
+        adds = [
+            str(n.target)
+            for n in ep.graph_module.graph.nodes
+            if n.op == "call_function" and "add" in str(n.target)
+        ]
+        self.assertEqual(len(adds), 1, f"expected CSE to leave one add, got {adds}")

--- a/backends/native/test/test_preprocess.py
+++ b/backends/native/test/test_preprocess.py
@@ -1,0 +1,101 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.nn as nn
+
+from executorch.backends.native import get_default_compile_config
+from executorch.backends.native.partitioner import NativePartitioner
+from executorch.backends.native.passes import get_default_passes
+from executorch.backends.native.serialization import (
+    deserialize_graph,
+    deserialize_program,
+)
+from executorch.backends.native.serialization.schema import OpKind, OutputKind
+from executorch.exir import to_edge_transform_and_lower
+
+
+def _lower(model, example_inputs):
+    ep = torch.export.export(model, example_inputs)
+    return to_edge_transform_and_lower(
+        ep,
+        transform_passes=get_default_passes(),
+        partitioner=[NativePartitioner()],
+        compile_config=get_default_compile_config(),
+    )
+
+
+def _get_delegate_blob(edge):
+    """Extract the single delegate's processed bytes from the lowered program."""
+    et = edge.to_executorch()
+    delegates = et.executorch_program.backend_delegate_data
+    assert len(delegates) == 1, f"Expected 1 delegate blob, got {len(delegates)}"
+    return bytes(delegates[0].data)
+
+
+def _call_function_targets(graph):
+    return [n.target for n in graph.nodes if n.op_kind == OpKind.CALL_FUNCTION]
+
+
+class PreprocessSerializationTest(unittest.TestCase):
+    def test_payload_has_native_file_identifier(self):
+        blob = _get_delegate_blob(_lower(nn.Linear(4, 4), (torch.randn(1, 4),)))
+        self.assertEqual(blob[4:8], b"NPTG")
+
+    def test_linear_op_roundtrips(self):
+        blob = _get_delegate_blob(_lower(nn.Linear(4, 4), (torch.randn(1, 4),)))
+        graph = deserialize_graph(blob)
+        targets = _call_function_targets(graph)
+        self.assertTrue(
+            any(t is not None and "linear" in t for t in targets),
+            f"expected linear op, got {targets}",
+        )
+
+    def test_add_op_roundtrips(self):
+        class AddModel(nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        blob = _get_delegate_blob(
+            _lower(AddModel(), (torch.randn(2, 3), torch.randn(2, 3)))
+        )
+        graph = deserialize_graph(blob)
+        targets = _call_function_targets(graph)
+        self.assertTrue(any(t is not None and "add" in t for t in targets))
+
+    def test_non_persistent_buffer_recorded_as_mutable_buffer(self):
+        # A KV-cache-style non-persistent buffer, mutated in place, must survive
+        # the full .pte lowering route as a mutable buffer (no shipped data), with
+        # its mutation captured as a BUFFER_MUTATION output writeback.
+        class KVCacheModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(4), persistent=False)
+
+            def forward(self, x):
+                self.cache.add_(x)
+                return self.cache + 1.0
+
+        blob = _get_delegate_blob(_lower(KVCacheModel(), (torch.randn(4),)))
+        method = deserialize_program(blob).methods[0]
+        self.assertIn("cache", {mb.fqn for mb in (method.mutable_buffers or [])})
+        self.assertNotIn("cache", {c.data_key for c in (method.constants or [])})
+        self.assertTrue(
+            any(
+                s.kind == OutputKind.BUFFER_MUTATION
+                for s in (method.output_specs or [])
+            )
+        )
+
+    def test_constants_shipped_via_named_data(self):
+        edge = _lower(nn.Linear(4, 4), (torch.randn(1, 4),))
+        blob = _get_delegate_blob(edge)
+        method = deserialize_program(blob).methods[0]
+        self.assertTrue(method.constants)
+        data_keys = {c.data_key for c in method.constants}
+        self.assertTrue(any("weight" in k for k in data_keys))


### PR DESCRIPTION
Summary:

NativePartitioner claims core ATen ops plus a small non-core opt-in set
(matmul/linear/addmm/sdpa) and preserves them via ops_to_not_decompose.
NativeBackend.preprocess serializes the delegated subgraph and ships constants
through the NamedDataStore by fqn. get_default_passes() runs CSE, view_copy
collapsing, and reinplace as pre-lowering transform passes.

Reviewed By: digantdesai

Differential Revision: D111753291


