### PR TITLE
Plumb share_mutable_buffers through llama xnnpack shim

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -983,6 +983,8 @@ def _to_edge_and_lower_llama_xnnpack(
     generate_etrecord: bool = False,
     verbose: bool = False,
     gen_tag_fn: Optional[Callable[[torch.fx.Node], Optional[str]]] = None,
+    share_mutable_buffers: bool = False,
+    allow_lifetime_and_storage_overlap: bool = False,
 ) -> LLMEdgeManager:  # noqa: C901
     partitioners = []
 
@@ -1025,7 +1027,10 @@ def _to_edge_and_lower_llama_xnnpack(
 
     # Add gen_tag_fn to tag non-delegated weights as well.
     return builder.to_executorch(
-        passes=additional_passes, external_constants_tag=gen_tag_fn
+        passes=additional_passes,
+        external_constants_tag=gen_tag_fn,
+        share_mutable_buffers=share_mutable_buffers,
+        allow_lifetime_and_storage_overlap=allow_lifetime_and_storage_overlap,
     )
 
 

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -983,6 +983,7 @@ def _to_edge_and_lower_llama_xnnpack(
     generate_etrecord: bool = False,
     verbose: bool = False,
     gen_tag_fn: Optional[Callable[[torch.fx.Node], Optional[str]]] = None,
+    share_mutable_buffers: bool = False,
 ) -> LLMEdgeManager:  # noqa: C901
     partitioners = []
 
@@ -1025,7 +1026,9 @@ def _to_edge_and_lower_llama_xnnpack(
 
     # Add gen_tag_fn to tag non-delegated weights as well.
     return builder.to_executorch(
-        passes=additional_passes, external_constants_tag=gen_tag_fn
+        passes=additional_passes,
+        external_constants_tag=gen_tag_fn,
+        share_mutable_buffers=share_mutable_buffers,
     )
 
 

--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -528,6 +528,7 @@ class LLMEdgeManager:
             Callable[[torch.fx.Node], Optional[str]]
         ] = None,
         share_mutable_buffers: bool = False,
+        allow_lifetime_and_storage_overlap: bool = False,
     ) -> "LLMEdgeManager":
         """
         Lower the model to executorch and get an ExecutorchProgram.
@@ -561,6 +562,7 @@ class LLMEdgeManager:
                 memory_planning_pass=MemoryPlanningPass(
                     alloc_graph_input=False,
                     share_mutable_buffers=share_mutable_buffers,
+                    allow_lifetime_and_storage_overlap=allow_lifetime_and_storage_overlap,
                 ),
                 sym_shape_eval_pass=ConstraintBasedSymShapeEvalPass(),
                 external_constants=external_constants_tag,


### PR DESCRIPTION
Summary:
LLMEdgeManager.to_executorch() already accepts a `share_mutable_buffers`
kwarg (default False) that it forwards to MemoryPlanningPass. When True,
the planner segregates tensors registered as mutable buffers into a separate mem_id=2
arena, shrinking the transient mem_id=1 arena by whatever those buffers
were consuming. Total non-const bytes stay the same.

The `_to_edge_and_lower_llama_xnnpack()` shim in export_llama_lib.py
wasn't surfacing the kwarg, so llama4 STITO exports (which route through
this shim) had no clean way to opt in. This diff plumbs it it through.

Differential Revision: D114737792


