### PR TITLE
Run coreml_static_int8 macOS tests on the nightly schedule only

### DIFF
--- a/.github/workflows/test-backend-coreml.yml
+++ b/.github/workflows/test-backend-coreml.yml
@@ -38,10 +38,13 @@ jobs:
     uses: ./.github/workflows/_test_backend.yml
     with:
       backend: coreml
+      # The heavier coreml_static_int8 macOS matrix saturates the shared
+      # macOS runner pool, so run it only on the nightly schedule. Every-commit
+      # events (push, pull_request) run the lighter coreml flow only.
       flows: >-
-        ${{ github.event_name == 'pull_request'
-            && '["coreml"]'
-            || '["coreml", "coreml_static_int8"]' }}
+        ${{ github.event_name == 'schedule'
+            && '["coreml", "coreml_static_int8"]'
+            || '["coreml"]' }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 180
       run-macos: true


### PR DESCRIPTION
### Problem
The CoreML backend test workflow (`test-backend-coreml.yml`) runs its macOS jobs on every commit. On busy days the `coreml_static_int8` macOS jobs (the slowest variant) queue for hours and saturate the shared macOS runner pool, which blocks other required macOS jobs from starting. When those required jobs never run, no commit completes its required checks.

### Fix
Run the heavier `coreml_static_int8` macOS matrix only on the nightly `schedule`. Pushes and pull requests keep running the lighter `coreml` flow. This roughly halves this workflow's per-commit macOS load while keeping full `coreml_static_int8` coverage nightly.

Note: this workflow runs macOS only (`run-linux` is not set), so Linux coverage is unchanged.