### PR TITLE
Arm backend: Generate runner-specific operator libs

### DIFF
--- a/backends/arm/cmake/ArmRunnerUtils.cmake
+++ b/backends/arm/cmake/ArmRunnerUtils.cmake
@@ -8,6 +8,19 @@ include_guard(GLOBAL)
 # Helper routines shared by the standalone runner and any superbuild that reuses
 # the runner targets.
 
+get_filename_component(
+  _arm_runner_executorch_root "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE
+)
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT "${_arm_runner_executorch_root}")
+endif()
+
+# Make sure codegen function used below is loaded.
+if(NOT COMMAND gen_selected_ops)
+  include(${EXECUTORCH_ROOT}/tools/cmake/Codegen.cmake)
+endif()
+
+# Verify that targets required for building the executor runner are present.
 function(arm_runner_require_baremetal_targets)
   if(NOT TARGET extension_runner_util)
     message(
@@ -16,19 +29,136 @@ function(arm_runner_require_baremetal_targets)
     )
   endif()
 
-  if(NOT TARGET quantized_ops_lib OR NOT TARGET quantized_kernels)
-    message(
-      FATAL_ERROR
-        "quantized kernels not found. Ensure EXECUTORCH_BUILD_KERNELS_QUANTIZED=ON when configuring ExecuTorch."
+endfunction()
+
+#[[
+Create a selected operator registration library for one operator family.
+
+Arguments:
+  LIB_NAME: Name of the generated registration library target.
+	example: arm_cortex_m_ops_lib
+
+  FUNCTIONS_YAML: Portable ATen operator YAML used to generate bindings.
+	example: ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
+
+  CUSTOM_OPS_YAML: Custom/backend operator YAML used to generate bindings.
+	example: ${EXECUTORCH_ROOT}/backends/cortex_m/ops/operators.yaml
+
+  OP_LIST: Operators to select.
+	example: ${EXECUTORCH_SELECT_OPS_LIST}
+
+  OPS_FROM_MODEL: ExecuTorch model file used to select operators.
+	example: ${ET_PTE_FILE_PATH}
+
+  DTYPE_SELECTIVE_BUILD: Enables dtype filtering for operator libraries that support it.
+	example: ${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}
+
+  KERNEL_LIBS: Kernel implementation libraries used by the generated target.
+	example: cortex_m_kernels
+
+  DEPS: Additional libraries required by the generated registration target.
+	example: executorch
+
+  INCLUDE_ALL_OPS: Generate a non-selective registration library for the
+	selected operator family.
+
+The lib will always be created, even when no operators are selected.
+OP_LIST and OPS_FROM_MODEL can be used additively.
+]]
+function(arm_runner_create_selected_ops_lib)
+  # Parse arguments
+  set(options INCLUDE_ALL_OPS)
+  set(one_value_args LIB_NAME FUNCTIONS_YAML CUSTOM_OPS_YAML OP_LIST
+                     OPS_FROM_MODEL DTYPE_SELECTIVE_BUILD
+  )
+  set(multi_value_args KERNEL_LIBS DEPS)
+  cmake_parse_arguments(
+    ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
+  )
+
+  # Validate and normalize arguments
+  if(ARG_LIB_NAME)
+    set(_arm_runner_create_selected_ops_lib_context
+        "arm_runner_create_selected_ops_lib(${ARG_LIB_NAME})"
+    )
+  else()
+    set(_arm_runner_create_selected_ops_lib_context
+        "arm_runner_create_selected_ops_lib"
     )
   endif()
 
-  if(NOT TARGET cortex_m_ops_lib OR NOT TARGET cortex_m_kernels)
+  if(ARG_UNPARSED_ARGUMENTS)
     message(
       FATAL_ERROR
-        "cortex_m backend not found. Ensure EXECUTORCH_BUILD_CORTEX_M=ON when configuring ExecuTorch."
+        "${_arm_runner_create_selected_ops_lib_context} got unexpected arguments: ${ARG_UNPARSED_ARGUMENTS}."
     )
   endif()
+
+  if(NOT ARG_LIB_NAME)
+    message(
+      FATAL_ERROR
+        "${_arm_runner_create_selected_ops_lib_context} requires LIB_NAME."
+    )
+  endif()
+
+  if(NOT ARG_FUNCTIONS_YAML AND NOT ARG_CUSTOM_OPS_YAML)
+    message(
+      FATAL_ERROR
+        "${_arm_runner_create_selected_ops_lib_context} requires FUNCTIONS_YAML or CUSTOM_OPS_YAML."
+    )
+  endif()
+
+  if(ARG_DTYPE_SELECTIVE_BUILD)
+    executorch_load_build_variables()
+  endif()
+
+  verify_targets_exist(
+    CONTEXT "${_arm_runner_create_selected_ops_lib_context}" TARGETS
+    ${ARG_KERNEL_LIBS} ${ARG_DEPS}
+  )
+
+  # Generate selected operator list file.
+  set(_arm_runner_selected_ops_args
+      LIB_NAME
+      "${ARG_LIB_NAME}"
+      ROOT_OPS
+      "${ARG_OP_LIST}"
+      OPS_FROM_MODEL
+      "${ARG_OPS_FROM_MODEL}"
+      DTYPE_SELECTIVE_BUILD
+      "${ARG_DTYPE_SELECTIVE_BUILD}"
+  )
+  if(ARG_INCLUDE_ALL_OPS)
+    list(APPEND _arm_runner_selected_ops_args INCLUDE_ALL_OPS "ON")
+  endif()
+  gen_selected_ops(${_arm_runner_selected_ops_args})
+
+  # Codegen for operator library.
+  set(_arm_ops_binding_args LIB_NAME "${ARG_LIB_NAME}")
+  if(ARG_FUNCTIONS_YAML)
+    list(APPEND _arm_ops_binding_args FUNCTIONS_YAML "${ARG_FUNCTIONS_YAML}")
+  endif()
+  if(ARG_CUSTOM_OPS_YAML)
+    list(APPEND _arm_ops_binding_args CUSTOM_OPS_YAML "${ARG_CUSTOM_OPS_YAML}")
+  endif()
+  if(ARG_DTYPE_SELECTIVE_BUILD)
+    list(APPEND _arm_ops_binding_args DTYPE_SELECTIVE_BUILD
+         "${ARG_DTYPE_SELECTIVE_BUILD}"
+    )
+  endif()
+  generate_bindings_for_kernels(${_arm_ops_binding_args})
+
+  # Finally, build operator library.
+  gen_operators_lib(
+    LIB_NAME
+    "${ARG_LIB_NAME}"
+    KERNEL_LIBS
+    ${ARG_KERNEL_LIBS}
+    DEPS
+    ${ARG_DEPS}
+    DTYPE_SELECTIVE_BUILD
+    "${ARG_DTYPE_SELECTIVE_BUILD}"
+  )
 endfunction()
 
 # Ensure a runner target emits its binary to a predictable location. Uses

--- a/backends/arm/test/setup_testing.sh
+++ b/backends/arm/test/setup_testing.sh
@@ -13,15 +13,25 @@ build_root_test_dir=${et_root_dir}/arm_test/arm_semihosting_executor_runner
 extraflags="-DET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE=83886080"
 portable_extraflags="${extraflags} -DHEAP_SIZE=0x00007000"
 
+join_by_comma() {
+    local IFS=,
+    echo "$*"
+}
+
 # By default tests with an elf without any portable_ops
 # If you supply use_portable_ops=True when creating the ArmTester()
 # you will instead test with some portable ops compiled in, see list below.
 
 #--target --system_config --memory_mode should match the ArmTester used setup see backends/arm/test/common.py
 
-${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --output="${build_root_test_dir}_corstone-300" --extra_build_flags=${extraflags}
-${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --output="${build_root_test_dir}_corstone-300-u65" --extra_build_flags=${extraflags}
-${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --output="${build_root_test_dir}_corstone-320" --extra_build_flags=${extraflags}
+ops_list_quantized_decomposed=(
+    quantized_decomposed::quantize_per_tensor.out
+    quantized_decomposed::dequantize_per_tensor.out
+)
+
+${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-300" --extra_build_flags=${extraflags}
+${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-300-u65" --extra_build_flags=${extraflags}
+${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-320" --extra_build_flags=${extraflags}
 
 # List of portable ops used by testing, this is mainly used to test models in the flow
 # test setup to make sure models that are not fully delegated can still be tested and run OK
@@ -38,10 +48,47 @@ ${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_confi
 # aten::scalar_tensor.out                        - U85 operator-suite aggregate fallback coverage
 # aten::where.self_out                           - U85 operator-suite aggregate fallback coverage
 
-portable_ops_list_u55="aten::permute_copy.out,aten::convolution.out,aten::relu.out,aten::_native_batch_norm_legit_no_training.out,aten::as_strided_copy.out,aten::mean.out,aten::squeeze_copy.dims,aten::avg_pool2d.out,aten::gt.Tensor_out,aten::where.self_out,aten::expand_copy.out,aten::clamp.out,aten::mul.out,aten::index_select.out,aten::fmod.Scalar_out,aten::add.out,aten::arange.start_out,aten::eq.Tensor_out,aten::logical_not.out,dim_order_ops::_clone_dim_order.out,dim_order_ops::_to_dim_order_copy.out"
-portable_ops_list_u65="${portable_ops_list_u55}"
-portable_ops_list_u85="aten::permute_copy.out,aten::convolution.out,aten::relu.out,aten::_native_batch_norm_legit_no_training.out,aten::as_strided_copy.out,aten::mean.out,aten::full_like.out,aten::bmm.out,aten::scalar_tensor.out,aten::index.Tensor_out,aten::where.self_out,dim_order_ops::_to_dim_order_copy.out"
+ops_list_u55=(
+    aten::permute_copy.out
+    aten::convolution.out
+    aten::relu.out
+    aten::_native_batch_norm_legit_no_training.out
+    aten::as_strided_copy.out
+    aten::mean.out
+    aten::squeeze_copy.dims
+    aten::avg_pool2d.out
+    aten::gt.Tensor_out
+    aten::where.self_out
+    aten::expand_copy.out
+    aten::clamp.out
+    aten::mul.out
+    aten::index_select.out
+    aten::fmod.Scalar_out
+    aten::add.out
+    aten::arange.start_out
+    aten::eq.Tensor_out
+    aten::logical_not.out
+    dim_order_ops::_clone_dim_order.out
+    dim_order_ops::_to_dim_order_copy.out
+    "${ops_list_quantized_decomposed[@]}"
+)
+ops_list_u65=("${ops_list_u55[@]}")
+ops_list_u85=(
+    aten::permute_copy.out
+    aten::convolution.out
+    aten::relu.out
+    aten::_native_batch_norm_legit_no_training.out
+    aten::as_strided_copy.out
+    aten::mean.out
+    aten::full_like.out
+    aten::bmm.out
+    aten::scalar_tensor.out
+    aten::index.Tensor_out
+    aten::where.self_out
+    dim_order_ops::_to_dim_order_copy.out
+    "${ops_list_quantized_decomposed[@]}"
+)
 
-${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --select_ops_list="${portable_ops_list_u55}" --output="${build_root_test_dir}_portable-ops_corstone-300" --extra_build_flags="${portable_extraflags}"
-${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --select_ops_list="${portable_ops_list_u65}" --output="${build_root_test_dir}_portable-ops_corstone-300-u65" --extra_build_flags="${portable_extraflags}"
-${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="${portable_ops_list_u85}" --output="${build_root_test_dir}_portable-ops_corstone-320" --extra_build_flags=${extraflags}
+${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --select_ops_list="$(join_by_comma "${ops_list_u55[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-300" --extra_build_flags="${portable_extraflags}"
+${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_u65[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-300-u65" --extra_build_flags="${portable_extraflags}"
+${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_u85[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-320" --extra_build_flags=${extraflags}

--- a/backends/cortex_m/test/build_test_runner.sh
+++ b/backends/cortex_m/test/build_test_runner.sh
@@ -35,18 +35,42 @@ build_dir="${et_root_dir}/arm_test"
 build_executor_runner="${et_root_dir}/backends/arm/scripts/build_executor_runner.sh"
 build_root_test_dir="${et_root_dir}/arm_test/arm_semihosting_executor_runner_corstone-300_${target}"
 
-select_ops_list="\
-aten::add.out,\
-aten::clamp.out,\
-aten::mul.out,\
-aten::convolution.out,\
-aten::max_pool2d_with_indices.out,\
-dim_order_ops::_clone_dim_order.out,\
-aten::cat.out,\
-aten::full.out,\
-aten::ge.Tensor_out,\
-aten::unsqueeze_copy.out,\
-aten::select_copy.int_out,\
-aten::amax.out"
+join_by_comma() {
+    local IFS=,
+    echo "$*"
+}
 
-${build_executor_runner} --pte=semihosting --bundleio --target="${target}" --output="${build_root_test_dir}" --select_ops_list="${select_ops_list}" --extra_build_flags="-DET_ATOL=5.0 -DET_RTOL=1.0 -DET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=0"
+ops_list=(
+    aten::add.out
+    aten::clamp.out
+    aten::mul.out
+    aten::convolution.out
+    aten::max_pool2d_with_indices.out
+    dim_order_ops::_clone_dim_order.out
+    aten::cat.out
+    aten::full.out
+    aten::ge.Tensor_out
+    aten::unsqueeze_copy.out
+    aten::select_copy.int_out
+    aten::amax.out
+    cortex_m::quantize_per_tensor.out
+    cortex_m::dequantize_per_tensor.out
+    cortex_m::quantized_add.out
+    cortex_m::quantized_div.out
+    cortex_m::quantized_mul.out
+    cortex_m::quantized_activation.out
+    cortex_m::minimum.out
+    cortex_m::maximum.out
+    cortex_m::quantized_linear.out
+    cortex_m::softmax.out
+    cortex_m::transpose.out
+    cortex_m::pad.out
+    cortex_m::quantized_conv2d.out
+    cortex_m::quantized_depthwise_conv2d.out
+    cortex_m::quantized_transpose_conv2d.out
+    cortex_m::quantized_avg_pool2d.out
+    cortex_m::quantized_max_pool2d.out
+    cortex_m::quantized_batch_matmul.out
+)
+
+${build_executor_runner} --pte=semihosting --bundleio --target="${target}" --output="${build_root_test_dir}" --select_ops_list="$(join_by_comma "${ops_list[@]}")" --extra_build_flags="-DET_ATOL=5.0 -DET_RTOL=1.0 -DET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=0"

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -320,100 +320,112 @@ list(
   ethosu_target_init
   -Wl,--whole-archive
   executorch
-  quantized_ops_lib
-  cortex_m_ops_lib
   executorch_delegate_ethos_u
   -Wl,--no-whole-archive
-  quantized_kernels
-  cortex_m_kernels
-  portable_kernels
-  cmsis-nn
-  kernels_util_all_deps
   -Wl,--end-group
   -Xlinker
   -Map=arm_executor_runner.map
 )
 
-# Figure out which ops to include: For semihosting build, use
-# (user-set)SELECT_OPS_MODEL variable. For normal build, use
-# EXECUTORCH_SELECT_OPS_MODEL to include ops automatically. If the pte contains
-# no undelegated ops, use neither.
-set(FOUND_OPS_IN_FILE FALSE)
-if(NOT ET_MODEL_PTE_ADDR
-   AND NOT "${ET_PTE_FILE_PATH}" STREQUAL ""
-   AND EXISTS "${ET_PTE_FILE_PATH}"
+# Create ops libraries from included operators. Handle portable, cortex_m, and
+# quantized ops.
+set(_arm_runner_dtype_selective_build
+    "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
 )
-  execute_process(
-    COMMAND
-      ${PYTHON_EXECUTABLE} "${EXECUTORCH_ROOT}/codegen/tools/gen_oplist.py"
-      --model_file_path=${ET_PTE_FILE_PATH}
-      --output_path=${CMAKE_CURRENT_BINARY_DIR}/temp.yaml
-    OUTPUT_VARIABLE CMD_RESULT
-  )
-
-  if(CMD_RESULT MATCHES "aten::" OR CMD_RESULT MATCHES "dim_order_ops::")
-    set(FOUND_OPS_IN_FILE TRUE)
-  endif()
+if(NOT ET_PTE_FILE_PATH)
+  set(_arm_runner_dtype_selective_build "")
 endif()
 
-if(SEMIHOSTING AND "${ET_PTE_FILE_PATH}" STREQUAL "")
-  set(EXECUTORCH_SELECT_OPS_MODEL "")
-  message(
-    "gen_oplist: Building with semihosting, no model is used to auto generate ops from will use EXECUTORCH_SELECT_OPS_LIST=${EXECUTORCH_SELECT_OPS_LIST}"
-  )
-elseif(FOUND_OPS_IN_FILE)
-  set(EXECUTORCH_SELECT_OPS_LIST "")
-  set(EXECUTORCH_SELECT_OPS_MODEL "${ET_PTE_FILE_PATH}")
-  message(
-    "gen_oplist:  EXECUTORCH_SELECT_OPS_MODEL=${ET_PTE_FILE_PATH} is used to auto generate ops from"
-  )
-else()
-  set(EXECUTORCH_SELECT_OPS_MODEL "")
-  message(
-    "gen_oplist: No non-delegated ops were found in ${ET_PTE_FILE_PATH}; no ops added to build"
-  )
-endif()
+set(_arm_runner_selected_ops_libs)
+set(_arm_runner_normal_archive_libs)
 
-# Ensure that either executorch_select_ops_list or executorch_select_ops_model
-# is set - otherwise assume no kernels needs to be registered
-if(NOT ("${EXECUTORCH_SELECT_OPS_LIST}" STREQUAL ""
-        AND "${EXECUTORCH_SELECT_OPS_MODEL}" STREQUAL "")
+arm_runner_create_selected_ops_lib(
+  LIB_NAME
+  "arm_portable_ops_lib"
+  FUNCTIONS_YAML
+  "${EXECUTORCH_ROOT}/kernels/portable/functions.yaml"
+  OP_LIST
+  "${EXECUTORCH_SELECT_OPS_LIST}"
+  OPS_FROM_MODEL
+  "${ET_PTE_FILE_PATH}"
+  DTYPE_SELECTIVE_BUILD
+  "${_arm_runner_dtype_selective_build}"
+  KERNEL_LIBS
+  portable_kernels
+  DEPS
+  executorch
 )
-  gen_selected_ops(
-    LIB_NAME
-    "arm_portable_ops_lib"
-    OPS_SCHEMA_YAML
-    ""
-    ROOT_OPS
-    "${EXECUTORCH_SELECT_OPS_LIST}"
-    INCLUDE_ALL_OPS
-    ""
-    OPS_FROM_MODEL
-    "${EXECUTORCH_SELECT_OPS_MODEL}"
-    DTYPE_SELECTIVE_BUILD
-    "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
-  )
+list(APPEND _arm_runner_selected_ops_libs arm_portable_ops_lib)
+set(_arm_runner_portable_archive_libs portable_kernels kernels_util_all_deps)
+verify_targets_exist(
+  CONTEXT arm_executor_runner TARGETS ${_arm_runner_portable_archive_libs}
+)
+list(APPEND _arm_runner_normal_archive_libs
+     ${_arm_runner_portable_archive_libs}
+)
 
-  generate_bindings_for_kernels(
-    LIB_NAME "arm_portable_ops_lib" FUNCTIONS_YAML
-    ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml DTYPE_SELECTIVE_BUILD
-    "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
-  )
-  gen_operators_lib(
-    LIB_NAME
-    "arm_portable_ops_lib"
-    KERNEL_LIBS
-    portable_kernels
-    DEPS
-    executorch
-    DTYPE_SELECTIVE_BUILD
-    "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
-  )
-  list(FIND arm_executor_runner_link -Wl,--no-whole-archive
-       _arm_runner_no_whole_archive_idx
-  )
-  list(INSERT arm_executor_runner_link ${_arm_runner_no_whole_archive_idx}
-       arm_portable_ops_lib
+arm_runner_create_selected_ops_lib(
+  LIB_NAME
+  "arm_quantized_ops_lib"
+  CUSTOM_OPS_YAML
+  "${EXECUTORCH_ROOT}/kernels/quantized/quantized.yaml"
+  OP_LIST
+  "${EXECUTORCH_SELECT_OPS_LIST}"
+  OPS_FROM_MODEL
+  "${ET_PTE_FILE_PATH}"
+  KERNEL_LIBS
+  quantized_kernels
+  DEPS
+  executorch_core
+)
+list(APPEND _arm_runner_selected_ops_libs arm_quantized_ops_lib)
+set(_arm_runner_quantized_archive_libs quantized_kernels portable_kernels
+                                       kernels_util_all_deps
+)
+verify_targets_exist(
+  CONTEXT arm_executor_runner TARGETS ${_arm_runner_quantized_archive_libs}
+)
+list(APPEND _arm_runner_normal_archive_libs
+     ${_arm_runner_quantized_archive_libs}
+)
+
+arm_runner_create_selected_ops_lib(
+  LIB_NAME
+  "arm_cortex_m_ops_lib"
+  CUSTOM_OPS_YAML
+  "${EXECUTORCH_ROOT}/backends/cortex_m/ops/operators.yaml"
+  OP_LIST
+  "${EXECUTORCH_SELECT_OPS_LIST}"
+  OPS_FROM_MODEL
+  "${ET_PTE_FILE_PATH}"
+  KERNEL_LIBS
+  cortex_m_kernels
+  DEPS
+  executorch
+)
+list(APPEND _arm_runner_selected_ops_libs arm_cortex_m_ops_lib)
+set(_arm_runner_cortex_m_archive_libs cortex_m_kernels portable_kernels
+                                      cmsis-nn kernels_util_all_deps
+)
+verify_targets_exist(
+  CONTEXT arm_executor_runner TARGETS ${_arm_runner_cortex_m_archive_libs}
+)
+list(APPEND _arm_runner_normal_archive_libs
+     ${_arm_runner_cortex_m_archive_libs}
+)
+
+list(FIND arm_executor_runner_link -Wl,--no-whole-archive
+     _arm_runner_no_whole_archive_idx
+)
+list(INSERT arm_executor_runner_link ${_arm_runner_no_whole_archive_idx}
+     ${_arm_runner_selected_ops_libs}
+)
+
+if(_arm_runner_normal_archive_libs)
+  list(REMOVE_DUPLICATES _arm_runner_normal_archive_libs)
+  list(FIND arm_executor_runner_link -Wl,--end-group _arm_runner_end_group_idx)
+  list(INSERT arm_executor_runner_link ${_arm_runner_end_group_idx}
+       ${_arm_runner_normal_archive_libs}
   )
 endif()
 
@@ -475,12 +487,9 @@ endif()
 # link list rather than through INTERFACE_LINK_OPTIONS. The latter is emitted
 # before this target's objects and before the runner's dependency closure, which
 # breaks bare-metal archive resolution for the runner.
-set(_arm_runner_whole_archive_targets
-    executorch quantized_ops_lib cortex_m_ops_lib executorch_delegate_ethos_u
+set(_arm_runner_whole_archive_targets executorch executorch_delegate_ethos_u
+                                      ${_arm_runner_selected_ops_libs}
 )
-if(TARGET arm_portable_ops_lib)
-  list(APPEND _arm_runner_whole_archive_targets arm_portable_ops_lib)
-endif()
 foreach(_arm_runner_whole_archive_target IN
         LISTS _arm_runner_whole_archive_targets
 )
@@ -492,8 +501,7 @@ foreach(_arm_runner_whole_archive_target IN
   endif()
 endforeach()
 
-# Need whole-archive to ensure C++ ctors are called. This may be wasteful for
-# binary size as we link in a number of other symbols.
+# Need whole-archive to ensure C++ ctors are called for registration targets.
 target_link_libraries(arm_executor_runner PUBLIC ${arm_executor_runner_link})
 
 # Ensure the ELF lands next to the CMake build tree so run.sh (and downstream

--- a/examples/arm/executor_runner/standalone/CMakeLists.txt
+++ b/examples/arm/executor_runner/standalone/CMakeLists.txt
@@ -86,12 +86,11 @@ set(EXECUTORCH_SKIP_ARM_EXECUTOR_RUNNER
     CACHE BOOL "" FORCE
 )
 
-# examples/arm/executor_runner/CMakeLists.txt generates the runner-specific
-# portable-op registration based on the PTE or an explicit select-ops list.
-# Avoid feeding those cache entries into the top-level ExecuTorch configure,
-# otherwise executorch_core auto-right-sizes MAX_KERNEL_NUM from the runner's
-# placeholder/selective build inputs even though the runner also links
-# quantized/cortex-m registration libraries.
+# examples/arm/executor_runner/CMakeLists.txt generates runner-specific
+# registration libraries based on the PTE or an explicit select-ops list. Avoid
+# feeding those cache entries into the top-level ExecuTorch configure, otherwise
+# executorch_core auto-right-sizes MAX_KERNEL_NUM from the runner's
+# placeholder/selective build inputs.
 set(_arm_runner_selective_cache_vars
     EXECUTORCH_SELECT_OPS_LIST EXECUTORCH_SELECT_OPS_MODEL
     EXECUTORCH_SELECT_OPS_YAML

--- a/examples/arm/image_classification_example_ethos_u/model_export/export_deit.py
+++ b/examples/arm/image_classification_example_ethos_u/model_export/export_deit.py
@@ -14,6 +14,9 @@ from executorch.backends.arm.quantizer import (
     EthosUQuantizer,
     get_symmetric_quantization_config,
 )
+from executorch.backends.cortex_m.passes.replace_quant_nodes_pass import (
+    ReplaceQuantNodesPass,
+)
 from executorch.exir import (
     EdgeCompileConfig,
     ExecutorchBackendConfig,
@@ -167,6 +170,7 @@ if __name__ == "__main__":
             _check_ir_validity=False,
         ),
     )
+    edge_encoder = edge_encoder.transform([ReplaceQuantNodesPass()])
     edge_manager = edge_encoder.to_executorch(
         config=ExecutorchBackendConfig(extract_delegate_segments=False)
     )

--- a/examples/arm/image_classification_example_ethos_u/runtime/CMakeLists.txt
+++ b/examples/arm/image_classification_example_ethos_u/runtime/CMakeLists.txt
@@ -71,6 +71,7 @@ endif()
 find_package(
   executorch REQUIRED HINTS "${ET_BUILD_DIR_PATH}/lib/cmake/ExecuTorch"
 )
+include(${ET_DIR_PATH}/backends/arm/cmake/ArmRunnerUtils.cmake)
 
 # The core_platform project defines the corstone-320 target and contains the
 # start-up code for the Cortex-M
@@ -86,15 +87,29 @@ target_sources(
           ${CMAKE_SOURCE_DIR}/../../executor_runner/arm_memory_allocator.cpp
 )
 
+arm_runner_create_selected_ops_lib(
+  LIB_NAME
+  "image_classification_cortex_m_ops_lib"
+  CUSTOM_OPS_YAML
+  "${ET_DIR_PATH}/backends/cortex_m/ops/operators.yaml"
+  OPS_FROM_MODEL
+  "${ET_PTE_FILE_PATH}"
+  KERNEL_LIBS
+  cortex_m_kernels
+  DEPS
+  executorch
+)
+
+verify_targets_exist(
+  CONTEXT img_class_example TARGETS image_classification_cortex_m_ops_lib
+  cortex_m_kernels portable_kernels
+)
+
 target_link_libraries(
   img_class_example
-  PUBLIC executorch
-         ethosu_target_init
-         extension_runner_util
-         quantized_ops_lib
+  PUBLIC executorch ethosu_target_init extension_runner_util
+         image_classification_cortex_m_ops_lib cortex_m_kernels
          portable_kernels
-         cortex_m_kernels
-         cortex_m_ops_lib
 )
 
 # Apply whole-archive helper where available to keep static initializers.

--- a/zephyr/samples/hello-executorch/CMakeLists.txt
+++ b/zephyr/samples/hello-executorch/CMakeLists.txt
@@ -52,39 +52,6 @@ set(ET_PTE_FILE_PATH
           FORCE
 )
 
-execute_process(
-  COMMAND
-    python "${CMAKE_CURRENT_LIST_DIR}/../../../codegen/tools/gen_oplist.py"
-    --model_file_path=${ET_PTE_FILE_PATH}
-    --output_path=${CMAKE_CURRENT_BINARY_DIR}/temp.yaml
-  OUTPUT_VARIABLE CMD_RESULT
-)
-
-if(CMD_RESULT MATCHES "aten::" OR CMD_RESULT MATCHES "dim_order_ops::")
-  set(FOUND_OPS_IN_FILE "true")
-else()
-  set(FOUND_OPS_IN_FILE "false")
-endif()
-
-if(${FOUND_OPS_IN_FILE})
-  set(EXECUTORCH_SELECT_OPS_LIST "")
-  set(EXECUTORCH_SELECT_OPS_MODEL
-      "${ET_PTE_FILE_PATH}"
-      CACHE STRING "Select operators from this ExecuTorch model" FORCE
-  )
-  set(_EXECUTORCH_GEN_ZEPHYR_PORTABLE_OPS ON)
-  message(
-    "gen_oplist:  EXECUTORCH_SELECT_OPS_MODEL=${ET_PTE_FILE_PATH} is used to auto generate ops from"
-  )
-else()
-  set(EXECUTORCH_SELECT_OPS_LIST "")
-  set(EXECUTORCH_SELECT_OPS_MODEL "")
-  set(_EXECUTORCH_GEN_ZEPHYR_PORTABLE_OPS OFF)
-  message(
-    "gen_oplist: No non-delegated ops were found in ${ET_PTE_FILE_PATH}; no ops added to build"
-  )
-endif()
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(executorch_executor_runner)
 
@@ -122,9 +89,8 @@ else()
   message(STATUS "Using predefined EXECUTORCH_DIR=${EXECUTORCH_DIR}")
 endif()
 
-# Set EXECUTORCH_ROOT for the Codegen.cmake file
-set(EXECUTORCH_ROOT ${EXECUTORCH_DIR})
 include(${EXECUTORCH_DIR}/tools/cmake/Utils.cmake)
+include(${EXECUTORCH_DIR}/backends/arm/cmake/ArmRunnerUtils.cmake)
 
 # Ensure the portable kernels target exists even when portable ops are disabled
 # in the global build.
@@ -136,42 +102,41 @@ if(NOT TARGET portable_kernels)
   )
   unset(EXECUTORCH_PORTABLE_BUILD_KERNELS_ONLY)
 endif()
-set(EXECUTORCH_OPS_LIB "")
-if(_EXECUTORCH_GEN_ZEPHYR_PORTABLE_OPS)
-  include(${EXECUTORCH_DIR}/tools/cmake/Codegen.cmake)
-  if(NOT DEFINED EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD)
-    set(EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD "")
-  endif()
-  gen_selected_ops(
+set(_executorch_zephyr_selected_ops_libs)
+if(NOT DEFINED EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD)
+  set(EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD "")
+endif()
+
+arm_runner_create_selected_ops_lib(
+  LIB_NAME
+  "cpu_portable_ops_lib"
+  FUNCTIONS_YAML
+  "${EXECUTORCH_DIR}/kernels/portable/functions.yaml"
+  OPS_FROM_MODEL
+  "${ET_PTE_FILE_PATH}"
+  KERNEL_LIBS
+  portable_kernels
+  DEPS
+  executorch
+  DTYPE_SELECTIVE_BUILD
+  "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
+)
+list(APPEND _executorch_zephyr_selected_ops_libs cpu_portable_ops_lib)
+
+if(TARGET cortex_m_kernels)
+  arm_runner_create_selected_ops_lib(
     LIB_NAME
-    "cpu_portable_ops_lib"
-    OPS_SCHEMA_YAML
-    ""
-    ROOT_OPS
-    "${EXECUTORCH_SELECT_OPS_LIST}"
-    INCLUDE_ALL_OPS
-    ""
+    "zephyr_cortex_m_ops_lib"
+    CUSTOM_OPS_YAML
+    "${EXECUTORCH_DIR}/backends/cortex_m/ops/operators.yaml"
     OPS_FROM_MODEL
-    "${EXECUTORCH_SELECT_OPS_MODEL}"
-    DTYPE_SELECTIVE_BUILD
-    "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
-  )
-  generate_bindings_for_kernels(
-    LIB_NAME "cpu_portable_ops_lib" FUNCTIONS_YAML
-    ${EXECUTORCH_DIR}/kernels/portable/functions.yaml DTYPE_SELECTIVE_BUILD
-    "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
-  )
-  gen_operators_lib(
-    LIB_NAME
-    "cpu_portable_ops_lib"
+    "${ET_PTE_FILE_PATH}"
     KERNEL_LIBS
-    portable_kernels
+    cortex_m_kernels
     DEPS
     executorch
-    DTYPE_SELECTIVE_BUILD
-    "${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}"
   )
-  set(EXECUTORCH_OPS_LIB "cpu_portable_ops_lib")
+  list(APPEND _executorch_zephyr_selected_ops_libs zephyr_cortex_m_ops_lib)
 endif()
 
 set(_local_flatcc_root ${CMAKE_BINARY_DIR}/flatcc_src)
@@ -229,26 +194,7 @@ endif()
 
 # Link with ExecuTorch and our operators library
 target_link_libraries(app PRIVATE libexecutorch)
-if(EXECUTORCH_OPS_LIB)
-  target_link_libraries(app PRIVATE ${EXECUTORCH_OPS_LIB})
-endif()
-if(CONFIG_CPU_CORTEX_M)
-  if(TARGET cortex_m_ops_lib)
-    target_link_libraries(app PRIVATE cortex_m_ops_lib)
-  endif()
-  if(TARGET cortex_m_kernels)
-    executorch_target_link_options_shared_lib(cortex_m_kernels)
-    target_link_libraries(app PRIVATE cortex_m_kernels)
-  endif()
-endif()
-if(TARGET quantized_kernels)
-  executorch_target_link_options_shared_lib(quantized_kernels)
-  target_link_libraries(app PRIVATE quantized_kernels)
-endif()
-if(TARGET portable_kernels)
-  executorch_target_link_options_shared_lib(portable_kernels)
-  target_link_libraries(app PRIVATE portable_kernels)
-endif()
+target_link_libraries(app PRIVATE ${_executorch_zephyr_selected_ops_libs})
 if(TARGET executorch_delegate_ethos_u)
   executorch_target_link_options_shared_lib(executorch_delegate_ethos_u)
   target_link_libraries(app PRIVATE executorch_delegate_ethos_u)


### PR DESCRIPTION
Previously, all cortex_m and quantized operators
were included, wasting binary space.

Implement a helper arm_runner_create_selected_ops_lib that makes it easy to create operator registration libs, for specific kernel libraries.

Use this in
- The arm example executor_runner
- The image_classification_ethos_u example
- The zephyr hello-executorch sample

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani