### PR TITLE
Use dynamic CPU count for -j in vendor/example scripts and docs

### DIFF
--- a/backends/apple/coreml/scripts/build_tests.sh
+++ b/backends/apple/coreml/scripts/build_tests.sh
@@ -36,7 +36,7 @@ cmake "$EXECUTORCH_ROOT_PATH" -B"$CMAKE_EXECUTORCH_BUILD_DIR_PATH" \
 -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=OFF \
 -DEXECUTORCH_BUILD_XNNPACK=OFF
 
-cmake --build "$CMAKE_EXECUTORCH_BUILD_DIR_PATH"  -j9 -t executorch
+cmake --build "$CMAKE_EXECUTORCH_BUILD_DIR_PATH"  -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -t executorch
 
 # Build protobuf
 echo "ExecuTorch: Building libprotobuf-lite"
@@ -53,7 +53,7 @@ cmake "$PROTOBUF_DIR_PATH/cmake" -B"$CMAKE_PROTOBUF_BUILD_DIR_PATH" \
 -DCMAKE_MACOSX_BUNDLE=OFF \
 -DCMAKE_CXX_STANDARD=17
 
-cmake --build "$CMAKE_PROTOBUF_BUILD_DIR_PATH"  -j9 -t libprotobuf-lite
+cmake --build "$CMAKE_PROTOBUF_BUILD_DIR_PATH"  -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -t libprotobuf-lite
 
 # Copy required libraries
 echo "ExecuTorch: Copying libraries"

--- a/backends/cadence/build_cadence_fusionG3.sh
+++ b/backends/cadence/build_cadence_fusionG3.sh
@@ -55,7 +55,7 @@ if $STEPWISE_BUILD; then
         -DFLATCC_ALLOW_WERROR=OFF \
         -Bcmake-out/backends/cadence \
         backends/cadence
-    cmake --build cmake-out/backends/cadence  -j8
+    cmake --build cmake-out/backends/cadence  -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 else
     echo "Building Cadence toolchain with ExecuTorch packages"
     cmake_prefix_path="${PWD}/cmake-out/lib/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"
@@ -80,7 +80,7 @@ else
         -DHAVE_FNMATCH_H=OFF \
         -DFLATCC_ALLOW_WERROR=OFF \
         -Bcmake-out
-    cmake --build cmake-out --target install --config Release -j8
+    cmake --build cmake-out --target install --config Release -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 fi
 
 echo "Run simple model to verify cmake build"

--- a/backends/cadence/build_cadence_hifi4.sh
+++ b/backends/cadence/build_cadence_hifi4.sh
@@ -54,7 +54,7 @@ if $STEPWISE_BUILD; then
         -DFLATCC_ALLOW_WERROR=OFF \
         -Bcmake-out/backends/cadence \
         backends/cadence
-    cmake --build cmake-out/backends/cadence  -j8
+    cmake --build cmake-out/backends/cadence  -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 else
     echo "Building Cadence toolchain with ExecuTorch packages"
     cmake_prefix_path="${PWD}/cmake-out/lib/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"
@@ -78,7 +78,7 @@ else
         -DHAVE_FNMATCH_H=OFF \
         -DFLATCC_ALLOW_WERROR=OFF \
         -Bcmake-out
-    cmake --build cmake-out --target install --config Release -j8
+    cmake --build cmake-out --target install --config Release -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 fi
 
 echo "Run simple model to verify cmake build"

--- a/backends/cadence/build_cadence_runner.sh
+++ b/backends/cadence/build_cadence_runner.sh
@@ -27,7 +27,7 @@ main() {
     -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
     -DEXECUTORCH_ENABLE_LOGGING=ON \
     -Bcmake-out .
-  cmake --build cmake-out --target install --config Release -j16
+  cmake --build cmake-out --target install --config Release -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 
   local example_dir=backends/cadence
   local build_dir="cmake-out/${example_dir}"
@@ -46,7 +46,7 @@ main() {
     -DPYTHON_EXECUTABLE="$(which python3)" \
     -B"${build_dir}" \
     "${example_dir}"
-  cmake --build "${build_dir}" --config Release -j16
+  cmake --build "${build_dir}" --config Release -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 
   local runner="${PWD}/${build_dir}/cadence_runner"
   if [[ ! -f "${runner}" ]]; then

--- a/backends/cadence/build_cadence_vision.sh
+++ b/backends/cadence/build_cadence_vision.sh
@@ -54,7 +54,7 @@ if $STEPWISE_BUILD; then
         -DFLATCC_ALLOW_WERROR=OFF \
         -Bcmake-out/backends/cadence \
         backends/cadence
-    cmake --build cmake-out/backends/cadence  -j8
+    cmake --build cmake-out/backends/cadence  -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 else
     echo "Building Cadence toolchain with ExecuTorch packages"
     cmake_prefix_path="${PWD}/cmake-out/lib/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"
@@ -78,7 +78,7 @@ else
         -DHAVE_FNMATCH_H=OFF \
         -DFLATCC_ALLOW_WERROR=OFF \
         -Bcmake-out
-    cmake --build cmake-out --target install --config Release -j8
+    cmake --build cmake-out --target install --config Release -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 fi
 
 echo "Run simple model to verify cmake build"

--- a/backends/cadence/runtime/executor_main.sh
+++ b/backends/cadence/runtime/executor_main.sh
@@ -24,7 +24,7 @@ cmake_install_executorch_devtools_lib() {
           -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           -Bcmake-out .
-  cmake --build cmake-out -j9 --target install --config Release
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 }
 
 test_cmake_devtools_example_runner() {
@@ -40,7 +40,7 @@ test_cmake_devtools_example_runner() {
         ${example_dir}
 
   echo "Building ${example_dir}"
-  cmake --build ${build_dir} -j9 --config Release
+  cmake --build ${build_dir} -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 
   echo 'Running devtools/example_runner'
   ${build_dir}/example_runner --bundled_program_path="./CadenceDemoModel.bpte"

--- a/backends/mediatek/scripts/mtk_build.sh
+++ b/backends/mediatek/scripts/mtk_build.sh
@@ -35,7 +35,7 @@ cmake -DCMAKE_INSTALL_PREFIX="${build_dir}" \
       -B"${build_dir}"
 
 # Build the project
-cmake --build "${build_dir}" --target install --config Release -j5
+cmake --build "${build_dir}" --target install --config Release -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 
 # Switch back to the original directory
 cd - > /dev/null

--- a/backends/mlx/test/test_utils.py
+++ b/backends/mlx/test/test_utils.py
@@ -587,7 +587,14 @@ def rebuild_op_test_runner(verbose: bool = False) -> bool:
 
     print(f"Rebuilding op_test_runner in {build_dir}...")
 
-    cmd = ["cmake", "--build", str(build_dir), "--target", "op_test_runner", "-j8"]
+    cmd = [
+        "cmake",
+        "--build",
+        str(build_dir),
+        "--target",
+        "op_test_runner",
+        f"-j{(os.cpu_count() or 1) + 1}",
+    ]
 
     if verbose:
         print(f"Running: {' '.join(cmd)}")

--- a/backends/samsung/README.md
+++ b/backends/samsung/README.md
@@ -64,7 +64,7 @@ cmake extension/android \
   -DCMAKE_INSTALL_PREFIX=cmake-android-out \
   -Bcmake-android-out/extension/android
 
-cmake --build cmake-android-out/extension/android -j8
+cmake --build cmake-android-out/extension/android -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ```
 
 ## Examples

--- a/backends/vulkan/test/custom_ops/build_and_run.sh
+++ b/backends/vulkan/test/custom_ops/build_and_run.sh
@@ -30,13 +30,13 @@ configure_and_build_main() {
         -B$CMAKE_OUT_DIR
     fi
 
-    cmake --build $CMAKE_OUT_DIR -j16 --target install
+    cmake --build $CMAKE_OUT_DIR -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install
     # -DCMAKE_CXX_FLAGS="-DVULKAN_DEBUG" \
 }
 
 # Function to build main project only
 build_main() {
-    cmake --build $CMAKE_OUT_DIR -j16 --target install
+    cmake --build $CMAKE_OUT_DIR -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install
 }
 
 # Function to configure and build tests
@@ -65,12 +65,12 @@ configure_and_build_tests() {
             -B$CMAKE_OUT_DIR/backends/vulkan/test/custom_ops
     fi
 
-    cmake --build $CMAKE_OUT_DIR/backends/vulkan/test/custom_ops -j16 --target all
+    cmake --build $CMAKE_OUT_DIR/backends/vulkan/test/custom_ops -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target all
 
 }
 
 build_tests() {
-    cmake --build $CMAKE_OUT_DIR/backends/vulkan/test/custom_ops -j16 --target all
+    cmake --build $CMAKE_OUT_DIR/backends/vulkan/test/custom_ops -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target all
 }
 
 # Function to rebuild both main and tests

--- a/backends/vulkan/test/scripts/test_model.sh
+++ b/backends/vulkan/test/scripts/test_model.sh
@@ -95,7 +95,7 @@ clean_build_directory() {
 }
 
 recompile() {
-  cmake --build cmake-out -j64 --target install
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install
 }
 
 build_core_libraries_and_devtools() {
@@ -119,7 +119,7 @@ build_core_libraries_and_devtools() {
     -DEXECUTORCH_BUILD_VULKAN=ON \
     -DEXECUTORCH_BUILD_XNNPACK=ON \
     -Bcmake-out && \
-  cmake --build cmake-out -j64 --target install
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install
 
   # Build devtools example runner
   cmake examples/devtools \
@@ -127,7 +127,7 @@ build_core_libraries_and_devtools() {
     -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
     -DEXECUTORCH_BUILD_VULKAN=ON \
     -Bcmake-out/examples/devtools && \
-  cmake --build cmake-out/examples/devtools -j16 --config Release
+  cmake --build cmake-out/examples/devtools -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 }
 
 run_example_runner() {

--- a/backends/vulkan/test/scripts/test_op.sh
+++ b/backends/vulkan/test/scripts/test_op.sh
@@ -149,7 +149,7 @@ build_core_libraries() {
     -DEXECUTORCH_BUILD_XNNPACK=ON \
     -DEXECUTORCH_BUILD_TESTS=ON \
     -Bcmake-out && \
-  cmake --build cmake-out -j64 --target install
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install
 }
 
 build_operator_tests() {
@@ -195,13 +195,13 @@ build_operator_tests() {
   # Build operator tests
   cmake "${CMAKE_ARGS[@]}" \
     -Bcmake-out/backends/vulkan/test/op_tests && \
-  cmake --build cmake-out/backends/vulkan/test/op_tests -j16
+  cmake --build cmake-out/backends/vulkan/test/op_tests -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 }
 
 recompile() {
   echo "Recompiling..."
-  cmake --build cmake-out -j64 --target install
-  cmake --build cmake-out/backends/vulkan/test/op_tests -j16
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install
+  cmake --build cmake-out/backends/vulkan/test/op_tests -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 }
 
 run_operator_test() {

--- a/docs/source/backends-cadence.md
+++ b/docs/source/backends-cadence.md
@@ -311,7 +311,7 @@ cmake -DCMAKE_BUILD_TYPE=Debug \
     -Bcmake-out/examples/cadence \
     examples/cadence
 
-cmake --build cmake-out/examples/cadence -j8 -t cadence_executorch_example
+cmake --build cmake-out/examples/cadence -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -t cadence_executorch_example
 ```
 
 After having succesfully run the above step you should see two binary files in their CMake output directory.

--- a/docs/source/backends/vulkan/tutorials/etvk-llama-tutorial.md
+++ b/docs/source/backends/vulkan/tutorials/etvk-llama-tutorial.md
@@ -93,7 +93,7 @@ cmake . \
     -DEXECUTORCH_BUILD_VULKAN=ON \
     -DEXECUTORCH_BUILD_TESTS=OFF \
     -Bcmake-out-android-so && \
-cmake --build cmake-out-android-so -j16 --target install --config Release
+cmake --build cmake-out-android-so -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 ```
 
 ## Build and push the llama runner binary to Android
@@ -111,7 +111,7 @@ cmake examples/models/llama \
     -DCMAKE_BUILD_TYPE=Release \
     -DPYTHON_EXECUTABLE=python \
     -Bcmake-out-android-so/examples/models/llama && \
-cmake --build cmake-out-android-so/examples/models/llama -j16 --config Release
+cmake --build cmake-out-android-so/examples/models/llama -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 ```
 
 Once the binary is built, it can be pushed to your Android device.

--- a/docs/source/backends/vulkan/tutorials/etvk-profiling-tutorial.md
+++ b/docs/source/backends/vulkan/tutorials/etvk-profiling-tutorial.md
@@ -71,7 +71,7 @@ cmake . \
     -DEXECUTORCH_BUILD_EXECUTOR_RUNNER=ON \
     -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
     -Bcmake-out-android-so && \
-cmake --build cmake-out-android-so -j16 --target install --config Release
+cmake --build cmake-out-android-so -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 ```
 
 Once the build completes, we can push the runner binary to device.

--- a/docs/source/tutorial-xnnpack-delegate-lowering.md
+++ b/docs/source/tutorial-xnnpack-delegate-lowering.md
@@ -166,7 +166,7 @@ cmake \
 Then you can build the runtime componenets with
 
 ```bash
-cmake --build cmake-out -j9 --target install --config Release
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 ```
 
 Now you should be able to find the executable built at `./cmake-out/executor_runner` you can run the executable with the model you generated as such

--- a/examples/apple/mps/README.md
+++ b/examples/apple/mps/README.md
@@ -40,7 +40,7 @@ cmake -DCMAKE_INSTALL_PREFIX=cmake-out \
           -DEXECUTORCH_BUILD_MPS=ON \
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           -Bcmake-out .
-cmake --build cmake-out -j9 --target install --config Release
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 CMAKE_PREFIX_PATH="${PWD}/cmake-out/lib/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"
 # build mps_executor_runner
 rm -rf cmake-out/examples/apple/mps
@@ -51,7 +51,7 @@ cmake \
     -Bcmake-out/examples/apple/mps \
     examples/apple/mps
 
-cmake --build cmake-out/examples/apple/mps -j9 --config Release
+cmake --build cmake-out/examples/apple/mps -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 
 # Run the mv2 generated model using the mps_executor_runner
 ./cmake-out/examples/apple/mps/mps_executor_runner --model_path mv2_mps_bundled.pte --bundled_program

--- a/examples/apple/mps/scripts/build_mps_executor_runner.sh
+++ b/examples/apple/mps/scripts/build_mps_executor_runner.sh
@@ -50,7 +50,7 @@ cmake \
           -DEXECUTORCH_BUILD_MPS=ON \
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           -Bcmake-out .
-cmake --build cmake-out -j9 --target install --config "$MODE"
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config "$MODE"
 CMAKE_PREFIX_PATH="${PWD}/cmake-out/lib/cmake/ExecuTorch;${PWD}/cmake-out/third-party/gflags"
 # build mps_executor_runner
 rm -rf cmake-out/examples/apple/mps
@@ -61,6 +61,6 @@ cmake \
     -Bcmake-out/examples/apple/mps \
     examples/apple/mps
 
-cmake --build cmake-out/examples/apple/mps -j9 --config "$MODE"
+cmake --build cmake-out/examples/apple/mps -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config "$MODE"
 
 echo "Build succeeded!"

--- a/examples/apple/mps/test_mps.sh
+++ b/examples/apple/mps/test_mps.sh
@@ -25,7 +25,7 @@ cmake_install_executorch_devtools_lib() {
           -DEXECUTORCH_ENABLE_EVENT_TRACER=ON \
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           -Bcmake-out .
-  cmake --build cmake-out -j9 --target install --config Release
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 }
 
 test_cmake_mps() {
@@ -45,7 +45,7 @@ test_cmake_mps() {
         ${example_dir}
 
       echo "Building ${example_dir}"
-  cmake --build ${build_dir} -j9 --config Release
+  cmake --build ${build_dir} -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 
   echo 'Running mps_executor_runner'
   ${build_dir}/mps_executor_runner --bundled_program=True --model_path="./mv2_mps_bundled.pte"

--- a/examples/mediatek/mtk_build_examples.sh
+++ b/examples/mediatek/mtk_build_examples.sh
@@ -43,7 +43,7 @@ main() {
           -B"${example_build_dir}" \
           $EXECUTORCH_ROOT/$example_dir
 
-    cmake --build "${example_build_dir}" -j5
+    cmake --build "${example_build_dir}" -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 
     # Switch back to the original directory
     cd - > /dev/null

--- a/examples/models/llama/README.md
+++ b/examples/models/llama/README.md
@@ -288,7 +288,7 @@ cmake -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
     -DEXECUTORCH_BUILD_KERNELS_LLM=ON \
     -Bcmake-out-android .
 
-cmake --build cmake-out-android -j16 --target install --config Release
+cmake --build cmake-out-android -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 ```
 
 **1.2 Build llama runner for android**
@@ -307,7 +307,7 @@ cmake  -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake \
     -Bcmake-out-android/examples/models/llama \
     examples/models/llama
 
-cmake --build cmake-out-android/examples/models/llama -j16 --config Release
+cmake --build cmake-out-android/examples/models/llama -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 ```
 
 **2. Run on Android via adb shell**
@@ -400,7 +400,7 @@ cmake -DPYTHON_EXECUTABLE=python \
     -DEXECUTORCH_BUILD_EXTENSION_LLM=ON \
     -DEXECUTORCH_BUILD_KERNELS_LLM=ON \
     -Bcmake-out .
-cmake --build cmake-out -j16 --config Release --target install
+cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release --target install
 ```
 
 Next install the llama runner with torchao kernels enabled (similar to step 3.2 above):
@@ -410,7 +410,7 @@ cmake -DPYTHON_EXECUTABLE=python \
     -DCMAKE_BUILD_TYPE=Release \
     -Bcmake-out/examples/models/llama \
     examples/models/llama
-cmake --build cmake-out/examples/models/llama -j16 --config Release
+cmake --build cmake-out/examples/models/llama -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 ```
 
 Finally run your model (similar to step 3.3 above):

--- a/examples/models/phi-3-mini-lora/README.md
+++ b/examples/models/phi-3-mini-lora/README.md
@@ -24,7 +24,7 @@ python export_model.py
 (mkdir cmake-out && cd cmake-out && cmake ..)
 
 # Build the executor_runner target
-cmake --build cmake-out --target executor_runner -j9
+cmake --build cmake-out --target executor_runner -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 
 # Run the model for inference.
 ./cmake-out/executor_runner --model_path phi3_mini_lora.pte

--- a/examples/models/phi-3-mini/README.md
+++ b/examples/models/phi-3-mini/README.md
@@ -39,7 +39,7 @@ cmake -DCMAKE_PREFIX_PATH=cmake-out \
       -Bcmake-out/examples/models/phi-3-mini \
       examples/models/phi-3-mini
 
-cmake --build cmake-out/examples/models/phi-3-mini -j16 --config Release
+cmake --build cmake-out/examples/models/phi-3-mini -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 ```
 - Run model. Options available [here](https://github.com/pytorch/executorch/blob/main/examples/models/phi-3-mini/main.cpp#L16-L33)
 ```

--- a/examples/nxp/run.sh
+++ b/examples/nxp/run.sh
@@ -19,7 +19,7 @@ rm -rf ${SCRIPT_DIR}/executor_runner/build/*
 
 pushd ${SCRIPT_DIR}/executor_runner/build
 cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j8 nxp_executor_runner
+make -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) nxp_executor_runner
 popd
 
 echo "** Export cifar10 model to executorch"

--- a/examples/portable/README.md
+++ b/examples/portable/README.md
@@ -49,7 +49,7 @@ Use `-h` (or `--help`) to see all the supported models.
 (mkdir cmake-out \
     && cd cmake-out \
     && cmake -DEXECUTORCH_PAL_DEFAULT=posix ..) \
-  && cmake --build cmake-out -j32 --target executor_runner
+  && cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target executor_runner
 
 # Run the tool on the generated model.
 ./cmake-out/executor_runner --model_path mv2.pte

--- a/examples/portable/custom_ops/test_custom_ops.sh
+++ b/examples/portable/custom_ops/test_custom_ops.sh
@@ -30,7 +30,7 @@ test_cmake_custom_op_1() {
         ${example_dir}
 
   echo "Building ${example_dir}"
-  cmake --build ${build_dir} -j9 --config Release
+  cmake --build ${build_dir} -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 
   echo 'Running custom_ops_executor_runner'
   ${build_dir}/custom_ops_executor_runner --model_path="./${model_name}.pte"
@@ -66,7 +66,7 @@ test_cmake_custom_op_2() {
         ${example_dir}
 
   echo "Building ${example_dir}"
-  cmake --build ${build_dir} -j9 --config Release
+  cmake --build ${build_dir} -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 
   EXT=$(get_shared_lib_ext)
   echo "Exporting ${model_name}.pte"

--- a/examples/portable/scripts/test_demo_backend_delegation.sh
+++ b/examples/portable/scripts/test_demo_backend_delegation.sh
@@ -24,7 +24,7 @@ build_cmake_executor_runner() {
     && cd ${CMAKE_OUTPUT_DIR} \
     && retry cmake -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
 
-  cmake --build ${CMAKE_OUTPUT_DIR} -j4
+  cmake --build ${CMAKE_OUTPUT_DIR} -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 }
 
 test_demo_backend_delegation() {

--- a/examples/qualcomm/test_qualcomm.sh
+++ b/examples/qualcomm/test_qualcomm.sh
@@ -21,7 +21,7 @@ cmake_install_executorch_qnn_lib() {
           -DEXECUTORCH_BUILD_QNN=ON \
           -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
           -Bcmake-out .
-  cmake --build cmake-out -j9 --target install --config Release
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target install --config Release
 }
 
 test_cmake_qualcomm() {
@@ -45,7 +45,7 @@ test_cmake_qualcomm() {
         ${example_dir}
 
     echo "Building ${example_dir}"
-    cmake --build ${build_dir} -j9 --config Release
+    cmake --build ${build_dir} -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
     # Need to run on device
 #   ${build_dir}/qnn_executor_runner --model_path="./mv2_qnn.pte"
 }

--- a/examples/selective_build/README.md
+++ b/examples/selective_build/README.md
@@ -18,7 +18,7 @@ python -m examples.portable.scripts.export --model_name="mv2" # Create a PTE fil
 cd examples/selective_build/basic
 mkdir cmake-out && cd cmake-out
 cmake .. -DEXECUTORCH_SELECT_OPS_MODEL="../../mv2.pte" # Build with kernels needed for mv2.pte
-cmake --build . -j8
+cmake --build . -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ./selective_build_test --model_path="../../mv2.pte" # Run the model with the selective kernel library
 ```
 
@@ -78,7 +78,7 @@ python -m examples.portable.custom_ops.custom_ops_1 # Create a model PTE file
 cd examples/selective_build/basic
 mkdir cmake-out && cd cmake-out
 cmake .. -DEXECUTORCH_SELECT_OPS_MODEL="../../custom_ops_1.pte" -DEXECUTORCH_EXAMPLE_USE_CUSTOM_OPS=ON # Build with kernels needed for the model
-cmake --build . -j8
+cmake --build . -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ./selective_build_test --model_path="../../custom_ops_1.pte" # Run the model with the selective kernel library
 ```
 

--- a/examples/selective_build/test_selective_build.sh
+++ b/examples/selective_build/test_selective_build.sh
@@ -105,7 +105,7 @@ aten,aten::clone.out" \
             ${example_dir}
 
     echo "Building ${example_dir}"
-    cmake --build ${build_dir} -j9 --config Release
+    cmake --build ${build_dir} -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 
     echo 'Running selective build test'
     ${build_dir}/selective_build_test --model_path="./mv2.pte"
@@ -129,7 +129,7 @@ test_cmake_select_ops_in_yaml() {
             ${example_dir}
 
     echo "Building ${example_dir}"
-    cmake --build ${build_dir} -j9 --config Release
+    cmake --build ${build_dir} -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config Release
 
     echo 'Running selective build test'
     ${build_dir}/selective_build_test --model_path="./custom_ops_1.pte"
@@ -158,7 +158,7 @@ test_cmake_select_ops_in_model() {
             ${example_dir}
 
     echo "Building ${example_dir}"
-    cmake --build ${build_dir} -j9 --config $CMAKE_BUILD_TYPE
+    cmake --build ${build_dir} -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --config $CMAKE_BUILD_TYPE
 
     echo "Verifying auto-right-sized MAX_KERNEL_NUM header was generated"
     local generated_header

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -51,13 +51,13 @@ Use -h (or --help) to see all the supported models. For the browser example, mak
 (mkdir cmake-out-wasm \
     && cd cmake-out-wasm \
     && emcmake cmake -DEXECUTORCH_PAL_DEFAULT=posix ..) \
-  && cmake --build cmake-out-wasm -j32 --target executor_runner
+  && cmake --build cmake-out-wasm -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target executor_runner
 ```
 
 If you need to rebuild `executor_runner` after modifying the contents of `./models/`, you can run the following command
 
 ```bash
-cmake --build cmake-out-wasm -j32 --target executor_runner --clean-first
+cmake --build cmake-out-wasm -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target executor_runner --clean-first
 ```
 
 4. Run the model with Node.js. Emscripten should come preinstalled with a compatible version of Node.js. If you have an incompatible version of Node.js installed, you can use the Emscripten-provided version by running `$EMSDK_NODE` instead of `node`.
@@ -91,7 +91,7 @@ echo $EMSDK_NODE
 The file may not have been present while building the Wasm binary. You can rebuild with the following command
 
 ```bash
-cmake --build cmake-out-wasm -j32 --target executor_runner --clean-first
+cmake --build cmake-out-wasm -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target executor_runner --clean-first
 ```
 
 The path may also be incorrect. The files in the `WASM_MODEL_DIR` are placed into the root directory of the virtual file system, so you would use `--model_path mv2.pte` instead of `--model_path models/mv2.pte`, for example.

--- a/examples/wasm/test_build_wasm.sh
+++ b/examples/wasm/test_build_wasm.sh
@@ -23,7 +23,7 @@ test_build_wasm() {
     retry emcmake cmake -DWASM_MODEL_DIR="$(realpath "${model_dir_name}")" -B${build_dir} .
 
     echo "Building ${example_dir}"
-    cmake --build ${build_dir} -j9 --target executor_runner
+    cmake --build ${build_dir} -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target executor_runner
 
     echo "Removing ${model_dir_name}"
     rm -rf "${model_dir_name}"

--- a/examples/xnnpack/quantization/test_quantize.sh
+++ b/examples/xnnpack/quantization/test_quantize.sh
@@ -56,7 +56,7 @@ test_cmake_quantization() {
       -DEXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT=ON \
       -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" ..)
 
-  cmake --build cmake-out -j4
+  cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 
   EXT=$(get_shared_lib_ext)
   SO_LIB="cmake-out/kernels/quantized/libquantized_ops_aot_lib$EXT"

--- a/extension/llm/export/quantizer_lib.py
+++ b/extension/llm/export/quantizer_lib.py
@@ -109,7 +109,7 @@ def get_pt2e_quantizers(
                     "Need to specify shared library path to register quantized ops (and their out variants) into EXIR.\n"
                     "Follow the following steps to build the needed lib via cmake.\n"
                     "Then from root executorch dir do the following:\n"
-                    "rm -rf cmake-out && mkdir cmake-out && (cd cmake-out && cmake -DEXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT=ON ..) && cmake --build . -j16\n"
+                    "rm -rf cmake-out && mkdir cmake-out && (cd cmake-out && cmake -DEXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT=ON ..) && cmake --build . -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))\n"
                     'To find the location of the lib: find cmake-out -name "libquantized_ops_aot_lib*"\n'
                     "Then specify the said library via -s <path to libquantized_ops_aot_lib.so\n"
                 )

--- a/extension/wasm/README.md
+++ b/extension/wasm/README.md
@@ -30,7 +30,7 @@ emcmake cmake . -DEXECUTORCH_BUILD_WASM=ON \
     -Bcmake-out-wasm
 
 # Build the Wasm extension
-cmake --build cmake-out-wasm --target executorch_wasm -j32
+cmake --build cmake-out-wasm --target executorch_wasm -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ```
 
 To reduce the binary size, you may also use the selective build options found in the [Kernel Library Selective Build guide](../../docs/source/kernel-library-selective-build.md). You may also use optimized kernels with the `EXECUTORCH_BUILD_KERNELS_OPTIMIZED` option. Portable kernels are used by default.

--- a/extension/wasm/tokenizers/README.md
+++ b/extension/wasm/tokenizers/README.md
@@ -14,7 +14,7 @@ emcmake cmake . -DEXECUTORCH_BUILD_TOKENIZERS_WASM=ON \
     -Bcmake-out-wasm
 
 # Build the Wasm extension
-cmake --build cmake-out-wasm --target tokenizers_wasm -j32
+cmake --build cmake-out-wasm --target tokenizers_wasm -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ```
 
 Emscripten modules are loaded into the global `Module` object by default. This means you cannot have multiple modules in the same page. If you are also using the ExecuTorch Wasm bindings, it is recommended to use the `MODULARIZE` option to avoid conflicts.

--- a/tools/cmake/preset/README.md
+++ b/tools/cmake/preset/README.md
@@ -12,7 +12,7 @@ See: https://github.com/pytorch/executorch/discussions/10661. tl;dr instead of t
 
 ```bash
 $ cmake --preset macos
-$ cmake --build cmake-out -j100 --target executor_runner
+$ cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) --target executor_runner
 ```
 
 ## Working with Presets


### PR DESCRIPTION
### Summary

Follow-up to #20436, which replaced the hardcoded `cmake --build -j` parallelism in the general
build docs and `test/` scripts. This PR finishes the same job for the vendor backend scripts,
example scripts, and their documentation — 65 sites across 37 files, all mechanical:

    -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))

`nproc` on Linux, `sysctl -n hw.ncpu` on macOS (the mps and coreml scripts are Apple-only), and the
arithmetic degrades to `-j1` if neither tool exists. "Core count + 1" is the guidance already in
`docs/source/using-executorch-building-from-source.md`. The pinned values being removed ranged from
`-j4` to `-j100`, including `-j64` in the Vulkan test scripts and `-j100` in
`tools/cmake/preset/README.md`.

Two Python sites differ. `extension/llm/export/quantizer_lib.py` holds a shell command inside a
user-facing error string, so it takes the same shell expression. `backends/mlx/test/test_utils.py`
builds an argv list handed to `subprocess.run` with no shell, where a shell expression would reach
`cmake` as a literal string, so it uses `f"-j{(os.cpu_count() or 1) + 1}"` instead.

Deliberately out of scope: `.ci/**` and `.github/workflows/**`, where the runners are fixed-size and
the parallelism is a resource-tuning decision rather than a portability problem (`cuda.yml` pins
`-j4`, likely to bound peak memory); the `-j4` in `backends/mlx`'s READMEs and `run_all_tests.py`,
which is a test-worker count and not a build flag; and `docs/source/archive/`. Happy to take the CI
files in a separate PR if you'd like them changed.

Review order: the three groups are independent — vendor backend scripts under `backends/`, example
scripts and docs under `examples/`, then the two Python files, which are the only sites that are not
a pure token swap.

Partial fix for #10887.

### Test plan

ExecuTorch does not build on my Windows host, so verification is static and per-site:

- `bash -n` passes on all 20 modified shell scripts.
- Every edited command line was re-run with `cmake --build`/`make` swapped for `echo`, confirming all
  65 sites expand to a single valid integer flag (`-j17` on this 16-core machine) with zero
  expansion failures. This covers the markdown sites too, including the two lines that begin with
  `&& ` and the one with a `$ ` prompt prefix.
- `git diff` normalised on the `-j` token shows every removed line has a matching added line, so
  nothing outside the flag changed. Every changed markdown line contains a `-j` token.
- Both Python files parse; the argv site renders `-j17`; the instruction string was extracted via
  `ast` and shell-expanded to confirm a user pasting it gets `-j17`.
- `black --check` reports both Python files unchanged. Line endings are unchanged (still LF) and
  `git diff --check` reports no whitespace errors.
- `lintrunner` was **not** run locally — it is not installed on this Windows host and is unavailable
  in my WSL environment, so CI lint is the gate for that. E501 is in the repo's flake8 ignore list,
  so the one long instruction string in `quantizer_lib.py` (already 165 chars before this change) is
  not a new violation.

This PR was authored with AI assistance (Claude Code); the diff and every verification step above
were reviewed by me.

cc @GregoryComer @digantdesai @cbilgin @JakeStevens @larryliu0820
