### PR TITLE
[MLX] Lower and bind the off-graph KV-cache op

### DIFF
--- a/backends/mlx/CMakeLists.txt
+++ b/backends/mlx/CMakeLists.txt
@@ -296,8 +296,12 @@ target_include_directories(
 # Link against MLX and executorch. mlx is an imported static lib (built by
 # mlx_external); it is only consumed at build time here, not re-exported, so
 # downstream consumers must link to mlx separately via the package config.
+# extension_llm_cache carries the off-graph KV-cache registry the backend binds
+# to in init(); it is defined under EXECUTORCH_BUILD_EXTENSION_LLM, which the
+# mlx preset enables.
 target_link_libraries(
-  mlxdelegate PRIVATE mlx_schema executorch_core $<BUILD_INTERFACE:mlx>
+  mlxdelegate PRIVATE mlx_schema executorch_core extension_llm_cache
+                      $<BUILD_INTERFACE:mlx>
 )
 
 executorch_target_link_options_shared_lib(mlxdelegate)

--- a/backends/mlx/ops.py
+++ b/backends/mlx/ops.py
@@ -159,6 +159,7 @@ from executorch.backends.mlx.serialization.mlx_graph_schema import (
     TransposeNode,
     TrilNode,
     TriuNode,
+    UpdateAndAttendNode,
     VarNode,
     VidOrTid,
     WhereNode,
@@ -169,6 +170,12 @@ from executorch.backends.mlx.serialization.mlx_graph_schema import (
 # For ops that are not in aten (e.g., dim order ops), directly register on exir_ops
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.passes.reinplace import _derive_edge_inplace_overload
+
+# Registers kvcache::update_and_attend, the neutral off-graph KV-cache op this
+# backend lowers below.
+from executorch.extension.llm.cache import (  # noqa: F401
+    update_and_attend as _kvcache_op,
+)
 from torch.fx.node import Node
 
 _LEAKY_RELU_DEFAULT_NEGATIVE_SLOPE = 0.01
@@ -2840,6 +2847,36 @@ def _rope_handler(P: MLXProgramBuilder, n: Node) -> Slot:
         )
     )
 
+    return out
+
+
+@REGISTRY.register(target=[torch.ops.kvcache.update_and_attend.default])
+def _update_and_attend_handler(P: MLXProgramBuilder, n: Node) -> Slot:
+    """Handle kvcache.update_and_attend: append this step's K/V, then attend.
+
+    The cache itself is off-graph runtime state, so nothing about it is
+    serialized: the node carries only the tensor operands plus the three
+    per-call-site constants the runtime handler needs.
+    """
+    args = P.args(n)
+    require_args(args, 7, 7, "kvcache.update_and_attend")
+    require_kwargs(P.kwargs(n), set(), "kvcache.update_and_attend")
+    q, k, v, position, layer_id, scale, out_dtype = args
+    require_static_int(layer_id, "layer_id", "kvcache.update_and_attend")
+    require_static_float(scale, "scale", "kvcache.update_and_attend")
+    out = P.make_or_get_slot(n)
+    P.emit(
+        UpdateAndAttendNode(
+            q=P.slot_to_tid(q),
+            k=P.slot_to_tid(k),
+            v=P.slot_to_tid(v),
+            position=P.slot_to_tid(position),
+            out=P.slot_to_tid(out),
+            layer_id=layer_id,
+            scale=float(scale),
+            out_dtype=torch_dtype_to_scalar_type(out_dtype),
+        )
+    )
     return out
 
 

--- a/backends/mlx/runtime/MLXBackend.cpp
+++ b/backends/mlx/runtime/MLXBackend.cpp
@@ -6,10 +6,14 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+#include "MLXCache.h"
 #include "MLXExecutor.h"
 #include "MLXInterpreter.h"
 #include "MLXLoader.h"
+#include "MLXSequenceCache.h"
 #include "mlx_mutable_state.h"
+
+#include <executorch/extension/llm/cache/cache_registry.h>
 
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/error.h>
@@ -177,6 +181,11 @@ struct MLXHandle {
   int clear_cache_interval_{0};
   uint64_t execute_count_{0};
 
+  // Keep-alive for the off-graph KV cache bound in init(). state.cache is a
+  // non-owning view of the same object, so the cache must outlive the handle
+  // even if the runner's session is torn down first.
+  std::shared_ptr<::executorch::extension::llm::cache::CacheBase> cache_shared;
+
   // Keep the constant buffers alive for zero-copy constants
   // Each FreeableBuffer must outlive the MLX arrays that reference it
   std::vector<FreeableBuffer> constant_buffers;
@@ -309,6 +318,32 @@ class MLXBackend final : public ::executorch::runtime::BackendInterface {
       // Bind execution state (reused across execute() calls)
       handle->state.bind(
           handle->program, handle->constants, handle->mutable_buffers);
+
+      // Bind the off-graph KV cache, if the runner installed one under a key it
+      // passed as a runtime spec. Bound before the init chain runs so an
+      // update_and_attend node there sees the same cache execute() will.
+      if (auto spec = context.get_runtime_spec<const char*>(kCacheKeyKey);
+          spec.ok() && spec.get() != nullptr && *spec.get() != '\0') {
+        const char* cache_key = spec.get();
+        handle->cache_shared =
+            cache::CacheRegistry::global().get(std::string(cache_key));
+        if (!handle->cache_shared) {
+          throw std::runtime_error(
+              std::string("init: cache_key '") + cache_key +
+              "' is not installed in the CacheRegistry");
+        }
+        // Cross-cast from the neutral ownership anchor to this backend's
+        // tensor-typed op face; the two are deliberately unrelated bases (see
+        // MLXCache.h), so nullptr here means the key names another backend's
+        // cache.
+        handle->state.cache =
+            dynamic_cast<MLXCache*>(handle->cache_shared.get());
+        if (handle->state.cache == nullptr) {
+          throw std::runtime_error(
+              std::string("init: cache under key '") + cache_key +
+              "' is not an MLX cache");
+        }
+      }
 
       // Run init chain if present.
       // SAFETY: The >= 0 check ensures init_chain_idx is non-negative, so the
@@ -516,6 +551,18 @@ namespace {
 auto cls = MLXBackend();
 Backend backend{kMLXBackendId, &cls};
 static auto success_with_compiler = register_backend(backend);
+
+// Cache kind is named by the builder tag rather than an enum on the config: a
+// runner asks the registry for (backend_id, kind) and gets back a neutral
+// CacheBase it installs under a cache_key. Adding a kind is a new builder here.
+const int cache_builders_registered = [] {
+  cache::CacheBuilderRegistry::global().register_builder(
+      kMLXBackendId, "seq", [](const cache::CacheConfig& cfg) {
+        return std::shared_ptr<cache::CacheBase>(
+            std::make_shared<MLXSequenceCache>(cfg));
+      });
+  return 0;
+}();
 } // namespace
 
 } // namespace mlx

--- a/backends/mlx/runtime/MLXExecutor.h
+++ b/backends/mlx/runtime/MLXExecutor.h
@@ -166,6 +166,12 @@ struct ExecutionState {
   // Init chain flag: when true, set_tensor allows writing to constants
   bool is_init_chain{false};
 
+  // Host-side position for the current execute, cached by the position Tid so
+  // the off-graph update_and_attend handler reads it once per step instead of
+  // one device->host sync per layer. Cleared by reset(): the same Tid carries a
+  // new value each step, so it must not persist across executes.
+  std::optional<std::pair<uint32_t, int>> cached_position;
+
   // Logging context
   size_t current_op_idx{0};
   const char* current_op_name{nullptr};
@@ -262,6 +268,7 @@ struct ExecutionState {
     for (auto& v : values) {
       v = std::nullopt;
     }
+    cached_position = std::nullopt;
   }
 
   static inline const char* dtype_str(::mlx::core::Dtype dtype) {

--- a/backends/mlx/runtime/MLXExecutor.h
+++ b/backends/mlx/runtime/MLXExecutor.h
@@ -166,12 +166,6 @@ struct ExecutionState {
   // Init chain flag: when true, set_tensor allows writing to constants
   bool is_init_chain{false};
 
-  // Host-side position for the current execute, cached by the position Tid so
-  // the off-graph update_and_attend handler reads it once per step instead of
-  // one device->host sync per layer. Cleared by reset(): the same Tid carries a
-  // new value each step, so it must not persist across executes.
-  std::optional<std::pair<uint32_t, int>> cached_position;
-
   // Logging context
   size_t current_op_idx{0};
   const char* current_op_name{nullptr};
@@ -268,7 +262,6 @@ struct ExecutionState {
     for (auto& v : values) {
       v = std::nullopt;
     }
-    cached_position = std::nullopt;
   }
 
   static inline const char* dtype_str(::mlx::core::Dtype dtype) {

--- a/backends/mlx/runtime/MLXInterpreter.h
+++ b/backends/mlx/runtime/MLXInterpreter.h
@@ -311,17 +311,24 @@ inline void exec_update_and_attend(
   // the query side (q, scale) and calls SDPA.
   const array& q = st.const_tensor_ref(n.q);
   // The run's start is position[0], read host-side so the cache stays pure
-  // graph + integer bookkeeping. Every layer of a step sees the same position
-  // tensor (same Tid), so read + sync it once per execute and reuse across
-  // layers; reset() clears the cache so the next step re-reads its new value.
+  // graph + integer bookkeeping. Every layer of a step reads the same position
+  // tensor, so evaluating it in place costs one sync for the first layer and
+  // nothing for the rest -- casting first would instead build a fresh array per
+  // layer and sync on each one.
+  auto pos = st.const_tensor_ref(n.position);
+  eval(pos);
   int position;
-  if (st.cached_position && st.cached_position->first == n.position.idx) {
-    position = st.cached_position->second;
-  } else {
-    array pos = astype(st.const_tensor_ref(n.position), int32, s);
-    eval(pos);
-    position = pos.data<int32_t>()[0];
-    st.cached_position = std::make_pair(n.position.idx, position);
+  switch (pos.dtype()) {
+    case ::mlx::core::int32:
+      position = pos.data<int32_t>()[0];
+      break;
+    case ::mlx::core::int64:
+      position = static_cast<int>(pos.data<int64_t>()[0]);
+      break;
+    default:
+      throw std::runtime_error(
+          std::string("update_and_attend: position must be int32 or int64, ") +
+          "got " + ExecutionState::dtype_str(pos.dtype()));
   }
   AttendSpec spec = st.cache->update_and_fetch(
       *n.layer_id,

--- a/backends/mlx/runtime/MLXInterpreter.h
+++ b/backends/mlx/runtime/MLXInterpreter.h
@@ -311,13 +311,18 @@ inline void exec_update_and_attend(
   // the query side (q, scale) and calls SDPA.
   const array& q = st.const_tensor_ref(n.q);
   // The run's start is position[0], read host-side so the cache stays pure
-  // graph + integer bookkeeping. This is a device->host sync per node, i.e.
-  // n_layers stalls per step -- not one -- even though every layer of a step
-  // sees the same position. The fix is for position to arrive as a host-side
-  // constant instead of a graph tensor; this is the single spot to change.
-  array pos = astype(st.const_tensor_ref(n.position), int32, s);
-  eval(pos);
-  const int position = pos.data<int32_t>()[0];
+  // graph + integer bookkeeping. Every layer of a step sees the same position
+  // tensor (same Tid), so read + sync it once per execute and reuse across
+  // layers; reset() clears the cache so the next step re-reads its new value.
+  int position;
+  if (st.cached_position && st.cached_position->first == n.position.idx) {
+    position = st.cached_position->second;
+  } else {
+    array pos = astype(st.const_tensor_ref(n.position), int32, s);
+    eval(pos);
+    position = pos.data<int32_t>()[0];
+    st.cached_position = std::make_pair(n.position.idx, position);
+  }
   AttendSpec spec = st.cache->update_and_fetch(
       *n.layer_id,
       position,

--- a/backends/mlx/runtime/backend_options.h
+++ b/backends/mlx/runtime/backend_options.h
@@ -42,6 +42,14 @@ inline constexpr char kClearCacheIntervalKey[] = "clear_cache_interval";
 // errors otherwise). Saves one full mutable-buffer (KV-cache) copy per handle.
 inline constexpr char kSkipMutableBufferInitKey[] = "skip_mutable_buffer_init";
 
+// Per-model runtime-spec key (string). Names the off-graph KV cache this handle
+// binds to: the runner creates the cache, installs it in the process-global
+// CacheRegistry under this key, and the delegate looks it up in init(). The
+// DelegateHandle is opaque to the host, so the key is the only rendezvous
+// channel. Unset means no cache, and any update_and_attend node then fails at
+// execute() rather than silently attending nothing.
+inline constexpr char kCacheKeyKey[] = "cache_key";
+
 } // namespace mlx
 } // namespace backends
 } // namespace executorch

--- a/backends/mlx/test/CMakeLists.txt
+++ b/backends/mlx/test/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 target_link_libraries(
   op_test_runner PRIVATE extension_module extension_tensor executorch
-                         mlxdelegate
+                         mlxdelegate extension_llm_cache
 )
 
 # --------------------------------------------------------------------------

--- a/backends/mlx/test/op_test_runner.cpp
+++ b/backends/mlx/test/op_test_runner.cpp
@@ -19,7 +19,8 @@
  *   ./cmake-out-mlx/backends/mlx/test/op_test_runner \
  *       --pte <model.pte> \
  *       --input <input.bin> \
- *       --output <output.bin>
+ *       --output <output.bin> \
+ *       [--kv-cache <capacity,n_layers,n_kv_heads,head_dim[,kv_dtype]>]
  *
  * Binary file format:
  *   - 4 bytes: number of tensors (uint32_t)
@@ -40,11 +41,17 @@
 #include <executorch/extension/tensor/tensor.h>
 #pragma clang diagnostic pop
 
+#include <executorch/backends/mlx/runtime/backend_options.h>
+#include <executorch/extension/llm/cache/cache_registry.h>
+#include <executorch/runtime/backend/backend_options_map.h>
+#include <executorch/runtime/backend/options.h>
+
 #include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -200,19 +207,62 @@ void write_tensors_to_bin(
 }
 
 void print_usage(const char* prog_name) {
-  std::cerr << "Usage: " << prog_name << " [options]\n"
-            << "Options:\n"
-            << "  --pte <path>     Path to .pte model file (required)\n"
-            << "  --input <path>   Path to input .bin file (required)\n"
-            << "  --output <path>  Path to output .bin file (required)\n"
-            << "  --verbose        Print verbose output\n"
-            << std::endl;
+  std::cerr
+      << "Usage: " << prog_name << " [options]\n"
+      << "Options:\n"
+      << "  --pte <path>     Path to .pte model file (required)\n"
+      << "  --input <path>   Path to input .bin file (required)\n"
+      << "  --output <path>  Path to output .bin file (required)\n"
+      << "  --kv-cache <capacity,n_layers,n_kv_heads,head_dim[,dtype]>\n"
+      << "                   Install an off-graph KV cache for the run;\n"
+      << "                   dtype is an ET ScalarType (default 6/Float)\n"
+      << "  --verbose        Print verbose output\n"
+      << std::endl;
+}
+
+// Parse "capacity,n_layers,n_kv_heads,head_dim[,kv_dtype]" into a uniform-layer
+// CacheConfig. Sizing is on the command line because the architecture facts are
+// not yet published in .pte metadata; a runner that reads them lands with the
+// metadata writer.
+bool parse_kv_cache_spec(
+    const std::string& spec,
+    executorch::extension::llm::cache::CacheConfig& cfg) {
+  std::vector<int> fields;
+  size_t pos = 0;
+  while (pos <= spec.size()) {
+    const size_t comma = spec.find(',', pos);
+    const std::string field = spec.substr(
+        pos, comma == std::string::npos ? std::string::npos : comma - pos);
+    if (field.empty()) {
+      return false;
+    }
+    try {
+      fields.push_back(std::stoi(field));
+    } catch (const std::exception&) {
+      return false;
+    }
+    if (comma == std::string::npos) {
+      break;
+    }
+    pos = comma + 1;
+  }
+  if (fields.size() < 4 || fields.size() > 5) {
+    return false;
+  }
+  cfg.capacity = fields[0];
+  cfg.n_layers = fields[1];
+  cfg.layers = {{{}, /*n_kv_heads=*/fields[2], /*head_dim=*/fields[3]}};
+  cfg.kv_dtype = fields.size() == 5
+      ? fields[4]
+      : static_cast<int>(executorch::runtime::etensor::ScalarType::Float);
+  return executorch::extension::llm::cache::valid(cfg);
 }
 
 int main(int argc, char* argv[]) {
   std::string pte_path;
   std::string input_path;
   std::string output_path;
+  std::string kv_cache_spec;
   bool verbose = false;
 
   for (int i = 1; i < argc; ++i) {
@@ -223,6 +273,8 @@ int main(int argc, char* argv[]) {
       input_path = argv[++i];
     } else if (arg == "--output" && i + 1 < argc) {
       output_path = argv[++i];
+    } else if (arg == "--kv-cache" && i + 1 < argc) {
+      kv_cache_spec = argv[++i];
     } else if (arg == "--verbose") {
       verbose = true;
     } else if (arg == "--help" || arg == "-h") {
@@ -246,8 +298,50 @@ int main(int argc, char* argv[]) {
       std::cout << "Loading model from: " << pte_path << std::endl;
     }
 
+    namespace cache = ::executorch::extension::llm::cache;
+
+    // Build and install the off-graph KV cache before the Module, so the
+    // registry entry exists by the time the delegate's init() looks it up.
+    // Declared here so the session outlives the module.
+    std::optional<cache::CacheSession> cache_session;
+    if (!kv_cache_spec.empty()) {
+      cache::CacheConfig cfg{};
+      if (!parse_kv_cache_spec(kv_cache_spec, cfg)) {
+        std::cerr << "Invalid --kv-cache spec: " << kv_cache_spec << std::endl;
+        return 1;
+      }
+      auto built = cache::CacheBuilderRegistry::global().build(
+          ::executorch::backends::mlx::kMLXBackendId, "seq", cfg);
+      if (!built.ok()) {
+        std::cerr << "Failed to build KV cache: "
+                  << static_cast<int>(built.error()) << std::endl;
+        return 1;
+      }
+      cache_session.emplace(cache::make_unique_key(), built.get());
+      if (verbose) {
+        std::cout << "Installed KV cache under key " << cache_session->key()
+                  << std::endl;
+      }
+    }
+
     Module module(pte_path);
-    auto load_error = module.load();
+    Error load_error = Error::Ok;
+    if (cache_session) {
+      ::executorch::runtime::BackendOptions<1> mlx_opts;
+      ::executorch::runtime::LoadBackendOptionsMap options_map;
+      if (mlx_opts.set_option(
+              ::executorch::backends::mlx::kCacheKeyKey,
+              cache_session->key().c_str()) != Error::Ok ||
+          options_map.set_options(
+              ::executorch::backends::mlx::kMLXBackendId, mlx_opts.view()) !=
+              Error::Ok) {
+        std::cerr << "Failed to set cache_key backend option" << std::endl;
+        return 1;
+      }
+      load_error = module.load(options_map);
+    } else {
+      load_error = module.load();
+    }
     if (load_error != Error::Ok) {
       std::cerr << "Failed to load model: " << static_cast<int>(load_error)
                 << std::endl;

--- a/backends/mlx/test/test_ops.py
+++ b/backends/mlx/test/test_ops.py
@@ -35,6 +35,7 @@ from executorch.backends.mlx import (  # noqa: F401 - registers mlx ops  # noqa:
     custom_ops,
     ops,
 )
+from executorch.backends.mlx.builder.op_helpers import torch_dtype_to_scalar_type
 from executorch.backends.mlx.llm.sampling import SamplingHead
 from torch.export import Dim
 
@@ -8313,3 +8314,145 @@ class MoeScatterOutputsTest(OpTestCase):
             "x": {0: batch_dim},
             "expert_indices": {0: batch_dim},
         }
+
+
+# Off-graph KV cache (kvcache::update_and_attend)
+class UpdateAndAttendModel(nn.Module):
+    """Multi-layer attention over the off-graph cache, one op call per layer."""
+
+    def __init__(self, n_layers: int, head_dim: int, out_dtype: torch.dtype):
+        super().__init__()
+        self.n_layers = n_layers
+        self.out_dtype = out_dtype
+        self.scale = head_dim**-0.5
+
+    def forward(self, q, k, v, position):
+        # Layers are summed, not chained: a chained query would arrive in
+        # out_dtype, and the two implementations disagree on compute precision
+        # for a half-precision query -- the MLX handler attends in the query's
+        # dtype, the eager reference always promotes to fp32. Keeping q as the
+        # graph input holds both at fp32. Distinct K/V per layer keeps each
+        # layer's cells apart.
+        total = None
+        for layer in range(self.n_layers):
+            kv_scale = layer + 1
+            out = torch.ops.kvcache.update_and_attend(
+                q,
+                k * kv_scale,
+                v * kv_scale,
+                position,
+                layer,
+                self.scale,
+                self.out_dtype,
+            )
+            total = out if total is None else total + out
+        return total
+
+
+@register_test
+class UpdateAndAttendTest(OpTestCase):
+    """Eager reference cache vs MLX runtime, through the delegate."""
+
+    name = "update_and_attend"
+    rtol = 1e-3
+    atol = 1e-3
+    expected_node_counts = {"UpdateAndAttendNode": 2}
+
+    n_layers = 2
+    n_heads = 4
+    n_kv_heads = 2
+    head_dim = 8
+    export_seq_len = 3
+    capacity = 16
+
+    def __init__(
+        self,
+        test_seq_len: int = 3,
+        out_dtype: torch.dtype = torch.float32,
+        kv_dtype: torch.dtype = torch.float32,
+    ):
+        self.test_seq_len = test_seq_len
+        self.out_dtype = out_dtype
+        self.kv_dtype = kv_dtype  # KV *storage* precision, not the op's output
+
+        parts = [] if test_seq_len == self.export_seq_len else ["decode"]
+        if out_dtype != torch.float32:
+            parts.append(f"{str(out_dtype).split('.')[-1]}_out")
+        if kv_dtype != torch.float32:
+            parts.append(f"{str(kv_dtype).split('.')[-1]}_kv")
+        self.name = "_".join(["update_and_attend", *parts])
+
+        self.kv_cache = ",".join(
+            str(x)
+            for x in [
+                self.capacity,
+                self.n_layers,
+                self.n_kv_heads,
+                self.head_dim,
+                torch_dtype_to_scalar_type(kv_dtype),
+            ]
+        )
+
+    @classmethod
+    def get_test_configs(cls) -> List["UpdateAndAttendTest"]:
+        return [
+            cls(),  # prefill: T=3, Causal
+            cls(test_seq_len=1),  # decode-shaped: T=1, Mask::None
+            cls(out_dtype=torch.float16),  # output contract != operand dtype
+            cls(kv_dtype=torch.float16),  # KV stored as Half, computed in fp32
+        ]
+
+    def create_model(self) -> nn.Module:
+        return UpdateAndAttendModel(self.n_layers, self.head_dim, self.out_dtype)
+
+    def _inputs(self, seq_len: int) -> Tuple[torch.Tensor, ...]:
+        return (
+            torch.randn(1, self.n_heads, seq_len, self.head_dim),
+            torch.randn(1, self.n_kv_heads, seq_len, self.head_dim),
+            torch.randn(1, self.n_kv_heads, seq_len, self.head_dim),
+            torch.arange(seq_len, dtype=torch.int32).reshape(seq_len, 1),
+        )
+
+    def create_inputs(self) -> Tuple[torch.Tensor, ...]:
+        return self._inputs(self.export_seq_len)
+
+    def create_test_inputs(self) -> Tuple[torch.Tensor, ...]:
+        return self._inputs(self.test_seq_len)
+
+    def get_dynamic_shapes(self) -> Optional[Dict[str, any]]:
+        # Prefill and decode run the same graph, so no length may be baked in.
+        seq = Dim("kv_seq", min=1, max=self.capacity)
+        return {
+            "q": {2: seq},
+            "k": {2: seq},
+            "v": {2: seq},
+            "position": {0: seq},
+        }
+
+    def compute_expected_outputs(self, model, test_inputs):
+        # The op dispatches to whichever cache is active, so the eager run needs
+        # an oracle cache installed for its duration.
+        from executorch.extension.llm.cache.reference_cache import (
+            CacheConfig,
+            ContiguousReferenceCache,
+        )
+        from executorch.extension.llm.cache.update_and_attend import REGISTRY
+
+        key = f"{self.name}-oracle"
+        REGISTRY.install(
+            key,
+            ContiguousReferenceCache(
+                CacheConfig(
+                    n_layers=self.n_layers,
+                    n_kv_heads=self.n_kv_heads,
+                    head_dim=self.head_dim,
+                    capacity=self.capacity,
+                    dtype=self.kv_dtype,  # must match the runtime pool's storage
+                )
+            ),
+        )
+        try:
+            with REGISTRY.active(key):
+                return model(*test_inputs)
+        finally:
+            REGISTRY.uninstall(key)

--- a/backends/mlx/test/test_utils.py
+++ b/backends/mlx/test/test_utils.py
@@ -616,6 +616,7 @@ def run_cpp_test_runner(
     output_path: Path,
     verbose: bool = False,
     timeout: Optional[int] = None,
+    kv_cache: Optional[str] = None,
 ) -> bool:
     """
     Run the C++ op_test_runner binary.
@@ -626,6 +627,10 @@ def run_cpp_test_runner(
         output_path: Path to write output .bin file.
         verbose: Whether to print verbose output.
         timeout: Timeout in seconds. None means use DEFAULT_TEST_TIMEOUT.
+        kv_cache: Optional off-graph KV cache spec,
+            "capacity,n_layers,n_kv_heads,head_dim[,kv_dtype]". Required by
+            models containing kvcache::update_and_attend, which fail at
+            execute() with no cache installed.
 
     Returns:
         True if execution succeeded, False otherwise.
@@ -644,6 +649,8 @@ def run_cpp_test_runner(
         "--output",
         str(output_path),
     ]
+    if kv_cache:
+        cmd += ["--kv-cache", kv_cache]
     if verbose:
         cmd.append("--verbose")
 
@@ -860,6 +867,9 @@ class OpTestCase:
     expected_node_counts: Optional[Dict[str, int]] = (
         None  # Expected serialized node counts
     )
+    # Off-graph KV cache spec "capacity,n_layers,n_kv_heads,head_dim[,kv_dtype]"
+    # installed for the run; required by models using update_and_attend.
+    kv_cache: Optional[str] = None
 
     def _set_seed(self) -> None:
         """Set random seed for reproducibility."""
@@ -1064,7 +1074,12 @@ class OpTestCase:
         print("\nStep 3: Running C++ binary...")
         actual_path = self.get_test_dir() / "actual_output.bin"
         if not run_cpp_test_runner(
-            pte_path, input_path, actual_path, verbose=verbose, timeout=timeout
+            pte_path,
+            input_path,
+            actual_path,
+            verbose=verbose,
+            timeout=timeout,
+            kv_cache=self.kv_cache,
         ):
             return False
 


### PR DESCRIPTION
**Summary**

  Makes the off-graph KV-cache op runnable on MLX end to end. The op (kvcache::update_and_attend), its MLX handler, and MLXSequenceCache landed earlier but were unreachable: nothing emitted the node during lowering and nothing bound a cache at runtime. This wires both ends. AOT emits an UpdateAndAttendNode during partitioning; at runtime the delegate reads a cache_key load-time spec, looks the cache up in the process-global registry, and binds it. Rendezvous is by key because the DelegateHandle is opaque to the host. Models that pass no cache_key are unaffected — the mutable-buffer path is untouched.

  **Files**

  * backends/mlx/ops.py — partitioner handler lowering update_and_attend to an UpdateAndAttendNode; layer_id/scale/out_dtype ride as node constants, the cache stays off-graph.
  *  backends/mlx/runtime/backend_options.h — kCacheKeyKey, the load-time spec that names the cache to bind.
  * backends/mlx/runtime/MLXBackend.cpp — init reads cache_key, gets the cache from  the CacheRegistry, keeps a shared_ptr alive on the handle, and cross-casts it to the MLXCache op face builder so a runner can construct one.
  * backends/mlx/CMakeLists.txt — link extension_llm_cache (the registry) into mlxdelegate.
  * backends/mlx/test/op_test_runner.cpp — --kv-cache builds a config, installs a cache via the builder registry, and passes cache_key through a LoadBackendOptionsMap; no flag = today's path unchanged.
*   backends/mlx/test/test_utils.py — kv_cache field on OpTestCase, forwarded to the runner.
 *  backends/mlx/test/CMakeLists.txt — link extension_llm_cache into op_test_runner.
 *  backends/mlx/test/test_ops.py — UpdateAndAttendTest: a two-layer model over the op, checked MLX-runtime against the eager reference cache installed as the oracle.

  **Testing**

  Four configs: prefill (Causal), a decode-shaped single-token step (Mask::None), an fp16 output contract over fp32 operands, and fp16 KV storage computed in fp32 — the last exercising the cache's storage-vs-compute dtype split. 

  cmake --preset mlx-release -DEXECUTORCH_BUILD_TESTS=ON
  cmake --build cmake-out --target op_test_runner
  python -m executorch.backends.mlx.test.run_all_tests -v update_and_attend
