### PR TITLE
Stop gathering yolo26 for the portable CI matrix

### DIFF
--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -107,6 +107,10 @@ def model_should_run_on_target_os(model: str, target_os: str) -> bool:
     A helper function to decide whether a model should be tested on a target os (linux/macos).
     For example, a big model can be disabled in macos due to the limited macos resources.
     """
+    # yolo26 was contributed as an OpenVINO/XNNPACK example and has never passed on
+    # the portable backend, so gathering it only ever produces a permanently red job.
+    if model == "yolo26":
+        return False
     if target_os == "macos":
         # Disabled in macos due to limited resources, and should stay that way even if
         # we otherwise re-enable.

--- a/.ci/scripts/gather_test_models.py
+++ b/.ci/scripts/gather_test_models.py
@@ -109,6 +109,7 @@ def model_should_run_on_target_os(model: str, target_os: str) -> bool:
     """
     # yolo26 was contributed as an OpenVINO/XNNPACK example and has never passed on
     # the portable backend, so gathering it only ever produces a permanently red job.
+    # TODO(#21621): drop this skip once yolo26 exports cleanly on portable.
     if model == "yolo26":
         return False
     if target_os == "macos":


### PR DESCRIPTION
`test-models-linux (yolo26, portable)` has been red since yolo26 was added and has never had a green run, so it produces no signal and just adds noise to every periodic run.

yolo26 is registered in the shared model registry (`examples/models/__init__.py`), and `gather_test_models.py` expands every registry entry across the `portable` and `xnnpack` backends. yolo26 is not in `MODEL_NAME_TO_OPTIONS`, so the xnnpack variant is already skipped, which means the portable job is the only one this gather step ever produced.

This change skips yolo26 in the gather step. Verified locally by running the script before and after: the gathered matrix goes from 53 records to 52, and the only record removed is

```
{'build-tool': 'cmake', 'model': 'yolo26', 'backend': 'portable', 'runner': 'linux.2xlarge', 'timeout': 90}
```

The model itself, its example code, and its OpenVINO / XNNPACK / RISC-V paths are all untouched.

@daniil-lyakhov flagging you since you added yolo26 in #18583. If you do want portable coverage for it, the fix is to make it export cleanly on the portable backend and then drop this skip. Happy to revert this if you pick it up.
