### PR TITLE
Remove the conv2d op-test case that can never be delegated, so the WebGPU op tests can run

### DIFF
--- a/backends/webgpu/test/op_tests/cases.py
+++ b/backends/webgpu/test/op_tests/cases.py
@@ -1254,10 +1254,12 @@ from executorch.backends.webgpu.test.ops.test_conv2d import _chw_ramp, make_conv
 def _conv2d_suite() -> WebGPUTestSuite:
     # DaViT patch-embed / downsample convs + conv_transpose2d (same registration,
     # folded by the `transposed` arg). NCHW fp32. Routing coverage (all vs the
-    # same fp64 golden): patch_embed/conv3x3_pad1/strided/gemm_batched are
-    # groups==1 → im2col tiled GEMM (gemm_batched pins the B>1 output write);
-    # grouped_vec4 (groups=2, icpg=4) → direct vec4 kernel; depthwise (groups=8,
-    # icpg=1) → direct scalar; transpose2x → conv_transpose2d.
+    # same fp64 golden): patch_embed/conv3x3_pad1/strided are groups==1 → im2col
+    # tiled GEMM; grouped_vec4 (groups=2, icpg=4) → direct vec4 kernel; depthwise
+    # (groups=8, icpg=1) → direct scalar; transpose2x → conv_transpose2d.
+    # No batched (B>1) case: check_conv_node in backends/vulkan/op_registry.py
+    # refuses to delegate a 4-D convolution whose batch is not 1, so the export
+    # would fall back to CPU and test nothing. Add one back once it is accepted.
     return WebGPUTestSuite(
         module_factory=make_conv,
         cases=[
@@ -1303,11 +1305,6 @@ def _conv2d_suite() -> WebGPUTestSuite:
                     "groups": 2,
                 },
                 inputs=(InputSpec(shape=(1, 8, 8, 8), gen=_chw_ramp),),
-            ),
-            Case(
-                name="gemm_batched",
-                construct={"in_ch": 8, "out_ch": 16, "kernel": 3, "padding": 1},
-                inputs=(InputSpec(shape=(2, 8, 16, 16), gen=_chw_ramp),),
             ),
             Case(
                 name="transpose2x",


### PR DESCRIPTION
## What is broken

The WebGPU op-test generator refuses to run:

```
RuntimeError: conv2d/gemm_batched produced NO VulkanBackend delegate (silent CPU fallback) - this case would not exercise the WebGPU path.
```

## Why it happens

The op-test generator exports every case in
`backends/webgpu/test/op_tests/cases.py` and then checks that the exported
program really contains a WebGPU (Vulkan) delegate. If it does not, the case
would run on CPU and prove nothing, so the generator refuses to write it.

The `gemm_batched` case gives conv2d an input of shape `(2, 8, 16, 16)`, so a
batch of 2. `check_conv_node` in `backends/vulkan/op_registry.py` returns False
for any 4-D convolution whose batch is not 1:

```python
if len(x_shape) == 4:
    batches = x.meta["val"].size()[0]
    if batches != 1:
        return False
```

So this case can never be delegated. It has been in `cases.py` since the suite
was added and has never worked.

## Why it only turns the job red now

This is an old failure that was being hidden, not a new one.

The generator has raised on this case since #21620 landed, which is the change
that added `generate_op_tests.py` to main. But the CI script wrapped the whole
stage in an `if`:

```bash
if $PYTHON_EXECUTABLE -m ...generate_op_tests --output "${OP_TEST_DIR}"; then
  ...
else
  echo "WARN: op-test manifest generation failed (needs the executorch wheel); skipping"
fi
```

So generation did run on every nightly, and it did fail on this exact case every
time. Run
[31194597529](https://github.com/pytorch/executorch/actions/runs/31194597529),
from 2026-08-07, shows the whole sequence: the native tests pass, the generator
then runs for about 17 minutes, dies on
`conv2d/gemm_batched produced NO VulkanBackend delegate`, and the `else` branch
prints the WARN and the job goes green.

The part that had genuinely never run is the second half of the stage, the C++
op-test binary, because there was no manifest for it to load.

#21646 removed the `if`/`else` and left a plain call. The script runs under
`set -e`, so the same failure that had been warned about for weeks became fatal.

Making it fatal is the right call. The op tests are meant to run. This change
removes the one case that stops them.

## The fix

Delete the `gemm_batched` case, and say in the suite comment why there is no
batched case, so it is clear what to add back once the partitioner accepts
batch > 1.

## Why not mark the case `required=False` instead

`required=False` makes the generator print a warning instead of raising, but it
still writes the `.pte` and still adds the case to the manifest. The C++ driver
would then load a CPU-only program, compare it to the torch golden, and pass.
That is a green tick for a test that never touches the GPU, which is worse than
having no case at all.

Teaching the generator to also drop the manifest entry in that situation would
be a reasonable follow-up, but it is a separate change.

## Test plan

`test-webgpu-native` is the only job that runs the op tests, and on its own this
branch cannot reach them: the job still stops earlier on the missing RoPE fixture
that #21690 fixes. So the two changes were tested together, on a branch holding
both, and that run passes:

```
[       OK ] WebGPUNative.RopeHfDynamicSequenceReusedGraph (29 ms)
=== WebGPU native tests on Dawn: all run targets passed ===
Generated 390 cases -> /tmp/webgpu_op_tests/manifest.json
[----------] 6 tests from OpTest_conv2d
[==========] 391 tests from 88 test suites ran. (37413 ms total)
[  PASSED  ] 391 tests.
=== WebGPU op-test framework on Dawn: passed ===
```

So the generator now gets all the way through, the op-test binary runs for the
first time, and all 391 generated tests pass, `conv2d` included with its
remaining 6 cases.

Tested on this branch alone as well, to confirm this change does not break
anything earlier: the job reaches the native tests and 28 of them pass, with the
single failure being the RoPE fixture that #21690 fixes.

## What this costs in runner time

Generating the 390 cases takes about 35 minutes. In the green run above the whole
job took 75.5 minutes, of which 17.7 was setup and 57.4 was the test script.

That fits inside the current 120 minute limit, but only because that run had a
fast setup. The same setup steps have been measured as high as 64 minutes on the
same runner label, which would put this job at about 121 minutes. #21690 raises
the limit to 150 for that reason.
