### PR TITLE
Arm backend: Various build fixes

### DIFF
--- a/backends/arm/scripts/corstone_utils.cmake
+++ b/backends/arm/scripts/corstone_utils.cmake
@@ -78,6 +78,36 @@ function(fetch_ethos_u_content ETHOS_SDK_PATH ET_DIR_PATH)
   )
 endfunction()
 
+function(set_ethosu_dedicated_sram_fast_scratch_size OUT_VAR MEMORY_MODE)
+  if("${MEMORY_MODE}" STREQUAL "Dedicated_Sram")
+    set(${OUT_VAR}
+        0x60000
+        PARENT_SCOPE
+    )
+    return()
+  endif()
+
+  if(NOT "${MEMORY_MODE}" MATCHES "^Dedicated_Sram_([0-9]+)(KB|MB)$")
+    message(
+      FATAL_ERROR
+        "Unsupported Dedicated_Sram MEMORY_MODE ${MEMORY_MODE}. Expected Dedicated_Sram_<size>KB, Dedicated_Sram_<size>MB, or Dedicated_Sram."
+    )
+  endif()
+
+  set(_fast_scratch_value "${CMAKE_MATCH_1}")
+  set(_fast_scratch_unit "${CMAKE_MATCH_2}")
+  if(_fast_scratch_unit STREQUAL "KB")
+    math(EXPR _fast_scratch_size "${_fast_scratch_value} * 1024")
+  else()
+    math(EXPR _fast_scratch_size "${_fast_scratch_value} * 1024 * 1024")
+  endif()
+
+  set(${OUT_VAR}
+      ${_fast_scratch_size}
+      PARENT_SCOPE
+  )
+endfunction()
+
 function(add_corstone_subdirectory SYSTEM_CONFIG ETHOS_SDK_PATH)
   if(SYSTEM_CONFIG MATCHES "Ethos_U55" OR SYSTEM_CONFIG MATCHES "Ethos_U65")
     add_subdirectory(
@@ -90,11 +120,29 @@ function(add_corstone_subdirectory SYSTEM_CONFIG ETHOS_SDK_PATH)
   else()
     message(FATAL_ERROR "Unsupported SYSTEM_CONFIG ${SYSTEM_CONFIG}.")
   endif()
-  if(MEMORY_MODE MATCHES "Dedicated_Sram")
+  if(MEMORY_MODE MATCHES "^Dedicated_Sram($|_)")
+    # Both model and scratch in DRAM.
+    set(ETHOSU_MODEL
+        1
+        PARENT_SCOPE
+    )
+    set(ETHOSU_ARENA
+        1
+        PARENT_SCOPE
+    )
     target_compile_definitions(
       ethosu_target_common INTERFACE ETHOSU_MODEL=1 ETHOSU_ARENA=1
     )
   elseif(MEMORY_MODE MATCHES "Shared_Sram" OR MEMORY_MODE MATCHES "Sram_Only")
+    # Model in DRAM, scratch in SRAM.
+    set(ETHOSU_MODEL
+        1
+        PARENT_SCOPE
+    )
+    set(ETHOSU_ARENA
+        0
+        PARENT_SCOPE
+    )
     target_compile_definitions(
       ethosu_target_common INTERFACE ETHOSU_MODEL=1 ETHOSU_ARENA=0
     )
@@ -341,7 +389,7 @@ function(configure_timing_adapters SYSTEM_CONFIG MEMORY_MODE)
                   ETHOSU_TA_HISTBIN_1=0
                   ETHOSU_TA_HISTCNT_1=0
       )
-    elseif(MEMORY_MODE MATCHES "Dedicated_Sram")
+    elseif(MEMORY_MODE MATCHES "^Dedicated_Sram($|_)")
       target_compile_definitions(
         ethosu_target_common
         INTERFACE # Configure NPU architecture timing adapters This is just
@@ -389,7 +437,7 @@ function(configure_timing_adapters SYSTEM_CONFIG MEMORY_MODE)
         "corstone-320"
         PARENT_SCOPE
     )
-    if(MEMORY_MODE MATCHES "Dedicated_Sram")
+    if(MEMORY_MODE MATCHES "^Dedicated_Sram($|_)")
       target_compile_definitions(
         ethosu_target_common
         INTERFACE # Configure NPU architecture timing adapters This is just
@@ -465,7 +513,7 @@ function(configure_timing_adapters SYSTEM_CONFIG MEMORY_MODE)
         "corstone-320"
         PARENT_SCOPE
     )
-    if(MEMORY_MODE MATCHES "Dedicated_Sram")
+    if(MEMORY_MODE MATCHES "^Dedicated_Sram($|_)")
       target_compile_definitions(
         ethosu_target_common
         INTERFACE # Configure NPU architecture timing adapters This is just
@@ -577,7 +625,7 @@ function(configure_timing_adapters SYSTEM_CONFIG MEMORY_MODE)
               NPU_REGIONCFG_6=0
               NPU_REGIONCFG_7=0
     )
-  elseif(MEMORY_MODE MATCHES "Dedicated_Sram")
+  elseif(MEMORY_MODE MATCHES "^Dedicated_Sram($|_)")
     target_compile_definitions(
       ethosu_core_driver
       PRIVATE NPU_QCONFIG=3

--- a/examples/arm/ethos-u-porting-guide.md
+++ b/examples/arm/ethos-u-porting-guide.md
@@ -85,17 +85,17 @@ expected to place the scratch buffer and NN in the correct memory location.
 For example, if you generate a pte file with compile specification for Shared Sram, the scratch buffer should be placed in the SRAM and the NN in the external memory in the runtime application code. You can see we are following
 this approach in the `examples/arm/executor_runner/arm_executor_runner.cpp` example application. In the linker scripts for the application(`examples/arm/executor_runner/Corstone-320.ld` and
 `examples/arm/executor_runner/Corstone-300.ld`) we check the value of `ETHOSU_ARENA` to determine whether the ethos-u scratch buffer is placed in the on-chip memory or in the external memory. In this
-way, depending on the `ETHOSU_ARENA` parameter, the linker knows whether the symbol is to be placed in the .ddr or .sram.bss sections. The `ETHOSU_ARENA` parameter is set in the `backends/arm/scripts/corstone_utils.cmake` and
-its value is derived based on the memory mode parameter that is passed to the `examples/arm/run.sh` shell script. Then, at link time, the .ddr section is always placed in the external memory and the .sram.bss is always placed in the SRAM.
+way, depending on the `ETHOSU_ARENA` parameter, the linker knows whether the input section is to be placed in the .ddr.bss or .sram.bss sections. The `ETHOSU_ARENA` parameter is set in the `backends/arm/scripts/corstone_utils.cmake` and
+its value is derived based on the memory mode parameter that is passed to the `examples/arm/run.sh` shell script. Then, at link time, the .ddr.bss section is always placed in the external memory and the .sram.bss is always placed in the SRAM.
 Finally, note that in the `examples/arm/executor_runner/arm_executor_runner.cpp` application code, we place the buffers for the Ethos-u scratch and the neural network in the correct symbol from the linker script. For instance,
-the Ethos-u scratch buffer corresponds to the the `.bss.tensor_arena` section in the linker script, In the application code, when we allocate memory for the Ethos-u scratch buffer, we place this array in the .bss.tensor_arena section in the memory map.
+the Ethos-u scratch buffer corresponds to the the `.bss.tensor_arena` input section in the linker script, In the application code, when we allocate memory for the Ethos-u scratch buffer, we place this array in the .bss.tensor_arena section in the memory map.
 
 ```
 unsigned char __attribute__((
     section(".bss.tensor_arena"),
     aligned(16))) temp_allocation_pool[temp_allocation_pool_size];
 ```
-and the `.bss.tensor_arena` section is placed in the correct location in the memory map thanks to
+and the `.bss.tensor_arena` input section is placed in the correct location in the memory map thanks to
 the `ETHOSU_ARENA` parameter.
 
 There is a tight coupling between the memory mode for the Ethos-U and the placement of the ethos-u scratch buffer,

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -178,14 +178,16 @@ message(STATUS "MEMORY_MODE is ${MEMORY_MODE}")
 message(STATUS "ET_NUM_INFERENCES is ${ET_NUM_INFERENCES}")
 
 # By default, use 2MB of temporary scratch buffer. For Dedicated_Sram, use 64MB
-# for the temporary scratch buffer and 384KB for the fast scratch buffer (the
-# cache, applicable only for Ethos-U65 and Ethos-U85). Allow -D overrides.
-if(MEMORY_MODE MATCHES "Dedicated_Sram")
+# for the temporary scratch buffer and derive the fast scratch buffer size from
+# the memory mode suffix, e.g. Dedicated_Sram_384KB. Allow -D overrides.
+if(MEMORY_MODE MATCHES "^Dedicated_Sram($|_)")
   if(NOT DEFINED ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
     set(ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x4000000)
   endif()
   if(NOT DEFINED ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
-    set(ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x60000)
+    set_ethosu_dedicated_sram_fast_scratch_size(
+      ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE "${MEMORY_MODE}"
+    )
   endif()
 else()
   if(NOT DEFINED ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
@@ -289,7 +291,9 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 set(_arm_runner_linker_preprocessor_options ${COMPILER_PREPROCESSOR_OPTIONS})
-foreach(_arm_runner_linker_define IN ITEMS HEAP_SIZE STACK_SIZE)
+foreach(_arm_runner_linker_define IN ITEMS HEAP_SIZE STACK_SIZE ETHOSU_MODEL
+                                           ETHOSU_ARENA
+)
   if(DEFINED ${_arm_runner_linker_define})
     list(APPEND _arm_runner_linker_preprocessor_options
          "-D${_arm_runner_linker_define}=${${_arm_runner_linker_define}}"

--- a/examples/arm/executor_runner/Corstone-300.ld
+++ b/examples/arm/executor_runner/Corstone-300.ld
@@ -49,6 +49,7 @@ PHDRS
 {
     rom_exec PT_LOAD;
     rom_dram PT_LOAD;
+    rom_model PT_LOAD;
     null     PT_NULL;
 }
 
@@ -208,35 +209,35 @@ SECTIONS
     __data_end__ = .;
   } > DTCM :rom_exec
 
-  .sram.bss :
+#if (ETHOSU_MODEL == 0)
+  .sram.rodata :
   {
     . = ALIGN(16);
-#if (ETHOSU_MODEL == 0)
-  * (network_model_sec)
+    *(network_model_sec)
+  } > SRAM :rom_model
+#else
+  .ddr.rodata :
+  {
+    . = ALIGN(16);
+    *(network_model_sec)
+  } > DDR :rom_model
 #endif
 
+  .sram.bss (NOLOAD) :
+  {
 #if (ETHOSU_ARENA == 0)
     . = ALIGN(32);
     *(.bss.tensor_arena)
 #endif
     . = ALIGN(16);
     *(.bss.ethosu_scratch);
-    *.(output_data_sec)
   } > SRAM :null
 
   .ddr :
   {
-#if (ETHOSU_ARENA == 1)
-    . = ALIGN(32);
-    *(.bss.tensor_arena)
-#endif
-
     . = ALIGN(4);
     *(input_data_sec)
     . = ALIGN(16);
-#if (ETHOSU_MODEL == 1)
-    *(network_model_sec)
-#endif
     * (expected_output_data_sec)
     . = ALIGN(16);
     * (sec_command_stream, sec_weight_data, sec_input_data)
@@ -252,12 +253,15 @@ SECTIONS
     KEEP(*(.asan_shadow))
     __asan_shadow_end = .;
   } > DDR :null
-  .ddr_noload (NOLOAD) :
+
+  .ddr.bss (NOLOAD) :
   {
-    . = ALIGN(16);
-    *(input_data_sec)
-    . = ALIGN(16);
+#if (ETHOSU_ARENA == 1)
+    . = ALIGN(32);
+    *(.bss.tensor_arena)
+#endif
   } > DDR :null
+
   __eddr_data = ALIGN(4);
   .sram.data :
   {
@@ -288,7 +292,7 @@ SECTIONS
     __bss_end__ = .;
   } > DTCM :null
 
-  .heap (COPY) :
+  .heap (NOLOAD) :
   {
     . = ALIGN(8);
     __end__ = .;
@@ -298,7 +302,7 @@ SECTIONS
     __HeapLimit = .;
   } > DTCM :null
 
-  .stack (ORIGIN(DTCM) + LENGTH(DTCM) - __STACK_SIZE) (COPY) :
+  .stack (ORIGIN(DTCM) + LENGTH(DTCM) - __STACK_SIZE) (NOLOAD) :
   {
     . = ALIGN(8);
     __StackLimit = .;

--- a/examples/arm/executor_runner/Corstone-320.ld
+++ b/examples/arm/executor_runner/Corstone-320.ld
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Arm Limited and/or its affiliates.
+ * Copyright 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -51,6 +51,7 @@ PHDRS
     rom_boot PT_LOAD;
     rom_exec PT_LOAD;
     rom_dram PT_LOAD;
+    rom_model PT_LOAD;
     null     PT_NULL;
 }
 
@@ -188,11 +189,6 @@ SECTIONS
 
   .sram : AT(__etext)
   {
-#if (ETHOSU_MODEL == 0)
-    . = ALIGN(16);
-    *(network_model_sec)
-#endif
-
     . = ALIGN(16);
     *(.sram.data)
 
@@ -219,29 +215,32 @@ SECTIONS
     KEEP(*(.jcr*))
   } > SRAM :rom_dram
 
-  .sram.bss :
+#if (ETHOSU_MODEL == 0)
+  .sram.rodata :
+  {
+    . = ALIGN(16);
+    *(network_model_sec)
+  } > SRAM :rom_model
+#else
+  .ddr.rodata :
+  {
+    . = ALIGN(16);
+    *(network_model_sec)
+  } > DDR :rom_model
+#endif
+
+  .sram.bss (NOLOAD) :
   {
 #if (ETHOSU_ARENA == 0)
     . = ALIGN(32);
     *(.bss.tensor_arena)
 #endif
-
     . = ALIGN(16);
     *(.bss.ethosu_scratch);
   } > SRAM :null
 
   .ddr :
   {
-#if (ETHOSU_ARENA == 1)
-    . = ALIGN(32);
-    *(.bss.tensor_arena)
-#endif
-
-#if (ETHOSU_MODEL == 1)
-    . = ALIGN(16);
-    *(network_model_sec)
-#endif
-
     . = ALIGN(4);
     *(input_data_sec)
     *(expected_output_data_sec)
@@ -259,11 +258,15 @@ SECTIONS
     KEEP(*(.asan_shadow))
     __asan_shadow_end = .;
   } > DDR :null
-  .ddr_noload (NOLOAD) :
+
+  .ddr.bss (NOLOAD) :
   {
-    . = ALIGN(16);
-    *(input_data_sec)
+#if (ETHOSU_ARENA == 1)
+    . = ALIGN(32);
+    *(.bss.tensor_arena)
+#endif
   } > DDR :null
+
   .bss :
   {
     . = ALIGN(4);
@@ -277,7 +280,7 @@ SECTIONS
     __bss_end__ = .;
   } > BRAM :null
 
-  .heap (ORIGIN(BRAM) + LENGTH(BRAM) - __HEAP_SIZE) (COPY) :
+  .heap (ORIGIN(BRAM) + LENGTH(BRAM) - __HEAP_SIZE) (NOLOAD) :
   {
     . = ALIGN(8);
     __end__ = .;
@@ -287,7 +290,7 @@ SECTIONS
     __HeapLimit = .;
   } > BRAM :null
 
-  .stack (ORIGIN(DTCM) + LENGTH(DTCM) - __STACK_SIZE) (COPY) :
+  .stack (ORIGIN(DTCM) + LENGTH(DTCM) - __STACK_SIZE) (NOLOAD) :
   {
     . = ALIGN(8);
     __StackLimit = .;

--- a/examples/arm/executor_runner/pte_to_header.py
+++ b/examples/arm/executor_runner/pte_to_header.py
@@ -60,7 +60,10 @@ parser.add_argument(
 if __name__ == "__main__":
     args = parser.parse_args()
     outfile = os.path.join(args.outdir, args.outfile)
-    attr = f'__attribute__((section("{args.section}"), aligned(16))) unsigned char '
+    attr = (
+        f'__attribute__((section("{args.section}"), aligned(16))) '
+        "const unsigned char "
+    )
 
     with open(args.pte, "rb") as fr, open(outfile, "w") as fw:
         data = fr.read()

--- a/examples/arm/mobilesam_prompt_segmentation_example_ethos_u/runtime/CMakeLists.txt
+++ b/examples/arm/mobilesam_prompt_segmentation_example_ethos_u/runtime/CMakeLists.txt
@@ -126,13 +126,15 @@ target_link_libraries(
   mobilesam_prompt_segmentation_example PUBLIC executorch_delegate_ethos_u
 )
 
-if(MEMORY_MODE MATCHES "Dedicated_Sram")
+if(MEMORY_MODE MATCHES "^Dedicated_Sram($|_)")
   set(ETHOSU_ARENA "1")
   if(NOT DEFINED ET_SEGMENTATION_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
     set(ET_SEGMENTATION_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x1000000)
   endif()
   if(NOT DEFINED ET_SEGMENTATION_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
-    set(ET_SEGMENTATION_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE 0x60000)
+    set_ethosu_dedicated_sram_fast_scratch_size(
+      ET_SEGMENTATION_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE "${MEMORY_MODE}"
+    )
   endif()
 else()
   set(ETHOSU_ARENA "0")


### PR DESCRIPTION
- Set ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE depending on Dedicated_Sram configuration.

- Refactor linker scripts to allow NOLOAD on zero-initialized sections, reducing built binary size.
  - Add functional output sections: - .sram.rodata / .ddr.rodata for constant data. - .sram.bss / rename ddr_noload ->.ddr.bss for memory arenas. These sections are NOLOAD.
  - Add rom_model PHDR so model data has its own load segment.
  - Change .heap and .stack from COPY to NOLOAD.

  - Move input sections:
    - network_model_sec: .sram/.ddr -> .sram.rodata/.ddr.rodata
    - .bss.tensor_arena: .sram.bss/.ddr -> .sram.bss/.ddr.bss

- Make generated embedded PTE data const.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani