### PR TITLE
Dedupe getitem nodes in ExportedProgramPassManager (#21590)

### DIFF
--- a/exir/pass_manager.py
+++ b/exir/pass_manager.py
@@ -8,6 +8,7 @@
 import copy
 import inspect
 import logging
+import operator
 from typing import Callable, List, Optional, Type, TypeAlias, Union
 
 import torch
@@ -21,6 +22,7 @@ from executorch.exir.error import ExportError, ExportErrorType
 from executorch.exir.pass_base import ExportedProgramPassBase, ExportedProgramPassResult
 from torch._export.verifier import Verifier
 from torch.export import ExportedProgram
+from torch.export.exported_program import _common_getitem_elimination_pass
 from torch.fx.passes.infra.pass_base import PassResult
 from torch.fx.passes.infra.pass_manager import pass_result_wrapper
 
@@ -35,6 +37,29 @@ PassType: TypeAlias = Union[
 def _get_pass_name(fn: PassType) -> str:
     """Returns a human-readable name for a pass."""
     return fn.__name__ if inspect.isfunction(fn) else type(fn).__name__
+
+
+def _can_eliminate_common_getitems(gm: torch.fx.GraphModule) -> bool:
+    """Whether ``_common_getitem_elimination_pass`` can run on this graph.
+
+    That pass identifies a getitem by ``node_id[source]``, so it assumes every
+    getitem indexes a Node. Mid-pipeline graphs can hold getitems that index a
+    list instead -- an ``immutable_list`` is hashable, so the lookup raises
+    KeyError rather than being caught by a type check. Skip deduplication for
+    those graphs instead of crashing; they simply keep their duplicate getitems,
+    which is the behaviour that predates deduplication here.
+    """
+    for module in gm.modules():
+        if not isinstance(module, torch.fx.GraphModule):
+            continue
+        for node in module.graph.nodes:
+            if (
+                node.op == "call_function"
+                and node.target is operator.getitem
+                and not isinstance(node.args[0], torch.fx.Node)
+            ):
+                return False
+    return True
 
 
 class PassManager(fx.PassManager):
@@ -195,14 +220,23 @@ class ExportedProgramPassManager(fx.PassManager):
                             # possible that the verifier will fail upon new ExportedProgram construction,
                             # and we should only run verification after each pass if
                             # run_checks_after_each_pass is True.
+                            new_graph_signature = _get_updated_graph_signature(
+                                exported_program.graph_signature,
+                                res.graph_module,
+                            )
+                            # ExportedProgram.__init__ runs this, but this path mutates
+                            # the program in place and never reconstructs it. Duplicate
+                            # getitem nodes survive otherwise, and serialization only
+                            # names one node per output index.
+                            if _can_eliminate_common_getitems(res.graph_module):
+                                _common_getitem_elimination_pass(
+                                    res.graph_module,
+                                    new_graph_signature,
+                                    exported_program.module_call_graph,
+                                )
                             res.graph_module.recompile()
                             exported_program._graph_module = res.graph_module
-                            exported_program._graph_signature = (
-                                _get_updated_graph_signature(
-                                    exported_program.graph_signature,
-                                    res.graph_module,
-                                )
-                            )
+                            exported_program._graph_signature = new_graph_signature
                             exported_program._range_constraints = (
                                 _get_updated_range_constraints(res.graph_module)
                             )


### PR DESCRIPTION
Summary:

`ExportedProgramPassManager` mutates `exported_program._graph_module` in place
after each GraphModule pass and never reconstructs the `ExportedProgram`. That
skips `_common_getitem_elimination_pass`, which `ExportedProgram.__init__` runs
to collapse `getitem` nodes sharing a source and index.

The legacy `PassManager` path got that dedup for free: `_transform_with_pass_manager`
routed it through `_update_exported_program_graph_module`, which builds a fresh
`ExportedProgram`. So the dedup silently disappeared for anything moving onto the
ExportedProgram manager, including `ExportedProgram.transform()`.

Duplicate getitems then break serialization. `_handle_getitem_users`
(torch/_export/serde/serialize.py) keys `idx_to_name` by output index, so only
one duplicate per index gets a name. The other is never entered into `def_table`,
and `torch.export.save` fails in `_canonicalize_graph`:

```
AssertionError: symbol 'getitem_3' not in def_table or graph_inputs
```

This surfaced as 16 broken on_device_ai tests (T283476440) after D114618938
switched the `fuse()` / `extract()` call sites in
`on_device_ai/helios/quantization/transforms.py` to `ExportedProgramPassManager`.
Instrumenting `extract()` immediately before the failing `torch.export.save`
printed 4 surviving duplicate getitem nodes.

Fix is to mirror what `ExportedProgram.__init__` does: compute the updated graph
signature first, run `_common_getitem_elimination_pass` against it (the
signature's replace hook keeps it in step as nodes are collapsed), then
recompile. Recompile moves after the pass so the regenerated forward reflects
the erased nodes.

Jarvis-style dual-cell source, so the fbcode and xplat copies are kept in sync.

Reviewed By: angelayi

Differential Revision: D114897499


