### PR TITLE
Arm backend: Handle empty target-less model suite

### DIFF
--- a/backends/arm/test/test_arm_backend.sh
+++ b/backends/arm/test/test_arm_backend.sh
@@ -90,7 +90,8 @@ test_pytest_models_no_target() {
     source backends/arm/scripts/install_models_for_test.sh
 
     # Run arm baremetal pytest tests without FVP
-    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k "${EXCLUDE_TARGET_EXPR}" -m "not xlarge"
+    # Exit code 5 means no tests were collected; preserve all other failures.
+    pytest "${PYTEST_RETRY_ARGS[@]}" --verbose --color=yes --numprocesses=auto --durations=0 backends/arm/test/models -k "${EXCLUDE_TARGET_EXPR}" -m "not xlarge" || [[ $? -eq 5 ]]
     echo "${TEST_SUITE_NAME}: PASS"
 }
 


### PR DESCRIPTION
Treat pytest status 5 as success when the target-less selector finds no tests. Preserve all other failure statuses.



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell @rascani