### PR TITLE
[ExecuTorch][WebGPU] Support byte-packed BOOL storage

### DIFF
--- a/backends/webgpu/runtime/WebGPUGraph.cpp
+++ b/backends/webgpu/runtime/WebGPUGraph.cpp
@@ -212,6 +212,31 @@ bool vk_datatype_is_int(vkgraph::VkDataType dtype) {
   }
 }
 
+size_t storage_buffer_size(size_t nbytes) {
+  const size_t at_least_four = std::max(nbytes, size_t(4));
+  if (at_least_four > std::numeric_limits<size_t>::max() - 3u) {
+    throw std::runtime_error("WebGPU: storage buffer size overflows alignment");
+  }
+  return (at_least_four + 3u) & ~size_t(3);
+}
+
+void write_storage_buffer(
+    WGPUQueue queue,
+    WGPUBuffer buffer,
+    const void* data,
+    size_t nbytes) {
+  if (nbytes == 0u) {
+    return;
+  }
+  if (nbytes % 4u == 0u) {
+    wgpuQueueWriteBuffer(queue, buffer, 0, data, nbytes);
+    return;
+  }
+  std::vector<uint8_t> padded(storage_buffer_size(nbytes), 0u);
+  std::memcpy(padded.data(), data, nbytes);
+  wgpuQueueWriteBuffer(queue, buffer, 0, padded.data(), padded.size());
+}
+
 // Normalize a possibly-negative dim against rank; throws (fail-loud) if OOR.
 int normalize_dim(int dim, int rank, const char* op) {
   if (dim < 0) {
@@ -276,7 +301,7 @@ WebGPUGraph::WebGPUGraph() = default;
 
 WGPUBuffer WebGPUGraph::create_scratch_buffer(size_t nbytes) {
   WGPUBufferDescriptor buf_desc = {};
-  buf_desc.size = nbytes > 0 ? nbytes : 4;
+  buf_desc.size = storage_buffer_size(nbytes);
   buf_desc.usage = WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst |
       WGPUBufferUsage_CopySrc;
   buf_desc.mappedAtCreation = false;
@@ -286,7 +311,7 @@ WGPUBuffer WebGPUGraph::create_scratch_buffer(size_t nbytes) {
 }
 
 WGPUBuffer WebGPUGraph::acquire_scratch(size_t nbytes) {
-  nbytes = nbytes > 0 ? nbytes : 4;
+  nbytes = storage_buffer_size(nbytes);
   // Best-fit reuse: smallest free slot with size in [nbytes, 2*nbytes] -- the
   // 2x cap stops a large Cmax-sized buffer from backing a tiny request. Never
   // reuse an in_use slot (co-live safety).
@@ -890,6 +915,7 @@ void WebGPUGraph::build(
           throw std::runtime_error("WebGPU: tensor byte size overflows");
         }
         tensor.is_int = vk_datatype_is_int(vk_tensor->datatype());
+        tensor.is_bool = vk_tensor->datatype() == vkgraph::VkDataType::BOOL;
         tensor.is_int8 = vk_tensor->datatype() == vkgraph::VkDataType::INT8;
         tensor.nbytes = numel * tensor.elem_size;
         // Live dims start == max (serialized upper bound); resize_input shrinks
@@ -911,7 +937,7 @@ void WebGPUGraph::build(
           tensor.cur_nbytes = tensor.nbytes;
           tensor_mem_obj_ids_[i] = -1;
           WGPUBufferDescriptor buf_desc = {};
-          buf_desc.size = std::max(tensor.nbytes, size_t(4));
+          buf_desc.size = storage_buffer_size(tensor.nbytes);
           buf_desc.usage = WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst |
               WGPUBufferUsage_CopySrc;
           buf_desc.mappedAtCreation = false;
@@ -936,10 +962,9 @@ void WebGPUGraph::build(
                 std::memcpy(&value, src + e * sizeof(float), sizeof(float));
                 converted[e] = executorch::runtime::etensor::Half(value);
               }
-              wgpuQueueWriteBuffer(
+              write_storage_buffer(
                   queue_,
                   tensor.buffer,
-                  0,
                   converted.data(),
                   converted.size() * sizeof(converted[0]));
             };
@@ -1013,7 +1038,7 @@ void WebGPUGraph::build(
               prepack_src_ids.count(i) != 0 && direct_use_ids.count(i) == 0;
           if (!defer) {
             WGPUBufferDescriptor buf_desc = {};
-            buf_desc.size = std::max(tensor.nbytes, size_t(4));
+            buf_desc.size = storage_buffer_size(tensor.nbytes);
             buf_desc.usage = WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst |
                 WGPUBufferUsage_CopySrc;
             buf_desc.mappedAtCreation = false;
@@ -1110,7 +1135,7 @@ void WebGPUGraph::build(
   shared_buffers_.resize(shared_buffer_sizes_.size(), nullptr);
   for (size_t id = 0; id < shared_buffer_sizes_.size(); id++) {
     WGPUBufferDescriptor buf_desc = {};
-    buf_desc.size = std::max(shared_buffer_sizes_[id], size_t(4));
+    buf_desc.size = storage_buffer_size(shared_buffer_sizes_[id]);
     buf_desc.usage = WGPUBufferUsage_Storage | WGPUBufferUsage_CopyDst |
         WGPUBufferUsage_CopySrc;
     buf_desc.mappedAtCreation = false;
@@ -1138,7 +1163,7 @@ void WebGPUGraph::build(
 
       // Create staging buffer for output readback
       WGPUBufferDescriptor staging_desc = {};
-      staging_desc.size = std::max(tensors_[oid].nbytes, size_t(4));
+      staging_desc.size = storage_buffer_size(tensors_[oid].nbytes);
       staging_desc.usage = WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst;
       staging_desc.mappedAtCreation = false;
       output_staging_buffers_.push_back(
@@ -1313,7 +1338,7 @@ void WebGPUGraph::materialize_constant(int const_value_id, WGPUBuffer dst) {
         cs.nbytes,
         "WebGPU: inline constant exceeds constant data");
     if (cs.nbytes != 0) {
-      wgpuQueueWriteBuffer(queue_, dst, 0, data, cs.nbytes);
+      write_storage_buffer(queue_, dst, data, cs.nbytes);
     }
   } else if (cs.nbytes == 0) {
     return;
@@ -1327,7 +1352,7 @@ void WebGPUGraph::materialize_constant(int const_value_id, WGPUBuffer dst) {
       throw std::runtime_error(
           "WebGPU: named constant '" + cs.named_key + "' undersized");
     }
-    wgpuQueueWriteBuffer(queue_, dst, 0, buf->data(), cs.nbytes);
+    write_storage_buffer(queue_, dst, buf->data(), cs.nbytes);
     buf->Free();
   } else {
     throw std::runtime_error("WebGPU: constant has no source");
@@ -1419,7 +1444,7 @@ void WebGPUGraph::copy_inputs(const std::vector<InputData>& inputs) {
 
     // Fast path: host and GPU element types match byte-for-byte.
     if (in.nbytes == live_nbytes) {
-      wgpuQueueWriteBuffer(queue_, tensor.buffer, 0, in.data, live_nbytes);
+      write_storage_buffer(queue_, tensor.buffer, in.data, live_nbytes);
       continue;
     }
 
@@ -1439,8 +1464,7 @@ void WebGPUGraph::copy_inputs(const std::vector<InputData>& inputs) {
 #endif
         narrowed[e] = static_cast<int32_t>(src[e]);
       }
-      wgpuQueueWriteBuffer(
-          queue_, tensor.buffer, 0, narrowed.data(), live_nbytes);
+      write_storage_buffer(queue_, tensor.buffer, narrowed.data(), live_nbytes);
       continue;
     }
 
@@ -1454,8 +1478,7 @@ void WebGPUGraph::copy_inputs(const std::vector<InputData>& inputs) {
       for (size_t e = 0; e < numel; e++) {
         narrowed[e] = executorch::runtime::etensor::Half(src[e]);
       }
-      wgpuQueueWriteBuffer(
-          queue_, tensor.buffer, 0, narrowed.data(), live_nbytes);
+      write_storage_buffer(queue_, tensor.buffer, narrowed.data(), live_nbytes);
       continue;
     }
 
@@ -1684,10 +1707,11 @@ size_t WebGPUGraph::execute(const WebGPUExecutionPlan& plan) {
     }
 
     for (size_t i = 0; i < output_copies_.size(); i++) {
-      const size_t copy_nbytes = tensors_[output_ids_[i]].cur_nbytes;
-      if (!plan.copy_outputs[i] || copy_nbytes == 0) {
+      const size_t logical_nbytes = tensors_[output_ids_[i]].cur_nbytes;
+      if (!plan.copy_outputs[i] || logical_nbytes == 0) {
         continue;
       }
+      const size_t copy_nbytes = storage_buffer_size(logical_nbytes);
       const auto& copy = output_copies_[i];
       wgpuCommandEncoderCopyBufferToBuffer(
           encoder, copy.src_buffer, 0, copy.staging_buffer, 0, copy_nbytes);
@@ -1759,10 +1783,11 @@ size_t WebGPUGraph::execute(const WebGPUExecutionPlan& plan) {
 
     if (chunk_index + 1 == plan.dispatch_chunks.size()) {
       for (size_t i = 0; i < output_copies_.size(); i++) {
-        const size_t copy_nbytes = tensors_[output_ids_[i]].cur_nbytes;
-        if (!plan.copy_outputs[i] || copy_nbytes == 0) {
+        const size_t logical_nbytes = tensors_[output_ids_[i]].cur_nbytes;
+        if (!plan.copy_outputs[i] || logical_nbytes == 0) {
           continue;
         }
+        const size_t copy_nbytes = storage_buffer_size(logical_nbytes);
         const auto& copy = output_copies_[i];
         wgpuCommandEncoderCopyBufferToBuffer(
             encoder, copy.src_buffer, 0, copy.staging_buffer, 0, copy_nbytes);
@@ -1813,13 +1838,13 @@ void WebGPUGraph::copy_outputs(
       continue;
     }
     const auto& tensor = tensors_[output_ids_[i]];
-    const size_t map_nbytes = tensor.cur_nbytes;
-    if (map_nbytes == 0) {
+    const size_t logical_nbytes = tensor.cur_nbytes;
+    if (logical_nbytes == 0) {
       continue;
     }
     const size_t dst_nbytes = outputs[i].nbytes;
     const bool is_double_width =
-        dst_nbytes % 2 == 0 && dst_nbytes / 2 == map_nbytes;
+        dst_nbytes % 2 == 0 && dst_nbytes / 2 == logical_nbytes;
     const bool widen_fp16 =
         is_double_width && !tensor.is_int && tensor.elem_size == 2;
     const bool widen_int32 =
@@ -1832,7 +1857,7 @@ void WebGPUGraph::copy_outputs(
     if (outputs[i].host_is_fp32 && buffer_is_fp16 && !widen_fp16) {
       throw std::runtime_error("WebGPU: fp16 output buffer size mismatch");
     }
-    if (dst_nbytes != map_nbytes && !widen_fp16 && !widen_int32) {
+    if (dst_nbytes != logical_nbytes && !widen_fp16 && !widen_int32) {
       throw std::runtime_error("WebGPU: output buffer size mismatch");
     }
   }
@@ -1842,13 +1867,14 @@ void WebGPUGraph::copy_outputs(
       continue;
     }
     const auto& tensor = tensors_[output_ids_[i]];
-    const size_t map_nbytes = tensor.cur_nbytes;
-    if (map_nbytes == 0) {
+    const size_t logical_nbytes = tensor.cur_nbytes;
+    if (logical_nbytes == 0) {
       continue;
     }
+    const size_t map_nbytes = storage_buffer_size(logical_nbytes);
     const size_t dst_nbytes = outputs[i].nbytes;
     const bool is_double_width =
-        dst_nbytes % 2 == 0 && dst_nbytes / 2 == map_nbytes;
+        dst_nbytes % 2 == 0 && dst_nbytes / 2 == logical_nbytes;
     const bool widen_fp16 =
         is_double_width && !tensor.is_int && tensor.elem_size == 2;
     const bool widen_int32 =
@@ -1887,7 +1913,7 @@ void WebGPUGraph::copy_outputs(
       const auto* src =
           static_cast<const executorch::runtime::etensor::Half*>(mapped);
       auto* dst = static_cast<float*>(outputs[i].data);
-      const size_t n = map_nbytes / sizeof(*src);
+      const size_t n = logical_nbytes / sizeof(*src);
       for (size_t k = 0; k < n; k++) {
         dst[k] = static_cast<float>(src[k]);
       }
@@ -1895,12 +1921,12 @@ void WebGPUGraph::copy_outputs(
       // int64 host output backed by an int32 GPU buffer: widen (sign-extend).
       const int32_t* src = static_cast<const int32_t*>(mapped);
       int64_t* dst = static_cast<int64_t*>(outputs[i].data);
-      const size_t n = map_nbytes / sizeof(int32_t);
+      const size_t n = logical_nbytes / sizeof(int32_t);
       for (size_t k = 0; k < n; k++) {
         dst[k] = static_cast<int64_t>(src[k]);
       }
     } else {
-      std::memcpy(outputs[i].data, mapped, map_nbytes);
+      std::memcpy(outputs[i].data, mapped, logical_nbytes);
     }
     wgpuBufferUnmap(output_staging_buffers_[i]);
   }

--- a/backends/webgpu/runtime/WebGPUGraph.h
+++ b/backends/webgpu/runtime/WebGPUGraph.h
@@ -39,6 +39,8 @@ struct WebGPUTensor {
   // Serialized (GPU-side) element type, used to narrow wider host inputs.
   size_t elem_size = 0;
   bool is_int = false;
+  // Exact BOOL tag for byte-packed WGSL storage.
+  bool is_bool = false;
   // Exactly int8 (not uint8/bool), so int8-only ops can guard their dtype.
   bool is_int8 = false;
 };

--- a/backends/webgpu/runtime/WebGPUShaderRegistry.cpp
+++ b/backends/webgpu/runtime/WebGPUShaderRegistry.cpp
@@ -124,6 +124,7 @@
 #include <executorch/backends/webgpu/runtime/ops/slice/slice_wgsl.h>
 #include <executorch/backends/webgpu/runtime/ops/softmax/log_softmax_wgsl.h>
 #include <executorch/backends/webgpu/runtime/ops/softmax/softmax_wgsl.h>
+#include <executorch/backends/webgpu/runtime/ops/to_copy/to_copy_bool_to_float_wgsl.h>
 #include <executorch/backends/webgpu/runtime/ops/to_copy/to_copy_float_to_int_wgsl.h>
 #include <executorch/backends/webgpu/runtime/ops/to_copy/to_copy_int_to_float_wgsl.h>
 #include <executorch/backends/webgpu/runtime/ops/unary/abs_wgsl.h>
@@ -151,7 +152,7 @@
 namespace executorch::backends::webgpu {
 namespace {
 
-constexpr std::array<WebGPUShaderInfo, 133> kShaderRegistry = {{
+constexpr std::array<WebGPUShaderInfo, 134> kShaderRegistry = {{
     {
         "abs",
         kAbsWGSL,
@@ -1033,6 +1034,13 @@ constexpr std::array<WebGPUShaderInfo, 133> kShaderRegistry = {{
         kTanhWorkgroupSizeX,
         kTanhWorkgroupSizeY,
         kTanhWorkgroupSizeZ,
+    },
+    {
+        "to_copy_bool_to_float",
+        kToCopyBoolToFloatWGSL,
+        kToCopyBoolToFloatWorkgroupSizeX,
+        kToCopyBoolToFloatWorkgroupSizeY,
+        kToCopyBoolToFloatWorkgroupSizeZ,
     },
     {
         "to_copy_float_to_int",

--- a/backends/webgpu/runtime/ops/compare/Compare.cpp
+++ b/backends/webgpu/runtime/ops/compare/Compare.cpp
@@ -58,13 +58,13 @@ void compare_impl(
       in2_tensor.elem_size != 4) {
     throw std::runtime_error("compare: fp32 inputs only");
   }
-  if (!out_tensor.is_int || out_tensor.elem_size != 1) {
+  if (!out_tensor.is_bool || out_tensor.elem_size != 1) {
     throw std::runtime_error("compare: output must be a 1-byte bool tensor");
   }
   const uint64_t numel = out_tensor.nbytes;
-  // out bool packed 4/word (array<u32>); numel%4==0 gates the readback map.
-  if (numel == 0u || numel % 4u != 0u || numel > UINT32_MAX) {
-    throw std::runtime_error("compare: numel must be a nonzero mult of 4");
+  // out bool is byte-packed into ceil(numel / 4) u32 storage words.
+  if (numel == 0u || numel > UINT32_MAX) {
+    throw std::runtime_error("compare: numel must be nonzero and fit u32");
   }
   const uint64_t in_numel = in1_tensor.nbytes / sizeof(float);
   if (in1_tensor.nbytes != in2_tensor.nbytes || in_numel != numel) {
@@ -75,7 +75,7 @@ void compare_impl(
   params.num_elements = static_cast<uint32_t>(numel);
   params.op = op;
 
-  const uint32_t words = static_cast<uint32_t>(numel / 4u);
+  const uint32_t words = static_cast<uint32_t>((numel + 3u) / 4u);
   uint32_t wg_size =
       utils::clamp_workgroup_size(device, kCompareWorkgroupSizeX);
   utils::WgCount workgroup_count =
@@ -97,7 +97,7 @@ void compare_impl(
           {0,
            WGPUBufferBindingType_Storage,
            out_tensor.buffer,
-           out_tensor.nbytes},
+           static_cast<size_t>(words) * sizeof(uint32_t)},
           {1,
            WGPUBufferBindingType_ReadOnlyStorage,
            in1_tensor.buffer,
@@ -127,9 +127,8 @@ void compare_impl(
                     WebGPUGraph& g) {
     const auto& d = g.cur_dims(in1_id);
     const uint64_t n = utils::numel_of(d);
-    if (n == 0u || n % 4u != 0u || n > UINT32_MAX ||
-        utils::numel_of(g.cur_dims(in2_id)) != n) {
-      throw std::runtime_error("compare(resize): numel must be a mult of 4");
+    if (n == 0u || n > UINT32_MAX || utils::numel_of(g.cur_dims(in2_id)) != n) {
+      throw std::runtime_error("compare(resize): invalid numel");
     }
     g.set_cur_dims(out_id, d);
     CompareParams p = {};
@@ -137,7 +136,7 @@ void compare_impl(
     p.op = op;
     wgpuQueueWriteBuffer(g.queue(), params_buf, 0, &p, sizeof(p));
     const utils::WgCount wgc = utils::compute_2d_workgroup_count(
-        g.device(), static_cast<uint32_t>(n / 4u), wg_size, "compare");
+        g.device(), static_cast<uint32_t>((n + 3u) / 4u), wg_size, "compare");
     g.dispatch_at(dispatch_idx).workgroup_count_x = wgc.x;
     g.dispatch_at(dispatch_idx).workgroup_count_y = wgc.y;
   };

--- a/backends/webgpu/runtime/ops/compare/compare.wgsl
+++ b/backends/webgpu/runtime/ops/compare/compare.wgsl
@@ -16,27 +16,29 @@ override wg_size: u32 = 64u;
 fn main(
     @builtin(global_invocation_id) gid: vec3<u32>,
     @builtin(num_workgroups) num_workgroups: vec3<u32>) {
-  // One thread per output word = 4 bool bytes; num_elements%4==0 (host).
+  // One thread per output word = up to 4 bool bytes.
   let widx = gid.x + gid.y * (num_workgroups.x * wg_size);
-  let words = (params.num_elements + 3u) / 4u;
+  let words = (params.num_elements - 1u) / 4u + 1u;
   if (widx >= words) {
     return;
   }
   var packed: u32 = 0u;
   for (var j: u32 = 0u; j < 4u; j = j + 1u) {
     let i = widx * 4u + j;
-    let a = input1[i];
-    let b = input2[i];
-    var r: bool;
-    switch params.op {
-      case 0u: { r = a == b; }  // eq
-      case 1u: { r = a < b; }   // lt
-      case 2u: { r = a <= b; }  // le
-      case 3u: { r = a > b; }   // gt
-      default: { r = a >= b; }  // ge
-    }
-    if (r) {
-      packed = packed | (1u << (j * 8u));
+    if (i < params.num_elements) {
+      let a = input1[i];
+      let b = input2[i];
+      var r: bool;
+      switch params.op {
+        case 0u: { r = a == b; }  // eq
+        case 1u: { r = a < b; }   // lt
+        case 2u: { r = a <= b; }  // le
+        case 3u: { r = a > b; }   // gt
+        default: { r = a >= b; }  // ge
+      }
+      if (r) {
+        packed = packed | (1u << (j * 8u));
+      }
     }
   }
   t_out[widx] = packed;

--- a/backends/webgpu/runtime/ops/compare/compare_wgsl.h
+++ b/backends/webgpu/runtime/ops/compare/compare_wgsl.h
@@ -13,7 +13,7 @@
 namespace executorch::backends::webgpu {
 
 // @generated from compare.wgsl - DO NOT EDIT.
-// wgsl-sha256: 241e7e6762b1eded07d28a3767936c970f509f6591e7cbf599d0b1eb61efb181
+// wgsl-sha256: 8f330b5a1e29a1fb8135e64600dadb1dc64c98f8f5371357f8de73a1808b76d6
 inline constexpr const char* kCompareWGSL = R"(
 @group(0) @binding(0) var<storage, read_write> t_out: array<u32>;
 @group(0) @binding(1) var<storage, read> input1: array<f32>;
@@ -33,27 +33,29 @@ override wg_size: u32 = 64u;
 fn main(
     @builtin(global_invocation_id) gid: vec3<u32>,
     @builtin(num_workgroups) num_workgroups: vec3<u32>) {
-  // One thread per output word = 4 bool bytes; num_elements%4==0 (host).
+  // One thread per output word = up to 4 bool bytes.
   let widx = gid.x + gid.y * (num_workgroups.x * wg_size);
-  let words = (params.num_elements + 3u) / 4u;
+  let words = (params.num_elements - 1u) / 4u + 1u;
   if (widx >= words) {
     return;
   }
   var packed: u32 = 0u;
   for (var j: u32 = 0u; j < 4u; j = j + 1u) {
     let i = widx * 4u + j;
-    let a = input1[i];
-    let b = input2[i];
-    var r: bool;
-    switch params.op {
-      case 0u: { r = a == b; }  // eq
-      case 1u: { r = a < b; }   // lt
-      case 2u: { r = a <= b; }  // le
-      case 3u: { r = a > b; }   // gt
-      default: { r = a >= b; }  // ge
-    }
-    if (r) {
-      packed = packed | (1u << (j * 8u));
+    if (i < params.num_elements) {
+      let a = input1[i];
+      let b = input2[i];
+      var r: bool;
+      switch params.op {
+        case 0u: { r = a == b; }  // eq
+        case 1u: { r = a < b; }   // lt
+        case 2u: { r = a <= b; }  // le
+        case 3u: { r = a > b; }   // gt
+        default: { r = a >= b; }  // ge
+      }
+      if (r) {
+        packed = packed | (1u << (j * 8u));
+      }
     }
   }
   t_out[widx] = packed;

--- a/backends/webgpu/runtime/ops/to_copy/ToCopy.cpp
+++ b/backends/webgpu/runtime/ops/to_copy/ToCopy.cpp
@@ -10,12 +10,14 @@
 #include <executorch/backends/webgpu/runtime/WebGPUUtils.h>
 #include <executorch/backends/webgpu/runtime/ops/OperatorRegistry.h>
 #include <executorch/backends/webgpu/runtime/ops/to_copy/to_copy.h>
+#include <executorch/backends/webgpu/runtime/ops/to_copy/to_copy_bool_to_float_wgsl.h>
 #include <executorch/backends/webgpu/runtime/ops/to_copy/to_copy_float_to_int_wgsl.h>
 #include <executorch/backends/webgpu/runtime/ops/to_copy/to_copy_int_to_float_wgsl.h>
 #include <executorch/backends/webgpu/runtime/ops/view_copy/view_copy.h>
 
 #include <webgpu/webgpu.h>
 
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -118,6 +120,98 @@ void add_convert_op(
   graph.own_uniform_buffer(uniform_buffer);
 }
 
+// Decode byte-packed bool storage into numeric fp32 values.
+void add_bool_to_float_op(WebGPUGraph& graph, int in_id, int out_id) {
+  WGPUDevice device = graph.device();
+  const auto& in_tensor = graph.get_tensor(in_id);
+  const auto& out_tensor = graph.get_tensor(out_id);
+  if (in_tensor.buffer == nullptr || out_tensor.buffer == nullptr) {
+    throw std::runtime_error("to_copy_bool_to_float: null buffer binding");
+  }
+  if (!in_tensor.is_bool || in_tensor.elem_size != 1 || out_tensor.is_int ||
+      out_tensor.elem_size != sizeof(float) ||
+      out_tensor.nbytes % sizeof(float) != 0 ||
+      out_tensor.nbytes / sizeof(float) != in_tensor.nbytes) {
+    throw std::runtime_error("to_copy_bool_to_float: dtype/numel mismatch");
+  }
+  if (in_tensor.nbytes == 0u ||
+      in_tensor.nbytes > std::numeric_limits<uint32_t>::max()) {
+    throw std::runtime_error(
+        "to_copy_bool_to_float: numel must be nonzero and fit u32");
+  }
+
+  const uint32_t num_elements = static_cast<uint32_t>(in_tensor.nbytes);
+  const uint64_t input_bind_size_u64 =
+      (static_cast<uint64_t>(in_tensor.nbytes) + 3u) & ~uint64_t(3);
+  if (input_bind_size_u64 > std::numeric_limits<size_t>::max()) {
+    throw std::runtime_error(
+        "to_copy_bool_to_float: input binding size overflows");
+  }
+  const size_t input_bind_size = static_cast<size_t>(input_bind_size_u64);
+
+  const uint32_t wg_size =
+      utils::clamp_workgroup_size(device, kToCopyBoolToFloatWorkgroupSizeX);
+  const uint32_t workgroup_count = utils::compute_1d_workgroup_count(
+      device, num_elements, wg_size, "to_copy_bool_to_float");
+
+  WGPUConstantEntry wg_size_constant = {};
+  wg_size_constant.key = {"wg_size", WGPU_STRLEN};
+  wg_size_constant.value = static_cast<double>(wg_size);
+
+  ConvertParams params = {};
+  params.num_elements = num_elements;
+  WGPUBuffer uniform_buffer =
+      utils::make_uniform(device, &params, sizeof(ConvertParams));
+  graph.add_uniform_buffer_bytes(sizeof(ConvertParams));
+
+  utils::ComputePipelineBundle bundle = utils::make_compute_pipeline(
+      device,
+      kToCopyBoolToFloatWGSL,
+      {
+          {0,
+           WGPUBufferBindingType_ReadOnlyStorage,
+           in_tensor.buffer,
+           input_bind_size},
+          {1,
+           WGPUBufferBindingType_Storage,
+           out_tensor.buffer,
+           out_tensor.nbytes},
+          {2,
+           WGPUBufferBindingType_Uniform,
+           uniform_buffer,
+           sizeof(ConvertParams)},
+      },
+      &wg_size_constant,
+      1);
+
+  const size_t dispatch_idx =
+      graph.add_dispatch({bundle.pipeline, bundle.bind_group, workgroup_count});
+
+  WGPUBuffer params_buf = uniform_buffer;
+  graph.add_tensor_resize_hook(
+      in_id,
+      [in_id, out_id, wg_size, dispatch_idx, params_buf](WebGPUGraph& g) {
+        const auto& dims = g.cur_dims(in_id);
+        const uint64_t numel = utils::numel_of(dims);
+        if (numel == 0u || numel > std::numeric_limits<uint32_t>::max()) {
+          throw std::runtime_error(
+              "to_copy_bool_to_float(resize): invalid numel");
+        }
+        g.set_cur_dims(out_id, dims);
+        ConvertParams p = {};
+        p.num_elements = static_cast<uint32_t>(numel);
+        wgpuQueueWriteBuffer(g.queue(), params_buf, 0, &p, sizeof(p));
+        g.dispatch_at(dispatch_idx).workgroup_count_x =
+            utils::compute_1d_workgroup_count(
+                g.device(),
+                static_cast<uint32_t>(numel),
+                wg_size,
+                "to_copy_bool_to_float(resize)");
+      });
+
+  graph.own_uniform_buffer(uniform_buffer);
+}
+
 void to_copy_impl(WebGPUGraph& graph, const std::vector<int>& args) {
   // aten._to_copy.default args: [self, ...kwargs, out]; out = last value id.
   add_to_copy_node(graph, args.at(0), args.at(args.size() - 1));
@@ -137,7 +231,10 @@ void add_to_copy_node(WebGPUGraph& graph, int in_id, int out_id) {
   }
 
   // int<->float = numeric convert (mirrors Vulkan add_view_copy_convert_node).
-  if (in_tensor.is_int && !out_tensor.is_int) {
+  if (in_tensor.is_bool && !out_tensor.is_int &&
+      out_tensor.elem_size == sizeof(float)) {
+    add_bool_to_float_op(graph, in_id, out_id);
+  } else if (in_tensor.is_int && !out_tensor.is_int) {
     add_convert_op(
         graph,
         in_id,

--- a/backends/webgpu/runtime/ops/to_copy/to_copy_bool_to_float.wgsl
+++ b/backends/webgpu/runtime/ops/to_copy/to_copy_bool_to_float.wgsl
@@ -1,0 +1,24 @@
+override wg_size: u32 = 256u;
+
+struct Params {
+  num_elements: u32,
+  _pad0: u32,
+  _pad1: u32,
+  _pad2: u32,
+};
+
+@group(0) @binding(0) var<storage, read> input: array<u32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(wg_size)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.num_elements) {
+    return;
+  }
+  let word = input[idx / 4u];
+  let byte_shift = (idx % 4u) * 8u;
+  let value = (word >> byte_shift) & 0xffu;
+  output[idx] = select(0.0, 1.0, value != 0u);
+}

--- a/backends/webgpu/runtime/ops/to_copy/to_copy_bool_to_float_wgsl.h
+++ b/backends/webgpu/runtime/ops/to_copy/to_copy_bool_to_float_wgsl.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace executorch::backends::webgpu {
+
+// @generated from to_copy_bool_to_float.wgsl - DO NOT EDIT.
+// wgsl-sha256: 29fd43b2f638489e9b8d72b2cc9140d07174c750cbdc291e63793319a2fa5961
+inline constexpr const char* kToCopyBoolToFloatWGSL = R"(
+override wg_size: u32 = 256u;
+
+struct Params {
+  num_elements: u32,
+  _pad0: u32,
+  _pad1: u32,
+  _pad2: u32,
+};
+
+@group(0) @binding(0) var<storage, read> input: array<u32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(wg_size)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let idx = gid.x;
+  if (idx >= params.num_elements) {
+    return;
+  }
+  let word = input[idx / 4u];
+  let byte_shift = (idx % 4u) * 8u;
+  let value = (word >> byte_shift) & 0xffu;
+  output[idx] = select(0.0, 1.0, value != 0u);
+}
+)";
+
+inline constexpr uint32_t kToCopyBoolToFloatWorkgroupSizeX = 256;
+inline constexpr uint32_t kToCopyBoolToFloatWorkgroupSizeY = 1;
+inline constexpr uint32_t kToCopyBoolToFloatWorkgroupSizeZ = 1;
+
+} // namespace executorch::backends::webgpu

--- a/backends/webgpu/test/test_wgsl_codegen.py
+++ b/backends/webgpu/test/test_wgsl_codegen.py
@@ -77,6 +77,16 @@ def _function_source(text: str, name: str) -> str:
 
 
 class WgslCodegenTest(unittest.TestCase):
+    def test_compare_word_count_does_not_overflow_u32(self) -> None:
+        source = (g.BACKEND_ROOT / "runtime/ops/compare/compare.wgsl").read_text()
+        expression = "(params.num_elements - 1u) / 4u + 1u"
+        self.assertIn(expression, source)
+        for num_elements in (1, 4, 5, (1 << 32) - 3, (1 << 32) - 2, (1 << 32) - 1):
+            self.assertEqual(
+                (num_elements - 1) // 4 + 1,
+                (num_elements + 3) // 4,
+            )
+
     def test_registry_entries_match_concrete_headers(self) -> None:
         entries = g.registry_entries()
         names = [entry.name for entry in entries]
@@ -210,14 +220,14 @@ class WgslCodegenTest(unittest.TestCase):
             digest.update(b"\0")
             digest.update(output.read_bytes())
             digest.update(b"\0")
-        self.assertEqual(len(outputs), 134)
+        self.assertEqual(len(outputs), 135)
         self.assertEqual(
             digest.hexdigest(),
-            "e502196846f0f8100f468e5d9f8f9c006b67e08df54e1e2e667daa2fc50d8844",
+            "61bcf7671ba11a1d9f26e6488d7c62de855728e6cef6ef7983e2a04c4e1c79ca",
         )
         self.assertEqual(
             hashlib.sha256(g.registry_path().read_bytes()).hexdigest(),
-            "492535b396833ad6ebfed29b093057e38f40b1182b5c7d6b3eb2f3577cab024e",
+            "b3e84b54e6fcb7e48477018d91de62977202418f3b45cb6c28a70dfe86944176",
         )
 
     def test_rope_hf_reconstructs_full_2d_grid_stride(self) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #21602
* #21601
* #21600
* #21599
* __->__ #21598
* #21597
* #21483
* #21451
* #21450
* #21449
* #21448
* #21136
* #21135
* #21134
* #21133
* #21132
* #21131
* #21130
* #21129
* #21128
* #21127

**Support exact byte-packed BOOL tensors**

WebGPU storage and transfers require four-byte alignment while serialized `BOOL` tensors use one logical byte per element. The runtime now preserves exact `BOOL` dtype and logical byte counts while padding physical storage, uploads, and readback.

Key changes:

- Compare output — packs guarded tail lanes for arbitrary nonzero lengths.
- `BOOL`-to-fp32 — decodes packed values numerically instead of reinterpreting bytes.
- `_to_copy` routing — mirrors Vulkan exact-dtype conversion intent in `backends/vulkan/runtime/graph/ops/impl/View.cpp:183` while keeping `BOOL` separate from `INT8` and `UINT8`.
- Generated sources — refresh WGSL registry output and drift digests.

Logical tensor sizes and existing non-`BOOL` routes are unchanged.

Co-authored-with: Claude Code.

Differential Revision: [D114936143](https://our.internmc.facebook.com/intern/diff/D114936143/)