### PR TITLE
Fix INT16 TABLE virtual endpoint (#21629)

### DIFF
--- a/backends/arm/_passes/insert_table_ops.py
+++ b/backends/arm/_passes/insert_table_ops.py
@@ -211,11 +211,22 @@ class InsertTableOpsPass(ArmPass):
         """
 
         def f(x: torch.Tensor) -> torch.Tensor:
+            int16_max = torch.iinfo(torch.int16).max
+            has_full_int16_upper_range = (
+                in_quantargs.dtype == torch.int16 and in_quantargs.qmax == int16_max
+            )
             x = x.clamp(in_quantargs.qmin, in_quantargs.qmax).to(
                 dtype=in_quantargs.dtype
             )
             # Dont use the 7 LSBs.
             x = in_quantargs.dequantize_value((x & ~0x7F))
+            if has_full_int16_upper_range:
+                # TOSA uses table[512] as the virtual right endpoint when
+                # interpolating raw INT16 input codes [32640, 32767]. Evaluate
+                # its real value at affine code 32768 without casting to int16.
+                x[-1] = (
+                    int16_max + 1 - in_quantargs.get_zp_per_tensor()
+                ) * in_quantargs.get_scale_per_tensor()
             x = torch_op(x)
             return out_quantargs.quantize_value(x)
 

--- a/backends/arm/test/passes/test_insert_table_ops_pass.py
+++ b/backends/arm/test/passes/test_insert_table_ops_pass.py
@@ -98,3 +98,126 @@ def test_generate_8bit_table_values_matches_reference_for_qmin_minus_127() -> No
     assert torch.equal(lut_values, expected_lut_values)
     assert int(lut_values[0]) == int(lut_values[1])
     assert int(lut_values[zero_input_index]) == expected_zero_output
+
+
+def test_generate_16bit_identity_table_is_antisymmetric() -> None:
+    """Equal zero-point-zero qparams produce an antisymmetric full-range LUT."""
+    qargs = QuantArgs(
+        scale=1.0,
+        zp=0,
+        qmin=-32767,
+        qmax=32767,
+        dtype=torch.int16,
+    )
+
+    lut_values, lshift = InsertTableOpsPass.generate_16_bit_table_values(
+        torch.nn.Identity(),
+        qargs,
+        qargs,
+    )
+
+    assert lshift == -7
+    for i in range(len(lut_values) // 2):
+        neg_value = int(lut_values[i])
+        pos_value = int(lut_values[~i])
+        assert neg_value == -pos_value, (
+            "Expected a zero-point-zero identity LUT to be antisymmetric, but "
+            f"lut_values[{i}]={neg_value} and "
+            f"lut_values[{~i}]={pos_value}"
+        )
+
+
+def test_generate_16bit_full_range_identity_table_applies_zero_point_delta() -> None:
+    """Changing only zero point offsets each LUT value by output_zp - input_zp."""
+    input_qargs = QuantArgs(
+        scale=1.0,
+        zp=1,
+        qmin=-32767,
+        qmax=32767,
+        dtype=torch.int16,
+    )
+    output_qargs = QuantArgs(
+        scale=1.0,
+        zp=-1,
+        qmin=-32767,
+        qmax=32767,
+        dtype=torch.int16,
+    )
+
+    lut_values, lshift = InsertTableOpsPass.generate_16_bit_table_values(
+        torch.nn.Identity(),
+        input_qargs,
+        output_qargs,
+    )
+
+    table_input_codes = torch.arange(-32768, 32769, 128, dtype=torch.int32)
+    zero_point_delta = (
+        output_qargs.get_zp_per_tensor() - input_qargs.get_zp_per_tensor()
+    )
+    expected_lut_values = (table_input_codes + zero_point_delta).clamp(
+        output_qargs.qmin,
+        output_qargs.qmax,
+    )
+
+    assert lshift == -7
+    assert torch.equal(lut_values.to(torch.int32), expected_lut_values)
+
+
+def test_generate_16bit_full_range_identity_table_applies_scale_ratio() -> None:
+    """Changing only scale multiplies each LUT value by input / output scale."""
+    input_qargs = QuantArgs(
+        scale=0.5,
+        zp=0,
+        qmin=-32767,
+        qmax=32767,
+        dtype=torch.int16,
+    )
+    output_qargs = QuantArgs(
+        scale=1.0,
+        zp=0,
+        qmin=-32767,
+        qmax=32767,
+        dtype=torch.int16,
+    )
+
+    lut_values, lshift = InsertTableOpsPass.generate_16_bit_table_values(
+        torch.nn.Identity(),
+        input_qargs,
+        output_qargs,
+    )
+
+    table_input_codes = torch.arange(-32768, 32769, 128, dtype=torch.int32)
+    scale_ratio = (
+        input_qargs.get_scale_per_tensor() / output_qargs.get_scale_per_tensor()
+    )
+    expected_lut_values = (table_input_codes * scale_ratio).round().to(torch.int32)
+
+    assert lshift == -7
+    assert torch.equal(lut_values.to(torch.int32), expected_lut_values)
+
+
+def test_generate_16bit_table_clamps_endpoint_for_restricted_range() -> None:
+    """A restricted input qmax clamps the final LUT value."""
+    input_qargs = QuantArgs(
+        scale=1.0,
+        zp=0,
+        qmin=-32767,
+        qmax=30080,
+        dtype=torch.int16,
+    )
+    output_qargs = QuantArgs(
+        scale=1.0,
+        zp=0,
+        qmin=-32767,
+        qmax=32767,
+        dtype=torch.int16,
+    )
+
+    lut_values, lshift = InsertTableOpsPass.generate_16_bit_table_values(
+        torch.nn.Identity(),
+        input_qargs,
+        output_qargs,
+    )
+
+    assert lshift == -7
+    assert int(lut_values[-1]) == input_qargs.qmax


### PR DESCRIPTION
Summary:

TOSA INT16 TABLE stores 513 values for 512 fixed 128-code interpolation intervals. The final value is a virtual sample at affine code 32768: valid input 32767 uses table[511] as its base and table[512] to calculate the final interval's slope.

The previous generator clamped the virtual coordinate to 32767, cast it to INT16, and then cleared the lower seven bits. This reduced the final sample to 32640, duplicating table[511] and creating a zero-slope plateau over inputs [32640, 32767]. Any activation expecting a change in value over this upper range will see an error (e.g. ReLU-like activations [expected slope == 1 vs 0] and exp [growing slope])

When the input uses the full INT16 upper range, evaluate table[512] directly as:

```
(32768 - input_zero_point) * input_scale
```

This preserves the virtual coordinate without attempting to store it in INT16. Restricted input ranges retain the existing clamp-then-align behavior and do not use the virtual full-range endpoint.

Add focused identity-LUT tests that make the expected affine behavior explicit:
- equal zero-point-zero qparams produce an antisymmetric table;
- changing only zero point offsets every table value by the zero-point delta;
- changing only scale applies the input/output scale ratio, including at code 32768;
- restricting qmax clamps the last value instead of injecting the full-range endpoint.

Reviewed By: rascani

Differential Revision: D115076485


