### PR TITLE
Arm backend: Add linting for banned functions

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -11,7 +11,7 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/_claude-code.yml@main
     with:
       setup_script: |
-        pip install lintrunner==0.12.7 lintrunner-adapters==0.14.0
+        pip install lintrunner==0.12.7 lintrunner-adapters==0.14.1
         pip install -r requirements-lintrunner.txt
         lintrunner init
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install lintrunner==0.12.7 lintrunner-adapters==0.14.0
+          pip install lintrunner==0.12.7 lintrunner-adapters==0.14.1
           pip install -r requirements-lintrunner.txt
           USE_CPP=0 pip install --no-build-isolation third-party/ao
           pip install pytest numpy parameterized huggingface_hub transformers timm expecttest types-requests
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install lintrunner and linters
         run: |
-          pip install lintrunner==0.12.7 lintrunner-adapters==0.14.0
+          pip install lintrunner==0.12.7 lintrunner-adapters==0.14.1
           pip install -r requirements-lintrunner.txt
           lintrunner init
 

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -732,3 +732,28 @@ init_command = [
   '--requirement=requirements-lintrunner.txt',
 ]
 is_formatter = true
+
+
+[[linter]]
+code = 'CPP_BANNED_FUNCTIONS'
+include_patterns = [
+    'examples/arm/**/*.c',
+    'examples/arm/**/*.cc',
+    'examples/arm/**/*.cpp',
+    'examples/arm/**/*.h',
+    'examples/arm/**/*.hpp',
+]
+exclude_patterns = [
+    'third-party/**',
+    '**/third-party/**',
+]
+command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'cpp_banned_functions_linter',
+    '--config=backends/arm/scripts/banned_functions.json',
+    '--',
+    '@{{PATHSFILE}}',
+]

--- a/backends/arm/scripts/LICENSE-MIT
+++ b/backends/arm/scripts/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backends/arm/scripts/banned_functions.json
+++ b/backends/arm/scripts/banned_functions.json
@@ -1,0 +1,107 @@
+{
+  "banned_functions": [
+    {
+      "names": ["alloca"],
+      "replacements": ["malloc", "new"]
+    },
+    {
+      "names": ["gets"],
+      "replacements": ["fgets"]
+    },
+    {
+      "names": ["memcpy"],
+      "replacements": ["memcpy_s"]
+    },
+    {
+      "names": ["wmemcpy"],
+      "replacements": ["wmemcpy_s"]
+    },
+    {
+      "names": ["memmove"],
+      "replacements": ["memmove_s"]
+    },
+    {
+      "names": ["wmemmove"],
+      "replacements": ["wmemmove_s"]
+    },
+    {
+      "names": ["readdir_r"],
+      "replacements": ["readdir"]
+    },
+    {
+      "names": ["scanf", "wscanf", "_tscanf", "sscanf", "swscanf", "_stscanf"],
+      "replacements": ["fgets"]
+    },
+    {
+      "names": [
+        "strcat",
+        "wcscat",
+        "_tcscat",
+        "_mbscat",
+        "StrCat",
+        "lstrcat",
+        "lStrCatBuff",
+        "_tccat",
+        "_mbccat",
+        "_ftcscat",
+        "strncat",
+        "wcsncat",
+        "_tcsncat",
+        "_mbsncat",
+        "_mbsnbcat",
+        "StrCatN",
+        "StrNCat",
+        "lstrncat",
+        "lstrcatn"
+      ],
+      "replacements": ["strcat_s", "strncat_s"]
+    },
+    {
+      "names": [
+        "strcpy",
+        "wcscpy",
+        "_tcscpy",
+        "_mbscpy",
+        "StrCpy",
+        "lstrcpy",
+        "_tccpy",
+        "_mbccpy",
+        "_ftcscpy",
+        "strncpy",
+        "wcsncpy",
+        "_tcsncpy",
+        "_mbsncpy",
+        "_mbsnbcpy",
+        "StrCpyN",
+        "StrNCpy",
+        "lstrcpyn"
+      ],
+      "replacements": ["strcpy_s", "strncpy_s"]
+    },
+    {
+      "names": ["strlen"],
+      "replacements": ["strnlen_s"]
+    },
+    {
+      "names": ["wcslen"],
+      "replacements": ["wcsnlen_s"]
+    },
+    {
+      "names": ["strtok", "_tcstok", "wcstok", "_mbstok"],
+      "replacements": ["strtok_s"]
+    },
+    {
+      "names": [
+        "wsprintf",
+        "sprintf",
+        "swprintf",
+        "_stprintf",
+        "wvsprintf",
+        "vsprintf",
+        "_vstprintf",
+        "vswprintf"
+      ],
+      "replacements": ["snprintf", "snprintf_s"]
+    }
+  ]
+}

--- a/backends/arm/scripts/banned_functions.json.license
+++ b/backends/arm/scripts/banned_functions.json.license
@@ -1,0 +1,5 @@
+SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+SPDX-License-Identifier: MIT
+
+File copied from https://github.com/justinchuby/lintrunner-adapters/ which has an MIT license.
+File permalink: https://github.com/justinchuby/lintrunner-adapters/blob/772e5936d9b02814e29e12ca1355d33b029688c2/examples/adapters/cpp_banned_functions_linter/example_banned_functions.json

--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -485,7 +485,10 @@ Error prepare_input_tensors(
       } else if (input_evalues[i].isTensor()) {
         // Copy the data from the input buffer to the tensor
         Tensor& tensor = input_evalues[i].toTensor();
-        std::memcpy(tensor.mutable_data_ptr<int8_t>(), buffer, buffer_size);
+        std::memcpy( // NOLINT(memcpy) - Buffer size is checked
+            tensor.mutable_data_ptr<int8_t>(),
+            buffer,
+            buffer_size);
       }
     }
 

--- a/repro_mypy_ci.sh
+++ b/repro_mypy_ci.sh
@@ -29,7 +29,7 @@ run_in_env() {
 
 run_in_env python -m pip install --upgrade pip
 run_in_env python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-run_in_env python -m pip install lintrunner==0.12.7 lintrunner-adapters==0.14.0
+run_in_env python -m pip install lintrunner==0.12.7 lintrunner-adapters==0.14.1
 run_in_env python -m pip install -r requirements-lintrunner.txt
 run_in_env lintrunner init
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ wheel  # For building the pip package archive.
 zstd  # Imported by resolve_buck.py.
 certifi  # Imported by resolve_buck.py.
 lintrunner==0.12.7
-lintrunner-adapters==0.14.0
+lintrunner-adapters==0.14.1
 ruff==0.15.4
 
 pytest<9.0


### PR DESCRIPTION
* Use CPP_BANNED_FUNCTIONS linter in lintrunner
* Bump lintrunner-adapters version

Signed-off-by: Tom Allsop <tom.allsop@arm.com>

Change-Id: Ic93db54b4de0e2248fff61d081bc066d4520db3e

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani