### PR TITLE
Fix linear_dq8ca_q4gsw wrong output when M > K

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
@@ -833,10 +833,18 @@ void quantized_linear_impl(
     num_groups = graph.size_at<int64_t>(-2, weight_scales_data);
   }
 
+  // Per-group int8 input sums buffer, indexed as ivec4[group_idx * M4 + m4]
+  // by both the producer (quantize_and_pack_4h4w_with_group_sums.glsl) and the
+  // consumer (linear_int8_input_sums_load.glslh). Capacity must therefore be
+  // num_groups * M4 ivec4 texels, sized by the input row count M -- NOT K.
+  // dtype is kInt to match the shaders' `int`/ivec4 binding (each texel is 4
+  // int32 sums = 16 bytes).
+  const int64_t M = utils::val_at(-2, input_sizes);
+  const int64_t M4 = utils::div_up(M, int64_t(4));
   TmpTensor int_input_sums(
       &graph,
-      {num_groups, K},
-      graph.dtype_of(output),
+      {num_groups * M4 * 4},
+      vkapi::kInt,
       utils::kBuffer,
       utils::kWidthPacked);
 

--- a/backends/vulkan/test/custom_ops/test_q4gsw_linear.cpp
+++ b/backends/vulkan/test/custom_ops/test_q4gsw_linear.cpp
@@ -269,6 +269,8 @@ std::vector<TestCase> generate_quantized_linear_test_cases() {
       {32, 64, 32, 16},
       {32, 128, 64, 32},
       {32, 256, 128, 64},
+      {256, 128, 128, 32}, // M=256 > K=128; all dims < kRefDimSizeLimit
+
       // Coopmat-eligible correctness shapes (M%64==0, N%64==0, K%32==0,
       // group_size%32==0). The Buffer+Half variant fires linear_q4gsw_coopmat /
       // linear_dq8ca_q4gsw_coopmat and is validated against the CPU reference.


### PR DESCRIPTION
Summary:
`et_vk.linear_dq8ca_q4gsw` (dynamic per-channel int8 activation x per-group
4-bit weight linear) silently produced wrong results whenever the input row
count M exceeded K (e.g. M=256, K=128, N=128), on all hardware.

Root cause: the per-group int8 input-sums scratch buffer was allocated sized by
K (`{num_groups, K}` -> capacity `num_groups * K4` ivec4 texels), but both the
producer (`quantize_and_pack_4h4w_with_group_sums.glsl`) and the consumer
(`linear_int8_input_sums_load.glslh`) index it with a per-group stride of
`M4 = div_up_4(M)`: `t_int8_input_sums[group_idx * M4 + m4]`. The buffer needs
`num_groups * M4` texels. When `M4 > K4` (i.e. M > K) the producer wrote out of
bounds and the GEMM read stale/garbage per-row input sums for every group,
corrupting the int8 dequant correction term. When M <= K the K-sized buffer was
coincidentally large enough, so the bug never surfaced -- every prior ACCU shape
had M <= K.

Fix: size the buffer by the input row count M and allocate it as `kInt` to match
the shaders' `int`/ivec4 binding, giving exactly `num_groups * M4` ivec4 texels.
The `kInt` dtype also fixes a latent under-sizing on the fp16 path, where the
buffer was previously allocated with the (2-byte) output dtype while the shaders
read 16-byte ivec4 texels. M is taken at graph-build time (max prefill M);
decode M=1 is always <= build M, matching the existing `transposed_input`
allocation convention.

Also adds an M > K regression case ({256, 128, 128, 32}) to
test_q4gsw_linear.cpp.

Authored with AI assistance (Claude Code).

Differential Revision: D113962415


