### PR TITLE
Fix the nightly link check: tell a broken runner from a dead link, repair every dead link it found

### DIFF
--- a/.ci/docker/common/install_openssl.sh
+++ b/.ci/docker/common/install_openssl.sh
@@ -5,8 +5,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# NB: This script is needed for sccache and is adopted from PyTorch core repo at
-# https://github.com/pytorch/pytorch/blob/main/.ci/docker/common/install_openssl.sh
+# NB: This script is needed for sccache and is adopted from PyTorch core repo.
+# Core deleted its copy in pytorch/pytorch#179513, so this points at the last
+# revision that still had it instead of at a branch.
+# https://github.com/pytorch/pytorch/blob/9274b93eac9f026e9f51e282449b0300b8e05482/.ci/docker/common/install_openssl.sh
 set -ex
 
 OPENSSL=openssl-1.1.1k

--- a/.ci/scripts/test_llava.sh
+++ b/.ci/scripts/test_llava.sh
@@ -114,7 +114,7 @@ export_llava() {
 # Download a new image
 download_image() {
     echo "Downloading image"
-    curl -o basketball.jpg https://upload.wikimedia.org/wikipedia/commons/7/73/Chicago_Bulls_and_New_Jersey_Nets%2C_March_28%2C_1991.jpg
+    curl -fL -o basketball.jpg https://upload.wikimedia.org/wikipedia/commons/3/3e/Chicago_Bulls_-_New_Jersey_Nets_match_on_March_28%2C_1991.jpg
 }
 
 run_and_verify() {

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <div align="center">
   <a href="https://pypi.org/project/executorch/"><img src="https://img.shields.io/pypi/v/executorch?style=for-the-badge&color=blue" alt="PyPI - Version"></a>
   <a href="https://github.com/pytorch/executorch/graphs/contributors"><img src="https://img.shields.io/github/contributors/pytorch/executorch?style=for-the-badge&color=blue" alt="GitHub - Contributors"></a>
-  <a href="https://github.com/pytorch/executorch/stargazers"><img src="https://img.shields.io/github/stars/pytorch/executorch?style=for-the-badge&color=blue" alt="GitHub - Stars"></a>
+  <a href="https://github.com/pytorch/executorch/stargazers"><!-- @lint-ignore GitHub serves 404 on /stargazers to non-browser clients --><img src="https://img.shields.io/github/stars/pytorch/executorch?style=for-the-badge&color=blue" alt="GitHub - Stars"></a>
   <a href="https://discord.gg/Dh43CKSAdc"><img src="https://img.shields.io/badge/Discord-Join%20Us-blue?logo=discord&logoColor=white&style=for-the-badge" alt="Discord - Chat with Us"></a>
   <a href="https://docs.pytorch.org/executorch/main/index.html"><img src="https://img.shields.io/badge/Documentation-blue?logo=googledocs&logoColor=white&style=for-the-badge" alt="Documentation"></a>
 </div>

--- a/backends/arm/scripts/toolchain_utils.sh
+++ b/backends/arm/scripts/toolchain_utils.sh
@@ -75,7 +75,9 @@ function musl_select_toolchain() {
     fi
 
     if [[ "${ARCH}" == "x86_64" ]] ; then
-        toolchain_url="https://musl.cc/aarch64-linux-musl-cross.tgz"
+        # musl.cc serves this fine to developers but has never answered the link
+        # check from a GitHub hosted runner.
+        toolchain_url="https://musl.cc/aarch64-linux-musl-cross.tgz" # @lint-ignore
         toolchain_dir="aarch64-linux-musl-cross"
         toolchain_md5_checksum="a6bb806af217a91cf575e15163e8b12b"
         toolchain_archive="${toolchain_dir}.tgz"

--- a/backends/qualcomm/scripts/download_qnn_sdk.py
+++ b/backends/qualcomm/scripts/download_qnn_sdk.py
@@ -75,7 +75,7 @@ _QNN_CONFIG = _read_qnn_config()
 QNN_VERSION = _QNN_CONFIG.get("QNN_VERSION", "2.37.0.250724")
 QNN_ZIP_URL = _QNN_CONFIG.get(
     "QNN_ZIP_URL",
-    f"https://softwarecenter.qualcomm.com/api/download/software/sdks/"
+    f"https://softwarecenter.qualcomm.com/api/download/software/sdks/"  # @lint-ignore only half of a URL, the rest is on the next line
     f"Qualcomm_AI_Runtime_Community/All/{QNN_VERSION}/v{QNN_VERSION}.zip",
 )
 

--- a/docs/source/kernel-library-custom-aten-kernel.md
+++ b/docs/source/kernel-library-custom-aten-kernel.md
@@ -207,7 +207,7 @@ Unlike the YAML entry API, the C++ API only uses C++ macros `EXECUTORCH_LIBRARY`
 
 Please refer to [Custom Ops Best Practices](#custom-ops-api-best-practices) on which API to use.
 
-Similar to [`TORCH_LIBRARY`](https://pytorch.org/cppdocs/library.html#library_8h_1a0bd5fb09d25dfb58e750d712fc5afb84) in PyTorch, `EXECUTORCH_LIBRARY` takes the operator name and the C++ function name and register them into ExecuTorch runtime.
+Similar to [`TORCH_LIBRARY`](https://docs.pytorch.org/cppdocs/api/library/index.html) in PyTorch, `EXECUTORCH_LIBRARY` takes the operator name and the C++ function name and register them into ExecuTorch runtime.
 
 #### Prepare custom kernel implementation
 

--- a/docs/source/success-stories.md
+++ b/docs/source/success-stories.md
@@ -66,7 +66,7 @@ PrivateMind delivers a fully private AI assistant using ExecuTorch's .pte format
 
 NimbleEdge successfully integrated ExecuTorch with its open-source DeliteAI platform to enable agentic workflows orchestrated in Python on mobile devices. The extensible ExecuTorch ecosystem allowed implementation of on-device optimization techniques leveraging contextual sparsity. ExecuTorch significantly accelerated the release of "NimbleEdge AI" for iOS, enabling models like Qwen 2.5 with tool calling support and achieving up to 30% higher transactions per second.
 
-[Visit →](https://nimbleedge.com) • [Blog →](https://www.nimbleedge.com/blog/meet-nimbleedge-ai-the-first-truly-private-on-device-assistant) • [iOS App →](https://apps.apple.com/in/app/nimbleedge-ai/id6746237456)
+[Visit →](https://nimbleedge.com) • [Blog →](https://www.nimbleedge.com/blog/meet-nimbleedge-ai-the-first-truly-private-on-device-assistant)
 :::
 
 ::::

--- a/examples/models/llama/runner/generation.py
+++ b/examples/models/llama/runner/generation.py
@@ -74,7 +74,7 @@ class LlamaRunner(ABC):
         self.use_kv_cache = use_kv_cache
         self.tokenizer = get_tokenizer(tokenizer_path, tokenizer_config_path)
         self.device = device
-        # For some models like qwen, mismatch is acceptable: https://github.com/QwenLM/Qwen2.5/issues/466#issuecomment-2146759706
+        # For some models like qwen, mismatch is acceptable: https://github.com/QwenLM/Qwen3/issues/466#issuecomment-2146759706
         if vocab_size != self.tokenizer.n_words:
             print(
                 "Warning - given vocab_size in params is unequal to tokenizer vocab size."

--- a/scripts/lint_urls.sh
+++ b/scripts/lint_urls.sh
@@ -12,6 +12,7 @@ trap 'kill 0' SIGINT
 status=0
 green='\e[1;32m'; red='\e[1;31m'; cyan='\e[1;36m'; yellow='\e[1;33m'; reset='\e[0m'
 user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36"
+egress_probe_url="https://api.github.com"
 max_jobs=10
 pids=()
 
@@ -26,28 +27,18 @@ while IFS=: read -r filepath url; do
       sleep 1
       code=$(curl -k -gsLm30 --retry 3 --retry-delay 3 --retry-connrefused -o /dev/null -w "%{http_code}" -r 0-0 -A "$user_agent" "$url") || code=000
     fi
-    if [ "$code" -lt 200 ] || [ "$code" -ge 400 ]; then
-      sleep 1
-      request_id=$(curl -sS -G -H 'Accept: application/json' \
-        --data-urlencode "host=$url" \
-        --data-urlencode "max_nodes=1" \
-        --data-urlencode "node=us3.node.check-host.net" \
-        https://check-host.net/check-http \
-        | jq -r .request_id) || request_id=""
-      if [ -n "$request_id" ]; then
-        sleep 5
-        for _ in {1..5}; do
-          new_code=$(curl -sS -H 'Accept: application/json' \
-            "https://check-host.net/check-result/$request_id" \
-            | jq -r -e '.[][0][3]') || new_code=000
-          [[ "$new_code" =~ ^[0-9]+$ ]] || new_code=000
-          if [ "$new_code" -ge 200 ] && [ "$new_code" -lt 400 ]; then
-            code=$new_code
-            break
-          fi
-          sleep 5
-        done
+    if [[ "$code" == "000" ]]; then
+      # No HTTP response at all. Usually a dead host, but a runner with no egress
+      # gets 000 for everything, and failing 2000 live links helps nobody. One
+      # probe of a host the runner already depends on tells the two apart.
+      probe=$(curl -k -gsLm10 -o /dev/null -w "%{http_code}" "$egress_probe_url") || probe=000
+      if [[ "$probe" == "000" ]]; then
+        printf "${yellow}WARN %s${reset} ${cyan}%s${reset} %s\n" "$code" "$url" "$filepath"
+        exit 0
       fi
+      # Egress works, so the host is either dead or slow. Give it one more try
+      # with a longer timeout before failing it.
+      code=$(curl -k -gsLm60 -o /dev/null -w "%{http_code}" -A "$user_agent" "$url") || code=000
     fi
     # Treat Cloudflare JS-challenge and rate-limit as success.
     if [[ "$code" == "403" || "$code" == "429" || "$code" == "503" ]]; then

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Part of this code is from pybind11 cmake_example:
-# https://github.com/pybind/cmake_example/blob/master/setup.py so attach the
-# license below.
+# Part of this code is from pybind11 cmake_example, so attach the license below.
+# That project has since dropped setup.py, so this points at the last revision
+# that still had it instead of at a branch.
+# https://github.com/pybind/cmake_example/blob/7a94877f581a14de4de1a096fb053a55fc2a66bf/setup.py
 
 # Copyright (c) 2016 The Pybind Development Team, All rights reserved.
 #

--- a/test/models/export_program.py
+++ b/test/models/export_program.py
@@ -59,7 +59,7 @@ class ModuleIndex(nn.Module):
     def forward(self, x):
         # Weird index that happens to generate a None in torch.index.Tensor_out
         # which is desirable for deserialization testing. A modified form of
-        # an example index from https://pytorch.org/cppdocs/notes/tensor_indexing.html.
+        # an example index from the PyTorch C++ tensor indexing notes.
         return x[1::2, torch.tensor([1, 2])]
 
     def get_random_inputs(self):


### PR DESCRIPTION
The nightly `link-check / lint-urls` job has been red for weeks. There are two separate problems behind that, and this PR fixes both.

## Problem 1: the script cannot tell a dead host from a broken runner

`scripts/lint_urls.sh` gets `000` back from curl when there is no HTTP response at
all. That happens for two very different reasons: the host is dead, or the runner
has no working egress. The script treated both as `WARN` and moved on.

That is unsafe in both directions:

- A genuinely dead host is silently tolerated. The 000 case is exactly the one we
  most want to catch.
- More importantly it also disables the pull request gate. `.github/workflows/lint.yml`
  runs this same script in diff mode on every pull request, where the only URLs
  checked are the ones that pull request adds. A new link with a typo in the host
  name gives 000 and passes today. A runner with no egress makes every link WARN
  and the whole job green. Both were reproduced locally.

### The fix

On `000`, probe one known-good URL, `https://api.github.com`, which the runner
already depends on:

- probe also returns `000`, so this runner has no egress: `WARN`, as before.
- probe returns anything else, so egress works and the problem is the host: retry
  the URL once with a 60 second timeout, then judge it on that result, which for a
  dead host means `FAIL`.

One deliberate addition worth calling out: the retry with the longer timeout is
more than the minimum needed to close the hole. It is there because the same URLs
were sampled across six nights of nightly logs and a small number of them, one or
two per night out of about 2100, return `000` once and then answer normally. The
default timeout is 10 seconds. Without the retry, this change would turn those
into hard failures and the nightly would stay red for no good reason.

### Also removed: the check-host.net fallback

When the first request failed, the script asked `check-host.net` whether the URL
was reachable from elsewhere and could then overwrite the verdict. That is
removed. Note this makes the script stricter, not more lenient: on a 404 or a 500
the fallback could turn a `FAIL` into an `OK`. Dropping it means a real 404 stays a
404, and it also removes a third-party service from the critical path of a lint
job.

## Problem 2: eight actually dead links

With problem 1 fixed the nightly would still be red, because there really are dead
links in the tree. The most recent nightly on main
([31350839957](https://github.com/pytorch/executorch/actions/runs/31350839957))
reported 7 x `FAIL 404` and 1 x `FAIL 000`. All eight are handled here:

| file | link | what happened | fix |
| --- | --- | --- | --- |
| `setup.py` | pybind/cmake_example `blob/master/setup.py` | that project deleted its `setup.py`, so a `master` link cannot work | pin to the last revision that still had it |
| `.ci/docker/common/install_openssl.sh` | pytorch/pytorch `blob/main/.ci/docker/common/install_openssl.sh` | the file moved on `main` | pin to a revision where it exists |
| `.ci/scripts/test_llava.sh` | Wikimedia basketball photo | the photo was renamed on Wikimedia, not deleted | point at the same photo under its current name |
| `docs/source/kernel-library-custom-aten-kernel.md` | `pytorch.org/cppdocs/library.html#...` | page and anchor both gone | current cppdocs library index |
| `test/models/export_program.py` | `pytorch.org/cppdocs/notes/tensor_indexing.html` | gone, and it was only mentioned in a comment | drop the URL, keep the sentence |
| `docs/source/success-stories.md` | an App Store listing | app delisted | drop the link, keep the text |
| `README.md` | `github.com/pytorch/executorch/stargazers` | returns 404 to an unauthenticated bot, works fine in a browser | `@lint-ignore` |
| `backends/arm/scripts/toolchain_utils.sh` | `musl.cc` toolchain tarball | serves fine to developers, has never once answered from a GitHub hosted runner | `@lint-ignore` |

Two more URLs are cleaned up along the way: a truncated Qualcomm SDK URL in
`backends/qualcomm/scripts/download_qnn_sdk.py` that was never a real link, and a
Qwen issue link in `examples/models/llama/runner/generation.py` pointing at the
old repository name.

On the Wikimedia one specifically: `examples/models/llava/README.md` already
embeds the renamed photo and documents the caption the model produces for it,
which matches the `EXPECTED_PREFIX` the script asserts. So this restores the
original input rather than substituting a different picture. Worth knowing, and
the reason this is low risk: no workflow runs `.ci/scripts/test_llava.sh`. Both
`pull.yml` and `trunk.yml` carry the comment "llava gives segfault so not
covering", so llava is not in CI at all right now.

## How this was verified

A whole-tree scan is nightly-only, so a pull request run here would only check the
handful of URLs this PR adds. To get real numbers, `_link_check.yml` was dispatched
in whole-tree mode against this branch's contents
([31417702080](https://github.com/pytorch/executorch/actions/runs/31417702080)):

| | main, nightly | this branch, whole tree |
| --- | --- | --- |
| URLs scanned | 2148 | 2147 |
| OK | 2116 | 2116 |
| WARN | 24 | 31 |
| FAIL | **8** | **0** |

Reconciling the two totals, since they should not match exactly:

- 11 URLs leave the scan: 5 replaced by a working equivalent, 4 deleted outright,
  and 2 now marked `@lint-ignore`.
- 6 join it: the 5 replacements, plus `https://api.github.com`, which is now
  written in `lint_urls.sh` as the probe target and so gets scanned itself.
- That is 2148 minus 5, which is 2143. The remaining 4 are URLs that landed on main
  during the day, in `examples/models/muse-glimmer/`, and are unrelated to this
  change. All 4 pass.

The 7 extra WARNs are the same thing that produces the existing 24: sites that
return `403` to an automated client. Between the two runs, `cppreference.com`,
`stackoverflow.com` and `vulkan.org` happened to answer `403` instead of `200`.
Those are already treated as warnings and are not affected by this PR.

The 000 handling itself was also exercised directly, in a scratch repository:

- no egress at all: `WARN 000`, exit 0, matching a broken runner.
- egress working, host that does not exist: `FAIL 000`, exit 1.
- `OK 200`, `WARN 403` and `FAIL 404` all still behave as before.
- diff mode still only looks at added lines.
