### PR TITLE
Infer XNNPACK conv dimensionality from the weight rank

### DIFF
--- a/backends/xnnpack/_passes/conv1d_unsqueeze_pass.py
+++ b/backends/xnnpack/_passes/conv1d_unsqueeze_pass.py
@@ -7,6 +7,7 @@
 from typing import Optional
 
 import torch
+from executorch.backends.transforms import get_shape
 from executorch.backends.xnnpack._passes.xnnpack_pass import XNNPACKPass
 from executorch.backends.xnnpack.utils.quant_utils import (
     is_dequant,
@@ -127,14 +128,16 @@ class Conv1dUnsqueezePass(XNNPACKPass):
         for node in node_list:
             if node.op == "call_function":
                 if node.target.__name__ == "aten.convolution.default":
-                    stride = list(node.args[3])
-                    if len(stride) != 1:
-                        # skip conv if it is not 1d
-                        continue
-
                     kernel_node = node.args[1]
                     if is_dequant(kernel_node) and not is_quant(kernel_node.args[0]):
                         kernel_node = kernel_node.args[0]
+
+                    # The weight rank is the only reliable indicator of the conv
+                    # dimensionality. stride, padding and dilation may each be a
+                    # single value that ATen broadcasts over every spatial dim.
+                    if len(get_shape(kernel_node)) != 3:
+                        # skip conv if it is not 1d
+                        continue
 
                     if not is_param_node(self.exported_program, kernel_node):
                         raise AssertionError(

--- a/backends/xnnpack/operators/op_conv2d.py
+++ b/backends/xnnpack/operators/op_conv2d.py
@@ -141,8 +141,14 @@ class Conv2d(NodeVisitor):
         padding = cast(List[int], node.args[4])
         dilation = cast(List[int], node.args[5])
         output_padding = cast(List[int], node.args[7])
+        # ATen broadcasts a single spatial value over every spatial dim, so any of
+        # these may arrive with length 1 for a 2d convolution.
+        if len(stride) == 1:
+            stride = stride + stride
         if len(padding) == 1:
             padding = padding + padding
+        if len(dilation) == 1:
+            dilation = dilation + dilation
         if len(output_padding) == 1:
             output_padding = output_padding + output_padding
 

--- a/backends/xnnpack/partition/config/gemm_configs.py
+++ b/backends/xnnpack/partition/config/gemm_configs.py
@@ -361,21 +361,23 @@ class ConvolutionConfig(GEMMConfig):
         if not super().check_constraints(node, ep):
             return False
 
-        conv_stride = cast(List[int], node.args[3])
-        if len(conv_stride) > 2:
+        kernel_node = get_input_node(node, 1)
+        kernel_shape = get_shape(kernel_node)
+        # The weight rank is the only reliable indicator of the conv dimensionality.
+        # stride, padding and dilation may each be a single value that ATen
+        # broadcasts over every spatial dim.
+        conv_dim = len(kernel_shape) - 2
+        if conv_dim > 2:
             why(node, "Only support 1D + 2D Conv")
             return False  # Only support 1D + 2D Conv
 
-        kernel_node = get_input_node(node, 1)
-        kernel_shape = get_shape(kernel_node)
         weight_quant_params = QuantParams.from_weights(kernel_node, ep)
         groups = cast(int, node.args[8])
         is_transpose = node.args[6]
 
         # XNNPACK does not support dynamic quantization convs that are not 2D or are depthwise
         if self._detect_precision(node) == ConfigPrecisionType.DYNAMIC_QUANT and (
-            len(conv_stride) != 2
-            or is_depthwise_conv(kernel_shape, groups, is_transpose)
+            conv_dim != 2 or is_depthwise_conv(kernel_shape, groups, is_transpose)
         ):
             why(
                 node,
@@ -409,9 +411,9 @@ class ConvolutionConfig(GEMMConfig):
             and act_input.target == exir_ops.edge.aten.constant_pad_nd.default
             and len(act_input.users) == 1
         ):
-            conv_padding = cast(List[int], node.args[4])
-            is_1d = len(conv_padding) == 1
-            is_2d = len(conv_padding) == 2
+            conv_dim = len(get_shape(get_input_node(node, 1))) - 2
+            is_1d = conv_dim == 1
+            is_2d = conv_dim == 2
 
             pad_value = (
                 cast(float, act_input.args[2]) if len(act_input.args) > 2 else 0.0

--- a/backends/xnnpack/test/ops/test_conv2d.py
+++ b/backends/xnnpack/test/ops/test_conv2d.py
@@ -173,6 +173,18 @@ class Conv2dPermute(torch.nn.Module):
         return (torch.randn(2, 2, 4, 4),)
 
 
+class Conv3d(torch.nn.Module):
+    def __init__(self, stride):
+        super().__init__()
+        self.conv = torch.nn.Conv3d(2, 2, (2, 2, 2), stride=stride)
+
+    def forward(self, x):
+        return self.conv(x)
+
+    def get_inputs(self):
+        return (torch.randn(1, 2, 4, 4, 4),)
+
+
 class Conv2dDQSeq(torch.nn.Module):
     def __init__(self, transpose=False):
         super().__init__()
@@ -289,6 +301,41 @@ class TestConv2d(unittest.TestCase):
         for transpose in (True, False):
             for has_bias in (True, False):
                 self._test(Conv2d(bias=has_bias, transpose=transpose))
+
+    def test_fp32_conv2d_single_element_spatial_params(self) -> None:
+        # ATen broadcasts a single stride/padding/dilation value over every
+        # spatial dim, so a 2d conv can carry length-1 spatial params.
+        for transpose in (True, False):
+            self._test(
+                Conv2d(
+                    kernel_size=(3, 3),
+                    stride=(2,),
+                    padding=(1,),
+                    transpose=transpose,
+                )
+            )
+
+    def test_fp32_conv2d_single_element_dilation(self) -> None:
+        self._test(
+            Conv2d(
+                kernel_size=(3, 3),
+                stride=(1,),
+                padding=(1,),
+                dilation=(2,),
+            )
+        )
+
+    def test_fp32_conv3d_single_element_stride_doesnt_partition(self) -> None:
+        # XNNPACK has no conv3d support, and a length-1 stride must not make a 3d
+        # conv look 1d or 2d to the partitioner.
+        m = Conv3d(stride=(2,))
+        (
+            Tester(m, m.get_inputs())
+            .export()
+            .to_edge_transform_and_lower()
+            .check_count({"torch.ops.higher_order.executorch_call_delegate": 0})
+            .run_method_and_compare_outputs()
+        )
 
     def test_fp32_conv2d_permute(self) -> None:
         for transpose in (True, False):


### PR DESCRIPTION
### Summary

Fixes #10965.

ATen lets `stride`, `padding`, `dilation` and `output_padding` be a single value that is broadcast over every spatial dim, so `len(stride)` is not the convolution's dimensionality. `torch.nn.Conv2d(3, 3, 5, [2])` keeps `stride=(2,)` because `_pair` passes an iterable through unchanged, and that reaches the edge graph as `aten.convolution.default` with a length-1 stride on a rank-4 weight.

The XNNPACK backend infers dimensionality from that length in three places, so a 2d conv with a length-1 stride is mistaken for a 1d conv:

`Conv1dUnsqueezePass` skips a node unless `len(stride) == 1`, so it picked up the 2d conv, unsqueezed the already-4d weight to 5d and then failed inside the fake tensor convolution rule. That is the traceback in the issue.

`ConvolutionConfig.check_constraints` rejects 3d convs with `len(conv_stride) > 2`. A `Conv3d` built with `stride=[2]` passes that guard, gets partitioned, and then hits the same unsqueeze path. The dynamic-quant guard right below it has the same problem in reverse: a genuine 2d conv with a length-1 stride is refused for no reason.

`Conv2d.define_node` already normalizes `padding` and `output_padding` from length 1 to length 2, but not `stride` or `dilation`, so `check_or_raise(len(stride) == 2)` fires and `dilation[1]` would be out of range. That is the second failure the issue describes, the one reached by adding `dilation=[2]`.

The fix takes the dimensionality from the weight rank, which is unambiguous, and normalizes `stride` and `dilation` in the node visitor the same way the two neighbouring params already are. `_get_act_deps` moves to the same weight-rank derivation, which also stops a length-1 `padding` from making a 2d conv look 1d and silently blocking the `constant_pad_nd` fusion.

Review order: `_passes/conv1d_unsqueeze_pass.py`, then `partition/config/gemm_configs.py`, then `operators/op_conv2d.py`, then the tests.

### Test plan

Added to `backends/xnnpack/test/ops/test_conv2d.py`:

- `test_fp32_conv2d_single_element_spatial_params`, transposed and not, covering `stride=(2,)` with `padding=(1,)`
- `test_fp32_conv2d_single_element_dilation`, covering `dilation=(2,)`
- `test_fp32_conv3d_single_element_stride_doesnt_partition`, asserting a 3d conv with `stride=(2,)` still produces zero delegates

I do not have an ExecuTorch C++ runtime built on this machine, so I could not run `run_method_and_compare_outputs`, and the three tests above were not executed as unit tests. I verified the export and lowering half of them directly against this branch and against `upstream/main` at efd6b55, driving the same modules through `torch.export.export` plus `to_edge_transform_and_lower([XnnpackPartitioner()])` and counting delegate and leftover convolution nodes.

On `upstream/main`:

```
conv2d stride=[2]              -> Exception: An error occurred when running the 'Conv1dUnsqueezePass' pass
conv2d stride=[2] dilation=[2] -> Exception: An error occurred when running the 'Conv1dUnsqueezePass' pass
conv3d stride=[2]              -> Exception: An error occurred when running the 'Conv1dUnsqueezePass' pass
```

The conv3d row is the partitioner half of the bug. Today that conv is accepted by `ConvolutionConfig` and then dies in the same pass, so the "Only support 1D + 2D Conv" guard is not actually holding.

On this branch:

```
conv2d stride=(2,) padding=(1,) transpose=True   delegates=1 undelegated_conv=0
conv2d stride=(2,) padding=(1,) transpose=False  delegates=1 undelegated_conv=0
conv2d stride=(1,) padding=(1,) dilation=(2,)    delegates=1 undelegated_conv=0
conv2d stride=2  (unchanged baseline)            delegates=1 undelegated_conv=0
conv1d stride=2  (unchanged baseline)            delegates=1 undelegated_conv=0
conv3d stride=(2,)                               delegates=0 undelegated_conv=1
```

The conv1d and plain conv2d rows are there to show the unsqueeze path and the ordinary 2d path are untouched.

Because `Conv1dUnsqueezePass` now resolves the weight node before deciding, I also ran the same check through `XNNPACKQuantizer` plus `prepare_pt2e` and `convert_pt2e`, to exercise the dequant-unwrap branch. All four still fully delegate on this branch:

```
q conv1d baseline        delegates=1 undelegated_conv=0
q conv2d stride=[2]      delegates=1 undelegated_conv=0
q conv2d baseline        delegates=1 undelegated_conv=0
q conv1d per-channel     delegates=1 undelegated_conv=0
```

And because `_get_act_deps` changed how it decides 1d versus 2d, I re-ran the even-kernel `same`-padding cases that exercise the `constant_pad_nd` fusion. The pad and the conv are still both absorbed into one delegate:

```
qs8 conv2d even-kernel same-padding      delegates=1 conv=0 pad=0
qs8 conv1d even-kernel same-padding k=4  delegates=1 conv=0 pad=0
qs8 conv1d same-padding k=4 dilation=2   delegates=1 conv=0 pad=0
```

This PR was authored with AI assistance using Claude Code.


cc @GregoryComer @digantdesai @cbilgin @JakeStevens