### PR TITLE
Ship the quantized kernels as their own library

### DIFF
--- a/.ci/scripts/wheel/test_cpp_sdk.py
+++ b/.ci/scripts/wheel/test_cpp_sdk.py
@@ -784,7 +784,7 @@ target_link_libraries(component_consumer PRIVATE executorch::runtime)
 
 # Link every component this wheel offers, and report which ones those are so the test
 # can check the result. Guarded individually because the set depends on the wheel.
-foreach(_component threadpool kernels_optimized)
+foreach(_component threadpool kernels_optimized kernels_quantized)
   if(TARGET executorch::${_component})
     target_link_libraries(component_consumer PRIVATE executorch::${_component})
     # Report the library file, not just the target name: the two differ, and the test

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -170,10 +170,33 @@ target_compile_options(quantized_kernels PUBLIC ${_common_compile_options})
 # Build a library for _quantized_kernels_srcs
 #
 # quantized_ops_lib: Register quantized ops kernels into Executorch runtime
+
+# Ship this as a shared library so an installed package has something a C++
+# application can link. A static library would need whole-archive linking on the
+# consumer side for the kernel registration to survive.
+if(EXECUTORCH_BUILD_SHARED)
+  set(_quantized_ops_shared SHARED)
+else()
+  set(_quantized_ops_shared "")
+endif()
 gen_operators_lib(
-  LIB_NAME "quantized_ops_lib" KERNEL_LIBS quantized_kernels DEPS
+  ${_quantized_ops_shared}
+  LIB_NAME
+  "quantized_ops_lib"
+  KERNEL_LIBS
+  quantized_kernels
+  DEPS
   executorch_core
 )
+if(EXECUTORCH_BUILD_SHARED)
+  # Name the file after the component that selects it, so the pair reads
+  # together: executorch::kernels_quantized resolves to
+  # libexecutorch_kernels_quantized.so. The helper would otherwise name it after
+  # its internal target.
+  set_target_properties(
+    quantized_ops_lib PROPERTIES OUTPUT_NAME executorch_kernels_quantized
+  )
+endif()
 
 install(
   TARGETS quantized_kernels quantized_ops_lib

--- a/setup.py
+++ b/setup.py
@@ -1201,6 +1201,11 @@ class CustomBuild(build):
                 cmake_build_args += ["--target", "aoti_cuda_backend"]
                 cmake_build_args += ["--target", "aoti_common_shims_slim"]
 
+            if cmake_cache.is_enabled("EXECUTORCH_BUILD_KERNELS_QUANTIZED"):
+                # Nothing else in the wheel links this, so without naming it here the
+                # target is declared but never built and packaging finds no file.
+                cmake_build_args += ["--target", "quantized_ops_lib"]
+
             if cmake_cache.is_enabled("EXECUTORCH_BUILD_EXTENSION_MODULE"):
                 cmake_build_args += ["--target", "extension_module"]
 
@@ -1323,6 +1328,29 @@ setup(
                     dependent_cmake_flags=[
                         "EXECUTORCH_BUILD_SHARED",
                         "EXECUTORCH_BUILD_KERNELS_OPTIMIZED",
+                    ],
+                ),
+                # Install the quantized kernels the same way. A model exported
+                # with quantized operators needs these registered at run time,
+                # and they existed only inside the Python extension before, so a
+                # C++ application had nothing to link.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/kernels/quantized/",
+                    src_name=(
+                        "libexecutorch_kernels_quantized.so."
+                        f"{get_runtime_soname_major()}.*"
+                    ),
+                    dst=(
+                        "executorch/lib/"
+                        "libexecutorch_kernels_quantized.so."
+                        f"{get_runtime_soname_major()}"
+                    ),
+                    # The target is only created when the quantized kernels are
+                    # enabled, so packaging has to require that too rather than
+                    # looking for a file a shared build may never have produced.
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_KERNELS_QUANTIZED",
                     ],
                 ),
                 # Install the prebuilt pybindings extension wrapper for the runtime,

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -356,6 +356,10 @@ executorch_define_component(threadpool executorch_threadpool)
 # to be defined here or a consumer following the documentation gets a bare name that CMake hands
 # to the linker as a literal flag.
 executorch_define_component(kernels_optimized executorch_kernels_optimized)
+# The quantized kernel set, for a model exported with quantized operators that runs them on plain
+# CPU. A model delegated to XNNPACK does not need this, because that delegate claims the quantize
+# and dequantize operators itself.
+executorch_define_component(kernels_quantized executorch_kernels_quantized)
 
 # A consumer that links the thread pool has to see the same switch a source build sets, or the
 # parallel helpers in the runtime headers compile their serial fallback instead and the library


### PR DESCRIPTION
A model quantized before export needs the quantized operator kernels
registered when it runs. Those kernels were only ever built into the Python
extension, so a C++ application had nothing to link and could not run such a
model from an installed package. The only way to get them was to build
ExecuTorch from source and link the target directly, which is what the
embedded examples in this repo do.

The registration library was built as a static archive. That is awkward to
ship, because the kernels register themselves from a static initializer and
an initializer in an archive is discarded unless the consumer opts into
whole-archive linking. Build it as a shared library instead, the same way the
merged CPU kernel set already is, and install it:

    find_package(executorch CONFIG REQUIRED COMPONENTS kernels_quantized)
    target_link_libraries(
      app PRIVATE executorch::runtime executorch::kernels_quantized
    )

The library is named after the component that selects it, so the pair reads
together: executorch::kernels_quantized resolves to
libexecutorch_kernels_quantized.so. The code generation helper would
otherwise name it after its internal target, which would not match.

Nothing else in the wheel links this library, so it also has to be named as a
build target explicitly, or it is declared but never built and packaging
looks for a file that does not exist.

Note that a quantized model delegated to XNNPACK does not need this: that
delegate claims the quantize and dequantize operators itself, so nothing is
left for the CPU kernels to run. These are for a quantized model running on
plain CPU, or on a backend that does not claim those operators.

Tested by building a wheel and installing it into a clean environment, with
imports confirmed to resolve to the installed package rather than a checkout:

- The wheel ships libexecutorch_kernels_quantized.so.1 next to the runtime, the
  thread pool and the merged CPU kernels.
- It is a shared library whose soname matches, and it resolves the runtime from
  libexecutorch.so.1 rather than carrying its own copy of the core.
- Loading it adds 19 quantized_decomposed operators to the registry, including
  the out variants of quantize_per_tensor and dequantize_per_tensor. None were
  present beforehand.
- A C++ application that asks for the component by name links it and reports
  the same 19 kernels registered at startup, which confirms the library is
  retained on the link line even though the application references no symbol
  from it directly.
- The merged CPU kernel set is unaffected and builds to the same shape.
- The existing aggregate library over these kernels still builds, and now
  resolves them through this shared library instead of a static archive.