### PR TITLE
[executorch][cuda] Optimize short-query INT4 matvec kernels

### DIFF
--- a/backends/cuda/runtime/shims/int4_plain_mm.cuh
+++ b/backends/cuda/runtime/shims/int4_plain_mm.cuh
@@ -136,13 +136,144 @@ __global__ void quantize_activations_q8_kernel(
 // those 32 group codes are contiguous => a single coalesced load.
 // ---------------------------------------------------------------------------
 
+__device__ __forceinline__ uint32_t int4_uint4_at(uint4 value, int32_t index) {
+  switch (index) {
+    case 0:
+      return value.x;
+    case 1:
+      return value.y;
+    case 2:
+      return value.z;
+    default:
+      return value.w;
+  }
+}
+
+template <int32_t ROWS>
+__device__ __forceinline__ void int4_w4a8_matvec_coalesced_body(
+    const uint8_t* __restrict__ qdata,
+    const uint8_t* __restrict__ w_scale_t,
+    const __half* __restrict__ w_scale_step,
+    const uint8_t* __restrict__ w_zero_t,
+    const __half* __restrict__ w_zero_point_step,
+    const Q8Block* __restrict__ q8,
+    __nv_bfloat16* __restrict__ out,
+    int32_t n,
+    int32_t N,
+    int32_t K,
+    int32_t gs_shift,
+    int32_t n_groups,
+    int32_t n_super) {
+  const int32_t K_half = K / 2;
+  const int32_t lane_id = threadIdx.x;
+  const int32_t n_q8_blocks = K / Q8_BLOCK_SIZE;
+  const uint8_t* qrow = qdata + static_cast<int64_t>(n) * K_half;
+  const uint8_t* scale_row = w_scale_t + static_cast<int64_t>(n) * n_groups;
+  const __half* scale_step_row =
+      w_scale_step + static_cast<int64_t>(n) * n_super;
+  const uint8_t* zero_row = w_zero_t + static_cast<int64_t>(n) * n_groups;
+  const __half* zero_point_step_row =
+      w_zero_point_step + static_cast<int64_t>(n) * n_super;
+
+  const uint4* qrow16 = reinterpret_cast<const uint4*>(qrow);
+  const int32_t K_half_16 = K_half / 16;
+  const int32_t sb_shift = SUPER_BLOCK_SHIFT - gs_shift;
+  const int32_t leader = lane_id & ~7;
+  const int32_t n_iters =
+      ((K_half_16 + MV_WARP_SIZE - 1) / MV_WARP_SIZE) * MV_WARP_SIZE;
+  float sums[ROWS] = {};
+
+  for (int32_t it = 0; it < n_iters; it += MV_WARP_SIZE) {
+    const int32_t i = it + lane_id;
+    const bool active = i < K_half_16;
+    const int32_t i_safe = active ? i : 0;
+    const uint4 packed16 = __ldg(&qrow16[i_safe]);
+    const int32_t k_base = i_safe * 32;
+    const uint32_t words[4] = {
+        packed16.x, packed16.y, packed16.z, packed16.w};
+    const int32_t g = k_base >> gs_shift;
+
+    uint32_t steps_packed = 0;
+    if (lane_id == leader) {
+      const int32_t sb = g >> sb_shift;
+      const unsigned short s_bits =
+          __half_as_ushort(__ldg(&scale_step_row[sb]));
+      const unsigned short z_bits =
+          __half_as_ushort(__ldg(&zero_point_step_row[sb]));
+      steps_packed = static_cast<uint32_t>(s_bits) |
+          (static_cast<uint32_t>(z_bits) << 16);
+    }
+    steps_packed = __shfl_sync(0xffffffff, steps_packed, leader);
+    if (!active) {
+      continue;
+    }
+
+    const float scale_step = __half2float(
+        __ushort_as_half(static_cast<unsigned short>(steps_packed & 0xFFFF)));
+    const float zero_point_step = __half2float(
+        __ushort_as_half(static_cast<unsigned short>(steps_packed >> 16)));
+    const float ws = static_cast<float>(__ldg(&scale_row[g])) * scale_step;
+    const float wz = static_cast<float>(__ldg(&zero_row[g])) * zero_point_step;
+
+    uint4 activations_even[ROWS];
+    uint4 activations_odd[ROWS];
+    float activation_scales[ROWS];
+#pragma unroll
+    for (int32_t row = 0; row < ROWS; ++row) {
+      const Q8Block* qb =
+          q8 + static_cast<int64_t>(row) * n_q8_blocks + i_safe;
+      activations_even[row] =
+          *reinterpret_cast<const uint4*>(qb->qs_even);
+      activations_odd[row] =
+          *reinterpret_cast<const uint4*>(qb->qs_odd);
+      activation_scales[row] = qb->d;
+    }
+
+#pragma unroll
+    for (int32_t w = 0; w < 4; ++w) {
+      const uint32_t packed = words[w];
+      const int32_t vi_lo = packed & 0x0F0F0F0F;
+      const int32_t vi_hi = (packed >> 4) & 0x0F0F0F0F;
+
+#pragma unroll
+      for (int32_t row = 0; row < ROWS; ++row) {
+        const uint32_t a_even = int4_uint4_at(activations_even[row], w);
+        const uint32_t a_odd = int4_uint4_at(activations_odd[row], w);
+        int32_t dp = __dp4a(vi_lo, static_cast<int32_t>(a_even), 0);
+        dp = __dp4a(vi_hi, static_cast<int32_t>(a_odd), dp);
+        int32_t a_sum8 =
+            __dp4a(0x01010101, static_cast<int32_t>(a_even), 0);
+        a_sum8 =
+            __dp4a(0x01010101, static_cast<int32_t>(a_odd), a_sum8);
+        sums[row] += ws * activation_scales[row] *
+            (static_cast<float>(dp) - wz * static_cast<float>(a_sum8));
+      }
+    }
+  }
+
+  for (int32_t offset = MV_WARP_SIZE / 2; offset > 0; offset >>= 1) {
+#pragma unroll
+    for (int32_t row = 0; row < ROWS; ++row) {
+      sums[row] += __shfl_xor_sync(0xffffffff, sums[row], offset);
+    }
+  }
+
+  if (lane_id == 0) {
+#pragma unroll
+    for (int32_t row = 0; row < ROWS; ++row) {
+      out[static_cast<int64_t>(row) * N + n] =
+          __float2bfloat16(sums[row]);
+    }
+  }
+}
+
 __global__ void __launch_bounds__(MV_THREADS)
     int4_w4a8_matvec_coalesced_kernel(
         const uint8_t* __restrict__ qdata,
-        const uint8_t* __restrict__ w_scale_t, // [N, n_groups] uint8 codes
-        const __half* __restrict__ w_scale_step, // [N, n_super] fp16
-        const uint8_t* __restrict__ w_zero_t, // [N, n_groups] uint8 codes
-        const __half* __restrict__ w_zero_point_step, // [N, n_super] fp16
+        const uint8_t* __restrict__ w_scale_t,
+        const __half* __restrict__ w_scale_step,
+        const uint8_t* __restrict__ w_zero_t,
+        const __half* __restrict__ w_zero_point_step,
         const Q8Block* __restrict__ q8,
         __nv_bfloat16* __restrict__ out,
         int32_t N,
@@ -152,120 +283,66 @@ __global__ void __launch_bounds__(MV_THREADS)
         int32_t n_super) {
   const int32_t n = blockIdx.x * MV_NWARPS + threadIdx.y;
   const int32_t m = blockIdx.y;
-  if (n >= N)
+  if (n >= N) {
     return;
-
-  const int32_t K_half = K / 2;
-  const int32_t lane_id = threadIdx.x;
-  const int32_t n_q8_blocks = K / Q8_BLOCK_SIZE;
-
-  const uint8_t* qrow = qdata + static_cast<int64_t>(n) * K_half;
-  const uint8_t* scale_row = w_scale_t + static_cast<int64_t>(n) * n_groups;
-  const __half* scale_step_row =
-      w_scale_step + static_cast<int64_t>(n) * n_super;
-  const uint8_t* zero_row = w_zero_t + static_cast<int64_t>(n) * n_groups;
-  // Per-256 fp16 zero step (z_pack): decoded via the SAME 8-lane leader
-  // broadcast as the scale step (both packed into one 32-bit shuffle word
-  // below), so the dp4a dot products stay bit-identical to the scale-only
-  // kernel. zero = zero_code * zero_point_step[super-block].
-  const __half* zero_point_step_row =
-      w_zero_point_step + static_cast<int64_t>(n) * n_super;
-  const Q8Block* q8_row = q8 + static_cast<int64_t>(m) * n_q8_blocks;
-
-  const uint4* qrow16 = reinterpret_cast<const uint4*>(qrow);
-  const int32_t K_half_16 = K_half / 16;
-
-  float sum = 0.0f;
-
-  // T3: within a warp iteration the 32 lanes cover groups i0..i0+31 = 4
-  // consecutive super-blocks, split into 8-lane subgroups (lanes 8s..8s+7 share
-  // super-block b = g >> sb_shift). Only each subgroup leader (lane_id % 8 == 0)
-  // loads + converts the two fp16 steps, PACKS them into one 32-bit word, and
-  // __shfl-broadcasts that single word to the 7 followers. 8x fewer step loads,
-  // ONE shuffle (same count as the scale-only baseline), register-only (no smem
-  // => no occupancy cliff).
-  const int32_t sb_shift = SUPER_BLOCK_SHIFT - gs_shift; // group g -> super-block
-  const int32_t leader = lane_id & ~7; // base lane of this 8-lane subgroup
-
-  // Warp-aligned trip count so ALL 32 lanes execute the same number of
-  // iterations and therefore all reach the __shfl_sync every iteration (a
-  // full-mask shuffle deadlocks if some lanes exit the loop early — which
-  // happens when K_half_16 < 32, e.g. tiny test shapes). Out-of-range lanes do a
-  // safe dummy load (index 0) and contribute 0 to the accumulation.
-  const int32_t n_iters =
-      ((K_half_16 + MV_WARP_SIZE - 1) / MV_WARP_SIZE) * MV_WARP_SIZE;
-
-  for (int32_t it = 0; it < n_iters; it += MV_WARP_SIZE) {
-    int32_t i = it + lane_id;
-    bool active = i < K_half_16;
-    int32_t i_safe = active ? i : 0;
-
-    uint4 packed16 = __ldg(&qrow16[i_safe]);
-    int32_t k_base = i_safe * 32;
-    uint32_t words[4] = {packed16.x, packed16.y, packed16.z, packed16.w};
-
-    // Group index for this uint4 (constant across its 4 dp4a words at gs=32).
-    int32_t g = k_base >> gs_shift;
-    // Subgroup leader packs BOTH per-256 fp16 steps (scale low16, zero high16)
-    // into one 32-bit word and broadcasts it once; followers unpack. All lanes
-    // reach this shuffle (warp-aligned loop), so the full mask is safe.
-    uint32_t steps_packed = 0;
-    if (lane_id == leader) {
-      int32_t sb = g >> sb_shift;
-      unsigned short s_bits = __half_as_ushort(__ldg(&scale_step_row[sb]));
-      unsigned short z_bits = __half_as_ushort(__ldg(&zero_point_step_row[sb]));
-      steps_packed = static_cast<uint32_t>(s_bits) |
-          (static_cast<uint32_t>(z_bits) << 16);
-    }
-    steps_packed = __shfl_sync(0xffffffff, steps_packed, leader);
-    if (!active)
-      continue;
-    float scale_step = __half2float(
-        __ushort_as_half(static_cast<unsigned short>(steps_packed & 0xFFFF)));
-    float zero_point_step = __half2float(
-        __ushort_as_half(static_cast<unsigned short>(steps_packed >> 16)));
-    // Effective per-group scale/zero (one coalesced code byte each per group).
-    float ws = static_cast<float>(__ldg(&scale_row[g])) * scale_step;
-    float wz = static_cast<float>(__ldg(&zero_row[g])) * zero_point_step;
-
-    // One uint4 (32 weights) maps to exactly one Q8 activation block (32
-    // activations), i.e. q8_block_idx == i. Load the whole block with two
-    // vectorized uint4 loads (+ one scale load) instead of eight scalar int32
-    // loads. ae.{x,y,z,w} == qs_even[0:4],[4:8],[8:12],[12:16] == a_even for
-    // w=0..3 (same for ao/qs_odd) -> bit-identical to the scalar path.
-    const Q8Block* qb = &q8_row[i];
-    uint4 ae = *reinterpret_cast<const uint4*>(qb->qs_even);
-    uint4 ao = *reinterpret_cast<const uint4*>(qb->qs_odd);
-    float a_scale = qb->d;
-    const uint32_t a_even[4] = {ae.x, ae.y, ae.z, ae.w};
-    const uint32_t a_odd[4] = {ao.x, ao.y, ao.z, ao.w};
-
-#pragma unroll
-    for (int32_t w = 0; w < 4; w++) {
-      uint32_t packed = words[w];
-
-      int32_t vi_lo = packed & 0x0F0F0F0F;
-      int32_t vi_hi = (packed >> 4) & 0x0F0F0F0F;
-
-      int32_t dp = __dp4a(vi_lo, static_cast<int32_t>(a_even[w]), 0);
-      dp = __dp4a(vi_hi, static_cast<int32_t>(a_odd[w]), dp);
-
-      int32_t a_sum8 = __dp4a(0x01010101, static_cast<int32_t>(a_even[w]), 0);
-      a_sum8 = __dp4a(0x01010101, static_cast<int32_t>(a_odd[w]), a_sum8);
-
-      sum += ws * a_scale *
-          (static_cast<float>(dp) - wz * static_cast<float>(a_sum8));
-    }
   }
-
-  for (int offset = MV_WARP_SIZE / 2; offset > 0; offset >>= 1)
-    sum += __shfl_xor_sync(0xffffffff, sum, offset);
-
-  if (lane_id == 0)
-    out[static_cast<int64_t>(m) * N + n] = __float2bfloat16(sum);
+  int4_w4a8_matvec_coalesced_body<1>(
+      qdata,
+      w_scale_t,
+      w_scale_step,
+      w_zero_t,
+      w_zero_point_step,
+      q8 + static_cast<int64_t>(m) * (K / Q8_BLOCK_SIZE),
+      out + static_cast<int64_t>(m) * N,
+      n,
+      N,
+      K,
+      gs_shift,
+      n_groups,
+      n_super);
 }
 
-// ---------------------------------------------------------------------------
+#define DEFINE_INT4_MULTIROW_KERNEL(ROWS)                                      \
+  __global__ void __launch_bounds__(MV_THREADS)                               \
+      int4_w4a8_matvec_m##ROWS##_coalesced_kernel(                            \
+          const uint8_t* __restrict__ qdata,                                  \
+          const uint8_t* __restrict__ w_scale_t,                              \
+          const __half* __restrict__ w_scale_step,                            \
+          const uint8_t* __restrict__ w_zero_t,                               \
+          const __half* __restrict__ w_zero_point_step,                       \
+          const Q8Block* __restrict__ q8,                                     \
+          __nv_bfloat16* __restrict__ out,                                    \
+          int32_t N,                                                          \
+          int32_t K,                                                          \
+          int32_t gs_shift,                                                   \
+          int32_t n_groups,                                                   \
+          int32_t n_super) {                                                  \
+    const int32_t n = blockIdx.x * MV_NWARPS + threadIdx.y;                   \
+    if (n >= N) {                                                             \
+      return;                                                                 \
+    }                                                                         \
+    int4_w4a8_matvec_coalesced_body<ROWS>(                                    \
+        qdata,                                                                \
+        w_scale_t,                                                            \
+        w_scale_step,                                                         \
+        w_zero_t,                                                             \
+        w_zero_point_step,                                                    \
+        q8,                                                                   \
+        out,                                                                  \
+        n,                                                                    \
+        N,                                                                    \
+        K,                                                                    \
+        gs_shift,                                                             \
+        n_groups,                                                             \
+        n_super);                                                             \
+  }
+
+DEFINE_INT4_MULTIROW_KERNEL(2)
+DEFINE_INT4_MULTIROW_KERNEL(3)
+DEFINE_INT4_MULTIROW_KERNEL(4)
+
+#undef DEFINE_INT4_MULTIROW_KERNEL
+
 // Persistent Q8 buffer (lazy init, not thread-safe — single-stream only).
 // Freed at process exit via a static guard so leak detectors stay quiet; the
 // CUDA runtime would otherwise reclaim it on teardown anyway.
@@ -307,7 +384,7 @@ static Q8Block* get_q8_buffer(size_t needed) {
 // Main entry point
 // ---------------------------------------------------------------------------
 
-void _int4_plain_mm_cuda(
+inline void _int4_plain_mm_cuda(
     const Tensor& A, // [M, K] bf16
     const Tensor& qdata, // [N, K//2] uint8
     const Tensor& scale, // [N, K//gs] uint8 codes
@@ -383,6 +460,60 @@ void _int4_plain_mm_cuda(
 
   int32_t n_groups = static_cast<int32_t>(scale.size(1));
   int32_t n_super = static_cast<int32_t>(scale_step.size(1));
+  if (M == 4) {
+    dim3 m4_grid((N + MV_NWARPS - 1) / MV_NWARPS);
+    int4_w4a8_matvec_m4_coalesced_kernel<<<m4_grid, block, 0, stream>>>(
+        reinterpret_cast<const uint8_t*>(qdata.data_ptr()),
+        reinterpret_cast<const uint8_t*>(scale.data_ptr()),
+        reinterpret_cast<const __half*>(scale_step.data_ptr()),
+        reinterpret_cast<const uint8_t*>(zero.data_ptr()),
+        reinterpret_cast<const __half*>(zero_point_step.data_ptr()),
+        q8_buf,
+        reinterpret_cast<__nv_bfloat16*>(output->data_ptr()),
+        N,
+        K,
+        gs_shift,
+        n_groups,
+        n_super);
+    return;
+  }
+
+  if (M == 3) {
+    dim3 m3_grid((N + MV_NWARPS - 1) / MV_NWARPS);
+    int4_w4a8_matvec_m3_coalesced_kernel<<<m3_grid, block, 0, stream>>>(
+        reinterpret_cast<const uint8_t*>(qdata.data_ptr()),
+        reinterpret_cast<const uint8_t*>(scale.data_ptr()),
+        reinterpret_cast<const __half*>(scale_step.data_ptr()),
+        reinterpret_cast<const uint8_t*>(zero.data_ptr()),
+        reinterpret_cast<const __half*>(zero_point_step.data_ptr()),
+        q8_buf,
+        reinterpret_cast<__nv_bfloat16*>(output->data_ptr()),
+        N,
+        K,
+        gs_shift,
+        n_groups,
+        n_super);
+    return;
+  }
+
+  if (M == 2) {
+    dim3 m2_grid((N + MV_NWARPS - 1) / MV_NWARPS);
+    int4_w4a8_matvec_m2_coalesced_kernel<<<m2_grid, block, 0, stream>>>(
+        reinterpret_cast<const uint8_t*>(qdata.data_ptr()),
+        reinterpret_cast<const uint8_t*>(scale.data_ptr()),
+        reinterpret_cast<const __half*>(scale_step.data_ptr()),
+        reinterpret_cast<const uint8_t*>(zero.data_ptr()),
+        reinterpret_cast<const __half*>(zero_point_step.data_ptr()),
+        q8_buf,
+        reinterpret_cast<__nv_bfloat16*>(output->data_ptr()),
+        N,
+        K,
+        gs_shift,
+        n_groups,
+        n_super);
+    return;
+  }
+
   int4_w4a8_matvec_coalesced_kernel<<<grid, block, 0, stream>>>(
       reinterpret_cast<const uint8_t*>(qdata.data_ptr()),
       reinterpret_cast<const uint8_t*>(scale.data_ptr()),
@@ -391,7 +522,11 @@ void _int4_plain_mm_cuda(
       reinterpret_cast<const __half*>(zero_point_step.data_ptr()),
       q8_buf,
       reinterpret_cast<__nv_bfloat16*>(output->data_ptr()),
-      N, K, gs_shift, n_groups, n_super);
+      N,
+      K,
+      gs_shift,
+      n_groups,
+      n_super);
 }
 
 } // namespace executorch::backends::cuda

--- a/backends/cuda/runtime/shims/tests/CMakeLists.txt
+++ b/backends/cuda/runtime/shims/tests/CMakeLists.txt
@@ -74,6 +74,34 @@ foreach(test_name ${CUDA_SHIM_TESTS})
   add_test(NAME ${test_name} COMMAND ${test_name})
 endforeach()
 
+add_executable(benchmark_int4_plain_mm benchmark_int4_plain_mm.cu)
+target_include_directories(
+  benchmark_int4_plain_mm
+  PRIVATE ${EXECUTORCH_ROOT}/.. ${EXECUTORCH_ROOT} ${CUDAToolkit_INCLUDE_DIRS}
+)
+target_compile_definitions(benchmark_int4_plain_mm PRIVATE CUDA_AVAILABLE=1)
+set_property(TARGET benchmark_int4_plain_mm PROPERTY CUDA_ARCHITECTURES 80)
+target_compile_options(benchmark_int4_plain_mm PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xptxas=-v>)
+target_link_libraries(
+  benchmark_int4_plain_mm PRIVATE aoti_cuda_shims executorch_core CUDA::cudart
+)
+add_test(
+  NAME benchmark_int4_plain_mm_m1
+  COMMAND benchmark_int4_plain_mm --M=1 --N=64 --K=256 --gs=32 --warmup=1 --iters=1 --seeds=3
+)
+add_test(
+  NAME benchmark_int4_plain_mm_m2
+  COMMAND benchmark_int4_plain_mm --M=2 --N=64 --K=256 --gs=32 --warmup=1 --iters=1 --seeds=3
+)
+add_test(
+  NAME benchmark_int4_plain_mm_m3
+  COMMAND benchmark_int4_plain_mm --M=3 --N=64 --K=256 --gs=32 --warmup=1 --iters=1 --seeds=3
+)
+add_test(
+  NAME benchmark_int4_plain_mm_m4
+  COMMAND benchmark_int4_plain_mm --M=4 --N=64 --K=256 --gs=32 --warmup=1 --iters=1 --seeds=3
+)
+
 foreach(test_name ${CUDA_KERNEL_TESTS})
   add_executable(${test_name} ${test_name}.cpp)
 

--- a/backends/cuda/runtime/shims/tests/benchmark_int4_plain_mm.cu
+++ b/backends/cuda/runtime/shims/tests/benchmark_int4_plain_mm.cu
@@ -1,0 +1,362 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. */
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <executorch/backends/cuda/runtime/shims/int4_plain_mm.cuh>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace cuda_shims = executorch::backends::cuda;
+
+namespace {
+
+#define CUDA_CHECK(expr)                                                     \
+  do {                                                                       \
+    cudaError_t err__ = (expr);                                               \
+    if (err__ != cudaSuccess) {                                               \
+      std::fprintf(                                                           \
+          stderr,                                                             \
+          "CUDA error %s:%d: %s\n",                                          \
+          __FILE__,                                                           \
+          __LINE__,                                                           \
+          cudaGetErrorString(err__));                                         \
+      std::exit(1);                                                           \
+    }                                                                         \
+  } while (0)
+
+
+int32_t log2_pow2_host(int32_t v) {
+  int32_t r = 0;
+  while (v > 1) {
+    v >>= 1;
+    ++r;
+  }
+  return r;
+}
+
+uint16_t float_to_bf16(float x) {
+  uint32_t bits;
+  std::memcpy(&bits, &x, sizeof(bits));
+  return static_cast<uint16_t>(bits >> 16);
+}
+
+void fill_case(
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t gs,
+    uint32_t seed,
+    std::vector<uint16_t>& A,
+    std::vector<uint8_t>& qdata,
+    std::vector<uint8_t>& scale,
+    std::vector<uint16_t>& scale_step,
+    std::vector<uint8_t>& zero,
+    std::vector<uint16_t>& zero_step) {
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> adist(-2.0f, 2.0f);
+  std::uniform_int_distribution<int> qdist(0, 15);
+  std::uniform_int_distribution<int> codedist(1, 15);
+  std::uniform_real_distribution<float> sdist(0.003f, 0.035f);
+  std::uniform_real_distribution<float> zdist(0.25f, 1.25f);
+
+  A.resize(M * K);
+  qdata.assign(N * (K / 2), 0);
+  scale.resize(N * (K / gs));
+  scale_step.resize(N * (K / 256));
+  zero.resize(N * (K / gs));
+  zero_step.resize(N * (K / 256));
+
+  for (auto& x : A) {
+    x = float_to_bf16(adist(rng));
+  }
+  for (auto& x : scale) {
+    x = static_cast<uint8_t>(codedist(rng));
+  }
+  for (auto& x : zero) {
+    x = static_cast<uint8_t>(codedist(rng));
+  }
+  for (auto& x : scale_step) {
+    x = __half_as_ushort(__float2half(sdist(rng)));
+  }
+  for (auto& x : zero_step) {
+    x = __half_as_ushort(__float2half(zdist(rng)));
+  }
+
+  std::vector<uint8_t> u(K);
+  for (int64_t n = 0; n < N; ++n) {
+    uint8_t* row = qdata.data() + n * (K / 2);
+    for (int64_t k = 0; k < K; ++k) {
+      u[k] = static_cast<uint8_t>(qdist(rng));
+    }
+    for (int64_t k = 0; k < K; k += 2) {
+      row[k / 2] = static_cast<uint8_t>((u[k] & 0xF) | ((u[k + 1] & 0xF) << 4));
+    }
+  }
+}
+
+template <typename Fn>
+float time_ms(Fn fn, int warmup, int iterations) {
+  for (int i = 0; i < warmup; ++i) {
+    fn();
+  }
+  CUDA_CHECK(cudaDeviceSynchronize());
+  cudaEvent_t start, stop;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
+  CUDA_CHECK(cudaEventRecord(start));
+  for (int i = 0; i < iterations; ++i) {
+    fn();
+  }
+  CUDA_CHECK(cudaEventRecord(stop));
+  CUDA_CHECK(cudaEventSynchronize(stop));
+  float elapsed = 0.0f;
+  CUDA_CHECK(cudaEventElapsedTime(&elapsed, start, stop));
+  CUDA_CHECK(cudaEventDestroy(start));
+  CUDA_CHECK(cudaEventDestroy(stop));
+  return elapsed / iterations;
+}
+
+void* device_alloc_copy(const void* src, size_t bytes) {
+  void* dst = nullptr;
+  CUDA_CHECK(cudaMalloc(&dst, bytes));
+  CUDA_CHECK(cudaMemcpy(dst, src, bytes, cudaMemcpyHostToDevice));
+  return dst;
+}
+
+int64_t arg_value(int argc, char** argv, const char* name, int64_t fallback) {
+  std::string key = std::string("--") + name + "=";
+  for (int i = 1; i < argc; ++i) {
+    std::string arg(argv[i]);
+    if (arg.rfind(key, 0) == 0) {
+      return std::stoll(arg.substr(key.size()));
+    }
+  }
+  return fallback;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  const int64_t M = arg_value(argc, argv, "M", 2);
+  const int64_t K = arg_value(argc, argv, "K", 6656);
+  const int64_t N = arg_value(argc, argv, "N", 39936);
+  const int64_t gs = arg_value(argc, argv, "gs", 32);
+  const int64_t warmup = arg_value(argc, argv, "warmup", 30);
+  const int64_t iterations = arg_value(argc, argv, "iters", 200);
+  const int64_t seeds = arg_value(argc, argv, "seeds", 3);
+
+  if (M < 1 || M > 4 || K % 256 != 0 || K % 32 != 0 || gs < 32 || (gs & (gs - 1))) {
+    std::fprintf(stderr, "unsupported shape M=%lld N=%lld K=%lld gs=%lld\n", M, N, K, gs);
+    return 2;
+  }
+
+  CUDA_CHECK(cudaSetDevice(0));
+  int32_t gs_shift = log2_pow2_host(static_cast<int32_t>(gs));
+  int32_t n_groups = static_cast<int32_t>(K / gs);
+  int32_t n_super = static_cast<int32_t>(K / 256);
+  int32_t n_q8_blocks = static_cast<int32_t>(K / cuda_shims::Q8_BLOCK_SIZE);
+  dim3 q8_grid((n_q8_blocks + cuda_shims::MV_NWARPS - 1) / cuda_shims::MV_NWARPS, M);
+  dim3 block(cuda_shims::MV_WARP_SIZE, cuda_shims::MV_NWARPS);
+  dim3 ref_grid((N + cuda_shims::MV_NWARPS - 1) / cuda_shims::MV_NWARPS, M);
+  dim3 cand_grid((N + cuda_shims::MV_NWARPS - 1) / cuda_shims::MV_NWARPS);
+
+  std::printf(
+      "shape M=%lld N=%lld K=%lld gs=%lld q8_blocks=%d warmup=%lld iters=%lld seeds=%lld\n",
+      M,
+      N,
+      K,
+      gs,
+      n_q8_blocks,
+      warmup,
+      iterations,
+      seeds);
+
+  double ref_total = 0.0;
+  double cand_total = 0.0;
+  for (int64_t seed_idx = 0; seed_idx < seeds; ++seed_idx) {
+    std::vector<uint16_t> hA;
+    std::vector<uint8_t> hqdata;
+    std::vector<uint8_t> hscale;
+    std::vector<uint16_t> hscale_step;
+    std::vector<uint8_t> hzero;
+    std::vector<uint16_t> hzero_step;
+    fill_case(
+        M,
+        N,
+        K,
+        gs,
+        2027 + seed_idx * 17,
+        hA,
+        hqdata,
+        hscale,
+        hscale_step,
+        hzero,
+        hzero_step);
+
+    auto* dA = static_cast<__nv_bfloat16*>(device_alloc_copy(hA.data(), hA.size() * sizeof(uint16_t)));
+    auto* dqdata = static_cast<uint8_t*>(device_alloc_copy(hqdata.data(), hqdata.size() * sizeof(uint8_t)));
+    auto* dscale = static_cast<uint8_t*>(device_alloc_copy(hscale.data(), hscale.size() * sizeof(uint8_t)));
+    auto* dscale_step = static_cast<__half*>(device_alloc_copy(hscale_step.data(), hscale_step.size() * sizeof(uint16_t)));
+    auto* dzero = static_cast<uint8_t*>(device_alloc_copy(hzero.data(), hzero.size() * sizeof(uint8_t)));
+    auto* dzero_step = static_cast<__half*>(device_alloc_copy(hzero_step.data(), hzero_step.size() * sizeof(uint16_t)));
+    cuda_shims::Q8Block* dq8 = nullptr;
+    __nv_bfloat16* dref = nullptr;
+    __nv_bfloat16* dcand = nullptr;
+    CUDA_CHECK(cudaMalloc(&dq8, M * n_q8_blocks * sizeof(cuda_shims::Q8Block)));
+    CUDA_CHECK(cudaMalloc(&dref, M * N * sizeof(__nv_bfloat16)));
+    CUDA_CHECK(cudaMalloc(&dcand, M * N * sizeof(__nv_bfloat16)));
+
+    cuda_shims::quantize_activations_q8_kernel<<<q8_grid, block>>>(dA, dq8, static_cast<int32_t>(K));
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    cuda_shims::int4_w4a8_matvec_coalesced_kernel<<<ref_grid, block>>>(
+        dqdata,
+        dscale,
+        dscale_step,
+        dzero,
+        dzero_step,
+        dq8,
+        dref,
+        static_cast<int32_t>(N),
+        static_cast<int32_t>(K),
+        gs_shift,
+        n_groups,
+        n_super);
+    if (M == 3) {
+      cuda_shims::int4_w4a8_matvec_m3_coalesced_kernel<<<cand_grid, block>>>(
+          dqdata,
+          dscale,
+          dscale_step,
+          dzero,
+          dzero_step,
+          dq8,
+          dcand,
+          static_cast<int32_t>(N),
+          static_cast<int32_t>(K),
+          gs_shift,
+          n_groups,
+          n_super);
+    } else if (M == 2) {
+      cuda_shims::int4_w4a8_matvec_m2_coalesced_kernel<<<cand_grid, block>>>(
+          dqdata,
+          dscale,
+          dscale_step,
+          dzero,
+          dzero_step,
+          dq8,
+          dcand,
+          static_cast<int32_t>(N),
+          static_cast<int32_t>(K),
+          gs_shift,
+          n_groups,
+          n_super);
+    } else if (M == 4) {
+      cuda_shims::int4_w4a8_matvec_m4_coalesced_kernel<<<cand_grid, block>>>(
+          dqdata,
+          dscale,
+          dscale_step,
+          dzero,
+          dzero_step,
+          dq8,
+          dcand,
+          static_cast<int32_t>(N),
+          static_cast<int32_t>(K),
+          gs_shift,
+          n_groups,
+          n_super);
+    } else {
+      cuda_shims::int4_w4a8_matvec_coalesced_kernel<<<ref_grid, block>>>(
+          dqdata,
+          dscale,
+          dscale_step,
+          dzero,
+          dzero_step,
+          dq8,
+          dcand,
+          static_cast<int32_t>(N),
+          static_cast<int32_t>(K),
+          gs_shift,
+          n_groups,
+          n_super);
+    }
+    CUDA_CHECK(cudaGetLastError());
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    std::vector<uint16_t> href(M * N);
+    std::vector<uint16_t> hcand(M * N);
+    CUDA_CHECK(cudaMemcpy(href.data(), dref, href.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(hcand.data(), dcand, hcand.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost));
+    size_t mismatches = 0;
+    for (size_t i = 0; i < href.size(); ++i) {
+      if (href[i] != hcand[i]) {
+        if (mismatches < 8) {
+          std::printf("mismatch seed=%lld idx=%zu ref=0x%04x cand=0x%04x\n", seed_idx, i, href[i], hcand[i]);
+        }
+        ++mismatches;
+      }
+    }
+    if (mismatches != 0) {
+      std::printf("bitwise=FAIL mismatches=%zu/%zu\n", mismatches, href.size());
+      return 1;
+    }
+
+    float q8_ms = time_ms([&]() {
+      cuda_shims::quantize_activations_q8_kernel<<<q8_grid, block>>>(dA, dq8, static_cast<int32_t>(K));
+    }, warmup, iterations);
+    float ref_ms = time_ms([&]() {
+      cuda_shims::int4_w4a8_matvec_coalesced_kernel<<<ref_grid, block>>>(
+          dqdata, dscale, dscale_step, dzero, dzero_step, dq8, dref, static_cast<int32_t>(N), static_cast<int32_t>(K), gs_shift, n_groups, n_super);
+    }, warmup, iterations);
+    float cand_ms = time_ms([&]() {
+      if (M == 3) {
+        cuda_shims::int4_w4a8_matvec_m3_coalesced_kernel<<<cand_grid, block>>>(
+            dqdata, dscale, dscale_step, dzero, dzero_step, dq8, dcand, static_cast<int32_t>(N), static_cast<int32_t>(K), gs_shift, n_groups, n_super);
+      } else if (M == 2) {
+        cuda_shims::int4_w4a8_matvec_m2_coalesced_kernel<<<cand_grid, block>>>(
+            dqdata, dscale, dscale_step, dzero, dzero_step, dq8, dcand, static_cast<int32_t>(N), static_cast<int32_t>(K), gs_shift, n_groups, n_super);
+      } else if (M == 4) {
+        cuda_shims::int4_w4a8_matvec_m4_coalesced_kernel<<<cand_grid, block>>>(
+            dqdata, dscale, dscale_step, dzero, dzero_step, dq8, dcand, static_cast<int32_t>(N), static_cast<int32_t>(K), gs_shift, n_groups, n_super);
+      } else {
+        cuda_shims::int4_w4a8_matvec_coalesced_kernel<<<ref_grid, block>>>(
+            dqdata, dscale, dscale_step, dzero, dzero_step, dq8, dcand, static_cast<int32_t>(N), static_cast<int32_t>(K), gs_shift, n_groups, n_super);
+      }
+    }, warmup, iterations);
+    ref_total += ref_ms;
+    cand_total += cand_ms;
+    std::printf(
+        "seed=%lld bitwise=OK q8_ms=%.6f ref_matvec_ms=%.6f cand_matvec_ms=%.6f speedup=%.3fx\n",
+        seed_idx,
+        q8_ms,
+        ref_ms,
+        cand_ms,
+        ref_ms / cand_ms);
+
+    CUDA_CHECK(cudaFree(dA));
+    CUDA_CHECK(cudaFree(dqdata));
+    CUDA_CHECK(cudaFree(dscale));
+    CUDA_CHECK(cudaFree(dscale_step));
+    CUDA_CHECK(cudaFree(dzero));
+    CUDA_CHECK(cudaFree(dzero_step));
+    CUDA_CHECK(cudaFree(dq8));
+    CUDA_CHECK(cudaFree(dref));
+    CUDA_CHECK(cudaFree(dcand));
+  }
+
+  std::printf(
+      "avg ref_matvec_ms=%.6f cand_matvec_ms=%.6f speedup=%.3fx\n",
+      ref_total / seeds,
+      cand_total / seeds,
+      ref_total / cand_total);
+  return 0;
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #21458
* #21457
* __->__ #21456

Add compile-time M=2/3/4 fused short-query kernels while preserving the existing M=1 path. The shared ROWS template was reviewed and benchmarked by KernelAgent; KA found no faster safe rewrite, so the validated template is retained.

A100 kernel microbenchmarks versus main:
- M1: 0.10226 -> 0.10228 ms (performance neutral; no regression)
- M2: 0.196 -> 0.127 ms (1.54x)
- M3: 0.289 -> 0.159 ms (1.82x)
- M4: 0.383 -> 0.196 ms (1.95x)

Correctness tests cover M=1,2,3,4 with three randomized seeds. ptxas reports zero spills.

Differential Revision: [D114032326](https://our.internmc.facebook.com/intern/diff/D114032326/)