### PR TITLE
Revert "Build PyTorch wheel via PEP 517 instead of setup.py" (#21562)

### DIFF
--- a/.ci/docker/common/install_pytorch.sh
+++ b/.ci/docker/common/install_pytorch.sh
@@ -49,18 +49,8 @@ install_pytorch_and_domains() {
     export MAX_JOBS="${PYTORCH_BUILD_MAX_JOBS}"
   fi
   configure_pytorch_compiler
-  # PyTorch no longer supports "python setup.py bdist_wheel"; it now builds
-  # through scikit-build-core (PEP 517). Build the wheel with the standard
-  # frontend and keep build isolation off, so PyTorch builds against this
-  # environment's numpy and toolchain (avoids an ABI mismatch) and reuses
-  # sccache. With isolation off the frontend does not fetch the PEP 517 build
-  # requirements, so install the ones not already in the image here. Keep in
-  # sync with pytorch/pyproject.toml [build-system].requires.
-  # cmake stays below 4 because the wheel lands on PATH ahead of the image's
-  # cmake 3.x, so every later build in the image would jump a major version.
-  conda_run pip install build "scikit-build-core>=1.0" "setuptools>=77.0.0,<82" \
-    "cmake>=3.27,<4" ninja "packaging>=24.2" "typing-extensions>=4.10.0" pyyaml six
-  conda_run python -m build --wheel --no-isolation
+  # Then build and install PyTorch
+  conda_run python setup.py bdist_wheel
   pip_install "$(echo dist/*.whl)"
 
   # Grab the pinned audio and vision commits from PyTorch


### PR DESCRIPTION
Reverts the `install_pytorch.sh` change from #21562.

### Why

#21562 broke `test-riscv` on main. 17 of 17 jobs, on every commit that has landed since it went in. Failing step is `pip install --no-build-isolation extension/llm/tokenizers`:

```
[299/312] Generating CXX dyndep file CMakeFiles/pytorch_tokenizers_cpp.dir/CXX.dd
FAILED: CMakeFiles/pytorch_tokenizers_cpp.dir/src/python_bindings.cpp.o
cc1plus: error: to generate dependencies you must specify either '-M' or '-MM'
```

### Cause

The PEP 517 change itself is correct and should come back. The problem is how the build requirements are installed.

To run `python -m build --wheel --no-isolation`, #21562 installs `build`, `scikit-build-core`, `setuptools`, `cmake` and `ninja` permanently into the image's conda environment. `scikit-build-core` ships a setuptools plugin that registers itself as the `build_ext` command class. Every later `pip install --no-build-isolation` in that image then runs its CMake configure instead of the plain setuptools one, which switches on C++20 module dependency scanning. The image's GCC 14.2.0 cannot produce the scan output CMake asks for, so the tokenizers build dies.

Two greps confirm it. `dyndep` has zero hits in the last green job log and one in the red one. `scikit_build_core` is absent from the green log and present in the red traceback.

### Why CI did not catch it

`test-riscv` lives in its own workflow, `Test RISC-V Backend`. It does not run on pull requests unless the change touches specific RISC-V paths, it is not a required merge context, and it does not gate viable/strict. So nothing in the pre-merge gate could have seen this.

### Next

Re-landing separately with the build requirements confined to a throwaway virtualenv, so they stop leaking into every later build in the image. That PR will carry a `ciflow/trunk` tag so `test-riscv` actually runs on it before it merges.