### PR TITLE
Fix XNNPACK pooling crashing on default stride and single-element kernel_size

### DIFF
--- a/backends/xnnpack/operators/op_avg_pooling2d.py
+++ b/backends/xnnpack/operators/op_avg_pooling2d.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import cast, Dict, List
+from typing import cast, Dict
 
 import torch
 from executorch.backends.xnnpack.operators.node_visitor import (
@@ -16,6 +16,7 @@ from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
     XNNGraph,
     XNode,
 )
+from executorch.backends.xnnpack.utils.utils import normalize_pool2d_args
 from executorch.backends.xnnpack.utils.xnnpack_constants import XNN_FLAG_KEEP_DIMS
 
 
@@ -43,16 +44,10 @@ class AveragePooling2d(NodeVisitor):
         # output
         output_id = vals_to_ids[node]
 
-        # kernel_size
-        pooling_height, pooling_width = cast(List, node.args[1])
-
-        # stride
-        stride_height, stride_width = cast(List, node.args[2])
-
-        # padding
-        padding_height, padding_width = 0, 0
-        if node.args[3] is not None:
-            padding_height, padding_width = cast(List[int], node.args[3])
+        kernel, stride, padding, _ = normalize_pool2d_args(node, has_dilation=False)
+        pooling_height, pooling_width = kernel
+        stride_height, stride_width = stride
+        padding_height, padding_width = padding
 
         ser_node = XNode(
             xnode_union=XNNAvgPooling2d(

--- a/backends/xnnpack/operators/op_max_pool2d.py
+++ b/backends/xnnpack/operators/op_max_pool2d.py
@@ -6,7 +6,7 @@
 
 # pyre-unsafe
 
-from typing import cast, Dict, List
+from typing import Dict
 
 import torch
 from executorch.backends.xnnpack.operators.node_visitor import (
@@ -20,6 +20,7 @@ from executorch.backends.xnnpack.serialization.xnnpack_graph_schema import (
     XNNMaxPooling2d,
     XNode,
 )
+from executorch.backends.xnnpack.utils.utils import normalize_pool2d_args
 from executorch.backends.xnnpack.utils.xnnpack_constants import XNN_FLAG_KEEP_DIMS
 
 
@@ -52,36 +53,23 @@ class MaxPooling2d(NodeVisitor):
         kwargs["input_id"] = vals_to_ids[node.all_input_nodes[0]]
         kwargs["output_id"] = vals_to_ids[node]
 
-        # kernel info
-        kernel_shape = cast(List[int], node.args[1])
+        kernel_shape, stride, padding_shape, dilation = normalize_pool2d_args(
+            node, has_dilation=True
+        )
+
         kwargs["pooling_height"] = kernel_shape[0]
         kwargs["pooling_width"] = kernel_shape[1]
 
-        # stride info
-        stride = cast(List[int], node.args[2])
         kwargs["stride_height"] = stride[0]
         kwargs["stride_width"] = stride[1]
 
-        # padding info
-        kwargs["padding_top"] = 0
-        kwargs["padding_right"] = 0
-        kwargs["padding_bottom"] = 0
-        kwargs["padding_left"] = 0
+        kwargs["padding_top"] = padding_shape[0]
+        kwargs["padding_right"] = padding_shape[1]
+        kwargs["padding_bottom"] = padding_shape[0]
+        kwargs["padding_left"] = padding_shape[1]
 
-        if len(node.args) > 3:
-            padding_shape = cast(List[int], node.args[3])
-            kwargs["padding_top"] = padding_shape[0]
-            kwargs["padding_right"] = padding_shape[1]
-            kwargs["padding_bottom"] = padding_shape[0]
-            kwargs["padding_left"] = padding_shape[1]
-
-        # dilation info
-        kwargs["dilation_height"] = 1
-        kwargs["dilation_width"] = 1
-        if len(node._args) > 4:
-            dilation = cast(List[int], node.args[4])
-            kwargs["dilation_height"] = dilation[0]
-            kwargs["dilation_width"] = dilation[1]
+        kwargs["dilation_height"] = dilation[0]
+        kwargs["dilation_width"] = dilation[1]
 
         # ceil mode
         ceil_mode = node.args[5] if len(node.args) > 5 else False

--- a/backends/xnnpack/partition/config/generic_node_configs.py
+++ b/backends/xnnpack/partition/config/generic_node_configs.py
@@ -21,7 +21,11 @@ from executorch.backends.xnnpack.utils.quant_utils import (
     is_quant,
     tag_as_implicit_q_dq,
 )
-from executorch.backends.xnnpack.utils.utils import get_input_node, normalize_mean_dims
+from executorch.backends.xnnpack.utils.utils import (
+    get_input_node,
+    normalize_mean_dims,
+    normalize_pool2d_args,
+)
 from executorch.exir.backend.canonical_partitioners.config_partitioner import (
     format_target_name,
 )
@@ -180,7 +184,7 @@ class AvgPoolingConfig(GenericNodePartitionerConfig):
         if len(args) >= 6:
             count_include_pad = cast(bool, args[5])
 
-        kernel_size = cast(List[int], args[1])
+        kernel_size, _, _, _ = normalize_pool2d_args(node, has_dilation=False)
         pooling_region = kernel_size[0] * kernel_size[1]
         divisor_override = pooling_region  # Default divisor is pooling_region
         if len(args) >= 7:
@@ -348,8 +352,7 @@ class MaxPool2dConfig(GenericNodePartitionerConfig):
         if not self.check_common_constraints(node, ep):
             return False
 
-        kernel_size = node.args[1]
-        stride = node.args[2]
+        kernel_size, stride, _, _ = normalize_pool2d_args(node, has_dilation=True)
         is_ceil_mode = len(node.args) >= 6 and cast(bool, node.args[5])
 
         # Ceil mode is supported via op padding, which must be statically known.
@@ -357,7 +360,7 @@ class MaxPool2dConfig(GenericNodePartitionerConfig):
             why(node, reason="ceil mode is not supported for dynamic shapes")
             return False
 
-        if stride[0] > kernel_size[0] or stride[1] > kernel_size[1]:  # pyre-ignore[16]
+        if stride[0] > kernel_size[0] or stride[1] > kernel_size[1]:
             why(
                 node,
                 reason=f"stride ({stride}) must be less than or equal to kernel size ({kernel_size})",

--- a/backends/xnnpack/test/ops/test_avgpool2d.py
+++ b/backends/xnnpack/test/ops/test_avgpool2d.py
@@ -78,6 +78,48 @@ class TestAvgPool2d(unittest.TestCase):
             .check_not(["torch.ops.higher_order.executorch_call_delegate"])
         )
 
+    class AvgPool2dSingleElementKernel(torch.nn.Module):
+        def __init__(self, divisor_override=None):
+            super().__init__()
+            self.avgPool = torch.nn.AvgPool2d(
+                kernel_size=[3],
+                count_include_pad=False,
+                divisor_override=divisor_override,
+            )
+
+        def forward(self, x):
+            return self.avgPool(x)
+
+    def test_fp32_avgpool2d_single_element_kernel_size(self):
+        """
+        int[2] arguments accept a 1-element list, which broadcasts to both dims.
+        """
+        inputs = (torch.randn(1, 1, 10, 10),)
+        (
+            Tester(self.AvgPool2dSingleElementKernel(), inputs)
+            .export()
+            .check_count({"torch.ops.aten.avg_pool2d.default": 1})
+            .to_edge_transform_and_lower()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_avgpool2d_single_element_kernel_size_divisor_override(self):
+        """
+        A broadcast kernel_size must still produce a real pooling region to compare
+        against divisor_override. Here the region is 3 * 3, so 5 is unsupported.
+        """
+        inputs = (torch.randn(1, 1, 10, 10),)
+        (
+            Tester(self.AvgPool2dSingleElementKernel(divisor_override=5), inputs)
+            .export()
+            .check_count({"torch.ops.aten.avg_pool2d.default": 1})
+            .to_edge_transform_and_lower()
+            .check_not(["torch.ops.higher_order.executorch_call_delegate"])
+        )
+
     def test_fp32_avgpool2d_divisor_override(self):
         """
         The XNNPACK backend does not support divisor overrides not equal to the pooling region.

--- a/backends/xnnpack/test/ops/test_maxpool2d.py
+++ b/backends/xnnpack/test/ops/test_maxpool2d.py
@@ -188,6 +188,43 @@ class TestMaxPool2d(unittest.TestCase):
             .run_method_and_compare_outputs()
         )
 
+    def test_fp32_maxpool2d_default_stride(self):
+        """
+        stride defaults to kernel_size when omitted, and is absent from node.args.
+        """
+
+        class MaxPool2dDefaultStride(torch.nn.Module):
+            def forward(self, x):
+                return torch.nn.functional.max_pool2d(x, 2)
+
+        inputs = (torch.randn(4, 3, 24, 24),)
+        (
+            Tester(MaxPool2dDefaultStride(), inputs)
+            .export()
+            .check_count({"torch.ops.aten.max_pool2d.default": 1})
+            .to_edge_transform_and_lower()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
+    def test_fp32_maxpool2d_single_element_kernel_size(self):
+        """
+        int[2] arguments accept a 1-element list, which broadcasts to both dims.
+        """
+        inputs = (torch.randn(4, 3, 24, 24),)
+        (
+            Tester(self.MaxPool2d(kernel_size=[3], stride=[2]), inputs)
+            .export()
+            .check_count({"torch.ops.aten.max_pool2d.default": 1})
+            .to_edge_transform_and_lower()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 1})
+            .to_executorch()
+            .serialize()
+            .run_method_and_compare_outputs()
+        )
+
     def test_qs8_maxpool2d(self):
         class MaxPool(torch.nn.Module):
             def __init__(self, maxpool_params):

--- a/backends/xnnpack/utils/utils.py
+++ b/backends/xnnpack/utils/utils.py
@@ -74,6 +74,33 @@ def normalize_mean_dims(mean_dims: Sequence[int] | int | None, rank: int) -> Lis
     return normalized_dims
 
 
+def normalize_pool2d_args(
+    node: torch.fx.Node, has_dilation: bool
+) -> Tuple[List[int], List[int], List[int], List[int]]:
+    """Return (kernel, stride, padding, dilation) for a pool2d node as 2-element lists.
+
+    Applies the aten schema defaults: an int or 1-element list broadcasts to both
+    dimensions, an omitted or empty stride means kernel_size, padding defaults to
+    0 and dilation to 1.
+    """
+    args = node.args
+
+    def pair(index: int, default: Optional[List[int]] = None) -> List[int]:
+        value = args[index] if len(args) > index else None
+        if isinstance(value, int):
+            return [value, value]
+        values = list(value) if value is not None else []
+        if not values:
+            return cast(List[int], default)
+        return [values[0], values[0]] if len(values) == 1 else [values[0], values[1]]
+
+    kernel = pair(1)
+    stride = pair(2, kernel)
+    padding = pair(3, [0, 0])
+    dilation = pair(4, [1, 1]) if has_dilation else [1, 1]
+    return kernel, stride, padding, dilation
+
+
 def get_relu_fused_node(node: torch.fx.Node) -> Optional[torch.fx.Node]:
     """
     Checks if the current node is only consumed by a relu node and can be fused,


### PR DESCRIPTION
Fixes #21488
Fixes #10968
Fixes #10969

## Problem

The aten schemas are

```
avg_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, ...)
max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0,
           int[2] dilation=1, bool ceil_mode=False)
```

Two schema facts the XNNPACK pooling code does not account for. `stride` defaults to the empty list, meaning "use kernel_size", and may be absent from `node.args` entirely. And `int[2]` accepts a scalar or a 1-element list, which broadcasts to both dimensions.

`MaxPool2dConfig.check_constraints` indexed positionally:

```python
kernel_size = node.args[1]
stride = node.args[2]
...
if stride[0] > kernel_size[0] or stride[1] > kernel_size[1]:
```

and `AvgPoolingConfig.check_constraints` did

```python
kernel_size = cast(List[int], args[1])
pooling_region = kernel_size[0] * kernel_size[1]
```

Both assume a fully populated 2-element list, so three plain uses of the documented API raise `IndexError` from inside the partitioner's own constraint check, before any support decision is reached:

```
F.max_pool2d(x, 2)     IndexError: tuple index out of range   generic_node_configs.py:352
nn.MaxPool2d([3])      IndexError: list index out of range    generic_node_configs.py:360
nn.AvgPool2d([3])      IndexError: list index out of range    generic_node_configs.py:184
```

The visitors index the same way, so even a node that passed the config would fail during serialization.

Declaring `target_name = "max_pool2d.default"` promises the whole schema. The identical models with an explicit 2-element stride lower and run correctly today.

## Fix

One helper, `normalize_pool2d_args`, placed next to the existing `normalize_mean_dims` in `backends/xnnpack/utils/utils.py`, which exists for exactly this reason on `mean.dim` and is already called from both that config and that visitor:

```python
kernel = pair(1)
stride = pair(2, kernel)
padding = pair(3, [0, 0])
dilation = pair(4, [1, 1]) if has_dilation else [1, 1]
```

It is called from `AvgPoolingConfig.check_constraints`, `MaxPool2dConfig.check_constraints`, `MaxPooling2d.define_node` and `AveragePooling2d.define_node` in place of the raw indexing.

This is the same normalization five other backends here already do, so "the partitioner may assume canonical args" is contradicted by standing practice in the repo. `backends/arm/_passes/rewrite_max_pool2d_pass.py:82-87` is structurally the same helper:

```python
stride = to_2tuple(args[2]) if len(args) > 2 else ()
if not stride:
    stride = kernel  # default to kernel_size
padding = to_2tuple(args[3]) if len(args) > 3 else (0, 0)
dilation = to_2tuple(args[4]) if len(args) > 4 else (1, 1)
```

`backends/samsung/builders/op_max_pool2d.py:51-55` does the same, including `stride = cast(List[int], node.args[2]) if len(node.args) > 2 else kernel_size`. `backends/mlx/ops.py` carries the comment `if not stride:  # empty list means default to kernel_size`. `backends/qualcomm/builders/op_max_pool2d.py:63-76` and `backends/apple/mps/operators/convolution_ops.py:53-57` both broadcast 1-element kernel, stride, padding and dilation.

`AvgPoolingConfig` already conceded the point internally. It guards `len(args) >= 5`, `>= 6` and `>= 7` for `ceil_mode`, `count_include_pad` and `divisor_override` on the lines around the crash. It knows arg tuples arrive short, it just started guarding at index 5 instead of index 2.

Two incidental cleanups caused by the change, called out so they are not a surprise in review: the `# pyre-ignore[16]` on the stride comparison is dropped because `stride` is now typed, and `cast`/`List` imports that became unused are removed.

## Effect

Same script run on either side of the change. `delegated` is whether the node reached XNNPACK, `maxdiff` is deviation from eager.

```
                                     BEFORE                          AFTER
max_pool2d(x, 2)            IndexError :352                 delegated  maxdiff=0.00e+00
nn.MaxPool2d([3])   #10969  IndexError :360                 delegated  maxdiff=0.00e+00
nn.AvgPool2d([3])   #10968  IndexError :184                 delegated  maxdiff=5.96e-08
CONTROL explicit [2,2]      delegated  maxdiff=0.00e+00     delegated  maxdiff=0.00e+00
CONTROL explicit [3,3]      delegated  maxdiff=1.19e-07     delegated  maxdiff=1.19e-07
NEGATIVE stride > kernel    not delegated                   not delegated
```

The negative control is the important one. Normalization could have turned "correctly decline" into "delegate something XNNPACK cannot do", and it does not.

Declining these nodes instead of normalizing them would also have fixed the crash, but it is strictly worse. All four cases match eager once they delegate, so XNNPACK does support them, and silently dropping `F.max_pool2d(x, 2)` out of the delegate would be a performance regression on one of the most common CNN patterns there is.

## Blast radius

Only nodes whose pooling args are currently missing or scalar, which is exactly the set that raises today. For fully specified 2-element args the helper returns the same lists, so existing behaviour is unchanged. No serialization format or runtime change; the `.pte` schema already carries separate height and width fields.

## Testing

Four cases added, two per file. `test_maxpool2d.py` gets default stride and a 1-element `kernel_size`. `test_avgpool2d.py` gets a 1-element `kernel_size`, and a 1-element `kernel_size` with `divisor_override=5`. The second matters because normalizing turns the `divisor_override != pooling_region` comparison from a crash into a live code path, and it must still decline, since the region is 3 * 3 rather than 5.

Verified failing-first by reverting only the four source files and keeping the tests: all four fail with `IndexError` at `generic_node_configs.py:352`, `:360` and `:184`.

```
backends/xnnpack/test/ops/test_maxpool2d.py + test_avgpool2d.py
  main    : 12 passed
  this PR : 16 passed

backends/xnnpack/test/ops/  (whole directory)
  main    : 222 passed, 4 subtests passed, 0 failed
  this PR : 226 passed, 4 subtests passed, 0 failed
```

Which spellings are affected, for reference:

```
nn.MaxPool2d(2)            kernel=[2, 2]  stride=[2, 2]   works today
nn.MaxPool2d(2, stride=2)  kernel=[2, 2]  stride=[2, 2]   works today
F.max_pool2d(x, 2, 2)      kernel=[2, 2]  stride=[2, 2]   works today
nn.MaxPool2d([3])          kernel=[3]     stride=[3]      IndexError
F.max_pool2d(x, 2)         kernel=[2, 2]  stride=MISSING  IndexError
F.max_pool2d(x, [3])       kernel=[3]     stride=MISSING  IndexError
```

`nn.MaxPool2d` supplies `stride` from `kernel_size` in its own `__init__`, and a bare int is expanded to `[n, n]` before the op is called, so the common spelling is safe on both counts and existing coverage never reaches these paths.

`lintrunner` reports no issues on all six changed files.


cc @GregoryComer @digantdesai @cbilgin @JakeStevens