### PR TITLE
Build the custom ops AOT libs as C++20

### DIFF
--- a/extension/llm/custom_ops/CMakeLists.txt
+++ b/extension/llm/custom_ops/CMakeLists.txt
@@ -130,6 +130,8 @@ if(EXECUTORCH_BUILD_KERNELS_LLM_AOT)
     ${CMAKE_CURRENT_SOURCE_DIR}/op_tile_crop.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/op_tile_crop_aot.cpp
   )
+  # This lib compiles real PyTorch headers, which require C++20.
+  set_target_properties(custom_ops_aot_lib PROPERTIES CXX_STANDARD 20)
   target_include_directories(
     custom_ops_aot_lib PRIVATE "${_common_include_directories}"
   )

--- a/tools/cmake/Codegen.cmake
+++ b/tools/cmake/Codegen.cmake
@@ -330,6 +330,8 @@ function(gen_custom_ops_aot_lib)
   find_package_torch()
   # This lib uses ATen lib, so we explicitly enable rtti and exceptions.
   target_compile_options(${GEN_LIB_NAME} PRIVATE -frtti -fexceptions)
+  # ATen headers require C++20.
+  set_target_properties(${GEN_LIB_NAME} PROPERTIES CXX_STANDARD 20)
   target_compile_definitions(${GEN_LIB_NAME} PRIVATE USE_ATEN_LIB=1)
   include_directories(${TORCH_INCLUDE_DIRS})
   target_link_libraries(${GEN_LIB_NAME} PRIVATE torch)


### PR DESCRIPTION
### Summary

A few ExecuTorch build targets compile real PyTorch headers, instead of the small copy of `c10` that ships inside this repo. ATen (the PyTorch tensor library) now needs C++20, so every one of those targets has to ask for C++20 explicitly.

Most already do: `util`, `portable_lib`, `_training_lib`, and the LLM runner all set `CXX_STANDARD 20`. Two were missed:

- `custom_ops_aot_lib` in `extension/llm/custom_ops/CMakeLists.txt`. It compiles `op_sdpa_aot.cpp`, which includes `<torch/library.h>`.
- The library built by `gen_custom_ops_aot_lib` in `tools/cmake/Codegen.cmake`. It compiles the generated `RegisterSchema.cpp`, which includes the same header.

Both still build at C++17 against the currently pinned PyTorch, so nothing is broken today. The problem shows up when building against a newer PyTorch, where the compile fails inside `c10/util/intrusive_ptr.h`, which uses `std::strong_ordering`, a C++20 feature:

```
c10/util/intrusive_ptr.h:775:8: error: 'strong_ordering' is not a member of 'std'
```

The fix is two lines, in the same form the other targets already use:

```cmake
set_target_properties(custom_ops_aot_lib PROPERTIES CXX_STANDARD 20)
```

### Test plan

Configured on Linux x86_64 with `EXECUTORCH_BUILD_KERNELS_LLM_AOT=ON` and `EXECUTORCH_BUILD_KERNELS_QUANTIZED=ON`, then compared the compile flags in `compile_commands.json` before and after the change:

```
target                     before     after
custom_ops                 gnu++17    gnu++17
custom_ops_aot_lib         gnu++17    gnu++20   <== changed
quantized_ops_aot_lib      gnu++17    gnu++20   <== changed
quantized_ops_lib          gnu++17    gnu++17
portable_lib               gnu++20    gnu++20
util                       gnu++20    gnu++20
```

In this configuration exactly the two targets above change. Note that
`gen_custom_ops_aot_lib` has three call sites
(`examples/portable/custom_ops/CMakeLists.txt`, `kernels/portable/CMakeLists.txt`,
`kernels/quantized/CMakeLists.txt`), so builds that enable the other two also flip those
libs to C++20. That is intended: all three pass `USE_ATEN_LIB=1` and link `torch`, so all
three compile the ATen headers that require C++20.

Also compiled every source file shared by these targets under C++20 to confirm none of them relies on C++17-only behavior (7 files, all pass).

