### PR TITLE
[RELEASE ONLY CHANGES] Fix Python 3.14 wheel dependency setup

### DIFF
--- a/.ci/scripts/wheel/pre_build_script.sh
+++ b/.ci/scripts/wheel/pre_build_script.sh
@@ -66,7 +66,7 @@ fi
 # which does install them. Though we'd need to disable build isolation to be
 # able to see the installed torch package.
 
-"${GITHUB_WORKSPACE}/${REPOSITORY}/install_requirements.sh"
+"${GITHUB_WORKSPACE}/${REPOSITORY}/install_requirements.sh" --example
 
 # Enable VGF in pybind wheel builds when the platform-specific build input is
 # available from pip.

--- a/.ci/scripts/wheel/pre_build_script.sh
+++ b/.ci/scripts/wheel/pre_build_script.sh
@@ -66,7 +66,7 @@ fi
 # which does install them. Though we'd need to disable build isolation to be
 # able to see the installed torch package.
 
-"${GITHUB_WORKSPACE}/${REPOSITORY}/install_requirements.sh" --example
+"${GITHUB_WORKSPACE}/${REPOSITORY}/install_requirements.sh"
 
 # Enable VGF in pybind wheel builds when the platform-specific build input is
 # available from pip.

--- a/.github/workflows/build-wheels-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-aarch64-linux.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/build-wheels-aarch64-linux.yml
       - examples/**/*
       - pyproject.toml
+      - requirements-examples.txt
       - setup.py
   push:
     branches:

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/build-wheels-linux.yml
       - examples/**/*
       - pyproject.toml
+      - requirements-examples.txt
       - setup.py
   push:
     branches:

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/build-wheels-macos.yml
       - examples/**/*
       - pyproject.toml
+      - requirements-examples.txt
       - setup.py
   push:
     branches:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/build-wheels-windows.yml
       - examples/**/*
       - pyproject.toml
+      - requirements-examples.txt
       - setup.py
   push:
     branches:

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -3,5 +3,5 @@
 datasets == 3.6.0 # 4.0.0 deprecates trust_remote_code and load scripts. For now pin to 3.6.0
 timm == 1.0.7
 torchsr == 1.0.4
-torchtune @ git+https://github.com/pytorch/torchtune.git@3c1872ace149f03ef4ffec765d3f0a5fd0399497
+torchtune @ git+https://github.com/pytorch/torchtune.git@3c1872ace149f03ef4ffec765d3f0a5fd0399497 ; python_version < "3.14"
 transformers == 5.0.0rc1

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -3,5 +3,6 @@
 datasets == 3.6.0 # 4.0.0 deprecates trust_remote_code and load scripts. For now pin to 3.6.0
 timm == 1.0.7
 torchsr == 1.0.4
-torchtune @ git+https://github.com/pytorch/torchtune.git@3c1872ace149f03ef4ffec765d3f0a5fd0399497
+# torchtune pins pyarrow<21, which has no Python 3.14 wheels.
+torchtune @ git+https://github.com/pytorch/torchtune.git@3c1872ace149f03ef4ffec765d3f0a5fd0399497 ; python_version < "3.14"
 transformers == 5.0.0rc1

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -3,6 +3,5 @@
 datasets == 3.6.0 # 4.0.0 deprecates trust_remote_code and load scripts. For now pin to 3.6.0
 timm == 1.0.7
 torchsr == 1.0.4
-# torchtune pins pyarrow<21, which has no Python 3.14 wheels.
-torchtune @ git+https://github.com/pytorch/torchtune.git@3c1872ace149f03ef4ffec765d3f0a5fd0399497 ; python_version < "3.14"
+torchtune @ git+https://github.com/pytorch/torchtune.git@3c1872ace149f03ef4ffec765d3f0a5fd0399497
 transformers == 5.0.0rc1


### PR DESCRIPTION
Release-only change. Do not merge to main.

Python 3.14 macOS and Windows wheel builds fail during dependency setup because the pinned torchtune revision requires `pyarrow<21`. PyArrow releases before 21 do not provide Python 3.14 wheels, so pip attempts an unsupported source build.

Keep the existing example dependency installation because wheel smoke tests export MobileNetV3 through torchvision. Skip only torchtune on Python 3.14; it is not used by wheel construction or the wheel smoke tests. Python 3.10-3.13 and the normal Llama setup continue to install torchtune.

Also add `requirements-examples.txt` to the wheel workflow path filters because the pre-build script consumes it.

Failed post-merge jobs:
- macOS: https://github.com/pytorch/executorch/actions/runs/30957868484/job/92155043950
- Windows: https://github.com/pytorch/executorch/actions/runs/30957868415/job/92155038157

Test plan:
- `bash -n .ci/scripts/wheel/pre_build_script.sh install_requirements.sh`
- Parsed all four modified workflow YAML files
- Verified the torchtune environment marker selects Python 3.10-3.13 and excludes Python 3.14
- `git diff --check`
- Full Python 3.10-3.14 Linux, AArch64, macOS, and Windows wheel matrices delegated to CI.

Authored with Codex.