### PR TITLE
Test permutation-sink view that splits the non-unit dim

### DIFF
--- a/backends/transforms/test/test_permute_optimization_passes.py
+++ b/backends/transforms/test/test_permute_optimization_passes.py
@@ -1098,6 +1098,45 @@ class RemovePermutesAcrossViewTest(unittest.TestCase):
             "upstream_view_rank_mismatch_no_crash",
         )
 
+    def test_permutation_sink_view_splitting_the_non_unit_dim(self) -> None:
+        """A reshape whose input has a single non-unit dim is a permutation sink
+        even when it splits that dim rather than flattening it:
+        (1, 1, 1, 4) -> (1, 2, 2) walks the same elements under any layout, so
+        the upstream permute is dropped with no compensating permute and the
+        view's shape arg must be left untouched."""
+        x_data = torch.randn(1, 4, 1, 1)
+        builder = GraphBuilder()
+        x = builder.placeholder("x", x_data)
+        permute = builder.call_operator(
+            op=exir_ops.edge.aten.permute_copy.default, args=(x, [0, 2, 3, 1])
+        )
+        mul = builder.call_operator(
+            op=exir_ops.edge.aten.mul.Tensor, args=(permute, permute)
+        )
+        view = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default, args=(mul, [1, 2, 2])
+        )
+        builder.output([view])
+        original = builder.get_graph_module()
+        gm_before = copy.deepcopy(original)
+
+        p = RemovePermutesAroundElementwiseOps()
+        result = cast(PassResult, p(original))
+        self.assertTrue(result.modified)
+        self.assertEqual(
+            count_node(result.graph_module, exir_ops.edge.aten.permute_copy.default), 0
+        )
+        (view_after,) = result.graph_module.graph.find_nodes(
+            op="call_function", target=exir_ops.edge.aten.view_copy.default
+        )
+        self.assertEqual(view_after.args[1], [1, 2, 2])
+        validate_numerics(
+            gm_before,
+            result.graph_module,
+            [x_data],
+            "permutation_sink_view_splitting_the_non_unit_dim",
+        )
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Tests for RemovePermutesAroundElementwiseOps


### PR DESCRIPTION
Summary:
`RemovePermutesAroundElementwiseOps._is_permutation_sink_view` treats a reshape
whose input has at most one non-unit dim as a point where an incoming
permutation dies, so the region terminates there with no compensating permute.

Existing coverage only exercised the global-pool flatten shape
(`[1, C, 1, 1] -> [1, C]`), and lived in
`on_device_ai/sas_compiler/tests/test_optimizations.py` wired through
fused_quant ops. But the sink is generic base-class behavior, and the path that
reaches real models is the Cadence subclass via `CommonRemovePasses` -- no
fused_quant involved. It also fires on reshapes that *split* the non-unit dim
rather than flatten it: on the POR `hand_detection_400` model the sink triggers
on `(1, 4, 1, 1) -> (1, 2, 2)`.

Add a generic test for that shape in the shared ExecuTorch pass test file. It
asserts:

- the upstream permute is removed
- the sink view's shape arg is left untouched -- the sink view is deliberately
  not added to `subgraph.nodes`, so `update_view_copy` must never rewrite it
- numerics match before/after (`validate_numerics`)

Test-only change; no pass behavior is modified. Mirrored into the fbcode and
xplat copies of the file.

Differential Revision: D114941738


