### PR TITLE
Fix the crash when a program keeps its activations on the GPU

### DIFF
--- a/backends/cuda/runtime/cuda_allocator.cpp
+++ b/backends/cuda/runtime/cuda_allocator.cpp
@@ -29,13 +29,16 @@ Error copy_impl(
     DeviceIndex index,
     cudaMemcpyKind kind) {
   ET_CHECK_OR_RETURN_ERROR(
-      kind == cudaMemcpyHostToDevice || kind == cudaMemcpyDeviceToHost,
+      kind == cudaMemcpyHostToDevice || kind == cudaMemcpyDeviceToHost ||
+          kind == cudaMemcpyDeviceToDevice,
       InvalidArgument,
       "CudaAllocator::copy_impl: unsupported cudaMemcpyKind %d",
       static_cast<int>(kind));
   const char* method = kind == cudaMemcpyHostToDevice
       ? "CudaAllocator::copy_host_to_device"
-      : "CudaAllocator::copy_device_to_host";
+      : (kind == cudaMemcpyDeviceToHost
+             ? "CudaAllocator::copy_device_to_host"
+             : "CudaAllocator::copy_device_to_device");
   ET_CHECK_OR_RETURN_ERROR(
       dst != nullptr, InvalidArgument, "%s: dst is null", method);
   ET_CHECK_OR_RETURN_ERROR(
@@ -218,6 +221,18 @@ Error CudaAllocator::copy_device_to_host(
     size_t nbytes,
     DeviceIndex index) {
   return copy_impl(dst, src, nbytes, index, cudaMemcpyDeviceToHost);
+}
+
+Error CudaAllocator::copy_device_to_device(
+    void* dst,
+    DeviceIndex dst_index,
+    const void* src,
+    DeviceIndex src_index,
+    size_t nbytes) {
+  // Both ends are on this device type, so either index identifies the stream to copy on. Passing the
+  // destination's, because that is the device the copy is filling.
+  (void)src_index;
+  return copy_impl(dst, src, nbytes, dst_index, cudaMemcpyDeviceToDevice);
 }
 
 DeviceType CudaAllocator::device_type() const {

--- a/backends/cuda/runtime/cuda_allocator.h
+++ b/backends/cuda/runtime/cuda_allocator.h
@@ -46,6 +46,13 @@ class CudaAllocator final : public executorch::runtime::DeviceAllocator {
       size_t nbytes,
       executorch::runtime::etensor::DeviceIndex index) override;
 
+  executorch::runtime::Error copy_device_to_device(
+      void* dst,
+      executorch::runtime::etensor::DeviceIndex dst_index,
+      const void* src,
+      executorch::runtime::etensor::DeviceIndex src_index,
+      size_t nbytes) override;
+
   executorch::runtime::etensor::DeviceType device_type() const override;
 
   /// Returns the global CudaAllocator singleton.

--- a/runtime/core/device_allocator.h
+++ b/runtime/core/device_allocator.h
@@ -92,6 +92,35 @@ class DeviceAllocator {
       etensor::DeviceIndex index) = 0;
 
   /**
+   * Copy data between two buffers on this device type.
+   *
+   * Needed by a program whose activations stay on the device: the caller hands over device memory
+   * and the runtime copies it into the device buffer the memory plan reserved, so neither end is
+   * host memory. Not pure virtual, because an allocator for a device that cannot do this can decline
+   * rather than be forced to implement it.
+   *
+   * @param dst Destination pointer (device memory).
+   * @param dst_index The device index the destination lives on.
+   * @param src Source pointer (device memory).
+   * @param src_index The device index the source lives on.
+   * @param nbytes Number of bytes to copy.
+   * @return Error::Ok on success, or an appropriate error code on failure.
+   */
+  virtual Error copy_device_to_device(
+      void* dst,
+      etensor::DeviceIndex dst_index,
+      const void* src,
+      etensor::DeviceIndex src_index,
+      size_t nbytes) {
+    (void)dst;
+    (void)dst_index;
+    (void)src;
+    (void)src_index;
+    (void)nbytes;
+    return Error::NotSupported;
+  }
+
+  /**
    * Returns the device type this allocator handles.
    */
   virtual etensor::DeviceType device_type() const = 0;

--- a/runtime/core/exec_aten/util/targets.bzl
+++ b/runtime/core/exec_aten/util/targets.bzl
@@ -54,6 +54,7 @@ def define_common_targets():
             exported_deps = [
                 ":tensor_dimension_limit",
                 "//executorch/runtime/core:core",
+                "//executorch/runtime/core:device_allocator",
                 "//executorch/runtime/core/portable_type/c10/c10:c10",
             ] + [
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -1175,45 +1175,52 @@ ET_NODISCARD Error copy_tensor_data(
  * activations on an accelerator plans its inputs into device memory, so copying an input into one
  * has to go through that device's allocator. Kept as one helper because both the portable and the
  * ATen tensor implementations need it and neither may name a specific accelerator.
+ *
+ * The device is taken as the runtime's own type rather than the tensor library's, because in ATen
+ * mode a tensor reports a c10::DeviceType while the allocator registry is keyed on the runtime's
+ * enum, and the two are distinct types.
  */
 ET_NODISCARD inline Error copy_between_devices(
     void* dst,
-    executorch::aten::Device dst_device,
+    etensor::DeviceType dst_type,
+    etensor::DeviceIndex dst_index,
     const void* src,
-    executorch::aten::Device src_device,
+    etensor::DeviceType src_type,
+    etensor::DeviceIndex src_index,
     size_t nbytes) {
-  if (dst_device.is_cpu() && src_device.is_cpu()) {
+  const bool dst_is_cpu = dst_type == etensor::DeviceType::CPU;
+  const bool src_is_cpu = src_type == etensor::DeviceType::CPU;
+  if (dst_is_cpu && src_is_cpu) {
     std::memcpy(dst, src, nbytes);
     return Error::Ok;
   }
 
   // Whichever end is not the host owns the copy, and the allocator is reached through the registry a
   // backend populates, so this stays free of any accelerator dependency.
-  const auto device = dst_device.is_cpu() ? src_device : dst_device;
-  auto* allocator = get_device_allocator(device.type());
+  const auto type = dst_is_cpu ? src_type : dst_type;
+  auto* allocator = get_device_allocator(type);
   ET_CHECK_OR_RETURN_ERROR(
       allocator != nullptr,
       NotFound,
       "No allocator is registered for device type %d, so a copy involving its memory cannot be "
       "performed. The backend that owns that device registers one when it is linked in.",
-      static_cast<int>(device.type()));
+      static_cast<int>(type));
 
-  if (src_device.is_cpu()) {
-    return allocator->copy_host_to_device(dst, src, nbytes, dst_device.index());
+  if (src_is_cpu) {
+    return allocator->copy_host_to_device(dst, src, nbytes, dst_index);
   }
-  if (dst_device.is_cpu()) {
-    return allocator->copy_device_to_host(dst, src, nbytes, src_device.index());
+  if (dst_is_cpu) {
+    return allocator->copy_device_to_host(dst, src, nbytes, src_index);
   }
   // Neither end is the host. One allocator cannot own memory belonging to a different device type,
   // so that combination is refused rather than handed to whichever type was looked up.
   ET_CHECK_OR_RETURN_ERROR(
-      src_device.type() == dst_device.type(),
+      src_type == dst_type,
       NotSupported,
       "Copying directly between device types %d and %d is not supported; route through the host.",
-      static_cast<int>(src_device.type()),
-      static_cast<int>(dst_device.type()));
-  return allocator->copy_device_to_device(
-      dst, dst_device.index(), src, src_device.index(), nbytes);
+      static_cast<int>(src_type),
+      static_cast<int>(dst_type));
+  return allocator->copy_device_to_device(dst, dst_index, src, src_index, nbytes);
 }
 
 /**

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -20,6 +20,7 @@
 
 #include <c10/util/irange.h>
 #include <executorch/runtime/core/array_ref.h>
+#include <executorch/runtime/core/device_allocator.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
@@ -1166,6 +1167,54 @@ ET_NODISCARD Error share_tensor_data(
 ET_NODISCARD Error copy_tensor_data(
     const executorch::aten::Tensor& t_dst,
     const executorch::aten::Tensor& t_src);
+
+/**
+ * Copy nbytes between two buffers, each of which may live on the host or on a device.
+ *
+ * A plain memcpy is only correct when both ends are host memory. A program exported to keep
+ * activations on an accelerator plans its inputs into device memory, so copying an input into one
+ * has to go through that device's allocator. Kept as one helper because both the portable and the
+ * ATen tensor implementations need it and neither may name a specific accelerator.
+ */
+ET_NODISCARD inline Error copy_between_devices(
+    void* dst,
+    executorch::aten::Device dst_device,
+    const void* src,
+    executorch::aten::Device src_device,
+    size_t nbytes) {
+  if (dst_device.is_cpu() && src_device.is_cpu()) {
+    std::memcpy(dst, src, nbytes);
+    return Error::Ok;
+  }
+
+  // Whichever end is not the host owns the copy, and the allocator is reached through the registry a
+  // backend populates, so this stays free of any accelerator dependency.
+  const auto device = dst_device.is_cpu() ? src_device : dst_device;
+  auto* allocator = get_device_allocator(device.type());
+  ET_CHECK_OR_RETURN_ERROR(
+      allocator != nullptr,
+      NotFound,
+      "No allocator is registered for device type %d, so a copy involving its memory cannot be "
+      "performed. The backend that owns that device registers one when it is linked in.",
+      static_cast<int>(device.type()));
+
+  if (src_device.is_cpu()) {
+    return allocator->copy_host_to_device(dst, src, nbytes, dst_device.index());
+  }
+  if (dst_device.is_cpu()) {
+    return allocator->copy_device_to_host(dst, src, nbytes, src_device.index());
+  }
+  // Neither end is the host. One allocator cannot own memory belonging to a different device type,
+  // so that combination is refused rather than handed to whichever type was looked up.
+  ET_CHECK_OR_RETURN_ERROR(
+      src_device.type() == dst_device.type(),
+      NotSupported,
+      "Copying directly between device types %d and %d is not supported; route through the host.",
+      static_cast<int>(src_device.type()),
+      static_cast<int>(dst_device.type()));
+  return allocator->copy_device_to_device(
+      dst, dst_device.index(), src, src_device.index(), nbytes);
+}
 
 /**
  * Set the data_ptr of t to buffer.

--- a/runtime/core/exec_aten/util/tensor_util_aten.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_aten.cpp
@@ -177,7 +177,12 @@ Error copy_tensor_data(const at::Tensor& t_dst, const at::Tensor& t_src) {
         t_src.nbytes());
     // Copy the source data to the preallocated memory of the destination, which
     // must be the same size as the source.
-    std::memcpy(dst_data_ptr, t_src.const_data_ptr(), t_src.nbytes());
+    return copy_between_devices(
+        dst_data_ptr,
+        t_dst.device(),
+        t_src.const_data_ptr(),
+        t_src.device(),
+        t_src.nbytes());
   }
 
   return Error::Ok;

--- a/runtime/core/exec_aten/util/tensor_util_aten.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_aten.cpp
@@ -20,6 +20,27 @@ namespace ET_RUNTIME_NAMESPACE {
  * at::Tensor (instead of executorch::aten::Tensor) to make sure it fails at
  * compile time if built incorrectly.
  */
+
+namespace {
+
+// An ATen tensor reports a c10::DeviceType, while the allocator registry is keyed on the runtime's
+// own enum. Translated here rather than in the shared helper, because only this variant sees c10.
+etensor::DeviceType to_runtime_device_type(c10::DeviceType type) {
+  switch (type) {
+    case c10::DeviceType::CPU:
+      return etensor::DeviceType::CPU;
+    case c10::DeviceType::CUDA:
+      return etensor::DeviceType::CUDA;
+    default:
+      ET_CHECK_MSG(
+          false,
+          "Device type %d is not supported by the ExecuTorch runtime",
+          static_cast<int>(type));
+  }
+}
+
+} // namespace
+
 Error get_dim_order(
     const at::Tensor& tensor,
     executorch::aten::DimOrderType* out_dim_order,
@@ -179,9 +200,11 @@ Error copy_tensor_data(const at::Tensor& t_dst, const at::Tensor& t_src) {
     // must be the same size as the source.
     return copy_between_devices(
         dst_data_ptr,
-        t_dst.device(),
+        to_runtime_device_type(t_dst.device().type()),
+        static_cast<etensor::DeviceIndex>(t_dst.device().index()),
         t_src.const_data_ptr(),
-        t_src.device(),
+        to_runtime_device_type(t_src.device().type()),
+        static_cast<etensor::DeviceIndex>(t_src.device().index()),
         t_src.nbytes());
   }
 

--- a/runtime/core/exec_aten/util/tensor_util_portable.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_portable.cpp
@@ -180,9 +180,11 @@ Error copy_tensor_data(
         t_src.nbytes());
     return copy_between_devices(
         t_dst.mutable_data_ptr(),
-        t_dst.device(),
+        t_dst.device().type(),
+        t_dst.device().index(),
         t_src.const_data_ptr(),
-        t_src.device(),
+        t_src.device().type(),
+        t_src.device().index(),
         t_src.nbytes());
   }
   return Error::Ok;

--- a/runtime/core/exec_aten/util/tensor_util_portable.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_portable.cpp
@@ -178,8 +178,12 @@ Error copy_tensor_data(
         "t_dst.nbytes() %zu != t_src.nbytes(). %zu",
         t_dst.nbytes(),
         t_src.nbytes());
-    std::memcpy(
-        t_dst.mutable_data_ptr(), t_src.const_data_ptr(), t_src.nbytes());
+    return copy_between_devices(
+        t_dst.mutable_data_ptr(),
+        t_dst.device(),
+        t_src.const_data_ptr(),
+        t_src.device(),
+        t_src.nbytes());
   }
   return Error::Ok;
 }

--- a/runtime/core/exec_aten/util/test/CMakeLists.txt
+++ b/runtime/core/exec_aten/util/test/CMakeLists.txt
@@ -20,7 +20,7 @@ set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../..)
 include(${EXECUTORCH_ROOT}/tools/cmake/Test.cmake)
 
 set(_test_srcs
-    dim_order_util_test.cpp operator_impl_example_test.cpp
+    device_copy_test.cpp dim_order_util_test.cpp operator_impl_example_test.cpp
     scalar_type_util_test.cpp tensor_shape_to_c_string_test.cpp
     tensor_util_test.cpp
 )

--- a/runtime/core/exec_aten/util/test/device_copy_test.cpp
+++ b/runtime/core/exec_aten/util/test/device_copy_test.cpp
@@ -16,7 +16,6 @@
 
 #include <array>
 
-using executorch::aten::Device;
 using executorch::aten::DeviceType;
 using executorch::runtime::Error;
 using executorch::runtime::internal::copy_between_devices;
@@ -41,8 +40,8 @@ class DeviceCopyTest : public ::testing::Test {
   }
 
   static MockCudaAllocator* allocator_;
-  static constexpr Device kHost{DeviceType::CPU};
-  static constexpr Device kDevice{DeviceType::CUDA, 0};
+  static constexpr DeviceType kHost = DeviceType::CPU;
+  static constexpr DeviceType kDevice = DeviceType::CUDA;
   std::array<uint8_t, 8> source_{1, 2, 3, 4, 5, 6, 7, 8};
   std::array<uint8_t, 8> destination_{};
 };
@@ -52,7 +51,7 @@ MockCudaAllocator* DeviceCopyTest::allocator_ = nullptr;
 TEST_F(DeviceCopyTest, HostToHostDoesNotReachTheAllocator) {
   ASSERT_EQ(
       copy_between_devices(
-          destination_.data(), kHost, source_.data(), kHost, source_.size()),
+          destination_.data(), kHost, 0, source_.data(), kHost, 0, source_.size()),
       Error::Ok);
   EXPECT_EQ(destination_, source_);
   // A host copy must not depend on a device being registered at all.
@@ -64,7 +63,7 @@ TEST_F(DeviceCopyTest, HostToHostDoesNotReachTheAllocator) {
 TEST_F(DeviceCopyTest, HostToDeviceUsesTheAllocator) {
   ASSERT_EQ(
       copy_between_devices(
-          destination_.data(), kDevice, source_.data(), kHost, source_.size()),
+          destination_.data(), kDevice, 0, source_.data(), kHost, 0, source_.size()),
       Error::Ok);
   EXPECT_EQ(allocator_->h2d_count_, 1);
   EXPECT_EQ(allocator_->last_h2d_size_, source_.size());
@@ -74,7 +73,7 @@ TEST_F(DeviceCopyTest, HostToDeviceUsesTheAllocator) {
 TEST_F(DeviceCopyTest, DeviceToHostUsesTheAllocator) {
   ASSERT_EQ(
       copy_between_devices(
-          destination_.data(), kHost, source_.data(), kDevice, source_.size()),
+          destination_.data(), kHost, 0, source_.data(), kDevice, 0, source_.size()),
       Error::Ok);
   EXPECT_EQ(allocator_->d2h_count_, 1);
   EXPECT_EQ(destination_, source_);
@@ -85,7 +84,7 @@ TEST_F(DeviceCopyTest, DeviceToDeviceUsesTheAllocator) {
   // and the runtime fills the device buffer the memory plan reserved, so neither end is host memory.
   ASSERT_EQ(
       copy_between_devices(
-          destination_.data(), kDevice, source_.data(), kDevice, source_.size()),
+          destination_.data(), kDevice, 0, source_.data(), kDevice, 0, source_.size()),
       Error::Ok);
   EXPECT_EQ(allocator_->d2d_count_, 1);
   EXPECT_EQ(allocator_->h2d_count_, 0);
@@ -96,7 +95,8 @@ TEST_F(DeviceCopyTest, ZeroBytesIsAccepted) {
   // A tensor with a zero-sized dimension reaches here with nothing to copy, and that is not an
   // error. It is worth pinning because the device path is easy to write in a way that rejects it.
   ASSERT_EQ(
-      copy_between_devices(destination_.data(), kDevice, source_.data(), kHost, 0),
+      copy_between_devices(
+          destination_.data(), kDevice, 0, source_.data(), kHost, 0, 0),
       Error::Ok);
   EXPECT_EQ(allocator_->h2d_count_, 1);
   EXPECT_EQ(allocator_->last_h2d_size_, 0u);

--- a/runtime/core/exec_aten/util/test/device_copy_test.cpp
+++ b/runtime/core/exec_aten/util/test/device_copy_test.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/core/device_allocator.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+#include <executorch/runtime/core/test/mock_cuda_allocator.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+using executorch::aten::Device;
+using executorch::aten::DeviceType;
+using executorch::runtime::Error;
+using executorch::runtime::internal::copy_between_devices;
+using executorch::runtime::testing::MockCudaAllocator;
+
+// Copying into memory a program planned on an accelerator has to go through that device's allocator.
+// A plain memcpy into a device pointer is undefined, and it crashed a program exported to keep its
+// activations on the device, which is the case these tests cover.
+class DeviceCopyTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    executorch::runtime::runtime_init();
+    // Registered once for the whole suite, because the registry refuses a second allocator for a
+    // device type and holds the pointer for the lifetime of the process.
+    static MockCudaAllocator allocator;
+    allocator_ = &allocator;
+    executorch::runtime::register_device_allocator(allocator_);
+  }
+
+  void SetUp() override {
+    allocator_->reset();
+  }
+
+  static MockCudaAllocator* allocator_;
+  static constexpr Device kHost{DeviceType::CPU};
+  static constexpr Device kDevice{DeviceType::CUDA, 0};
+  std::array<uint8_t, 8> source_{1, 2, 3, 4, 5, 6, 7, 8};
+  std::array<uint8_t, 8> destination_{};
+};
+
+MockCudaAllocator* DeviceCopyTest::allocator_ = nullptr;
+
+TEST_F(DeviceCopyTest, HostToHostDoesNotReachTheAllocator) {
+  ASSERT_EQ(
+      copy_between_devices(
+          destination_.data(), kHost, source_.data(), kHost, source_.size()),
+      Error::Ok);
+  EXPECT_EQ(destination_, source_);
+  // A host copy must not depend on a device being registered at all.
+  EXPECT_EQ(allocator_->h2d_count_, 0);
+  EXPECT_EQ(allocator_->d2h_count_, 0);
+  EXPECT_EQ(allocator_->d2d_count_, 0);
+}
+
+TEST_F(DeviceCopyTest, HostToDeviceUsesTheAllocator) {
+  ASSERT_EQ(
+      copy_between_devices(
+          destination_.data(), kDevice, source_.data(), kHost, source_.size()),
+      Error::Ok);
+  EXPECT_EQ(allocator_->h2d_count_, 1);
+  EXPECT_EQ(allocator_->last_h2d_size_, source_.size());
+  EXPECT_EQ(destination_, source_);
+}
+
+TEST_F(DeviceCopyTest, DeviceToHostUsesTheAllocator) {
+  ASSERT_EQ(
+      copy_between_devices(
+          destination_.data(), kHost, source_.data(), kDevice, source_.size()),
+      Error::Ok);
+  EXPECT_EQ(allocator_->d2h_count_, 1);
+  EXPECT_EQ(destination_, source_);
+}
+
+TEST_F(DeviceCopyTest, DeviceToDeviceUsesTheAllocator) {
+  // The case a program with device activations actually needs: the caller hands over device memory
+  // and the runtime fills the device buffer the memory plan reserved, so neither end is host memory.
+  ASSERT_EQ(
+      copy_between_devices(
+          destination_.data(), kDevice, source_.data(), kDevice, source_.size()),
+      Error::Ok);
+  EXPECT_EQ(allocator_->d2d_count_, 1);
+  EXPECT_EQ(allocator_->h2d_count_, 0);
+  EXPECT_EQ(destination_, source_);
+}
+
+TEST_F(DeviceCopyTest, ZeroBytesIsAccepted) {
+  // A tensor with a zero-sized dimension reaches here with nothing to copy, and that is not an
+  // error. It is worth pinning because the device path is easy to write in a way that rejects it.
+  ASSERT_EQ(
+      copy_between_devices(destination_.data(), kDevice, source_.data(), kHost, 0),
+      Error::Ok);
+  EXPECT_EQ(allocator_->h2d_count_, 1);
+  EXPECT_EQ(allocator_->last_h2d_size_, 0u);
+}

--- a/runtime/core/exec_aten/util/test/targets.bzl
+++ b/runtime/core/exec_aten/util/test/targets.bzl
@@ -51,6 +51,16 @@ def define_common_targets():
         )
 
     runtime.cxx_test(
+        name = "device_copy_test",
+        srcs = ["device_copy_test.cpp"],
+        deps = [
+            "//executorch/runtime/core:device_allocator",
+            "//executorch/runtime/core/exec_aten/util:tensor_util",
+            "//executorch/runtime/core/test:mock_cuda_allocator",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "tensor_shape_to_c_string_test",
         srcs = ["tensor_shape_to_c_string_test.cpp"],
         deps = [

--- a/runtime/core/test/mock_cuda_allocator.h
+++ b/runtime/core/test/mock_cuda_allocator.h
@@ -80,6 +80,22 @@ class MockCudaAllocator : public DeviceAllocator {
     return Error::Ok;
   }
 
+  Error copy_device_to_device(
+      void* dst,
+      etensor::DeviceIndex dst_index,
+      const void* src,
+      etensor::DeviceIndex src_index,
+      size_t nbytes) override {
+    std::memcpy(dst, src, nbytes);
+    d2d_count_++;
+    last_d2d_dst_ = dst;
+    last_d2d_src_ = src;
+    last_d2d_size_ = nbytes;
+    last_d2d_dst_index_ = dst_index;
+    last_d2d_src_index_ = src_index;
+    return Error::Ok;
+  }
+
   etensor::DeviceType device_type() const override {
     return etensor::DeviceType::CUDA;
   }
@@ -102,6 +118,7 @@ class MockCudaAllocator : public DeviceAllocator {
     deallocate_count_ = 0;
     h2d_count_ = 0;
     d2h_count_ = 0;
+    d2d_count_ = 0;
     last_allocate_size_ = 0;
     last_allocate_index_ = -1;
     last_allocate_ptr_ = nullptr;
@@ -139,6 +156,14 @@ class MockCudaAllocator : public DeviceAllocator {
   const void* last_d2h_src_ = nullptr;
   size_t last_d2h_size_ = 0;
   etensor::DeviceIndex last_d2h_index_ = -1;
+
+  // Device-to-device copy tracking
+  int d2d_count_ = 0;
+  void* last_d2d_dst_ = nullptr;
+  const void* last_d2d_src_ = nullptr;
+  size_t last_d2d_size_ = 0;
+  etensor::DeviceIndex last_d2d_dst_index_ = -1;
+  etensor::DeviceIndex last_d2d_src_index_ = -1;
 };
 
 } // namespace testing

--- a/test/utils/OSSTestConfig.json
+++ b/test/utils/OSSTestConfig.json
@@ -97,6 +97,7 @@
     {
         "directory": "runtime/core/exec_aten/util/test",
         "sources": [
+            "device_copy_test.cpp",
             "dim_order_util_test.cpp",
             "operator_impl_example_test.cpp",
             "scalar_type_util_test.cpp",


### PR DESCRIPTION
## The problem

ExecuTorch can export a model two ways for a GPU. The default copies your input from
main memory (the host) to the GPU for you. The other way skips those copies, so you
hand over memory that is already on the GPU and the output stays there. That second
way saves a round trip, which matters for a model in a loop.

The second way crashes. It crashes from Python and from C++, immediately, before your
data is touched:

```
[cuda_backend.cpp:429] Created new CUDA stream 0x10ae920 for method
Segmentation fault (core dumped)
```

The reason is one line. When the runtime puts your input into the buffer the memory
plan reserved, it always used a plain host copy:

```cpp
std::memcpy(t_dst.mutable_data_ptr(), t_src.const_data_ptr(), t_src.nbytes());
```

If that destination is GPU memory, a host `memcpy` into it is undefined and the process
dies. The memory itself was allocated correctly on the GPU; only the copy assumed the
host.

## The change

Route the copy through the device that owns the memory instead of assuming the host.
ExecuTorch already has an interface for this, and a backend registers an implementation
when it is linked in, so the core runtime still names no GPU code and still builds for
bare metal:

```
core (no GPU code)                        CUDA backend
copy_between_devices()
  -> get_device_allocator(CUDA) ────────  register_device_allocator(...)
  -> allocator->copy_host_to_device() ──► cudaMemcpy
```

A host to host copy keeps using `memcpy` and does not need any device registered.

One primitive was missing. The interface had host to device and device to host, but not
device to device, which is exactly what this feature needs: your input is already on the
GPU and the planned buffer is too. It is added with a default that returns
`NotSupported`, so an allocator that cannot do it declines instead of being forced to
implement it, and the CUDA one implements it.

## Test plan

Added `device_copy_test.cpp`, which needs no GPU: the repository already has a mock
allocator that copies with `memcpy` and counts calls, so the routing is observable.

- a host to host copy still works and does not touch the allocator
- host to device, device to host, and device to device each reach the matching call
- zero bytes is accepted, which a tensor with an empty dimension relies on

Before this change no test executed a program with device activations at all. The
closest one loads the method and tolerates failure without running it, so the crash had
no coverage.

Also built the runtime and ran the existing runtime and extension tests on Linux
x86_64.

## Known gaps, not fixed here

Two problems on the same feature remain, and each deserves its own change:

- The Python bindings build the source tensor without reading its device, so a GPU input
  is labelled as host memory. A caller passing GPU tensors from Python is still not
  correctly described to the runtime.
- For a program whose output stays on the GPU, the Python return path reads that memory
  as if it were host memory.
