### PR TITLE
Bound the dynamic-qdq traceback in XNNPACK ChannelsLastTaggedReshapePass

### DIFF
--- a/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
+++ b/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
@@ -7,14 +7,15 @@
 # pyre-unsafe
 
 from enum import Enum
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 from executorch.backends.xnnpack._passes.xnnpack_pass import XNNPACKPass
 from executorch.backends.xnnpack.utils.quant_utils import (
+    extract_qdq_affine_op_args_for_decomposed_ops,
+    is_affine_qdq,
     is_dequant,
     is_dynamic_qdq,
-    is_qparam,
     is_tagged_as_implicit_q_dq,
     tag_as_implicit_q_dq,
 )
@@ -367,16 +368,21 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
             )
 
     @staticmethod
-    def redirect_dynamic_uses_to_nhwc(
-        input_node: torch.fx.Node, input_node_nhwc: torch.fx.Node
+    def redirect_dynamic_chain_to_nhwc(
+        input_node: torch.fx.Node,
+        input_node_nhwc: torch.fx.Node,
+        chain: List[torch.fx.Node],
     ) -> None:
-        """Point the stepped-over quantize wrapper and its choose_qparams at the
-        NHWC copy; every other consumer keeps the source.
+        """Point the traversed chain's quantize and the choose_qparams feeding it
+        at the NHWC copy; consumers outside the chain keep the source.
         """
-        for user in list(input_node.users):
-            if not (is_dynamic_qdq(user) or is_qparam(user)):
-                continue
-            user.replace_input_with(input_node, input_node_nhwc)
+        quantize = chain[-1]
+        quantize_args = quantize.args
+        if is_affine_qdq(quantize):
+            quantize_args = extract_qdq_affine_op_args_for_decomposed_ops(quantize)
+        qparam = quantize_args[1].args[0]
+        quantize.replace_input_with(input_node, input_node_nhwc)
+        qparam.replace_input_with(input_node, input_node_nhwc)
 
     def input_to_nhwc(
         self,
@@ -422,14 +428,15 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
             # Check if input uses dynamic quantization
             is_dynamic_input = is_dynamic_qdq(input_node)
 
+            dynamic_chain = []
             if is_dynamic_input:
-                # Trace back over the dynamic q/dq wrapper to the source node, so the
-                # copy lands ahead of the quantize. Only the wrapper may be stepped
-                # over: walking further reaches ordinary compute, whose consumers the
-                # rewrite below has no business redirecting.
+                # Trace back over this consumer's own q/dq chain to the source
+                # node, so the copy lands ahead of the quantize, and remember the
+                # chain: only it is redirected below.
                 while is_dynamic_qdq(input_node) and isinstance(
                     input_node.args[0], torch.fx.Node
                 ):
+                    dynamic_chain.append(input_node)
                     input_node = input_node.args[0]
 
             with graph_module.graph.inserting_after(input_node):
@@ -442,8 +449,10 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
                 # Use static method for consistency
                 ChannelsLastTaggedReshapePass.mark_as_nhwc_node(input_node_nhwc)
 
-            if is_dynamic_input:
-                self.redirect_dynamic_uses_to_nhwc(input_node, input_node_nhwc)
+            if dynamic_chain:
+                self.redirect_dynamic_chain_to_nhwc(
+                    input_node, input_node_nhwc, dynamic_chain
+                )
 
         self.insert_copy_and_assign_partner_nodes_quantization_sensitive(
             graph_module=graph_module,

--- a/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
+++ b/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
@@ -14,6 +14,7 @@ from executorch.backends.xnnpack._passes.xnnpack_pass import XNNPACKPass
 from executorch.backends.xnnpack.utils.quant_utils import (
     is_dequant,
     is_dynamic_qdq,
+    is_qparam,
     is_tagged_as_implicit_q_dq,
     tag_as_implicit_q_dq,
 )
@@ -369,14 +370,11 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
     def redirect_dynamic_uses_to_nhwc(
         input_node: torch.fx.Node, input_node_nhwc: torch.fx.Node
     ) -> None:
-        """Point the source node's consumers at its NHWC copy.
-
-        The graph output is left out: it has to keep returning the source in its
-        original memory format, and call() reads it as out_node.meta["val"], which
-        the copy does not carry until the pass retraces.
+        """Point the stepped-over quantize wrapper and its choose_qparams at the
+        NHWC copy; every other consumer keeps the source.
         """
         for user in list(input_node.users):
-            if user is input_node_nhwc or user.op == "output":
+            if not (is_dynamic_qdq(user) or is_qparam(user)):
                 continue
             user.replace_input_with(input_node, input_node_nhwc)
 

--- a/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
+++ b/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
@@ -14,7 +14,6 @@ from executorch.backends.xnnpack._passes.xnnpack_pass import XNNPACKPass
 from executorch.backends.xnnpack.utils.quant_utils import (
     is_dequant,
     is_dynamic_qdq,
-    is_quant,
     is_tagged_as_implicit_q_dq,
     tag_as_implicit_q_dq,
 )
@@ -366,6 +365,21 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
                 else ChannelsLastTaggedReshapePass.is_nhwc_node(input_node)
             )
 
+    @staticmethod
+    def redirect_dynamic_uses_to_nhwc(
+        input_node: torch.fx.Node, input_node_nhwc: torch.fx.Node
+    ) -> None:
+        """Point the source node's consumers at its NHWC copy.
+
+        The graph output is left out: it has to keep returning the source in its
+        original memory format, and call() reads it as out_node.meta["val"], which
+        the copy does not carry until the pass retraces.
+        """
+        for user in list(input_node.users):
+            if user is input_node_nhwc or user.op == "output":
+                continue
+            user.replace_input_with(input_node, input_node_nhwc)
+
     def input_to_nhwc(
         self,
         graph_module: torch.fx.GraphModule,
@@ -411,11 +425,11 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
             is_dynamic_input = is_dynamic_qdq(input_node)
 
             if is_dynamic_input:
-                # Trace back over the q/dq wrapper to the source node, so the copy
-                # lands ahead of the quantize. Only q/dq nodes may be stepped over:
-                # walking further reaches ordinary compute, which the blanket
-                # replace_all_uses_with below has no business rewriting.
-                while (is_quant(input_node) or is_dequant(input_node)) and isinstance(
+                # Trace back over the dynamic q/dq wrapper to the source node, so the
+                # copy lands ahead of the quantize. Only the wrapper may be stepped
+                # over: walking further reaches ordinary compute, whose consumers the
+                # rewrite below has no business redirecting.
+                while is_dynamic_qdq(input_node) and isinstance(
                     input_node.args[0], torch.fx.Node
                 ):
                     input_node = input_node.args[0]
@@ -431,9 +445,7 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
                 ChannelsLastTaggedReshapePass.mark_as_nhwc_node(input_node_nhwc)
 
             if is_dynamic_input:
-                # Replace downstream input_nodes with NHWC node
-                input_node.replace_all_uses_with(input_node_nhwc)
-                input_node_nhwc.args = (input_node,)
+                self.redirect_dynamic_uses_to_nhwc(input_node, input_node_nhwc)
 
         self.insert_copy_and_assign_partner_nodes_quantization_sensitive(
             graph_module=graph_module,

--- a/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
+++ b/backends/xnnpack/_passes/channels_last_tagged_reshape_pass.py
@@ -14,6 +14,7 @@ from executorch.backends.xnnpack._passes.xnnpack_pass import XNNPACKPass
 from executorch.backends.xnnpack.utils.quant_utils import (
     is_dequant,
     is_dynamic_qdq,
+    is_quant,
     is_tagged_as_implicit_q_dq,
     tag_as_implicit_q_dq,
 )
@@ -410,9 +411,11 @@ class ChannelsLastTaggedReshapePass(XNNPACKPass):
             is_dynamic_input = is_dynamic_qdq(input_node)
 
             if is_dynamic_input:
-                # Trace back to original source node. Stop if args[0] is not
-                # a Node (e.g., immutable_list from cat).
-                while getattr(input_node, "args", None) and isinstance(
+                # Trace back over the q/dq wrapper to the source node, so the copy
+                # lands ahead of the quantize. Only q/dq nodes may be stepped over:
+                # walking further reaches ordinary compute, which the blanket
+                # replace_all_uses_with below has no business rewriting.
+                while (is_quant(input_node) or is_dequant(input_node)) and isinstance(
                     input_node.args[0], torch.fx.Node
                 ):
                     input_node = input_node.args[0]

--- a/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
+++ b/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
@@ -22,6 +22,7 @@ from executorch.backends.xnnpack.test.test_xnnpack_utils_classes import (
 from executorch.backends.xnnpack.test.tester import Quantize, RunPasses, Tester
 from executorch.backends.xnnpack.utils.quant_utils import (
     is_dequant,
+    is_dynamic_qdq,
     is_quant,
     is_tagged_as_implicit_q_dq,
 )
@@ -521,6 +522,62 @@ class TestChannelsLastTaggedReshapePass(unittest.TestCase):
 
         # Only the quantize wrapper moved to the NHWC copy.
         self.assertEqual(tanhs[0].args[0].target, exir_ops.edge.aten.sigmoid.default)
+
+        tester.run_method_and_compare_outputs()
+
+    class SharedLinearConvDynamicQuant(torch.nn.Module):
+        """Two dynamically quantized siblings sharing one source; only the conv
+        wants NHWC.
+        """
+
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(8, 8)
+            self.conv = torch.nn.Conv2d(3, 4, 1)
+
+        def forward(self, x):
+            act = torch.sigmoid(x)
+            # Keep linear before conv so it is processed first.
+            return self.linear(act), self.conv(act)
+
+    def test_dq_shared_linear_conv_channels_last_tagged_reshape_pass(self) -> None:
+        tester = (
+            Tester(
+                self.SharedLinearConvDynamicQuant().eval(),
+                (torch.randn(1, 3, 8, 8),),
+            )
+            .quantize(
+                Quantize(
+                    quantization_config=get_symmetric_quantization_config(
+                        is_dynamic=True
+                    )
+                )
+            )
+            .export()
+            .to_edge()
+            .run_passes(self.PassStage)
+        )
+
+        graph_module = (
+            tester.get_artifact(StageType.RUN_PASSES).exported_program().graph_module
+        )
+        quantizes = [
+            node
+            for node in graph_module.graph.nodes
+            if is_dynamic_qdq(node) and is_quant(node)
+        ]
+        self.assertEqual(len(quantizes), 2)
+        for quantize in quantizes:
+            consumer = next(iter(next(iter(quantize.users)).users))
+            source = quantize.args[0].target
+            qparam_source = quantize.args[1].args[0].args[0].target
+            self.assertEqual(source, qparam_source)
+            if consumer.target == exir_ops.edge.aten.convolution.default:
+                # The conv's chain reads the NHWC copy.
+                self.assertEqual(source, exir_ops.edge.aten._to_copy.default)
+            else:
+                # The linear's chain keeps the source.
+                self.assertEqual(source, exir_ops.edge.aten.sigmoid.default)
 
         tester.run_method_and_compare_outputs()
 

--- a/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
+++ b/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
@@ -412,6 +412,74 @@ class TestChannelsLastTaggedReshapePass(unittest.TestCase):
 
         tester.run_method_and_compare_outputs()
 
+    class SiLUStemSharedConv2dDynamicQuant(torch.nn.Module):
+        """A SiLU stem ahead of the first convolution, as detection backbones have.
+
+        Two producers here have more than one consumer: the input activation feeds
+        both the sigmoid and the mul, and the SiLU output feeds both the quantized
+        convolution and the graph output. Both are reachable by the blanket
+        ``replace_all_uses_with`` in the dynamic-quant branch of ``input_to_nhwc``.
+        """
+
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 8, 3, padding=1)
+
+        def forward(self, x):
+            act = x * torch.sigmoid(x)
+            return self.conv(act), act
+
+    def test_dq_conv2d_silu_stem_shared_channels_last_tagged_reshape_pass(self) -> None:
+        tester = (
+            Tester(
+                self.SiLUStemSharedConv2dDynamicQuant().eval(),
+                (torch.randn(1, 3, 16, 16),),
+            )
+            .quantize(
+                Quantize(
+                    quantization_config=get_symmetric_quantization_config(
+                        is_dynamic=True
+                    )
+                )
+            )
+            .export()
+            .to_edge()
+            .run_passes(self.PassStage)
+        )
+
+        graph_module = (
+            tester.get_artifact(StageType.RUN_PASSES).exported_program().graph_module
+        )
+        muls = [
+            node
+            for node in graph_module.graph.nodes
+            if node.target == exir_ops.edge.aten.mul.Tensor
+        ]
+        self.assertEqual(len(muls), 1)
+        silu = muls[0]
+
+        # The walk must stop at the SiLU output rather than run on to the input
+        # activation, which would leave the mul and the sigmoid reading NHWC while
+        # their own outputs stay NCHW.
+        for arg in silu.all_input_nodes:
+            self.assertNotEqual(arg.target, exir_ops.edge.aten._to_copy.default)
+
+        # The SiLU output is converted once, for the convolution only. The graph
+        # output keeps the unconverted node.
+        copies = [
+            user
+            for user in silu.users
+            if user.target == exir_ops.edge.aten._to_copy.default
+            and user.kwargs.get("memory_format") == torch.channels_last
+        ]
+        self.assertEqual(len(copies), 1)
+        output_node = next(
+            node for node in graph_module.graph.nodes if node.op == "output"
+        )
+        self.assertIn(silu, output_node.args[0])
+
+        tester.run_method_and_compare_outputs()
+
     class ConvAddConvOutput(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
+++ b/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
@@ -480,6 +480,50 @@ class TestChannelsLastTaggedReshapePass(unittest.TestCase):
 
         tester.run_method_and_compare_outputs()
 
+    class SiblingBranchConv2dDynamicQuant(torch.nn.Module):
+        """A producer feeding both a quantized conv and an ordinary op."""
+
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 8, 3, padding=1)
+
+        def forward(self, x):
+            act = torch.sigmoid(x)
+            return self.conv(act), torch.tanh(act)
+
+    def test_dq_conv2d_sibling_branch_channels_last_tagged_reshape_pass(self) -> None:
+        tester = (
+            Tester(
+                self.SiblingBranchConv2dDynamicQuant().eval(),
+                (torch.randn(1, 3, 16, 16),),
+            )
+            .quantize(
+                Quantize(
+                    quantization_config=get_symmetric_quantization_config(
+                        is_dynamic=True
+                    )
+                )
+            )
+            .export()
+            .to_edge()
+            .run_passes(self.PassStage)
+        )
+
+        graph_module = (
+            tester.get_artifact(StageType.RUN_PASSES).exported_program().graph_module
+        )
+        tanhs = [
+            node
+            for node in graph_module.graph.nodes
+            if node.target == exir_ops.edge.aten.tanh.default
+        ]
+        self.assertEqual(len(tanhs), 1)
+
+        # Only the quantize wrapper moved to the NHWC copy.
+        self.assertEqual(tanhs[0].args[0].target, exir_ops.edge.aten.sigmoid.default)
+
+        tester.run_method_and_compare_outputs()
+
     class ConvAddConvOutput(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
+++ b/backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py
@@ -364,6 +364,54 @@ class TestChannelsLastTaggedReshapePass(unittest.TestCase):
             .run_method_and_compare_outputs()
         )
 
+    class EltwiseConv2dDynamicQuant(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = torch.nn.Conv2d(3, 10, 3)
+
+        def forward(self, x):
+            return self.conv(torch.sigmoid(x))
+
+    def test_dq_conv2d_eltwise_source_channels_last_tagged_reshape_pass(self) -> None:
+        # The conv's input is sigmoid -> q -> dq. Stepping past the q/dq pair leaves
+        # the sigmoid reading NHWC while its own output stays NCHW, which XNNPACK
+        # only rejects at runtime.
+        tester = (
+            Tester(self.EltwiseConv2dDynamicQuant().eval(), (torch.randn(1, 3, 8, 8),))
+            .quantize(
+                Quantize(
+                    quantization_config=get_symmetric_quantization_config(
+                        is_dynamic=True
+                    )
+                )
+            )
+            .export()
+            .to_edge()
+            .run_passes(self.PassStage)
+        )
+
+        artifact = tester.get_artifact(StageType.RUN_PASSES)
+        graph_module = artifact.exported_program().graph_module
+        sigmoid_nodes = [
+            node
+            for node in graph_module.graph.nodes
+            if node.target == exir_ops.edge.aten.sigmoid.default
+        ]
+        self.assertEqual(len(sigmoid_nodes), 1)
+        sigmoid = sigmoid_nodes[0]
+
+        # The sigmoid keeps its NCHW input and the copy sits on its output instead.
+        self.assertEqual(sigmoid.args[0].op, "placeholder")
+        copies = [
+            user
+            for user in sigmoid.users
+            if user.target == exir_ops.edge.aten._to_copy.default
+            and user.kwargs.get("memory_format") == torch.channels_last
+        ]
+        self.assertEqual(len(copies), 1)
+
+        tester.run_method_and_compare_outputs()
+
     class ConvAddConvOutput(torch.nn.Module):
         def __init__(self):
             super().__init__()


### PR DESCRIPTION
### Summary

The dynamic-quant branch of `ChannelsLastTaggedReshapePass.input_to_nhwc` traces back over the
q/dq wrapper so the NHWC copy is inserted ahead of the quantize, keeping the `x -> q -> dq -> conv`
chain XNNPACK matches intact. The loop stops on "`args[0]` is not a Node" rather than on "this is
not a q/dq node", so it does not stop at the quantized tensor and continues into ordinary compute:

```python
while getattr(input_node, "args", None) and isinstance(
    input_node.args[0], torch.fx.Node
):
    input_node = input_node.args[0]
```

The `input_node.replace_all_uses_with(input_node_nhwc)` that follows is then applied from wherever
the walk landed, rewriting consumers the pass never reasoned about. That shows up two ways:

If the walk stops on an intermediate op, lowering succeeds but the serialized graph is
inconsistent, and only the first `execute()` reports it:

```
[XNNExecutor.cpp:133] Internal Error: Propagating input shapes failed with code: xnn_status_invalid_parameter
[method.cpp:1421] CALL_DELEGATE execute failed at instruction 3: 0x1
```

The failing partition contains an elementwise op whose input and output dims disagree, next to a
correct one in the sibling branch:

```
[0] XNNStaticTranspose  (0)[1,32,160,160] -> (1)[1,160,160,32]
[1] XNNSigmoid          (1)[1,160,160,32] -> (2)[1,32,160,160]
[2] XNNStaticTranspose  (2)[1,32,160,160] -> (3)[1,160,160,32]
[3] XNNSigmoid          (5)[1,32,160,160] -> (4)[1,32,160,160]
```

If the walk reaches a non-4D constant it fails earlier, during the pass:

```
RuntimeError: required rank 4 tensor to use channels_last format
While executing _to_copy(%b_mul_10_const_input, memory_format=channels_last)
```

`b_mul_10_const_input` is a `(256, 1, 1)` per-channel constant. A placeholder has no `args`, so the
walk stops there and tries to convert it. `can_be_converted_to_nhwc` does check rank 4, but this
path never calls it.

Both were found on w8a8 dynamic-quantized vision models, a YOLOX detector for the first and a SAM
image encoder for the second.

### Fix

Restrict the walk to q/dq nodes. `dq -> q -> source` is two hops and the source is not a q/dq node,
so the walk stops at the source, which is the node it was aiming for, and the
`x -> _to_copy -> q -> dq -> conv` ordering is unchanged. `is_quant` is already exported from
`backends/xnnpack/utils/quant_utils.py` alongside the `is_dynamic_qdq` this file imports.

Instrumenting the loop on the YOLOX graph: 83 invocations, every one with exactly 2 q/dq hops, and
69 of them (83%) walking past that, up to 26 hops. Bounding the walk leaves the delegate count at
16 either way and removes 16 `XNNStaticTranspose` nodes (414 to 398 total), so the overshoot was
not buying larger fused partitions.

### Test

`test_dq_conv2d_eltwise_source_channels_last_tagged_reshape_pass` builds the smallest graph that
triggers it: a dynamically quantized conv whose input is a `sigmoid` reading the placeholder, so
the conv sees `sigmoid -> q -> dq`. It asserts the sigmoid keeps its placeholder input and that the
channels-last copy sits on the sigmoid's output.

Without the fix the pass produces `x -> _to_copy(channels_last) -> sigmoid -> q -> dq -> conv` and
the test fails with `AssertionError: 'call_function' != 'placeholder'`; with it the order is
`x -> sigmoid -> _to_copy(channels_last) -> q -> dq -> conv`. The assertion is structural because
`channels_last` does not change eager results, so `run_method_and_compare_outputs` alone cannot
catch this.

```
pytest backends/xnnpack/test/passes/test_channels_last_tagged_reshape.py -k eltwise_source
```

The full file passes (22 tests). Separately, 10 w8a8 dynamic models that already lowered and
executed correctly before this change (googlenet, inception_v3, efficientnet_b4, wideresnet50,
sesr_m5, mobile_vit_s, swin_t, vit_b_16, quicksrnet_small, squeezenet1_0) were re-lowered with the
grouped partitioner and executed: 10/10 pass. The two models above now lower and execute, with
output shapes matching a per-op-partitioned reference build.

cc @GregoryComer @digantdesai @cbilgin @JakeStevens
