### PR TITLE
Stop using deprecated executorch PassManager (#21576)

### DIFF
--- a/export/stages.py
+++ b/export/stages.py
@@ -15,12 +15,12 @@ import torch
 from executorch.devtools.backend_debug import get_delegation_info
 from executorch.exir import EdgeCompileConfig, EdgeProgramManager, ExportedProgram
 from executorch.exir.backend.backend_api import validation_disabled
-from executorch.exir.pass_manager import PassManager
 from executorch.exir.program import to_edge, to_edge_transform_and_lower
 from executorch.export.recipe import LoweringRecipe, QuantizationRecipe
 from executorch.export.types import StageType
 from torch import nn
 from torch._export.pass_base import PassType
+from torch.fx.passes.infra.pass_manager import PassManager as GraphModulePassManager
 from torchao.quantization import quantize_
 from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
 from torchao.quantization.pt2e.quantizer import (
@@ -176,7 +176,12 @@ class EdgeTransformAndLowerStage(Stage):
         self,
         partitioners: Optional[List[Any]] = None,
         transform_passes: (
-            None | List[Callable[[str, ExportedProgram], List[PassType] | PassManager]]
+            None
+            | List[
+                Callable[
+                    [str, ExportedProgram], List[PassType] | GraphModulePassManager
+                ]
+            ]
         ) = None,
         compile_config: Optional[Any] = None,
     ) -> None:
@@ -229,7 +234,7 @@ class EdgeTransformAndLowerStage(Stage):
                         "Transform passes must be a callable that resolves to passes"
                     )
                 passes = pass_callable(method_name, ep)
-                if isinstance(passes, PassManager):
+                if isinstance(passes, GraphModulePassManager):
                     pass_manager = passes
                     break
                 else:
@@ -514,10 +519,18 @@ class EdgeProgramManagerTransformStage(Stage):
     def __init__(
         self,
         edge_transform_passes: (
-            None | List[Callable[[str, ExportedProgram], List[PassType] | PassManager]]
+            None
+            | List[
+                Callable[
+                    [str, ExportedProgram], List[PassType] | GraphModulePassManager
+                ]
+            ]
         ) = None,
         edge_manager_transform_passes: (
-            None | List[Callable[[EdgeProgramManager], List[PassType] | PassManager]]
+            None
+            | List[
+                Callable[[EdgeProgramManager], List[PassType] | GraphModulePassManager]
+            ]
         ) = None,
     ) -> None:
         """
@@ -590,7 +603,7 @@ class EdgeProgramManagerTransformStage(Stage):
                         "Transform passes must be a callable that resolves to passes"
                     )
                 passes = pass_callable(method_name, ep)
-                if isinstance(passes, PassManager):
+                if isinstance(passes, GraphModulePassManager):
                     pass_manager = passes
                     break
                 else:


### PR DESCRIPTION
Summary:

`executorch.exir.pass_manager.PassManager.__init__` logs "PassManager is
deprecated. Please use ExportedProgramPassManager instead." on every
instantiation, which is noisy across on_device_ai builds and test runs.

Note there are two unrelated `PassManager` classes. Only the ExecuTorch one is
deprecated; `torch.fx.passes.infra.pass_manager.PassManager` (referred to in
ExecuTorch as `GraphModulePassManager`) is not.

This diff is deliberately scoped to the cases where the deprecated base is
vestigial, so it is a no-op behaviorally.

`PreTracePassManager`, `TuringPassManager` and `DebugPassManager` all subclass
the deprecated class but fully override `__call__` and manage their own pass
lists. All they actually consume from the ExecuTorch base is keyword `__init__`
config, the `run_checks_after_each_pass` flag, the `check()` helper, and (for
`DebugPassManager`) pass-list normalization. Everything else already comes from
the `torch.fx` base that the ExecuTorch class itself extends. So they are
rebased directly onto the `torch.fx` manager.

This is type- and behavior-compatible: both dispatch points already accept the
FX manager and route it down the identical GraphModule path --
`_transform_with_pass_manager` (executorch/exir/program/_program.py:163-193)
branches on `isinstance(pass_manager, ExportedProgramPassManager)` and anything
else takes the same `else` branch, and `EdgeProgramManager.transform`
(_program.py:1548-1615) lists `GraphModulePassManager` in its signature. This
mirrors what the Arm backend settled on in D108449791, which kept the FX
manager for its GraphModule-only paths.

Two behaviors are carried over by hand because the FX base does not provide
them:

- `check()` -- FX's is a no-op (`pass`, pass_manager.py:251) while ExecuTorch's
  recompiles, lints and rejects `call_method` nodes. Reimplemented in
  `PreTracePassManager` and `TuringPassManager`, which call it.
  `DebugPassManager` never calls `check()`, so it does not get one.
- `pass_result_wrapper` + pytree flatten -- ExecuTorch's `__init__` did this;
  FX's just assigns `self.passes`. Applied explicitly in `DebugPassManager` and
  at the two bare-GraphModule call sites so passes returning `None` still
  behave identically.

Also switched two genuinely bare-GraphModule call sites (no ExportedProgram in
play, so the GraphModule manager is semantically correct rather than a
workaround): `Assistant/Jarvis/delegate/program_splitter.py` and two sites in
`compiler/tests/test_streaming_passes.py`.

Jarvis sources are dual-cell, so the fbcode and xplat copies are kept in sync.
`arc lint -a` updated autodeps in the fbcode BUCK files; the same two dep
removals were mirrored to xplat by hand since autodeps does not run there.

Explicitly NOT in this diff: the ~11 call sites that wrap passes in
`PassManager(...)` inside `.transform()`. Those are deliberate opt-outs added
by D106014451 and D105991832 to skip the `ExportedProgram.validate()` that
D91725222 introduced, because the incoming programs were already invalid. They
still carry stale T272462131 / D91725222 comments. Un-wrapping them is a real
behavioral change that will surface invalid EPs, so it is being assessed
separately. T272462131 is closed and was never done for on_device_ai.

Reviewed By: DrJessop

Differential Revision: D114610728


