### PR TITLE
Zero grad_input in max_pool2d_with_indices_backward

### DIFF
--- a/kernels/portable/cpu/op_max_pool2d_with_indices_backward.cpp
+++ b/kernels/portable/cpu/op_max_pool2d_with_indices_backward.cpp
@@ -9,6 +9,8 @@
 #include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
 #include <executorch/runtime/kernel/kernel_includes.h>
 
+#include <cstring>
+
 namespace torch {
 namespace executor {
 namespace native {
@@ -170,6 +172,13 @@ Tensor& max_pool2d_with_indices_backward_out(
       grad_input);
 
   static constexpr auto name = "max_pool2d_with_indices_backward.grad_input";
+
+  // max_pool_backward_impl scatter-adds into grad_input (`grad_input_ptr[maxindex] += ...`), writing
+  // only the argmax positions. resize_tensor does not clear the buffer and the memory planner recycles
+  // arena allocations across ops and iterations, so every other element would accumulate onto stale
+  // data. ATen zeroes gradInput before dispatching the identical loop
+  // (aten/src/ATen/native/DilatedMaxPool2d.cpp).
+  memset(grad_input.mutable_data_ptr(), 0, grad_input.nbytes());
 
   ET_SWITCH_FLOATHBF16_TYPES(input.scalar_type(), ctx, name, CTYPE, [&]() {
     max_pool_backward_impl<CTYPE, false>(grad_input, grad_output, indices);


### PR DESCRIPTION
Fixes #21686.

`max_pool_backward_impl` scatter-adds into `grad_input`, writing only the argmax positions:

```cpp
grad_input_ptr[maxindex] += grad_output_ptr[index];
```

but the kernel only *resizes* `grad_input` and never clears it. Since the memory planner recycles arena
buffers across ops and across iterations, every non-argmax element accumulates onto stale data.

ATen does the same accumulation and zeroes first —
[`DilatedMaxPool2d.cpp`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/DilatedMaxPool2d.cpp#L202)
calls `gradInput.zero_()` before dispatching, and
[`MaxPoolKernel.cpp`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cpu/MaxPoolKernel.cpp#L524)
holds the character-for-character same `+=` loop. The loop was ported here; the `zero_()` was not.

### Effect

Any trainable graph containing `Conv2d -> MaxPool2d` gets corrupted weight gradients, because the
polluted `grad_input` feeds `convolution_backward`. Pool-only graphs are unaffected — there the maxpool
`grad_input` is the gradient w.r.t. the network input and is discarded before reaching a parameter,
which is why the bug looks so selective.

The failure mode depends on model size, and the large-model case is the concerning one:

| model | before | after |
|---|---|---|
| `Conv2d->MaxPool2d->Linear` (67,642 params) | 2.309544 -> **NaN** (291/300 NaN steps) | 2.309544 -> **0.003952** (0 NaN) |
| ResNet-18 GroupNorm (11,177,538 params) | 0.693080 -> **0.814618**, **0 NaN**, never improves | 0.693080 -> **0.018742** |

At 11M parameters there is no NaN at all — the loss just wanders and ends above where it started.

### Validation

- **No regression:** five other trainable models (strided-conv CNN, conv-only, pool-only, MLP, a second
  strided variant) produce **byte-identical** loss curves before and after, under identical flags and a
  fixed batch, with only this file changed.
- **Gradient correctness:** against an independently-built LiteRT/TF graph on the same task and init, the
  patched curve is **bit-identical for the first 5 steps** (max abs deviation `0.000e+00`) and tracks
  within <1% from step 100 to 300.
- **On device:** cross-compiled `arm64-v8a` (NDK 27.1.12297006), run on a Snapdragon 845 / Android 10
  handset pinned to the big cluster. Same before/after, and the fixed curve agrees with the macOS arm64
  host to `3.07e-04` max deviation, within 1 ULP on the final loss.
- **Cost:** +0.06% median step latency on the handset (239.94 ms -> 240.09 ms); peak RSS 10.38 -> 10.48 MB.

All-zero is the correct bit pattern for every dtype `ET_SWITCH_FLOATHBF16_TYPES` covers
(float / half / bfloat16).

Reproduced on v1.3.1 and verified still present on `main` and in v1.4.0.


cc @larryliu0820 @manuelcandales @JakeStevens