### PR TITLE
Fix create_mutable_buffer recording the requested name instead of the name torch.fx assigned

### DIFF
--- a/backends/transforms/test/test_create_mutable_buffer.py
+++ b/backends/transforms/test/test_create_mutable_buffer.py
@@ -93,7 +93,7 @@ class TestMutableBufferCreation(unittest.TestCase):
             == target_name
         )
 
-    def test_create_mutable_buffer_sanitized_name(self):
+    def test_create_mutable_buffer_renamed_name(self):
         """
         torch.fx renames a placeholder whose requested name is not a valid
         identifier or collides with an existing node. Node target, graph

--- a/backends/transforms/test/test_create_mutable_buffer.py
+++ b/backends/transforms/test/test_create_mutable_buffer.py
@@ -10,7 +10,10 @@ import unittest
 
 import executorch
 import torch
-from executorch.backends.transforms.utils import create_mutable_buffer
+from executorch.backends.transforms.utils import (
+    create_constant_placeholder,
+    create_mutable_buffer,
+)
 from executorch.exir import ExecutorchBackendConfig, to_edge
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -19,6 +22,7 @@ from executorch.extension.pybindings.portable_lib import (  # @manual
     Verification,
 )
 from torch.export import export
+from torch.export.graph_signature import InputKind
 from torch.utils._pytree import tree_flatten
 
 
@@ -169,6 +173,55 @@ class TestMutableBufferCreation(unittest.TestCase):
                     name=requested_name,
                     data=torch.ones(1),
                 )
+
+    def test_mixed_kind_same_name_raises(self):
+        """
+        A name used by a mutable buffer cannot be reused by a constant
+        placeholder in either creation order; the constant dedup must not hand
+        back a mutable buffer node.
+        """
+
+        class EmptyNetwork(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x
+
+            test_data: torch.Tensor = (torch.zeros(1),)
+
+        def fresh_program():
+            ep = export(EmptyNetwork(), args=EmptyNetwork.test_data, strict=True)
+            return to_edge(ep).exported_program()
+
+        # mutable first, then constant
+        exported_program = fresh_program()
+        graph = exported_program.graph_module.graph
+        create_mutable_buffer(
+            exp_program=exported_program, name="b_cache", data=torch.ones(1)
+        )
+        with self.assertRaises(RuntimeError):
+            with graph.inserting_before(list(graph.nodes)[0]):
+                create_constant_placeholder(
+                    exp_program=exported_program,
+                    graph=graph,
+                    name="b_cache",
+                    kind=InputKind.PARAMETER,
+                    data=torch.ones(1),
+                )
+
+        # constant first, then mutable
+        exported_program = fresh_program()
+        graph = exported_program.graph_module.graph
+        with graph.inserting_before(list(graph.nodes)[0]):
+            create_constant_placeholder(
+                exp_program=exported_program,
+                graph=graph,
+                name="b_cache",
+                kind=InputKind.PARAMETER,
+                data=torch.ones(1),
+            )
+        with self.assertRaises(RuntimeError):
+            create_mutable_buffer(
+                exp_program=exported_program, name="b_cache", data=torch.ones(1)
+            )
 
 
 class TestRegisterMutableBufferPass(unittest.TestCase):

--- a/backends/transforms/test/test_create_mutable_buffer.py
+++ b/backends/transforms/test/test_create_mutable_buffer.py
@@ -140,6 +140,36 @@ class TestMutableBufferCreation(unittest.TestCase):
             # Recompiling emits the placeholder target as a parameter name
             assert exported_program.module()(torch.zeros(1)) == 0
 
+    def test_create_mutable_buffer_duplicate_name_raises(self):
+        """
+        A mutable buffer cannot be silently shared, so repeating a request must
+        raise instead of deduplicating, even when torch.fx renamed the node.
+        """
+
+        class EmptyNetwork(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x
+
+            test_data: torch.Tensor = (torch.zeros(1),)
+
+        for requested_name in ("b_cache", "0_cache"):
+            exported_program = export(
+                EmptyNetwork(), args=EmptyNetwork.test_data, strict=True
+            )
+            exported_program = to_edge(exported_program).exported_program()
+
+            create_mutable_buffer(
+                exp_program=exported_program,
+                name=requested_name,
+                data=torch.ones(1),
+            )
+            with self.assertRaises(RuntimeError):
+                create_mutable_buffer(
+                    exp_program=exported_program,
+                    name=requested_name,
+                    data=torch.ones(1),
+                )
+
 
 class TestRegisterMutableBufferPass(unittest.TestCase):
     """

--- a/backends/transforms/test/test_create_mutable_buffer.py
+++ b/backends/transforms/test/test_create_mutable_buffer.py
@@ -93,6 +93,53 @@ class TestMutableBufferCreation(unittest.TestCase):
             == target_name
         )
 
+    def test_create_mutable_buffer_sanitized_name(self):
+        """
+        torch.fx renames a placeholder whose requested name is not a valid
+        identifier or collides with an existing node. Node target, graph
+        signature and state_dict must follow the assigned name.
+        """
+
+        class EmptyNetwork(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x
+
+            test_data: torch.Tensor = (torch.zeros(1),)
+
+        # "0_cache" is not a valid identifier; "x" collides with the user input
+        for requested_name in ("0_cache", "x"):
+            exported_program = export(
+                EmptyNetwork(), args=EmptyNetwork.test_data, strict=True
+            )
+            exported_program = to_edge(exported_program).exported_program()
+            graph = exported_program.graph_module.graph
+
+            buffer_node = create_mutable_buffer(
+                exp_program=exported_program,
+                name=requested_name,
+                data=torch.ones(1) * 2,
+            )
+
+            assert buffer_node.name != requested_name
+            assert buffer_node.target == buffer_node.name
+            signature = exported_program.graph_signature
+            assert buffer_node.name in signature.inputs_to_buffers
+            target = signature.inputs_to_buffers[buffer_node.name]
+            assert target in exported_program.state_dict
+            assert signature.buffers_to_mutate[buffer_node.name] == target
+
+            input_node = list(graph.nodes)[1]
+            with graph.inserting_after(input_node):
+                graph.create_node(
+                    "call_function",
+                    exir_ops.edge.aten.add.Tensor,
+                    args=(input_node, buffer_node),
+                    kwargs={},
+                )
+
+            # Recompiling emits the placeholder target as a parameter name
+            assert exported_program.module()(torch.zeros(1)) == 0
+
 
 class TestRegisterMutableBufferPass(unittest.TestCase):
     """

--- a/backends/transforms/test/test_create_mutable_buffer.py
+++ b/backends/transforms/test/test_create_mutable_buffer.py
@@ -156,7 +156,12 @@ class TestMutableBufferCreation(unittest.TestCase):
 
             test_data: torch.Tensor = (torch.zeros(1),)
 
-        for requested_name in ("b_cache", "0_cache"):
+        # A clean repeat is caught by the state_dict target check, a renamed
+        # repeat by the placeholder lookup; pin each to its own error.
+        for requested_name, error in (
+            ("b_cache", "already exists in state_dict"),
+            ("0_cache", "already exists in the graph"),
+        ):
             exported_program = export(
                 EmptyNetwork(), args=EmptyNetwork.test_data, strict=True
             )
@@ -167,7 +172,7 @@ class TestMutableBufferCreation(unittest.TestCase):
                 name=requested_name,
                 data=torch.ones(1),
             )
-            with self.assertRaises(RuntimeError):
+            with self.assertRaisesRegex(RuntimeError, error):
                 create_mutable_buffer(
                     exp_program=exported_program,
                     name=requested_name,
@@ -197,7 +202,7 @@ class TestMutableBufferCreation(unittest.TestCase):
         create_mutable_buffer(
             exp_program=exported_program, name="b_cache", data=torch.ones(1)
         )
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "already exists as a mutable buffer"):
             with graph.inserting_before(list(graph.nodes)[0]):
                 create_constant_placeholder(
                     exp_program=exported_program,
@@ -218,7 +223,7 @@ class TestMutableBufferCreation(unittest.TestCase):
                 kind=InputKind.PARAMETER,
                 data=torch.ones(1),
             )
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "already exists in the graph"):
             create_mutable_buffer(
                 exp_program=exported_program, name="b_cache", data=torch.ones(1)
             )

--- a/backends/transforms/utils.py
+++ b/backends/transforms/utils.py
@@ -137,9 +137,14 @@ def create_constant_placeholder(
     """
 
     # Multiple pattern replacements may request the same shared weight; return
-    # the existing node to avoid duplicate parameter names on recompile.
+    # the existing node to avoid duplicate parameter names on recompile. A
+    # mutable buffer of the same name is not a constant and cannot be shared.
     existing = _find_placeholder(graph, name)
     if existing is not None:
+        if existing.name in exp_program.graph_signature.buffers_to_mutate:
+            raise RuntimeError(
+                f"Placeholder '{name}' already exists as a mutable buffer"
+            )
         return existing
 
     fake_tensor = _get_fake_tensor_mode(graph, data)

--- a/backends/transforms/utils.py
+++ b/backends/transforms/utils.py
@@ -95,6 +95,27 @@ def get_param_tensor(
     raise RuntimeError(f"unsupported param type, {node.op}.")
 
 
+def _find_placeholder(graph: torch.fx.Graph, name: str) -> Optional[torch.fx.Node]:
+    """Return the placeholder previously created for this requested name, if any."""
+    for n in graph.nodes:
+        if n.op == "placeholder" and n.meta.get("requested_name") == name:
+            return n
+    return None
+
+
+def _create_placeholder_node(graph: torch.fx.Graph, name: str) -> torch.fx.Node:
+    """Create a placeholder at the current insertion point.
+
+    torch.fx may rename the node (invalid identifier or collision); the target,
+    state_dict key and graph signature must follow the assigned name, so the
+    target is set to node.name and the requested name is kept in node.meta.
+    """
+    node = graph.create_node(op="placeholder", name=name, target=name)
+    node.target = node.name
+    node.meta["requested_name"] = name
+    return node
+
+
 def create_constant_placeholder(
     exp_program: ExportedProgram,
     graph: torch.fx.Graph,
@@ -111,18 +132,15 @@ def create_constant_placeholder(
 
     # Multiple pattern replacements may request the same shared weight; return
     # the existing node to avoid duplicate parameter names on recompile.
-    for n in graph.nodes:
-        if n.op == "placeholder" and n.meta.get("requested_name") == name:
-            return n
+    existing = _find_placeholder(graph, name)
+    if existing is not None:
+        return existing
 
     fake_tensor = _get_fake_tensor_mode(graph, data)
 
-    # torch.fx may rename the node (invalid identifier or collision); the
-    # target, state_dict key and graph signature must follow the assigned name.
-    node = graph.create_node(op="placeholder", name=name, target=name)
-    target = node.target = node.name
+    node = _create_placeholder_node(graph, name)
+    target = node.name
     node.meta["val"] = fake_tensor
-    node.meta["requested_name"] = name
 
     # Add data to state_dict/ constants
     match kind:
@@ -314,6 +332,11 @@ def create_mutable_buffer(
 
     graph = exp_program.graph_module.graph
 
+    # Unlike create_constant_placeholder, a mutable buffer cannot be silently
+    # shared, so a repeated request is an error rather than a dedup hit.
+    if _find_placeholder(graph, name) is not None:
+        raise RuntimeError(f"Placeholder for '{name}' already exists in the graph")
+
     # Create fake tensor using helper function
     fake_tensor = _get_fake_tensor_mode(graph, data)
 
@@ -337,21 +360,18 @@ def create_mutable_buffer(
     ):
         # No const or user input nodes
         node_index = len(input_specs)
-        node = graph.create_node(op="placeholder", name=name, target=name)
+        node = _create_placeholder_node(graph, name)
     else:
         # Find the first constant or user input node
         for i, spec in enumerate(input_specs):
             if spec.kind in [InputKind.CONSTANT_TENSOR, InputKind.USER_INPUT]:
                 node_index = i
                 with graph.inserting_before(_spec_to_node(exp_program, spec)):
-                    node = graph.create_node(op="placeholder", name=name, target=name)
+                    node = _create_placeholder_node(graph, name)
                 break
 
     assert node is not None, "node should be created at this point"
 
-    # torch.fx may rename the node (invalid identifier or collision); the
-    # target, state_dict key and graph signature must follow the assigned name.
-    node.target = node.name
     if node.name != name:
         target = node.name[2:] if node.name.startswith("b_") else node.name
         if target in exp_program.state_dict:

--- a/backends/transforms/utils.py
+++ b/backends/transforms/utils.py
@@ -311,7 +311,6 @@ def create_mutable_buffer(
     _validate_graph_signature(exp_program)
 
     persistent_buffer = True
-    exp_program.state_dict[target] = data
 
     graph = exp_program.graph_module.graph
 
@@ -349,9 +348,20 @@ def create_mutable_buffer(
                 break
 
     assert node is not None, "node should be created at this point"
+
+    # torch.fx may rename the node (invalid identifier or collision); the
+    # target, state_dict key and graph signature must follow the assigned name.
+    node.target = node.name
+    if node.name != name:
+        target = node.name[2:] if node.name.startswith("b_") else node.name
+        if target in exp_program.state_dict:
+            graph.erase_node(node)
+            raise RuntimeError(f"Buffer target '{target}' already exists in state_dict")
+    exp_program.state_dict[target] = data
+
     node.meta["val"] = fake_tensor
     buffer_input_spec = InputSpec(
-        InputKind.BUFFER, TensorArgument(name), target, persistent_buffer
+        InputKind.BUFFER, TensorArgument(node.name), target, persistent_buffer
     )
     input_specs.insert(node_index, buffer_input_spec)
 
@@ -367,7 +377,7 @@ def create_mutable_buffer(
 
     output_specs = exp_program.graph_signature.output_specs
     mutation_output_spec = OutputSpec(
-        OutputKind.BUFFER_MUTATION, TensorArgument(name), target
+        OutputKind.BUFFER_MUTATION, TensorArgument(node.name), target
     )
     output_specs.insert(output_index, mutation_output_spec)
 

--- a/backends/transforms/utils.py
+++ b/backends/transforms/utils.py
@@ -95,6 +95,12 @@ def get_param_tensor(
     raise RuntimeError(f"unsupported param type, {node.op}.")
 
 
+def _buffer_target(node_name: str) -> str:
+    """Map a placeholder name to its state_dict target per the export
+    convention: placeholder "b_foo" corresponds to buffer target "foo"."""
+    return node_name[2:] if node_name.startswith("b_") else node_name
+
+
 def _find_placeholder(graph: torch.fx.Graph, name: str) -> Optional[torch.fx.Node]:
     """Return the placeholder previously created for this requested name, if any."""
     for n in graph.nodes:
@@ -316,11 +322,7 @@ def create_mutable_buffer(
     if not isinstance(data, torch.Tensor):
         raise ValueError("Data must be a torch.Tensor")
 
-    # Extract target name (remove "b_" prefix if present, following export convention)
-    if name.startswith("b_"):
-        target = name[2:]
-    else:
-        target = name
+    target = _buffer_target(name)
 
     # Check if target already exists
     if target in exp_program.state_dict:
@@ -372,8 +374,10 @@ def create_mutable_buffer(
 
     assert node is not None, "node should be created at this point"
 
+    # If fx renamed the node, the caller's name is stale; re-apply the target
+    # convention to the assigned name.
     if node.name != name:
-        target = node.name[2:] if node.name.startswith("b_") else node.name
+        target = _buffer_target(node.name)
         if target in exp_program.state_dict:
             graph.erase_node(node)
             raise RuntimeError(f"Buffer target '{target}' already exists in state_dict")


### PR DESCRIPTION
Follow up from the review discussion on #21542 where @JakeStevens flagged that `create_mutable_buffer` probably has the same latent bug. It does, and the collision case is a bit worse.

Same pattern, the node gets created with the requested name and the signature records that name instead of whatever fx actually assigned:

```python
node = graph.create_node(op="placeholder", name=name, target=name)
...
InputSpec(InputKind.BUFFER, TensorArgument(name), target, persistent_buffer)
...
OutputSpec(OutputKind.BUFFER_MUTATION, TensorArgument(name), target)
```

A digit-leading name leaves dangling refs in both the input and output specs and recompile dies with `SyntaxError: invalid decimal literal`. A name that collides with an existing placeholder is nastier, fx renames the node and the output spec silently binds to the colliding node, so the mutation entry points at the wrong tensor before recompile fails with `SyntaxError: duplicate argument`.

No in-repo callers yet (came in with #13813, only its tests use it), so this is hardening a public utility rather than fixing a user visible crash.

Fix is the same as #21542, everything follows the assigned name: `node.target`, the state_dict key and both `TensorArgument`s use `node.name`, with the `b_` prefix convention applied to the assigned name when deriving the target. If a rename lands on an existing state_dict key the node is removed and the existing duplicate-target error is raised instead of overwriting the entry. Valid unique names behave exactly as before.

Per review, the creation logic is now a shared helper, `_create_placeholder_node`, used by both functions so they stay in sync, with a `_find_placeholder` lookup beside it. The dedup semantics stay deliberately different: `create_constant_placeholder` returns the existing node for a repeated request, while `create_mutable_buffer` raises, since a mutable buffer cannot be silently shared.

Before/after with the same probe, checking signature consistency and a recompile round trip:

```
                          BEFORE                                    AFTER
b_my_cache (control)      consistent, runs                          unchanged
0_cache (digit-leading)   dangling input and output spec refs,      consistent, runs
                          SyntaxError: invalid decimal literal
x (collides with input)   output spec bound to the wrong node,      consistent, runs
                          SyntaxError: duplicate argument 'x'
```

Two new tests: one covers both rename triggers, asserting node, signature and state_dict consistency plus a recompile round trip, and is verified failing-first by reverting just `backends/transforms/utils.py`. The other pins the duplicate-request error for a clean and a renamed name; it passes before the helper change too and exists to guard the raise semantics.

```
backends/transforms/test
  main    : 120 passed, 50 skipped
  this PR : 122 passed, 50 skipped
```

lintrunner is clean on the changed files. Independent of #21542, either can merge first.

cc @cccclai @JakeStevens @digantdesai
