### PR TITLE
Fix DS-CNN Cortex-M input memory format

### DIFF
--- a/examples/models/mlperf_tiny/ds_cnn.py
+++ b/examples/models/mlperf_tiny/ds_cnn.py
@@ -83,4 +83,8 @@ class DSCNNKWSModel(EagerModelBase):
         return DSCNNKWS().eval()
 
     def get_example_inputs(self):
-        return (torch.rand(1, 1, 49, 10) * 2 - 1,)
+        return (
+            (torch.rand(1, 1, 49, 10) * 2 - 1).to(
+                memory_format=torch.channels_last
+            ),
+        )

--- a/examples/models/mlperf_tiny/ds_cnn.py
+++ b/examples/models/mlperf_tiny/ds_cnn.py
@@ -84,7 +84,5 @@ class DSCNNKWSModel(EagerModelBase):
 
     def get_example_inputs(self):
         return (
-            (torch.rand(1, 1, 49, 10) * 2 - 1).to(
-                memory_format=torch.channels_last
-            ),
+            (torch.rand(1, 1, 49, 10) * 2 - 1).to(memory_format=torch.channels_last),
         )


### PR DESCRIPTION
### Summary

The shared DS-CNN model wrapper returned a contiguous NCHW example input, while the Cortex-M backend requires channels-last inputs. This caused the nightly Cortex-M FVP run to abort in `cortex_m::quantized_depthwise_conv2d.out` with `input must be channels_last`.

Convert the example input to channels-last, matching the existing Cortex-M DS-CNN tests and backend contract. The tensor values and eager model output are unchanged.

### Test plan

Ran `python -m py_compile examples/models/mlperf_tiny/ds_cnn.py` and `git diff --check`. Loaded the patched wrapper and verified input stride `(490, 1, 10, 1)`, eager output shape `(1, 12)`, and the exported user-input stride `(490, 1, 10, 1)`.

Authored with Claude.