### PR TITLE
Treat aten.slice.Tensor as a shared-observer op in XNNPACKQuantizer

### DIFF
--- a/backends/xnnpack/quantizer/xnnpack_quantizer_utils.py
+++ b/backends/xnnpack/quantizer/xnnpack_quantizer_utils.py
@@ -1102,6 +1102,7 @@ def _is_share_obs_or_fq_op(op: Callable) -> bool:
         torch.ops.aten.view_copy.default,
         torch.ops.aten.view.default,
         torch.ops.aten.reshape.default,
+        torch.ops.aten.slice.Tensor,
         torch.ops.aten.slice_copy.Tensor,
         torch.ops.aten.flatten.using_ints,
     ]

--- a/backends/xnnpack/test/ops/test_slice_copy.py
+++ b/backends/xnnpack/test/ops/test_slice_copy.py
@@ -140,10 +140,9 @@ class TestSliceCopy(unittest.TestCase):
             .check_not(["torch.ops.higher_order.executorch_call_delegate"])
         )
 
-    # Note: Slice ends up as slice_copy later in the process, but during quantization,
-    # it's still slice, which isn't supported by the XNNPACK quantizer.
-    @unittest.skip("T156004676 - slice isn't propagated")
-    def _test_qs8_slice_copy(self):
+    # Note: Slice ends up as slice_copy later in the process, but during quantization
+    # it's still slice, so the quantizer shares observers on aten.slice.Tensor.
+    def test_qs8_slice_copy(self):
         class SliceCopy(torch.nn.Module):
             def forward(self, x):
                 y = x + x
@@ -157,8 +156,9 @@ class TestSliceCopy(unittest.TestCase):
             .export()
             .check_node_count(
                 {
-                    "aten::slice.Tensor": 3,
-                    "quantized_decomposed::quantize_per_tensor": 3,
+                    torch.ops.aten.slice.Tensor: 3,
+                    # 3 slices, plus the input and the add output
+                    torch.ops.quantized_decomposed.quantize_per_tensor.default: 5,
                 }
             )
             .to_edge_transform_and_lower()


### PR DESCRIPTION
### Summary

`_is_share_obs_or_fq_op` lists `aten.slice_copy.Tensor` but not `aten.slice.Tensor`.
The quantizer runs before `to_edge()`, so the op it actually sees is
`aten.slice.Tensor`, the `_copy` entry never matches, and `propagate_annotation`
does not give the slice its producer's `SharedQuantizationSpec`.

The other data-movement ops in that list are registered under both names
(`permute.default`/`permute_copy.default`, `squeeze.dim`/`squeeze_copy.dim`,
`view.default`/`view_copy.default`); slice only had the `_copy` one. `slice` has
no `.default` overload, which is why the pre-functionalization name is
`slice.Tensor` and not `slice_copy.default`.

Without the shared spec, the slice input and output end up with different quant
params. XNNPACK's `static_slice` requires them to be equal, so the model
partitions and lowers fine and then fails at runtime init:

```
[XNNCompiler.cpp:1421] Failed to create static slice node 377 with code: xnn_status_invalid_parameter
[XNNPACKBackend.cpp:119] XNNCompiler::compileModel failed: 0x1
[method.cpp:110] Init failed for backend XnnpackBackend: 0x1
```

I hit this quantizing a Gemma-family embedding model with `XNNPACKQuantizer`
(per-channel W8A8 static), where all 96 slices from the RoPE `rotate_half`
pattern were left without quant params.

`_test_qs8_slice_copy` was already disabled for this ("T156004676 - slice isn't
propagated"), and its comment names the same cause, so I re-enabled it here.

### Test plan

```
pytest backends/xnnpack/test/ops/test_slice_copy.py -k qs8
```

The test runs end to end now: quantize, lower, serialize, run and compare
outputs. Reverting the one-line change makes it fail with 2
`quantize_per_tensor` nodes instead of 5.

Two assertions in it needed updating first. `check_node_count` takes op
overloads rather than the `"aten::slice.Tensor"` strings the test was written
with, so it reported `Expected 3 aten::slice.Tensor nodes but found 0` on a
graph that did contain them. And the expected `quantize_per_tensor` count is 5,
not 3, since the three slices are now quantized along with the input and the add
output.

`lintrunner -m upstream/main` is clean.


cc @GregoryComer @digantdesai @cbilgin @JakeStevens