### PR TITLE
Skip redundant recompile after permute propagation retrace (#21696)

### DIFF
--- a/backends/arm/_passes/propagate_view_copy_permute_pass.py
+++ b/backends/arm/_passes/propagate_view_copy_permute_pass.py
@@ -122,7 +122,6 @@ class PropagateViewCopyPermutePass(ArmPass, ABC):
 
         if modified:
             graph_module = self._retrace(graph_module)
-            graph_module.recompile()
 
         return PassResult(graph_module, modified)
 


### PR DESCRIPTION
Summary:

Remove redundant `GraphModule.recompile()` at end of `PropagateViewCopyPermutePass.call()`.

When pass modifies graph it already calls `_retrace()`, which eliminates dead code, lints, and runs ARM ExportPass retracing to return rebuilt graph module. Immediately following `recompile()` recompiles Python code not needed before pass manager continues, adding wall time.

Keep `_retrace()` and drop extra compile step.

Differential Revision: D114790177


