### PR TITLE
Document how to hand GPU memory straight to a CUDA model

### DIFF
--- a/docs/source/backends/cuda/cuda-overview.md
+++ b/docs/source/backends/cuda/cuda-overview.md
@@ -198,19 +198,28 @@ inside it.
 exported without them expects device tensors. Passing the wrong kind is a caller error, not
 something the runtime corrects, so the two are not interchangeable at run time.
 
-**From C++ it is the same contract.** With the copies skipped, build the input tensor over a
-device pointer:
+**From C++ it is the same contract.** With the copies skipped, the input has to be a tensor
+the delegate will accept as device resident. `clone_tensor_ptr_to` allocates on the device
+and copies the data across:
 
 ```cpp
-void* device = nullptr;
-cudaMalloc(&device, count * sizeof(float));
-cudaMemcpy(device, host.data(), count * sizeof(float), cudaMemcpyHostToDevice);
-
-auto input = from_blob(device, {rows, columns}, ScalarType::Float);
+auto host_input = make_tensor_ptr({rows, columns}, std::move(data));
+auto input = clone_tensor_ptr_to(host_input, DeviceType::CUDA);
 auto result = module.forward(input);
 ```
 
-With the default export, pass a host pointer instead and the runtime handles the transfer.
+`from_blob` is not enough on its own. It has no device parameter, so the tensor it returns
+is tagged CPU whatever the pointer points at, and the delegate rejects it.
+
+**How the delegate decides a tensor is device resident.** Two checks, in this order. First
+the tensor's own `device_type` has to be `CUDA`, which is metadata set by whoever built the
+tensor. Then, because that tag is only a claim, the delegate calls
+`cudaPointerGetAttributes` on the data pointer and requires the memory to really be
+`cudaMemoryTypeDevice` or `cudaMemoryTypeManaged`. A CUDA-tagged tensor backed by host
+memory is caught there rather than corrupting the run.
+
+With the default export, pass an ordinary host tensor instead and the runtime handles the
+transfer.
 
 ----
 

--- a/docs/source/backends/cuda/cuda-overview.md
+++ b/docs/source/backends/cuda/cuda-overview.md
@@ -130,6 +130,7 @@ instead:
 
 ```python
 from executorch.exir import ExecutorchBackendConfig
+from executorch.exir.passes import MemoryPlanningPass
 from executorch.exir.passes.propagate_device_config import PropagateDeviceConfig
 
 exec_program = et_program.to_executorch(
@@ -139,6 +140,13 @@ exec_program = et_program.to_executorch(
             skip_d2h_for_method_outputs=True,
         ),
         enable_non_cpu_memory_planning=True,
+        # Required alongside the skips. Memory planning reserves a buffer for graph inputs and
+        # outputs by default, and the runtime fills a planned input by copying the caller's
+        # memory into that buffer, which reintroduces the copy you just asked to skip. On device
+        # memory that copy is a host memcpy into a device pointer, which is undefined.
+        memory_planning_pass=MemoryPlanningPass(
+            alloc_graph_input=False, alloc_graph_output=False
+        ),
     )
 )
 ```
@@ -156,18 +164,35 @@ also on the GPU.
 **The two flags are independent.** Skip only the input copies if you produce data on the GPU but
 want results back on the host, or only the output copies for the reverse.
 
-**Both flags require `enable_non_cpu_memory_planning=True`.** Setting one without it raises a
-`ValueError`, because copy insertion happens during device-aware memory planning. The error
-message says as much.
+**Both flags need `enable_non_cpu_memory_planning=True`.** It defaults to `True`, so leaving it
+out works, and the snippet above sets it explicitly only to make the requirement visible. Setting
+it to `False` while asking for either skip raises a `ValueError`, because copy insertion happens
+during device-aware memory planning.
 
-**You can choose per method.** Each flag also accepts a dict keyed by method name, so one
-program can have a GPU-resident fast path and a host-copying convenience path:
+**Both flags also need unplanned graph inputs and outputs**, via
+`MemoryPlanningPass(alloc_graph_input=False, alloc_graph_output=False)` as shown above. Without
+it the program still reserves its own buffer and the runtime copies into it, so the copy comes
+back at run time. The runtime rejects that case rather than performing a host copy into device
+memory.
+
+**Per-method selection is on the outer config, not on the flags.** Pass a dict of
+`PropagateDeviceConfig` keyed by method name:
 
 ```python
-PropagateDeviceConfig(
-    skip_h2d_for_method_inputs={"forward": True, "forward_from_host": False},
+ExecutorchBackendConfig(
+    propagate_device_config={
+        "forward": PropagateDeviceConfig(
+            skip_h2d_for_method_inputs=True, skip_d2h_for_method_outputs=True
+        ),
+        "forward_from_host": PropagateDeviceConfig(),
+    },
+    ...
 )
 ```
+
+Do not pass a dict to `skip_h2d_for_method_inputs` itself. The pass reads that field for
+truthiness, so any non-empty dict enables the skip for every method regardless of the values
+inside it.
 
 **The choice is baked into the `.pte`.** A program exported with copies expects host tensors; one
 exported without them expects device tensors. Passing the wrong kind is a caller error, not

--- a/docs/source/backends/cuda/cuda-overview.md
+++ b/docs/source/backends/cuda/cuda-overview.md
@@ -172,8 +172,8 @@ during device-aware memory planning.
 **Both flags also need unplanned graph inputs and outputs**, via
 `MemoryPlanningPass(alloc_graph_input=False, alloc_graph_output=False)` as shown above. Without
 it the program still reserves its own buffer and the runtime copies into it, so the copy comes
-back at run time. The runtime rejects that case rather than performing a host copy into device
-memory.
+back at run time. On device memory that copy is a host memcpy into a device pointer, which is
+undefined, so the program crashes rather than returning a wrong answer.
 
 **Per-method selection is on the outer config, not on the flags.** Pass a dict of
 `PropagateDeviceConfig` keyed by method name:

--- a/docs/source/backends/cuda/cuda-overview.md
+++ b/docs/source/backends/cuda/cuda-overview.md
@@ -103,6 +103,92 @@ No additional steps are necessary to use the backend beyond linking the target. 
 
 ----
 
+## Activation memory: who owns the GPU copies
+
+A CUDA model has to get its input data onto the GPU somehow. There are two ways, and you pick
+one at export time.
+
+**Default: the runtime copies for you.** Export inserts a host-to-device copy in front of each
+delegate input and a device-to-host copy after each delegate output. You pass ordinary CPU
+tensors and the runtime moves the data:
+
+```python
+exec_program = et_program.to_executorch()
+```
+
+```python
+# CPU tensors. The runtime copies them to the GPU and copies results back.
+outputs = method([torch.randn(4, 64)])
+```
+
+This is the simplest option and the right default. The cost is a copy in each direction on
+every call.
+
+**Opt out: you hand over GPU memory directly.** If your data is already on the device, those
+copies are wasted. Turn them off and the input placeholders are treated as device memory
+instead:
+
+```python
+from executorch.exir import ExecutorchBackendConfig
+from executorch.exir.passes.propagate_device_config import PropagateDeviceConfig
+
+exec_program = et_program.to_executorch(
+    ExecutorchBackendConfig(
+        propagate_device_config=PropagateDeviceConfig(
+            skip_h2d_for_method_inputs=True,
+            skip_d2h_for_method_outputs=True,
+        ),
+        enable_non_cpu_memory_planning=True,
+    )
+)
+```
+
+```python
+# Now the tensors must already be on the GPU. Passing CPU tensors is a caller error.
+outputs = method([torch.randn(4, 64, device="cuda")])
+```
+
+Outputs also stay on the device, which is what you want when the next stage of your pipeline is
+also on the GPU.
+
+### Things worth knowing
+
+**The two flags are independent.** Skip only the input copies if you produce data on the GPU but
+want results back on the host, or only the output copies for the reverse.
+
+**Both flags require `enable_non_cpu_memory_planning=True`.** Setting one without it raises a
+`ValueError`, because copy insertion happens during device-aware memory planning. The error
+message says as much.
+
+**You can choose per method.** Each flag also accepts a dict keyed by method name, so one
+program can have a GPU-resident fast path and a host-copying convenience path:
+
+```python
+PropagateDeviceConfig(
+    skip_h2d_for_method_inputs={"forward": True, "forward_from_host": False},
+)
+```
+
+**The choice is baked into the `.pte`.** A program exported with copies expects host tensors; one
+exported without them expects device tensors. Passing the wrong kind is a caller error, not
+something the runtime corrects, so the two are not interchangeable at run time.
+
+**From C++ it is the same contract.** With the copies skipped, build the input tensor over a
+device pointer:
+
+```cpp
+void* device = nullptr;
+cudaMalloc(&device, count * sizeof(float));
+cudaMemcpy(device, host.data(), count * sizeof(float), cudaMemcpyHostToDevice);
+
+auto input = from_blob(device, {rows, columns}, ScalarType::Float);
+auto result = module.forward(input);
+```
+
+With the default export, pass a host pointer instead and the runtime handles the transfer.
+
+----
+
 ## Examples
 
 For complete end-to-end examples of exporting and running models with the CUDA backend, see:


### PR DESCRIPTION
A CUDA model has to get its input data onto the GPU somehow, and there are two ways. You
pick one at export time.

**By default the runtime copies for you.** Export inserts a host-to-device copy in front of
every delegate input and a device-to-host copy after every output, so you pass ordinary CPU
tensors:

```python
outputs = method([torch.randn(4, 64)])
```

**If your data is already on the GPU, those copies are wasted.** You can turn them off, and
then the input placeholders are treated as device memory:

```python
exec_program = et_program.to_executorch(
    ExecutorchBackendConfig(
        propagate_device_config=PropagateDeviceConfig(
            skip_h2d_for_method_inputs=True,
            skip_d2h_for_method_outputs=True,
        ),
        enable_non_cpu_memory_planning=True,
        memory_planning_pass=MemoryPlanningPass(
            alloc_graph_input=False, alloc_graph_output=False
        ),
    )
)
```

```python
outputs = method([torch.randn(4, 64, device="cuda")])
```

Outputs stay on the device too, which is what you want when the next stage of the pipeline
is also on the GPU.

## Why this PR

None of this appears anywhere in the documentation. I only found it by reading
`PropagateDevicePass`, and I got it wrong twice on the way.

The first mistake was assuming the two skip flags were enough. They are not. Memory
planning reserves a buffer for every graph input and output by default, and the runtime
fills a planned input by copying the caller's memory into that buffer, which puts back the
copy the export just asked to skip. On device memory that copy is a host `memcpy` into a
GPU pointer, which is undefined. So the pairing with
`MemoryPlanningPass(alloc_graph_input=False, alloc_graph_output=False)` is required, not
optional, and the page now says so where the recipe is given.

The second mistake was not realising the choice is baked into the `.pte`. A program
exported with copies expects host tensors and one exported without them expects device
tensors, so the two are not interchangeable at run time.

The new section covers both modes, the memory-planning requirement, the fact that
`enable_non_cpu_memory_planning` already defaults to `True`, how to select per method, and
the matching C++ side where the input tensor is built over a device pointer.

Documentation only, no code changes.

## A note on selecting per method

Per-method selection works on `propagate_device_config` itself, which accepts a dict keyed
by method name:

```python
ExecutorchBackendConfig(
    propagate_device_config={
        "forward": PropagateDeviceConfig(
            skip_h2d_for_method_inputs=True, skip_d2h_for_method_outputs=True
        ),
        "forward_from_host": PropagateDeviceConfig(),
    },
    ...
)
```

It does not work by passing a dict to `skip_h2d_for_method_inputs`. That field is read for
truthiness, so any non-empty dict enables the skip for every method whatever the values
inside it say. The page warns against that form rather than showing it.

## Tested

Exercised both modes on real hardware while writing this, on x86_64 and on two Jetson
devices. The default export contained two copy operators and the opt-out export contained
none, which is the difference the flags control.

Checked the claims the page makes rather than assuming them:

- exported a two-input model with the recipe above and confirmed memory planning leaves
  the graph inputs and outputs unallocated, where the earlier version of this page left
  them allocated and would have hit the undefined copy
- `enable_non_cpu_memory_planning` is declared `bool = True`, so omitting it raises
  nothing, and the guard that raises `ValueError` fires only when either skip is set
  alongside an explicit `False`
- `skip_h2d_for_method_inputs` is declared `bool` and read for truthiness, so a non-empty
  dict enables the skip whatever it contains, which is why the page steers to the outer
  `propagate_device_config` form that resolves per method by name

Every Python snippet in the page parses.
