### PR TITLE
Optimized blas bf16 sdpa

### DIFF
--- a/kernels/optimized/blas/BlasKernel.cpp
+++ b/kernels/optimized/blas/BlasKernel.cpp
@@ -22,6 +22,9 @@
 #ifdef __aarch64__
 #include <arm_neon.h>
 #include <cpuinfo.h>
+#elif defined(__x86_64__)
+#include <cpuinfo.h>
+#include <immintrin.h>
 #endif
 
 namespace vec = at::vec;
@@ -115,6 +118,17 @@ float reduce(vec::VectorizedN<float, kF32RegistersPerIteration>& x) {
 #define COMPILER_SUPPORTS_BF16_TARGET 0
 #endif // defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE) &&
        // defined(__clang__) && __clang_major__ > 15
+
+// GCC 10 / Clang 9 are the first versions with both the target("avx512bf16")
+// function attribute and _mm512_dpbf16_ps.
+#if defined(__x86_64__) && defined(__clang__) && __clang_major__ >= 9
+#define COMPILER_SUPPORTS_X86_BF16_TARGET 1
+#elif defined(__x86_64__) && !defined(__clang__) && defined(__GNUC__) && \
+    __GNUC__ >= 10
+#define COMPILER_SUPPORTS_X86_BF16_TARGET 1
+#else
+#define COMPILER_SUPPORTS_X86_BF16_TARGET 0
+#endif
 
 #if COMPILER_SUPPORTS_BF16_TARGET
 #define TARGET_ARM_BF16_ATTRIBUTE __attribute__((target("arch=armv8.2-a+bf16")))
@@ -326,6 +340,62 @@ dot_with_fp32_arith_no_bfdot(const T* vec1, const T* vec2, int64_t len) {
 }
 #undef DOT_WITH_FP32_ARITH_TAIL_AFTER_MAIN_LOOP_BODY
 
+#if COMPILER_SUPPORTS_X86_BF16_TARGET
+// Native x86 bf16 dot using AVX512-BF16's vdpbf16ps (_mm512_dpbf16_ps),
+// which computes bf16 x bf16 -> fp32 accumulate in a single instruction.
+__attribute__((target("avx512f,avx512bw,avx512vl,avx512bf16"))) float
+dot_with_fp32_arith_x86bfdot(
+    const BFloat16* vec1,
+    const BFloat16* vec2,
+    int64_t len) {
+  // Each __m512bh holds 32 bf16; _mm512_dpbf16_ps accumulates bf16 x bf16
+  // products into a __m512 of 16 fp32 lanes.
+  constexpr int kBF16PerRegister = 32;
+  constexpr int kAccumulators = 4;
+  constexpr int kBF16PerIteration = kBF16PerRegister * kAccumulators;
+
+  __m512 acc[kAccumulators];
+  for (int i = 0; i < kAccumulators; ++i) {
+    acc[i] = _mm512_setzero_ps();
+  }
+
+  int64_t j = 0;
+  // Main loop: 4 independent accumulators for ILP, 128 bf16 per iteration.
+  const int64_t len_main = len - (len % kBF16PerIteration);
+  for (; j < len_main; j += kBF16PerIteration) {
+    for (int i = 0; i < kAccumulators; ++i) {
+      const int64_t off = j + i * kBF16PerRegister;
+      const __m512bh a =
+          (__m512bh)_mm512_loadu_si512((const void*)(vec1 + off));
+      const __m512bh b =
+          (__m512bh)_mm512_loadu_si512((const void*)(vec2 + off));
+      acc[i] = _mm512_dpbf16_ps(acc[i], a, b);
+    }
+  }
+
+  // 32-wide cleanup loop for the remaining full registers.
+  const int64_t len_vec = len - (len % kBF16PerRegister);
+  for (; j < len_vec; j += kBF16PerRegister) {
+    const __m512bh a = (__m512bh)_mm512_loadu_si512((const void*)(vec1 + j));
+    const __m512bh b = (__m512bh)_mm512_loadu_si512((const void*)(vec2 + j));
+    acc[0] = _mm512_dpbf16_ps(acc[0], a, b);
+  }
+
+  float reduced_sum = 0;
+  for (int i = 0; i < kAccumulators; ++i) {
+    reduced_sum += _mm512_reduce_add_ps(acc[i]);
+  }
+
+  // Scalar fp32 tail for the remainder, matching no_bfdot numerics.
+  for (; j < len; ++j) {
+    float x1 = vec1[j];
+    float x2 = vec2[j];
+    reduced_sum += x1 * x2;
+  }
+  return reduced_sum;
+}
+#endif // COMPILER_SUPPORTS_X86_BF16_TARGET
+
 } // namespace
 
 float bf16_dot_with_fp32_arith(
@@ -333,10 +403,16 @@ float bf16_dot_with_fp32_arith(
     const at::BFloat16* vec2,
     int64_t len) {
 #if COMPILER_SUPPORTS_BF16_TARGET
-  if (cpuinfo_has_arm_bf16()) {
+  // cpuinfo_has_* reads a zeroed struct until cpuinfo_initialize() runs.
+  if (cpuinfo_initialize() && cpuinfo_has_arm_bf16()) {
     return dot_with_fp32_arith_bfdot(vec1, vec2, len);
   } else
 #endif // COMPILER_SUPPORTS_BF16_TARGET
+#if COMPILER_SUPPORTS_X86_BF16_TARGET
+      if (cpuinfo_initialize() && cpuinfo_has_x86_avx512bf16()) {
+    return dot_with_fp32_arith_x86bfdot(vec1, vec2, len);
+  } else
+#endif // COMPILER_SUPPORTS_X86_BF16_TARGET
   {
     return dot_with_fp32_arith_no_bfdot(vec1, vec2, len);
   }

--- a/kernels/optimized/blas/BlasKernel.h
+++ b/kernels/optimized/blas/BlasKernel.h
@@ -15,6 +15,7 @@
 #include <executorch/runtime/kernel/thread_parallel_interface.h>
 
 #include <array>
+#include <vector>
 
 namespace executorch {
 namespace cpublas {
@@ -140,6 +141,42 @@ float bf16_dot_with_fp32_arith(
     int64_t len);
 } // namespace internal
 
+// Used by custom SDPA's attn@V. Serial on purpose: SDPA already parallelizes
+// its outer head loop, and executorch's threadpool deadlocks on a nested
+// parallel_for.
+// clang-format off
+template <>
+inline typename std::enable_if<
+    !std::is_same<torch::executor::BFloat16, float>::value,
+    void>::type
+gemm_notrans_<torch::executor::BFloat16, float, float>(
+    int64_t m, int64_t n, int64_t k,
+    float alpha,
+    const torch::executor::BFloat16 *a, int64_t lda,
+    const torch::executor::BFloat16 *b, int64_t ldb,
+    float beta,
+    float *c, int64_t ldc) {
+  // a's k-dimension is strided by lda; bf16_dot_with_fp32_arith needs it
+  // contiguous.
+  std::vector<torch::executor::BFloat16> a_row(k);
+  for (int64_t i = 0; i < m; ++i) {
+    for (int64_t l = 0; l < k; ++l) {
+      a_row[l] = a[l * lda + i];
+    }
+    const torch::executor::BFloat16 *b_ = b;
+    for (int64_t j = 0; j < n; ++j) {
+      const float dot = internal::bf16_dot_with_fp32_arith(a_row.data(), b_, k);
+      b_ += ldb;
+      if (beta == 0) {
+        c[j * ldc + i] = alpha * dot;
+      } else {
+        c[j * ldc + i] = beta * c[j * ldc + i] + alpha * dot;
+      }
+    }
+  }
+}
+// clang-format on
+
 // clang-format off
 template <typename scalar_t, typename opmath_t, typename out_t = scalar_t>
 void gemm_transa_(
@@ -208,6 +245,32 @@ inline void gemm_transa_<torch::executor::BFloat16, torch::executor::BFloat16, t
       a_ += lda;
     }
   });
+}
+
+// Used by custom SDPA's q@k.T; both k-dimensions are already contiguous.
+// Serial for the same reason as the gemm_notrans_ specialization above.
+template <>
+inline void gemm_transa_<torch::executor::BFloat16, float, float>(
+    int64_t m, int64_t n, int64_t k,
+    float alpha,
+    const torch::executor::BFloat16 *a, int64_t lda,
+    const torch::executor::BFloat16 *b, int64_t ldb,
+    float beta,
+    float *c, int64_t ldc) {
+  const auto *a_ = a;
+  for (int i = 0; i < m; ++i) {
+    const auto *b_ = b;
+    for (int j = 0; j < n; ++j) {
+      const float dot = internal::bf16_dot_with_fp32_arith(a_, b_, k);
+      b_ += ldb;
+      if (beta == 0) {
+        c[j*ldc+i] = alpha*dot;
+      } else {
+        c[j*ldc+i] = beta*c[j*ldc+i]+alpha*dot;
+      }
+    }
+    a_ += lda;
+  }
 }
 // clang-format on
 

--- a/kernels/optimized/test/libblas_test.cpp
+++ b/kernels/optimized/test/libblas_test.cpp
@@ -11,6 +11,10 @@
 #include <executorch/kernels/optimized/blas/CPUBlas.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string>
 #include <vector>
 
 #define TEST_FORALL_SUPPORTED_CTYPES(_, N)   \
@@ -44,6 +48,68 @@ bool check_all_equal_to(std::vector<T>& arr, const float value) {
   }
   return true;
 }
+
+template <typename T>
+std::vector<T> make_values(size_t n, uint32_t seed) {
+  std::vector<T> v(n);
+  uint32_t state = seed;
+  for (size_t i = 0; i < n; ++i) {
+    state = state * 1664525u + 1013904223u;
+    v[i] = static_cast<T>(
+        static_cast<float>(state >> 8) / static_cast<float>(1 << 23) - 1.0f);
+  }
+  return v;
+}
+
+template <typename T>
+float reference_dot(const T* a, const T* b, int64_t len) {
+  float sum = 0;
+  for (int64_t i = 0; i < len; ++i) {
+    sum += static_cast<float>(a[i]) * static_cast<float>(b[i]);
+  }
+  return sum;
+}
+
+// Column-major c = beta * c + alpha * (op(a) @ b), accumulated in fp32, mirror-
+// ing the generic gemm_{transa,notrans}_ templates the bf16 specializations
+// replace.
+template <typename T>
+void reference_gemm(
+    bool transa,
+    int64_t m,
+    int64_t n,
+    int64_t k,
+    float alpha,
+    const T* a,
+    int64_t lda,
+    const T* b,
+    int64_t ldb,
+    float beta,
+    std::vector<float>& c,
+    int64_t ldc) {
+  for (int64_t i = 0; i < m; ++i) {
+    for (int64_t j = 0; j < n; ++j) {
+      float dot = 0;
+      for (int64_t l = 0; l < k; ++l) {
+        const float av = transa ? static_cast<float>(a[i * lda + l])
+                                : static_cast<float>(a[l * lda + i]);
+        dot += av * static_cast<float>(b[j * ldb + l]);
+      }
+      c[j * ldc + i] =
+          beta == 0 ? alpha * dot : beta * c[j * ldc + i] + alpha * dot;
+    }
+  }
+}
+
+void expect_near_relative(float actual, float expected, const char* context) {
+  EXPECT_NEAR(actual, expected, 1e-4f * std::max(1.0f, std::abs(expected)))
+      << context;
+}
+
+// Straddle the vectorized main-loop, cleanup-loop and scalar-tail boundaries of
+// the bfdot paths: 128 and 32 bf16 per iteration on x86, 32 and 8 on ARM.
+constexpr int64_t kDotLengths[] =
+    {0, 1, 7, 8, 15, 16, 31, 32, 33, 63, 64, 96, 127, 128, 129, 160, 255, 257};
 
 } // namespace
 
@@ -79,4 +145,123 @@ void test_matmul_ones() {
 
 TEST(BlasTest, MatmulOnes) {
   TEST_FORALL_SUPPORTED_CTYPES(test_matmul_ones, 25);
+}
+
+// bf16_dot_with_fp32_arith has three implementations -- ARM bfdot, x86
+// AVX512-BF16 and the portable fp32 fallback -- selected by compile-time
+// support and runtime cpuinfo. Only the one this host dispatches to is covered
+// by a given run.
+TEST(BlasTest, BF16DotMatchesScalarAccumulation) {
+  using torch::executor::BFloat16;
+
+  for (const int64_t len : kDotLengths) {
+    const auto a = make_values<BFloat16>(len, 1);
+    const auto b = make_values<BFloat16>(len, 2);
+
+    const float actual =
+        executorch::cpublas::internal::bf16_dot_with_fp32_arith(
+            a.data(), b.data(), len);
+
+    expect_near_relative(
+        actual,
+        reference_dot(a.data(), b.data(), len),
+        ("len=" + std::to_string(len)).c_str());
+  }
+}
+
+// The bf16-in/float-out gemm specializations used by custom SDPA.
+TEST(BlasTest, BF16FloatGemmMatchesScalarAccumulation) {
+  using executorch::aten::BFloat16;
+  using executorch::cpublas::TransposeType;
+
+  constexpr int64_t kM = 3;
+  constexpr int64_t kN = 5;
+
+  for (const bool transa : {false, true}) {
+    for (const int64_t k : kDotLengths) {
+      if (k == 0) {
+        continue;
+      }
+      // Pad the leading dimensions so a stride bug can't hide behind tightly
+      // packed operands.
+      const int64_t lda = (transa ? k : kM) + 2;
+      const int64_t ldb = k + 3;
+      const int64_t ldc = kM + 1;
+
+      const auto a = make_values<BFloat16>(lda * (transa ? kM : k), 3);
+      const auto b = make_values<BFloat16>(ldb * kN, 4);
+
+      for (const float alpha : {1.0f, -0.5f}) {
+        for (const float beta : {0.0f, 1.0f, 0.25f}) {
+          auto c = make_values<float>(ldc * kN, 5);
+          auto expected = c;
+
+          // clang-format off
+          reference_gemm(
+              transa,
+              kM, kN, k,
+              alpha,
+              a.data(), lda,
+              b.data(), ldb,
+              beta,
+              expected, ldc);
+
+          executorch::cpublas::gemm(
+              transa ? TransposeType::Transpose : TransposeType::NoTranspose,
+              TransposeType::NoTranspose,
+              kM, kN, k,
+              alpha,
+              a.data(), lda,
+              b.data(), ldb,
+              beta,
+              c.data(), ldc);
+          // clang-format on
+
+          const std::string context = "transa=" + std::to_string(transa) +
+              " k=" + std::to_string(k) + " alpha=" + std::to_string(alpha) +
+              " beta=" + std::to_string(beta);
+          for (int64_t j = 0; j < kN; ++j) {
+            for (int64_t i = 0; i < kM; ++i) {
+              expect_near_relative(
+                  c[j * ldc + i], expected[j * ldc + i], context.c_str());
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// beta == 0 must overwrite c rather than read it, so uninitialized garbage in
+// the output cannot poison the result.
+TEST(BlasTest, BF16FloatGemmBetaZeroIgnoresOutput) {
+  using executorch::aten::BFloat16;
+  using executorch::cpublas::TransposeType;
+
+  constexpr int64_t kM = 3;
+  constexpr int64_t kN = 5;
+  constexpr int64_t kK = 40;
+
+  const auto a = make_values<BFloat16>(kK * kM, 6);
+  const auto b = make_values<BFloat16>(kK * kN, 7);
+
+  for (const bool transa : {false, true}) {
+    std::vector<float> c(kM * kN, std::numeric_limits<float>::quiet_NaN());
+
+    // clang-format off
+    executorch::cpublas::gemm(
+        transa ? TransposeType::Transpose : TransposeType::NoTranspose,
+        TransposeType::NoTranspose,
+        kM, kN, kK,
+        1.0f,
+        a.data(), transa ? kK : kM,
+        b.data(), kK,
+        0.0f,
+        c.data(), kM);
+    // clang-format on
+
+    for (const float v : c) {
+      EXPECT_FALSE(std::isnan(v)) << "transa=" << transa;
+    }
+  }
 }


### PR DESCRIPTION
Custom SDPA runs its q@k.T and attn@v matmuls with bf16 inputs and fp32 accumulation, which instantiates gemm_transa_<BFloat16, float, float> and gemm_notrans_<BFloat16, float, float>. Neither had an optimized specialization, so both fell through to the generic scalar templates

This PR adds vectorized specializations for those two instantiations on top of the existing internal::bf16_dot_with_fp32_arith, which accumulates in fp32 and so is numerically equivalent to the scalar path it replaces It also makes bf16_dot_with_fp32_arith itself faster on x86 by adding an AVX512-BF16 path using _mm512_dpbf16_ps, behind m__attribute__((target(...))) so the feature is enabled for that one function rather than the whole translation unit, and dispatched at runtime via cpuinfo_has_x86_avx512bf16.

Finally, it routes both dispatch checks through cpuinfo_initialize(). cpuinfo_has_* reads a zeroed struct until initialization runs, so a caller that hasn't already initialized cpuinfo will fall back to the scalar. This fixes this without relying on someone else (threadpool, in ET case currently) calling it first.
