### PR TITLE
CoreML-safe RMSNormWithInputScale for fp16 export

### DIFF
--- a/examples/models/llama/norm.py
+++ b/examples/models/llama/norm.py
@@ -114,6 +114,49 @@ class RMSNormWithInputScale(torch.nn.Module):
         return F.rms_norm(scaled, (self.dim,), None, self.eps)
 
 
+class RMSNormWithInputScaleCoreML(torch.nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-5):
+        """
+        CoreML-friendly RMSNormWithInputScale.
+
+        Standard RMSNormWithInputScale emits ``F.rms_norm`` which lowers to
+        ``aten.rms_norm.default``. coremltools materializes that op's eps as an
+        fp32 constant and adds it to the fp16 mean-square, raising an fp16/fp32
+        dtype mismatch during conversion. This variant uses the same
+        ``vector_norm`` formulation as ``RMSNormCoreML`` so the op survives fp16
+        lowering. The learnable scale is applied to the input (matching
+        ``RMSNormWithInputScale``); the norm itself is affine-free.
+
+        Args:
+            dim (int): The dimension of the input tensor.
+            eps (float, optional): Floor on the L2-norm denominator
+                (`clamp_min(‖x‖₂, √(dim·eps))`), matching RMSNormCoreML. Must be > 0.
+        """
+        super().__init__()
+        assert eps > 0, (
+            "RMSNormWithInputScaleCoreML requires eps > 0; eps=0 collapses the "
+            "denominator floor and produces NaN on zero-padded positions"
+        )
+        self.eps = eps
+        self.dim = dim
+        self.weight = torch.nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        floor_val = torch.sqrt(torch.tensor(self.dim * self.eps, dtype=x.dtype))
+        norm_val = torch.clamp_min(
+            torch.linalg.vector_norm(x, dim=-1, keepdim=True), floor_val
+        )
+        return (
+            x
+            * torch.sqrt(torch.tensor(self.dim, dtype=x.dtype))
+            * torch.reciprocal(norm_val)
+        )
+
+    def forward(self, x):
+        scaled = self.weight * x
+        return self._norm(scaled)
+
+
 class RMSNormGated(nn.Module):
     def __init__(self, hidden_size: int, eps: float = 1e-6):
         super().__init__()
@@ -143,25 +186,39 @@ def replace_rms_norm_for_coreml_(model: torch.nn.Module) -> torch.nn.Module:
       * `RMSNorm` (this module)
       * `ScalelessRMSNorm` (this module — no-op weight)
       * `torch.nn.RMSNorm` (used for affine q_norm/k_norm in StaticAttention)
+      * `RMSNormWithInputScale` (this module — post-FFN learnable scale) is
+        swapped for `RMSNormWithInputScaleCoreML`, which preserves the
+        input-scale semantics while avoiding the fused `aten.rms_norm` op.
     """
     for name, mod in list(model.named_modules()):
-        if not isinstance(mod, (RMSNorm, ScalelessRMSNorm, torch.nn.RMSNorm)):
-            continue
-        # All three carry the normalized dim either as `dim` or in `normalized_shape[-1]`.
-        dim = getattr(mod, "dim", None) or mod.normalized_shape[-1]
-        eps = getattr(mod, "eps", 1e-6) or 1e-6
-        new = RMSNormCoreML(dim, eps=eps)
-        # Preserve trained scale (no-op for ScalelessRMSNorm).
-        if getattr(mod, "weight", None) is not None:
+        if isinstance(mod, RMSNormWithInputScale):
+            # Input-scale norm: swap to the CoreML-safe input-scale variant so
+            # the learnable pre-scale semantics are preserved (RMSNormCoreML
+            # applies its scale post-norm, which would change the math here).
+            dim = getattr(mod, "dim", None) or mod.normalized_shape[-1]
+            eps = getattr(mod, "eps", 1e-6) or 1e-6
+            new = RMSNormWithInputScaleCoreML(dim, eps=eps)
             new.weight = mod.weight
+        elif isinstance(mod, (RMSNorm, ScalelessRMSNorm, torch.nn.RMSNorm)):
+            # All three carry the normalized dim either as `dim` or in `normalized_shape[-1]`.
+            dim = getattr(mod, "dim", None) or mod.normalized_shape[-1]
+            eps = getattr(mod, "eps", 1e-6) or 1e-6
+            new = RMSNormCoreML(dim, eps=eps)
+            # Preserve trained scale (no-op for ScalelessRMSNorm).
+            if getattr(mod, "weight", None) is not None:
+                new.weight = mod.weight
+            else:
+                # Source was weightless (e.g. ScalelessRMSNorm). The freshly-allocated
+                # `nn.Parameter(torch.ones(dim))` inside RMSNormCoreML defaults to fp32,
+                # which causes an fp32 leak in fp16 export. Match the model's existing
+                # parameter dtype/device.
+                ref = next(
+                    (p for p in model.parameters() if p.is_floating_point()), None
+                )
+                if ref is not None:
+                    new.to(dtype=ref.dtype, device=ref.device)
         else:
-            # Source was weightless (e.g. ScalelessRMSNorm). The freshly-allocated
-            # `nn.Parameter(torch.ones(dim))` inside RMSNormCoreML defaults to fp32,
-            # which causes an fp32 leak in fp16 export. Match the model's existing
-            # parameter dtype/device.
-            ref = next((p for p in model.parameters() if p.is_floating_point()), None)
-            if ref is not None:
-                new.to(dtype=ref.dtype, device=ref.device)
+            continue
         # Locate parent module via the dotted name and rebind the attribute.
         if "." in name:
             parent_name, attr = name.rsplit(".", 1)


### PR DESCRIPTION
Reviewed By: billmguo

Differential Revision: D114650766


