### PR TITLE
Fix broken torchao documentation links

### DIFF
--- a/backends/arm/scripts/docgen/ethos-u/backends-arm-ethos-u-overview.md.in
+++ b/backends/arm/scripts/docgen/ethos-u/backends-arm-ethos-u-overview.md.in
@@ -48,8 +48,8 @@ See [Partitioner API](arm-ethos-u-partitioner.md) for more information of the Pa
 ## Quantization
 
 Since the Ethos-U backend is integer-only, all operators intended be executed on the NPU needs to be quantized. The Ethos-U quantizer supports
-[Post Training Quantization (PT2E)](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_ptq.html)  and
-[Quantization-Aware Training (QAT)](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_qat.html) quantization.
+[Post Training Quantization (PT2E)](https://docs.pytorch.org/ao/main/pt2e_quantization/pt2e_quant_ptq.html)  and
+[Quantization-Aware Training (QAT)](https://docs.pytorch.org/ao/main/pt2e_quantization/pt2e_quant_qat.html) quantization.
 
 For more information on quantization, see [Quantization](arm-ethos-u-quantization.md) <!-- @lint-ignore -->
 

--- a/docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md
+++ b/docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md
@@ -102,8 +102,8 @@ See [Partitioner API](arm-ethos-u-partitioner.md) for more information of the Pa
 ## Quantization
 
 Since the Ethos-U backend is integer-only, all operators intended be executed on the NPU needs to be quantized. The Ethos-U quantizer supports
-[Post Training Quantization (PT2E)](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_ptq.html)  and
-[Quantization-Aware Training (QAT)](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_qat.html) quantization.
+[Post Training Quantization (PT2E)](https://docs.pytorch.org/ao/main/pt2e_quantization/pt2e_quant_ptq.html)  and
+[Quantization-Aware Training (QAT)](https://docs.pytorch.org/ao/main/pt2e_quantization/pt2e_quant_qat.html) quantization.
 
 For more information on quantization, see [Quantization](arm-ethos-u-quantization.md) <!-- @lint-ignore -->
 

--- a/docs/source/backends/coreml/coreml-quantization.md
+++ b/docs/source/backends/coreml/coreml-quantization.md
@@ -97,7 +97,7 @@ quantizer = CoreMLQuantizer(weight_only_8bit_config)
 
 Quantizing activations requires calibrating the model on representative data.  Also note that PT2E currently requires passing at least 1 calibration sample before calling `convert_pt2e`, even for data-free weight-only quantization.
 
-See [PyTorch 2 Export Post Training Quantization](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_ptq.html) for more information.
+See [PyTorch 2 Export Post Training Quantization](https://docs.pytorch.org/ao/main/pt2e_quantization/pt2e_quant_ptq.html) for more information.
 
 ### LLM quantization with quantize_
 

--- a/docs/source/backends/samsung/samsung-quantization.md
+++ b/docs/source/backends/samsung/samsung-quantization.md
@@ -56,5 +56,5 @@ et_program = to_edge_transform_and_lower( # (6)
 ).to_executorch()
 ```
 
-See [PyTorch 2 Export Post Training Quantization](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_ptq.html)
+See [PyTorch 2 Export Post Training Quantization](https://docs.pytorch.org/ao/main/pt2e_quantization/pt2e_quant_ptq.html)
 for more information.

--- a/docs/source/backends/xnnpack/xnnpack-quantization.md
+++ b/docs/source/backends/xnnpack/xnnpack-quantization.md
@@ -62,7 +62,7 @@ XNNPACK, `get_transform_passes()` is recommended in general because it runs
 pre-partition graph transforms that expose supported patterns to the
 partitioner.
 
-See [PyTorch 2 Export Post Training Quantization](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_ptq.html) for more information.
+See [PyTorch 2 Export Post Training Quantization](https://docs.pytorch.org/ao/main/pt2e_quantization/pt2e_quant_ptq.html) for more information.
 
 ### LLM quantization with quantize_
 
@@ -71,7 +71,7 @@ The XNNPACK backend also supports quantizing models with the [torchao](https://g
 * Quantize embeddings with `IntxWeightOnlyConfig` (with weight_dtype torch.int2, torch.int4, or torch.int8, using PerGroup or PerAxis granularity)
 * Quantize linear layers with 4 bit weight and 8bit dynamic activation, use `Int8DynamicActivationIntxWeightConfig` (with weight_dtype=torch.int4, using PerGroup or PerAxis granularity)
 
-Below is a simple example, but a more detailed tutorial including accuracy evaluation on popular LLM benchmarks can be found in the [torchao documentation](https://docs.pytorch.org/ao/main/serving.html#mobile-deployment-with-executorch).
+Below is a simple example, but a more detailed tutorial including accuracy evaluation on popular LLM benchmarks can be found in the [torchao documentation](https://docs.pytorch.org/ao/main/eager_tutorials/serving.html#mobile-deployment-with-executorch).
 
 ```python
 from torchao.quantization.granularity import PerGroup, PerAxis

--- a/docs/source/llm/export-llm.md
+++ b/docs/source/llm/export-llm.md
@@ -84,8 +84,8 @@ python -m extension.llm.export.export_llm \
 
 ## Quantization
 Quantization options are defined by [`QuantizationConfig`](https://github.com/pytorch/executorch/blob/main/extension/llm/export/config/llm_config.py#L283). ExecuTorch does quantization in two ways:
-1. TorchAO [`quantize_`](https://docs.pytorch.org/ao/stable/generated/torchao.quantization.quantize_.html) API
-2. [pt2e quantization](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_ptq.html)
+1. TorchAO [`quantize_`](https://docs.pytorch.org/ao/stable/api_reference/generated/torchao.quantization.quantize_.html) API
+2. [pt2e quantization](https://docs.pytorch.org/ao/main/pt2e_quantization/pt2e_quant_ptq.html)
 
 ### TorchAO (XNNPACK)
 TorchAO quantizes at the source code level, swapping out Linear modules for QuantizedLinear modules.
@@ -127,7 +127,7 @@ python -m extension.llm.export.export_llm \
 ### pt2e (QNN, CoreML, and Vulkan)
 pt2e quantizes at the post-export graph level, swapping nodes and injecting quant/dequant nodes.
 **To quantize on non-CPU backends (QNN, CoreML, Vulkan), this is the quantization path to follow.**
-Read more about pt2e [here](https://docs.pytorch.org/ao/main/tutorials_source/pt2e_quant_ptq.html), and how ExecuTorch uses pt2e [here](https://github.com/pytorch/executorch/blob/main/docs/source/quantization-overview.md).
+Read more about pt2e [here](https://docs.pytorch.org/ao/main/pt2e_quantization/pt2e_quant_ptq.html), and how ExecuTorch uses pt2e [here](https://github.com/pytorch/executorch/blob/main/docs/source/quantization-overview.md).
 
 *CoreML and Vulkan support for export_llm is currently experimental and limited. To read more about QNN export, please read [Running on Android (Qualcomm)](build-run-llama3-qualcomm-ai-engine-direct-backend.md).*
 


### PR DESCRIPTION
### Problem
Several documentation pages link to torchao URLs that are dead. Two of them are subtle: the URL returns HTTP 200, but the page is a stub whose only content is a meta-refresh redirect back to a 404. So a status-code check passes while a human clicking the link still lands on a 404.

### Fix
Point each link at the page that actually serves the content. The pt2e tutorials now live under `pt2e_quantization/`, which is the path this repo already uses in `arm-vgf-overview.md`, `nxp-quantization.md`, and `quantization-overview.md`, so this also makes the links consistent.

| Old | New |
|---|---|
| `ao/main/tutorials_source/pt2e_quant_ptq.html` | `ao/main/pt2e_quantization/pt2e_quant_ptq.html` |
| `ao/main/tutorials_source/pt2e_quant_qat.html` | `ao/main/pt2e_quantization/pt2e_quant_qat.html` |
| `ao/main/serving.html#mobile-deployment-with-executorch` | `ao/main/eager_tutorials/serving.html#mobile-deployment-with-executorch` |
| `ao/stable/generated/torchao.quantization.quantize_.html` | `ao/stable/api_reference/generated/torchao.quantization.quantize_.html` |

The last one now goes to the specific `quantize_` API page rather than the general quantization index.

### Verification
Each target was fetched and confirmed to render the expected page, following both HTTP redirects and html meta-refresh, rather than only checking the status code. The `#mobile-deployment-with-executorch` anchor was confirmed present in the served page.

### Files
xnnpack, samsung, coreml and arm-ethos-u quantization docs, the LLM export guide, and the Arm Ethos-U docgen template. 11 links total. The docgen template and its generated page are kept in sync.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani
