### PR TITLE
MovePermuteAfterConcat made generic reorder pass (#21557)

### DIFF
--- a/backends/cadence/aot/reorder_ops.py
+++ b/backends/cadence/aot/reorder_ops.py
@@ -705,6 +705,95 @@ class PostponePermuteOpBelowSqueezeOrUnsqueezeLikeView(
 
 
 @register_cadence_pass(CadencePassAttribute(opt_level=1))
+class MovePermuteAfterConcat(RemoveOrReplacePassInterface):
+    """Move matching single-use permutes after a cat.
+
+    For example,
+
+        cat(
+            [
+                permute(x[80, 16, 32], [1, 2, 0]),  # [16, 32, 80]
+                permute(y[1, 16, 32], [1, 2, 0]),   # [16, 32, 1]
+            ],
+            dim=2,
+        )  # [16, 32, 81]
+
+    becomes
+
+        permute(cat([x, y], dim=0), [1, 2, 0])
+                # cat: [81, 16, 32], output: [16, 32, 81]
+    """
+
+    @property
+    def targets(self) -> list[EdgeOpOverload]:
+        return [exir_ops.edge.aten.cat.default]
+
+    @staticmethod
+    def _match_inputs(
+        cat_node: torch.fx.Node,
+    ) -> Optional[Tuple[List[torch.fx.Node], Tuple[int, ...]]]:
+        inputs = get_arg(
+            cat_node,
+            "tensors",
+            # pyre-ignore[6]
+            list[torch.fx.Node] | tuple[torch.fx.Node, ...],
+        )
+
+        unpermuted_inputs: List[torch.fx.Node] = []
+        common_permutation: Optional[Tuple[int, ...]] = None
+        for permute_node in inputs:
+            if (
+                permute_node.target != exir_ops.edge.aten.permute_copy.default
+                or len(permute_node.users) != 1
+            ):
+                return None
+
+            permute_input = cast(torch.fx.Node, permute_node.args[0])
+            dims = get_arg(
+                permute_node,
+                "dims",
+                # pyre-ignore[6]
+                list[int] | tuple[int, ...],
+            )
+            rank = len(dims)
+            permutation = tuple(dim % rank for dim in dims)
+            if common_permutation is None:
+                common_permutation = permutation
+            elif permutation != common_permutation:
+                return None
+            unpermuted_inputs.append(permute_input)
+
+        return unpermuted_inputs, cast(Tuple[int, ...], common_permutation)
+
+    def maybe_remove_or_replace(self, node: torch.fx.Node) -> bool:
+        match = self._match_inputs(node)
+        if match is None:
+            return False
+        inputs, permutation = match
+
+        output_cat_dim = get_arg(node, "dim", int) % len(permutation)
+        input_cat_dim = permutation[output_cat_dim]
+        graph = node.graph
+
+        with graph.inserting_before(node):
+            new_cat = graph.call_function(
+                exir_ops.edge.aten.cat.default,
+                args=(inputs, input_cat_dim),
+            )
+            new_cat.meta["val"] = exir_ops.edge.aten.cat.default(
+                [inp.meta["val"] for inp in inputs], input_cat_dim
+            )
+            new_permute = graph.call_function(
+                exir_ops.edge.aten.permute_copy.default,
+                args=(new_cat, list(permutation)),
+            )
+            new_permute.meta = node.meta.copy()
+
+        node.replace_all_uses_with(new_permute)
+        return True
+
+
+@register_cadence_pass(CadencePassAttribute(opt_level=1))
 class MoveSliceBeforePermutePass(RemoveOrReplacePassInterface):
     """Move slice_copy ops before permute_copy to reduce permute data volume.
 
@@ -1268,6 +1357,7 @@ class CadenceReorderOpsInGraph:
         # Hoist/sink nodes closer to their SSA def/use
         HoistOpsCloserToDefPass,
         SinkOpsCloserToUsePass,
+        MovePermuteAfterConcat,
         # For quantize/dequantize ops, move them above/below their def chain.
         # This is a more aggressive optimization than just hoisting/sinking
         # nodes closer to their def/use.

--- a/backends/cadence/aot/tests/test_reorder_ops_passes.py
+++ b/backends/cadence/aot/tests/test_reorder_ops_passes.py
@@ -23,6 +23,7 @@ from executorch.backends.cadence.aot.pass_utils import (
 from executorch.backends.cadence.aot.reorder_ops import (
     AdvanceQuantizeOpAboveDefChainPass,
     AdvanceQuantizeOpAboveDefInBranchPass,
+    MovePermuteAfterConcat,
     MoveSliceBeforePermutePass,
     MoveSliceBeforeViewPass,
     PostponeDequantizeOpBelowUseChainPass,
@@ -637,6 +638,128 @@ class TestReorderPasses(unittest.TestCase):
         self.assertTrue(nodes[1] == exir_ops.edge.aten.permute_copy)
         self.assertTrue(nodes[2] == exir_ops.edge.aten.view_copy)
         self.assertTrue(nodes[3] == exir_ops.edge.aten.permute_copy)
+
+
+class TestMovePermuteAfterConcat(unittest.TestCase):
+    def test_matching_single_user_permutes_moved_after_cat(self) -> None:
+        x_data = torch.randn(1, 16, 32)
+        y_data = torch.randn(80, 16, 32)
+        builder = GraphBuilder()
+        x = builder.placeholder("x", x_data)
+        y = builder.placeholder("y", y_data)
+        permutation = [1, 2, 0]
+        permuted_x = builder.call_operator(
+            exir_ops.edge.aten.permute_copy.default,
+            args=(x, permutation),
+        )
+        permuted_y = builder.call_operator(
+            exir_ops.edge.aten.permute_copy.default,
+            args=(y, permutation),
+        )
+        cat = builder.call_operator(
+            exir_ops.edge.aten.cat.default,
+            args=([permuted_x, permuted_y], 2),
+        )
+        builder.output([cat])
+
+        result = transform_and_check_numerics(
+            builder.get_graph_module(),
+            (x_data, y_data),
+            MovePermuteAfterConcat(),
+        )
+
+        self.assertTrue(result.modified)
+        converted = result.graph_module
+        self.assertEqual(
+            get_compute_nodes_in_gm(converted),
+            [exir_ops.edge.aten.cat, exir_ops.edge.aten.permute_copy],
+        )
+        cat_nodes = converted.graph.find_nodes(
+            op="call_function", target=exir_ops.edge.aten.cat.default
+        )
+        self.assertEqual(len(cat_nodes), 1)
+        self.assertEqual(cat_nodes[0].args[1], 0)
+        placeholder_nodes = converted.graph.find_nodes(op="placeholder")
+        self.assertEqual(cat_nodes[0].args[0], placeholder_nodes)
+
+    def test_different_permutations_not_moved(self) -> None:
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.randn(2, 3, 4))
+        y = builder.placeholder("y", torch.randn(4, 3, 5))
+        permuted_x = builder.call_operator(
+            exir_ops.edge.aten.permute_copy.default,
+            args=(x, [1, 2, 0]),
+        )
+        permuted_y = builder.call_operator(
+            exir_ops.edge.aten.permute_copy.default,
+            args=(y, [1, 0, 2]),
+        )
+        cat = builder.call_operator(
+            exir_ops.edge.aten.cat.default,
+            args=([permuted_x, permuted_y], 2),
+        )
+        builder.output([cat])
+
+        result = cast(PassResult, MovePermuteAfterConcat()(builder.get_graph_module()))
+
+        self.assertFalse(result.modified)
+        self.assertEqual(
+            count_node(result.graph_module, exir_ops.edge.aten.permute_copy.default),
+            2,
+        )
+
+    def test_permute_with_another_user_not_moved(self) -> None:
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.randn(1, 16, 32))
+        y = builder.placeholder("y", torch.randn(80, 16, 32))
+        permutation = [1, 2, 0]
+        permuted_x = builder.call_operator(
+            exir_ops.edge.aten.permute_copy.default,
+            args=(x, permutation),
+        )
+        permuted_y = builder.call_operator(
+            exir_ops.edge.aten.permute_copy.default,
+            args=(y, permutation),
+        )
+        cat = builder.call_operator(
+            exir_ops.edge.aten.cat.default,
+            args=([permuted_x, permuted_y], 2),
+        )
+        other_user = builder.call_operator(
+            exir_ops.edge.aten.abs.default,
+            args=(permuted_x,),
+        )
+        builder.output([cat, other_user])
+
+        result = cast(PassResult, MovePermuteAfterConcat()(builder.get_graph_module()))
+
+        self.assertFalse(result.modified)
+        self.assertEqual(
+            count_node(result.graph_module, exir_ops.edge.aten.permute_copy.default),
+            2,
+        )
+
+    def test_non_permuted_input_not_moved(self) -> None:
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.randn(1, 16, 32))
+        y = builder.placeholder("y", torch.randn(16, 32, 80))
+        permuted_x = builder.call_operator(
+            exir_ops.edge.aten.permute_copy.default,
+            args=(x, [1, 2, 0]),
+        )
+        cat = builder.call_operator(
+            exir_ops.edge.aten.cat.default,
+            args=([permuted_x, y], 2),
+        )
+        builder.output([cat])
+
+        result = cast(PassResult, MovePermuteAfterConcat()(builder.get_graph_module()))
+
+        self.assertFalse(result.modified)
+        self.assertEqual(
+            count_node(result.graph_module, exir_ops.edge.aten.permute_copy.default),
+            1,
+        )
 
 
 class TestMoveSliceBeforePermutePass(unittest.TestCase):


### PR DESCRIPTION
Summary:

There is a common pattern in which we permute all inputs to a cat in the same way. Instead of permuting all inputs, we can instead cat first and then permute the output.

Reviewed By: aliafzal

Differential Revision: D114628981


