### PR TITLE
[ET-VK][ops] Add scalar comparison operators

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_buffer.yaml
@@ -24,3 +24,18 @@ binary_scalar_buffer:
     - NAME: eq_scalar_buffer
       OPERATOR: X == Y
       IS_COMPARISON_OP: true
+    - NAME: ne_scalar_buffer
+      OPERATOR: X != Y
+      IS_COMPARISON_OP: true
+    - NAME: lt_scalar_buffer
+      OPERATOR: X < Y
+      IS_COMPARISON_OP: true
+    - NAME: le_scalar_buffer
+      OPERATOR: X <= Y
+      IS_COMPARISON_OP: true
+    - NAME: gt_scalar_buffer
+      OPERATOR: X > Y
+      IS_COMPARISON_OP: true
+    - NAME: ge_scalar_buffer
+      OPERATOR: X >= Y
+      IS_COMPARISON_OP: true

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_texture.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_texture.yaml
@@ -24,3 +24,18 @@ binary_scalar_texture:
     - NAME: eq_scalar_texture3d
       OPERATOR: equal(X, Y)
       IS_COMPARISON_OP: true
+    - NAME: ne_scalar_texture3d
+      OPERATOR: notEqual(X, Y)
+      IS_COMPARISON_OP: true
+    - NAME: lt_scalar_texture3d
+      OPERATOR: lessThan(X, Y)
+      IS_COMPARISON_OP: true
+    - NAME: le_scalar_texture3d
+      OPERATOR: lessThanEqual(X, Y)
+      IS_COMPARISON_OP: true
+    - NAME: gt_scalar_texture3d
+      OPERATOR: greaterThan(X, Y)
+      IS_COMPARISON_OP: true
+    - NAME: ge_scalar_texture3d
+      OPERATOR: greaterThanEqual(X, Y)
+      IS_COMPARISON_OP: true

--- a/backends/vulkan/runtime/graph/ops/impl/BinaryScalarOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/BinaryScalarOp.cpp
@@ -127,9 +127,34 @@ void eq_tensor_scalar(ComputeGraph& graph, const std::vector<ValueRef>& args) {
   return add_binary_scalar_op_node(graph, args[0], args[1], args[2], "eq");
 }
 
+void ne_tensor_scalar(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  return add_binary_scalar_op_node(graph, args[0], args[1], args[2], "ne");
+}
+
+void lt_tensor_scalar(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  return add_binary_scalar_op_node(graph, args[0], args[1], args[2], "lt");
+}
+
+void le_tensor_scalar(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  return add_binary_scalar_op_node(graph, args[0], args[1], args[2], "le");
+}
+
+void gt_tensor_scalar(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  return add_binary_scalar_op_node(graph, args[0], args[1], args[2], "gt");
+}
+
+void ge_tensor_scalar(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  return add_binary_scalar_op_node(graph, args[0], args[1], args[2], "ge");
+}
+
 REGISTER_OPERATORS {
   VK_REGISTER_OP(aten.pow.Tensor_Scalar, pow_tensor_scalar);
   VK_REGISTER_OP(aten.eq.Scalar, eq_tensor_scalar);
+  VK_REGISTER_OP(aten.ne.Scalar, ne_tensor_scalar);
+  VK_REGISTER_OP(aten.lt.Scalar, lt_tensor_scalar);
+  VK_REGISTER_OP(aten.le.Scalar, le_tensor_scalar);
+  VK_REGISTER_OP(aten.gt.Scalar, gt_tensor_scalar);
+  VK_REGISTER_OP(aten.ge.Scalar, ge_tensor_scalar);
 }
 
 } // namespace vkcompute

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -2250,3 +2250,42 @@ def get_eq_scalar_inputs():
     test_suite.dtypes = ["at::kInt", "at::kFloat"]
     test_suite.data_gen = "make_seq_tensor"
     return test_suite
+
+
+def _get_compare_scalar_inputs():
+    test_suite = VkTestSuite(
+        [
+            ((M2, M1), 2.5),
+            ((S1, M1, M2), 1000),
+        ]
+    )
+    test_suite.storage_types = ["utils::kBuffer", "utils::kTexture3D"]
+    test_suite.layouts = ["utils::kWidthPacked", "utils::kChannelsPacked"]
+    test_suite.dtypes = ["at::kFloat"]
+    test_suite.data_gen = "make_seq_tensor"
+    return test_suite
+
+
+@register_test_suite("aten.ne.Scalar")
+def get_ne_scalar_inputs():
+    return _get_compare_scalar_inputs()
+
+
+@register_test_suite("aten.lt.Scalar")
+def get_lt_scalar_inputs():
+    return _get_compare_scalar_inputs()
+
+
+@register_test_suite("aten.le.Scalar")
+def get_le_scalar_inputs():
+    return _get_compare_scalar_inputs()
+
+
+@register_test_suite("aten.gt.Scalar")
+def get_gt_scalar_inputs():
+    return _get_compare_scalar_inputs()
+
+
+@register_test_suite("aten.ge.Scalar")
+def get_ge_scalar_inputs():
+    return _get_compare_scalar_inputs()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #21521
* #21520
* __->__ #21519

Add Vulkan buffer and texture kernels for `ne`, `lt`, `le`, `gt`, and `ge` tensor-scalar comparisons. Register each ATen operator and cover float comparison behavior across buffer and texture storage.

Authored with Codex.

Differential Revision: [D114382683](https://our.internmc.facebook.com/intern/diff/D114382683/)