### PR TITLE
Keep DS-CNN example inputs portable-safe

### DIFF
--- a/backends/arm/scripts/aot_arm_compiler.py
+++ b/backends/arm/scripts/aot_arm_compiler.py
@@ -925,12 +925,16 @@ def _to_edge_cortex_m(
 
     def _to_channels_last(x):
         if isinstance(x, torch.Tensor):
-            if x.dim() == 4 and not x.is_contiguous(memory_format=torch.channels_last):
-                logging.warning(
-                    "Converting input tensor with shape %s to channels_last",
-                    list(x.shape),
-                )
-                return x.to(memory_format=torch.channels_last)
+            if x.dim() == 4:
+                # Singleton channels can satisfy both contiguity checks while
+                # retaining NCHW strides, so always request the target format.
+                channels_last = x.to(memory_format=torch.channels_last)
+                if channels_last.stride() != x.stride():
+                    logging.warning(
+                        "Converting input tensor with shape %s to channels_last",
+                        list(x.shape),
+                    )
+                return channels_last
             return x
         elif isinstance(x, tuple):
             return tuple(_to_channels_last(t) for t in x)
@@ -979,7 +983,7 @@ def _to_edge_cortex_m(
     )
     edge._edge_programs["forward"] = pass_manager.transform()
 
-    return model_quant, edge
+    return model_quant, edge, example_inputs
 
 
 def _to_edge_no_delegate(
@@ -1078,7 +1082,7 @@ def main() -> None:  # noqa: C901
                 "(this target does not use delegated ops)."
             )
             args.delegate = False
-        model_quant, edge = _to_edge_cortex_m(
+        model_quant, edge, example_inputs = _to_edge_cortex_m(
             exported_program,
             args,
             model,

--- a/examples/models/mlperf_tiny/ds_cnn.py
+++ b/examples/models/mlperf_tiny/ds_cnn.py
@@ -83,6 +83,4 @@ class DSCNNKWSModel(EagerModelBase):
         return DSCNNKWS().eval()
 
     def get_example_inputs(self):
-        return (
-            (torch.rand(1, 1, 49, 10) * 2 - 1).to(memory_format=torch.channels_last),
-        )
+        return (torch.rand(1, 1, 49, 10) * 2 - 1,)


### PR DESCRIPTION
## Summary

PR #21485 moved the shared DS-CNN example input to channels-last to satisfy the Cortex-M backend. That regressed the portable model test because portable convolution expects the input's standard NCHW dim order.

DS-CNN's input shape is `(1, 1, 49, 10)`. With a singleton channel, its original NCHW tensor reports both contiguous and channels-last contiguous even though its strides remain `(490, 490, 10, 1)`. The Cortex-M compiler's conditional conversion therefore did not materialize channels-last strides.

- Restore the shared DS-CNN example input to standard contiguous NCHW layout.
- Always request channels-last for 4D tensors inside the Cortex-M compiler.
- Propagate the converted example inputs for downstream bundle/reference generation.

This ports the release/1.4 fix from #21563 to main.

## Test plan

- `python3 -m py_compile examples/models/mlperf_tiny/ds_cnn.py backends/arm/scripts/aot_arm_compiler.py`
- `git diff --check`
- Loaded the wrapper with PyTorch 2.13 and verified:
  - portable input shape `(1, 1, 49, 10)`
  - portable stride `(490, 490, 10, 1)`
  - Cortex-M channels-last stride `(490, 1, 10, 1)`
  - converted values are unchanged
- Portable and Cortex-M end-to-end coverage delegated to CI.
- The identical change is already running on release/1.4 and passed its full 20-wheel matrix.

Authored with Codex.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani