### PR TITLE
[RELEASE ONLY CHANGES] Finalize Python 3.14 wheel support

### DIFF
--- a/.ci/scripts/wheel/test_linux.py
+++ b/.ci/scripts/wheel/test_linux.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import platform
+import sys
 
 import test_base
 from examples.models import Backend, Model
@@ -41,15 +42,20 @@ if __name__ == "__main__":
 
         test_base.test_cmsis_nn_install()
 
-    test_base.run_tests(
-        model_tests=[
-            test_base.ModelTest(
-                model=Model.Mv3,
-                backend=Backend.XnnpackQuantizationDelegation,
-            ),
+    model_tests = [
+        test_base.ModelTest(
+            model=Model.Mv3,
+            backend=Backend.XnnpackQuantizationDelegation,
+        ),
+    ]
+    if sys.version_info < (3, 14):
+        model_tests.append(
             test_base.ModelTest(
                 model=Model.Mv3,
                 backend=Backend.CoreMlExportOnly,
-            ),
-        ]
-    )
+            )
+        )
+    else:
+        print("Skipping Core ML export: coremltools 9.0 does not support Python 3.14")
+
+    test_base.run_tests(model_tests=model_tests)

--- a/.ci/scripts/wheel/test_macos.py
+++ b/.ci/scripts/wheel/test_macos.py
@@ -6,21 +6,28 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+
 import test_base
 from examples.models import Backend, Model
 
 if __name__ == "__main__":
     test_base.test_cmsis_nn_install()
 
-    test_base.run_tests(
-        model_tests=[
-            test_base.ModelTest(
-                model=Model.Mv3,
-                backend=Backend.XnnpackQuantizationDelegation,
-            ),
+    model_tests = [
+        test_base.ModelTest(
+            model=Model.Mv3,
+            backend=Backend.XnnpackQuantizationDelegation,
+        ),
+    ]
+    if sys.version_info < (3, 14):
+        model_tests.append(
             test_base.ModelTest(
                 model=Model.Mv3,
                 backend=Backend.CoreMlExportAndTest,
-            ),
-        ]
-    )
+            )
+        )
+    else:
+        print("Skipping Core ML test: coremltools 9.0 does not support Python 3.14")
+
+    test_base.run_tests(model_tests=model_tests)

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ def _base_dependencies() -> List[str]:
         "packaging",
         "pandas>=2.2.2; python_version >= '3.10'",
         "parameterized",
-        "pytorch-tokenizers>=1.4.0",
+        "pytorch-tokenizers>=1.4.1",
         "pyyaml",
         "ruamel.yaml",
         "sympy",


### PR DESCRIPTION
Release-only change. Do not merge to main.

This resolves the remaining Python 3.14 wheel blockers found in the post-merge release/1.4 matrices.

Core ML:
- ExecuTorch runtime metadata already excludes `coremltools==9.0` on Python 3.14 because coremltools 9.0 publishes no CPython 3.14 wheels.
- Keep the XNNPACK wheel smoke tests active on Python 3.14, but run the Linux Core ML export and macOS Core ML export/test only on Python 3.10-3.13.
- Core ML coverage is unchanged on supported Python versions.

Tokenizers:
- Update the tokenizers submodule from v1.4.0 to v1.4.1.
- Raise the ExecuTorch wheel dependency floor from `pytorch-tokenizers>=1.4.0` to `>=1.4.1`.
- Tokenizers 1.4.1 publishes CPython 3.10-3.14 wheels for Linux x86_64, Linux AArch64, macOS arm64, and Windows x86_64.

Failed post-merge jobs:
- Linux Python 3.14: https://github.com/pytorch/executorch/actions/runs/30975467772/job/92208475180
- macOS Python 3.14: https://github.com/pytorch/executorch/actions/runs/30975467751/job/92208463631
- Windows Python 3.14: https://github.com/pytorch/executorch/actions/runs/30975467764/job/92208468555

Test plan:
- `python3 -m py_compile .ci/scripts/wheel/test_linux.py .ci/scripts/wheel/test_macos.py`
- Exercised both smoke scripts with mocked Python 3.13 and 3.14 versions; verified 3.13 retains Core ML and 3.14 retains XNNPACK while omitting Core ML.
- Verified the tokenizers submodule commit exactly matches tag v1.4.1.
- Verified production PyPI has all 20 tokenizers 1.4.1 wheels, including `cp314-cp314-win_amd64`.
- Downloaded the tokenizers CPython 3.14 macOS wheel from PyPI/TestPyPI and passed all 17 wheel tests locally.
- `git diff --check`.
- Full ExecuTorch wheel matrices delegated to post-merge CI.

Authored with Codex.