### PR TITLE
Ship the CUDA delegate as its own library

### DIFF
--- a/.ci/scripts/wheel/test_cpp_sdk.py
+++ b/.ci/scripts/wheel/test_cpp_sdk.py
@@ -50,6 +50,10 @@ _XNNPACK_SYMBOLS = (
     "executorch::backends::xnnpack::XnnpackBackendOptions::workspace_manager",
 )
 
+# A representative symbol from the CUDA delegate's shim layer. The delegate's own
+# methods are weak symbols, so this checks a strong one instead.
+_CUDA_SYMBOLS = ("executorch::backends::cuda::clearCurrentCUDAStream",)
+
 # `nm -DC` prints "<hexaddr> <kind> <name>" for a definition and
 # "                 U <name>" for an undefined reference.
 _DEFINED = re.compile(r"^[0-9a-fA-F]+\s+(?P<kind>[A-Za-z])\s+(?P<name>.+)$")
@@ -113,8 +117,12 @@ def _defines_symbol(library: Path, symbol: str) -> bool:
     return False
 
 
-def _assert_single_definer(symbols, what: str) -> None:
-    """Exactly one shipped library may define each of `symbols`."""
+def _assert_single_definer(symbols, what: str, optional: bool = False) -> None:
+    """Exactly one shipped library may define each of `symbols`.
+
+    `optional` allows a component that is only present in some wheel flavors,
+    such as an accelerator delegate, to be absent without failing.
+    """
     assert shutil.which("nm") is not None, "nm is required to inspect the wheel"
 
     package_dir = _installed_package_dir()
@@ -124,6 +132,9 @@ def _assert_single_definer(symbols, what: str) -> None:
     for symbol in symbols:
         definers = [lib for lib in libraries if _defines_symbol(lib, symbol)]
         pretty = [str(lib.relative_to(package_dir)) for lib in definers]
+        if optional and not definers:
+            print(f"- no {what} in this wheel, skipping")
+            return
         assert len(definers) == 1, (
             f"expected exactly one library to define {symbol}, found "
             f"{len(definers)}: {pretty}. More than one definition means the "
@@ -150,6 +161,11 @@ def test_single_kernel_registration() -> None:
 def test_single_xnnpack_delegate() -> None:
     """Exactly one shipped library may define the XNNPACK delegate."""
     _assert_single_definer(_XNNPACK_SYMBOLS, "XNNPACK delegate")
+
+
+def test_single_cuda_delegate() -> None:
+    """Exactly one shipped library may define the CUDA delegate, if present."""
+    _assert_single_definer(_CUDA_SYMBOLS, "CUDA delegate", optional=True)
 
 
 def test_cpp_consumer(work_dir: Path) -> None:
@@ -209,4 +225,5 @@ def run_tests(work_dir: Path) -> None:
     test_single_threadpool()
     test_single_kernel_registration()
     test_single_xnnpack_delegate()
+    test_single_cuda_delegate()
     test_cpp_consumer(work_dir)

--- a/backends/cuda/CMakeLists.txt
+++ b/backends/cuda/CMakeLists.txt
@@ -93,8 +93,17 @@ target_compile_options(
   PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:${_cuda_cxx_compile_options}>"
 )
 
-# Link against ExecuTorch core libraries
-target_link_libraries(cuda_platform PRIVATE executorch_core ${CMAKE_DL_LIBS})
+# Link against ExecuTorch core libraries. Resolve them from the shared runtime
+# when there is one, so this does not carry a second copy of the backend
+# registry.
+if(EXECUTORCH_BUILD_SHARED)
+  target_link_libraries(
+    cuda_platform PRIVATE executorch_shared ${CMAKE_DL_LIBS}
+  )
+  executorch_target_link_shared_runtime(cuda_platform)
+else()
+  target_link_libraries(cuda_platform PRIVATE executorch_core ${CMAKE_DL_LIBS})
+endif()
 
 install(
   TARGETS cuda_platform
@@ -169,14 +178,9 @@ if(_cuda_is_msvc_toolchain)
 else()
   target_link_libraries(
     aoti_cuda_shims
-    PRIVATE cuda_platform
-    PUBLIC -Wl,--whole-archive
-           aoti_common_shims_slim
-           -Wl,--no-whole-archive
-           CUDA::cudart
-           CUDA::curand
-           extension_cuda
-           ${CMAKE_DL_LIBS}
+    PRIVATE cuda_platform -Wl,--whole-archive aoti_common_shims_slim
+            -Wl,--no-whole-archive
+    PUBLIC CUDA::cudart CUDA::curand extension_cuda ${CMAKE_DL_LIBS}
   )
 endif()
 
@@ -200,7 +204,33 @@ if(_cuda_is_msvc_toolchain)
   list(APPEND _aoti_cuda_backend_sources runtime/cuda_allocator.cpp)
 endif()
 
-add_library(aoti_cuda_backend STATIC ${_aoti_cuda_backend_sources})
+# Build the delegate as a shared library for the wheel so a process has one copy
+# of it, and keep it static everywhere else so no other build changes.
+if(EXECUTORCH_BUILD_SHARED)
+  set(_aoti_cuda_backend_library_type SHARED)
+else()
+  set(_aoti_cuda_backend_library_type STATIC)
+endif()
+add_library(
+  aoti_cuda_backend ${_aoti_cuda_backend_library_type}
+                    ${_aoti_cuda_backend_sources}
+)
+if(EXECUTORCH_BUILD_SHARED)
+  set_target_properties(
+    aoti_cuda_backend
+    PROPERTIES OUTPUT_NAME executorch_cuda_backend
+               VERSION "${PROJECT_VERSION}"
+               SOVERSION "${PROJECT_VERSION_MAJOR}"
+  )
+  if(NOT APPLE)
+    # Ships beside the runtime in the wheel's lib/ directory. libcudart and
+    # friends come from the environment, so they are not bundled here.
+    set_target_properties(
+      aoti_cuda_backend PROPERTIES BUILD_RPATH "$ORIGIN" INSTALL_RPATH
+                                                         "$ORIGIN"
+    )
+  endif()
+endif()
 
 target_include_directories(
   aoti_cuda_backend

--- a/setup.py
+++ b/setup.py
@@ -1160,6 +1160,23 @@ setup(
                         "EXECUTORCH_BUILD_XNNPACK",
                     ],
                 ),
+                # Install the CUDA delegate beside them when it is built. The CUDA
+                # runtime itself is not bundled; it comes from the environment.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/backends/cuda/",
+                    src_name=(
+                        "libexecutorch_cuda_backend.so."
+                        f"{get_runtime_soname_major()}.*"
+                    ),
+                    dst=(
+                        "executorch/lib/libexecutorch_cuda_backend.so."
+                        f"{get_runtime_soname_major()}"
+                    ),
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_CUDA",
+                    ],
+                ),
                 # Install the prebuilt pybindings extension wrapper for the runtime,
                 # portable kernels, and a selection of backends. This lets users
                 # load and execute .pte files from python.


### PR DESCRIPTION
The CUDA delegate is compiled into whichever component links it, so a C++
application cannot use it without building from source, and the shim layer it
depends on ends up duplicated across several shipped libraries.

Build the delegate as a shared library and ship it in the wheel, so a process
has one copy and both the Python bindings and a C++ application can link the
same one. The CUDA runtime itself is not bundled; it continues to come from the
environment.

Two things were needed to make that actually reduce duplication:

The platform helper resolved the ExecuTorch core statically, which would give
the delegate its own copy of the backend registry. It now resolves the runtime
from the shared runtime library instead.

The shim library force-links its shim objects so their symbols survive, which is
correct, but it did so as a public link option. That propagated to every
consumer, so each one embedded another copy of the same shim code. Making it
private keeps the symbols in the library that owns them while consumers resolve
against it, which takes a representative shim symbol from three definitions down
to one.

Registration still happens through a static initializer, and the delegate is
retained on the link line so that initializer runs even though no symbol from it
is referenced directly.

This is gated on the existing `EXECUTORCH_BUILD_SHARED` option, so only the
Linux wheel changes; every other build keeps linking static libraries exactly as
before.

Test plan:

The wheel smoke test now asserts that exactly one shipped library defines the
CUDA delegate, alongside the existing backend-registry, thread-pool, CPU kernel,
and XNNPACK assertions. Because the delegate is only present in wheels built
with CUDA, that assertion skips cleanly when it is absent rather than failing.
All three behaviors were confirmed: it passes on a wheel built with this change,
it fails on a wheel built before it (correctly reporting three definers by
name), and it skips on a wheel built without CUDA.

The delegate's own methods are weak symbols, so the assertion checks a strong
symbol from the shim layer instead.

Built the wheel with CUDA enabled from a clean checkout and verified against a
fresh virtual environment with a normal dependency-resolving install:

- The wheel ships the delegate as its own versioned library next to the runtime,
  the thread pool, the CPU kernels, and the XNNPACK delegate.
- `nm -DC` across every shipped shared object shows exactly one definition of a
  representative delegate symbol, down from three.
- Only the runtime library defines the backend registry, so the delegate does
  not introduce a second one.
- The thread-pool, CPU kernel, and XNNPACK assertions all still hold with the
  CUDA delegate loaded.
- With `EXECUTORCH_BUILD_SHARED` off, the delegate remains a static library and
  no new shared object is produced, so every build that does not opt in is
  unaffected.

Note for anyone building with CUDA: the build needs an explicit
`CMAKE_CUDA_ARCHITECTURES` for compute capability 6.1 or newer, otherwise an
integer dot-product intrinsic used by one of the kernels does not compile. That
is independent of this change.