### PR TITLE
[ET-VK][ops] Add log10 support

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/unary_op.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/unary_op.yaml
@@ -44,6 +44,8 @@ unary_op:
       OPERATOR: hardsigmoid(X)
     - NAME: leaky_relu
       OPERATOR: leaky_relu(X, A)
+    - NAME: log10
+      OPERATOR: log(X) * 0.4342944819
     - NAME: round
       OPERATOR: round(X)
     - NAME: bitwise_not_uint8

--- a/backends/vulkan/runtime/graph/ops/impl/UnaryOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/UnaryOp.cpp
@@ -157,6 +157,7 @@ DEFINE_HARDSHRINK_FN(hardshrink);
 DEFINE_ACTIVATION_FN(hardswish);
 DEFINE_ACTIVATION_FN(hardsigmoid);
 DEFINE_LEAKY_RELU_FN(leaky_relu);
+DEFINE_ACTIVATION_FN(log10);
 DEFINE_ACTIVATION_FN(round);
 DEFINE_ACTIVATION_FN(bitwise_not);
 
@@ -179,6 +180,7 @@ REGISTER_OPERATORS {
   VK_REGISTER_OP(aten.hardswish.default, hardswish);
   VK_REGISTER_OP(aten.hardsigmoid.default, hardsigmoid);
   VK_REGISTER_OP(aten.leaky_relu.default, leaky_relu);
+  VK_REGISTER_OP(aten.log10.default, log10);
   VK_REGISTER_OP(aten.round.default, round);
   VK_REGISTER_OP(aten.bitwise_not.default, bitwise_not);
 }

--- a/backends/vulkan/test/op_tests/cases.py
+++ b/backends/vulkan/test/op_tests/cases.py
@@ -1813,6 +1813,7 @@ def get_var_inputs():
         "aten.hardswish.default",
         "aten.hardsigmoid.default",
         "aten.leaky_relu.default",
+        "aten.log10.default",
         "aten.round.default",
         "aten.tan.default",
         "aten.relu6.default",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #21521
* __->__ #21520
* #21519

Add `aten.log10.default` to the existing Vulkan unary shader family and cover float behavior across buffer and texture storage. Authored with Codex.

Differential Revision: [D114382686](https://our.internmc.facebook.com/intern/diff/D114382686/)