### PR TITLE
Ship the profiler as its own library so a C++ app can use it

### DIFF
--- a/devtools/etdump/CMakeLists.txt
+++ b/devtools/etdump/CMakeLists.txt
@@ -39,8 +39,19 @@ add_custom_command(
   COMMENT "Generating etdump headers"
 )
 
+# The profiler is reachable from both the Python extension and a standalone C++
+# application, and each one linking it statically would keep its own tracing state.
+# Build it shared for the wheel, where both are loaded into one process, and keep it
+# static everywhere else so no other build changes.
+if(EXECUTORCH_BUILD_SHARED)
+  set(_etdump_library_type SHARED)
+else()
+  set(_etdump_library_type STATIC)
+endif()
+
 add_library(
   etdump
+  ${_etdump_library_type}
   ${_schema_outputs}
   ${CMAKE_CURRENT_SOURCE_DIR}/etdump_flatcc.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/emitter.cpp
@@ -49,7 +60,9 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/data_sinks/file_data_sink.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_sinks/file_data_sink.h
 )
-target_link_libraries(etdump PUBLIC flatccrt)
+# Private, not public: the flatbuffer runtime is an implementation detail and the wheel
+# does not ship it, so exposing it would make the shipped header unlinkable.
+target_link_libraries(etdump PRIVATE flatccrt)
 # As with bundled_program, avoid the whole-archive of the `executorch` target so
 # the primitive operator registrations are not duplicated alongside the copy
 # already inside libexecutorch.so.
@@ -58,6 +71,15 @@ if(EXECUTORCH_BUILD_SHARED)
 else()
   target_link_libraries(etdump PRIVATE executorch)
 endif()
+if(EXECUTORCH_BUILD_SHARED)
+  set_target_properties(
+    etdump
+    PROPERTIES OUTPUT_NAME executorch_etdump
+               VERSION "${PROJECT_VERSION}"
+               SOVERSION "${PROJECT_VERSION_MAJOR}"
+  )
+endif()
+
 target_include_directories(
   etdump
   PUBLIC ${DEVTOOLS_INCLUDE_DIR}

--- a/setup.py
+++ b/setup.py
@@ -941,6 +941,7 @@ class CustomBuildPy(build_py):
                 "extension/named_data_map/",
                 "extension/tensor/",
                 "extension/threadpool/",
+                "devtools/etdump/",
             ]:
                 src_list = Path(include_dir).rglob("*.h")
                 for src in src_list:
@@ -1281,6 +1282,26 @@ setup(
                     src_name=f"libexecutorch.so.{get_runtime_soname_major()}.*",
                     dst=f"executorch/lib/libexecutorch.so.{get_runtime_soname_major()}",
                     dependent_cmake_flags=["EXECUTORCH_BUILD_SHARED"],
+                ),
+                # Install the profiler next to it. Keeping it separate lets a C++
+                # application link it without pulling in the Python extension, which
+                # is where it was only reachable before.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/devtools/etdump/",
+                    src_name=(
+                        f"libexecutorch_etdump.so.{get_runtime_soname_major()}.*"
+                    ),
+                    dst=(
+                        "executorch/lib/libexecutorch_etdump.so."
+                        f"{get_runtime_soname_major()}"
+                    ),
+                    # The target only exists when the developer tools are built, so
+                    # packaging has to require that too or a shared build without them
+                    # looks for a file that was never built.
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_DEVTOOLS",
+                    ],
                 ),
                 # Install the shared thread pool next to it. It is a separate
                 # library so that a process has one pool rather than one per

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -356,6 +356,9 @@ executorch_define_component(threadpool executorch_threadpool)
 # to be defined here or a consumer following the documentation gets a bare name that CMake hands
 # to the linker as a literal flag.
 executorch_define_component(kernels_optimized executorch_kernels_optimized)
+# The profiler. A C++ application could not record timing data from an installed package before,
+# because the implementation shipped only inside the Python extension.
+executorch_define_component(etdump executorch_etdump)
 
 # A consumer that links the thread pool has to see the same switch a source build sets, or the
 # parallel helpers in the runtime headers compile their serial fallback instead and the library


### PR DESCRIPTION
ExecuTorch can record timing and tracing data while a model runs. That
profiler is useful for finding out which operator is slow, and today it is
reachable only from Python: its code is compiled into the Python extension,
and the wheel ships none of its headers. A C++ application has nothing to
link and nothing to include, so it cannot profile a model at all unless it
builds ExecuTorch from source.

This builds the profiler as its own shared library and ships it, the same
way the runtime, the thread pool and the CPU kernels are already shipped:

    find_package(executorch CONFIG REQUIRED COMPONENTS etdump)
    target_link_libraries(app PRIVATE executorch::runtime executorch::etdump)

Then an application constructs a tracer, hands it to the module, runs a
method, and reads the trace back:

    auto tracer = std::make_unique<ETDumpGen>();
    ETDumpGen* raw = tracer.get();
    Module module(path, Module::LoadMode::MmapUseMlockIgnoreErrors,
                  std::move(tracer));
    module.forward(input);
    const auto trace = raw->get_etdump_data();

One detail worth explaining. The profiler's implementation uses a flatbuffer
runtime that the wheel does not ship, and that dependency used to be public,
which would make the shipped header impossible to link against. It is now
private, so it stays inside the library. The public header includes only
runtime headers, which is what makes shipping it possible.

Before this change the Python extension defined the profiler's symbols
itself. Now it imports them from the shared library, so a process has one
profiler rather than one per component that uses it, matching the thread
pool.

Tested by building the wheel and inspecting it: the profiler ships as a
versioned library, its seven public headers ship, the Python extension no
longer defines any of its symbols and links the library instead, and the
public header compiles against the installed package.