### PR TITLE
Fix test-webgpu-native: export the missing rope fixture, raise the job timeout

### DIFF
--- a/.github/workflows/test-webgpu-native.yml
+++ b/.github/workflows/test-webgpu-native.yml
@@ -36,7 +36,11 @@ jobs:
       runner: linux.4xlarge.memory
       docker-image: ci-image:executorch-ubuntu-22.04-clang12
       submodules: recursive
-      timeout: 120
+      # The test script alone runs about 60 minutes, and the checkout plus the
+      # Dawn and SwiftShader source builds in front of it have been measured
+      # between 18 and 64 minutes on this same runner type, so 120 does not
+      # cover a slow setup.
+      timeout: 150
       script: |
         set -eux
 

--- a/backends/webgpu/scripts/test_webgpu_native_ci.sh
+++ b/backends/webgpu/scripts/test_webgpu_native_ci.sh
@@ -106,8 +106,12 @@ export_rope_model('${ROPE_DECODE_MODEL}', '${ROPE_DECODE_XQ_GOLDEN}', '${ROPE_DE
 "
 
 $PYTHON_EXECUTABLE -c "
-from executorch.backends.webgpu.test.ops.test_rope_hf import export_rope_hf_dynamic
+from executorch.backends.webgpu.test.ops.test_rope_hf import (
+    export_rope_hf_dynamic,
+    export_rope_hf_dynamic_sequence,
+)
 export_rope_hf_dynamic('${ROPE_HF_DIR}')
+export_rope_hf_dynamic_sequence('${ROPE_HF_DIR}')
 "
 
 $PYTHON_EXECUTABLE -c "
@@ -157,6 +161,7 @@ export_incache_decode('/tmp')
 "
 
 require_file "${ROPE_HF_DIR}/rope_hf_dynamic.pte"
+require_file "${ROPE_HF_DIR}/rope_hf_dynamic_sequence.pte"
 require_file "${SYMINT_BLOB}"
 require_file "${OUTPUT_SUPPRESSION_DIR}/input.bin"
 

--- a/backends/webgpu/test/test_native_ci_contract.py
+++ b/backends/webgpu/test/test_native_ci_contract.py
@@ -71,5 +71,9 @@ class TestNativeCIContract(unittest.TestCase):
         ).read_text()
 
         self.assertIn("export_rope_hf_dynamic('${ROPE_HF_DIR}')", script)
+        self.assertIn("export_rope_hf_dynamic_sequence('${ROPE_HF_DIR}')", script)
         self.assertIn('WEBGPU_TEST_ROPE_HF_DIR="${ROPE_HF_DIR}"', script)
         self.assertIn('require_file "${ROPE_HF_DIR}/rope_hf_dynamic.pte"', script)
+        self.assertIn(
+            'require_file "${ROPE_HF_DIR}/rope_hf_dynamic_sequence.pte"', script
+        )


### PR DESCRIPTION
## What is broken

`test-webgpu-native` is red on main. The failing test is `WebGPUNative.RopeHfDynamicSequenceReusedGraph` and it fails with `Error::AccessFailed`, which is what ExecuTorch returns when it cannot open a `.pte` file.

A second, quieter problem in the same job: its 120 minute limit does not cover the slow end of its own setup. That is not what is red today, but it is close enough to the edge to be worth fixing in the same change. Details below.

## Why the test is broken

The C++ test loads a model file named `rope_hf_dynamic_sequence.pte` out of the directory given by the `WEBGPU_TEST_ROPE_HF_DIR` environment variable.

The CI script that prepares the test fixtures, `backends/webgpu/scripts/test_webgpu_native_ci.sh`, only called `export_rope_hf_dynamic(...)`. It never called `export_rope_hf_dynamic_sequence(...)`, so `rope_hf_dynamic_sequence.pte` was never written. The test then tried to open a file that did not exist.

The Python helper `export_rope_hf_dynamic_sequence` already exists in `backends/webgpu/test/ops/test_rope_hf.py`. It was just never called from CI.

The contract test that is supposed to catch exactly this kind of gap only checked for the other fixture, so nothing failed at lint time either.

## The fix

1. Call `export_rope_hf_dynamic_sequence('${ROPE_HF_DIR}')` in the CI script, right next to the existing `export_rope_hf_dynamic` call.
2. Add a `require_file` check for each of the two `.pte` files. If a fixture ever goes missing again, the script now stops early with a readable message instead of failing deep inside a C++ test with a numeric error code.
3. Extend `test_native_ci_contract.py` so it asserts that both exports and both `require_file` checks are present.
4. Raise the job `timeout` from 120 to 150 minutes.

No test logic and no backend code changed. Items 1 to 3 only produce a file the test always expected to find.

## Why the timeout has to go up

The relevant numbers, all from `test-webgpu-native` runs on the same `linux.4xlarge.memory` runner label:

| run | setup: checkout, docker pull, Dawn and SwiftShader source build | test script | job total |
| --- | --- | --- | --- |
| [31297680898](https://github.com/pytorch/executorch/actions/runs/31297680898) (the green run below) | 17.7 min | 57.4 min | 75.5 min |
| [31194258936](https://github.com/pytorch/executorch/actions/runs/31194258936) | 52.7 min | 28.6 min | 81.7 min |
| [31194597529](https://github.com/pytorch/executorch/actions/runs/31194597529) | 64.0 min | 29.9 min | 94.3 min |

The test script is the stable part. The setup in front of it is not: the Dawn plus SwiftShader source build alone has been measured at 9.7, 44.0 and 55.9 minutes. The dependency versions are pinned and the build is the same one every time, so this is runner variance, not anything the repo controls.

The two slow runs are short on the test side only because they were before #21646, when the op-test stage was still wrapped in a warning and skipped. With today's script the test side is the 57.4 minute figure. Put the worst setup we have observed in front of it and the job needs 121 minutes, which is already over the current 120 limit.

150 leaves real headroom without letting a genuinely hung job sit for hours.

## How this was verified

`test-webgpu-native` was dispatched on this branch. In that run
`WebGPUNative.RopeHfDynamicSequenceReusedGraph` passes and the script prints
`=== WebGPU native tests on Dawn: all run targets passed ===`, so the fixture is
now produced and the test that is red on main is green.

On its own this branch does not make the whole job green: the script then reaches
a separate op-test stage that fails on an unrelated problem in the op-test
generator, which #21697 fixes. The two were therefore also tested together, on a
branch holding both changes, and that run passes end to end:

```
[       OK ] WebGPUNative.RopeHfDynamicSequenceReusedGraph (29 ms)
=== WebGPU native tests on Dawn: all run targets passed ===
Generated 390 cases -> /tmp/webgpu_op_tests/manifest.json
[==========] 391 tests from 88 test suites ran. (37413 ms total)
[  PASSED  ] 391 tests.
=== WebGPU op-test framework on Dawn: passed ===
```

So this PR plus #21697 turn `test-webgpu-native` green. Either one alone is not
enough, and they are separate problems, so they are separate changes.

## Overlap with other pull requests

`.github/workflows/test-webgpu-native.yml` is also edited by #21691, which changes
the `concurrency:` block near the top of the file. This PR changes `timeout:` in
the job block further down. The hunks do not touch, and the two merge cleanly in
either order.
