### PR TITLE
[EIEX-844] Use neutron kernel names in profiling table

### DIFF
--- a/backends/nxp/runtime/NeutronBackend.cpp
+++ b/backends/nxp/runtime/NeutronBackend.cpp
@@ -636,6 +636,11 @@ class NeutronBackend final : public PyTorchBackendInterface {
           index++;
         }
       }
+      NeutronSdkVersion neutron_sdk_version = neutronGetSdkVersion();
+      uint16_t neutron_sdk_version_uint16 =
+          static_cast<const uint16_t>(neutron_sdk_version.major << 8) |
+          static_cast<const uint16_t>(neutron_sdk_version.minor << 4) |
+          static_cast<const uint16_t>(neutron_sdk_version.patch);
       event_tracer_log_profiling_delegate(
           tracer,
           nullptr,
@@ -643,9 +648,8 @@ class NeutronBackend final : public PyTorchBackendInterface {
           neutron_events[events_num - 1].startEvent.time,
           neutron_events[events_num - 1].stopEvent.time + stop_ticks -
               start_ticks,
-          static_cast<const void*>(
-              &neutron_events[events_num - 1].startEvent.functionCode),
-          sizeof(uint8_t));
+          static_cast<const void*>(&neutron_sdk_version_uint16),
+          sizeof(uint16_t));
     }
 #endif
 

--- a/backends/nxp/runtime/NeutronBackend.cpp
+++ b/backends/nxp/runtime/NeutronBackend.cpp
@@ -636,6 +636,8 @@ class NeutronBackend final : public PyTorchBackendInterface {
           index++;
         }
       }
+      // The neutronGetSdkVersion() function is available starting with Neutron Software 3.2.1.
+      // The code below is not backward compatible with earlier Neutron Software versions.
       NeutronSdkVersion neutron_sdk_version = neutronGetSdkVersion();
       uint16_t neutron_sdk_version_uint16 =
           static_cast<const uint16_t>(neutron_sdk_version.major << 8) |

--- a/backends/nxp/runtime/NeutronBackend.cpp
+++ b/backends/nxp/runtime/NeutronBackend.cpp
@@ -636,8 +636,9 @@ class NeutronBackend final : public PyTorchBackendInterface {
           index++;
         }
       }
-      // The neutronGetSdkVersion() function is available starting with Neutron Software 3.2.1.
-      // The code below is not backward compatible with earlier Neutron Software versions.
+      // The neutronGetSdkVersion() function is available starting with Neutron
+      // Software 3.2.1. The code below is not backward compatible with earlier
+      // Neutron Software versions.
       NeutronSdkVersion neutron_sdk_version = neutronGetSdkVersion();
       uint16_t neutron_sdk_version_uint16 =
           static_cast<const uint16_t>(neutron_sdk_version.major << 8) |

--- a/backends/nxp/runtime/NeutronDriver.h
+++ b/backends/nxp/runtime/NeutronDriver.h
@@ -124,6 +124,14 @@ typedef struct {
   void (*wait)(uint32_t channel);
 } NeutronConfig;
 
+/// This structure contains a semantic version of the Neutron SDK in the form
+/// major.minor.patch.
+typedef struct {
+  uint32_t major;
+  uint32_t minor;
+  uint32_t patch;
+} NeutronSdkVersion;
+
 /* Invalid handle, returned by neutronModelPrepare() if an error occurred. */
 #define NEUTRON_INVALID_HANDLE NULL
 
@@ -223,6 +231,9 @@ NeutronError neutronSetConfig(NeutronConfig* config);
 
 /// - Used to get NeutronContext size.
 size_t neutronGetModelContextSize();
+
+/// - Used to get Neutron SDK version.
+NeutronSdkVersion neutronGetSdkVersion();
 
 /// - Allocates size bytes and returns a pointer to the allocated memory.
 ///   The returned pointer address will be a multiple of the alignment.

--- a/backends/nxp/runtime/NeutronDriver.h
+++ b/backends/nxp/runtime/NeutronDriver.h
@@ -124,14 +124,14 @@ typedef struct {
   void (*wait)(uint32_t channel);
 } NeutronConfig;
 
-/// This structure contains semantic version of the Neutron SDK (major.minor.patch)
-/// and the SHA version (string and uint32_t).
+/// This structure contains semantic version of the Neutron SDK
+/// (major.minor.patch) and the SHA version (string and uint32_t).
 typedef struct {
-    uint32_t major;
-    uint32_t minor;
-    uint32_t patch;
-    const char *hashString;
-    uint32_t hashUint32;
+  uint32_t major;
+  uint32_t minor;
+  uint32_t patch;
+  const char* hashString;
+  uint32_t hashUint32;
 } NeutronSdkVersion;
 
 /* Invalid handle, returned by neutronModelPrepare() if an error occurred. */

--- a/backends/nxp/runtime/NeutronDriver.h
+++ b/backends/nxp/runtime/NeutronDriver.h
@@ -124,12 +124,14 @@ typedef struct {
   void (*wait)(uint32_t channel);
 } NeutronConfig;
 
-/// This structure contains a semantic version of the Neutron SDK in the form
-/// major.minor.patch.
+/// This structure contains semantic version of the Neutron SDK (major.minor.patch)
+/// and the SHA version (string and uint32_t).
 typedef struct {
-  uint32_t major;
-  uint32_t minor;
-  uint32_t patch;
+    uint32_t major;
+    uint32_t minor;
+    uint32_t patch;
+    const char *hashString;
+    uint32_t hashUint32;
 } NeutronSdkVersion;
 
 /* Invalid handle, returned by neutronModelPrepare() if an error occurred. */

--- a/backends/nxp/tests/generic_tests/test_profiling.py
+++ b/backends/nxp/tests/generic_tests/test_profiling.py
@@ -22,6 +22,11 @@ from executorch.backends.nxp.tests.nsys_testing import (
     OUTPUTS_DIR,
 )
 
+from executorch.backends.nxp.tests.profiling_utils import (
+    get_neutron_converter_version,
+    get_neutron_driver_version,
+    get_neutron_kernel_kinds,
+)
 from executorch.devtools.inspector._inspector import Inspector
 from executorch.examples.models.mlperf_tiny import (
     DeepAutoEncoder,
@@ -65,12 +70,15 @@ def inspector_check(test_name: str) -> None:
       5. The profiling dump event does not have associated op types.
     """
 
+    # Global mapping of Neutron kernel IDs to names used by the delegate metadata parser.
+    kernel_kinds = {}
+
     def parse_delegate_metadata(
         delegate_metadatas: list[bytes],
     ) -> Union[list[str], dict[str, Any]]:
         """Metadata parser for Neutron Backend metadata.
 
-        The parser is a callable that deserializes the data and returns neutron kernel number.
+        The parser deserializes delegate metadata and converts kernel IDs into human-readable kernel names when available.
         The deserialized data is then added back to the corresponding event in the event block for user consumption.
         """
 
@@ -81,7 +89,13 @@ def inspector_check(test_name: str) -> None:
                 if function_code == 0:
                     metadata_list.append("Profiling dump")
                 else:
-                    metadata_list.append("Neutron kernel " + str(function_code))
+                    metadata_list.append(
+                        kernel_kinds.get(
+                            function_code, "Neutron kernel " + str(function_code)
+                        )
+                    )
+            elif len(metadata_bytes) == 2:
+                metadata_list.append("Profiling dump")
             else:
                 metadata_list.append("Invalid metadata size")
         return metadata_list
@@ -95,6 +109,16 @@ def inspector_check(test_name: str) -> None:
         assert os.path.isfile(
             file_path
         ), f"Required profiling file does not exist: {file_path}"
+
+    # Validate driver/converter version compatibility and load kernel names
+    # used to decode delegate metadata.
+    driver_version = get_neutron_driver_version(etdump_path)
+    converter_version = get_neutron_converter_version()
+    if driver_version:
+        assert (
+            driver_version == converter_version
+        ), "Driver and converter versions do not match"
+        kernel_kinds = get_neutron_kernel_kinds()
 
     # Create Inspector and parse profiling data.
     try:
@@ -123,18 +147,22 @@ def inspector_check(test_name: str) -> None:
 
     assert numeric_events, "No numeric delegate profiling events found"
 
-    # All delegate events except the last one should describe
-    # individual Neutron kernels.
+    # All numeric delegate events except the last contain either
+    # resolved kernel names or fallback "Neutron kernel <id>" metadata.
     for event in numeric_events[:-1]:
-        metadata = str(event.delegate_debug_metadatas)
-
-        assert "Neutron kernel" in metadata, (
-            f"Event {event.name}: expected 'Neutron kernel', " f"got {metadata}"
-        )
+        metadata = event.delegate_debug_metadatas
+        if kernel_kinds:
+            assert "Neutron kernel" not in metadata, (
+                f"Event {event.name}: expected kernel kind, " f"got {metadata}"
+            )
+        else:
+            assert "Neutron kernel" in metadata, (
+                f"Event {event.name}: expected 'Neutron kernel', " f"got {metadata}"
+            )
 
     # The final numeric event should represent the profiling dump.
     profiling_dump_event = numeric_events[-1]
-    profiling_metadata = str(profiling_dump_event.delegate_debug_metadatas)
+    profiling_metadata = profiling_dump_event.delegate_debug_metadatas
 
     assert "Profiling dump" in profiling_metadata, (
         f"Event {profiling_dump_event.name}: "
@@ -142,7 +170,7 @@ def inspector_check(test_name: str) -> None:
     )
 
     # Profiling dump event is expected to have no associated operators.
-    assert profiling_dump_event.op_types == [], (
+    assert not profiling_dump_event.op_types, (
         f"Event {profiling_dump_event.name}: expected empty op_types, "
         f"got {profiling_dump_event.op_types}"
     )

--- a/backends/nxp/tests/generic_tests/test_profiling.py
+++ b/backends/nxp/tests/generic_tests/test_profiling.py
@@ -23,7 +23,7 @@ from executorch.backends.nxp.tests.nsys_testing import (
 )
 
 from executorch.backends.nxp.tests.profiling_utils import (
-    get_neutron_converter_version,
+    get_neutron_compiler_version,
     get_neutron_driver_version,
     get_neutron_kernel_kinds,
 )
@@ -110,14 +110,14 @@ def inspector_check(test_name: str) -> None:
             file_path
         ), f"Required profiling file does not exist: {file_path}"
 
-    # Validate driver/converter version compatibility and load kernel names
+    # Validate driver/compiler version compatibility and load kernel names
     # used to decode delegate metadata.
     driver_version = get_neutron_driver_version(etdump_path)
-    converter_version = get_neutron_converter_version()
+    compiler_version = get_neutron_compiler_version()
     if driver_version:
         assert (
-            driver_version == converter_version
-        ), "Driver and converter versions do not match"
+            driver_version == compiler_version
+        ), "Driver and compiler versions do not match"
         kernel_kinds = get_neutron_kernel_kinds()
 
     # Create Inspector and parse profiling data.

--- a/backends/nxp/tests/profiling_utils.py
+++ b/backends/nxp/tests/profiling_utils.py
@@ -65,21 +65,21 @@ def get_neutron_driver_version(etdump_path: str) -> str:
         return ""
 
 
-def get_neutron_converter_version() -> str:
+def get_neutron_compiler_version() -> str:
     """
-    Get the Neutron Converter version reported by the neutron_converter tool.
+    Get the Neutron Compiler version reported by the neutron_compiler tool.
 
-    Executes `neutron_converter --version` and returns the version as
+    Executes `neutron_compiler --version` and returns the version as
     {major}.{minor}.{patch} string.
 
-    :return: The version string returned by neutron_converter, or empty string if
+    :return: The version string returned by neutron_compiler, or empty string if
     the command fails, times out, or the executable is not available.
     Errors are logged instead of being raised.
     """
 
     try:
         proc = subprocess.Popen(
-            ["neutron_converter", "--version"],
+            ["neutron_compiler", "--version"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
@@ -87,7 +87,7 @@ def get_neutron_converter_version() -> str:
         stdout, stderr = proc.communicate(timeout=10)
         if proc.returncode != 0:
             logging.error(
-                "Failed to get converter version: %s",
+                "Failed to get compiler version: %s",
                 stderr.strip(),
             )
             return ""
@@ -96,31 +96,31 @@ def get_neutron_converter_version() -> str:
             return version_match.group(1)
         else:
             logging.exception(
-                "Unexpected error while getting neutron converter version"
+                "Unexpected error while getting neutron compiler version"
             )
             return ""
     except Exception:
-        logging.exception("Error while getting neutron converter version")
+        logging.exception("Error while getting neutron compiler version")
         return ""
 
 
 def get_neutron_kernel_kinds(target: str = "imxrt700") -> dict[int, str]:
     """
-    Retrieve kernel kinds supported by neutron_converter for the specified target.
+    Retrieve kernel kinds supported by neutron_compiler for the specified target.
 
-    Executes the neutron_converter command with the --show-kernel-kinds option,
+    Executes the neutron_compiler command with the --show-kernel-kinds option,
     parses its output, and returns a dictionary mapping kernel IDs to kernel
     names.
 
     :param target: Target platform for which kernel kinds should be queried.
     Defaults to "imxrt700".
-    :return: Returns empty dict if neutron_converter exits with an error.
+    :return: Returns empty dict if neutron_compiler exits with an error.
     Otherwise, a dictionary where:
             - key: kernel ID (int)
             - value: kernel name (str)
     """
     proc = subprocess.Popen(
-        ["neutron_converter", "--target", target, "--show-kernel-kinds"],
+        ["neutron_compiler", "--target", target, "--show-kernel-kinds"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
@@ -128,7 +128,7 @@ def get_neutron_kernel_kinds(target: str = "imxrt700") -> dict[int, str]:
     stdout, stderr = proc.communicate(timeout=10)
     if proc.returncode != 0:
         logging.error(
-            "Failed to get kernrl kinds from neutron_converter: %s",
+            "Failed to get kernrl kinds from neutron_compiler: %s",
             stderr.strip(),
         )
         return {}

--- a/backends/nxp/tests/profiling_utils.py
+++ b/backends/nxp/tests/profiling_utils.py
@@ -1,0 +1,138 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import re
+import subprocess
+
+from executorch.devtools.etdump.serialize import deserialize_from_etdump_flatcc
+
+
+def get_neutron_driver_version(etdump_path: str) -> str:
+    """
+    Extract the Neutron Driver version from an ETDump file.
+
+    The Neutron Driver version is stored in the metadata of the last Neutron
+    delegate event. This event is emitted when the profiling dump is generated.
+    The version is encoded as a 16-bit value in little-endian format:
+    - 4 bits  - major version
+    - 4 bits  - minor version
+    - 4 bits  - patch version
+    - 4 bits  - reserved
+
+    :param etdump_path: Path to the ETDump binary file.
+    :return: Neutron Driver version string (e.g. "1.2.3") if successfully decoded,
+    otherwise empty string. Errors are logged instead of raised.
+    """
+
+    try:
+        with open(etdump_path, "rb") as f:
+            data = f.read()
+        etdump = deserialize_from_etdump_flatcc(data)
+    except Exception as e:
+        logging.exception("Failed to load ETDump: %s", e)
+        return ""
+
+    events = []
+    try:
+        for run in etdump.run_data:
+            for event in run.events:
+                profile_event = getattr(event, "profile_event", None)
+                if (
+                    profile_event is not None
+                    and getattr(profile_event, "delegate_debug_id_int", 0) > 0
+                ):
+                    events.append(event)
+    except Exception as e:
+        logging.exception("Failed while processing events: %s", e)
+        return ""
+
+    try:
+        metadata = events[-1].profile_event.delegate_debug_metadata
+        if not metadata or len(metadata) < 2:
+            logging.error("Invalid delegate_debug_metadata")
+            return ""
+
+        major, minor, patch = [
+            (int.from_bytes(metadata, "little") >> shift) & 0xF for shift in (8, 4, 0)
+        ]
+        return f"{major}.{minor}.{patch}"
+
+    except Exception as e:
+        logging.exception("Failed to extract version from metadata: %s", e)
+        return ""
+
+
+def get_neutron_converter_version() -> str:
+    """
+    Get the Neutron Converter version reported by the neutron_converter tool.
+
+    Executes `neutron_converter --version` and returns the version as
+    {major}.{minor}.{patch} string.
+
+    :return: The version string returned by neutron_converter, or empty string if
+    the command fails, times out, or the executable is not available.
+    Errors are logged instead of being raised.
+    """
+
+    try:
+        proc = subprocess.Popen(
+            ["neutron_converter", "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        stdout, stderr = proc.communicate(timeout=10)
+        if proc.returncode != 0:
+            logging.error(
+                "Failed to get converter version: %s",
+                stderr.strip(),
+            )
+            return ""
+        version_match = re.search(r"version\s(\d+\.\d+\.\d+)", stdout)
+        if version_match:
+            return version_match.group(1)
+        else:
+            logging.exception(
+                "Unexpected error while getting neutron converter version"
+            )
+            return ""
+    except Exception:
+        logging.exception("Error while getting neutron converter version")
+        return ""
+
+
+def get_neutron_kernel_kinds(target: str = "imxrt700") -> dict[int, str]:
+    """
+    Retrieve kernel kinds supported by neutron_converter for the specified target.
+
+    Executes the neutron_converter command with the --show-kernel-kinds option,
+    parses its output, and returns a dictionary mapping kernel IDs to kernel
+    names.
+
+    :param target: Target platform for which kernel kinds should be queried.
+    Defaults to "imxrt700".
+    :return: Returns empty dict if neutron_converter exits with an error.
+    Otherwise, a dictionary where:
+            - key: kernel ID (int)
+            - value: kernel name (str)
+    """
+    proc = subprocess.Popen(
+        ["neutron_converter", "--target", target, "--show-kernel-kinds"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout, stderr = proc.communicate(timeout=10)
+    if proc.returncode != 0:
+        logging.error(
+            "Failed to get kernrl kinds from neutron_converter: %s",
+            stderr.strip(),
+        )
+        return {}
+    return {
+        int(op_id): name
+        for op_id, name in re.findall(r"\[\s*(\d+)\s*\]\s+(.+)", stdout)
+    }

--- a/backends/nxp/tests/profiling_utils.py
+++ b/backends/nxp/tests/profiling_utils.py
@@ -95,9 +95,7 @@ def get_neutron_compiler_version() -> str:
         if version_match:
             return version_match.group(1)
         else:
-            logging.exception(
-                "Unexpected error while getting neutron compiler version"
-            )
+            logging.exception("Unexpected error while getting neutron compiler version")
             return ""
     except Exception:
         logging.exception("Error while getting neutron compiler version")

--- a/backends/nxp/tests/profiling_utils.py
+++ b/backends/nxp/tests/profiling_utils.py
@@ -78,6 +78,7 @@ def get_neutron_compiler_version() -> str:
     """
 
     try:
+        # Use neutron_compiler because neutron_converter executable is unavailable since NS 3.2.1.
         proc = subprocess.Popen(
             ["neutron_compiler", "--version"],
             stdout=subprocess.PIPE,
@@ -117,6 +118,8 @@ def get_neutron_kernel_kinds(target: str = "imxrt700") -> dict[int, str]:
             - key: kernel ID (int)
             - value: kernel name (str)
     """
+
+    # Use neutron_compiler because neutron_converter executable is unavailable since NS 3.2.1.
     proc = subprocess.Popen(
         ["neutron_compiler", "--target", target, "--show-kernel-kinds"],
         stdout=subprocess.PIPE,

--- a/examples/nxp/analyzing_with_inspector.py
+++ b/examples/nxp/analyzing_with_inspector.py
@@ -7,7 +7,16 @@
 
 from typing import Any, Union
 
+from executorch.backends.nxp.tests.profiling_utils import (
+    get_neutron_converter_version,
+    get_neutron_driver_version,
+    get_neutron_kernel_kinds,
+)
+
 from executorch.devtools import Inspector
+
+# Global mapping of Neutron kernel IDs to names used by the delegate metadata parser.
+kernel_kinds = {}
 
 
 def parse_delegate_metadata(
@@ -26,7 +35,13 @@ def parse_delegate_metadata(
             if function_code == 0:
                 metadata_list.append("Profiling dump")
             else:
-                metadata_list.append("Neutron kernel " + str(function_code))
+                metadata_list.append(
+                    kernel_kinds.get(
+                        function_code, "Neutron kernel " + str(function_code)
+                    )
+                )
+        elif len(metadata_bytes) == 2:
+            metadata_list.append("Profiling dump")
         else:
             metadata_list.append("Invalid metadata size")
     return metadata_list
@@ -37,6 +52,12 @@ if __name__ == "__main__":
     try:
         etrecord_path = "etrecord/etrecord.bin"
         etdump_path = "etdump/trace.etdump"
+
+        driver_version = get_neutron_driver_version(etdump_path)
+        converter_version = get_neutron_converter_version()
+        if driver_version and driver_version == converter_version:
+            kernel_kinds = get_neutron_kernel_kinds()
+
         inspector = Inspector(
             etdump_path=etdump_path,
             etrecord=etrecord_path,

--- a/examples/nxp/analyzing_with_inspector.py
+++ b/examples/nxp/analyzing_with_inspector.py
@@ -8,7 +8,7 @@
 from typing import Any, Union
 
 from executorch.backends.nxp.tests.profiling_utils import (
-    get_neutron_converter_version,
+    get_neutron_compiler_version,
     get_neutron_driver_version,
     get_neutron_kernel_kinds,
 )
@@ -54,8 +54,8 @@ if __name__ == "__main__":
         etdump_path = "etdump/trace.etdump"
 
         driver_version = get_neutron_driver_version(etdump_path)
-        converter_version = get_neutron_converter_version()
-        if driver_version and driver_version == converter_version:
+        compiler_version = get_neutron_compiler_version()
+        if driver_version and driver_version == compiler_version:
             kernel_kinds = get_neutron_kernel_kinds()
 
         inspector = Inspector(


### PR DESCRIPTION
### Summary
Replace neutron kernel kinds with names in profiling table if possible:
1. Add driver version into etdump as metadata for the last traced kernel (which corresponds to time needed for profiling info print) in runtime.
2. Check if eIQ SDK installed on host PC corresponds to the driver version from runtime. 
    - If versions match -> get list of kernel names from convertor (compiler) and replace kernel numbers with kernels name.
    - If versions doen't match -> use kernel numbers in result table.

### Test plan
Test included


cc @robert-kalmar @JakeStevens @digantdesai @rascani