### PR TITLE
[ExecuTorch][WebGPU] Cover Conv1d routes and dynamic manifests

### DIFF
--- a/backends/webgpu/test/native/test_compute_dispatch.cpp
+++ b/backends/webgpu/test/native/test_compute_dispatch.cpp
@@ -173,34 +173,31 @@ void build_conv1d_route_graph(
   std::vector<::flatbuffers::Offset<vk::VkValue>> values;
   auto add_tensor = [&](const std::vector<uint32_t>& dims, int mem_obj_id) {
     const int id = static_cast<int>(values.size());
-    values.push_back(
-        vk::CreateVkValue(
+    values.push_back(vk::CreateVkValue(
+        fbb,
+        vk::GraphTypes::VkTensor,
+        vk::CreateVkTensorDirect(
             fbb,
-            vk::GraphTypes::VkTensor,
-            vk::CreateVkTensorDirect(
-                fbb,
-                vk::VkDataType::FLOAT32,
-                &dims,
-                /*constant_id=*/-1,
-                mem_obj_id)
-                .Union()));
+            vk::VkDataType::FLOAT32,
+            &dims,
+            /*constant_id=*/-1,
+            mem_obj_id)
+            .Union()));
     return id;
   };
   auto add_int = [&](int64_t value) {
     const int id = static_cast<int>(values.size());
-    values.push_back(
-        vk::CreateVkValue(
-            fbb, vk::GraphTypes::Int, vk::CreateInt(fbb, value).Union()));
+    values.push_back(vk::CreateVkValue(
+        fbb, vk::GraphTypes::Int, vk::CreateInt(fbb, value).Union()));
     return id;
   };
   auto add_int_list = [&](int64_t value) {
     const int id = static_cast<int>(values.size());
     const std::vector<int64_t> items = {value};
-    values.push_back(
-        vk::CreateVkValue(
-            fbb,
-            vk::GraphTypes::IntList,
-            vk::CreateIntListDirect(fbb, &items).Union()));
+    values.push_back(vk::CreateVkValue(
+        fbb,
+        vk::GraphTypes::IntList,
+        vk::CreateIntListDirect(fbb, &items).Union()));
     return id;
   };
 
@@ -212,9 +209,8 @@ void build_conv1d_route_graph(
   const int padding = add_int_list(test_case.padding);
   const int dilation = add_int_list(test_case.dilation);
   const int transposed = static_cast<int>(values.size());
-  values.push_back(
-      vk::CreateVkValue(
-          fbb, vk::GraphTypes::Bool, vk::CreateBool(fbb, false).Union()));
+  values.push_back(vk::CreateVkValue(
+      fbb, vk::GraphTypes::Bool, vk::CreateBool(fbb, false).Union()));
   const int output_padding = add_int_list(0);
   const int groups = add_int(test_case.groups);
   const int output = add_tensor(test_case.output_dims, 2);

--- a/backends/webgpu/test/native/test_compute_dispatch.cpp
+++ b/backends/webgpu/test/native/test_compute_dispatch.cpp
@@ -153,6 +153,96 @@ void expect_dual_q4_topology(WebGPUGraph& graph) {
       1);
 }
 
+struct Conv1dRouteCase {
+  const char* name;
+  std::vector<uint32_t> input_dims;
+  std::vector<uint32_t> weight_dims;
+  std::vector<uint32_t> output_dims;
+  int64_t stride;
+  int64_t padding;
+  int64_t dilation;
+  int64_t groups;
+  const char* expected_kernel;
+};
+
+void build_conv1d_route_graph(
+    WebGPUGraph& graph,
+    const Conv1dRouteCase& test_case) {
+  namespace vk = vkgraph;
+  ::flatbuffers::FlatBufferBuilder fbb;
+  std::vector<::flatbuffers::Offset<vk::VkValue>> values;
+  auto add_tensor = [&](const std::vector<uint32_t>& dims, int mem_obj_id) {
+    const int id = static_cast<int>(values.size());
+    values.push_back(
+        vk::CreateVkValue(
+            fbb,
+            vk::GraphTypes::VkTensor,
+            vk::CreateVkTensorDirect(
+                fbb,
+                vk::VkDataType::FLOAT32,
+                &dims,
+                /*constant_id=*/-1,
+                mem_obj_id)
+                .Union()));
+    return id;
+  };
+  auto add_int = [&](int64_t value) {
+    const int id = static_cast<int>(values.size());
+    values.push_back(
+        vk::CreateVkValue(
+            fbb, vk::GraphTypes::Int, vk::CreateInt(fbb, value).Union()));
+    return id;
+  };
+  auto add_int_list = [&](int64_t value) {
+    const int id = static_cast<int>(values.size());
+    const std::vector<int64_t> items = {value};
+    values.push_back(
+        vk::CreateVkValue(
+            fbb,
+            vk::GraphTypes::IntList,
+            vk::CreateIntListDirect(fbb, &items).Union()));
+    return id;
+  };
+
+  const int input = add_tensor(test_case.input_dims, 0);
+  const int weight = add_tensor(test_case.weight_dims, 1);
+  const int bias = static_cast<int>(values.size());
+  values.push_back(vk::CreateVkValue(fbb));
+  const int stride = add_int_list(test_case.stride);
+  const int padding = add_int_list(test_case.padding);
+  const int dilation = add_int_list(test_case.dilation);
+  const int transposed = static_cast<int>(values.size());
+  values.push_back(
+      vk::CreateVkValue(
+          fbb, vk::GraphTypes::Bool, vk::CreateBool(fbb, false).Union()));
+  const int output_padding = add_int_list(0);
+  const int groups = add_int(test_case.groups);
+  const int output = add_tensor(test_case.output_dims, 2);
+  const std::vector<int32_t> args = {
+      input,
+      weight,
+      bias,
+      stride,
+      padding,
+      dilation,
+      transposed,
+      output_padding,
+      groups,
+      output};
+  std::vector<::flatbuffers::Offset<vk::OperatorCall>> chain;
+  chain.push_back(
+      vk::CreateOperatorCallDirect(fbb, 0, "aten.convolution.default", &args));
+  const std::vector<uint32_t> input_ids = {
+      static_cast<uint32_t>(input), static_cast<uint32_t>(weight)};
+  const std::vector<uint32_t> output_ids = {static_cast<uint32_t>(output)};
+  const auto root = vk::CreateVkGraphDirect(
+      fbb, "0", &chain, &values, &input_ids, &output_ids);
+  vk::FinishVkGraphBuffer(fbb, root);
+
+  graph.set_device(g_device);
+  graph.build(fbb.GetBufferPointer(), nullptr, 0, nullptr);
+}
+
 TEST(WebGPUShaderRegistry, FindsKnownShaderAndRejectsUnknownName) {
   const WebGPUShaderInfo& sigmoid = get_webgpu_shader_info("sigmoid");
   EXPECT_EQ(sigmoid.name, "sigmoid");
@@ -189,6 +279,29 @@ TEST(WebGPUQ4RouteSignal, PreservesStaticAndRecordsBothDynamicSignals) {
   EXPECT_TRUE(explicit_graph.config().record_q4gsw_decode_route);
   EXPECT_EQ(explicit_graph.num_dispatches(), 2);
   expect_dual_q4_topology(explicit_graph);
+}
+
+TEST(WebGPUConv1dRoute, SelectsPointwiseGeneralAndSingleChannelDepthwise) {
+  const Conv1dRouteCase cases[] = {
+      {"pointwise", {1, 4, 8}, {6, 4, 1}, {1, 6, 8}, 1, 0, 1, 1, "conv1d_pw"},
+      {"general", {1, 4, 10}, {6, 4, 3}, {1, 6, 4}, 2, 0, 1, 1, "conv1d"},
+      {"single-channel depthwise",
+       {1, 1, 8},
+       {1, 1, 3},
+       {1, 1, 8},
+       1,
+       1,
+       1,
+       1,
+       "conv1d_dw"},
+  };
+  for (const Conv1dRouteCase& test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    WebGPUGraph graph;
+    build_conv1d_route_graph(graph, test_case);
+    ASSERT_EQ(graph.num_dispatches(), 1);
+    EXPECT_EQ(graph.dispatch_at(0).kernel_name, test_case.expected_kernel);
+  }
 }
 
 TEST(WebGPUComputeDispatch, PipelineKeyCanonicalizesConstants) {

--- a/backends/webgpu/test/native/test_dynamic_shape.cpp
+++ b/backends/webgpu/test/native/test_dynamic_shape.cpp
@@ -18,6 +18,7 @@
 //   F  dyn_rms_chain (rms(rms(x))) at 3 S -> golden (resize CASCADE, DD-4)
 //   G  rms+residual  H rms*x  I dyn_linear  J sdpa_dyn  K emb_dyn  L rope_dyn
 //   M  dyn_sigmoid   N dyn_select (select_copy(0,-1), dynamic S)
+//   O  ONE dyn_conv1d graph reused across live input lengths
 // .pte + goldens from test/ops/dynamic_shape/test_dynamic_shape_export.py.
 //
 // Artifacts dir: $WEBGPU_DYNAMIC_SHAPE_DIR, else argv[1], else
@@ -125,6 +126,42 @@ void check_s(Module& m, const std::string& prefix, int s) {
   EXPECT_LT(e, 1e-3f) << prefix << " S=" << s << " max_err=" << e
                       << " (got.size=" << got.size()
                       << " golden.size=" << golden.size() << ")";
+}
+
+constexpr int kConv1dInChannels = 3;
+constexpr int kConv1dOutChannels = 4;
+constexpr int kConv1dKernel = 3;
+constexpr int kConv1dStride = 2;
+constexpr int kConv1dPadding = 1;
+constexpr int kConv1dDilation = 2;
+
+void check_conv1d(Module& module, int length) {
+  const std::string prefix = g_dir + "/dyn_conv1d.S" + std::to_string(length);
+  auto input = read_bin(prefix + ".input.bin");
+  auto golden = read_bin(prefix + ".golden.bin");
+  ASSERT_EQ(input.size(), static_cast<size_t>(kConv1dInChannels * length));
+  ASSERT_FALSE(golden.empty());
+  auto tensor =
+      make_tensor_ptr({1, kConv1dInChannels, length}, std::move(input));
+  auto result = module.forward({EValue(tensor)});
+  ASSERT_TRUE(
+      result.ok() && result.get().size() == 1 && result.get()[0].isTensor())
+      << "conv1d length=" << length << " forward failed";
+  const auto& output = result.get()[0].toTensor();
+  const int output_length = (length + 2 * kConv1dPadding -
+                             kConv1dDilation * (kConv1dKernel - 1) - 1) /
+          kConv1dStride +
+      1;
+  ASSERT_EQ(output.dim(), 3);
+  ASSERT_EQ(output.size(0), 1);
+  ASSERT_EQ(output.size(1), kConv1dOutChannels);
+  ASSERT_EQ(output.size(2), output_length);
+  const size_t numel = static_cast<size_t>(kConv1dOutChannels * output_length);
+  ASSERT_EQ(static_cast<size_t>(output.numel()), numel);
+  std::vector<float> got(
+      output.const_data_ptr<float>(), output.const_data_ptr<float>() + numel);
+  const float error = max_err(got, golden);
+  EXPECT_LT(error, 1e-3f) << "conv1d length=" << length << " max_err=" << error;
 }
 
 // Dynamic quantized linear: input [M, kLinK] -> output [M, n]. kLinN is the
@@ -890,6 +927,14 @@ TEST(DynamicShape, RmsNormReusedGraph) {
   ASSERT_EQ(m.load_forward(), Error::Ok) << "load dyn_rms.pte";
   for (int s : {128, 1, 64, 8, 128}) {
     check_s(m, "dyn_rms", s);
+  }
+}
+
+TEST(DynamicShape, Conv1dReusedGraph) {
+  Module module(g_dir + "/dyn_conv1d.pte");
+  ASSERT_EQ(module.load_forward(), Error::Ok) << "load dyn_conv1d.pte";
+  for (int length : {16, 9, 5, 16}) {
+    check_conv1d(module, length);
   }
 }
 

--- a/backends/webgpu/test/op_tests/cases.py
+++ b/backends/webgpu/test/op_tests/cases.py
@@ -53,7 +53,11 @@ from executorch.backends.webgpu.test.ops.test_compare import (
     CompareModule,
 )
 from executorch.backends.webgpu.test.ops.test_conv1d_dw import Conv1dDWModule
-from executorch.backends.webgpu.test.ops.test_conv1d_pw import Conv1dPwModule
+from executorch.backends.webgpu.test.ops.test_conv1d_pw import (
+    Conv1dModule,
+    Conv1dPwModule,
+    GENERAL_CONFIGS as _CONV1D_CONFIGS,
+)
 from executorch.backends.webgpu.test.ops.test_conv_with_clamp import ConvWithClampModule
 from executorch.backends.webgpu.test.ops.test_flip import FlipModule
 from executorch.backends.webgpu.test.ops.test_floor_divide import FloorDivideModule
@@ -654,6 +658,55 @@ def _conv1d_dw_suite() -> WebGPUTestSuite:
             case("k3s2p1", 4, 8, 3, 2, 1, 1, True),
             case("dil2", 3, 10, 3, 1, 2, 2, True),
             case("k5_nobias", 5, 7, 5, 1, 0, 1, False),
+            case("single_channel_route", 1, 8, 3, 1, 1, 1, True),
+        ],
+        atol=1e-3,
+        rtol=1e-3,
+    )
+
+
+@register_op_test("conv1d")
+def _conv1d_suite() -> WebGPUTestSuite:
+    # General groups=1 NCL conv1d; fp64 oracle. The neighboring pointwise and
+    # depthwise suites remain routing controls for the two retained fast paths.
+    def case(name, cfg):
+        n, ic, oc, length, kernel, stride, padding, dilation, bias = cfg
+        return Case(
+            name=name,
+            construct={
+                "in_channels": ic,
+                "out_channels": oc,
+                "kernel_size": kernel,
+                "stride": stride,
+                "padding": padding,
+                "dilation": dilation,
+                "bias": bias,
+            },
+            inputs=((n, ic, length),),
+        )
+
+    dynamic_cfg = _CONV1D_CONFIGS["voxtral_stride1"]
+    n, ic, oc, length, kernel, stride, padding, dilation, bias = dynamic_cfg
+    dynamic_length = torch.export.Dim("manifest_conv1d_length", min=7, max=length)
+    return WebGPUTestSuite(
+        module_factory=Conv1dModule,
+        cases=[
+            *[case(name, cfg) for name, cfg in _CONV1D_CONFIGS.items()],
+            Case(
+                name="dynamic_length_10_to_7",
+                construct={
+                    "in_channels": ic,
+                    "out_channels": oc,
+                    "kernel_size": kernel,
+                    "stride": stride,
+                    "padding": padding,
+                    "dilation": dilation,
+                    "bias": bias,
+                },
+                export_inputs=((n, ic, length),),
+                inputs=((n, ic, 7),),
+                dynamic_shapes=({2: dynamic_length},),
+            ),
         ],
         atol=1e-3,
         rtol=1e-3,

--- a/backends/webgpu/test/op_tests/generate_op_tests.py
+++ b/backends/webgpu/test/op_tests/generate_op_tests.py
@@ -55,13 +55,17 @@ def _materialize(spec) -> torch.Tensor:
 
 
 def export_case(suite: WebGPUTestSuite, case) -> tuple[torch.nn.Module, tuple, object]:
-    """Build the module + forward inputs and export to an ExecuTorch program."""
+    """Build the module and export it, returning the live runtime inputs."""
     module = suite.module_factory(**case.construct)
     # Seed so an unseeded-randn input is reproducible across generations (the golden uses
     # the SAME tensor, so this only affects which bytes a case sees, never pass/fail).
     torch.manual_seed(0)
     inputs = tuple(_materialize(s) for s in case.inputs)
-    ep = torch.export.export(module, inputs)
+    export_inputs = inputs
+    if case.export_inputs is not None:
+        torch.manual_seed(0)
+        export_inputs = tuple(_materialize(s) for s in case.export_inputs)
+    ep = torch.export.export(module, export_inputs, dynamic_shapes=case.dynamic_shapes)
     prog = to_edge_transform_and_lower(
         ep, partitioner=[VulkanPartitioner()]
     ).to_executorch()

--- a/backends/webgpu/test/op_tests/test_generator.py
+++ b/backends/webgpu/test/op_tests/test_generator.py
@@ -61,6 +61,27 @@ def test_generate_case_writes_artifacts(tmp_path):
     assert entry["golden"]["output_index"] == 0
 
 
+def test_export_case_separates_upper_bound_from_runtime_inputs(monkeypatch):
+    suite = op_test_registry["conv1d"]
+    case = next(c for c in suite.cases if c.name == "dynamic_length_10_to_7")
+    export_shapes = []
+    exported_dynamic_shapes = []
+    real_export = torch.export.export
+
+    def capture_export(module, inputs, **kwargs):
+        export_shapes.append(tuple(inputs[0].shape))
+        exported_dynamic_shapes.append(kwargs.get("dynamic_shapes"))
+        return real_export(module, inputs, **kwargs)
+
+    monkeypatch.setattr(torch.export, "export", capture_export)
+    _module, runtime_inputs, prog = g.export_case(suite, case)
+
+    assert export_shapes == [(1, 4, 10)]
+    assert exported_dynamic_shapes == [case.dynamic_shapes]
+    assert tuple(runtime_inputs[0].shape) == (1, 4, 7)
+    assert g._has_vulkan_delegate(prog)
+
+
 def test_generate_manifest(tmp_path):
     g.generate(str(tmp_path), ops=["add"])
     manifest = tmp_path / "manifest.json"

--- a/backends/webgpu/test/op_tests/test_suite.py
+++ b/backends/webgpu/test/op_tests/test_suite.py
@@ -58,6 +58,10 @@ class Case:
     required: bool = True
     heavy: bool = False
     golden_fn: Callable | None = None
+    # Optional upper-bound inputs and shape constraints for a dynamic export.
+    # `inputs` remain the live tensors written to the runtime manifest.
+    export_inputs: tuple[Input, ...] | None = None
+    dynamic_shapes: object | None = None
 
     def __post_init__(self) -> None:
         # Mirror kQ4gswConfigs: every heavy config is required=False (export-gated, never FAILs on absence).

--- a/backends/webgpu/test/ops/dynamic_shape/test_dynamic_shape_export.py
+++ b/backends/webgpu/test/ops/dynamic_shape/test_dynamic_shape_export.py
@@ -19,6 +19,7 @@ import unittest
 
 import torch
 from executorch.backends.vulkan.partitioner.vulkan_partitioner import VulkanPartitioner
+from executorch.backends.webgpu.test.ops.test_conv1d_pw import Conv1dModule
 from executorch.exir import to_edge_transform_and_lower
 from executorch.exir.backend.utils import get_delegates, get_non_lowered_nodes
 
@@ -252,9 +253,40 @@ def _write_goldens(model, prefix: str, out_dir: str, s_values) -> None:
         print(f"  golden {prefix} S={s}")
 
 
+def export_dynamic_conv1d_cases(out_dir: str) -> None:
+    """Write one dynamic Conv1d program and live-length runtime fixtures."""
+    os.makedirs(out_dir, exist_ok=True)
+    max_length = 16
+    lengths = (max_length, 9, 5)
+    model = Conv1dModule(
+        in_channels=3,
+        out_channels=4,
+        kernel_size=3,
+        stride=2,
+        padding=1,
+        dilation=2,
+        bias=True,
+    ).eval()
+    length_dim = torch.export.Dim("conv1d_length", min=5, max=max_length)
+    _export(
+        model,
+        (_ramp((1, 3, max_length)),),
+        {"x": {2: length_dim}},
+        os.path.join(out_dir, "dyn_conv1d.pte"),
+    )
+    for length in lengths:
+        x = _ramp((1, 3, length))
+        with torch.no_grad():
+            golden = model(x)
+        prefix = os.path.join(out_dir, f"dyn_conv1d.S{length}")
+        x.detach().numpy().astype("<f4").tofile(prefix + ".input.bin")
+        golden.detach().numpy().astype("<f4").tofile(prefix + ".golden.bin")
+
+
 def export_dynamic_shape_cases(out_dir: str) -> None:
     """Write the dynamic + static .pte's and per-S goldens for the native test."""
     os.makedirs(out_dir, exist_ok=True)
+    export_dynamic_conv1d_cases(out_dir)
     s_dim = torch.export.Dim("s", min=1, max=MAXS)
 
     # 1) Single dynamic rms_norm, graph built at S=MAXS (upper bound).
@@ -1536,6 +1568,13 @@ class TestDynamicShapeExport(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(d, "dyn_rms.pte")))
             self.assertTrue(os.path.exists(os.path.join(d, "dyn_rms.S1.golden.bin")))
             expected = [
+                "dyn_conv1d.pte",
+                "dyn_conv1d.S16.input.bin",
+                "dyn_conv1d.S16.golden.bin",
+                "dyn_conv1d.S9.input.bin",
+                "dyn_conv1d.S9.golden.bin",
+                "dyn_conv1d.S5.input.bin",
+                "dyn_conv1d.S5.golden.bin",
                 "dyn_linear_bk64.pte",
                 "dyn_linear_bk64.S512.input.bin",
                 "dyn_linear_bk64.S512.golden.bin",

--- a/backends/webgpu/test/ops/test_conv1d_pw.py
+++ b/backends/webgpu/test/ops/test_conv1d_pw.py
@@ -27,12 +27,54 @@ CONFIGS = {
     "batch2": (2, 3, 4, 5, True),
 }
 
+# name -> batch, in_channels, out_channels, L, kernel, stride, padding,
+# dilation, bias
+GENERAL_CONFIGS = {
+    "voxtral_stride1": (1, 4, 6, 10, 3, 1, 0, 1, True),
+    "voxtral_stride2": (1, 6, 5, 10, 3, 2, 0, 1, True),
+    "no_bias": (1, 3, 2, 9, 3, 1, 0, 1, False),
+    "padded": (1, 3, 4, 9, 3, 1, 1, 1, True),
+    "dilated": (1, 2, 3, 11, 3, 1, 2, 2, True),
+    "batch2": (2, 3, 4, 8, 3, 2, 1, 1, True),
+}
+
 
 class Conv1dPwModule(torch.nn.Module):
     def __init__(self, in_channels, out_channels, bias) -> None:
         super().__init__()
         g = torch.Generator().manual_seed(0)
         self.conv = torch.nn.Conv1d(in_channels, out_channels, 1, bias=bias)
+        with torch.no_grad():
+            self.conv.weight.normal_(generator=g)
+            if bias:
+                self.conv.bias.normal_(generator=g)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+class Conv1dModule(torch.nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        bias,
+    ) -> None:
+        super().__init__()
+        g = torch.Generator().manual_seed(0)
+        self.conv = torch.nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias,
+        )
         with torch.no_grad():
             self.conv.weight.normal_(generator=g)
             if bias:
@@ -54,6 +96,14 @@ def _lower(cfg):
     return to_edge_transform_and_lower(ep, partitioner=[VulkanPartitioner()])
 
 
+def _lower_general(cfg, dynamic_shapes=None):
+    n, ic, oc, length, kernel, stride, padding, dilation, bias = cfg
+    module = Conv1dModule(ic, oc, kernel, stride, padding, dilation, bias).eval()
+    inputs = (_det_input((n, ic, length)),)
+    ep = torch.export.export(module, inputs, dynamic_shapes=dynamic_shapes)
+    return to_edge_transform_and_lower(ep, partitioner=[VulkanPartitioner()])
+
+
 def _delegated(et) -> bool:
     return any(
         d.id == "VulkanBackend"
@@ -63,9 +113,19 @@ def _delegated(et) -> bool:
 
 
 def _op_delegated(edge, op_substr: str) -> bool:
-    # op must be absorbed into the delegate, not left as a top-level CPU-fallback node.
+    # The op must be absorbed into a delegate: absent from the top-level graph AND
+    # present inside a lowered submodule reached by an executorch_call_delegate node
+    # (a bare absence check also passes for an empty graph or a renamed op).
+    from executorch.exir.lowered_backend_module import get_lowered_submodules
+
     gm = edge.exported_program().graph_module
-    return all(op_substr not in str(getattr(n, "target", "")) for n in gm.graph.nodes)
+    if any(op_substr in str(getattr(n, "target", "")) for n in gm.graph.nodes):
+        return False
+    return any(
+        op_substr in str(getattr(dn, "target", ""))
+        for _, lowered, _ in get_lowered_submodules(gm)
+        for dn in lowered.original_module.graph_module.graph.nodes
+    )
 
 
 class Conv1dPwTest(unittest.TestCase):
@@ -82,3 +142,24 @@ class Conv1dPwTest(unittest.TestCase):
                     _op_delegated(edge, "convolution"),
                     f"conv1d not delegated (fell back to CPU) for {name}",
                 )
+
+
+class Conv1dTest(unittest.TestCase):
+    def test_export_delegates(self) -> None:
+        for name, cfg in GENERAL_CONFIGS.items():
+            with self.subTest(name=name):
+                edge = _lower_general(cfg)
+                self.assertTrue(
+                    _delegated(edge.to_executorch()),
+                    f"Expected a VulkanBackend delegate (conv1d {name})",
+                )
+                self.assertTrue(
+                    _op_delegated(edge, "convolution"),
+                    f"conv1d not delegated (fell back to CPU) for {name}",
+                )
+
+    def test_dynamic_length_export_delegates(self) -> None:
+        length = torch.export.Dim("conv1d_length", min=5, max=16)
+        edge = _lower_general(GENERAL_CONFIGS["padded"], dynamic_shapes=({2: length},))
+        self.assertTrue(_delegated(edge.to_executorch()))
+        self.assertTrue(_op_delegated(edge, "convolution"))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #21602
* __->__ #21601
* #21600
* #21599
* #21598
* #21597
* #21483
* #21451
* #21450
* #21449
* #21448
* #21136
* #21135
* #21134
* #21133
* #21132
* #21131
* #21130
* #21129
* #21128
* #21127

**Cover Conv1d routing, resize, and dynamic manifest replay**

Static numeric coverage pins the general groups=1 Conv1d kernel while preserving pointwise and depthwise routing. The manifest harness now separates upper-bound export inputs from live runtime inputs so dynamic execution proves a distinct shape through one loaded graph.

Key changes:

- Dispatch assertions distinguish general, pointwise, and depthwise Conv1d routes.
- Numeric cases cover padding, dilation, batching, optional bias, and dynamic resize.
- `Case.export_inputs` and `Case.dynamic_shapes` carry export-time samples and constraints while `Case.inputs` remains the live runtime input.
- Generator coverage proves export length 10 and runtime length 7.

This is coverage-only; runtime kernels are unchanged.

Co-authored-with: Claude Code.

Differential Revision: [D114936144](https://our.internmc.facebook.com/intern/diff/D114936144/)