### PR TITLE
Fix IndexError in RemovePermutesAroundElementwiseOps traversal

### DIFF
--- a/backends/transforms/remove_permutes_around_elementwise_ops.py
+++ b/backends/transforms/remove_permutes_around_elementwise_ops.py
@@ -149,6 +149,10 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
             dim = cast(int, node.args[1])
             rank = len(permute)
             index = dim if dim >= 0 else dim + rank + 1
+            if not 0 <= index <= rank:
+                # `permute` is not in this node's input-rank space, so it
+                # cannot be adapted across the boundary.
+                return None
             # `index` is a POSITION in the permuted output; the un-permuted
             # position the new dim lands at is the permutation VALUE there
             # (or the end, when appending). permute_subgraph rewrites the dim
@@ -165,6 +169,10 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
             dim = cast(int, node.args[1])
             rank = len(permute)
             index = dim if dim >= 0 else dim + rank
+            if not 0 <= index < rank:
+                # `permute` is not in this node's input-rank space, so it
+                # cannot be adapted across the boundary.
+                return None
             # index is a POSITION in the tensor; the permutation VALUE at
             # that position is the logical dim being removed.
             squeezed_value = permute[index]
@@ -180,6 +188,13 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
         assert isinstance(inp, torch.fx.Node)
         in_shape = inp.meta["val"].shape
         out_shape = node.meta["val"].shape
+
+        if len(permute) != len(in_shape):
+            # `permute` is expressed in this node's input-rank space; a
+            # mismatch means the traversal reached the view with a permutation
+            # already adapted to a different rank, so it cannot be adapted
+            # again here.
+            return None
 
         if len(out_shape) == len(in_shape) + 1:
             # unsqueeze: insert identity mapping at the new dim

--- a/backends/transforms/test/test_permute_optimization_passes.py
+++ b/backends/transforms/test/test_permute_optimization_passes.py
@@ -1170,6 +1170,74 @@ class RemovePermutesAcrossViewTest(unittest.TestCase):
             "permutation_sink_view_splitting_the_non_unit_dim",
         )
 
+    def test_upstream_squeeze_view_rank_mismatch_no_crash(self) -> None:
+        """Regression test for IndexError in _adapt_permute_across_view when
+        upstream traversal reaches a squeeze view after the permutation has
+        already been adapted to a lower rank.
+
+        Graph:
+            x [1, 8, 4, 2]                 y [2, 8, 4, 1]
+                    |                            |
+            permute [0, 3, 1, 2]           view_copy (squeeze trailing 1)
+            [1, 2, 8, 4]                   [2, 8, 4]
+                    |                            |
+            view_copy (squeeze dim 0)            |
+            [2, 8, 4]                            |
+                     \\                          /
+                      ---- add (3D) ------------
+                              |
+                      view_copy (unsqueeze dim 0)
+                              |
+                        permute [0, 2, 3, 1]
+
+        Traversal crosses the first view, so the permutation is adapted from
+        rank 4 to rank 3.  It then walks upstream from `add` into the second
+        view, whose input is still rank 4 and whose squeezed dim is the
+        trailing one (index 3).  Indexing the rank-3 permutation at 3 raised
+        IndexError; the adaptation must bail out and skip the subgraph."""
+        builder = GraphBuilder()
+        x_data = torch.randn(1, 8, 4, 2)
+        y_data = torch.randn(2, 8, 4, 1)
+        x = builder.placeholder("x", x_data)
+        y = builder.placeholder("y", y_data)
+        p1 = builder.call_operator(
+            op=exir_ops.edge.aten.permute_copy.default, args=(x, [0, 3, 1, 2])
+        )
+        squeeze_batch = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default, args=(p1, [2, 8, 4])
+        )
+        # Squeezes the TRAILING size-1 dim, so the squeezed index (3) is out of
+        # range for the rank-3 permutation reaching it.
+        squeeze_trailing = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default, args=(y, [2, 8, 4])
+        )
+        add = builder.call_operator(
+            op=exir_ops.edge.aten.add.Tensor, args=(squeeze_batch, squeeze_trailing)
+        )
+        unsqueeze_batch = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default, args=(add, [1, 2, 8, 4])
+        )
+        p2 = builder.call_operator(
+            op=exir_ops.edge.aten.permute_copy.default,
+            args=(unsqueeze_batch, [0, 2, 3, 1]),
+        )
+        builder.output([p2])
+        original = builder.get_graph_module()
+        gm_before = copy.deepcopy(original)
+
+        p = RemovePermutesAroundElementwiseOps()
+        result = cast(PassResult, p(original))
+        self.assertFalse(result.modified)
+        self.assertEqual(
+            count_node(result.graph_module, exir_ops.edge.aten.permute_copy.default), 2
+        )
+        validate_numerics(
+            gm_before,
+            result.graph_module,
+            [x_data, y_data],
+            "upstream_squeeze_view_rank_mismatch_no_crash",
+        )
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Tests for RemovePermutesAroundElementwiseOps


### PR DESCRIPTION
Summary:
`_adapt_permute_across_view` indexed the permutation without checking it was expressed in the view's input-rank space, so `visit()` crashed with `IndexError: list index out of range` instead of rejecting the subgraph.

- Traversal adapts the permutation when it crosses a rank-changing view. If it then reaches a *second* squeeze/unsqueeze view whose input is still at the original rank, `permute[index]` is out of range — e.g. squeezing a trailing size-1 dim gives `index == 3` for a rank-3 permutation.
- Fix: validate the index / rank in all three branches of `_adapt_permute_across_view` and return `None`, the function's documented "not possible" signal. All three call sites already handle `None` by skipping the subgraph.
- This mirrors the guard D105787161 added in `permute_subgraph()`, which only runs at apply time — traversal had no equivalent check.

Surfaced by D113424191: its `_is_permutation_sink_view` branch lets traversal continue past a layout-invariant flatten rather than aborting, which grows regions enough to reach a rank-mismatched view. That optimization is intentional and is preserved here; only the crash is fixed. The latent bug predates it.

Broke `test_auth_u85` (ECAPA -> Ethos-U85) — ARM's `RemovePermutesAroundElementwiseTosaOps` subclasses this shared pass, so it runs inside `ArmPassManager` on every Ethos-U lowering. That test is `CONTINUOUS_STATE`, so it is omitted on diffs and could not have blocked the landing.

Authored with AI assistance (Claude Code).

Differential Revision: D115062769


