### PR TITLE
Point ExecuTorch and AOTInductor at the real TORCH_CHECK

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -1,9 +1,8 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def get_preprocessor_flags(is_fbcode):
-    flags = ["-DSTANDALONE_TORCH_HEADER"]
     if runtime.is_oss:
-        return flags
+        return []
     # AT_BUILD_ARM_VEC256_WITH_SLEEF is off on Windows because Sleef
     # is off on Windows per get_sleef_deps below.
     arm64_flags = select({
@@ -31,7 +30,7 @@ def get_preprocessor_flags(is_fbcode):
         "ovr_config//cpu:arm64": arm64_flags,
         "DEFAULT": default_flags,
     })
-    return flags + ["-DET_USE_PYTORCH_HEADERS=ET_HAS_EXCEPTIONS"] + (fbcode_flags if is_fbcode else non_fbcode_flags)
+    return ["-DET_USE_PYTORCH_HEADERS=ET_HAS_EXCEPTIONS"] + (fbcode_flags if is_fbcode else non_fbcode_flags)
 
 def get_sleef_deps():
     if runtime.is_oss:


### PR DESCRIPTION
Summary:
## Why

Clears the **multiple ODR violations** carried by any binary that links both
ExecuTorch and libtorch. This is the diff that does it; the previous diff in the
stack is the prerequisite refactor.

## How

With `c10::Error` and `torchCheckFail()` now header-only, nothing needs
`STANDALONE_TORCH_HEADER` any more. This removes it at both definers -- the
ExecuTorch build config and AOTInductor's `cpp_builder` -- and deletes the second
`TORCH_CHECK` expansion it selected. One expansion means one definition of every
header-inline c10 function that uses `TORCH_CHECK`.

Libtorch-independent consumers do not regress: they now get the real
`c10::Error` with the real message, and simply no symbolized C++ stack unless a
backtrace fetcher is installed.

## Behaviour change worth noting

`TORCH_CHECK` in those builds now throws `c10::Error` instead of
`std::runtime_error`. `c10::Error` derives from `std::exception`, *not* from
`std::runtime_error`, so any `catch (const std::runtime_error&)` written around
a `TORCH_CHECK` in a flag-setting build will stop catching and needs updating.

Differential Revision: D114896618


