### PR TITLE
[do not land] CUDA wheel built with the device-activation copy fix

### DIFF
--- a/.ci/scripts/tests/test_wheel_platform_tag.py
+++ b/.ci/scripts/tests/test_wheel_platform_tag.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Unit tests for the wheel platform tag comparison.
+
+Here rather than in the wheel checks, because the decision under test is a pure
+function of two strings. Running it as part of the wheel checks meant it needed eleven
+built wheels to exercise one comparison, and it still could not run on a machine that
+had not built one.
+
+The comparison had a real defect that this covers. The release pipeline builds in a
+manylinux image and rewrites the wheel's file name, so the tag on the file and the tag
+auditwheel reports never agree in spelling, and comparing them as text rejected every
+correct wheel. No local build reproduces that rewrite, so nothing short of a unit test
+catches it before CI.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "wheel"))
+
+from test_shared_libraries import (  # noqa: E402
+    _tag_architectures_match,
+    _wheel_architecture,
+)
+
+
+@pytest.mark.parametrize(
+    "claimed,supported",
+    [
+        # What the release pipeline actually produces: it builds in a manylinux image
+        # and rewrites the file name, while auditwheel reports a plain linux tag
+        # because the wheel depends on torch without vendoring torch's libraries.
+        ("manylinux_2_28_x86_64", "linux_x86_64"),
+        ("manylinux_2_28_aarch64", "linux_aarch64"),
+        # The legacy spelling, which has no underscore before its version.
+        ("manylinux2014_x86_64", "linux_x86_64"),
+        ("manylinux2014_aarch64", "linux_aarch64"),
+        # A local build, where nothing rewrites the name.
+        ("linux_x86_64", "linux_x86_64"),
+        ("linux_aarch64", "linux_aarch64"),
+    ],
+)
+def test_accepts_tags_the_release_pipeline_produces(claimed, supported):
+    assert _tag_architectures_match(claimed, supported) is True
+
+
+@pytest.mark.parametrize(
+    "claimed,supported",
+    [
+        ("manylinux_2_28_aarch64", "linux_x86_64"),
+        ("manylinux_2_28_x86_64", "linux_aarch64"),
+        ("linux_aarch64", "linux_x86_64"),
+    ],
+)
+def test_rejects_an_architecture_mismatch(claimed, supported):
+    """A wheel labelled for the wrong architecture installs where it cannot run."""
+    assert _tag_architectures_match(claimed, supported) is False
+
+
+@pytest.mark.parametrize("tag", ["win_amd64", "macosx_11_0_arm64", "any", "", "linux"])
+def test_reports_a_tag_it_cannot_read(tag):
+    """None, not False, so an unreadable tag is not mistaken for a mismatch."""
+    assert _wheel_architecture(tag) is None
+    assert _tag_architectures_match(tag, "linux_x86_64") is None
+
+
+def test_reads_every_architecture_the_project_builds_for():
+    for architecture in ("x86_64", "aarch64", "i686", "ppc64le", "s390x", "armv7l"):
+        assert _wheel_architecture(f"linux_{architecture}") == architecture
+        assert _wheel_architecture(f"manylinux_2_28_{architecture}") == architecture

--- a/.ci/scripts/wheel/cuda_arch_list.sh
+++ b/.ci/scripts/wheel/cuda_arch_list.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# GPU architectures to compile device code for, chosen per release row rather than detected from
+# the build machine.
+#
+# Without this the build compiles for whichever GPU the builder happens to have. The wheel then
+# installs on every machine the row claims and fails when a model runs on a different generation,
+# with an error that looks like a model problem rather than a packaging one. Detection is the right
+# default for a local build and the wrong one for a published artifact.
+#
+# The value is published as TORCH_CUDA_ARCH_LIST rather than CMAKE_CUDA_ARCHITECTURES, because
+# PyTorch's CMake rejects the latter and overrides it, so setting only that reduces the build to a
+# single detected architecture.
+
+# The architectures each row serves. Two rules decide the list, and they pull in opposite directions.
+#
+# The upper end follows the published PyTorch build for that train, read from its own library rather than
+# chosen by reasoning about which GPUs matter. A delegate is only useful where torch already runs, and an
+# architecture torch supports but this wheel omits produces a wheel that installs and then fails at the
+# first kernel launch. Two omissions found that way were the GPU on the runner that tests these wheels,
+# and a common desktop card.
+#
+# The lower end does NOT follow torch. It stops at 8.0 even though torch reaches further down, because one
+# source here compiles an integer matrix-multiply path only at 8.0 and above. Below that a user gets a
+# delegate that loads, runs most models, and fails on one needing that operator, which is worse than a row
+# that never claimed the device. So these lists are narrower than torch at the bottom on purpose.
+_cuda_arch_x86_64_cu130="8.0 8.6 8.9 9.0 10.0 12.0"
+_cuda_arch_x86_64_cu132="${_cuda_arch_x86_64_cu130}"
+
+# The architectures the published aarch64 PyTorch CUDA build covers, read from its own library on an ARM
+# machine, for the same reason as the x86_64 rows above. Includes the ARM module whose train matches.
+_cuda_arch_aarch64_cu130="8.0 9.0 10.0 11.0 12.0"
+_cuda_arch_aarch64_cu132="${_cuda_arch_aarch64_cu130}"
+
+# The older CUDA train.
+#
+# The two architectures do not carry identical lists, because each covers what the published PyTorch
+# build for that architecture covers, and those differ. Matching them to each other instead would mean
+# advertising a GPU on one architecture that PyTorch cannot serve there.
+#
+# The smaller embedded modules are deliberately absent. An embedded-only architecture in a generic
+# wheel would advertise a device the row cannot otherwise serve, since those devices also need the
+# CUDA, TensorRT and PyTorch pinned by their own software release rather than the ones a generic
+# wheel resolves.
+#
+# The floor is 8.0 rather than the oldest architecture PyTorch still carries. One of these sources compiles
+# an integer matrix-multiply path only at 8.0 and newer, so an older architecture would get a delegate that
+# loads, runs most models, and fails on one that needs that operator. Claiming hardware the delegate only
+# partly serves is the same problem the embedded modules have, so the row leaves it out for the same reason.
+_cuda_arch_x86_64_cu126="8.0 8.6 8.9 9.0"
+_cuda_arch_aarch64_cu126="8.0 9.0"  # what the aarch64 build of this train covers
+
+# A CUDA train with no architecture list would leave the build detecting the builder's GPU, which is
+# the failure this file exists to prevent. Adding a train to the release matrix without adding its
+# architectures should fail loudly rather than silently produce a single-GPU wheel.
+_executorch_unknown_train() {
+  echo "cuda_arch_list.sh: no GPU architecture list for CUDA train '$1' on $(uname -m)." >&2
+  echo "Add one before building this row, or the wheel ships device code for one GPU only." >&2
+  return 64
+}
+
+# The architectures for the current row, space separated in the dotted form PyTorch expects.
+executorch_cuda_arch_list() {
+  local machine
+  machine="$(uname -m)"
+  # The wheel build exports the row's CUDA train as CU_VERSION. DESIRED_CUDA is the name of the
+  # matrix field rather than of the variable, so reading only that leaves every row falling back to
+  # detecting the builder's GPU.
+  local train="${CU_VERSION:-${DESIRED_CUDA:-}}"
+  # A CPU row names no CUDA train and needs no architectures, so it is not an error.
+  #
+  # A CUDA row always names one, so an empty value there means the row lost it. Treating that as a CPU
+  # row let the build fall back to detecting the builder's GPU, which produces a wheel carrying device
+  # code for whatever machine happened to build it while every check still reports green.
+  case "${train}" in
+    "" | cpu | CPU | none | NONE)
+      if [ "${EXECUTORCH_BUILD_CUDA:-}" = "1" ]; then
+        echo "this is a CUDA build but the row's CUDA version is '${train}', which names no CUDA" >&2
+        echo "train. Refusing to detect the builder GPU instead." >&2
+        return 65
+      fi
+      return 0
+      ;;
+  esac
+  # The value arrives as cu130, while some callers pass 13.0 instead.
+  train="${train#cu}"
+  train="${train//./}"
+
+  case "${machine}" in
+    aarch64 | arm64)
+      case "${train}" in
+        126) printf '%s' "${_cuda_arch_aarch64_cu126}" ;;
+        130) printf '%s' "${_cuda_arch_aarch64_cu130}" ;;
+        132) printf '%s' "${_cuda_arch_aarch64_cu132}" ;;
+        *) _executorch_unknown_train "${train}" ;;
+      esac
+      ;;
+    x86_64)
+      case "${train}" in
+        126) printf '%s' "${_cuda_arch_x86_64_cu126}" ;;
+        130) printf '%s' "${_cuda_arch_x86_64_cu130}" ;;
+        132) printf '%s' "${_cuda_arch_x86_64_cu132}" ;;
+        *) _executorch_unknown_train "${train}" ;;
+      esac
+      ;;
+    *) _executorch_unknown_train "${train}" ;;
+  esac
+}
+
+# The same list with a portable form appended for the newest architecture, so a GPU newer than any
+# in the row can still run the wheel by compiling that form at load time. Without it a newer GPU
+# gets no usable code at all.
+executorch_cuda_arch_list_with_ptx() {
+  local dotted top
+  # Propagate a failed lookup rather than reporting an empty list, since a caller cannot tell an
+  # unknown row from a CPU row and the unknown one must not pass silently.
+  dotted="$(executorch_cuda_arch_list)" || return $?
+  [ -n "${dotted}" ] || return 0
+  top="${dotted##* }"
+  printf '%s %s+PTX' "${dotted}" "${top}"
+}

--- a/.ci/scripts/wheel/envvar_cuda_linux.sh
+++ b/.ci/scripts/wheel/envvar_cuda_linux.sh
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This file is sourced into the environment before building a pip wheel. It
+# should typically only contain shell variable assignments. Be sure to export
+# any variables so that subprocesses will see them.
+
+source "${GITHUB_WORKSPACE}/${REPOSITORY}/.ci/scripts/wheel/envvar_base.sh"
+
+# Ask for the CUDA delegate explicitly rather than letting the build detect a toolkit. A detected
+# build is fine locally, but a release row states what it is producing, and a row that silently
+# produced a CPU wheel because the toolkit was missing would publish under a CUDA name.
+export EXECUTORCH_BUILD_CUDA=1
+export CMAKE_ARGS="${CMAKE_ARGS} -DEXECUTORCH_BUILD_CUDA=ON"
+
+# Fail the build if CUDA is not actually present. Without this the packaging step would look for
+# CUDA libraries that were never built and report a confusing missing-file error several minutes
+# after the real problem.
+if [ ! -x "${CUDA_HOME:-/usr/local/cuda}/bin/nvcc" ]; then
+  echo "EXECUTORCH_BUILD_CUDA is set but no nvcc was found. This row cannot build a CUDA wheel." >&2
+  exit 1
+fi
+
+# Compile device code for the GPUs this release row claims, rather than for whichever GPU the
+# builder happens to have. A wheel built by detection alone installs on every machine the row covers
+# and then fails when a model runs on a different generation.
+source "${GITHUB_WORKSPACE}/${REPOSITORY}/.ci/scripts/wheel/cuda_arch_list.sh"
+# The status is checked rather than only the output. An unrecognised row makes the lookup fail, and
+# this file is sourced rather than run under a failing-command shell, so ignoring the status would
+# leave the variable unset and let the build fall back to detecting the builder's own GPU. That is
+# exactly the outcome this is meant to prevent, and it would ship quietly.
+if ! _executorch_cuda_arch="$(executorch_cuda_arch_list_with_ptx)"; then
+  echo "could not resolve GPU architectures for CU_VERSION=${CU_VERSION:-unset}" >&2
+  exit 1
+fi
+if [ -n "${_executorch_cuda_arch}" ]; then
+  export TORCH_CUDA_ARCH_LIST="${_executorch_cuda_arch}"
+  echo "building device code for: ${TORCH_CUDA_ARCH_LIST}"
+fi

--- a/.ci/scripts/wheel/pre_build_script.sh
+++ b/.ci/scripts/wheel/pre_build_script.sh
@@ -44,6 +44,21 @@ if [[ "$(uname -m)" == "aarch64" ]]; then
     echo "the file $file has been modified for atomic to use full path"
 fi
 
+# A CPU row must say so, rather than relying on the builder having no CUDA toolkit installed. The build
+# turns CUDA on when it detects one, so a builder that gains a toolkit would silently start producing a
+# CPU wheel carrying the CUDA delegate. That already happened on Windows, where the image ships a toolkit
+# on PATH and the resulting wheel failed to load its own extension.
+#
+# A CPU row names no CUDA train. It may say so by leaving the variable unset or by setting it to a value
+# that means "no CUDA", so both spellings have to count: testing only for empty left a row that sets it to
+# cpu falling through, and that row then declared CUDA dependencies it never loads.
+case "${CU_VERSION:-${DESIRED_CUDA:-}}" in
+    "" | cpu | CPU | none | NONE)
+        export CMAKE_ARGS="${CMAKE_ARGS:-} -DEXECUTORCH_BUILD_CUDA=OFF"
+        echo "CMAKE_ARGS=${CMAKE_ARGS}" >> "${GITHUB_ENV}"
+        ;;
+esac
+
 # On Windows, enable symlinks and re-checkout the current revision to create
 # the symlinked src/ directory. This is needed to build the wheel.
 if [[ $UNAME_S == *"MINGW"* || $UNAME_S == *"MSYS"* ]]; then

--- a/.ci/scripts/wheel/test_cpp_sdk.py
+++ b/.ci/scripts/wheel/test_cpp_sdk.py
@@ -57,6 +57,25 @@ example = (torch.randn(2, 8), torch.randn(2, 1, 6, 6))
 with torch.no_grad():
     expected = model(*example)
 
+if mode == "quantized":
+    # Quantize with the same flow the documentation shows, so the exported program
+    # references the quantized operator set rather than the plain one.
+    # Importing this loads the ahead-of-time library, which is what registers the out
+    # variants of the quantized operators with torch. Without it the export fails with
+    # "Missing out variants: quantized_decomposed::quantize_per_tensor", because the
+    # lowering step has no out variant to select.
+    import executorch.kernels.quantized  # noqa: F401
+    from executorch.backends.xnnpack.quantizer.xnnpack_quantizer import (
+        get_symmetric_quantization_config,
+        XNNPACKQuantizer,
+    )
+    from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
+
+    quantizer = XNNPACKQuantizer().set_global(get_symmetric_quantization_config())
+    prepared = prepare_pt2e(torch.export.export(model, example).module(), quantizer)
+    prepared(*example)
+    model = convert_pt2e(prepared)
+
 partitioners = []
 if mode == "delegate":
     from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
@@ -85,6 +104,11 @@ print(
             "expected": expected.flatten().tolist(),
             "delegated": mode == "delegate",
             "has_xnnpack": b"XnnpackBackend" in bytes(buffer),
+            # Whether the program actually carries quantized operators. The numeric comparison alone
+            # cannot tell: an unquantized export of the same model produces a closer match than the
+            # tolerance a quantized one needs, so it would pass while proving nothing about the
+            # quantized kernels.
+            "has_quantized": b"quantized_decomposed" in bytes(buffer),
         }
     )
 )
@@ -190,8 +214,14 @@ int main(int argc, char** argv) {
   for (size_t i = 0; i < expected.size(); ++i) {
     worst = std::fmax(worst, std::fabs((double)actual[i] - (double)expected[i]));
   }
-  if (worst > 1e-4) {
-    std::printf("output differs from eager PyTorch by %g\n", worst);
+  // Passed in rather than fixed, because the acceptable difference depends on the
+  // model. A float32 model should match to within rounding, while an int8 quantized one
+  // legitimately differs by about one quantization step, and using the looser number
+  // for both would stop the float path catching a real regression.
+  const double tolerance = argc > 7 ? std::atof(argv[7]) : 1e-4;
+  if (worst > tolerance) {
+    std::printf(
+        "output differs from eager PyTorch by %g, tolerance %g\n", worst, tolerance);
     return 1;
   }
 
@@ -329,8 +359,16 @@ def _build_consumer(work_dir: Path, name: str, components) -> Path:
     return consumer
 
 
-def _run_consumer(consumer: Path, model: Path, reference, work_dir: Path) -> str:
-    """Run the application and require it to match eager PyTorch."""
+def _run_consumer(
+    consumer: Path, model: Path, reference, work_dir: Path, tolerance: float = 1e-4
+) -> str:
+    """Run the application and require it to match eager PyTorch within `tolerance`.
+
+    The tolerance is a parameter because the acceptable difference depends on the model.
+    A float32 model should match to within rounding, while an int8 quantized one
+    legitimately differs by about one quantization step, and using the looser number for
+    both would stop the float path catching a real regression.
+    """
     inputs = reference["inputs"]
     shape_a, data_a = _write_tensor(work_dir, "a", inputs[0])
     shape_b, data_b = _write_tensor(work_dir, "b", inputs[1])
@@ -352,6 +390,7 @@ def _run_consumer(consumer: Path, model: Path, reference, work_dir: Path) -> str
             str(shape_b),
             str(data_b),
             str(expected),
+            repr(tolerance),
         ],
         capture_output=True,
         text=True,
@@ -1005,6 +1044,46 @@ def test_documented_example_compiles(work_dir: Path) -> None:
     print("✓ the C++ example in the documentation compiles against the wheel")
 
 
+def test_quantized_kernels_component_runs_a_model(work_dir: Path) -> None:
+    """A C++ application can run a quantized model using the shipped quantized kernels.
+
+    Before the quantized kernels became their own library they existed only inside the
+    ahead-of-time extension beside the Python bindings, so a C++ application loading a
+    quantized program had nothing to link and failed at run time with the operators
+    reported missing.
+
+    Skipped rather than failed when the wheel ships no such library, because building
+    without the quantized kernels is a supported configuration.
+    """
+    package_dir = _installed_package_dir()
+    shipped = package_dir / "lib" / "libexecutorch_kernels_quantized.so"
+    if not shipped.is_file():
+        print("- this wheel ships no quantized kernels, skipping")
+        return
+
+    model, reference = _export(work_dir, "quantized")
+    # The export has to have produced a quantized program, or the rest of this proves nothing about the
+    # quantized kernels. The numeric comparison cannot tell the difference: an unquantized export of the
+    # same model lands well inside the tolerance a quantized one needs, so it would pass while linking a
+    # library it never exercised.
+    assert reference["has_quantized"], (
+        "the quantized export produced a program with no quantized operators, so this check would "
+        "prove nothing about the quantized kernels"
+    )
+    consumer = _build_consumer(
+        work_dir,
+        "with-quantized",
+        ["runtime", "kernels_optimized", "kernels_quantized"],
+    )
+    # One int8 quantization step over this model's output range is about 5e-3, so a
+    # float32 tolerance cannot be met by a correct quantized run.
+    output = _run_consumer(consumer, model, reference, work_dir, tolerance=2e-2)
+    print(
+        f"✓ a C++ app linking executorch::kernels_quantized runs a quantized model "
+        f"({output})"
+    )
+
+
 def run_tests(work_dir: Path) -> None:
     test_find_package_honours_a_version_request(work_dir)
     test_profiler_component_is_usable(work_dir)
@@ -1013,6 +1092,7 @@ def run_tests(work_dir: Path) -> None:
     test_documented_example_compiles(work_dir)
     test_runtime_alone_links_but_has_no_kernels(work_dir)
     test_kernels_component_runs_a_model(work_dir)
+    test_quantized_kernels_component_runs_a_model(work_dir)
     test_delegated_model_needs_the_delegate_component(work_dir)
     test_consumer_is_relocatable(work_dir)
     test_one_registry_in_the_cpp_process(work_dir)

--- a/.ci/scripts/wheel/test_cpp_sdk.py
+++ b/.ci/scripts/wheel/test_cpp_sdk.py
@@ -1,0 +1,1023 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Checks that a standalone C++ application can use the wheel as an SDK.
+
+The wheel ships prebuilt runtime, kernel, delegate, thread pool and profiler
+libraries, plus headers and a CMake package config. A Python test can exercise none
+of that: the Python extension links those libraries itself, so it passes whether or
+not the package config names them correctly, whether or not the headers are complete,
+and whether or not an application that links them can find them at run time.
+
+So these checks build and run a real application from outside the wheel. Nothing here
+uses the source tree, because a user has only the installed package.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Exports the model to a .pte and prints the reference outputs, so the C++ side can
+# be compared against eager PyTorch rather than merely checked for not crashing.
+#
+# The same network as the Python parity check: several operator kinds, so a run
+# exercises the merged CPU kernels rather than a single add.
+_EXPORT_SCRIPT = """
+import json
+import sys
+
+import torch
+from executorch.exir import to_edge_transform_and_lower
+
+
+class Net(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(8, 16)
+        self.conv = torch.nn.Conv2d(1, 4, 3, padding=1)
+
+    def forward(self, x, image):
+        a = torch.relu(self.linear(x))
+        b = self.conv(image).flatten(1)
+        return a.sum(dim=1, keepdim=True) + b.mean(dim=1, keepdim=True)
+
+
+destination, mode = sys.argv[1], sys.argv[2]
+torch.manual_seed(0)
+model = Net().eval()
+example = (torch.randn(2, 8), torch.randn(2, 1, 6, 6))
+with torch.no_grad():
+    expected = model(*example)
+
+partitioners = []
+if mode == "delegate":
+    from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+        XnnpackPartitioner,
+    )
+
+    partitioners = [XnnpackPartitioner()]
+
+program = to_edge_transform_and_lower(
+    torch.export.export(model, example), partitioner=partitioners
+).to_executorch()
+buffer = program.buffer
+with open(destination, "wb") as handle:
+    handle.write(buffer)
+
+# The inputs travel with the model so the C++ side feeds identical values. Written as
+# plain text rather than a tensor format, because reading one is not what is under
+# test here and a dependency on one would be a second thing that can fail.
+print(
+    json.dumps(
+        {
+            "inputs": [
+                {"shape": list(t.shape), "data": t.flatten().tolist()}
+                for t in example
+            ],
+            "expected": expected.flatten().tolist(),
+            "delegated": mode == "delegate",
+            "has_xnnpack": b"XnnpackBackend" in bytes(buffer),
+        }
+    )
+)
+"""
+
+
+_CONSUMER_SOURCE = r"""
+// A standalone application. It includes only what the wheel installs and links only
+// the wheel's imported targets, so it fails if the shipped headers are incomplete or
+// the package config does not make the libraries findable at run time.
+#include <executorch/extension/module/module.h>
+#include <executorch/extension/tensor/tensor.h>
+#include <executorch/runtime/backend/interface.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace executorch::extension;
+
+namespace {
+
+// A minimal reader for the numbers the export step printed. Deliberately not a JSON
+// library: adding a dependency here would mean a failure could come from the parser
+// rather than from the SDK.
+std::vector<float> read_floats(const std::string& path) {
+  std::ifstream file(path);
+  std::vector<float> values;
+  float value = 0.0f;
+  while (file >> value) {
+    values.push_back(value);
+  }
+  return values;
+}
+
+std::vector<int> read_ints(const std::string& path) {
+  std::ifstream file(path);
+  std::vector<int> values;
+  int value = 0;
+  while (file >> value) {
+    values.push_back(value);
+  }
+  return values;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  // Seven, because argv[6] is read below: the program name plus six arguments. A guard of six let a
+  // caller that passed one too few read past the end of argv.
+  if (argc < 7) {
+    std::printf("usage: consumer <pte> <shape0> <data0> <shape1> <data1> <expected>\n");
+    return 2;
+  }
+  executorch::runtime::runtime_init();
+
+  const auto shape_a = read_ints(argv[2]);
+  auto data_a = read_floats(argv[3]);
+  const auto shape_b = read_ints(argv[4]);
+  auto data_b = read_floats(argv[5]);
+  const auto expected = read_floats(argv[6]);
+
+  std::vector<executorch::aten::SizesType> sizes_a(shape_a.begin(), shape_a.end());
+  std::vector<executorch::aten::SizesType> sizes_b(shape_b.begin(), shape_b.end());
+
+  // The documented entry points, not the lower-level runtime API. Constructing these
+  // needs real definitions at link time, so it checks that the shipped headers and
+  // the shipped libraries agree rather than only that the headers parse.
+  module::Module module(argv[1]);
+  const auto load_error = module.load();
+  if (load_error != executorch::runtime::Error::Ok) {
+    std::printf("load failed: 0x%x\n", (unsigned)load_error);
+    return 1;
+  }
+
+  auto input_a = make_tensor_ptr(sizes_a, data_a.data());
+  auto input_b = make_tensor_ptr(sizes_b, data_b.data());
+
+  const auto result = module.forward({input_a, input_b});
+  if (!result.ok()) {
+    std::printf("forward failed: 0x%x\n", (unsigned)result.error());
+    return 1;
+  }
+
+  const auto output = result->at(0).toTensor();
+  if ((size_t)output.numel() != expected.size()) {
+    std::printf(
+        "output has %zu values, expected %zu\n",
+        (size_t)output.numel(),
+        expected.size());
+    return 1;
+  }
+
+  // Compared against eager PyTorch, not merely produced. A model that returns wrong
+  // numbers without erroring would satisfy every other check here.
+  const float* actual = output.const_data_ptr<float>();
+  double worst = 0.0;
+  for (size_t i = 0; i < expected.size(); ++i) {
+    worst = std::fmax(worst, std::fabs((double)actual[i] - (double)expected[i]));
+  }
+  if (worst > 1e-4) {
+    std::printf("output differs from eager PyTorch by %g\n", worst);
+    return 1;
+  }
+
+  std::printf(
+      "ok backends=%zu maxdiff=%g\n",
+      (size_t)executorch::runtime::get_num_registered_backends(),
+      worst);
+  return 0;
+}
+"""
+
+
+def _consumer_cmake(components) -> str:
+    """A consumer project that links the given components by their public names.
+
+    REQUIRED COMPONENTS rather than a bare find_package, because that is the form the
+    documentation shows and it has to fail loudly when the wheel does not ship what
+    it advertises.
+    """
+    requested = " ".join(components)
+    links = "\n".join(
+        f"target_link_libraries(consumer PRIVATE executorch::{name})"
+        for name in components
+    )
+    return f"""cmake_minimum_required(VERSION 3.28)
+project(consumer CXX)
+find_package(executorch REQUIRED COMPONENTS {requested})
+add_executable(consumer consumer.cpp)
+{links}
+"""
+
+
+def _tool(name: str) -> str:
+    """Locate a build tool, including one pip installed beside this interpreter.
+
+    `shutil.which` searches PATH only, and a virtual environment's bin is on PATH only
+    when the environment is activated. These checks run by invoking the interpreter
+    directly, so a tool installed into that environment is present on disk and
+    invisible to a PATH search.
+    """
+    found = shutil.which(name)
+    if found:
+        return found
+    beside = Path(sys.executable).parent / name
+    return str(beside) if beside.is_file() else name
+
+
+def _installed_package_dir() -> Path:
+    """Where the wheel installed itself, found without importing it.
+
+    Imported from the source tree, `executorch.__file__` points at the checkout rather
+    than at the installed package, so a check would read the wrong files and pass while
+    the wheel was broken.
+    """
+    for entry in sys.path:
+        candidate = Path(entry) / "executorch"
+        if (candidate / "share" / "cmake").is_dir():
+            return candidate
+    raise AssertionError(
+        "no installed executorch package with share/cmake on sys.path; these checks "
+        "must run against an installed wheel, not the source tree"
+    )
+
+
+def _write_tensor(directory: Path, stem: str, tensor) -> tuple:
+    """Write one tensor's shape and values as whitespace-separated text."""
+    shape_file = directory / f"{stem}.shape"
+    data_file = directory / f"{stem}.data"
+    shape_file.write_text(" ".join(str(n) for n in tensor["shape"]))
+    data_file.write_text(" ".join(repr(v) for v in tensor["data"]))
+    return shape_file, data_file
+
+
+def _export(work_dir: Path, mode: str) -> tuple:
+    """Export the model to a .pte and return it with the reference numbers."""
+    script = work_dir / "export.py"
+    script.write_text(_EXPORT_SCRIPT)
+    model = work_dir / f"model_{mode}.pte"
+    result = subprocess.run(
+        [sys.executable, str(script), str(model), mode],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"exporting the {mode} model failed, so the C++ side cannot be checked "
+        f"against it:\n{result.stdout[-2000:]}\n{result.stderr[-2000:]}"
+    )
+    reference = json.loads(result.stdout.strip().splitlines()[-1])
+    assert model.is_file(), f"the export step produced no {model}"
+    return model, reference
+
+
+def _build_consumer(work_dir: Path, name: str, components) -> Path:
+    """Configure and build the consumer application against the installed package."""
+    package_dir = _installed_package_dir()
+    config = package_dir / "share" / "cmake" / "executorch-config.cmake"
+    assert config.is_file(), f"the wheel ships no CMake package config at {config}"
+
+    source_dir = work_dir / name
+    build_dir = work_dir / f"{name}-build"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "consumer.cpp").write_text(_CONSUMER_SOURCE)
+    (source_dir / "CMakeLists.txt").write_text(_consumer_cmake(components))
+
+    configured = subprocess.run(
+        [
+            _tool("cmake"),
+            "-S",
+            str(source_dir),
+            "-B",
+            str(build_dir),
+            f"-DCMAKE_PREFIX_PATH={config.parent}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert configured.returncode == 0, (
+        f"a consumer requesting {list(components)} could not configure against the "
+        f"installed package:\n{configured.stdout[-2000:]}\n{configured.stderr[-2000:]}"
+    )
+    built = subprocess.run(
+        [_tool("cmake"), "--build", str(build_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert built.returncode == 0, (
+        f"a consumer requesting {list(components)} compiled against the shipped "
+        f"headers but did not link:\n{built.stdout[-3000:]}\n{built.stderr[-3000:]}"
+    )
+    consumer = build_dir / "consumer"
+    assert consumer.is_file(), f"the build produced no {consumer}"
+    return consumer
+
+
+def _run_consumer(consumer: Path, model: Path, reference, work_dir: Path) -> str:
+    """Run the application and require it to match eager PyTorch."""
+    inputs = reference["inputs"]
+    shape_a, data_a = _write_tensor(work_dir, "a", inputs[0])
+    shape_b, data_b = _write_tensor(work_dir, "b", inputs[1])
+    expected = work_dir / "expected.data"
+    expected.write_text(" ".join(repr(v) for v in reference["expected"]))
+
+    # No LD_LIBRARY_PATH. Making the shipped libraries findable is the package
+    # config's job, and inheriting one from the environment would hide a failure to
+    # do it.
+    environment = {
+        key: value for key, value in os.environ.items() if key != "LD_LIBRARY_PATH"
+    }
+    result = subprocess.run(
+        [
+            str(consumer),
+            str(model),
+            str(shape_a),
+            str(data_a),
+            str(shape_b),
+            str(data_b),
+            str(expected),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+    assert result.returncode == 0, (
+        "the C++ application built against the installed wheel did not run "
+        f"correctly:\n{result.stdout[-2000:]}\n{result.stderr[-2000:]}"
+    )
+    return result.stdout.strip()
+
+
+def test_runtime_alone_links_but_has_no_kernels(work_dir: Path) -> None:
+    """Linking only the runtime builds and loads, and cannot execute.
+
+    Measured rather than assumed: libexecutorch.so defines no operator kernels, so an
+    application linking it alone loads a program and then reports every operator as
+    missing. That is the intended split, and stating it here documents why the kernels
+    are a separate component instead of leaving a reader to guess.
+
+    The value of the check is the boundary. It fails if the runtime silently starts
+    carrying kernels again, which would mean the split had regressed, and it fails if
+    the runtime cannot even load a program.
+    """
+    model, reference = _export(work_dir, "plain")
+    consumer = _build_consumer(work_dir, "runtime-only", ["runtime"])
+
+    inputs = reference["inputs"]
+    shape_a, data_a = _write_tensor(work_dir, "ra", inputs[0])
+    shape_b, data_b = _write_tensor(work_dir, "rb", inputs[1])
+    expected = work_dir / "r_expected.data"
+    expected.write_text(" ".join(repr(v) for v in reference["expected"]))
+    environment = {
+        key: value for key, value in os.environ.items() if key != "LD_LIBRARY_PATH"
+    }
+    result = subprocess.run(
+        [
+            str(consumer),
+            str(model),
+            str(shape_a),
+            str(data_a),
+            str(shape_b),
+            str(data_b),
+            str(expected),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0, (
+        "an application linking only executorch::runtime executed a model, so the "
+        "runtime is carrying operator kernels that are supposed to live in their own "
+        "component"
+    )
+    assert "Missing operator" in combined, (
+        "an application linking only the runtime failed for some reason other than "
+        f"absent kernels, which is the documented behaviour:\n{combined[-1500:]}"
+    )
+    print("✓ executorch::runtime alone links and loads, and has no kernels to execute")
+
+
+def test_kernels_component_runs_a_model(work_dir: Path) -> None:
+    """Adding the CPU kernels component keeps the model running and correct."""
+    model, reference = _export(work_dir, "plain")
+    consumer = _build_consumer(
+        work_dir, "with-kernels", ["runtime", "kernels_optimized"]
+    )
+    output = _run_consumer(consumer, model, reference, work_dir)
+    print(f"✓ a C++ app linking executorch::kernels_optimized runs a model ({output})")
+
+
+def test_delegated_model_needs_the_delegate_component(work_dir: Path) -> None:
+    """A delegated model runs when the delegate is linked, and fails when it is not.
+
+    Both halves matter. Only running the positive case would pass even if the delegate
+    target did nothing, because the runtime falls back to portable kernels for
+    anything a backend does not claim. The negative case is what shows the delegate is
+    actually doing the work, and that the retention options on the target are what
+    make its registration reach the registry.
+    """
+    model, reference = _export(work_dir, "delegate")
+    assert reference["has_xnnpack"], (
+        "the exported program contains no XnnpackBackend payload, so this check would "
+        "prove nothing about the delegate"
+    )
+
+    # The kernels come too. A partitioner claims only what its backend supports, so a
+    # delegated program still has ordinary operators in it, and an application without
+    # the kernels fails on those rather than on anything to do with the delegate.
+    # Measured: this model keeps aten::mean.out outside the XNNPACK partition.
+    consumer = _build_consumer(
+        work_dir,
+        "with-delegate",
+        ["runtime", "kernels_optimized", "backend_xnnpack"],
+    )
+    output = _run_consumer(consumer, model, reference, work_dir)
+    print(
+        f"✓ a C++ app linking executorch::backend_xnnpack runs a delegated model "
+        f"({output})"
+    )
+
+    # The same program, run by an application that has the kernels but not the
+    # delegate. Only the delegate is removed, so a failure can only be about the
+    # missing backend rather than about absent operators.
+    without = _build_consumer(work_dir, "no-delegate", ["runtime", "kernels_optimized"])
+    environment = {
+        key: value for key, value in os.environ.items() if key != "LD_LIBRARY_PATH"
+    }
+    inputs = reference["inputs"]
+    shape_a, data_a = _write_tensor(work_dir, "na", inputs[0])
+    shape_b, data_b = _write_tensor(work_dir, "nb", inputs[1])
+    expected = work_dir / "n_expected.data"
+    expected.write_text(" ".join(repr(v) for v in reference["expected"]))
+    result = subprocess.run(
+        [
+            str(without),
+            str(model),
+            str(shape_a),
+            str(data_a),
+            str(shape_b),
+            str(data_b),
+            str(expected),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+    assert result.returncode != 0, (
+        "a delegated program ran in an application that never linked the delegate, so "
+        "either the delegate is reaching the registry without being asked for or the "
+        f"program was not delegated at all. Output was:\n{result.stdout[-1000:]}"
+    )
+    print(
+        "✓ the same delegated model fails without executorch::backend_xnnpack, "
+        "so the component is what registers it"
+    )
+
+
+def test_consumer_is_relocatable(work_dir: Path) -> None:
+    """The application still runs after being moved away from the wheel.
+
+    Building in place leaves the wheel's absolute lib directory on the link line, which
+    resolves the runtime whatever $ORIGIN says. Copying the application next to a copy
+    of the libraries, with the original package hidden, is what actually shows the
+    package is relocatable rather than only working where it was built.
+    """
+    model, reference = _export(work_dir, "plain")
+    consumer = _build_consumer(work_dir, "relocate", ["runtime", "kernels_optimized"])
+
+    assert shutil.which("readelf") is not None, "readelf is needed to read the RUNPATH"
+    dynamic = subprocess.run(
+        [_tool("readelf"), "-d", str(consumer)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "libexecutorch.so" in dynamic, (
+        "the application records no dependency on the shipped runtime, so it is not "
+        f"linking what the wheel ships:\n{dynamic}"
+    )
+    assert "$ORIGIN" in dynamic, (
+        "the application has no $ORIGIN-relative runtime search path, so it cannot "
+        f"work anywhere but where it was built:\n{dynamic}"
+    )
+
+    package_dir = _installed_package_dir()
+    deployed = work_dir / "deployed"
+    deployed.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(consumer, deployed / "consumer")
+    for library in sorted((package_dir / "lib").glob("lib*.so*")):
+        if library.is_file() and not library.is_symlink():
+            shutil.copy2(library, deployed / library.name)
+
+    moved = deployed / "consumer"
+    # Strip the absolute entry the build left behind, so only $ORIGIN can resolve the
+    # libraries. Without this the application would find the original wheel and the
+    # check would pass for the wrong reason.
+    # Fatal, not a skip. Stripping the absolute entry is the whole point: without it the
+    # relocated application finds the original package and this check passes for the
+    # wrong reason. A skip here is indistinguishable from a pass in the log, which is
+    # the shape of failure this suite exists to avoid.
+    patchelf = _tool("patchelf")
+    if shutil.which("patchelf") is None and not Path(patchelf).is_file():
+        print("- patchelf not present, installing it so this check can run")
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--quiet", "patchelf"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        patchelf = _tool("patchelf")
+    assert shutil.which("patchelf") or Path(patchelf).is_file(), (
+        "patchelf is required to prove the application is relocatable, and could not "
+        "be installed. Without it the relocated application resolves the original "
+        "package and the check would pass without testing anything."
+    )
+    current = subprocess.run(
+        [patchelf, "--print-rpath", str(moved)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    kept = [
+        entry
+        for entry in current.split(":")
+        if entry and not entry.startswith(str(package_dir))
+    ]
+    subprocess.run(
+        [patchelf, "--set-rpath", ":".join(kept) or "$ORIGIN", str(moved)], check=True
+    )
+
+    output = _run_consumer(moved, model, reference, work_dir)
+    print(f"✓ the application still runs deployed away from the wheel ({output})")
+
+
+def test_one_registry_in_the_cpp_process(work_dir: Path) -> None:
+    """An application linking several components gets one registry, not one each.
+
+    This is the property the split exists to create, checked in a C++ process rather
+    than only by inspecting symbol tables. Every component resolves the registry from
+    the one runtime library, so the count a consumer observes must not grow with the
+    number of components it links.
+    """
+    model, reference = _export(work_dir, "plain")
+
+    def backends_seen(name, components) -> int:
+        consumer = _build_consumer(work_dir, name, components)
+        output = _run_consumer(consumer, model, reference, work_dir)
+        for field in output.split():
+            if field.startswith("backends="):
+                return int(field.split("=", 1)[1])
+        raise AssertionError(f"the application printed no backend count: {output}")
+
+    # Both cases have to be able to run the model, so both link the kernels. The
+    # variable under test is how many further component libraries are linked, not
+    # whether the program executes.
+    lean = backends_seen("registry-lean", ["runtime", "kernels_optimized"])
+    full = backends_seen(
+        "registry-full",
+        ["runtime", "kernels_optimized", "threadpool", "etdump", "backend_xnnpack"],
+    )
+    # Equal, not merely non-zero. A second registry would show up as a different count
+    # once more registering libraries are linked.
+    # The delegate genuinely adds one backend, so the counts differ by exactly that.
+    # What must not happen is the count resetting or doubling, which is what a second
+    # registry in the process looks like.
+    assert full == lean + 1, (
+        f"an application linking two components sees {lean} registered backends while "
+        f"one linking five, of which exactly one registers a backend, sees {full}. A "
+        "component is carrying its own registry rather than resolving the shared one."
+    )
+    print(
+        f"✓ one shared registry: {lean} backends with two components, {full} with five"
+    )
+
+
+def test_find_package_honours_a_version_request(work_dir: Path) -> None:
+    """`find_package(executorch <version>)` must accept and reject correctly.
+
+    Without a version file CMake reports the package version as "unknown" and accepts
+    any request, so a consumer pinning a minimum silently gets whatever is installed.
+    The wheel generates the file at packaging time because the version is only known
+    then: the base comes from version.txt and a nightly overrides it.
+    """
+    package_dir = _installed_package_dir()
+    version_file = package_dir / "share" / "cmake" / "executorch-config-version.cmake"
+    assert version_file.is_file(), (
+        f"the wheel ships no CMake version file at {version_file}, so find_package "
+        "reports the version as unknown and accepts every request"
+    )
+
+    installed = None
+    build_version = None
+    for line in version_file.read_text().splitlines():
+        if line.startswith("set(PACKAGE_VERSION"):
+            installed = line.split('"')[1]
+        elif line.startswith("set(EXECUTORCH_BUILD_VERSION"):
+            build_version = line.split('"')[1]
+    assert installed, f"could not read PACKAGE_VERSION from {version_file}"
+    assert not installed.startswith("@"), (
+        f"the version file still holds an unsubstituted placeholder, {installed}, so "
+        "packaging copied the template instead of filling it in"
+    )
+
+    # The two variables report different things and are filled separately. Only checking the numeric one
+    # would pass on a file where the full version was truncated to it, or where its placeholder was never
+    # substituted, and the full version is what a consumer compares to pin an exact build.
+    assert build_version, f"could not read EXECUTORCH_BUILD_VERSION from {version_file}"
+    assert not build_version.startswith(
+        "@"
+    ), f"the build version still holds an unsubstituted placeholder, {build_version}"
+    assert build_version.startswith(installed), (
+        f"the build version {build_version} does not start with the numeric release {installed}, "
+        "so they describe different builds"
+    )
+    from executorch.version import __version__ as installed_version
+
+    assert build_version == installed_version, (
+        f"the version file says {build_version} but the installed package says {installed_version}, "
+        "so a consumer pinning an exact build would compare against the wrong one"
+    )
+
+    # CMake compares dotted integers only, and find_package rejects a REQUESTED version
+    # that is not one, so the numeric release part is what a consumer can ask for. The
+    # wheel's own version can carry more: a dev segment for a nightly and a local part
+    # such as +cpu or a commit hash. CMake truncates the stored version at the first
+    # non-numeric segment, which makes those compare equal to the release, so pinning
+    # the release is the behaviour a consumer actually gets.
+    release = re.match(r"\d+(?:\.\d+)*", installed)
+    assert release, f"no numeric release part in the installed version {installed}"
+    release = release.group(0)
+    major = release.split(".")[0]
+    too_new = f"{int(major) + 1}.0"
+    source_dir = work_dir / "version-probe"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "consumer.cpp").write_text("int main() { return 0; }\n")
+
+    for requested, must_accept in ((release, True), ("0.1", True), (too_new, False)):
+        # Deliberately the older floor: this probe never links an imported target, so it also checks
+        # that version acceptance answers correctly below the version those targets need.
+        (source_dir / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.24)\n"
+            "project(probe CXX)\n"
+            f"find_package(executorch {requested} REQUIRED)\n"
+            "add_executable(consumer consumer.cpp)\n"
+        )
+        build_dir = work_dir / f"version-probe-build-{requested}"
+        result = subprocess.run(
+            [
+                _tool("cmake"),
+                "-S",
+                str(source_dir),
+                "-B",
+                str(build_dir),
+                f"-DCMAKE_PREFIX_PATH={version_file.parent}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        accepted = result.returncode == 0
+        assert accepted == must_accept, (
+            f"find_package(executorch {requested}) against an installed {installed} "
+            f"{'was rejected' if must_accept else 'was accepted'}, which is wrong:\n"
+            f"{result.stdout[-800:]}{result.stderr[-800:]}"
+        )
+    print(
+        f"✓ find_package honours a version request (installed {installed}, "
+        f"accepts {release}, rejects {too_new})"
+    )
+
+
+def test_profiler_component_is_usable(work_dir: Path) -> None:
+    """A C++ application must be able to construct the profiler the etdump component represents.
+
+    Linking a component proves the library resolves. It does not prove a consumer can call anything in it,
+    and the profiler shipped for a while with only an internal alignment helper as its public surface, so
+    the component could be requested and linked but not used.
+    """
+    package_dir = _installed_package_dir()
+    # Globbed, not an exact name: the library carries a version suffix outside a wheel build, and an exact
+    # match would silently skip this check there. The profiler is required elsewhere in this suite, so its
+    # absence is a fault rather than a reason to skip.
+    shipped = sorted((package_dir / "lib").glob("libexecutorch_etdump.so*"))
+    assert shipped, (
+        f"the wheel ships no profiler library under {package_dir / 'lib'}, so the etdump component it "
+        "advertises cannot be linked"
+    )
+
+    source_dir = work_dir / "with-etdump"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "consumer.cpp").write_text(
+        "#include <executorch/devtools/etdump/etdump_flatcc.h>\n"
+        "#include <memory>\n"
+        "int main() {\n"
+        "  auto tracer = std::make_unique<executorch::etdump::ETDumpGen>();\n"
+        "  return tracer == nullptr ? 1 : 0;\n"
+        "}\n"
+    )
+    (source_dir / "CMakeLists.txt").write_text(_consumer_cmake(["runtime", "etdump"]))
+
+    build_dir = work_dir / "with-etdump-build"
+    configured = subprocess.run(
+        [
+            _tool("cmake"),
+            "-S",
+            str(source_dir),
+            "-B",
+            str(build_dir),
+            f"-DCMAKE_PREFIX_PATH={package_dir}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert configured.returncode == 0, (
+        "configuring an application that uses the profiler failed:\n"
+        f"{configured.stdout[-1500:]}\n{configured.stderr[-1500:]}"
+    )
+    built = subprocess.run(
+        [_tool("cmake"), "--build", str(build_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert built.returncode == 0, (
+        "an application that constructs the profiler failed to build against the installed wheel, so the "
+        f"component cannot be used by a consumer:\n{built.stdout[-2000:]}\n{built.stderr[-2000:]}"
+    )
+    print("✓ a C++ app linking executorch::etdump constructs the profiler")
+
+
+def test_every_shipped_header_compiles(work_dir: Path) -> None:
+    """Each installed header must compile on its own against the installed wheel.
+
+    A header that cannot be included is worse than one that is absent, because the failure arrives in
+    someone else's project at compile time. This caught a profiler header that includes a regular
+    expression library the wheel does not carry, and whose implementation the shipped library does not
+    define either.
+
+    Compiled one at a time rather than all together, so the message names the header at fault.
+    """
+    package_dir = _installed_package_dir()
+    include_root = package_dir / "include"
+    headers = sorted(include_root.rglob("*.h"))
+    assert (
+        headers
+    ), f"no headers found under {include_root}, so this check would prove nothing"
+
+    # The same include directories the CMake package exports, since that is what a consumer gets.
+    includes = [
+        f"-I{include_root}",
+        f"-I{include_root / 'executorch' / 'runtime' / 'core' / 'portable_type' / 'c10'}",
+        # The same definition every imported target carries. Without it the vendored c10 headers reach for
+        # a header generated inside a PyTorch build, which no wheel can carry, so compiling without it
+        # tests a configuration no consumer of this package is ever in.
+        "-DC10_USING_CUSTOM_GENERATED_MACROS",
+    ]
+    # A CUDA wheel's headers reference the CUDA runtime, which the wheel does not publish headers for and
+    # states as a requirement instead. A consumer of that component supplies a toolkit of its own, so this
+    # check does the same rather than treating the header as unbuildable. Taken from the toolkit itself, so
+    # it follows whichever toolkit the build used instead of a list of prefixes that goes stale.
+    nvcc = shutil.which("nvcc")
+    cuda_root = os.environ.get("CUDA_HOME") or (
+        str(Path(nvcc).parent.parent) if nvcc else ""
+    )
+    if cuda_root and (Path(cuda_root) / "include" / "cuda_runtime.h").is_file():
+        includes.append(f"-I{Path(cuda_root) / 'include'}")
+    # Headers a wheel-only consumer cannot compile and is not expected to. Each needs something outside the
+    # package: a platform that is not the one being built for, or a third-party library the wheel does not
+    # carry. They ship because a source build includes them, and holding them to this rule would report a
+    # defect with no available fix.
+    needs_more_than_the_wheel = (
+        # These ship because other shipped headers include them, so they cannot be left out, and they do
+        # not compile on their own: each needs a third-party library the wheel links but publishes no
+        # headers for, or a platform other than the one being built for.
+        "mman_windows.h",  # a Windows compatibility shim, needs the MinGW headers
+        "testing_util/tensor_util.h",  # a test helper, needs a test framework
+        # These say in their own text that they must not be included directly, and name the header to
+        # include instead. Including one anyway is a use error rather than a packaging defect.
+        "c10/util/complex_math.h",
+        "c10/util/complex_utils.h",
+    )
+
+    source = work_dir / "header_probe.cpp"
+    broken = []
+    skipped_but_fine = []
+    for header in headers:
+        relative = header.relative_to(include_root)
+        skipped = relative.as_posix().endswith(needs_more_than_the_wheel)
+        source.write_text(
+            f"#include <{relative.as_posix()}>\nint main() {{ return 0; }}\n"
+        )
+        result = subprocess.run(
+            [_tool("c++"), "-std=c++20", *includes, "-fsyntax-only", str(source)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if skipped:
+            if result.returncode == 0:
+                skipped_but_fine.append(str(relative))
+            continue
+        if result.returncode != 0:
+            missing = re.search(r"fatal error: ([^:]+): No such file", result.stderr)
+            broken.append(
+                f"{relative}: {missing.group(1) if missing else 'does not compile'}"
+            )
+
+    # A skip list quietly loses value as the code changes: an entry that starts compiling stays skipped and
+    # nobody notices the coverage was given up for nothing. So the skipped ones are compiled too, and an
+    # entry that now works is reported rather than left in place.
+    assert not skipped_but_fine, (
+        "these headers are on the skip list but compile now, so the list is stale and is giving up "
+        f"coverage for no reason. Remove them from it: {skipped_but_fine}"
+    )
+
+    assert not broken, (
+        "the wheel ships headers that cannot be included from the installed package, so a consumer "
+        "following the documentation would fail to compile:\n  " + "\n  ".join(broken)
+    )
+    print(f"✓ all {len(headers)} shipped headers compile against the installed wheel")
+
+
+def test_shipped_headers_have_implementations(work_dir: Path) -> None:
+    """A header that compiles but has no implementation in any shipped library is unusable.
+
+    Compiling proves only that the declarations parse. Two headers once shipped whose implementation
+    lived in a component no shipped library links, so a consumer got an undefined reference at link
+    time. A syntax check cannot see that, so this links a real program for each declaration a consumer
+    would reasonably call.
+    """
+    package = _installed_package_dir()
+    include_root = package / "include"
+
+    # One small program per header, calling the declaration a consumer would call first. Kept as source
+    # rather than derived, because there is no way to guess a usable call from a header alone.
+    probes = {
+        "extension/memory_allocator/malloc_memory_allocator.h": (
+            "#include <executorch/extension/memory_allocator/malloc_memory_allocator.h>\n"
+            "using namespace executorch::extension;\n"
+            "int main() { MallocMemoryAllocator allocator; return allocator.allocate(16) == nullptr; }\n"
+        ),
+        "extension/module/module.h": (
+            "#include <executorch/extension/module/module.h>\n"
+            "using namespace executorch::extension;\n"
+            'int main() { Module module("none.pte"); return module.method_names().ok() ? 0 : 1; }\n'
+        ),
+        "extension/tensor/tensor.h": (
+            "#include <executorch/extension/tensor/tensor.h>\n"
+            "using namespace executorch::extension;\n"
+            "int main() { float data[4] = {}; auto tensor = make_tensor_ptr({2, 2}, data); "
+            "return tensor->numel() == 4 ? 0 : 1; }\n"
+        ),
+    }
+
+    includes = [
+        f"-I{include_root}",
+        f"-I{include_root / 'executorch' / 'runtime' / 'core' / 'portable_type' / 'c10'}",
+        "-DC10_USING_CUSTOM_GENERATED_MACROS",
+    ]
+    library_dir = package / "lib"
+    unresolved = []
+    for header, program in probes.items():
+        assert (
+            include_root / "executorch" / header
+        ).is_file(), f"{header} is not shipped, so this probe is checking nothing"
+        source = work_dir / "link_probe.cpp"
+        source.write_text(program)
+        result = subprocess.run(
+            [
+                _tool("c++"),
+                "-std=c++17",
+                *includes,
+                str(source),
+                "-o",
+                str(work_dir / "link_probe"),
+                f"-L{library_dir}",
+                "-lexecutorch",
+                f"-Wl,-rpath,{library_dir}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            missing = re.findall(r"undefined reference to `([^']+)'", result.stderr)
+            unresolved.append(f"{header}: {sorted(set(missing))[:3] or 'did not link'}")
+
+    assert not unresolved, (
+        "the wheel ships headers whose implementation is in no shipped library, so a consumer compiles "
+        "and then fails to link:\n  " + "\n  ".join(unresolved)
+    )
+    print(f"✓ all {len(probes)} probed headers link against the shipped libraries")
+
+
+def test_documented_example_compiles(work_dir: Path) -> None:
+    """The C++ example in the documentation must compile against the installed wheel.
+
+    Extracted from the documentation rather than copied here, so the two cannot drift. A
+    reader who follows the documentation gets code that builds, and a dangling include or
+    a renamed entry point fails this check instead of shipping.
+    """
+    here = Path(__file__).resolve()
+    root = here.parents[3] if len(here.parents) > 3 else here.parent
+    documentation = root / "docs" / "source" / "using-executorch-cpp.md"
+    if not documentation.is_file():
+        print("- the documentation is not present, skipping the example check")
+        return
+
+    # The first fenced cpp block after the prebuilt-package heading. Anchored on the
+    # heading so an unrelated example elsewhere on the page is not picked up.
+    text = documentation.read_text()
+    marker = "### Using the prebuilt libraries from the pip package"
+    assert marker in text, (
+        f"{documentation.name} no longer documents the prebuilt package, so a reader has "
+        "no instructions for the libraries this wheel ships"
+    )
+    section = text[text.index(marker) :]
+    blocks = re.findall(r"```cpp\n(.*?)```", section, re.S)
+    assert blocks, (
+        f"{documentation.name} documents the prebuilt package but shows no C++ example, "
+        "so nothing proves the documented usage compiles"
+    )
+
+    source_dir = work_dir / "documented"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "main.cpp").write_text(blocks[0])
+    # The components the documentation itself tells a reader to ask for.
+    (source_dir / "CMakeLists.txt").write_text(
+        _consumer_cmake(["runtime", "kernels_optimized"]).replace(
+            "consumer.cpp", "main.cpp"
+        )
+    )
+
+    package_dir = _installed_package_dir()
+    config = package_dir / "share" / "cmake" / "executorch-config.cmake"
+    build_dir = work_dir / "documented-build"
+    configured = subprocess.run(
+        [
+            _tool("cmake"),
+            "-S",
+            str(source_dir),
+            "-B",
+            str(build_dir),
+            f"-DCMAKE_PREFIX_PATH={config.parent}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert configured.returncode == 0, (
+        "the documented example does not configure against the installed package:\n"
+        f"{configured.stdout[-1500:]}{configured.stderr[-1500:]}"
+    )
+    built = subprocess.run(
+        [_tool("cmake"), "--build", str(build_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert built.returncode == 0, (
+        "the documented example does not build against the installed package, so a "
+        f"reader following the documentation gets code that fails:\n"
+        f"{built.stdout[-2500:]}{built.stderr[-2500:]}"
+    )
+    print("✓ the C++ example in the documentation compiles against the wheel")
+
+
+def run_tests(work_dir: Path) -> None:
+    test_find_package_honours_a_version_request(work_dir)
+    test_profiler_component_is_usable(work_dir)
+    test_every_shipped_header_compiles(work_dir)
+    test_shipped_headers_have_implementations(work_dir)
+    test_documented_example_compiles(work_dir)
+    test_runtime_alone_links_but_has_no_kernels(work_dir)
+    test_kernels_component_runs_a_model(work_dir)
+    test_delegated_model_needs_the_delegate_component(work_dir)
+    test_consumer_is_relocatable(work_dir)
+    test_one_registry_in_the_cpp_process(work_dir)
+
+
+if __name__ == "__main__":
+    with tempfile.TemporaryDirectory() as directory:
+        run_tests(Path(directory))

--- a/.ci/scripts/wheel/test_cuda_linux.py
+++ b/.ci/scripts/wheel/test_cuda_linux.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Smoke test for a CUDA wheel row.
+
+Runs the same checks a CPU wheel gets, then the ones a GPU wheel needs on top. The extra
+checks exist because a GPU wheel can install cleanly, import cleanly, and still be unusable:
+
+  the CUDA libraries can be absent while the wheel is still named as a CUDA build
+  the runtime dependency can be undeclared, so a user has nothing to resolve it from
+  the loader path can point at the build machine's toolkit, which no user has
+  the device code can cover no GPU the row claims, which only appears when a model runs
+
+The build machines for these rows have no GPU, so this does not execute a model. It verifies
+everything that can be checked from the artifact, and the release gate runs a model on real
+hardware.
+"""
+
+import os
+import pathlib
+import platform
+import subprocess
+import tempfile
+from pathlib import Path
+
+import test_base
+import test_cpp_sdk
+import test_shared_libraries
+from examples.models import Backend, Model
+
+
+def _package_dir() -> Path:
+    import executorch
+
+    return Path(executorch.__path__[0])
+
+
+def test_cuda_libraries_are_shipped() -> None:
+    """The row is named for CUDA, so the CUDA libraries have to be in it."""
+    lib_dir = _package_dir() / "lib"
+    shipped = {path.name for path in lib_dir.iterdir()} if lib_dir.is_dir() else set()
+    expected = {
+        "libexecutorch_backend_cuda.so",
+        "libexecutorch_extension_cuda.so",
+    }
+    missing = sorted(expected - shipped)
+    assert not missing, (
+        f"this is a CUDA row but {missing} are not in the wheel, so it would install as a "
+        f"CUDA build with no CUDA delegate. Shipped: {sorted(shipped)}"
+    )
+    print(f"✓ the CUDA libraries ship ({len(expected)} of them)")
+
+
+def test_cuda_runtime_is_declared() -> None:
+    """The wheel links the CUDA runtime without bundling it, so it must declare it.
+
+    Without this a user installs the wheel and has nothing to resolve libcudart from, which
+    surfaces as a loader error at the first import rather than as a resolution failure at
+    install time.
+    """
+    import importlib.metadata as metadata
+
+    requirements = metadata.requires("executorch") or []
+    cuda = [
+        requirement
+        for requirement in requirements
+        if "nvidia" in requirement.lower() or "cuda" in requirement.lower()
+    ]
+    assert cuda, (
+        "this is a CUDA row but the wheel declares no CUDA runtime dependency, so nothing "
+        "would install the libraries its delegate links"
+    )
+    print(f"✓ the CUDA runtime is declared ({len(cuda)} requirements)")
+
+
+def test_cuda_libraries_resolve_relatively() -> None:
+    """Each CUDA library must reach its runtime through a relative path.
+
+    An absolute toolkit path names the machine that built the wheel. It resolves there and
+    nowhere else, so the wheel would work only on a builder.
+
+    Every shipped library that links the CUDA runtime is inspected, wherever it lives. Naming
+    only the two in lib/ skipped libaoti_cuda_shims.so, which sits under backends/cuda/, links
+    cudart and curand, and carries the device code, so an absolute toolkit path on the library
+    that matters most shipped green.
+    """
+    readelf = test_shared_libraries._tool("readelf")
+    assert readelf is not None, "readelf is required to inspect the wheel"
+
+    package_dir = _package_dir()
+    libraries = sorted(test_shared_libraries._shipped_shared_objects(package_dir))
+    # Without this the loop below finds nothing on a wheel that ships no CUDA library and
+    # reports a pass, which is the same as having no check at all.
+    assert libraries, f"no shared libraries found under {package_dir}"
+
+    linked_to_cuda = []
+    for library in libraries:
+        output = subprocess.run(
+            [readelf, "-d", str(library)], capture_output=True, text=True, check=True
+        ).stdout
+        if any("NEEDED" in line and "libcud" in line for line in output.splitlines()):
+            linked_to_cuda.append((library, output))
+
+    assert linked_to_cuda, (
+        "no shipped library links the CUDA runtime, so this check inspected nothing. A CUDA "
+        "row must ship the libraries it is named for."
+    )
+    for library, output in linked_to_cuda:
+        name = library.relative_to(package_dir)
+        entries: list[str] = []
+        for line in output.splitlines():
+            if "RPATH" in line or "RUNPATH" in line:
+                entries = line.split("[", 1)[1].rstrip("]").strip().split(":")
+        relative = [
+            entry
+            for entry in entries
+            if entry.startswith("$ORIGIN") and "nvidia" in entry
+        ]
+        assert relative, (
+            f"{name} links the CUDA runtime but has no relative path to the CUDA wheels "
+            f"installed beside it, so it can only resolve where the builder had a toolkit: "
+            f"{entries}"
+        )
+        print(f"✓ {name} resolves the CUDA runtime relatively ({relative[0]})")
+
+
+def _row_architectures() -> list[str]:
+    """The architectures this row claims, from the same script the build uses.
+
+    A refusal from that script is a fault, not an absence. It returns non-zero when a CUDA row reaches it
+    with no version, which is precisely the case that would otherwise build device code for whatever GPU the
+    builder happens to have, so swallowing it here would hide the one failure this check exists to catch.
+
+    EXECUTORCH_BUILD_CUDA is passed through because that is how the build invokes the script, and the
+    refusal is conditional on it. Without it the script returned an empty list on a CUDA row that had lost
+    its version, this check reported nothing to do, and the assertion below could never fire.
+    """
+    script = pathlib.Path(__file__).parent / "cuda_arch_list.sh"
+    assert script.is_file(), f"the architecture script is missing at {script}"
+    result = subprocess.run(
+        ["bash", "-c", f"source {script}; executorch_cuda_arch_list"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "EXECUTORCH_BUILD_CUDA": "1"},
+    )
+    assert result.returncode == 0, (
+        f"the architecture script refused this row with exit {result.returncode}, so the build had no list "
+        f"to compile against: {result.stderr.strip()[:300]}"
+    )
+    # "8.0 9.0" describes sm_80 and sm_90.
+    return ["sm_" + value.replace(".", "") for value in result.stdout.split()]
+
+
+def test_device_code_covers_the_row() -> None:
+    """Every GPU the row claims must have device code in the shipped libraries.
+
+    A row that promises a GPU it did not compile for produces a wheel that installs and then dies
+    at the first kernel launch, which is the worst failure to publish.
+    """
+    expected = _row_architectures()
+    if not expected:
+        print("- this row claims no GPU architectures, nothing to check")
+        return
+
+    cuobjdump = test_shared_libraries._tool("cuobjdump")
+    if cuobjdump is None:
+        raise AssertionError(
+            "cuobjdump is required to check device code, and this is a CUDA row. Without it a "
+            "wheel missing code for a claimed GPU would ship unnoticed."
+        )
+
+    # Searched across every shipped library rather than a named one. The kernels are compiled
+    # into their own library, not into the delegate, and which library holds them is an internal
+    # detail. What the row promises is that the wheel covers those GPUs.
+    present: set[str] = set()
+    inspected = []
+    for library in sorted(_package_dir().rglob("*.so")):
+        listed = subprocess.run(
+            [cuobjdump, "--list-elf", str(library)],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout
+        found = {
+            token
+            for token in listed.replace(".", " ").split()
+            if token.startswith("sm_")
+        }
+        if found:
+            inspected.append(f"{library.name} ({', '.join(sorted(found))})")
+            present |= found
+
+    assert inspected, (
+        "no shipped library contains any GPU device code, so this wheel cannot run a model on any "
+        f"GPU, while the row claims {expected}"
+    )
+    missing = sorted(set(expected) - present)
+    assert not missing, (
+        f"the row claims {expected} but the wheel carries no device code for {missing}. "
+        f"Found: {inspected}. A user with one of those GPUs would install this wheel and fail at "
+        "the first kernel launch."
+    )
+    print(f"✓ device code covers the row: {inspected}")
+
+
+def test_the_delegate_registers() -> None:
+    """The delegate has to appear in the runtime's backend list, not merely be present as a file.
+
+    Registration happens in a static initializer, which a normal link discards because nothing in the
+    program references it. Keeping it alive needs a linker option, and a wheel whose delegate ships but
+    does not register would load a delegated program and fail with an unregistered backend. That is the
+    failure this whole layout is most able to introduce, so it is worth asserting rather than assuming.
+
+    Needs no GPU: registration is a link-time property, checked by importing.
+    """
+    from executorch.extension.pybindings.portable_lib import (
+        _get_registered_backend_names,
+    )
+
+    registered = _get_registered_backend_names()
+    assert "CudaBackend" in registered, (
+        f"the wheel ships the CUDA delegate but CudaBackend is not registered: {registered}. "
+        "The library is present and its static initializer did not run, which means the option "
+        "that keeps it on the link line stopped working."
+    )
+    print(f"✓ the delegate registers: CudaBackend among {len(registered)} backend(s)")
+
+
+if __name__ == "__main__":
+    assert platform.system() == "Linux", "the CUDA rows are Linux only"
+
+    test_cuda_libraries_are_shipped()
+    test_cuda_runtime_is_declared()
+    test_cuda_libraries_resolve_relatively()
+    test_device_code_covers_the_row()
+    test_the_delegate_registers()
+
+    # Everything a CPU wheel is held to still applies: one owner per component, no
+    # build-tree paths, and a C++ application able to link what the wheel ships.
+    with tempfile.TemporaryDirectory() as work_dir:
+        test_shared_libraries.run_tests(Path(work_dir))
+    with tempfile.TemporaryDirectory() as work_dir:
+        test_cpp_sdk.run_tests(Path(work_dir))
+
+    test_base.run_tests(
+        model_tests=[
+            test_base.ModelTest(
+                model=Model.Mv3,
+                backend=Backend.XnnpackQuantizationDelegation,
+            ),
+        ]
+    )

--- a/.ci/scripts/wheel/test_linux.py
+++ b/.ci/scripts/wheel/test_linux.py
@@ -7,8 +7,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import platform
+import tempfile
+from pathlib import Path
 
 import test_base
+import test_shared_libraries
 from examples.models import Backend, Model
 
 if __name__ == "__main__":
@@ -40,6 +43,12 @@ if __name__ == "__main__":
             print("⚠ VulkanBackend not registered (expected for the default wheel)")
 
         test_base.test_cmsis_nn_install()
+
+        # The wheel ships the runtime, the kernels, the delegate, the thread
+        # pool and the profiler as separate shared libraries now, so check that
+        # each has exactly one owner and that all of them are loadable.
+        with tempfile.TemporaryDirectory() as work_dir:
+            test_shared_libraries.run_tests(Path(work_dir))
 
     test_base.run_tests(
         model_tests=[

--- a/.ci/scripts/wheel/test_linux.py
+++ b/.ci/scripts/wheel/test_linux.py
@@ -11,6 +11,7 @@ import tempfile
 from pathlib import Path
 
 import test_base
+import test_cpp_sdk
 import test_shared_libraries
 from examples.models import Backend, Model
 
@@ -49,6 +50,13 @@ if __name__ == "__main__":
         # each has exactly one owner and that all of them are loadable.
         with tempfile.TemporaryDirectory() as work_dir:
             test_shared_libraries.run_tests(Path(work_dir))
+
+        # And that a C++ application outside the wheel can actually use them.
+        # Nothing above covers this: the Python extension links those libraries
+        # itself, so it passes whether or not the package config names them or the
+        # shipped headers are complete.
+        with tempfile.TemporaryDirectory() as work_dir:
+            test_cpp_sdk.run_tests(Path(work_dir))
 
     test_base.run_tests(
         model_tests=[

--- a/.ci/scripts/wheel/test_linux_aarch64.py
+++ b/.ci/scripts/wheel/test_linux_aarch64.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 
 import test_base
+import test_cpp_sdk
 import test_shared_libraries
 from examples.models import Backend, Model
 
@@ -35,6 +36,11 @@ if __name__ == "__main__":
     # exactly one owner and that all of them are loadable.
     with tempfile.TemporaryDirectory() as work_dir:
         test_shared_libraries.run_tests(Path(work_dir))
+
+    # And that a C++ application outside the wheel can actually use those
+    # libraries, which nothing above covers.
+    with tempfile.TemporaryDirectory() as work_dir:
+        test_cpp_sdk.run_tests(Path(work_dir))
 
     test_base.run_tests(
         model_tests=[

--- a/.ci/scripts/wheel/test_linux_aarch64.py
+++ b/.ci/scripts/wheel/test_linux_aarch64.py
@@ -5,7 +5,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import tempfile
+from pathlib import Path
+
 import test_base
+import test_shared_libraries
 from examples.models import Backend, Model
 
 if __name__ == "__main__":
@@ -25,6 +29,12 @@ if __name__ == "__main__":
         "OpenvinoBackend" in registered
     ), f"OpenvinoBackend not found in registered backends: {registered}"
     print("✓ OpenvinoBackend is registered")
+
+    # The wheel ships the runtime, the kernels, the delegate, the thread pool and
+    # the profiler as separate shared libraries now, so check that each has
+    # exactly one owner and that all of them are loadable.
+    with tempfile.TemporaryDirectory() as work_dir:
+        test_shared_libraries.run_tests(Path(work_dir))
 
     test_base.run_tests(
         model_tests=[

--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -52,6 +52,14 @@ _THREADPOOL_SYMBOLS = ("executorch::extension::threadpool::get_threadpool",)
 # the operators are registered twice, which aborts at startup.
 _KERNEL_SYMBOLS = ("torch::executor::native::abs_out",)
 
+# The quantized kernels, whose own library the wheel ships when they are built.
+# A separate group because they have a separate owner, and because a wheel built
+# without them ships neither the library nor these symbols.
+_QUANTIZED_KERNEL_SYMBOLS = (
+    "torch::executor::native::quantize_per_tensor_out",
+    "torch::executor::native::dequantize_per_tensor_out",
+)
+
 # The registry entry points, kept separate from the kernel implementations above.
 # A library that carries its own copy of these has its own registration code, which
 # is what this split is meant to prevent: one owner of the operator table. Checking
@@ -247,6 +255,33 @@ def _defines_symbol(library: Path, symbol: str) -> bool:
     return False
 
 
+def _is_export_only(library: Path) -> bool:
+    """Whether a library exists to export a model rather than to run one.
+
+    The ahead-of-time operator libraries register kernels into torch so a model can be
+    exported, and they link torch to do it. They deliberately carry their own copy of
+    the kernels, because export happens in a Python process that never loads the
+    runtime libraries a C++ application links.
+
+    Excluded from the single-owner checks for that reason. Counting them would report a
+    duplicate for something that is not one, and the alternative, making them resolve
+    the kernels from the shipped library, would mean an export-time library depending on
+    a runtime layout it never uses.
+
+    Matched by what the file links rather than by its name, so a library renamed later
+    is still recognised.
+    """
+    if _tool("readelf") is None:
+        return library.name.endswith("_aot_lib.so")
+    dynamic = subprocess.run(
+        [_tool("readelf"), "-d", str(library)],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+    return "libtorch.so" in dynamic and "_aot_lib" in library.name
+
+
 def _assert_single_definer(symbols, what: str, owner: str | None = None) -> None:
     """At most one shipped library may define each of `symbols`.
 
@@ -262,7 +297,11 @@ def _assert_single_definer(symbols, what: str, owner: str | None = None) -> None
     assert _tool("nm") is not None, "nm is required to inspect the wheel"
 
     package_dir = _installed_package_dir()
-    libraries = _shipped_shared_objects(package_dir)
+    libraries = [
+        library
+        for library in _shipped_shared_objects(package_dir)
+        if not _is_export_only(library)
+    ]
     assert libraries, f"no shared libraries found under {package_dir}"
 
     # Every symbol is resolved before anything is reported, so a component that is only
@@ -333,6 +372,12 @@ _OWNED_COMPONENTS = (
         "set of CPU kernels",
         _KERNEL_SYMBOLS,
         "libexecutorch_kernels_optimized.so",
+        False,
+    ),
+    (
+        "set of quantized kernels",
+        _QUANTIZED_KERNEL_SYMBOLS,
+        "libexecutorch_kernels_quantized.so",
         False,
     ),
     # The third-party code these libraries bundle, checked separately from the
@@ -1172,15 +1217,41 @@ def test_extension_contains_no_component() -> None:
         ).stdout.splitlines()
         if "NEEDED" in line
     }
+    # Only the libraries whose code the extension used to contain. Those are the ones
+    # this split moved out of it, so the extension must now resolve them from outside or
+    # a retention option silently failed.
+    #
+    # Not every shipped library serves Python. The quantized kernels and the CUDA
+    # delegate exist for a C++ application: Python registers quantized operators through
+    # the torch-linked ahead-of-time library at export time, and never loads the CUDA
+    # delegate from this extension at all. Requiring a dependency on those would demand
+    # the extension link code it has no use for.
     shipped = {path.name for path in _shipped_runtime_libraries(package_dir)}
     assert shipped, (
         f"the wheel installed no runtime libraries under {package_dir / 'lib'}, so this check would "
         "compare the extension against nothing and pass"
     )
-    unused = sorted(shipped - needed)
+    expected = {
+        name
+        for name in shipped
+        if not any(
+            marker in name
+            for marker in ("kernels_quantized", "backend_cuda", "extension_cuda")
+        )
+    }
+    unused = sorted(expected - needed)
     assert not unused, (
         f"the wheel ships {unused} but {extension.name} does not depend on them, so "
         "either they are dead weight or a retention option did not hold"
+    )
+
+    # Two shipped libraries register the same quantized operators, one for export and one for a C++
+    # application, and the runtime treats a repeat registration as fatal. Reaching both from one process
+    # aborts it, and the only thing preventing that is this extension not depending on the run-time one.
+    assert not any("kernels_quantized" in name for name in needed), (
+        f"{extension.name} depends on the run-time quantized library, which registers the same operators "
+        "as the export-time one it already loads. The runtime aborts on a repeat registration, so "
+        "importing this extension would kill the process."
     )
 
     # Positive proof that the extension resolves these from elsewhere, rather than
@@ -1208,7 +1279,7 @@ def test_extension_contains_no_component() -> None:
     print(
         f"✓ {extension.name} ({extension.stat().st_size // 1024} KiB) contains no "
         f"component, imports the runtime symbols it uses, and depends on all "
-        f"{len(shipped)} shipped libraries"
+        f"{len(expected)} shipped libraries it used to contain"
     )
 
 
@@ -1252,6 +1323,7 @@ def test_shipped_library_names_are_expected() -> None:
     known = (
         "libexecutorch",
         "libexecutorch_kernels_optimized",
+        "libexecutorch_kernels_quantized",
         "libexecutorch_backend_xnnpack",
         "libexecutorch_threadpool",
         "libexecutorch_etdump",

--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -55,6 +55,27 @@ _KERNEL_SYMBOLS = ("torch::executor::native::abs_out",)
 # The quantized kernels, whose own library the wheel ships when they are built.
 # A separate group because they have a separate owner, and because a wheel built
 # without them ships neither the library nor these symbols.
+# The CUDA delegate and its stream helper, for a wheel built from a CUDA index. The
+# stream helper matters most: two copies means two notions of the caller's stream, so
+# work queued through one is invisible to the other.
+# A strongly defined symbol, chosen by reading the built library rather than guessed. The
+# CudaBackend methods are emitted weak, and a weak definition can be replaced at load time by a
+# strong one elsewhere, so naming one of those would count a definition that may not be the one
+# the process uses.
+_CUDA_BACKEND_SYMBOLS = ("executorch::backends::cuda::load_library",)
+_CUDA_STREAM_SYMBOLS = ("executorch::extension::cuda::getCallerStream",)
+
+# The AOTI shim layer and the stream-guard state that lives with it. This is the state that was
+# genuinely duplicated: extracting the shims with a PUBLIC whole-archive replayed the extraction at
+# every consumer's link, so the guard's thread_local and these shims landed in three shipped binaries
+# at once, and a stream selected through one copy was invisible to the other two. The row above cannot
+# catch that, because its symbol only ever existed in one unconditionally shared library.
+_AOTI_SHIM_SYMBOLS = (
+    "aoti_torch_empty_strided",
+    "aoti_torch_delete_tensor_object",
+    "executorch::backends::cuda::CUDAStreamGuard::create",
+)
+
 _QUANTIZED_KERNEL_SYMBOLS = (
     "torch::executor::native::quantize_per_tensor_out",
     "torch::executor::native::dequantize_per_tensor_out",
@@ -263,26 +284,34 @@ def _is_export_only(library: Path) -> bool:
     the kernels, because export happens in a Python process that never loads the
     runtime libraries a C++ application links.
 
-    Excluded from the single-owner checks for that reason. Counting them would report a
-    duplicate for something that is not one, and the alternative, making them resolve
-    the kernels from the shipped library, would mean an export-time library depending on
-    a runtime layout it never uses.
+    Excluded from the single-owner check for the one component that genuinely has two
+    copies. Counting them there would report a duplicate for something that is not one,
+    and the alternative, making them resolve the kernels from the shipped library, would
+    mean an export-time library depending on a runtime layout it never uses.
 
-    Matched by what the file links rather than by its name, so a library renamed later
-    is still recognised.
+    Recognised by linking torch, which is the property that makes a library export-side.
+    Python extensions link torch too and are not export-side operator libraries, so they
+    are excluded by their interpreter suffix rather than by an operator-library name,
+    which keeps the test's verdict the same whether or not readelf is installed.
     """
+    if ".cpython-" in library.name or library.name.endswith(".pyd"):
+        return False
+    if library.name.endswith("_aot_lib.so"):
+        return True
     if _tool("readelf") is None:
-        return library.name.endswith("_aot_lib.so")
+        return False
     dynamic = subprocess.run(
         [_tool("readelf"), "-d", str(library)],
         capture_output=True,
         text=True,
         check=False,
     ).stdout
-    return "libtorch.so" in dynamic and "_aot_lib" in library.name
+    return "libtorch.so" in dynamic
 
 
-def _assert_single_definer(symbols, what: str, owner: str | None = None) -> None:
+def _assert_single_definer(
+    symbols, what: str, owner: str | None = None, allow_export_copy: bool = False
+) -> None:
     """At most one shipped library may define each of `symbols`.
 
     The owner is named where one is expected, because counting definers alone does
@@ -293,6 +322,13 @@ def _assert_single_definer(symbols, what: str, owner: str | None = None) -> None
     A component the wheel does not ship at all is a valid configuration, not a
     fault. Delegates and kernel sets are build options, so a wheel built without one
     has zero definers and is reported as such. What must never happen is two.
+
+    `allow_export_copy` excuses the export-side libraries for one component only. The
+    quantized kernels genuinely exist twice, once in the runtime library and once in the
+    library torch loads at export time, and no process loads both. Excusing them for
+    every component would disarm this check where duplication is a real fault: two of
+    these libraries defined the backend registry symbols in one released wheel and not
+    in the release before it, so the duplication this catches does happen.
     """
     assert _tool("nm") is not None, "nm is required to inspect the wheel"
 
@@ -300,7 +336,7 @@ def _assert_single_definer(symbols, what: str, owner: str | None = None) -> None
     libraries = [
         library
         for library in _shipped_shared_objects(package_dir)
-        if not _is_export_only(library)
+        if not (allow_export_copy and _is_export_only(library))
     ]
     assert libraries, f"no shared libraries found under {package_dir}"
 
@@ -380,6 +416,24 @@ _OWNED_COMPONENTS = (
         "libexecutorch_kernels_quantized.so",
         False,
     ),
+    (
+        "CUDA delegate",
+        _CUDA_BACKEND_SYMBOLS,
+        "libexecutorch_backend_cuda.so",
+        False,
+    ),
+    (
+        "CUDA stream helper",
+        _CUDA_STREAM_SYMBOLS,
+        "libexecutorch_extension_cuda.so",
+        False,
+    ),
+    (
+        "AOTI shim layer",
+        _AOTI_SHIM_SYMBOLS,
+        "libaoti_cuda_shims.so",
+        False,
+    ),
     # The third-party code these libraries bundle, checked separately from the
     # wrappers above. A wrapper can have a single owner while the implementation
     # underneath it is bundled into two of these, which is two real thread pools or
@@ -405,6 +459,12 @@ _OWNED_COMPONENTS = (
     ),
 )
 
+# The one component that legitimately exists twice. The quantized kernels are compiled into the runtime
+# library and again into the library torch loads at export time, and no process loads both, so a second
+# definer there is expected rather than a fault. Named per component so the check stays armed for the
+# other ten, where a second definer means two registries or two thread pools in one process.
+_COMPONENTS_WITH_AN_EXPORT_COPY = frozenset({"set of quantized kernels"})
+
 
 def test_each_component_has_one_owner() -> None:
     """No component may be defined by more than one library the wheel ships.
@@ -414,16 +474,22 @@ def test_each_component_has_one_owner() -> None:
     registers into a table nothing else reads shows up as an operator missing at run
     time rather than as a link error.
     """
-    shipped = {
-        path.name for path in _shipped_runtime_libraries(_installed_package_dir())
-    }
+    # Every shipped shared object, not only the ones under lib/. One owner, libaoti_cuda_shims.so,
+    # ships under backends/cuda/, and scanning lib/ alone reported it as absent, which each row
+    # treats as an acceptable state and so would have skipped the check entirely.
+    shipped = {path.name for path in _shipped_shared_objects(_installed_package_dir())}
     for what, symbols, owner, required in _OWNED_COMPONENTS:
         present = any(name.startswith(owner) for name in shipped)
         assert present or not required, (
             f"the wheel ships no {owner}, which owns the {what}. Either packaging "
             "dropped it or the build did not produce it."
         )
-        _assert_single_definer(symbols, what, owner if present else None)
+        _assert_single_definer(
+            symbols,
+            what,
+            owner if present else None,
+            allow_export_copy=what in _COMPONENTS_WITH_AN_EXPORT_COPY,
+        )
 
 
 def test_python_extensions_import() -> None:
@@ -1097,7 +1163,8 @@ def test_no_absolute_runtime_paths() -> None:
     )
 
     offenders = {}
-    checked = 0
+    inspected = 0
+    with_a_runtime_path = 0
     for library in sorted(package_dir.rglob("*.so*")):
         if not library.is_file() or library.is_symlink():
             continue
@@ -1109,7 +1176,7 @@ def test_no_absolute_runtime_paths() -> None:
         )
         if result.returncode != 0:
             continue
-        checked += 1
+        inspected += 1
         # An absent RPATH and one containing a single empty entry both print as an
         # empty string, so treat empty output as "no runtime path" rather than as an
         # empty entry. A library with nothing to search is fine; the defect is
@@ -1117,6 +1184,7 @@ def test_no_absolute_runtime_paths() -> None:
         raw = result.stdout.strip()
         if not raw:
             continue
+        with_a_runtime_path += 1
         bad = []
         for entry in raw.split(":"):
             if not entry:
@@ -1142,13 +1210,15 @@ def test_no_absolute_runtime_paths() -> None:
         "the build tree that produced the wheel or, for an empty entry, the process "
         f"working directory: {offenders}"
     )
-    assert checked, (
-        f"no shipped library under {package_dir} carries a runtime search path, so this check examined "
-        "nothing and would pass on a wheel that shipped no libraries at all"
+    # Counted separately, because a wheel whose libraries all had their runtime paths removed
+    # entirely would satisfy a readable-file count while this check examined no path at all.
+    assert with_a_runtime_path, (
+        f"none of the {inspected} shipped libraries under {package_dir} carries a runtime search path, "
+        "so this check examined nothing. The shipped libraries need a relative path to reach each other."
     )
     print(
-        f"✓ none of the {checked} shipped libraries searches a build-tree or empty "
-        "runtime path"
+        f"✓ none of the {with_a_runtime_path} shipped libraries with a runtime path searches a "
+        f"build-tree or empty directory ({inspected} inspected)"
     )
 
 
@@ -1185,12 +1255,17 @@ def test_extension_contains_no_component() -> None:
     #
     # The bundled third-party groups are left out on purpose. That code is also linked by torch, and the
     # extension links torch, so seeing those symbols there says nothing about this split.
-    # Only components whose owning library is actually in this wheel. One of them is optional, so a build
-    # with it turned off ships no owner, and asserting the extension does not define its symbols would
-    # reject a configuration the table itself marks as supported.
-    shipped = {
-        path.name for path in _shipped_runtime_libraries(_installed_package_dir())
-    }
+    # Only components whose owning library is actually in this wheel. A build with an optional component
+    # turned off ships no owner, and asserting the extension does not define its symbols would reject a
+    # configuration the table itself marks as supported. Required rows are kept regardless, because their
+    # owner missing is a packaging fault the owner check reports.
+    shipped = {path.name for path in _shipped_runtime_libraries(package_dir)}
+    # Guarded here rather than further down, so it protects the filter that uses it: a wheel that
+    # installed no runtime libraries would otherwise compare the extension against an empty set and pass.
+    assert shipped, (
+        f"the wheel installed no runtime libraries under {package_dir / 'lib'}, so this check would "
+        "compare the extension against nothing and pass"
+    )
     owned = tuple(
         symbol
         for _, symbols, owner, required in _OWNED_COMPONENTS
@@ -1221,23 +1296,20 @@ def test_extension_contains_no_component() -> None:
     # this split moved out of it, so the extension must now resolve them from outside or
     # a retention option silently failed.
     #
-    # Not every shipped library serves Python. The quantized kernels and the CUDA
-    # delegate exist for a C++ application: Python registers quantized operators through
-    # the torch-linked ahead-of-time library at export time, and never loads the CUDA
-    # delegate from this extension at all. Requiring a dependency on those would demand
-    # the extension link code it has no use for.
-    shipped = {path.name for path in _shipped_runtime_libraries(package_dir)}
-    assert shipped, (
-        f"the wheel installed no runtime libraries under {package_dir / 'lib'}, so this check would "
-        "compare the extension against nothing and pass"
-    )
+    # Not every shipped library serves Python. The quantized kernels exist for a C++
+    # application, since Python registers those operators through the torch-linked
+    # ahead-of-time library at export time, and requiring a dependency would demand the
+    # extension link code it has no use for.
+    #
+    # The CUDA delegate is NOT in that category. The build deliberately links it into the
+    # extension with a retention option, so it does carry a dependency, and excluding it
+    # switched off the one check that would notice if that retention stopped working. The
+    # stream helper stays excluded because the extension reaches it only through the
+    # delegate's public link, with no retention of its own to protect.
     expected = {
         name
         for name in shipped
-        if not any(
-            marker in name
-            for marker in ("kernels_quantized", "backend_cuda", "extension_cuda")
-        )
+        if not any(marker in name for marker in ("kernels_quantized", "extension_cuda"))
     }
     unused = sorted(expected - needed)
     assert not unused, (
@@ -1292,11 +1364,13 @@ def test_shipped_library_names_are_expected() -> None:
     and still passed every symbol check, because those checks only ask how many
     definers a symbol has, never whether a file belongs in the wheel at all.
 
-    Three properties catch it. A library built by this project carries VERSION and
-    SOVERSION, so its file name ends in a major. Its recorded soname matches its
-    file name, or a consumer records a dependency the wheel does not contain. And
-    its name is one packaging knows how to produce, which is what a leftover from
-    an older layout fails.
+    Two properties catch it. Its name is one packaging knows how to produce, which is
+    what a leftover from an older layout fails. And its recorded soname matches its
+    file name, or a consumer records a dependency the wheel does not contain.
+
+    The names are unversioned, because these libraries ship one file each with no
+    symlink chain, and a versioned name without the usual symlinks is harder to load
+    rather than safer.
     """
     package_dir = _installed_package_dir()
     lib_dir = package_dir / "lib"
@@ -1324,6 +1398,8 @@ def test_shipped_library_names_are_expected() -> None:
         "libexecutorch",
         "libexecutorch_kernels_optimized",
         "libexecutorch_kernels_quantized",
+        "libexecutorch_backend_cuda",
+        "libexecutorch_extension_cuda",
         "libexecutorch_backend_xnnpack",
         "libexecutorch_threadpool",
         "libexecutorch_etdump",

--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -1,0 +1,1462 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Checks that the wheel ships its runtime as separate shared libraries.
+
+The Python bindings extension used to contain the runtime, the registries, the
+CPU kernels, the XNNPACK delegate and the profiler, all statically linked into
+one file. It now links them as shared libraries the wheel ships alongside it.
+These checks run against the installed wheel only; they never look at the source
+tree's build directory, because a checkout on the module search path makes every
+check below pass while inspecting the wrong thing.
+
+The properties verified here are the ones the split exists to create:
+
+1. Each component has exactly one definer, and it is the library that is meant
+   to own it. Counting definers alone is not enough: the monolithic layout also
+   had exactly one of each, inside the Python extension.
+2. The extension contains none of those components and depends on every shipped
+   library instead.
+3. Every shipped library loads with no absolute runtime search path, including
+   after being moved, so the wheel is relocatable rather than only working on
+   the machine that built it.
+"""
+
+import importlib.metadata
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Registry entry points. A second definer of any of these means a second
+# process-wide registry.
+_REGISTRY_SYMBOLS = (
+    "executorch::runtime::register_backend",
+    "executorch::runtime::get_num_registered_backends",
+    "executorch::runtime::get_backend_class",
+)
+
+# The thread pool accessor. A second definer means a second pool, which
+# oversubscribes the CPU because each pool sizes itself to all cores.
+_THREADPOOL_SYMBOLS = ("executorch::extension::threadpool::get_threadpool",)
+
+# A representative operator from the merged CPU kernels. A second definer means
+# the operators are registered twice, which aborts at startup.
+_KERNEL_SYMBOLS = ("torch::executor::native::abs_out",)
+
+# The registry entry points, kept separate from the kernel implementations above.
+# A library that carries its own copy of these has its own registration code, which
+# is what this split is meant to prevent: one owner of the operator table. Checking
+# only a kernel implementation would miss that entirely.
+_KERNEL_REGISTRY_SYMBOLS = (
+    "executorch::runtime::register_kernels",
+    "executorch::runtime::get_registered_kernels",
+)
+
+# A representative symbol from the XNNPACK delegate. A second definer means the
+# process carries two copies of the delegate.
+_XNNPACK_SYMBOLS = (
+    "executorch::backends::xnnpack::XnnpackBackendOptions::workspace_manager",
+)
+
+# Third-party code the shipped libraries bundle rather than depend on. These are C
+# symbols with default visibility, so a second copy in the same process is not a
+# duplicate of ExecuTorch's own code but it is still two thread pools or two
+# XNNPACK runtimes, and which one a caller reaches depends on load order.
+#
+# Checked separately from the wrapper symbols above because the wrappers can each
+# have exactly one owner while the bundled code underneath them does not. That is
+# the same failure the split exists to prevent, reached by a different route.
+_BUNDLED_THREADPOOL_SYMBOLS = ("pthreadpool_create", "cpuinfo_initialize")
+_BUNDLED_XNNPACK_SYMBOLS = ("xnn_create_runtime_v4",)
+
+# A representative symbol from the profiler. A second definer means two event
+# tracers, so a trace records only part of what ran.
+_ETDUMP_SYMBOLS = ("executorch::etdump::ETDumpGen::ETDumpGen",)
+
+# `nm -DC` prints "<hexaddr> <kind> <name>" for a definition and
+# "                 U <name>" for an undefined reference.
+_DEFINED = re.compile(r"^[0-9a-fA-F]+\s+(?P<kind>[A-Za-z])\s+(?P<name>.+)$")
+
+# Symbol kinds that mean the object owns the code or storage.
+_OWNING_KINDS = frozenset("TtBbDdGgSsRrWV")
+
+
+def _declared_requirements() -> set:
+    """Import names the installed wheel declares a requirement for.
+
+    Used to tell a package this environment simply does not have from one the wheel
+    said it needed, because only the second is a packaging defect.
+
+    Two sources, because neither alone is sufficient. importlib's reverse map is
+    authoritative where a distribution is INSTALLED, which is what makes
+    PyYAML -> yaml, ruamel.yaml -> ruamel and hydra-core -> hydra resolve correctly.
+    But it enumerates installed distributions only, so a declared dependency that is
+    MISSING can never appear in it, which is precisely the case this function exists
+    to catch. The transformed distribution name covers that case.
+    """
+    try:
+        from importlib.metadata import packages_distributions, requires
+    except ImportError:  # pragma: no cover
+        return set()
+    try:
+        declared = requires("executorch") or []
+    except Exception:
+        return set()
+
+    wanted, names = set(), set()
+    for requirement in declared:
+        # Only the distribution name, dropping any version specifier, extra or
+        # environment marker.
+        name = re.split(r"[\s;\[<>=!~(]", requirement.strip(), maxsplit=1)[0]
+        if not name:
+            continue
+        wanted.add(name.lower().replace("-", "_").replace(".", "_"))
+        # The likely import name, so a MISSING declared dependency is still
+        # recognised as declared rather than silently skipped.
+        names.add(name)
+        names.add(name.replace("-", "_"))
+        names.add(name.split(".")[0])
+
+    for import_name, distributions in packages_distributions().items():
+        for distribution in distributions:
+            if distribution.lower().replace("-", "_").replace(".", "_") in wanted:
+                names.add(import_name)
+    return names
+
+
+def _installed_package_dir() -> Path:
+    """The installed executorch package, never the source checkout.
+
+    Enforced rather than assumed. Python puts the working directory on the module
+    search path, so running from a checkout resolves `executorch` to the source
+    tree, where there are no shipped libraries and every check below passes while
+    testing nothing. That is worse than a failure, because it looks like a pass.
+    """
+    import executorch
+
+    paths = [Path(entry).resolve() for entry in executorch.__path__]
+    # Every entry, not just the first. This is a namespace package, so a checkout on
+    # the module search path adds a second entry, and a module can then resolve from
+    # the checkout while the first entry still looks like a clean install.
+    outside = [
+        path
+        for path in paths
+        if "site-packages" not in path.parts and "dist-packages" not in path.parts
+    ]
+    assert not outside, (
+        f"executorch also resolves through {outside}, which is not an installed "
+        "package. Run this from a directory that contains no executorch checkout, "
+        "or the checks silently inspect the source tree instead of the wheel."
+    )
+    assert len(paths) == 1, (
+        f"executorch resolves through {len(paths)} paths ({paths}). Even when all of "
+        "them are installs, a module could come from either, so which artifact is "
+        "under test is ambiguous."
+    )
+    return paths[0]
+
+
+def _tool(name: str):
+    """Locate a build tool, including one pip installed beside this interpreter.
+
+    `shutil.which` searches PATH only, and a virtual environment's `bin` is on PATH
+    only when the environment is activated. These tests are normally run by invoking
+    the interpreter directly, so a tool pip installed into that environment is present
+    on disk and invisible to a PATH search.
+    """
+    found = shutil.which(name)
+    if found:
+        return found
+    beside = Path(sys.executable).parent / name
+    return str(beside) if beside.is_file() else None
+
+
+def _shipped_shared_objects(package_dir: Path):
+    """Every shared object the wheel installed.
+
+    Asserts it found some, because a wheel that installed none would let every check that walks this list
+    report success having examined nothing.
+    """
+    found = [
+        path
+        for path in sorted(package_dir.rglob("*.so*"))
+        if path.is_file() and not path.is_symlink()
+    ]
+    assert (
+        found
+    ), f"no shared objects found under {package_dir}, so nothing below would be checking them"
+    return found
+
+
+def _shipped_runtime_libraries(package_dir: Path):
+    """The libraries the wheel ships under lib/, whatever it names them.
+
+    One place, because three checks previously spelled the pattern themselves as
+    `*.so.*` and every one of them silently stopped matching when the build moved to
+    unversioned names. The failure was invisible: a check that finds nothing reports
+    that the component is absent, which each of those treats as acceptable.
+
+    Matches a versioned name too, so a build that does set SOVERSION is still found.
+    """
+    lib_dir = package_dir / "lib"
+    if not lib_dir.is_dir():
+        return []
+    return [
+        path
+        for path in sorted(lib_dir.glob("lib*.so*"))
+        if path.is_file() and not path.is_symlink()
+    ]
+
+
+def _defines_symbol(library: Path, symbol: str) -> bool:
+    result = subprocess.run(
+        [_tool("nm"), "-DC", str(library)], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        # A file that is not an object file at all is not this check's concern: something whose
+        # name merely ends in .so must not abort the run. A shipped library the reader cannot
+        # parse is different, because a real definition could be hiding inside it, and reporting
+        # "defines nothing" would let a duplicate pass. The ELF magic bytes tell them apart
+        # without depending on the reader's wording.
+        with library.open("rb") as handle:
+            is_object_file = handle.read(4) == b"\x7fELF"
+        assert not is_object_file, (
+            f"nm could not read {library.name}, which is a shipped object file, so the symbol "
+            f"checks cannot be trusted: {result.stderr.strip()[:200]}"
+        )
+        return False
+    for line in result.stdout.splitlines():
+        if symbol not in line:
+            continue
+        match = _DEFINED.match(line)
+        if (
+            match
+            and match.group("name").startswith(symbol)
+            and match.group("kind") in _OWNING_KINDS
+        ):
+            return True
+    return False
+
+
+def _assert_single_definer(symbols, what: str, owner: str | None = None) -> None:
+    """At most one shipped library may define each of `symbols`.
+
+    The owner is named where one is expected, because counting definers alone does
+    not prove the split happened: the monolithic layout has exactly one definer too,
+    the Python extension. Requiring the symbol to live in the library that is
+    supposed to own it is what distinguishes the two.
+
+    A component the wheel does not ship at all is a valid configuration, not a
+    fault. Delegates and kernel sets are build options, so a wheel built without one
+    has zero definers and is reported as such. What must never happen is two.
+    """
+    assert _tool("nm") is not None, "nm is required to inspect the wheel"
+
+    package_dir = _installed_package_dir()
+    libraries = _shipped_shared_objects(package_dir)
+    assert libraries, f"no shared libraries found under {package_dir}"
+
+    # Every symbol is resolved before anything is reported, so a component that is only
+    # half present is described as such rather than looking like one that is absent.
+    found = {
+        symbol: [lib for lib in libraries if _defines_symbol(lib, symbol)]
+        for symbol in symbols
+    }
+    # A component is either wholly present or wholly absent. Some symbols defined and
+    # others not means a partial build, which is neither of those and is a fault.
+    present = {symbol for symbol, definers in found.items() if definers}
+    if not present:
+        # When the caller has already established that the owner library ships, finding none of its
+        # symbols is a fault rather than an absence. Returning success here made this a no-op the moment
+        # a sentinel symbol was renamed or inlined, which turns the ownership check off without anyone
+        # noticing, and one of these sentinels is a two-line accessor.
+        assert owner is None, (
+            f"the wheel ships {owner}, which owns the {what}, but none of its symbols "
+            f"{sorted(found)} are defined anywhere. Either the sentinel symbols were renamed or "
+            "inlined, in which case this check needs updating, or the library is empty."
+        )
+        print(f"- this wheel ships no {what}, nothing to check")
+        return
+    assert len(present) == len(found), (
+        f"the wheel defines only part of the {what}: {sorted(present)} are present "
+        f"and {sorted(set(found) - present)} are not, so it is neither shipped nor "
+        "absent"
+    )
+
+    for symbol, definers in found.items():
+        pretty = [str(lib.relative_to(package_dir)) for lib in definers]
+        assert len(definers) == 1, (
+            f"expected at most one library to define {symbol}, found "
+            f"{len(definers)}: {pretty}. More than one definition means the "
+            f"process has more than one {what}."
+        )
+        if owner is not None:
+            assert definers[0].name.startswith(owner), (
+                f"{symbol} is defined by {pretty[0]}, but it belongs in {owner}. One "
+                "definer is not enough on its own: the monolithic layout this change "
+                "replaces also had exactly one, inside the Python extension."
+            )
+    where = f" owned by {owner}" if owner else ""
+    print(f"✓ single {what}{where} across {len(libraries)} shipped libraries")
+
+
+# Each component the wheel ships as its own library, the symbols that identify it,
+# and the library that must own them. `required` says whether the owner has to be
+# present: the optimized kernels are optional, because a wheel built without them
+# deliberately links the portable ops into the Python extension instead, which is a
+# supported configuration rather than a duplicate.
+#
+# A table rather than one function per component, because the per-function form let
+# one of them drift: it looked up its library with its own glob, which silently
+# stopped matching when the libraries were renamed while the others kept working.
+_OWNED_COMPONENTS = (
+    ("backend registry", _REGISTRY_SYMBOLS, "libexecutorch.so", True),
+    ("operator registry", _KERNEL_REGISTRY_SYMBOLS, "libexecutorch.so", True),
+    ("thread pool", _THREADPOOL_SYMBOLS, "libexecutorch_threadpool.so", True),
+    ("profiler", _ETDUMP_SYMBOLS, "libexecutorch_etdump.so", True),
+    (
+        "XNNPACK delegate",
+        _XNNPACK_SYMBOLS,
+        "libexecutorch_backend_xnnpack.so",
+        True,
+    ),
+    (
+        "set of CPU kernels",
+        _KERNEL_SYMBOLS,
+        "libexecutorch_kernels_optimized.so",
+        False,
+    ),
+    # The third-party code these libraries bundle, checked separately from the
+    # wrappers above. A wrapper can have a single owner while the implementation
+    # underneath it is bundled into two of these, which is two real thread pools or
+    # two XNNPACK runtimes.
+    #
+    # One copy among the libraries this wheel ships, which is what this change
+    # controls. torch links the same projects and exports the same symbols, so the
+    # process still holds two definitions and which one a caller reaches depends on
+    # load order. Fixing that needs an explicit export list: hiding them wholesale
+    # with --exclude-libs,ALL breaks aarch64, where the optimized kernels resolve
+    # cpuinfo_initialize from the thread pool across a library boundary.
+    (
+        "bundled thread pool implementation",
+        _BUNDLED_THREADPOOL_SYMBOLS,
+        "libexecutorch_threadpool.so",
+        True,
+    ),
+    (
+        "bundled XNNPACK runtime",
+        _BUNDLED_XNNPACK_SYMBOLS,
+        "libexecutorch_backend_xnnpack.so",
+        True,
+    ),
+)
+
+
+def test_each_component_has_one_owner() -> None:
+    """No component may be defined by more than one library the wheel ships.
+
+    This is the property the split exists to create. Two copies of a component mean
+    two registries or two thread pools in one process, and a static initializer that
+    registers into a table nothing else reads shows up as an operator missing at run
+    time rather than as a link error.
+    """
+    shipped = {
+        path.name for path in _shipped_runtime_libraries(_installed_package_dir())
+    }
+    for what, symbols, owner, required in _OWNED_COMPONENTS:
+        present = any(name.startswith(owner) for name in shipped)
+        assert present or not required, (
+            f"the wheel ships no {owner}, which owns the {what}. Either packaging "
+            "dropped it or the build did not produce it."
+        )
+        _assert_single_definer(symbols, what, owner if present else None)
+
+
+def test_python_extensions_import() -> None:
+    """Every shipped Python extension must import from a clean environment.
+
+    The symbol and dependency checks work on the files. This covers the other
+    half: an extension can be packaged correctly and still fail to load because a
+    runtime path does not reach one of its dependencies. Run in a subprocess with
+    `LD_LIBRARY_PATH` removed so a value from the build environment cannot supply
+    a path the shipped library is missing.
+
+    The list is discovered from the installed package rather than written here, so
+    an extension added later is covered without anyone remembering to add it. A
+    hardcoded list is how the ones this change relinked went untested.
+    """
+    package_dir = _installed_package_dir()
+    modules = []
+    for extension in sorted(package_dir.rglob("*.so")):
+        # Only Python extensions, which carry the interpreter's suffix. The plain
+        # shared libraries under lib/ are checked by the load test instead.
+        if ".cpython-" not in extension.name:
+            continue
+        relative = extension.relative_to(package_dir).parent
+        module = extension.name.split(".", 1)[0]
+        modules.append(
+            ".".join(["executorch", *relative.parts, module]).replace("..", ".")
+        )
+    assert modules, "the wheel ships no Python extension, which cannot be right"
+
+    # Torch has to be installed, the same as for the dependency check: these
+    # extensions link it, so without it they cannot import for a reason that says
+    # nothing about packaging.
+    if importlib.util.find_spec("torch") is None:
+        print("- torch is not installed, skipping the extension import check")
+        return
+    environment = {
+        key: value for key, value in os.environ.items() if key != "LD_LIBRARY_PATH"
+    }
+    for module in modules:
+        result = subprocess.run(
+            [sys.executable, "-c", f"import {module}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=environment,
+        )
+        if result.returncode == 0:
+            print(f"✓ {module} imports from a clean environment")
+            continue
+        # A Python dependency that is simply not installed here, including torch,
+        # says nothing about how the wheel was built. Only a failure to load a
+        # native library does.
+        # A Python package this environment simply does not have says nothing about
+        # how the wheel was built, PROVIDED the wheel does not claim to require it.
+        # Match only that shape, so a native load failure reported as
+        # ModuleNotFoundError is still caught below.
+        missing_python_package = re.search(
+            r"ModuleNotFoundError: No module named '(?!executorch)([\w.]+)",
+            result.stderr,
+        )
+        if missing_python_package:
+            absent = missing_python_package.group(1).split(".")[0]
+            # A package the wheel declares as a requirement should have been
+            # installed with it, so its absence is a packaging defect rather than a
+            # property of this environment. Skipping there would report a broken
+            # dependency list as coverage.
+            assert absent not in _declared_requirements(), (
+                f"{module} cannot import because {absent} is missing, and the wheel "
+                "declares it as a requirement, so installing the wheel should have "
+                "provided it"
+            )
+            print(f"- {module} needs {absent}, which this environment lacks, skipping")
+            continue
+        # Anything else is a real failure to load what the wheel ships: a missing
+        # native library, an unresolved symbol, or an ABI mismatch.
+        raise AssertionError(
+            f"{module} ships in the wheel but does not import: "
+            f"{result.stderr.strip()[-500:]}"
+        )
+
+
+_CUSTOM_OP_SOURCE = """\
+// A custom operator, built the way an out-of-tree project builds one: against the
+// shipped Python extension rather than an ExecuTorch source tree.
+#include <executorch/extension/kernel_util/make_boxed_from_unboxed_functor.h>
+#include <executorch/runtime/kernel/kernel_includes.h>
+
+namespace {
+
+executorch::aten::Tensor& custom_double_out(
+    executorch::runtime::KernelRuntimeContext& context,
+    const executorch::aten::Tensor& input,
+    executorch::aten::Tensor& out) {
+  (void)context;
+  const float* in = input.const_data_ptr<float>();
+  float* dst = out.mutable_data_ptr<float>();
+  for (ssize_t i = 0; i < input.numel(); ++i) {
+    dst[i] = in[i] * 2.0f;
+  }
+  return out;
+}
+
+} // namespace
+
+// The registration macro is the point of the check: it has to compile and resolve
+// against the registry the shipped extension provides.
+EXECUTORCH_LIBRARY(wheel_check, "custom_double.out", custom_double_out);
+"""
+
+
+_CUSTOM_OP_CMAKE = """\
+cmake_minimum_required(VERSION 3.28)
+project(custom_op_check CXX)
+
+find_package(executorch REQUIRED)
+
+add_library(custom_op_check SHARED custom_op.cpp)
+# The legacy contract: a custom-op library links the shipped Python extension,
+# which owns the operator registry it registers into.
+target_link_libraries(custom_op_check PRIVATE _portable_lib)
+# The runtime headers include c10 headers, which belong to torch rather than to
+# this wheel, so an out-of-tree operator project supplies them the same way it
+# supplies torch itself. The package config does not and should not ship them.
+#
+# The include directory is passed in rather than found with find_package(Torch),
+# because that enables the CUDA language and fails on a machine with a CUDA
+# toolkit it cannot probe, which has nothing to do with compiling an operator.
+target_include_directories(custom_op_check PRIVATE ${TORCH_INCLUDE_DIR})
+# Deliberately no target_compile_features here. These headers need C++20, and the
+# package config is what has to say so. Setting it here would compile the check
+# correctly while leaving a real consumer to fail.
+"""
+
+
+# Libraries that belong to torch rather than to this wheel. A library here resolves when the
+# Python package that owns it is imported, so it is not something this wheel can or should ship.
+_TORCH_LIBRARY_PREFIXES = (
+    "libtorch",
+    "libc10",
+    "libshm",
+    "libgomp",
+    "libcudnn",
+    "libcublas",
+)
+
+
+def _is_torch_library(name: str) -> bool:
+    return name.startswith(_TORCH_LIBRARY_PREFIXES)
+
+
+def test_shipped_libraries_load() -> None:
+    """Every shipped library must depend only on things that exist.
+
+    The symbol checks prove each component is defined exactly once, but a library
+    can still be unloadable if it needs something nothing provides, which is a
+    packaging bug rather than a duplication bug.
+
+    A dependency the wheel ships elsewhere is fine even when `ldd` cannot resolve
+    it: some extensions are loaded after `import torch` has already brought their
+    dependencies into the process, so they intentionally carry no path to them.
+    Only a name nothing in the wheel provides is a real problem.
+    """
+    if _tool("ldd") is None:
+        print("- ldd not available, skipping the load check")
+        return
+    # Torch has to be installed for this to mean anything: several shipped libraries
+    # depend on it and resolve once it is imported. Without it every one of them looks
+    # broken, which would report a packaging fault that does not exist.
+    if importlib.util.find_spec("torch") is None:
+        print("- torch is not installed, skipping the load check")
+        return
+
+    package_dir = _installed_package_dir()
+    libraries = _shipped_shared_objects(package_dir)
+    shipped = {library.name for library in libraries}
+
+    # A dependency is only excusable when the wheel ships it AND the loader can
+    # actually reach it from the library that needs it. Loaded-later extensions
+    # such as the Torch libraries are the real exception: they resolve once the
+    # Python package that owns them is imported. Anything the wheel itself ships
+    # must resolve here, because a RUNPATH applies to the library carrying it and
+    # is not inherited on behalf of a dependency's own dependencies.
+    broken = {}
+    unreachable = {}
+    unresolved = {}
+    for library in libraries:
+        resolved = subprocess.run(
+            # -r resolves data and function symbols too, not just the NEEDED
+            # entries. A SHARED link does not error on undefined symbols, so
+            # without this an under-linked library passes here and fails at first
+            # use instead.
+            [_tool("ldd"), "-r", str(library)],
+            capture_output=True,
+            text=True,
+            check=False,
+            # Any LD_LIBRARY_PATH in the build environment would paper over a
+            # RUNPATH the shipped library is actually missing.
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if key != "LD_LIBRARY_PATH"
+            },
+        )
+        # ldd reports missing libraries on stdout but undefined symbols on stderr,
+        # so both streams matter.
+        combined = resolved.stdout + resolved.stderr
+        # A non-zero exit with none of the expected text means ldd could not inspect
+        # the file at all, which a text-only search reads as "nothing wrong". A file
+        # under lib/ that is not a loadable object is a packaging defect, so treat it
+        # as one rather than passing it.
+        if (
+            resolved.returncode != 0
+            and "not found" not in combined
+            and "undefined symbol" not in combined
+        ):
+            unresolved[str(library.relative_to(package_dir))] = [
+                f"ldd could not inspect this file: {combined.strip()[:160]}"
+            ]
+            continue
+        missing = [
+            line.split("=>")[0].strip()
+            for line in combined.splitlines()
+            if "not found" in line
+        ]
+        # Interpreter symbols are excluded rather than whole files. A library that
+        # is loaded by Python, whether a extension module or an ahead-of-time
+        # plugin, resolves those only once an interpreter is running, so ldd can
+        # never resolve them and their absence says nothing about packaging.
+        # Filtering the symbols rather than guessing from the file name keeps the
+        # check active for everything else those libraries need.
+        undefined = [
+            line.strip()
+            for line in combined.splitlines()
+            if "undefined symbol" in line
+            and not re.search(r"undefined symbol:\s+_?Py", line)
+        ]
+        if undefined:
+            unresolved[str(library.relative_to(package_dir))] = undefined[:5]
+        # Torch's own libraries are the documented exception. They are not in this wheel, and a
+        # library that needs them resolves once the Python package owning them is imported, which
+        # is how every accelerator and AOT library in this package is used. Treating them as
+        # missing fails a wheel that works, and it fires only where torch installs its libraries
+        # somewhere the plain loader search does not reach.
+        absent = [
+            name
+            for name in missing
+            if name not in shipped and not _is_torch_library(name)
+        ]
+        present_but_unreachable = [name for name in missing if name in shipped]
+        if absent:
+            broken[str(library.relative_to(package_dir))] = absent
+        if present_but_unreachable:
+            unreachable[str(library.relative_to(package_dir))] = present_but_unreachable
+
+    assert not broken, (
+        "shipped libraries need dependencies that nothing provides, so they will "
+        f"fail to load: {broken}"
+    )
+    assert not unreachable, (
+        "shipped libraries need dependencies the wheel ships but the loader "
+        "cannot reach from them, which usually means a missing RUNPATH entry: "
+        f"{unreachable}"
+    )
+    assert not unresolved, (
+        "shipped libraries reference symbols nothing provides, so they will fail "
+        f"at first use rather than at load: {unresolved}"
+    )
+    print("✓ every shipped library resolves in an environment with torch present")
+
+
+def test_shipped_libraries_resolve_without_build_tree() -> None:
+    """A shipped library must resolve using only its relative runtime paths.
+
+    Packaging copies binaries out of the build directory, so they still carry the
+    absolute paths they were linked with. On the machine that produced the wheel
+    those paths exist, which means a library whose relative path is wrong can still
+    resolve and look correct. Anywhere else it would fail.
+
+    Copy each library and its wheel-provided dependencies into a fresh tree that
+    mirrors the wheel layout, drop every absolute runtime path, and check what is
+    left is enough.
+    """
+    if _tool("ldd") is None or _tool("patchelf") is None:
+        print("- ldd or patchelf unavailable, skipping the relocated load check")
+        return
+
+    package_dir = _installed_package_dir()
+    libraries = _shipped_shared_objects(package_dir)
+    environment = {
+        key: value for key, value in os.environ.items() if key != "LD_LIBRARY_PATH"
+    }
+
+    with tempfile.TemporaryDirectory() as work_dir:
+        root = Path(work_dir) / package_dir.name
+        # Mirror the layout so a relative path such as $ORIGIN/../../lib still
+        # points where it would in a real install.
+        for library in libraries:
+            target = root / library.relative_to(package_dir)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(library, target)
+
+        broken = {}
+        for library in libraries:
+            target = root / library.relative_to(package_dir)
+            current = subprocess.run(
+                [_tool("patchelf"), "--print-rpath", str(target)],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout.strip()
+            relative = [
+                entry for entry in current.split(":") if entry.startswith("$ORIGIN")
+            ]
+            subprocess.run(
+                [_tool("patchelf"), "--set-rpath", ":".join(relative), str(target)],
+                # A failure here would leave the original absolute build paths in
+                # place, and the check below would then pass by resolving through
+                # them, which is exactly what this test exists to rule out.
+                check=True,
+            )
+            resolved = subprocess.run(
+                [_tool("ldd"), str(target)],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            ).stdout
+            shipped = {item.name for item in libraries}
+            all_missing = [
+                line.split("=>")[0].strip()
+                for line in resolved.splitlines()
+                if "not found" in line
+            ]
+            # Only wheel-provided dependencies are asserted on, because an external
+            # one is expected to come from the environment. They are still reported,
+            # since silently dropping them would hide a library that resolves only
+            # through an absolute build path.
+            missing = [name for name in all_missing if name in shipped]
+            external = [name for name in all_missing if name not in shipped]
+            if external:
+                print(
+                    f"- {library.relative_to(package_dir)} also needs "
+                    f"{external} from the environment"
+                )
+            if missing:
+                broken[str(library.relative_to(package_dir))] = missing
+
+        assert not broken, (
+            "shipped libraries only resolve their wheel-provided dependencies "
+            "through absolute build paths, so they would fail on any other "
+            f"machine: {broken}"
+        )
+    print("✓ every shipped library resolves without the build tree")
+
+
+def test_custom_op_compiles(work_dir: Path) -> None:
+    """A custom operator compiles and links against the shipped extension.
+
+    This is how an out-of-tree project adds its own kernels, and it points at the
+    Python extension rather than the runtime, so it is not covered by the consumer
+    check above.
+    """
+    # Skipped rather than asserted, the same as every other tool this suite needs.
+    # A missing compiler says nothing about the wheel, and aborting here would take
+    # the whole run down with it rather than reporting the one check it prevents.
+    if _tool("cmake") is None:
+        print("- cmake unavailable, skipping the custom op check")
+        return
+
+    package_dir = _installed_package_dir()
+    if not list(package_dir.glob("extension/pybindings/_portable_lib*")):
+        print("- the wheel ships no Python extension, skipping the custom op check")
+        return
+
+    source_dir = work_dir / "custom-op"
+    build_dir = work_dir / "custom-op-build"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "custom_op.cpp").write_text(_CUSTOM_OP_SOURCE)
+    (source_dir / "CMakeLists.txt").write_text(_CUSTOM_OP_CMAKE)
+
+    # Torch's include directory is handed over directly, because the runtime headers
+    # include c10 headers that belong to torch. A real out-of-tree project supplies
+    # them the same way; the package config has no business shipping another
+    # project's headers.
+    if importlib.util.find_spec("torch") is None:
+        print("- torch is not installed, skipping the custom op check")
+        return
+    import torch
+
+    torch_include = Path(torch.__path__[0]) / "include"
+
+    configure = subprocess.run(
+        [
+            _tool("cmake"),
+            "-S",
+            str(source_dir),
+            "-B",
+            str(build_dir),
+            f"-DCMAKE_PREFIX_PATH={package_dir / 'share' / 'cmake'}",
+            f"-DTORCH_INCLUDE_DIR={torch_include}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert configure.returncode == 0, (
+        "a custom operator project cannot configure against the wheel: "
+        f"{(configure.stderr or configure.stdout).strip()[-600:]}"
+    )
+
+    compiled = subprocess.run(
+        [_tool("cmake"), "--build", str(build_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert compiled.returncode == 0, (
+        "a custom operator does not compile or link against the shipped extension: "
+        f"{(compiled.stderr or compiled.stdout).strip()[-800:]}"
+    )
+    produced = list(build_dir.rglob("libcustom_op_check.so")) or list(
+        build_dir.rglob("custom_op_check.dll")
+    )
+    assert produced, "the custom operator library was not produced"
+
+    # Loaded, not just built. A shared library on Linux is allowed to have
+    # unresolved symbols, so an under-linked custom operator links successfully and
+    # fails only when something dlopens it and its registration initialiser runs.
+    # That is exactly the failure this contract exists to prevent.
+    if importlib.util.find_spec("torch") is None:
+        print("- torch is not installed, so the custom operator is only built")
+        return
+    loaded = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import torch\n"
+            "from executorch.extension.pybindings import portable_lib\n"
+            f"torch.ops.load_library({str(produced[0])!r})\n"
+            "print('loaded')",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            key: value for key, value in os.environ.items() if key != "LD_LIBRARY_PATH"
+        },
+    )
+    assert loaded.returncode == 0, (
+        "a custom operator built against the shipped extension cannot be loaded, so "
+        "it would fail at first use rather than at link time: "
+        f"{(loaded.stderr or loaded.stdout).strip()[-800:]}"
+    )
+    print("✓ a custom operator compiles against the shipped Python extension")
+
+
+def _find_wheel_files() -> list:
+    """The built wheel files, searched where a build actually leaves them.
+
+    WHEEL_DIR is honoured when set, but it is not set in the wheel-build job, so the
+    usual output directories are searched too. Without this the check has nothing to
+    inspect and skips.
+    """
+    candidates = []
+    configured = os.environ.get("WHEEL_DIR")
+    if configured:
+        candidates.append(Path(configured))
+    # The build leaves the wheel in dist/ at the repository root, and this file sits at a
+    # fixed depth below that root, so the location follows from __file__ rather than from
+    # the current directory. The release job runs the smoke test from the workspace above
+    # the repository, where a cwd-relative guess finds nothing.
+    #
+    # Guarded because a copy of this file can live outside that layout, where indexing
+    # past the available parents would raise instead of falling through to the other
+    # candidates.
+    here = Path(__file__).resolve()
+    repository_root = here.parents[3] if len(here.parents) > 3 else here.parent
+    candidates += [
+        repository_root / "dist",
+        Path.cwd() / "dist",
+        Path.cwd(),
+        repository_root / "wheelhouse",
+    ]
+    for directory in candidates:
+        try:
+            found = sorted(directory.glob("executorch-*.whl"))
+        except OSError:
+            continue
+        if found:
+            return found
+    return []
+
+
+# The architectures a Linux wheel tag can name. Matched by suffix rather than parsed
+# positionally, because the version part differs between spellings (linux_x86_64,
+# manylinux_2_28_x86_64, manylinux2014_x86_64) enough that a positional pattern picks
+# it up as part of the name.
+#
+# Linux only, which is what this check reads. `arm64` deliberately absent: it is the
+# macOS spelling, Linux uses aarch64, and including it made a macosx_11_0_arm64 tag
+# look like something this could compare. A tag naming none of these is reported as
+# unreadable rather than as a mismatch.
+_WHEEL_ARCHITECTURES = ("x86_64", "aarch64", "i686", "ppc64le", "s390x", "armv7l")
+
+
+def _wheel_architecture(tag: str):
+    """The architecture a platform tag names, or None if it names none of ours."""
+    for architecture in _WHEEL_ARCHITECTURES:
+        if tag.endswith("_" + architecture):
+            return architecture
+    return None
+
+
+def _tag_architectures_match(claimed: str, supported: str):
+    """Whether two platform tags name the same architecture.
+
+    Returned rather than asserted so the same decision can be unit tested without a
+    wheel. The previous arrangement duplicated the comparison in the test, which meant
+    the test could pass while the shipped check was wrong, and that is exactly what
+    happened: the original defect was in how the caller compared the two tags, and a
+    test that re-implemented the comparison could not see it.
+
+    None for either side means the tag names no architecture this project builds for,
+    which is a different failure from a mismatch and is reported separately.
+    """
+    claimed_arch = _wheel_architecture(claimed)
+    supported_arch = _wheel_architecture(supported)
+    if claimed_arch is None or supported_arch is None:
+        return None
+    return claimed_arch == supported_arch
+
+
+def test_wheel_platform_tag() -> None:
+    """The wheel's declared platform tag must name the architecture it was built for.
+
+    Only the architecture. auditwheel cannot certify a glibc baseline for this wheel:
+    it depends on torch without vendoring torch's libraries, so the contents reference
+    libtorch.so from outside any manylinux policy and auditwheel reports a plain
+    linux_<arch>. That is the expected answer for a torch-dependent wheel rather than
+    a defect, and the manylinux tag on the file comes from the build image. Asserting
+    the baseline here failed every correct wheel.
+
+    The architecture is still worth checking, because a wheel labelled with the wrong
+    one installs on machines it cannot run on at all, and that is a mistake this can
+    actually catch.
+    """
+    if importlib.util.find_spec("auditwheel") is None:
+        # Installed here rather than skipped, because auditwheel is not in any CI
+        # image and a skip is indistinguishable from a pass in the summary. This
+        # check is the only thing that compares the wheel's declared tag against
+        # what its libraries actually need, and this change adds five libraries
+        # under that tag.
+        print("- auditwheel not present, installing it so this check can run")
+        installed = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--quiet", "auditwheel"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if installed.returncode != 0 or importlib.util.find_spec("auditwheel") is None:
+            print(
+                "- auditwheel could not be installed, skipping the platform tag "
+                f"check: {installed.stderr.strip()[-200:]}"
+            )
+            return
+        importlib.invalidate_caches()
+
+    wheels = _find_wheel_files()
+    if not wheels:
+        print("- no wheel file to inspect, skipping the platform tag check")
+        return
+
+    result = subprocess.run(
+        [sys.executable, "-m", "auditwheel", "show", str(wheels[-1])],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # auditwheel wraps its verdict across lines, so compare on collapsed
+    # whitespace rather than the literal output.
+    combined = " ".join((result.stdout + result.stderr).split())
+    match = re.search(
+        r'consistent with the following platform tag: "([^"]+)"', combined
+    )
+    assert match, (
+        "auditwheel reported no platform tag for the wheel, so its contents could "
+        f"not be checked against what it claims: {combined[-400:]}"
+    )
+    claimed = wheels[-1].name.split("-")[-1].removesuffix(".whl")
+    supported = match.group(1)
+
+    claimed_arch = _wheel_architecture(claimed)
+    supported_arch = _wheel_architecture(supported)
+    matches = _tag_architectures_match(claimed, supported)
+    assert matches is not None, (
+        f"could not read an architecture from the declared tag {claimed} or from what "
+        f"auditwheel reported, {supported}"
+    )
+    assert matches, (
+        f"the wheel claims architecture {claimed_arch} but its contents are built for "
+        f"{supported_arch}, so it would install where it cannot run"
+    )
+    print(f"✓ the wheel is tagged for the architecture it contains ({claimed_arch})")
+
+
+def test_no_absolute_runtime_paths() -> None:
+    """No shipped library may search a directory a user does not have.
+
+    Packaging copies libraries out of the build tree rather than installing them, so
+    every directory the linker recorded ships as-is. Two kinds are rejected on every
+    shipped library, not only the lib/ payload:
+
+    - a directory inside the build, which names the machine that produced the wheel
+    - an empty entry, which the loader reads as the process working directory
+
+    Torch's own directory is accepted. The extensions link torch and resolve it
+    through the directory the linker recorded, so that entry is load-bearing rather
+    than leftover. Narrowing this check to lib/ once hid seven extensions carrying
+    build-tree paths, so the exclusion is by what an entry POINTS AT, never by which
+    file carries it.
+
+    The check reads the shipped file directly, with nothing stripped, which is what
+    a user actually receives.
+    """
+    # Fatal, not a skip. Packaging strips these paths best-effort, because it cannot
+    # guarantee patchelf on PATH, so this is the only place the guarantee can be
+    # enforced. If both went quiet on the same missing tool, a wheel carrying the
+    # build machine's directories would ship looking correct.
+    if _tool("patchelf") is None:
+        print("- patchelf not present, installing it so this check can run")
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--quiet", "patchelf"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    patchelf = _tool("patchelf")
+    assert patchelf is not None, (
+        "patchelf is required to check the shipped runtime paths and could not be "
+        "installed. Packaging uses it to strip build-tree directories, and without it "
+        "here neither side would notice that they were left in place."
+    )
+
+    package_dir = _installed_package_dir()
+
+    # Directories that only exist inside a build of this project.
+    build_markers = ("/pip-out/", "/cmake-out", "/build/lib.")
+
+    # This project's libraries must not name an absolute directory the wheel has a relative route to. The
+    # one that shipped was a CUDA toolkit prefix recorded on the build machine: it sat ahead of the relative
+    # hop, so a user with a toolkit at the same prefix resolved the CUDA runtime from there instead of from
+    # the declared dependency, and the builder always has one, so nothing exercised the hop.
+    #
+    # Stated as a property rather than a list of known-bad directories, because a list only catches what
+    # someone already thought of and that prefix was not on one.
+    #
+    # PyTorch's own directory is allowed: the wheel neither declares nor bundles PyTorch, so an absolute
+    # path is the only way to reach it. The maths library directories are allowed too, because they come
+    # from PyTorch's build flags and reach everything that links PyTorch, including this project's own
+    # extensions, naming a location on whichever machine built PyTorch that nothing here can change.
+    allowed_absolute = ("/torch/lib", "/lib/intel64", "/lib/win-x64")
+    # PyTorch's own libraries are vendored into the wheel and also record a CUDA toolkit directory. That is
+    # the one path this check exists to reject on our libraries, so it is allowed only on theirs.
+    vendored_prefixes = (
+        "libtorch",
+        "libc10",
+        "libshm",
+        "libcaffe2",
+        "libgomp",
+        "libiomp",
+    )
+
+    offenders = {}
+    checked = 0
+    for library in sorted(package_dir.rglob("*.so*")):
+        if not library.is_file() or library.is_symlink():
+            continue
+        result = subprocess.run(
+            [patchelf, "--print-rpath", str(library)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            continue
+        checked += 1
+        # An absent RPATH and one containing a single empty entry both print as an
+        # empty string, so treat empty output as "no runtime path" rather than as an
+        # empty entry. A library with nothing to search is fine; the defect is
+        # searching somewhere unusable.
+        raw = result.stdout.strip()
+        if not raw:
+            continue
+        bad = []
+        for entry in raw.split(":"):
+            if not entry:
+                bad.append("<empty>")
+            elif (
+                entry.startswith("/")
+                and not any(allowed in entry for allowed in allowed_absolute)
+                and not library.name.startswith(vendored_prefixes)
+            ):
+                # Named separately so the message says which kind it is: a build directory and a
+                # toolkit prefix are the same defect with different causes.
+                kind = (
+                    "inside a build of this project"
+                    if any(m in entry for m in build_markers)
+                    else "an absolute directory the wheel has a relative route to"
+                )
+                bad.append(f"{entry} ({kind})")
+        if bad:
+            offenders[str(library.relative_to(package_dir))] = bad
+
+    assert not offenders, (
+        "shipped libraries search directories a user does not have, either inside "
+        "the build tree that produced the wheel or, for an empty entry, the process "
+        f"working directory: {offenders}"
+    )
+    assert checked, (
+        f"no shipped library under {package_dir} carries a runtime search path, so this check examined "
+        "nothing and would pass on a wheel that shipped no libraries at all"
+    )
+    print(
+        f"✓ none of the {checked} shipped libraries searches a build-tree or empty "
+        "runtime path"
+    )
+
+
+def test_extension_contains_no_component() -> None:
+    """The Python extension must link the components, not contain them.
+
+    This is the property the change exists to create, and no count of definers
+    proves it: the monolithic layout has exactly one definer of every symbol too,
+    inside the extension. The direct statement is that the extension defines none of
+    what the shipped libraries own, and records a dependency on each instead.
+    """
+    assert _tool("nm") is not None, "nm is required to inspect the wheel"
+    if _tool("readelf") is None:
+        print("- readelf unavailable, skipping the extension composition check")
+        return
+
+    package_dir = _installed_package_dir()
+    extensions = sorted(
+        (package_dir / "extension" / "pybindings").glob("_portable_lib.*.so")
+    )
+    assert len(extensions) == 1, f"expected one _portable_lib, found {extensions}"
+    extension = extensions[0]
+
+    lib_dir = package_dir / "lib"
+    if not lib_dir.is_dir():
+        print("- this wheel ships no lib directory, nothing to check")
+        return
+
+    # Every symbol group a shipped library owns. The extension holding any of these
+    # means it still carries its own copy of that component.
+    # Derived from the ownership table rather than restated. A hand-written copy drifts: this once
+    # listed five symbol groups while the table covered eleven, so the components added later, including
+    # both CUDA ones, were never checked here.
+    #
+    # The bundled third-party groups are left out on purpose. That code is also linked by torch, and the
+    # extension links torch, so seeing those symbols there says nothing about this split.
+    # Only components whose owning library is actually in this wheel. One of them is optional, so a build
+    # with it turned off ships no owner, and asserting the extension does not define its symbols would
+    # reject a configuration the table itself marks as supported.
+    shipped = {
+        path.name for path in _shipped_runtime_libraries(_installed_package_dir())
+    }
+    owned = tuple(
+        symbol
+        for _, symbols, owner, required in _OWNED_COMPONENTS
+        if symbols not in (_BUNDLED_THREADPOOL_SYMBOLS, _BUNDLED_XNNPACK_SYMBOLS)
+        and (required or any(name.startswith(owner) for name in shipped))
+        for symbol in symbols
+    )
+    contained = [symbol for symbol in owned if _defines_symbol(extension, symbol)]
+    assert not contained, (
+        f"{extension.name} defines {contained}, which the shipped libraries own. The "
+        "extension is supposed to link them rather than contain them, so this is the "
+        "monolithic layout the split removes."
+    )
+
+    # And it has to actually depend on each shipped library. Defining nothing while
+    # depending on nothing would be an extension that cannot work at all.
+    needed = {
+        line.split("[", 1)[1].rstrip("]").strip()
+        for line in subprocess.run(
+            [_tool("readelf"), "-d", str(extension)],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.splitlines()
+        if "NEEDED" in line
+    }
+    shipped = {path.name for path in _shipped_runtime_libraries(package_dir)}
+    assert shipped, (
+        f"the wheel installed no runtime libraries under {package_dir / 'lib'}, so this check would "
+        "compare the extension against nothing and pass"
+    )
+    unused = sorted(shipped - needed)
+    assert not unused, (
+        f"the wheel ships {unused} but {extension.name} does not depend on them, so "
+        "either they are dead weight or a retention option did not hold"
+    )
+
+    # Positive proof that the extension resolves these from elsewhere, rather than
+    # only the absence of a visible definition. A hidden or local copy would not
+    # appear in the dynamic symbol table at all, so "defines nothing" on its own is
+    # satisfiable by an extension that still carries its own private runtime. An
+    # UNDEFINED reference cannot be faked that way: it says the definition is not
+    # here and has to come from a dependency.
+    undefined = subprocess.run(
+        [_tool("nm"), "-DC", "--undefined-only", str(extension)],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+    imported = [
+        symbol
+        for symbol in (*_REGISTRY_SYMBOLS, *_THREADPOOL_SYMBOLS)
+        if symbol in undefined
+    ]
+    assert len(imported) == len(_REGISTRY_SYMBOLS) + len(_THREADPOOL_SYMBOLS), (
+        f"{extension.name} does not import every registry and thread pool symbol it "
+        "uses, so it may carry a hidden copy that the visible symbol table does not "
+        f"show. Imported: {imported}"
+    )
+    print(
+        f"✓ {extension.name} ({extension.stat().st_size // 1024} KiB) contains no "
+        f"component, imports the runtime symbols it uses, and depends on all "
+        f"{len(shipped)} shipped libraries"
+    )
+
+
+def test_shipped_library_names_are_expected() -> None:
+    """Every library in lib/ must be one this build could have produced.
+
+    Packaging copies binaries out of a staging directory rather than running an
+    install step, so anything left there from an earlier build ships too. That
+    really happened: a wheel picked up three libraries from a different revision
+    and still passed every symbol check, because those checks only ask how many
+    definers a symbol has, never whether a file belongs in the wheel at all.
+
+    Three properties catch it. A library built by this project carries VERSION and
+    SOVERSION, so its file name ends in a major. Its recorded soname matches its
+    file name, or a consumer records a dependency the wheel does not contain. And
+    its name is one packaging knows how to produce, which is what a leftover from
+    an older layout fails.
+    """
+    package_dir = _installed_package_dir()
+    lib_dir = package_dir / "lib"
+    if not lib_dir.is_dir():
+        print("- this wheel ships no lib directory, nothing to check")
+        return
+
+    # Regular files only. A symlink here would be a deliberate alias rather than the
+    # stale-artifact case this check is about, and a leftover from an earlier build is
+    # a real file, so it is still caught.
+    shipped = sorted(
+        p for p in lib_dir.glob("*.so*") if p.is_file() and not p.is_symlink()
+    )
+    assert shipped, f"the wheel ships a lib directory with no libraries: {lib_dir}"
+
+    # The names packaging can put here. Listed rather than derived because setup.py
+    # names each one literally, and a file with any other name did not come from
+    # this build. Which of them are present depends on the build options, so
+    # absence is fine and an unknown name is not.
+    #
+    # Matched in full rather than by taking the part before the first ".so", because
+    # that prefix is satisfied by a name like libexecutorch.so.old.so.1, which is
+    # exactly the shape a leftover file takes.
+    known = (
+        "libexecutorch",
+        "libexecutorch_kernels_optimized",
+        "libexecutorch_backend_xnnpack",
+        "libexecutorch_threadpool",
+        "libexecutorch_etdump",
+    )
+    # A plain .so, because the wheel build does not version these. A trailing
+    # .so.<digits> would also be a name packaging did not produce here.
+    permitted = re.compile(rf"(?:{'|'.join(known)})\.so")
+    unknown = sorted(p.name for p in shipped if not permitted.fullmatch(p.name))
+    assert not unknown, (
+        f"the wheel ships {unknown} under lib/, which packaging does not produce. "
+        "A file packaging did not put there came from a stale staging directory, "
+        "and it ships while looking correct to every other check."
+    )
+
+    if _tool("readelf") is None:
+        print(f"✓ {len(shipped)} shipped libraries have expected names")
+        return
+
+    # The recorded soname has to match the file name, or a consumer records a
+    # dependency on a name the wheel does not contain.
+    mismatched = {}
+    for library in shipped:
+        dynamic = subprocess.run(
+            [_tool("readelf"), "-d", str(library)],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout
+        soname = next(
+            (
+                line.split("[", 1)[1].rstrip("]").strip()
+                for line in dynamic.splitlines()
+                if "SONAME" in line
+            ),
+            None,
+        )
+        if soname != library.name:
+            mismatched[library.name] = soname
+    assert not mismatched, (
+        "shipped libraries record a soname that is not their file name, so a "
+        f"consumer would look for a file the wheel does not ship: {mismatched}"
+    )
+    print(f"✓ {len(shipped)} shipped libraries have expected names and sonames")
+
+
+_PARITY_MODEL = '''
+import json
+import sys
+
+import torch
+from executorch.exir import to_edge_transform_and_lower
+from executorch.extension.pybindings.portable_lib import (
+    _load_for_executorch_from_buffer,
+)
+
+
+class Net(torch.nn.Module):
+    """Several operator kinds rather than one, so the run exercises the merged CPU
+    kernels rather than a single add."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(8, 16)
+        self.conv = torch.nn.Conv2d(1, 4, 3, padding=1)
+
+    def forward(self, x, image):
+        a = torch.relu(self.linear(x))
+        b = self.conv(image).flatten(1)
+        return a.sum(dim=1, keepdim=True) + b.mean(dim=1, keepdim=True)
+
+
+delegate = sys.argv[1] == "delegate"
+torch.manual_seed(0)
+model = Net().eval()
+example = (torch.randn(2, 8), torch.randn(2, 1, 6, 6))
+with torch.no_grad():
+    expected = model(*example)
+
+partitioners = []
+if delegate:
+    from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+        XnnpackPartitioner,
+    )
+
+    partitioners = [XnnpackPartitioner()]
+
+program = to_edge_transform_and_lower(
+    torch.export.export(model, example), partitioner=partitioners
+).to_executorch()
+buffer = program.buffer
+
+actual = _load_for_executorch_from_buffer(buffer).forward(list(example))[0]
+# Compared rather than merely run. The point of the split is that behaviour does
+# not change, and only a numeric comparison shows that; a model that returns
+# wrong values without erroring passes everything else.
+torch.testing.assert_close(actual, expected, rtol=1e-4, atol=1e-4)
+
+print(json.dumps({"delegated": delegate, "has_xnnpack": b"XnnpackBackend" in bytes(buffer)}))
+'''
+
+
+def test_model_matches_eager_pytorch(work_dir: Path) -> None:
+    """A model exported and run through the bindings must match eager PyTorch.
+
+    Twice: once plain, so the CPU kernels resolve from the shared library, and once
+    delegated to XNNPACK, so the delegate does. The delegated program is also
+    checked for the delegate's own identity, because a partitioner that claimed
+    nothing would silently fall back to the CPU kernels and still match.
+
+    Separate processes, because a fault in one export leaves state that makes the
+    next look broken when it is not.
+    """
+    if importlib.util.find_spec("torch") is None:
+        print("- torch is not installed, skipping the eager comparison")
+        return
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    script = work_dir / "parity.py"
+    script.write_text(_PARITY_MODEL)
+
+    # The delegated half only applies to a wheel that ships the delegate. A wheel
+    # built without XNNPACK is a supported configuration, and requiring delegated
+    # execution there would reject a correct artifact.
+    modes = ["plain"]
+    if any(
+        path.name.startswith("libexecutorch_backend_xnnpack.so")
+        for path in _shipped_runtime_libraries(_installed_package_dir())
+    ):
+        modes.append("delegate")
+    else:
+        print("- this wheel ships no XNNPACK delegate, checking the plain model only")
+
+    for mode in modes:
+        result = subprocess.run(
+            [sys.executable, str(script), mode],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(work_dir),
+        )
+        assert result.returncode == 0, (
+            f"the {mode} model does not export, run, and match eager PyTorch: "
+            f"{(result.stderr or result.stdout).strip()[-1500:]}"
+        )
+        report = json.loads(result.stdout.strip().splitlines()[-1])
+        if mode == "delegate":
+            assert report["has_xnnpack"], (
+                "the delegated export produced a program with no XNNPACK partition, "
+                "so the delegate was never exercised and the comparison only proves "
+                "the CPU kernels work"
+            )
+        print(f"✓ the {mode} model matches eager PyTorch")
+
+
+def test_declared_dependencies_match_the_wheel_tag() -> None:
+    """A CPU wheel must not declare the CUDA runtime, and a CUDA wheel must declare it.
+
+    The tag is what a user resolves against, so a mismatch is a promise the wheel cannot keep in
+    either direction: a CPU wheel that pulls the CUDA packages costs a user hundreds of megabytes it
+    never loads, and a CUDA wheel that declares nothing leaves the runtime unresolvable.
+
+    This is metadata only, so no library check can see it. A CPU wheel that wrongly declared the CUDA
+    runtime passed every other check in this file.
+    """
+    requirements = importlib.metadata.requires("executorch") or []
+    cuda = sorted(r.split()[0] for r in requirements if r.lower().startswith("nvidia"))
+
+    # The local version segment of the installed version states what the wheel was built for.
+    version = importlib.metadata.version("executorch")
+    local = version.partition("+")[2]
+    is_cuda_wheel = local.startswith("cu")
+
+    if is_cuda_wheel:
+        assert cuda, (
+            f"version {version} says this is a CUDA wheel, but it declares no CUDA runtime "
+            "packages, so nothing resolves the runtime it links"
+        )
+        print(f"✓ this CUDA wheel declares the runtime ({len(cuda)} packages)")
+    else:
+        assert not cuda, (
+            f"version {version} is not a CUDA wheel, yet it declares {cuda}. A user installing it "
+            "would download the CUDA runtime this wheel never loads."
+        )
+        print("✓ this non-CUDA wheel declares no CUDA runtime")
+
+
+def run_tests(work_dir: Path) -> None:
+    # Ordered by what a failure tells you, because these run in sequence and the
+    # first failure stops the rest. The checks that prove the split behaves
+    # correctly come first; packaging metadata comes last.
+    #
+    # This is not hypothetical ordering advice. The platform tag check used to sit
+    # in the middle, and when it failed it took the custom-operator, runtime-path
+    # and numeric-parity checks with it in all eleven wheel jobs, so the weakest
+    # check in the file hid the three strongest.
+    test_each_component_has_one_owner()
+    test_python_extensions_import()
+    test_declared_dependencies_match_the_wheel_tag()
+    test_extension_contains_no_component()
+    test_shipped_library_names_are_expected()
+    test_shipped_libraries_load()
+    test_shipped_libraries_resolve_without_build_tree()
+    test_custom_op_compiles(work_dir)
+    test_no_absolute_runtime_paths()
+    test_model_matches_eager_pytorch(work_dir)
+    # Last: a wrong answer here says the wheel is labelled wrong, not that the
+    # split is broken.
+    test_wheel_platform_tag()

--- a/.github/scripts/filter_cuda_matrix.py
+++ b/.github/scripts/filter_cuda_matrix.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Narrow the generated build matrix to the rows a GPU wheel can honestly support.
+
+The shared matrix generator emits every CUDA version and Python version it knows about.
+Building all of them would publish wheels for combinations nothing can verify, and a GPU
+wheel that installs and then cannot run is worse than one that does not exist: the failure
+appears when a model runs, and it looks like a model problem rather than a packaging one.
+
+A row is kept only when all three of these hold:
+
+  a GPU exists that the row's device code covers
+  a PyTorch build is published for that CUDA version and architecture
+  a machine is available to run a real model before release
+
+The values below are the current answers to those questions. They are written out rather
+than derived because each one is an external fact that can change independently.
+"""
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List
+
+# Python versions to skip. 3.14 is excluded because the current CPU wheel rows already fail
+# on it for an unrelated reason in the example requirements, so a GPU row would inherit a
+# known-broken build. The free-threaded builds are excluded because the CUDA dependencies
+# are not published for them.
+DISABLED_PYTHON_VERSIONS: List[str] = ["3.13t", "3.14", "3.14t", "3.15", "3.15t"]
+
+# CUDA versions to publish.
+#
+# Chosen so that every consumer row can find a matching wheel rather than by what is
+# convenient to verify. A delegate built against one of these has to be able to depend on an
+# ExecuTorch wheel for the same CUDA version, and a missing version means that consumer has
+# nothing to depend on:
+#
+#   cu126   the floor, and what Jetson devices are limited to
+#   cu130   the generator's stable choice, and the default for accelerator consumers
+#   cu132   the newest, which consumers building against a current TensorRT need
+#
+# cu132 is included even though no machine here can execute it, because omitting it would
+# leave a published consumer row with no ExecuTorch wheel to pair with. The packaging
+# properties are checked on every row; executing a model is a release-gate step on hardware
+# that has the matching GPU.
+SUPPORTED_CUDA_VERSIONS: List[str] = ["cu126", "cu130", "cu132"]
+
+# The single row built for a pull request. A full matrix on every push would cost hours for
+# little signal, and this pair is the one with a machine that can run a model on it.
+PR_PYTHON_VERSION: str = "3.12"
+PR_CUDA_VERSION: str = "cu130"
+
+# Jetson devices are their own row: a JetPack image, one Python version, and one CUDA
+# version. They cannot take a generic aarch64 wheel, because the generic builds carry no
+# device code for their GPU architecture and no portable fallback either.
+#
+# Kept empty on purpose. Published PyTorch stopped shipping sm_87 device code after 2.8.0,
+# so a Jetson row today would produce a wheel whose PyTorch dependency cannot execute on the
+# device. Populate this when that changes.
+# Windows CUDA is deliberately absent, and not because the matrix cannot express it: the generator
+# offers a Windows CUDA row, PyTorch publishes Windows CUDA wheels, and the CUDA backend already
+# handles Windows in its build.
+#
+# The blocker is that the separate shared libraries this wheel exists to ship are Linux only today.
+# On Windows the runtime stays fused into the Python extension, so a Windows CUDA wheel would carry a
+# delegate that a C++ application still could not link, which is the thing a GPU wheel is for.
+#
+# Splitting the libraries on Windows is the prerequisite. Once that lands, this row is a small change:
+# add "windows" to the architectures below and give it the same CUDA versions as Linux.
+WINDOWS_CUDA_PYTHON_VERSIONS: List[str] = []
+WINDOWS_CUDA_VERSIONS: List[str] = []
+
+JETPACK_PYTHON_VERSIONS: List[str] = []
+JETPACK_CUDA_VERSIONS: List[str] = []
+JETPACK_CONTAINER_IMAGE: str = "nvcr.io/nvidia/l4t-jetpack:r36.4.0"
+
+
+def keep(item: Dict[str, Any], is_jetpack: bool) -> bool:
+    """Whether this row should be built, adjusting its container image where needed."""
+    if item["python_version"] in DISABLED_PYTHON_VERSIONS:
+        return False
+
+    if is_jetpack:
+        if (
+            item["python_version"] in JETPACK_PYTHON_VERSIONS
+            and item["desired_cuda"] in JETPACK_CUDA_VERSIONS
+        ):
+            item["container_image"] = JETPACK_CONTAINER_IMAGE
+            return True
+        return False
+
+    if item["desired_cuda"] not in SUPPORTED_CUDA_VERSIONS:
+        return False
+
+    return True
+
+
+def _version_rank(cuda: str) -> int:
+    """Where a CUDA version sits in the supported list, or -1 when it is not supported at all."""
+    try:
+        return SUPPORTED_CUDA_VERSIONS.index(cuda)
+    except ValueError:
+        return -1
+
+
+def only_pull_request_row(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """One representative row, so a pull request does not build the whole matrix.
+
+    Chosen by preference rather than by exact match. An exact request degrades quietly when the
+    generator does not offer that combination: asking for a python version it did not emit once left
+    a pull request building the OLDEST CUDA version instead of the newest, which still passed and
+    tested the wrong thing.
+    """
+    if not items:
+        return []
+
+    # Looked up once, and tolerantly: a PR_CUDA_VERSION that falls off SUPPORTED_CUDA_VERSIONS used to
+    # raise here and break every pull request while releases kept working, which is the wrong way round
+    # for a constant that only chooses which single row to build.
+    wanted = _version_rank(PR_CUDA_VERSION)
+
+    def rank(item: Dict[str, Any]) -> tuple:
+        # Closeness peaks at the requested version, then falls off, and it outranks the python match.
+        # Ranking python first picked a wheel for a CUDA version nothing on hand can execute whenever the
+        # generator skewed the two axes, and the point of building one row is to get signal from it.
+        offered = _version_rank(item["desired_cuda"])
+        # Negative above the requested version, so a newer one never outranks an older one a machine here
+        # can actually run.
+        closeness = offered if offered <= wanted else wanted - offered
+        return (closeness, item["python_version"] == PR_PYTHON_VERSION)
+
+    return [max(items, key=rank)]
+
+
+def main(argv: List[str]) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--matrix", required=True, help="the generated matrix, as JSON")
+    parser.add_argument(
+        "--jetpack", default="false", help="build the Jetson row instead"
+    )
+    parser.add_argument("--limit-pr-builds", default="false", help="build one row only")
+    args = parser.parse_args(argv)
+
+    try:
+        matrix = json.loads(args.matrix)
+    except json.JSONDecodeError as error:
+        print(f"could not parse the matrix: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    is_jetpack = args.jetpack.lower() == "true"
+    items = [item for item in matrix.get("include", []) if keep(item, is_jetpack)]
+
+    if args.limit_pr_builds.lower() == "true" and items:
+        items = only_pull_request_row(items)
+    elif items:
+        # A release has to publish every combination this policy advertises. Comparing the result against
+        # what the generator offered cannot catch anything, because both sides apply the same conditions, so
+        # the difference is empty by construction and the check never fires. The policy's own list is the
+        # thing to compare against: a CUDA version the generator stopped offering otherwise disappears from
+        # the release silently, and a missing job is a green check for a wheel that was never built.
+        offered_python = {
+            item["python_version"]
+            for item in matrix.get("include", [])
+            if item["python_version"] not in DISABLED_PYTHON_VERSIONS
+        }
+        built = {(item["python_version"], item["desired_cuda"]) for item in items}
+        missing = sorted(
+            f"{python}/{cuda}"
+            for python in offered_python
+            for cuda in SUPPORTED_CUDA_VERSIONS
+            if (python, cuda) not in built
+        )
+        if missing:
+            print(
+                f"this policy advertises {SUPPORTED_CUDA_VERSIONS} for every python the generator "
+                f"offered, but {len(missing)} combination(s) produced no row, so a release would "
+                f"publish no wheel for them: {missing}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    # Fail loudly on an empty result. A silently empty matrix produces a workflow with no
+    # build job, which shows up as a green check for a build that never happened.
+    if not items:
+        print(
+            "the filter produced no rows to build, so nothing would be verified. "
+            f"jetpack={is_jetpack}, supported CUDA={SUPPORTED_CUDA_VERSIONS}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(json.dumps({"include": items}))
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/.github/workflows/build-wheels-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-aarch64-linux.yml
@@ -6,9 +6,11 @@ on:
     paths:
       - .ci/**/*
       - .github/workflows/build-wheels-aarch64-linux.yml
+      - '**/CMakeLists.txt'
       - examples/**/*
       - pyproject.toml
       - setup.py
+      - tools/cmake/**/*
   push:
     branches:
       - nightly

--- a/.github/workflows/build-wheels-cuda-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-cuda-aarch64-linux.yml
@@ -1,0 +1,97 @@
+# From https://github.com/pytorch/test-infra/wiki/Using-Nova-Reusable-Build-Workflows
+name: Build Aarch64 Linux CUDA Wheels
+
+on:
+  pull_request:
+    paths:
+      - .ci/**/*
+      - .github/scripts/filter_cuda_matrix.py
+      - .github/workflows/build-wheels-cuda-aarch64-linux.yml
+      - '**/CMakeLists.txt'
+      - backends/cuda/**/*
+      - extension/cuda/**/*
+      - pyproject.toml
+      - setup.py
+      - tools/cmake/**/*
+  push:
+    branches:
+      - nightly
+      - release/*
+    tags:
+      # NOTE: Binary build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - ciflow/binaries/*
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux-aarch64
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-cuda: enable
+      with-cpu: disable
+      with-rocm: disable
+      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+
+  # The generator emits every CUDA version it knows about. Publishing all of them would ship
+  # wheels for combinations nothing can verify, so this keeps only the rows with a GPU to run
+  # them on. The script fails rather than emitting an empty matrix, because a workflow with no
+  # build job reads as a pass.
+  filter-matrix:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - uses: actions/checkout@v4
+      - name: Filter the matrix
+        id: filter
+        run: |
+          set -eou pipefail
+          MATRIX_BLOB=${{ toJSON(needs.generate-matrix.outputs.matrix) }}
+          LIMIT_PR=${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          MATRIX_BLOB="$(python3 .github/scripts/filter_cuda_matrix.py \
+            --matrix "${MATRIX_BLOB}" --limit-pr-builds "${LIMIT_PR}")"
+          echo "${MATRIX_BLOB}"
+          echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
+
+  build:
+    needs: filter-matrix
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/executorch
+            pre-script: .ci/scripts/wheel/pre_build_script.sh
+            post-script: .ci/scripts/wheel/post_build_script.sh
+            smoke-test-script: .ci/scripts/wheel/test_cuda_linux.py
+            package-name: executorch
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    with:
+      repository: ${{ matrix.repository }}
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
+      submodules: recursive
+      env-var-script: .ci/scripts/wheel/envvar_cuda_linux.sh
+      pre-script: ${{ matrix.pre-script }}
+      post-script: ${{ matrix.post-script }}
+      package-name: ${{ matrix.package-name }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      trigger-event: ${{ github.event_name }}
+      # Required for aarch64. Without it the shared build workflow prepares an x86_64 job
+      # and skips the aarch64 conda install, so the first build step fails on a missing
+      # conda.
+      architecture: aarch64

--- a/.github/workflows/build-wheels-cuda-linux.yml
+++ b/.github/workflows/build-wheels-cuda-linux.yml
@@ -1,0 +1,93 @@
+# From https://github.com/pytorch/test-infra/wiki/Using-Nova-Reusable-Build-Workflows
+name: Build Linux CUDA Wheels
+
+on:
+  pull_request:
+    paths:
+      - .ci/**/*
+      - .github/scripts/filter_cuda_matrix.py
+      - .github/workflows/build-wheels-cuda-linux.yml
+      - '**/CMakeLists.txt'
+      - backends/cuda/**/*
+      - extension/cuda/**/*
+      - pyproject.toml
+      - setup.py
+      - tools/cmake/**/*
+  push:
+    branches:
+      - nightly
+      - release/*
+    tags:
+      # NOTE: Binary build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - ciflow/binaries/*
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-cuda: enable
+      with-cpu: disable
+      with-rocm: disable
+      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+
+  # The generator emits every CUDA version it knows about. Publishing all of them would ship
+  # wheels for combinations nothing can verify, so this keeps only the rows with a GPU to run
+  # them on. The script fails rather than emitting an empty matrix, because a workflow with no
+  # build job reads as a pass.
+  filter-matrix:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - uses: actions/checkout@v4
+      - name: Filter the matrix
+        id: filter
+        run: |
+          set -eou pipefail
+          MATRIX_BLOB=${{ toJSON(needs.generate-matrix.outputs.matrix) }}
+          LIMIT_PR=${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          MATRIX_BLOB="$(python3 .github/scripts/filter_cuda_matrix.py \
+            --matrix "${MATRIX_BLOB}" --limit-pr-builds "${LIMIT_PR}")"
+          echo "${MATRIX_BLOB}"
+          echo "matrix=${MATRIX_BLOB}" >> "${GITHUB_OUTPUT}"
+
+  build:
+    needs: filter-matrix
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/executorch
+            pre-script: .ci/scripts/wheel/pre_build_script.sh
+            post-script: .ci/scripts/wheel/post_build_script.sh
+            smoke-test-script: .ci/scripts/wheel/test_cuda_linux.py
+            package-name: executorch
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    with:
+      repository: ${{ matrix.repository }}
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
+      submodules: recursive
+      env-var-script: .ci/scripts/wheel/envvar_cuda_linux.sh
+      pre-script: ${{ matrix.pre-script }}
+      post-script: ${{ matrix.post-script }}
+      package-name: ${{ matrix.package-name }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      trigger-event: ${{ github.event_name }}

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -6,9 +6,11 @@ on:
     paths:
       - .ci/**/*
       - .github/workflows/build-wheels-linux.yml
+      - '**/CMakeLists.txt'
       - examples/**/*
       - pyproject.toml
       - setup.py
+      - tools/cmake/**/*
   push:
     branches:
       - nightly

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -6,9 +6,11 @@ on:
     paths:
       - .ci/**/*
       - .github/workflows/build-wheels-macos.yml
+      - '**/CMakeLists.txt'
       - examples/**/*
       - pyproject.toml
       - setup.py
+      - tools/cmake/**/*
   push:
     branches:
       - nightly

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -5,9 +5,11 @@ on:
     paths:
       - .ci/**/*
       - .github/workflows/build-wheels-windows.yml
+      - '**/CMakeLists.txt'
       - examples/**/*
       - pyproject.toml
       - setup.py
+      - tools/cmake/**/*
   push:
     branches:
       - nightly

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,19 @@ if(DEFINED EXECUTORCH_BAREMETAL_SKIP_INSTALL
 endif()
 
 if(EXECUTORCH_BUILD_SHARED)
+  # Linux only, and said here rather than left to fail somewhere downstream. The
+  # shared build names libraries with an ELF soname, records $ORIGIN runtime
+  # paths, and uses GNU linker options to keep a registration-only library on a
+  # link line. None of that applies on Apple, which is served by the Swift
+  # package distribution, or on Windows, where the runtime carries no export
+  # annotations for a DLL. Enabling it elsewhere failed much later and less
+  # clearly, when packaging looked for a .so the build never emitted.
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    message(
+      FATAL_ERROR "EXECUTORCH_BUILD_SHARED is supported on Linux only, not "
+                  "${CMAKE_SYSTEM_NAME}."
+    )
+  endif()
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
@@ -284,18 +297,54 @@ add_subdirectory(third-party)
 # state crash at import time. This function replaces pybind11::embed with
 # pybind11::module (which links Python::Module instead of Python::Python —
 # headers and ABI only, no libpython) and adds -undefined dynamic_lookup for
-# symbol resolution. No-op on non-Apple platforms.
+# symbol resolution.
+#
+# Linux needs the same treatment for a different reason. An extension is loaded
+# by an interpreter that already has the Python runtime in the process, so it
+# must not carry its own dependency on libpython: the interpreter's library
+# directory is not on any search path a wheel can predict, and an interpreter
+# built with a shared libpython leaves the extension unable to resolve it. The
+# undefined symbols are supplied by the loading process, which is how a Python
+# extension normally works. No-op on Windows, where extensions link the import
+# library by design.
 function(strip_python_lib target)
-  if(NOT APPLE)
+  if(MSVC)
     return()
   endif()
+  # The module helper links the embedding form of Python for anything that is
+  # not a MODULE library, and that form brings a hard dependency on the
+  # interpreter's shared library plus an absolute path to wherever it was found
+  # on the build machine. Neither survives being shipped: the loader cannot
+  # satisfy the dependency from an installed wheel, and the absolute path names
+  # the build machine.
+  #
+  # These targets cannot simply become MODULE libraries, because other targets
+  # link them and CMake refuses to link a MODULE. So keep the type and replace
+  # the Python library instead. An extension does not need it: the interpreter
+  # already provides those symbols to anything it loads.
+  #
+  # The interfaces arrive as PRIVATE links, so they appear in LINK_LIBRARIES
+  # wrapped rather than as bare target names. Rewrite the property from the
+  # filtered list instead of relying on a name match against the wrapped form.
   get_target_property(_libs ${target} LINK_LIBRARIES)
   if(_libs)
-    list(REMOVE_ITEM _libs Python::Python pybind11::embed)
-    list(APPEND _libs pybind11::module)
-    set_target_properties(${target} PROPERTIES LINK_LIBRARIES "${_libs}")
+    set(_kept "")
+    foreach(_lib IN LISTS _libs)
+      # Match the embedding interfaces however they are spelled, including
+      # inside a wrapper.
+      if(NOT _lib MATCHES "(pybind11::embed|Python3?::Python)")
+        list(APPEND _kept "${_lib}")
+      endif()
+    endforeach()
+    list(APPEND _kept pybind11::module)
+    set_target_properties(${target} PROPERTIES LINK_LIBRARIES "${_kept}")
   endif()
-  target_link_options(${target} PRIVATE "LINKER:-undefined,dynamic_lookup")
+  if(APPLE)
+    # Apple's linker needs telling that the undefined symbols resolve at load
+    # time. The Linux loader already permits that for a shared object and does
+    # not accept the flag.
+    target_link_options(${target} PRIVATE "LINKER:-undefined,dynamic_lookup")
+  endif()
 endfunction()
 
 # Size-optimized builds disable exceptions, RTTI, and unwind tables.
@@ -932,6 +981,55 @@ if(EXECUTORCH_BUILD_PTHREADPOOL AND EXECUTORCH_BUILD_CPUINFO)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/threadpool)
 endif()
 
+# Consolidated shared library: bundles executorch_core plus commonly used
+# extensions into a single libexecutorch.so. Defined before the pybind and
+# kernel targets below so they can link this one runtime instead of embedding a
+# private copy of the core, which would give the process a second backend
+# registry.
+if(EXECUTORCH_BUILD_SHARED)
+  executorch_add_shared_library(executorch_shared)
+  set_target_properties(
+    executorch_shared
+    PROPERTIES OUTPUT_NAME executorch
+               ARCHIVE_OUTPUT_NAME executorch_shared
+               EXPORT_NAME executorch-shared
+  )
+  # Ships in the wheel's lib/ directory beside the libraries that link it.
+  executorch_target_shipped_runtime_path(executorch_shared)
+  target_include_directories(
+    executorch_shared PUBLIC ${_common_include_directories}
+  )
+  target_compile_definitions(
+    executorch_shared PUBLIC C10_USING_CUSTOM_GENERATED_MACROS
+  )
+  # Link executorch without WHOLE_ARCHIVE because its INTERFACE link options
+  # (from executorch_target_link_options_shared_lib) already force
+  # whole-archive. Everything else is pulled in through link options rather than
+  # the WHOLE_ARCHIVE link feature, because these archives also reference each
+  # other plainly and CMake before 3.29 refuses to mix a feature with a plain
+  # reference to the same item.
+  target_link_libraries(executorch_shared PRIVATE executorch)
+  set(_executorch_shared_whole_archive executorch_core)
+  foreach(_ext_target
+          extension_data_loader extension_flat_tensor extension_named_data_map
+          extension_module_static extension_tensor
+  )
+    if(TARGET ${_ext_target})
+      list(APPEND _executorch_shared_whole_archive ${_ext_target})
+    endif()
+  endforeach()
+  foreach(_whole_target ${_executorch_shared_whole_archive})
+    executorch_target_whole_archive(executorch_shared ${_whole_target})
+  endforeach()
+  configure_file(
+    tools/cmake/executorch.pc.in ${CMAKE_CURRENT_BINARY_DIR}/executorch.pc
+    @ONLY
+  )
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/executorch.pc
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+  )
+endif()
+
 if(EXECUTORCH_BUILD_KERNELS_TORCHAO)
   if(NOT TARGET cpuinfo)
     message(
@@ -992,14 +1090,19 @@ if(EXECUTORCH_BUILD_KERNELS_TORCHAO)
 
 endif()
 
+# The shared build ships the profiler as one of its libraries, and the Python
+# extension records a hard dependency on it, so the target has to exist whenever
+# either of those is being built rather than only when devtools is asked for.
+if((EXECUTORCH_BUILD_PYBIND OR EXECUTORCH_BUILD_SHARED)
+   AND NOT EXECUTORCH_BUILD_DEVTOOLS
+)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/devtools)
+endif()
+
 if(EXECUTORCH_BUILD_PYBIND)
 
   if(NOT EXECUTORCH_BUILD_EXTENSION_DATA_LOADER)
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/data_loader)
-  endif()
-
-  if(NOT EXECUTORCH_BUILD_DEVTOOLS)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/devtools)
   endif()
 
   # Add codegen tools subdirectory for selective_build pybind module
@@ -1016,10 +1119,19 @@ if(EXECUTORCH_BUILD_PYBIND)
     # Ensure bundled_module waits for bundled_program's generated headers
     add_dependencies(bundled_module bundled_program)
 
-    target_link_libraries(bundled_module PRIVATE extension_data_loader)
-    target_link_libraries(
-      bundled_module PUBLIC extension_module_static bundled_program
-    )
+    # extension_module_static and the data loader are bundled into
+    # libexecutorch.so, so link that instead of pulling private static copies in
+    # through this target's PUBLIC interface.
+    if(EXECUTORCH_BUILD_SHARED)
+      target_link_libraries(
+        bundled_module PUBLIC executorch_shared bundled_program
+      )
+    else()
+      target_link_libraries(bundled_module PRIVATE extension_data_loader)
+      target_link_libraries(
+        bundled_module PUBLIC extension_module_static bundled_program
+      )
+    endif()
 
     target_include_directories(
       bundled_module PUBLIC ${_common_include_directories}
@@ -1038,16 +1150,36 @@ if(EXECUTORCH_BUILD_PYBIND)
     TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib"
   )
 
-  set(_dep_libs
-      ${TORCH_PYTHON_LIBRARY}
-      bundled_program
-      etdump
-      flatccrt
-      executorch
-      extension_data_loader
-      util
-      torch
-  )
+  # When the consolidated shared runtime is built, the pybind extension links it
+  # instead of whole-archiving the static core, so Python and C++ consumers
+  # share one backend registry. `executorch` and the extensions bundled into
+  # libexecutorch.so must stay off this list: their INTERFACE link options force
+  # whole-archive, which would give this module a private second registry.
+  # executorch_shared is named here for its include directories and compile
+  # definitions; executorch_target_link_shared_runtime below is what fixes its
+  # position on the link line.
+  if(EXECUTORCH_BUILD_SHARED)
+    set(_dep_libs
+        ${TORCH_PYTHON_LIBRARY}
+        bundled_program
+        etdump
+        flatccrt
+        executorch_shared
+        util
+        torch
+    )
+  else()
+    set(_dep_libs
+        ${TORCH_PYTHON_LIBRARY}
+        bundled_program
+        etdump
+        flatccrt
+        executorch
+        extension_data_loader
+        util
+        torch
+    )
+  endif()
 
   # Build common AOTI functionality if needed by CUDA or Metal backends
   if(EXECUTORCH_BUILD_CUDA)
@@ -1058,13 +1190,32 @@ if(EXECUTORCH_BUILD_PYBIND)
     list(APPEND _dep_libs aoti_common)
   endif()
 
-  # RPATH for _portable_lib.so
+  # RPATH for _portable_lib.so. It sits in
+  # <site-packages>/executorch/extension/pybindings, so torch is three levels up
+  # and the wheel's own lib/ directory is two.
   set(_portable_lib_rpath "$ORIGIN/../../../torch/lib")
+  if(EXECUTORCH_BUILD_SHARED)
+    # Two routes to the same runtime, because the two layouts put it in
+    # different places: a wheel keeps it in the package's own lib/ directory,
+    # while a normal install puts it in the prefix library directory. Adding
+    # only the first left a normally installed extension unable to resolve the
+    # runtime it now depends on.
+    string(APPEND _portable_lib_rpath ":$ORIGIN/../../lib")
+    file(RELATIVE_PATH _portable_lib_to_libdir
+         "${CMAKE_INSTALL_PREFIX}/executorch/extension/pybindings"
+         "${CMAKE_INSTALL_FULL_LIBDIR}"
+    )
+    string(APPEND _portable_lib_rpath ":$ORIGIN/${_portable_lib_to_libdir}")
+  endif()
 
   if(EXECUTORCH_BUILD_EXTENSION_MODULE)
-    # Always use static linking for pybindings to avoid runtime symbol
-    # resolution issues
-    list(APPEND _dep_libs extension_module_static)
+    # extension_module_static is already bundled into libexecutorch.so; linking
+    # it again here would whole-archive a second copy.
+    if(NOT EXECUTORCH_BUILD_SHARED)
+      # Always use static linking for pybindings to avoid runtime symbol
+      # resolution issues
+      list(APPEND _dep_libs extension_module_static)
+    endif()
     # Add bundled_module if available
     if(TARGET bundled_module)
       list(APPEND _dep_libs bundled_module)
@@ -1115,9 +1266,15 @@ if(EXECUTORCH_BUILD_PYBIND)
   endif()
 
   if(EXECUTORCH_BUILD_XNNPACK)
-    # need to explicitly specify XNNPACK and xnnpack-microkernels-prod here
-    # otherwise uses XNNPACK and microkernel-prod symbols from libtorch_cpu
-    list(APPEND _dep_libs xnnpack_backend XNNPACK xnnpack-microkernels-prod)
+    if(EXECUTORCH_BUILD_SHARED)
+      # The delegate bundles XNNPACK and its microkernels, so naming them again
+      # here would ship a second copy.
+      list(APPEND _dep_libs xnnpack_backend)
+    else()
+      # need to explicitly specify XNNPACK and xnnpack-microkernels-prod here
+      # otherwise uses XNNPACK and microkernel-prod symbols from libtorch_cpu
+      list(APPEND _dep_libs xnnpack_backend XNNPACK xnnpack-microkernels-prod)
+    endif()
   endif()
 
   if(EXECUTORCH_BUILD_VULKAN)
@@ -1150,7 +1307,11 @@ if(EXECUTORCH_BUILD_PYBIND)
   target_compile_definitions(util PUBLIC C10_USING_CUSTOM_GENERATED_MACROS)
 
   target_compile_options(util PUBLIC ${_pybind_compile_options})
-  target_link_libraries(util PRIVATE torch c10 executorch extension_tensor)
+  if(EXECUTORCH_BUILD_SHARED)
+    target_link_libraries(util PRIVATE torch c10 executorch_shared)
+  else()
+    target_link_libraries(util PRIVATE torch c10 executorch extension_tensor)
+  endif()
 
   # pybind portable_lib
   pybind11_add_module(portable_lib SHARED extension/pybindings/pybindings.cpp)
@@ -1167,6 +1328,25 @@ if(EXECUTORCH_BUILD_PYBIND)
   target_include_directories(portable_lib PRIVATE ${TORCH_INCLUDE_DIRS})
   target_compile_options(portable_lib PUBLIC ${_pybind_compile_options})
   target_link_libraries(portable_lib PRIVATE ${_dep_libs})
+  executorch_target_link_shared_runtime(portable_lib)
+  # These libraries register their operators or their backend from a static
+  # initializer, so nothing here references a symbol from them and some linkers
+  # drop them from DT_NEEDED. That surfaces at runtime as a missing kernel or an
+  # unregistered backend rather than as a link error. Every shipped library, not
+  # only the two that register something. A library reached transitively is
+  # still subject to --as-needed and gets dropped, so the thread pool and the
+  # profiler need naming here too even though the extension does reference
+  # symbols from them. A distro toolchain that defaults to --as-needed would
+  # otherwise leave them out of DT_NEEDED entirely.
+  foreach(_retained_component optimized_native_cpu_ops_lib xnnpack_backend
+                              extension_threadpool etdump
+  )
+    if(TARGET ${_retained_component})
+      executorch_target_retain_shared_library(
+        portable_lib ${_retained_component}
+      )
+    endif()
+  endforeach()
 
   # Set RPATH to find PyTorch and backend libraries relative to the installation
   # location. This goes from executorch/extension/pybindings up to
@@ -1199,7 +1379,24 @@ if(EXECUTORCH_BUILD_PYBIND)
   strip_python_lib(data_loader)
   target_include_directories(data_loader PRIVATE ${_common_include_directories})
   target_compile_options(data_loader PUBLIC ${_pybind_compile_options})
-  target_link_libraries(data_loader PRIVATE executorch)
+  # This module only exposes a pybind type and calls into no runtime symbols.
+  # The static target force-links every registration object, which would give
+  # this module its own operator registry alongside the one in the shared
+  # runtime, so resolve against the shared runtime instead when there is one.
+  if(TARGET executorch_shared)
+    target_link_libraries(data_loader PRIVATE executorch_shared)
+    if(EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
+      # Wheel-specific: this installs beside the other pybind extensions, two
+      # levels below the wheel's lib/ directory, so it needs the same relative
+      # path they use to reach the shared runtime.
+      set_target_properties(
+        data_loader PROPERTIES BUILD_RPATH "$ORIGIN/../../lib"
+                               INSTALL_RPATH "$ORIGIN/../../lib"
+      )
+    endif()
+  else()
+    target_link_libraries(data_loader PRIVATE executorch)
+  endif()
   install(TARGETS data_loader
           LIBRARY DESTINATION executorch/extension/pybindings
   )
@@ -1244,49 +1441,6 @@ if(EXECUTORCH_BUILD_KERNELS_LLM)
   # TODO: move all custom kernels to ${CMAKE_CURRENT_SOURCE_DIR}/kernels/custom
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/llm/custom_ops)
   list(APPEND _executorch_kernels custom_ops_aot_lib)
-endif()
-
-# Consolidated shared library: bundles executorch_core plus commonly used
-# extensions into a single libexecutorch.so.
-if(EXECUTORCH_BUILD_SHARED)
-  executorch_add_shared_library(executorch_shared)
-  set_target_properties(
-    executorch_shared
-    PROPERTIES OUTPUT_NAME executorch
-               ARCHIVE_OUTPUT_NAME executorch_shared
-               EXPORT_NAME executorch-shared
-  )
-  target_include_directories(
-    executorch_shared PUBLIC ${_common_include_directories}
-  )
-  target_compile_definitions(
-    executorch_shared PUBLIC C10_USING_CUSTOM_GENERATED_MACROS
-  )
-  # Link executorch without WHOLE_ARCHIVE because its INTERFACE link options
-  # (from executorch_target_link_options_shared_lib) already force
-  # whole-archive. Link executorch_core explicitly since executorch only has a
-  # PRIVATE dep on it (symbols wouldn't propagate otherwise).
-  target_link_libraries(
-    executorch_shared PRIVATE executorch
-                              $<LINK_LIBRARY:WHOLE_ARCHIVE,executorch_core>
-  )
-  foreach(_ext_target
-          extension_data_loader extension_flat_tensor extension_named_data_map
-          extension_module_static extension_tensor
-  )
-    if(TARGET ${_ext_target})
-      target_link_libraries(
-        executorch_shared PRIVATE $<LINK_LIBRARY:WHOLE_ARCHIVE,${_ext_target}>
-      )
-    endif()
-  endforeach()
-  configure_file(
-    tools/cmake/executorch.pc.in ${CMAKE_CURRENT_BINARY_DIR}/executorch.pc
-    @ONLY
-  )
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/executorch.pc
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
-  )
 endif()
 
 if(EXECUTORCH_BUILD_KERNELS_QUANTIZED)

--- a/backends/cuda/CMakeLists.txt
+++ b/backends/cuda/CMakeLists.txt
@@ -167,22 +167,30 @@ if(_cuda_is_msvc_toolchain)
   # avoiding duplicate static/object inclusion and interface leakage.
   target_link_libraries(aoti_cuda_shims PRIVATE aoti_common_shims_slim_obj)
 else()
+  # The whole-archive pair is PRIVATE so it applies to this library's own link
+  # and does not replay at the link of anything that links this one. In PUBLIC
+  # scope the archive was extracted again by each consumer, so the translation
+  # unit holding the caller-stream thread_local landed in three shipped
+  # binaries, and one copy per process is why that state lives in a shared
+  # library at all. The MSVC branch above uses PRIVATE for the same reason.
   target_link_libraries(
     aoti_cuda_shims
-    PRIVATE cuda_platform
-    PUBLIC -Wl,--whole-archive
-           aoti_common_shims_slim
-           -Wl,--no-whole-archive
-           CUDA::cudart
-           CUDA::curand
-           extension_cuda
-           ${CMAKE_DL_LIBS}
+    PRIVATE cuda_platform -Wl,--whole-archive aoti_common_shims_slim
+            -Wl,--no-whole-archive
+    PUBLIC CUDA::cudart CUDA::curand extension_cuda ${CMAKE_DL_LIBS}
   )
 endif()
 
 if(NOT _cuda_is_msvc_toolchain)
   executorch_target_link_options_shared_lib(aoti_cuda_shims)
 endif()
+
+# This library links the CUDA runtime directly and the wheel ships it, so it
+# needs a search path for the same reason the delegate does. Without one it can
+# ship with no runtime path at all, on a builder where the runtime resolves from
+# an implicit link directory, and the wheel then adds no relative hop either,
+# because the step that adds one has nothing to rewrite.
+executorch_target_shipped_runtime_path(aoti_cuda_shims)
 
 install(
   TARGETS aoti_cuda_shims
@@ -200,7 +208,17 @@ if(_cuda_is_msvc_toolchain)
   list(APPEND _aoti_cuda_backend_sources runtime/cuda_allocator.cpp)
 endif()
 
-add_library(aoti_cuda_backend STATIC ${_aoti_cuda_backend_sources})
+# Build the delegate as a shared library for the wheel so a process has one copy
+# of it, and keep it static everywhere else so no other build changes.
+if(EXECUTORCH_BUILD_SHARED)
+  set(_aoti_cuda_backend_library_type SHARED)
+else()
+  set(_aoti_cuda_backend_library_type STATIC)
+endif()
+add_library(
+  aoti_cuda_backend ${_aoti_cuda_backend_library_type}
+                    ${_aoti_cuda_backend_sources}
+)
 
 target_include_directories(
   aoti_cuda_backend
@@ -239,6 +257,22 @@ else()
 endif()
 
 executorch_target_link_options_shared_lib(aoti_cuda_backend)
+
+if(EXECUTORCH_BUILD_SHARED)
+  # Named after what the library provides rather than after the target that
+  # produces it, matching the other shipped delegates, so the file reads as
+  # libexecutorch_backend_cuda.so. The target name stays as it is because the
+  # rest of the build already refers to it.
+  set_target_properties(
+    aoti_cuda_backend PROPERTIES OUTPUT_NAME executorch_backend_cuda
+  )
+  executorch_target_soname_policy(aoti_cuda_backend)
+  # Resolve the runtime from the shared library rather than from the static
+  # core, so the delegate registers into the one registry the process has.
+  target_link_libraries(aoti_cuda_backend PUBLIC executorch_shared)
+  # Ships beside the runtime in the wheel's lib/ directory.
+  executorch_target_shipped_runtime_path(aoti_cuda_backend)
+endif()
 
 install(
   TARGETS aoti_cuda_backend

--- a/backends/cuda/CMakeLists.txt
+++ b/backends/cuda/CMakeLists.txt
@@ -42,6 +42,43 @@ if(NOT CMAKE_CUDA_COMPILER)
   check_language(CUDA)
 endif()
 
+# Take the architectures from the release row when it names them, before the
+# language is enabled, since CMake fixes them at that point. Without this the
+# build uses CMake's default, which on some devices is older than the intrinsics
+# these sources use, and the compile fails with an undefined identifier that
+# looks like a source problem.
+#
+# TORCH_CUDA_ARCH_LIST is the variable the surrounding build environment already
+# sets, in PyTorch's dotted form. CMake wants bare integers, so "9.0" becomes
+# 90, and the "+PTX" suffix asking for a portable form becomes the -virtual
+# kind.
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES AND DEFINED ENV{TORCH_CUDA_ARCH_LIST})
+  set(_cuda_arch_list "")
+  string(REPLACE " " ";" _cuda_arch_items "$ENV{TORCH_CUDA_ARCH_LIST}")
+  foreach(_cuda_arch_item IN LISTS _cuda_arch_items)
+    if(_cuda_arch_item STREQUAL "")
+      continue()
+    endif()
+    set(_cuda_arch_kind "real")
+    if(_cuda_arch_item MATCHES "\\+PTX$")
+      set(_cuda_arch_kind "virtual")
+      string(REPLACE "+PTX" "" _cuda_arch_item "${_cuda_arch_item}")
+    endif()
+    string(REPLACE "." "" _cuda_arch_number "${_cuda_arch_item}")
+    if(_cuda_arch_number MATCHES "^[0-9]+$")
+      list(APPEND _cuda_arch_list "${_cuda_arch_number}-${_cuda_arch_kind}")
+    endif()
+  endforeach()
+  if(_cuda_arch_list)
+    list(REMOVE_DUPLICATES _cuda_arch_list)
+    set(CMAKE_CUDA_ARCHITECTURES ${_cuda_arch_list})
+    message(
+      STATUS
+        "CUDA architectures from TORCH_CUDA_ARCH_LIST: ${CMAKE_CUDA_ARCHITECTURES}"
+    )
+  endif()
+endif()
+
 if(CMAKE_CUDA_COMPILER)
   enable_language(CUDA)
 endif()

--- a/backends/cuda/runtime/cuda_allocator.cpp
+++ b/backends/cuda/runtime/cuda_allocator.cpp
@@ -29,13 +29,16 @@ Error copy_impl(
     DeviceIndex index,
     cudaMemcpyKind kind) {
   ET_CHECK_OR_RETURN_ERROR(
-      kind == cudaMemcpyHostToDevice || kind == cudaMemcpyDeviceToHost,
+      kind == cudaMemcpyHostToDevice || kind == cudaMemcpyDeviceToHost ||
+          kind == cudaMemcpyDeviceToDevice,
       InvalidArgument,
       "CudaAllocator::copy_impl: unsupported cudaMemcpyKind %d",
       static_cast<int>(kind));
   const char* method = kind == cudaMemcpyHostToDevice
       ? "CudaAllocator::copy_host_to_device"
-      : "CudaAllocator::copy_device_to_host";
+      : (kind == cudaMemcpyDeviceToHost
+             ? "CudaAllocator::copy_device_to_host"
+             : "CudaAllocator::copy_device_to_device");
   ET_CHECK_OR_RETURN_ERROR(
       dst != nullptr, InvalidArgument, "%s: dst is null", method);
   ET_CHECK_OR_RETURN_ERROR(
@@ -218,6 +221,18 @@ Error CudaAllocator::copy_device_to_host(
     size_t nbytes,
     DeviceIndex index) {
   return copy_impl(dst, src, nbytes, index, cudaMemcpyDeviceToHost);
+}
+
+Error CudaAllocator::copy_device_to_device(
+    void* dst,
+    DeviceIndex dst_index,
+    const void* src,
+    DeviceIndex src_index,
+    size_t nbytes) {
+  // Both ends are on this device type, so either index identifies the stream to copy on. Passing the
+  // destination's, because that is the device the copy is filling.
+  (void)src_index;
+  return copy_impl(dst, src, nbytes, dst_index, cudaMemcpyDeviceToDevice);
 }
 
 DeviceType CudaAllocator::device_type() const {

--- a/backends/cuda/runtime/cuda_allocator.h
+++ b/backends/cuda/runtime/cuda_allocator.h
@@ -46,6 +46,13 @@ class CudaAllocator final : public executorch::runtime::DeviceAllocator {
       size_t nbytes,
       executorch::runtime::etensor::DeviceIndex index) override;
 
+  executorch::runtime::Error copy_device_to_device(
+      void* dst,
+      executorch::runtime::etensor::DeviceIndex dst_index,
+      const void* src,
+      executorch::runtime::etensor::DeviceIndex src_index,
+      size_t nbytes) override;
+
   executorch::runtime::etensor::DeviceType device_type() const override;
 
   /// Returns the global CudaAllocator singleton.

--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -255,8 +255,25 @@ target_link_libraries(
 )
 target_link_libraries(
   qnn_executorch_backend PRIVATE qnn_executorch_header qnn_schema qnn_manager
-                                 executorch_core qnn_backend_options
+                                 qnn_backend_options
 )
+# Resolve the runtime from the shared library when one is built, so this
+# delegate does not carry its own copy of the backend registry.
+if(EXECUTORCH_BUILD_SHARED)
+  target_link_libraries(qnn_executorch_backend PRIVATE executorch_shared)
+  executorch_target_link_shared_runtime(qnn_executorch_backend)
+  if(EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
+    # Wheel-specific: ships in executorch/backends/qualcomm, two levels below
+    # the wheel's lib/. A normal install puts the runtime in
+    # CMAKE_INSTALL_LIBDIR, which this relative path would not reach.
+    set_target_properties(
+      qnn_executorch_backend PROPERTIES BUILD_RPATH "$ORIGIN/../../lib"
+                                        INSTALL_RPATH "$ORIGIN/../../lib"
+    )
+  endif()
+else()
+  target_link_libraries(qnn_executorch_backend PRIVATE executorch_core)
+endif()
 
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES Hexagon)
   # Add macro here so we can dlopen the correct .so library.
@@ -359,12 +376,31 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|AMD64")
             qnn_schema
             qnn_manager
             qnn_executorch_header
-            executorch
-            extension_tensor
             qnn_backend_options
             wrappers
             qnn_executorch_logging
   )
+  # extension_tensor is bundled into the shared runtime, so naming it again here
+  # would give this module a second copy of what that library already provides.
+  if(NOT EXECUTORCH_BUILD_SHARED)
+    target_link_libraries(PyQnnManagerAdaptor PRIVATE extension_tensor)
+  endif()
+  # Same reasoning as the delegate above: take the runtime from the shared
+  # library when there is one, rather than embedding a second registry.
+  if(EXECUTORCH_BUILD_SHARED)
+    target_link_libraries(PyQnnManagerAdaptor PRIVATE executorch_shared)
+    executorch_target_link_shared_runtime(PyQnnManagerAdaptor)
+    if(EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
+      # Wheel-specific: ships in executorch/backends/qualcomm/python, three
+      # levels below the wheel's lib/.
+      set_target_properties(
+        PyQnnManagerAdaptor PROPERTIES BUILD_RPATH "$ORIGIN/../../../lib"
+                                       INSTALL_RPATH "$ORIGIN/../../../lib"
+      )
+    endif()
+  else()
+    target_link_libraries(PyQnnManagerAdaptor PRIVATE executorch)
+  endif()
 
   pybind11_extension(PyQnnManagerAdaptor)
   if(NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES RelWithDebInfo)

--- a/backends/xnnpack/CMakeLists.txt
+++ b/backends/xnnpack/CMakeLists.txt
@@ -96,16 +96,48 @@ target_include_directories(
     $<BUILD_INTERFACE:${EXECUTORCH_ROOT}/third-party/flatbuffers/include>
 )
 
-set(xnnpack_third_party pthreadpool extension_threadpool cpuinfo)
+if(EXECUTORCH_BUILD_SHARED)
+  # extension_threadpool is a shared library here and already provides
+  # pthreadpool and cpuinfo. Naming the static archives as well would give this
+  # delegate its own second copy of both, so a process would end up with two
+  # thread pools rather than the one the shared library exists to provide.
+  set(xnnpack_third_party extension_threadpool)
+else()
+  set(xnnpack_third_party pthreadpool extension_threadpool cpuinfo)
+endif()
 
 include(cmake/Dependencies.cmake)
 
 list(TRANSFORM _xnnpack_backend__srcs PREPEND "${EXECUTORCH_ROOT}/")
-add_library(xnnpack_backend ${_xnnpack_backend__srcs})
+# Build the delegate as a shared library for the wheel so a process has one copy
+# of it, and keep it static everywhere else so no other build changes.
+if(EXECUTORCH_BUILD_SHARED)
+  set(_xnnpack_backend_library_type SHARED)
+else()
+  set(_xnnpack_backend_library_type STATIC)
+endif()
+add_library(
+  xnnpack_backend ${_xnnpack_backend_library_type} ${_xnnpack_backend__srcs}
+)
 target_link_libraries(
-  xnnpack_backend PUBLIC ${xnnpack_third_party} executorch_core xnnpack_schema
+  xnnpack_backend PUBLIC ${xnnpack_third_party} xnnpack_schema
                          extension_threadpool
 )
+if(EXECUTORCH_BUILD_SHARED)
+  set_target_properties(
+    xnnpack_backend PROPERTIES OUTPUT_NAME executorch_backend_xnnpack
+  )
+  executorch_target_soname_policy(xnnpack_backend)
+  # XNNPACK and its microkernels are forced static, so bundle them inside this
+  # library instead of making every consumer supply them.
+  executorch_target_whole_archive(xnnpack_backend XNNPACK)
+  executorch_target_whole_archive(xnnpack_backend xnnpack-microkernels-prod)
+  target_link_libraries(xnnpack_backend PUBLIC executorch_shared)
+  # Ships beside the runtime in the wheel's lib/ directory.
+  executorch_target_shipped_runtime_path(xnnpack_backend)
+else()
+  target_link_libraries(xnnpack_backend PUBLIC executorch_core)
+endif()
 target_include_directories(
   xnnpack_backend PUBLIC ${_common_include_directories}
 )

--- a/codegen/tools/CMakeLists.txt
+++ b/codegen/tools/CMakeLists.txt
@@ -43,7 +43,25 @@ if(TARGET bundled_program)
   target_compile_definitions(selective_build PRIVATE -DET_BUNDLE_IO)
   target_link_libraries(selective_build PRIVATE bundled_program)
 endif()
-target_link_libraries(selective_build PRIVATE executorch_core program_schema)
+if(EXECUTORCH_BUILD_SHARED)
+  # This module calls into the runtime, so resolve those symbols from
+  # libexecutorch.so rather than baking in a second copy of the core. It lands
+  # in <site-packages>/executorch/codegen/tools, two levels below the wheel's
+  # lib/.
+  target_link_libraries(
+    selective_build PRIVATE executorch_shared program_schema
+  )
+  if(EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
+    # Wheel-specific: the runtime ships two levels up under lib/. A normal
+    # install puts it in CMAKE_INSTALL_LIBDIR, which this would not reach.
+    set_target_properties(
+      selective_build PROPERTIES BUILD_RPATH "$ORIGIN/../../lib"
+                                 INSTALL_RPATH "$ORIGIN/../../lib"
+    )
+  endif()
+else()
+  target_link_libraries(selective_build PRIVATE executorch_core program_schema)
+endif()
 
 # Install the module
 install(TARGETS selective_build LIBRARY DESTINATION executorch/codegen/tools)

--- a/configurations/CMakeLists.txt
+++ b/configurations/CMakeLists.txt
@@ -50,7 +50,15 @@ if(EXECUTORCH_BUILD_KERNELS_OPTIMIZED)
   else()
     set(_optimized_native_cpu_ops_lib_portable_kernels_lib portable_kernels)
   endif()
+  # Ship this as a shared library in the wheel so the kernels are registered
+  # once per process instead of once per component that links them.
+  if(EXECUTORCH_BUILD_SHARED)
+    set(_merged_cpu_ops_shared SHARED)
+  else()
+    set(_merged_cpu_ops_shared "")
+  endif()
   gen_operators_lib(
+    ${_merged_cpu_ops_shared}
     LIB_NAME
     "optimized_native_cpu_ops_lib"
     KERNEL_LIBS
@@ -65,4 +73,15 @@ if(EXECUTORCH_BUILD_KERNELS_OPTIMIZED)
     EXPORT ExecuTorchTargets
     DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
+  if(EXECUTORCH_BUILD_SHARED)
+    # Named after what the library provides rather than after the code
+    # generation target that produces it, so the shipped file reads as
+    # libexecutorch_kernels_optimized.so. The target name stays as it is because
+    # a source build already refers to it.
+    set_target_properties(
+      optimized_native_cpu_ops_lib PROPERTIES OUTPUT_NAME
+                                              executorch_kernels_optimized
+    )
+    executorch_target_soname_policy(optimized_native_cpu_ops_lib)
+  endif()
 endif()

--- a/devtools/bundled_program/CMakeLists.txt
+++ b/devtools/bundled_program/CMakeLists.txt
@@ -40,7 +40,14 @@ add_library(
   bundled_program ${_schema_outputs}
                   ${CMAKE_CURRENT_SOURCE_DIR}/bundled_program.cpp
 )
-target_link_libraries(bundled_program PUBLIC executorch)
+# The `executorch` target forces whole-archive of itself, which would duplicate
+# the primitive operator registrations already inside libexecutorch.so and abort
+# at load. Resolve them from the shared runtime instead when it is built.
+if(EXECUTORCH_BUILD_SHARED)
+  target_link_libraries(bundled_program PUBLIC executorch_shared)
+else()
+  target_link_libraries(bundled_program PUBLIC executorch)
+endif()
 target_include_directories(
   bundled_program
   PUBLIC

--- a/devtools/etdump/CMakeLists.txt
+++ b/devtools/etdump/CMakeLists.txt
@@ -39,8 +39,19 @@ add_custom_command(
   COMMENT "Generating etdump headers"
 )
 
+# The profiler is reachable from both the Python extension and a standalone C++
+# application, and each one linking it statically would keep its own tracing
+# state. Build it shared for the wheel, where both are loaded into one process,
+# and keep it static everywhere else so no other build changes.
+if(EXECUTORCH_BUILD_SHARED)
+  set(_etdump_library_type SHARED)
+else()
+  set(_etdump_library_type STATIC)
+endif()
+
 add_library(
   etdump
+  ${_etdump_library_type}
   ${_schema_outputs}
   ${CMAKE_CURRENT_SOURCE_DIR}/etdump_flatcc.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/emitter.cpp
@@ -49,11 +60,27 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/data_sinks/file_data_sink.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_sinks/file_data_sink.h
 )
-target_link_libraries(
-  etdump
-  PUBLIC flatccrt
-  PRIVATE executorch
-)
+# As with bundled_program, avoid the whole-archive of the `executorch` target so
+# the primitive operator registrations are not duplicated alongside the copy
+# already inside libexecutorch.so.
+if(EXECUTORCH_BUILD_SHARED)
+  # Private, not public: this library bundles the flatbuffer runtime rather than
+  # depending on it, and the wheel does not ship flatccrt, so exposing it would
+  # name something a consumer cannot link. Scoped to the shared build so a build
+  # that does not opt in keeps the parent's public dependency.
+  target_link_libraries(etdump PRIVATE flatccrt executorch_shared)
+else()
+  target_link_libraries(etdump PUBLIC flatccrt)
+  target_link_libraries(etdump PRIVATE executorch)
+endif()
+if(EXECUTORCH_BUILD_SHARED)
+  set_target_properties(etdump PROPERTIES OUTPUT_NAME executorch_etdump)
+  executorch_target_soname_policy(etdump)
+  # Ships beside libexecutorch.so in the wheel's lib/ directory, and needs it,
+  # so it has to be able to find it from wherever the package is installed.
+  executorch_target_shipped_runtime_path(etdump)
+endif()
+
 target_include_directories(
   etdump
   PUBLIC ${DEVTOOLS_INCLUDE_DIR}

--- a/docs/source/using-executorch-cpp.md
+++ b/docs/source/using-executorch-cpp.md
@@ -110,6 +110,8 @@ reported while CMake configures, rather than failing later at link time.
 | `executorch::kernels_optimized` | CPU operator kernels. Needed for any operator a delegate does not claim. |
 | `executorch::kernels_quantized` | quantized operator kernels, for a quantized model. |
 | `executorch::backend_xnnpack` | the XNNPACK delegate. |
+| `executorch::backend_cuda` | the CUDA delegate, in a CUDA wheel. |
+| `executorch::extension_cuda` | the CUDA stream helper, in a CUDA wheel. Its header includes `cuda_runtime.h`, so a consumer supplies a CUDA toolkit's include directory. |
 | `executorch::threadpool` | the shared thread pool. |
 | `executorch::etdump` | the profiler. |
 

--- a/docs/source/using-executorch-cpp.md
+++ b/docs/source/using-executorch-cpp.md
@@ -40,6 +40,92 @@ Running a model using the low-level runtime APIs allows for a high-degree of con
 
 ## Building with CMake
 
+There are two ways to get the C++ runtime. Linking the prebuilt libraries from the pip
+package needs no source checkout and is the quicker option. Building from source gives
+you every option the project has, and is what you need for a platform the wheel does not
+cover.
+
+### Using the prebuilt libraries from the pip package
+
+On Linux, `pip install executorch` includes prebuilt shared libraries, the public
+headers, and a CMake package, so a C++ application can link the runtime without building
+ExecuTorch itself:
+
+```cmake
+# CMakeLists.txt
+cmake_minimum_required(VERSION 3.28)
+project(my_app CXX)
+
+find_package(executorch REQUIRED COMPONENTS kernels_optimized)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app PRIVATE executorch::runtime
+                                     executorch::kernels_optimized)
+```
+
+Point CMake at the installed package when you configure:
+
+```
+cmake -S . -B build \
+  -DCMAKE_PREFIX_PATH="$(python -c 'import executorch, pathlib; print(pathlib.Path(executorch.__path__[0]) / "share" / "cmake")')"
+cmake --build build
+```
+
+The application uses the same `Module` and `TensorPtr` APIs described above:
+
+```cpp
+// main.cpp
+#include <executorch/extension/module/module.h>
+#include <executorch/extension/tensor/tensor.h>
+
+#include <cstdio>
+#include <vector>
+
+using namespace executorch::extension;
+
+int main() {
+  Module module("model.pte");
+
+  std::vector<float> data(2 * 8, 1.0f);
+  auto input = make_tensor_ptr({2, 8}, data.data());
+
+  const auto result = module.forward(input);
+  if (!result.ok()) {
+    std::printf("forward failed: 0x%x\n", (unsigned)result.error());
+    return 1;
+  }
+  std::printf("ok, %zu outputs\n", result->size());
+  return 0;
+}
+```
+
+#### What each component provides
+
+Ask for the components your model needs. A component the wheel was not built with is
+reported while CMake configures, rather than failing later at link time.
+
+| Component | What it provides |
+| --- | --- |
+| `executorch::runtime` | the program loader and executor. Always present. |
+| `executorch::kernels_optimized` | CPU operator kernels. Needed for any operator a delegate does not claim. |
+| `executorch::backend_xnnpack` | the XNNPACK delegate. |
+| `executorch::threadpool` | the shared thread pool. |
+| `executorch::etdump` | the profiler. |
+
+The runtime on its own loads a program but registers no operators, so a model that is
+not fully delegated needs a kernel component too. Linking a delegate is what registers
+it: a program delegated to XNNPACK fails to load in an application that did not link
+`executorch::backend_xnnpack`.
+
+To require a minimum version, pass it to `find_package`:
+
+```cmake
+find_package(executorch 1.0 REQUIRED)
+```
+
+### Building from source
+
+
 ExecuTorch uses CMake as the primary build system. Inclusion of the module and tensor APIs are controlled by the `EXECUTORCH_BUILD_EXTENSION_MODULE` and `EXECUTORCH_BUILD_EXTENSION_TENSOR` CMake options. As these APIs may not be supported on embedded systems, they are disabled by default when building from source. The low-level API surface is always included. To link, add the `executorch` target as a CMake dependency, along with `executorch_backends`, `executorch_extensions`, and `extension_kernels`, to link all configured backends, extensions, and kernels.
 
 ```

--- a/docs/source/using-executorch-cpp.md
+++ b/docs/source/using-executorch-cpp.md
@@ -108,6 +108,7 @@ reported while CMake configures, rather than failing later at link time.
 | --- | --- |
 | `executorch::runtime` | the program loader and executor. Always present. |
 | `executorch::kernels_optimized` | CPU operator kernels. Needed for any operator a delegate does not claim. |
+| `executorch::kernels_quantized` | quantized operator kernels, for a quantized model. |
 | `executorch::backend_xnnpack` | the XNNPACK delegate. |
 | `executorch::threadpool` | the shared thread pool. |
 | `executorch::etdump` | the profiler. |

--- a/extension/cuda/CMakeLists.txt
+++ b/extension/cuda/CMakeLists.txt
@@ -23,6 +23,21 @@ find_package(CUDAToolkit REQUIRED)
 # copy linked into multiple shared libraries would create multiple thread-locals
 # and silently break the caller-stream handshake.
 add_library(extension_cuda SHARED caller_stream.cpp)
+if(EXECUTORCH_BUILD_SHARED)
+  # Named after what it provides rather than after the target, matching the
+  # other libraries the wheel ships. The target name stays as it is because the
+  # rest of the build already refers to it.
+  set_target_properties(
+    extension_cuda PROPERTIES OUTPUT_NAME executorch_extension_cuda
+  )
+  executorch_target_soname_policy(extension_cuda)
+  # Without this the library can ship with no runtime search path at all, on a
+  # builder where the CUDA runtime resolves from an implicit link directory. The
+  # wheel then adds no relative hop either, because the step that adds one has
+  # nothing to rewrite and returns early, so the library would look correct on
+  # the machine that built it and fail to load anywhere else.
+  executorch_target_shipped_runtime_path(extension_cuda)
+endif()
 target_link_libraries(extension_cuda PUBLIC CUDA::cudart)
 target_include_directories(extension_cuda PUBLIC ${_common_include_directories})
 target_compile_options(

--- a/extension/llm/custom_ops/CMakeLists.txt
+++ b/extension/llm/custom_ops/CMakeLists.txt
@@ -144,19 +144,40 @@ if(EXECUTORCH_BUILD_KERNELS_LLM_AOT)
     set(RPATH "@loader_path/../../pybindings")
   else()
     set(RPATH "$ORIGIN/../../pybindings")
+    if(EXECUTORCH_BUILD_SHARED AND EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
+      # Wheel-specific: this library lands in
+      # <site-packages>/executorch/extension/llm/custom_ops, three levels below
+      # the wheel's lib/. A normal install puts the runtime in
+      # CMAKE_INSTALL_LIBDIR, which this relative path would not reach.
+      string(APPEND RPATH ":$ORIGIN/../../../lib")
+    endif()
   endif()
-  set_target_properties(custom_ops_aot_lib PROPERTIES INSTALL_RPATH ${RPATH})
+  if(EXECUTORCH_BUILD_SHARED)
+    # Also on the built artifact, not only on install. Packaging copies this
+    # library out of the build tree rather than running an install step, so
+    # without this the built file carries whatever the linker recorded. Scoped
+    # to the shared build so a build that does not opt in keeps the parent's
+    # install-only behaviour.
+    set_target_properties(
+      custom_ops_aot_lib PROPERTIES BUILD_RPATH ${RPATH} INSTALL_RPATH ${RPATH}
+    )
+  else()
+    set_target_properties(custom_ops_aot_lib PROPERTIES INSTALL_RPATH ${RPATH})
+  endif()
   if(TARGET portable_lib)
     # If we have portable_lib built, custom_ops_aot_lib gives the ability to use
     # the ops in PyTorch and ExecuTorch through pybind
     target_link_libraries(custom_ops_aot_lib PUBLIC portable_lib)
-  else()
+  elseif(NOT EXECUTORCH_BUILD_SHARED)
     # If no portable_lib, custom_ops_aot_lib still gives the ability to use the
     # ops in PyTorch
     target_link_libraries(
       custom_ops_aot_lib PUBLIC executorch_core kernels_util_all_deps
     )
+  else()
+    target_link_libraries(custom_ops_aot_lib PUBLIC kernels_util_all_deps)
   endif()
+  executorch_target_link_shared_runtime(custom_ops_aot_lib)
 
   target_link_libraries(
     custom_ops_aot_lib PUBLIC cpublas torch extension_tensor

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -123,6 +123,7 @@ if(EXECUTORCH_BUILD_PYBIND)
     _llm_runner PRIVATE extension_llm_runner tokenizers::tokenizers
                         portable_lib ${TORCH_PYTHON_LIBRARY} ${TORCH_LIBRARIES}
   )
+  executorch_target_link_shared_runtime(_llm_runner)
 
   set_target_properties(
     _llm_runner
@@ -137,6 +138,13 @@ if(EXECUTORCH_BUILD_PYBIND)
     )
   else()
     set(RPATH "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib")
+    if(EXECUTORCH_BUILD_SHARED AND EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
+      # Wheel-specific: this module lands in
+      # <site-packages>/executorch/extension/llm/runner, three levels below the
+      # wheel's lib/. A normal install puts the runtime in CMAKE_INSTALL_LIBDIR,
+      # which this relative path would not reach.
+      string(APPEND RPATH ":$ORIGIN/../../../lib")
+    endif()
   endif()
   set_target_properties(
     _llm_runner PROPERTIES BUILD_RPATH "${RPATH}" INSTALL_RPATH "${RPATH}"

--- a/extension/memory_allocator/memory_allocator_utils.h
+++ b/extension/memory_allocator/memory_allocator_utils.h
@@ -16,12 +16,10 @@
 #include <executorch/runtime/core/result.h>
 #include <executorch/runtime/platform/compiler.h>
 
-using executorch::runtime::Error;
-using executorch::runtime::Result;
 namespace executorch::extension::utils {
 
 // Util to get alighment adjusted allocation size
-inline Result<size_t> get_aligned_size(size_t size, size_t alignment) {
+inline runtime::Result<size_t> get_aligned_size(size_t size, size_t alignment) {
   // The minimum alignment that malloc() is guaranteed to provide.
   static constexpr size_t kMallocAlignment = alignof(std::max_align_t);
   if (alignment > kMallocAlignment) {
@@ -31,7 +29,7 @@ inline Result<size_t> get_aligned_size(size_t size, size_t alignment) {
     const size_t extra = alignment - 1;
     if ET_UNLIKELY (extra >= SIZE_MAX - size) {
       ET_LOG(Error, "Malloc size overflow: size=%zu + extra=%zu", size, extra);
-      return Result<size_t>(Error::InvalidArgument);
+      return runtime::Result<size_t>(runtime::Error::InvalidArgument);
     }
     size += extra;
   }

--- a/extension/threadpool/CMakeLists.txt
+++ b/extension/threadpool/CMakeLists.txt
@@ -30,13 +30,38 @@ else()
   set(_threadpool_size_flag "EXECUTORCH_THREADPOOL_USE_PERFORMANCE_CORES")
 endif()
 
+# The thread pool is a process-wide singleton held in a function-local static,
+# so every library that links it statically gets its own copy. Build it shared
+# for the wheel, where several extensions are loaded into one interpreter, and
+# keep it static everywhere else so no other build changes.
+if(EXECUTORCH_BUILD_SHARED)
+  set(_threadpool_library_type SHARED)
+else()
+  set(_threadpool_library_type STATIC)
+endif()
+
 add_library(
-  extension_threadpool threadpool.cpp threadpool_guard.cpp thread_parallel.cpp
-                       cpuinfo_utils.cpp
+  extension_threadpool
+  ${_threadpool_library_type} threadpool.cpp threadpool_guard.cpp
+  thread_parallel.cpp cpuinfo_utils.cpp
 )
-target_link_libraries(
-  extension_threadpool PUBLIC executorch_core cpuinfo pthreadpool
-)
+if(EXECUTORCH_BUILD_SHARED)
+  set_target_properties(
+    extension_threadpool PROPERTIES OUTPUT_NAME executorch_threadpool
+  )
+  executorch_target_soname_policy(extension_threadpool)
+  # Ships beside libexecutorch.so in the wheel's lib/ directory.
+  executorch_target_shipped_runtime_path(extension_threadpool)
+  # cpuinfo and pthreadpool are forced static, so bundle them inside this
+  # library instead of making every consumer supply them.
+  executorch_target_whole_archive(extension_threadpool cpuinfo)
+  executorch_target_whole_archive(extension_threadpool pthreadpool)
+  target_link_libraries(extension_threadpool PUBLIC executorch_shared)
+else()
+  target_link_libraries(
+    extension_threadpool PUBLIC executorch_core cpuinfo pthreadpool
+  )
+endif()
 target_include_directories(
   extension_threadpool PUBLIC ${_common_include_directories}
 )

--- a/extension/training/CMakeLists.txt
+++ b/extension/training/CMakeLists.txt
@@ -49,17 +49,31 @@ target_link_libraries(
 target_compile_options(train_xor PUBLIC ${_common_compile_options})
 
 if(EXECUTORCH_BUILD_PYBIND)
-  # Pybind library.
-  set(_pybind_training_dep_libs ${TORCH_PYTHON_LIBRARY} etdump executorch util
-                                torch extension_training
-  )
+  # Pybind library. When the consolidated shared runtime is built, the runtime
+  # is resolved from it rather than from the whole-archive-forcing static
+  # `executorch` target, so this module shares the one backend registry.
+  if(EXECUTORCH_BUILD_SHARED)
+    set(_pybind_training_dep_libs ${TORCH_PYTHON_LIBRARY} etdump util torch
+                                  extension_training
+    )
+  else()
+    set(_pybind_training_dep_libs ${TORCH_PYTHON_LIBRARY} etdump executorch
+                                  util torch extension_training
+    )
+  endif()
 
   if(EXECUTORCH_BUILD_XNNPACK)
-    # need to explicitly specify XNNPACK and xnnpack-microkernels-prod here
-    # otherwise uses XNNPACK and microkernel-prod symbols from libtorch_cpu
-    list(APPEND _pybind_training_dep_libs xnnpack_backend XNNPACK
-         xnnpack-microkernels-prod
-    )
+    if(EXECUTORCH_BUILD_SHARED)
+      # The delegate bundles XNNPACK and its microkernels, so naming them again
+      # here would ask for a second copy of what that library already provides.
+      list(APPEND _pybind_training_dep_libs xnnpack_backend)
+    else()
+      # need to explicitly specify XNNPACK and xnnpack-microkernels-prod here
+      # otherwise uses XNNPACK and microkernel-prod symbols from libtorch_cpu
+      list(APPEND _pybind_training_dep_libs xnnpack_backend XNNPACK
+           xnnpack-microkernels-prod
+      )
+    endif()
   endif()
 
   pybind11_add_module(
@@ -81,6 +95,38 @@ if(EXECUTORCH_BUILD_PYBIND)
            -fexceptions>
   )
   target_link_libraries(_training_lib PRIVATE ${_pybind_training_dep_libs})
+
+  if(EXECUTORCH_BUILD_SHARED
+     AND EXECUTORCH_BUILD_XNNPACK
+     AND TARGET xnnpack_backend
+  )
+    # The delegate registers itself from a static initializer, so nothing in
+    # this extension references a symbol from it and a normal link can drop it.
+    # Keeping it named on the link line is what makes an XNNPACK-delegated
+    # program usable from here.
+    executorch_target_retain_shared_library(_training_lib xnnpack_backend)
+  endif()
+  executorch_target_link_shared_runtime(_training_lib)
+
+  if(EXECUTORCH_BUILD_SHARED
+     AND NOT APPLE
+     AND EXECUTORCH_BUILD_WHEEL_DO_NOT_USE
+  )
+    # Wheel-specific: this module lands in
+    # <site-packages>/executorch/extension/training/pybindings, three levels
+    # below the wheel's lib/. A normal install puts the runtime in
+    # CMAKE_INSTALL_LIBDIR, which this relative path would not reach. The Torch
+    # path is listed too: this module links Torch directly, and the only other
+    # entry reaching it is the absolute build directory CMake adds, which does
+    # not exist anywhere else.
+    set(_training_lib_rpath
+        "$ORIGIN/../../../lib:$ORIGIN/../../../../torch/lib"
+    )
+    set_target_properties(
+      _training_lib PROPERTIES BUILD_RPATH "${_training_lib_rpath}"
+                               INSTALL_RPATH "${_training_lib_rpath}"
+    )
+  endif()
 
   install(TARGETS _training_lib
           LIBRARY DESTINATION executorch/extension/training/pybindings

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -45,7 +45,11 @@ def install_requirements(use_pytorch_nightly):
 
     # Determine the appropriate PyTorch URL based on CUDA delegate status
     torch_url = determine_torch_url(TORCH_URL_BASE)
-    torchao_url = determine_torch_url(TORCHAO_URL_BASE)
+    # torchao is deliberately NOT given the CUDA suffix. Its CUDA channel publishes x86_64 only, so
+    # asking for a CUDA build makes the pin unsatisfiable on other architectures, and the CUDA build
+    # is not needed: nothing in the wheel links or bundles torchao, which is a quantization-workflow
+    # dependency of the examples and tests.
+    torchao_url = TORCHAO_URL_BASE
 
     # pip packages needed by exir.
     TORCH_PACKAGE = [

--- a/install_utils.py
+++ b/install_utils.py
@@ -142,11 +142,33 @@ def _get_cuda_version():
 
 
 def _extract_cmake_define(args: List[str], name: str) -> Optional[str]:
-    prefix = f"-D{name}="
-    for arg in args:
-        if arg.startswith(prefix):
-            return arg[len(prefix) :]
-    return None
+    """The value CMake would use for -D<name>, which is the last one given.
+
+    Repeating a definition is how a caller overrides an earlier one, and CMake keeps the last, so returning
+    the first would let packaging read one value while the build used another.
+
+    All three spellings CMake accepts are matched, because it treats them identically: -D<name>=<value>,
+    -D<name>:<type>=<value>, and -D followed by <name>=<value> as a separate argument. Matching only the
+    first meant a caller who switched an option off in either of the other two forms was read as leaving it
+    on, so a CPU row could ship a wheel carrying CUDA.
+    """
+    # A bare -D takes its definition from the next argument, so both spellings collapse to one form.
+    definitions = []
+    remaining = iter(args)
+    for arg in remaining:
+        if arg == "-D":
+            definitions.append(next(remaining, ""))
+        elif arg.startswith("-D"):
+            definitions.append(arg[2:])
+
+    # The name may carry a CMake type, as in EXECUTORCH_BUILD_CUDA:BOOL.
+    pattern = re.compile(rf"{re.escape(name)}(?::\w+)?=(.*)", re.DOTALL)
+    value = None
+    for definition in definitions:
+        match = pattern.fullmatch(definition)
+        if match:
+            value = match.group(1)
+    return value
 
 
 def _normalize_cmake_bool(value: Optional[str], default: bool = False) -> bool:

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -167,14 +167,14 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode"
 endif()
 
 add_library(quantized_kernels ${_quantized_kernels__srcs})
-# The thread pool carries the define that switches parallel_for from a serial
-# fallback to the real threaded implementation, so without it quantize,
-# dequantize and choose_qparams run on one core. Guarded because a bare metal
-# target builds these kernels without a thread pool at all, where the serial
-# fallback is the only correct choice.
 target_link_libraries(
   quantized_kernels PRIVATE executorch_core kernels_util_all_deps
 )
+# The thread pool carries the define that switches parallel_for from a serial
+# fallback to the real threaded implementation. Without it choose_qparams runs
+# on one core, as does the ARM path in quantize. Guarded because a bare metal
+# target builds these kernels without a thread pool at all, where the serial
+# fallback is the only correct choice.
 if(TARGET extension_threadpool)
   target_link_libraries(quantized_kernels PRIVATE extension_threadpool)
 endif()
@@ -200,4 +200,15 @@ if(EXECUTORCH_BUILD_SHARED)
     executorch_quantized_ops quantized_ops_lib quantized_kernels
     executorch_shared
   )
+  # Named after what the library provides rather than after the target that
+  # produces it, matching the optimized kernels next to it, so the shipped file
+  # reads as libexecutorch_kernels_quantized.so. The target name stays as it is
+  # because a source build already refers to it.
+  set_target_properties(
+    executorch_quantized_ops PROPERTIES OUTPUT_NAME
+                                        executorch_kernels_quantized
+  )
+  # Ships beside libexecutorch.so in the wheel's lib/ directory, so it resolves
+  # the runtime from there rather than from wherever it was built.
+  executorch_target_shipped_runtime_path(executorch_quantized_ops)
 endif()

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -86,6 +86,24 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode"
     gen_custom_ops_aot_lib(
       LIB_NAME "quantized_ops_aot_lib" KERNEL_SOURCES "${_quantized_sources}"
     )
+    # Only when the pybind extension is absent. When it is present, the block
+    # below sets the full runtime path for this target in one place, and setting
+    # it here as well would leave two independent copies of the same logic where
+    # the later one wins.
+    if(EXECUTORCH_BUILD_SHARED
+       AND NOT APPLE
+       AND EXECUTORCH_BUILD_WHEEL_DO_NOT_USE
+       AND NOT TARGET portable_lib
+    )
+      # Wheel-specific: the generated library lands in
+      # <site-packages>/executorch/kernels/quantized, two levels below the
+      # wheel's lib/. A normal install puts the runtime in CMAKE_INSTALL_LIBDIR,
+      # which this relative path would not reach.
+      set_target_properties(
+        quantized_ops_aot_lib PROPERTIES BUILD_RPATH "$ORIGIN/../../lib"
+                                         INSTALL_RPATH "$ORIGIN/../../lib"
+      )
+    endif()
 
     # Register quantized ops to portable_lib, so that they're available via
     # pybindings.
@@ -126,11 +144,19 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode"
       # libraries will look like "@rpath/_portable_lib.cpython-310-darwin.so",
       # so we can add an LC_RPATH entry to look in a directory relative to the
       # installed location of our _portable_lib.so file. To see these LC_*
-      # values, run `otool -l libquantized_ops_lib.dylib`.
+      # values, run `otool -l libquantized_ops_lib.dylib`. "extension", not
+      # "extensions": the plural directory does not exist, so the parent's path
+      # reached nothing and this library could not find the extension it needs.
+      # Fixed on both branches so they cannot disagree. Not cosmetic: the
+      # dependency-closure check fails without it.
       if(APPLE)
-        set(RPATH "@loader_path/../../extensions/pybindings")
+        set(RPATH "@loader_path/../../extension/pybindings")
       else()
-        set(RPATH "$ORIGIN/../../extensions/pybindings")
+        set(RPATH "$ORIGIN/../../extension/pybindings")
+        if(EXECUTORCH_BUILD_SHARED AND EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
+          # Wheel-specific: two levels below the wheel's lib/ directory.
+          string(APPEND RPATH ":$ORIGIN/../../lib")
+        endif()
       endif()
       set_target_properties(
         quantized_ops_aot_lib PROPERTIES BUILD_RPATH ${RPATH} INSTALL_RPATH
@@ -141,9 +167,17 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode"
 endif()
 
 add_library(quantized_kernels ${_quantized_kernels__srcs})
+# The thread pool carries the define that switches parallel_for from a serial
+# fallback to the real threaded implementation, so without it quantize,
+# dequantize and choose_qparams run on one core. Guarded because a bare metal
+# target builds these kernels without a thread pool at all, where the serial
+# fallback is the only correct choice.
 target_link_libraries(
   quantized_kernels PRIVATE executorch_core kernels_util_all_deps
 )
+if(TARGET extension_threadpool)
+  target_link_libraries(quantized_kernels PRIVATE extension_threadpool)
+endif()
 target_compile_options(quantized_kernels PUBLIC ${_common_compile_options})
 # Build a library for _quantized_kernels_srcs
 #

--- a/runtime/core/device_allocator.h
+++ b/runtime/core/device_allocator.h
@@ -92,6 +92,35 @@ class DeviceAllocator {
       etensor::DeviceIndex index) = 0;
 
   /**
+   * Copy data between two buffers on this device type.
+   *
+   * Needed by a program whose activations stay on the device: the caller hands over device memory
+   * and the runtime copies it into the device buffer the memory plan reserved, so neither end is
+   * host memory. Not pure virtual, because an allocator for a device that cannot do this can decline
+   * rather than be forced to implement it.
+   *
+   * @param dst Destination pointer (device memory).
+   * @param dst_index The device index the destination lives on.
+   * @param src Source pointer (device memory).
+   * @param src_index The device index the source lives on.
+   * @param nbytes Number of bytes to copy.
+   * @return Error::Ok on success, or an appropriate error code on failure.
+   */
+  virtual Error copy_device_to_device(
+      void* dst,
+      etensor::DeviceIndex dst_index,
+      const void* src,
+      etensor::DeviceIndex src_index,
+      size_t nbytes) {
+    (void)dst;
+    (void)dst_index;
+    (void)src;
+    (void)src_index;
+    (void)nbytes;
+    return Error::NotSupported;
+  }
+
+  /**
    * Returns the device type this allocator handles.
    */
   virtual etensor::DeviceType device_type() const = 0;

--- a/runtime/core/exec_aten/util/targets.bzl
+++ b/runtime/core/exec_aten/util/targets.bzl
@@ -54,6 +54,7 @@ def define_common_targets():
             exported_deps = [
                 ":tensor_dimension_limit",
                 "//executorch/runtime/core:core",
+                "//executorch/runtime/core:device_allocator",
                 "//executorch/runtime/core/portable_type/c10/c10:c10",
             ] + [
                 "//executorch/runtime/core/exec_aten:lib" + aten_suffix,

--- a/runtime/core/exec_aten/util/tensor_dimension_limit.h
+++ b/runtime/core/exec_aten/util/tensor_dimension_limit.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace executorch::runtime {
 /**
  * The expected output size may not be the existing size of any inputs and

--- a/runtime/core/exec_aten/util/tensor_util.h
+++ b/runtime/core/exec_aten/util/tensor_util.h
@@ -20,6 +20,7 @@
 
 #include <c10/util/irange.h>
 #include <executorch/runtime/core/array_ref.h>
+#include <executorch/runtime/core/device_allocator.h>
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
@@ -1166,6 +1167,61 @@ ET_NODISCARD Error share_tensor_data(
 ET_NODISCARD Error copy_tensor_data(
     const executorch::aten::Tensor& t_dst,
     const executorch::aten::Tensor& t_src);
+
+/**
+ * Copy nbytes between two buffers, each of which may live on the host or on a device.
+ *
+ * A plain memcpy is only correct when both ends are host memory. A program exported to keep
+ * activations on an accelerator plans its inputs into device memory, so copying an input into one
+ * has to go through that device's allocator. Kept as one helper because both the portable and the
+ * ATen tensor implementations need it and neither may name a specific accelerator.
+ *
+ * The device is taken as the runtime's own type rather than the tensor library's, because in ATen
+ * mode a tensor reports a c10::DeviceType while the allocator registry is keyed on the runtime's
+ * enum, and the two are distinct types.
+ */
+ET_NODISCARD inline Error copy_between_devices(
+    void* dst,
+    etensor::DeviceType dst_type,
+    etensor::DeviceIndex dst_index,
+    const void* src,
+    etensor::DeviceType src_type,
+    etensor::DeviceIndex src_index,
+    size_t nbytes) {
+  const bool dst_is_cpu = dst_type == etensor::DeviceType::CPU;
+  const bool src_is_cpu = src_type == etensor::DeviceType::CPU;
+  if (dst_is_cpu && src_is_cpu) {
+    std::memcpy(dst, src, nbytes);
+    return Error::Ok;
+  }
+
+  // Whichever end is not the host owns the copy, and the allocator is reached through the registry a
+  // backend populates, so this stays free of any accelerator dependency.
+  const auto type = dst_is_cpu ? src_type : dst_type;
+  auto* allocator = get_device_allocator(type);
+  ET_CHECK_OR_RETURN_ERROR(
+      allocator != nullptr,
+      NotFound,
+      "No allocator is registered for device type %d, so a copy involving its memory cannot be "
+      "performed. The backend that owns that device registers one when it is linked in.",
+      static_cast<int>(type));
+
+  if (src_is_cpu) {
+    return allocator->copy_host_to_device(dst, src, nbytes, dst_index);
+  }
+  if (dst_is_cpu) {
+    return allocator->copy_device_to_host(dst, src, nbytes, src_index);
+  }
+  // Neither end is the host. One allocator cannot own memory belonging to a different device type,
+  // so that combination is refused rather than handed to whichever type was looked up.
+  ET_CHECK_OR_RETURN_ERROR(
+      src_type == dst_type,
+      NotSupported,
+      "Copying directly between device types %d and %d is not supported; route through the host.",
+      static_cast<int>(src_type),
+      static_cast<int>(dst_type));
+  return allocator->copy_device_to_device(dst, dst_index, src, src_index, nbytes);
+}
 
 /**
  * Set the data_ptr of t to buffer.

--- a/runtime/core/exec_aten/util/tensor_util_aten.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_aten.cpp
@@ -20,6 +20,27 @@ namespace ET_RUNTIME_NAMESPACE {
  * at::Tensor (instead of executorch::aten::Tensor) to make sure it fails at
  * compile time if built incorrectly.
  */
+
+namespace {
+
+// An ATen tensor reports a c10::DeviceType, while the allocator registry is keyed on the runtime's
+// own enum. Translated here rather than in the shared helper, because only this variant sees c10.
+etensor::DeviceType to_runtime_device_type(c10::DeviceType type) {
+  switch (type) {
+    case c10::DeviceType::CPU:
+      return etensor::DeviceType::CPU;
+    case c10::DeviceType::CUDA:
+      return etensor::DeviceType::CUDA;
+    default:
+      ET_CHECK_MSG(
+          false,
+          "Device type %d is not supported by the ExecuTorch runtime",
+          static_cast<int>(type));
+  }
+}
+
+} // namespace
+
 Error get_dim_order(
     const at::Tensor& tensor,
     executorch::aten::DimOrderType* out_dim_order,
@@ -177,7 +198,14 @@ Error copy_tensor_data(const at::Tensor& t_dst, const at::Tensor& t_src) {
         t_src.nbytes());
     // Copy the source data to the preallocated memory of the destination, which
     // must be the same size as the source.
-    std::memcpy(dst_data_ptr, t_src.const_data_ptr(), t_src.nbytes());
+    return copy_between_devices(
+        dst_data_ptr,
+        to_runtime_device_type(t_dst.device().type()),
+        static_cast<etensor::DeviceIndex>(t_dst.device().index()),
+        t_src.const_data_ptr(),
+        to_runtime_device_type(t_src.device().type()),
+        static_cast<etensor::DeviceIndex>(t_src.device().index()),
+        t_src.nbytes());
   }
 
   return Error::Ok;

--- a/runtime/core/exec_aten/util/tensor_util_portable.cpp
+++ b/runtime/core/exec_aten/util/tensor_util_portable.cpp
@@ -178,8 +178,14 @@ Error copy_tensor_data(
         "t_dst.nbytes() %zu != t_src.nbytes(). %zu",
         t_dst.nbytes(),
         t_src.nbytes());
-    std::memcpy(
-        t_dst.mutable_data_ptr(), t_src.const_data_ptr(), t_src.nbytes());
+    return copy_between_devices(
+        t_dst.mutable_data_ptr(),
+        t_dst.device().type(),
+        t_dst.device().index(),
+        t_src.const_data_ptr(),
+        t_src.device().type(),
+        t_src.device().index(),
+        t_src.nbytes());
   }
   return Error::Ok;
 }

--- a/runtime/core/exec_aten/util/test/CMakeLists.txt
+++ b/runtime/core/exec_aten/util/test/CMakeLists.txt
@@ -20,7 +20,7 @@ set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../..)
 include(${EXECUTORCH_ROOT}/tools/cmake/Test.cmake)
 
 set(_test_srcs
-    dim_order_util_test.cpp operator_impl_example_test.cpp
+    device_copy_test.cpp dim_order_util_test.cpp operator_impl_example_test.cpp
     scalar_type_util_test.cpp tensor_shape_to_c_string_test.cpp
     tensor_util_test.cpp
 )

--- a/runtime/core/exec_aten/util/test/device_copy_test.cpp
+++ b/runtime/core/exec_aten/util/test/device_copy_test.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/runtime/core/device_allocator.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/exec_aten/util/tensor_util.h>
+#include <executorch/runtime/core/test/mock_cuda_allocator.h>
+#include <executorch/runtime/platform/runtime.h>
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+using executorch::aten::DeviceType;
+using executorch::runtime::Error;
+using executorch::runtime::internal::copy_between_devices;
+using executorch::runtime::testing::MockCudaAllocator;
+
+// Copying into memory a program planned on an accelerator has to go through that device's allocator.
+// A plain memcpy into a device pointer is undefined, and it crashed a program exported to keep its
+// activations on the device, which is the case these tests cover.
+class DeviceCopyTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    executorch::runtime::runtime_init();
+    // Registered once for the whole suite, because the registry refuses a second allocator for a
+    // device type and holds the pointer for the lifetime of the process.
+    static MockCudaAllocator allocator;
+    allocator_ = &allocator;
+    executorch::runtime::register_device_allocator(allocator_);
+  }
+
+  void SetUp() override {
+    allocator_->reset();
+  }
+
+  static MockCudaAllocator* allocator_;
+  static constexpr DeviceType kHost = DeviceType::CPU;
+  static constexpr DeviceType kDevice = DeviceType::CUDA;
+  std::array<uint8_t, 8> source_{1, 2, 3, 4, 5, 6, 7, 8};
+  std::array<uint8_t, 8> destination_{};
+};
+
+MockCudaAllocator* DeviceCopyTest::allocator_ = nullptr;
+
+TEST_F(DeviceCopyTest, HostToHostDoesNotReachTheAllocator) {
+  ASSERT_EQ(
+      copy_between_devices(
+          destination_.data(), kHost, 0, source_.data(), kHost, 0, source_.size()),
+      Error::Ok);
+  EXPECT_EQ(destination_, source_);
+  // A host copy must not depend on a device being registered at all.
+  EXPECT_EQ(allocator_->h2d_count_, 0);
+  EXPECT_EQ(allocator_->d2h_count_, 0);
+  EXPECT_EQ(allocator_->d2d_count_, 0);
+}
+
+TEST_F(DeviceCopyTest, HostToDeviceUsesTheAllocator) {
+  ASSERT_EQ(
+      copy_between_devices(
+          destination_.data(), kDevice, 0, source_.data(), kHost, 0, source_.size()),
+      Error::Ok);
+  EXPECT_EQ(allocator_->h2d_count_, 1);
+  EXPECT_EQ(allocator_->last_h2d_size_, source_.size());
+  EXPECT_EQ(destination_, source_);
+}
+
+TEST_F(DeviceCopyTest, DeviceToHostUsesTheAllocator) {
+  ASSERT_EQ(
+      copy_between_devices(
+          destination_.data(), kHost, 0, source_.data(), kDevice, 0, source_.size()),
+      Error::Ok);
+  EXPECT_EQ(allocator_->d2h_count_, 1);
+  EXPECT_EQ(destination_, source_);
+}
+
+TEST_F(DeviceCopyTest, DeviceToDeviceUsesTheAllocator) {
+  // The case a program with device activations actually needs: the caller hands over device memory
+  // and the runtime fills the device buffer the memory plan reserved, so neither end is host memory.
+  ASSERT_EQ(
+      copy_between_devices(
+          destination_.data(), kDevice, 0, source_.data(), kDevice, 0, source_.size()),
+      Error::Ok);
+  EXPECT_EQ(allocator_->d2d_count_, 1);
+  EXPECT_EQ(allocator_->h2d_count_, 0);
+  EXPECT_EQ(destination_, source_);
+}
+
+TEST_F(DeviceCopyTest, ZeroBytesIsAccepted) {
+  // A tensor with a zero-sized dimension reaches here with nothing to copy, and that is not an
+  // error. It is worth pinning because the device path is easy to write in a way that rejects it.
+  ASSERT_EQ(
+      copy_between_devices(
+          destination_.data(), kDevice, 0, source_.data(), kHost, 0, 0),
+      Error::Ok);
+  EXPECT_EQ(allocator_->h2d_count_, 1);
+  EXPECT_EQ(allocator_->last_h2d_size_, 0u);
+}

--- a/runtime/core/exec_aten/util/test/targets.bzl
+++ b/runtime/core/exec_aten/util/test/targets.bzl
@@ -51,6 +51,16 @@ def define_common_targets():
         )
 
     runtime.cxx_test(
+        name = "device_copy_test",
+        srcs = ["device_copy_test.cpp"],
+        deps = [
+            "//executorch/runtime/core:device_allocator",
+            "//executorch/runtime/core/exec_aten/util:tensor_util",
+            "//executorch/runtime/core/test:mock_cuda_allocator",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "tensor_shape_to_c_string_test",
         srcs = ["tensor_shape_to_c_string_test.cpp"],
         deps = [

--- a/runtime/core/test/mock_cuda_allocator.h
+++ b/runtime/core/test/mock_cuda_allocator.h
@@ -80,6 +80,22 @@ class MockCudaAllocator : public DeviceAllocator {
     return Error::Ok;
   }
 
+  Error copy_device_to_device(
+      void* dst,
+      etensor::DeviceIndex dst_index,
+      const void* src,
+      etensor::DeviceIndex src_index,
+      size_t nbytes) override {
+    std::memcpy(dst, src, nbytes);
+    d2d_count_++;
+    last_d2d_dst_ = dst;
+    last_d2d_src_ = src;
+    last_d2d_size_ = nbytes;
+    last_d2d_dst_index_ = dst_index;
+    last_d2d_src_index_ = src_index;
+    return Error::Ok;
+  }
+
   etensor::DeviceType device_type() const override {
     return etensor::DeviceType::CUDA;
   }
@@ -102,6 +118,7 @@ class MockCudaAllocator : public DeviceAllocator {
     deallocate_count_ = 0;
     h2d_count_ = 0;
     d2h_count_ = 0;
+    d2d_count_ = 0;
     last_allocate_size_ = 0;
     last_allocate_index_ = -1;
     last_allocate_ptr_ = nullptr;
@@ -139,6 +156,14 @@ class MockCudaAllocator : public DeviceAllocator {
   const void* last_d2h_src_ = nullptr;
   size_t last_d2h_size_ = 0;
   etensor::DeviceIndex last_d2h_index_ = -1;
+
+  // Device-to-device copy tracking
+  int d2d_count_ = 0;
+  void* last_d2d_dst_ = nullptr;
+  const void* last_d2d_src_ = nullptr;
+  size_t last_d2d_size_ = 0;
+  etensor::DeviceIndex last_d2d_dst_index_ = -1;
+  etensor::DeviceIndex last_d2d_src_index_ = -1;
 };
 
 } // namespace testing

--- a/runtime/executor/platform_memory_allocator.h
+++ b/runtime/executor/platform_memory_allocator.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 
 #include <c10/util/safe_numerics.h>
+#include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/memory_allocator.h>
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/platform.h>

--- a/setup.py
+++ b/setup.py
@@ -1261,6 +1261,16 @@ class CustomBuild(build):
             if cmake_cache.is_enabled("EXECUTORCH_BUILD_MLX"):
                 cmake_build_args += ["--target", "mlxdelegate"]
 
+            # Named explicitly because nothing else links it. The other shipped
+            # libraries are built as dependencies of the Python extension, but a C++
+            # application is the only consumer of this one, so without naming it the
+            # target is generated and never built, and packaging then looks for a file
+            # that does not exist.
+            if cmake_cache.is_enabled("EXECUTORCH_BUILD_SHARED") and (
+                cmake_cache.is_enabled("EXECUTORCH_BUILD_KERNELS_QUANTIZED")
+            ):
+                cmake_build_args += ["--target", "executorch_quantized_ops"]
+
             if cmake_cache.is_enabled("EXECUTORCH_BUILD_KERNELS_LLM_AOT"):
                 cmake_build_args += ["--target", "custom_ops_aot_lib"]
                 cmake_build_args += ["--target", "quantized_ops_aot_lib"]
@@ -1376,6 +1386,19 @@ setup(
                     dependent_cmake_flags=[
                         "EXECUTORCH_BUILD_SHARED",
                         "EXECUTORCH_BUILD_KERNELS_OPTIMIZED",
+                    ],
+                ),
+                # The quantized kernels, as their own library rather than code
+                # fused into the AOT-only extension beside the Python bindings.
+                # A C++ application running a quantized model could not link
+                # them before.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/kernels/quantized/",
+                    src_name="libexecutorch_kernels_quantized.so",
+                    dst="executorch/lib/libexecutorch_kernels_quantized.so",
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_KERNELS_QUANTIZED",
                     ],
                 ),
                 # Install the XNNPACK delegate beside them, so a process has one

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,39 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
 )
 
+# Headers swept in by a directory copy that a consumer of the wheel cannot use, because each needs
+# something the wheel does not carry. Publishing one is worse than leaving it out: the failure arrives in
+# someone else's project rather than here.
+#
+# Matched on the path ending, not the bare file name. Two different headers here share the name
+# tensor_util.h, one a widely included utility and one a test helper, so a name match either kept the test
+# helper or removed the utility everything needs.
+#
+# Only headers that nothing else the wheel installs includes belong here. A header other shipped headers
+# pull in must keep shipping even when it cannot be compiled on its own.
+_UNSHIPPABLE_HEADERS = frozenset(
+    {
+        # Needs a header generated when the schema is compiled, which in turn needs the FlatBuffers C++
+        # headers. Those are a third-party library this wheel does not vendor.
+        "runtime/executor/tensor_parser.h",
+        # A test helper, needing a test framework the wheel does not ship.
+        "runtime/core/testing_util/error_matchers.h",
+        # Reads processor details through cpuinfo, whose headers the wheel does not publish.
+        "extension/threadpool/cpuinfo_utils.h",
+        # Holds a pthreadpool member by value, so it needs that library's header, which the wheel does not
+        # publish either. The component it belongs to is a link dependency the runtime carries, not
+        # something a consumer includes.
+        "extension/threadpool/threadpool.h",
+        # Declares CPUCachingAllocator, whose implementation is in a component no shipped library links,
+        # so including it compiles and then fails at link time with an undefined reference.
+        "extension/memory_allocator/cpu_caching_malloc_allocator.h",
+        # Declares BundledModule, which is built only for the Python bindings, so its implementation is in
+        # the Python extension. A C++ application cannot link that, and building the source instead needs
+        # bundled-program headers the wheel does not publish.
+        "extension/module/bundled_module.h",
+    }
+)
+
 try:
     from tools.cmake.cmake_cache import CMakeCache
 except ImportError:
@@ -822,10 +855,21 @@ class CustomBuildPy(build_py):
                     "tools/cmake/executorch-wheel-config.cmake",
                     "share/cmake/executorch-config.cmake",
                 ),
+                # And again where CMake looks when a consumer points CMAKE_PREFIX_PATH at the
+                # package root, which is the ordinary way to use an installed package. CMake
+                # searches <prefix>/lib/cmake/<name>, not <prefix>/share/cmake directly, so
+                # without this copy the root is not a usable prefix and a consumer needs a
+                # path that names this project's layout. The first location stays because the
+                # existing contract uses it.
+                (
+                    "tools/cmake/executorch-wheel-config.cmake",
+                    "lib/cmake/executorch/executorch-config.cmake",
+                ),
             ]
-            # Copy all the necessary headers into include/executorch/ so that they can
-            # be found in the pip package. This is the subset of headers that are
-            # essential for building custom ops extensions.
+            # The headers the package installs. Two audiences now: a custom-operator
+            # build, which needs the kernel and tensor helpers, and a C++ application
+            # using the shipped libraries as an SDK, which needs the documented entry
+            # points as well.
             # TODO: Use cmake to gather the headers instead of hard-coding them here.
             # For example:
             # https://discourse.cmake.org/t/installing-headers-the-modern-way-regurgitated-and-revisited/3238/3
@@ -838,9 +882,33 @@ class CustomBuildPy(build_py):
                 "extension/kernel_util/",
                 "extension/tensor/",
                 "extension/threadpool/",
+                # Module is how the documentation tells a C++ application to load and
+                # run a program. Without it the package ships the libraries to do that
+                # and no way to call them, which the C++ consumer check catches.
+                "extension/module/",
+                # Module's constructors take unique_ptr to the runtime's allocator
+                # and loader bases, whose headers already ship. These supply the
+                # concrete subclasses a caller has to construct to pass one, such as
+                # MallocMemoryAllocator and FileDataLoader.
+                "extension/memory_allocator/",
+                "extension/data_loader/",
+                # ETDump, whose library the package ships as a component. A profiler
+                # that cannot be included is a library nobody can call.
+                #
+                # The whole directory except the filter, which includes a regular
+                # expression library the wheel does not carry and whose implementation
+                # is not in the shipped library either. Publishing a header that cannot
+                # be included is worse than not publishing it, because the failure
+                # arrives at compile time in someone else's project.
+                "devtools/etdump/etdump_flatcc.h",
+                "devtools/etdump/emitter.h",
+                "devtools/etdump/utils.h",
+                "devtools/etdump/data_sinks/",
             ]:
-                src_list = Path(include_dir).rglob("*.h")
-                for src in src_list:
+                # A directory entry publishes everything under it, and a file entry publishes
+                # just that file. Some directories hold headers a consumer cannot compile
+                # against, so those are named individually rather than swept in.
+                for src in _headers_to_install(Path(include_dir)):
                     src_to_dst.append(
                         (str(src), os.path.join("include/executorch", str(src)))
                     )
@@ -877,6 +945,93 @@ class CustomBuildPy(build_py):
                     dst_file = os.path.join(dst_dir, rel_path)
                     self.mkpath(os.path.dirname(dst_file))
                     self.copy_file(src_file, dst_file, preserve_mode=False)
+
+        if not _is_minimal_build():
+            self._write_cmake_version_file(dst_root)
+
+    def _write_cmake_version_file(self, dst_root: str) -> None:
+        """Write the CMake package version file, so `find_package(executorch 1.2)` works.
+
+        Generated rather than copied, because the version is only known here:
+        version.txt gives the base and BUILD_VERSION overrides it for a nightly. A
+        checked-in file would go stale the first time either changed.
+        """
+        template = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "tools",
+            "cmake",
+            "executorch-wheel-config-version.cmake.in",
+        )
+        with open(template) as handle:
+            contents = handle.read()
+        # Only the numeric release part. A Python version can carry a local segment
+        # such as "1.5.0+cpu" or a development suffix, and `find_package(executorch
+        # 1.5.0+cpu)` is rejected by CMake as an invalid argument, so a consumer could
+        # not name the version this file reports. Strip to the dotted numbers CMake
+        # can compare, which is what a consumer asks for in practice.
+        # Two variables with different jobs. CMake compares PACKAGE_VERSION, so it has to be the
+        # numeric release and nothing else. EXECUTORCH_BUILD_VERSION is documented as the full
+        # version, which is what a consumer pinning an exact build compares against, so filling it
+        # from the numeric part would make that comparison pass against a different wheel.
+        build_version = Version.string()
+        cmake_version = re.match(r"\d+(?:\.\d+)*", build_version)
+        if not cmake_version:
+            # A version file claiming 0 would satisfy every version request, which is worse than
+            # not building at all.
+            raise RuntimeError(
+                f"cannot derive a numeric CMake version from {build_version!r}; the version file "
+                "would claim 0 and satisfy every version request"
+            )
+        contents = contents.replace("@EXECUTORCH_VERSION@", cmake_version.group(0))
+        contents = contents.replace("@EXECUTORCH_BUILD_VERSION@", build_version)
+        # CMake only reads a version file that sits beside the configuration file it found, so this
+        # goes to both locations the configuration is installed to. Writing it to one would leave a
+        # version request silently unchecked when the other location was used.
+        for destination in (
+            os.path.join(dst_root, "share", "cmake", "executorch-config-version.cmake"),
+            os.path.join(
+                dst_root,
+                "lib",
+                "cmake",
+                "executorch",
+                "executorch-config-version.cmake",
+            ),
+        ):
+            self.mkpath(os.path.dirname(destination))
+            with open(destination, "w") as handle:
+                handle.write(contents)
+
+
+def _headers_to_install(entry: Path):
+    """The headers a copy list entry publishes, skipping any a consumer could not or should not use.
+
+    A directory entry publishes everything under it, and a file entry publishes just that file. A header a
+    consumer cannot compile is worse than an absent one, because the failure lands in their project rather
+    than here, and the directory entries sweep in a few of those.
+
+    Test directories are skipped as a whole rather than by name. They hold mocks and stubs for this
+    project's own tests, nothing the wheel installs includes them, and a consumer linking a mock allocator
+    or a stub platform would get behaviour no release intends. Matched on any part starting with "test", so
+    a directory named testing_util counts too, which a plain equality check missed.
+    """
+    candidates = entry.rglob("*.h") if entry.is_dir() else [entry]
+    return [
+        src
+        for src in candidates
+        if not _is_unshippable_header(src)
+        and not any(part.startswith("test") for part in src.parts[:-1])
+    ]
+
+
+def _is_unshippable_header(src: Path) -> bool:
+    """Whether a header is on the list of ones a consumer of the wheel could not compile.
+
+    Compared on the path ending rather than the file name. Two headers here are both called
+    tensor_util.h, one a utility that many shipped headers include and one a test helper, so matching the
+    bare name either kept the helper or removed the utility everything needs.
+    """
+    posix = src.as_posix()
+    return any(posix.endswith(entry) for entry in _UNSHIPPABLE_HEADERS)
 
 
 class Buck2EnvironmentFixer(contextlib.AbstractContextManager):

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,13 @@ def _base_dependencies() -> List[str]:
         "packaging",
         "pandas>=2.2.2; python_version >= '3.10'",
         "parameterized",
+        # backends/qualcomm/__init__.py cannot be imported from a clean install
+        # without both of these. It reads the CPU vendor to disable an mkldnn path on
+        # AMD, and the module it imports first does a module-scope `import requests`,
+        # so declaring only the cpuinfo half leaves the import failing on the line
+        # before.
+        "py-cpuinfo",
+        "requests",
         "pytorch-tokenizers",
         "pyyaml",
         "ruamel.yaml",
@@ -665,6 +672,8 @@ class InstallerBuildExt(build_ext):
         # Copy the file.
         self.copy_file(os.fspath(src_file), os.fspath(dst_file))
 
+        _strip_absolute_runtime_paths(dst_file)
+
         # Ensure that the destination file is writable, even if the source was
         # not. build_py does this by passing preserve_mode=False to copy_file,
         # but that would clobber the X bit on any executables. TODO(dbort): This
@@ -672,6 +681,74 @@ class InstallerBuildExt(build_ext):
         if not os.access(src_file, os.W_OK):
             # Make the file writable. This should respect the umask.
             os.chmod(src_file, os.stat(src_file).st_mode | 0o222)
+
+
+def _strip_absolute_runtime_paths(library: Path) -> None:
+    """Remove unusable runtime search paths from a library the wheel ships.
+
+    These libraries are copied out of the build tree rather than installed, so they
+    still carry every directory the linker recorded while resolving their
+    dependencies. Two kinds of entry are removed:
+
+    - a directory inside this build, which names the machine that produced the
+      wheel and cannot exist for a user
+    - an empty entry, which the loader reads as the process working directory
+
+    Other absolute entries are kept. The Python extensions link torch and resolve it
+    through the directory the linker recorded, so dropping that would stop them
+    importing in an environment where torch is not beside them.
+
+    Best effort: a build without patchelf still produces a working wheel, with the
+    paths left in place. The tool cannot be guaranteed on PATH (the pip package does
+    not reliably provide a binary inside a build venv), so failing the build here
+    would break building from source on a machine that simply lacks it.
+
+    What must not happen is both this and its check going quiet together, which is how
+    a wheel carrying build-machine directories could ship unnoticed. So the check in
+    the release tests treats a missing patchelf as a failure rather than a skip: the
+    wheel-build environment has it, and that is where the guarantee belongs.
+    """
+    if library.suffix != ".so" and ".so." not in library.name:
+        return
+    patchelf = shutil.which("patchelf")
+    if patchelf is None:
+        return
+    result = subprocess.run(
+        [patchelf, "--print-rpath", os.fspath(library)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return
+    original = result.stdout.strip()
+    if not original:
+        # No runtime search path at all, which is nothing to clean. patchelf prints
+        # the same empty string for an absent tag and for one holding a single empty
+        # entry, so there is nothing to distinguish here and nothing to do either way.
+        return
+
+    def keep(entry: str) -> bool:
+        if not entry:
+            # The loader reads an empty entry as the process working directory.
+            return False
+        if not entry.startswith("/"):
+            return True
+        # Absolute, so decide by what it points at. A directory inside this build
+        # cannot exist for a user. Anything else absolute is a dependency the
+        # environment provides, such as torch's own lib directory, which is how
+        # these extensions resolve torch at all.
+        return not any(
+            marker in entry for marker in ("/pip-out/", "/cmake-out", "/build/lib.")
+        )
+
+    rewritten = ":".join(entry for entry in original.split(":") if keep(entry))
+    if rewritten == original:
+        return
+    subprocess.run(
+        [patchelf, "--set-rpath", rewritten, os.fspath(library)],
+        check=True,
+    )
 
 
 class CustomBuildPy(build_py):
@@ -1089,6 +1166,74 @@ setup(
             []
             if _is_minimal_build()
             else [
+                # Install the shared runtime the Python extension links, rather
+                # than having the extension contain its own copy. Named without a
+                # version, so a consumer's find_library(executorch) resolves it: that
+                # matches libexecutorch.so and not libexecutorch.so.1. A version is
+                # only useful where something upgrades the library independently of
+                # what links it, which never happens inside a wheel.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/",
+                    src_name="libexecutorch.so",
+                    dst="executorch/lib/libexecutorch.so",
+                    dependent_cmake_flags=["EXECUTORCH_BUILD_SHARED"],
+                ),
+                # Install the profiler next to it, as its own library rather than
+                # code fused into the Python extension, so a process has one copy of
+                # it however many consumers load.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/devtools/etdump/",
+                    src_name="libexecutorch_etdump.so",
+                    dst="executorch/lib/libexecutorch_etdump.so",
+                    # Not gated on EXECUTORCH_BUILD_DEVTOOLS. The shared build adds
+                    # the devtools subdirectory itself, so the library exists
+                    # whenever the shared build does. The Python extension carries a
+                    # hard dependency on it, so requiring the option here left a
+                    # wheel whose extension could not load at all.
+                    dependent_cmake_flags=["EXECUTORCH_BUILD_SHARED"],
+                ),
+                # Install the shared thread pool next to it. It is a separate
+                # library so that a process has one pool rather than one per
+                # component that uses it.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/extension/threadpool/",
+                    src_name="libexecutorch_threadpool.so",
+                    dst="executorch/lib/libexecutorch_threadpool.so",
+                    # The target only exists when both of its dependencies are
+                    # enabled, so packaging has to require them too or a shared
+                    # build with either turned off looks for a file that was
+                    # never built.
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_PTHREADPOOL",
+                        "EXECUTORCH_BUILD_CPUINFO",
+                    ],
+                ),
+                # Install the merged CPU kernels beside them, so the operators are
+                # registered once per process rather than once per component.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/configurations/",
+                    src_name="libexecutorch_kernels_optimized.so",
+                    dst="executorch/lib/libexecutorch_kernels_optimized.so",
+                    # The target is only created when the optimized kernels are
+                    # enabled, so packaging has to require that too rather than
+                    # looking for a file a shared build may never have produced.
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_KERNELS_OPTIMIZED",
+                    ],
+                ),
+                # Install the XNNPACK delegate beside them, so a process has one
+                # copy of it instead of one per component that uses it.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/backends/xnnpack/",
+                    src_name="libexecutorch_backend_xnnpack.so",
+                    dst="executorch/lib/libexecutorch_backend_xnnpack.so",
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_XNNPACK",
+                    ],
+                ),
                 # Install the prebuilt pybindings extension wrapper for the runtime,
                 # portable kernels, and a selection of backends. This lets users
                 # load and execute .pte files from python.

--- a/setup.py
+++ b/setup.py
@@ -54,13 +54,14 @@ import importlib.util
 import logging
 import os
 import re
+import shlex
 import shutil
 import site
 import subprocess
 import sys
 from distutils import log  # type: ignore[import-not-found]
 from distutils.sysconfig import get_python_lib  # type: ignore[import-not-found]
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import List, Optional
 
 # Clean dynamic import using importlib
@@ -198,6 +199,166 @@ def _minimal_packages() -> List[str]:
             ],
         )
     )
+
+
+# The published project names for the CUDA runtime components a CUDA wheel links but
+# does not bundle, keyed by CUDA major version. Not derivable from a suffix rule: the
+# CUDA 12 wheels carry a "-cu12" suffix while the CUDA 13 ones are published under
+# unsuffixed names. A train with no entry here declares nothing rather than guessing a
+# name that may not exist.
+_CUDA_RUNTIME_PACKAGES = {
+    "12": ("nvidia-cuda-runtime-cu12", "nvidia-cublas-cu12", "nvidia-curand-cu12"),
+    "13": ("nvidia-cuda-runtime", "nvidia-cublas", "nvidia-curand"),
+}
+
+# Where each train installs its libraries under site-packages. CUDA 13 collects them in
+# one directory while CUDA 12 gives each component its own, so the search path differs by
+# train and cannot be a single literal.
+_CUDA_LIBRARY_DIRECTORIES = {
+    "12": ("nvidia/cuda_runtime/lib", "nvidia/cublas/lib", "nvidia/curand/lib"),
+    "13": ("nvidia/cu13/lib",),
+}
+
+
+def _cuda_train() -> str:
+    """The CUDA major version this wheel is being built for, or "" for a CPU wheel.
+
+    The release row's own field wins when it is set, because a row states the train it
+    targets and that is more authoritative than whichever toolkit happens to sit on the
+    builder. The wheel build exports CU_VERSION; DESIRED_CUDA is the matrix field name.
+
+    Falling back to the installed toolkit matters for every build that is not a release
+    job. The build turns CUDA on by detecting a toolkit, so keying only off the release
+    field produced a wheel that carried the CUDA libraries with no dependency declarations
+    and no way to find the CUDA runtime.
+
+    Returns "" when the build did not enable CUDA, so a CPU wheel declares nothing even on
+    a machine that has a toolkit installed.
+    """
+    raw = os.environ.get("CU_VERSION") or os.environ.get("DESIRED_CUDA") or ""
+    digits = raw.lstrip("cu").replace(".", "")
+    if digits[:2] in _CUDA_RUNTIME_PACKAGES:
+        return digits[:2]
+
+    # Fall back to the installed toolkit, matching how the build itself decides. The build turns CUDA on
+    # when a toolkit is present and the option was not switched off, so keying this off a release variable
+    # alone produced a wheel that carried the CUDA libraries while declaring no CUDA runtime and recording
+    # no way to reach one. A release builder can also have a toolkit installed while building a CPU row, so
+    # an explicit OFF has to be honoured or that row declares a runtime it never loads.
+    if not install_utils.is_cmake_option_on(
+        shlex.split(os.environ.get("CMAKE_ARGS", "")),
+        "EXECUTORCH_BUILD_CUDA",
+        default=True,
+    ):
+        return ""
+    if not install_utils.is_cuda_available():
+        return ""
+    try:
+        major, _ = install_utils._get_cuda_version()
+    except Exception:
+        return ""
+    return str(major) if str(major) in _CUDA_RUNTIME_PACKAGES else ""
+
+
+def _cuda_libraries_built(cmake_cache_dir: Optional[str]) -> bool:
+    """Whether this build produced the CUDA libraries, read from the CMake cache.
+
+    The build turns CUDA on from the cache, so the cache is the fact that decides what ships. The
+    release row's CUDA version is a different question: a build on a toolkit whose train this packaging
+    does not recognise still produces the libraries while declaring no train, and gating anything else on
+    the train left that wheel carrying libraries with no matching header.
+
+    Falls back to the train when no cache is readable, which is the case for a source distribution where
+    nothing was built here anyway.
+    """
+    cache_path = os.path.join(cmake_cache_dir or "", "CMakeCache.txt")
+    if os.path.exists(cache_path):
+        return CMakeCache(cache_path=cache_path).is_enabled("EXECUTORCH_BUILD_CUDA")
+    return bool(_cuda_train())
+
+
+def _cuda_dependencies() -> List[str]:
+    """Runtime libraries a CUDA wheel needs but does not bundle.
+
+    Declared rather than vendored, the way the PyTorch CUDA wheels do it, so one copy is
+    shared with torch instead of shipping a second one.
+    """
+    train = _cuda_train()
+    # Marked for Linux, because a CUDA wheel is only built there and these nvidia wheels publish no
+    # distribution for the other platforms, so an unmarked requirement would make a source install
+    # elsewhere fail on a dependency it cannot satisfy and does not need.
+    return [
+        f"{name}; platform_system == 'Linux'"
+        for name in _CUDA_RUNTIME_PACKAGES.get(train, ())
+    ]
+
+
+# Directories inside the wheel that hold libraries a shipped library links, relative to the directory
+# holding the linking library.
+#
+# The CUDA libraries are split across two directories and reference each other in both directions:
+# the delegate in lib/ links the shims library in backends/cuda/, and the shims library links the
+# stream helper back in lib/. So both hops are needed.
+#
+# Applied to every shipped library rather than mapping each library to the directories it happens to
+# need. An unused hop costs nothing at load time, while a missing one produces a wheel that installs
+# and then fails to load, and a per-library mapping would have to be revisited every time a library
+# moves.
+_SIBLING_LIBRARY_SEARCH_PATHS = (
+    "$ORIGIN/../backends/cuda",
+    "$ORIGIN/../../lib",
+)
+
+
+def _cuda_runtime_search_paths(depth: int = 1) -> List[str]:
+    """Loader paths that reach the CUDA wheels installed beside this one.
+
+    Those wheels install as siblings of this package, so the hop has to climb out of the package first.
+    `depth` is how many directories separate the library from the package root, and the wheel ships
+    libraries at more than one depth: a hop sized for one of them lands inside this package from the
+    other, where nothing is found.
+    """
+    train = _cuda_train()
+    out = "/".join([".."] * (depth + 1))
+    return [
+        f"$ORIGIN/{out}/{directory}"
+        for directory in _CUDA_LIBRARY_DIRECTORIES.get(train, ())
+    ]
+
+
+def _is_cuda_toolkit_directory(entry: str) -> bool:
+    """Whether a runtime search path entry names a library directory inside a CUDA toolkit.
+
+    Matched on the layout a toolkit installs rather than on the word "cuda" appearing anywhere. A substring
+    test also dropped paths that merely sit under a directory named after a CUDA version, including a torch
+    directory, which is the one absolute path a shipped library has to keep.
+
+    The cuda-named component has to sit near the end for the same reason: scanning every component still
+    dropped a torch directory whose build root happened to be named after a CUDA version.
+    """
+    parts = [part.lower() for part in PurePosixPath(entry).parts]
+    if not parts or parts[-1] not in ("lib", "lib64"):
+        return False
+    # Only the components a toolkit puts between its root and its library directory: lib64 directly, or
+    # the targets/<arch>/lib layout. Anything further up is somebody's directory name.
+    return any(
+        re.fullmatch(r"cuda(?:-\d+(?:\.\d+)*|[-_]?toolkit)?", part)
+        for part in parts[-4:-1]
+    )
+
+
+def _package_relative_depth(library: Path) -> int:
+    """How many directories separate a shipped library from the installed package root.
+
+    Searched from the END of the path. At build time the path is absolute and a source checkout is
+    often named after the package too, so taking the first match found the checkout instead of the
+    package inside the build output and produced a hop that climbs out of the install directory.
+    """
+    parts = list(Path(library).parts)
+    if "executorch" not in parts:
+        return 1
+    index = len(parts) - 1 - parts[::-1].index("executorch")
+    return max(len(parts) - index - 2, 0)
 
 
 def _base_dependencies() -> List[str]:
@@ -705,7 +866,10 @@ class InstallerBuildExt(build_ext):
         # Copy the file.
         self.copy_file(os.fspath(src_file), os.fspath(dst_file))
 
-        _strip_absolute_runtime_paths(dst_file)
+        cmake_cache_dir = getattr(
+            self.get_finalized_command("build"), "cmake_cache_dir", None
+        )
+        _strip_absolute_runtime_paths(dst_file, _cuda_libraries_built(cmake_cache_dir))
 
         # Ensure that the destination file is writable, even if the source was
         # not. build_py does this by passing preserve_mode=False to copy_file,
@@ -716,7 +880,24 @@ class InstallerBuildExt(build_ext):
             os.chmod(src_file, os.stat(src_file).st_mode | 0o222)
 
 
-def _strip_absolute_runtime_paths(library: Path) -> None:
+def _append_relative_search_paths(entries: List[str], depth: int = 1) -> None:
+    """Add the relative hops a shipped library needs, skipping any already present.
+
+    Two kinds, both relative so the wheel works wherever the environment lives:
+    the CUDA runtime, which arrives in its own wheel installed beside this one, and a sibling
+    ExecuTorch library that the wheel installs in a different directory from the library linking it.
+
+    `depth` sizes the hop out of this package, since the wheel ships libraries at more than one depth.
+    """
+    for search_path in (
+        *_cuda_runtime_search_paths(depth),
+        *_SIBLING_LIBRARY_SEARCH_PATHS,
+    ):
+        if search_path not in entries:
+            entries.append(search_path)
+
+
+def _strip_absolute_runtime_paths(library: Path, ships_cuda: bool) -> None:
     """Remove unusable runtime search paths from a library the wheel ships.
 
     These libraries are copied out of the build tree rather than installed, so they
@@ -761,21 +942,55 @@ def _strip_absolute_runtime_paths(library: Path) -> None:
         # entry, so there is nothing to distinguish here and nothing to do either way.
         return
 
+    # Whether dropping an absolute CUDA toolkit path is safe. It is a cleanup when a relative hop replaces
+    # it, and also when this wheel carries no CUDA at all, because then nothing in it loads from that
+    # directory and the path only names the build machine. It is a regression only for a CUDA build whose
+    # train this packaging does not recognise, which declares no dependency and adds no hop, so dropping
+    # the path there would leave the delegate with no route to libcudart.
+    safe_to_drop_toolkit_paths = not ships_cuda or bool(
+        _cuda_runtime_search_paths(_package_relative_depth(library))
+    )
+
     def keep(entry: str) -> bool:
         if not entry:
             # The loader reads an empty entry as the process working directory.
             return False
         if not entry.startswith("/"):
             return True
-        # Absolute, so decide by what it points at. A directory inside this build
-        # cannot exist for a user. Anything else absolute is a dependency the
-        # environment provides, such as torch's own lib directory, which is how
-        # these extensions resolve torch at all.
-        return not any(
+        # Absolute, so decide by what it points at.
+        #
+        # A directory inside this build cannot exist for a user.
+        #
+        # A CUDA toolkit directory is dropped for a different reason: the wheel declares the CUDA runtime
+        # as a dependency and reaches it through a relative hop, so an absolute toolkit path is both
+        # unnecessary and harmful. It sits ahead of the hop, so a user who happens to have a toolkit at
+        # that prefix resolves the runtime from there instead of from the declared dependency.
+        #
+        # Whether that is safe is decided above, because the one case it is not is a CUDA build on an
+        # unrecognised train, which has no hop to fall back on.
+        #
+        # Anything else absolute stays, because it is a dependency the environment provides and the wheel
+        # has no relative answer for, such as torch's own lib directory, which is how these extensions
+        # resolve torch at all.
+        if any(
             marker in entry for marker in ("/pip-out/", "/cmake-out", "/build/lib.")
-        )
+        ):
+            return False
+        # Matched on the layout a CUDA toolkit actually installs, not on the word "cuda" anywhere in the
+        # path. A substring test dropped a torch directory that merely sat under a directory named after a
+        # CUDA version, which is the one absolute path that has to survive.
+        if safe_to_drop_toolkit_paths and _is_cuda_toolkit_directory(entry):
+            return False
+        return True
 
-    rewritten = ":".join(entry for entry in original.split(":") if keep(entry))
+    entries = [entry for entry in original.split(":") if keep(entry)]
+    # A CUDA wheel links the CUDA runtime from a separate wheel installed beside this
+    # one, so the loader needs a relative hop to reach it. Without this the library
+    # resolves the runtime only through the absolute toolkit path the linker recorded,
+    # which names the build machine and will not exist for a user who installed from an
+    # index. Appended, so a path already present keeps its position.
+    _append_relative_search_paths(entries, _package_relative_depth(library))
+    rewritten = ":".join(entries)
     if rewritten == original:
         return
     subprocess.run(
@@ -841,6 +1056,9 @@ class CustomBuildPy(build_py):
             ("schema/program.fbs", "exir/_serialize/program.fbs"),
         ]
         if not _is_minimal_build():
+            cmake_cache_dir = getattr(
+                self.get_finalized_command("build"), "cmake_cache_dir", None
+            )
             src_to_dst += [
                 (
                     "devtools/bundled_program/schema/bundled_program_schema.fbs",
@@ -904,7 +1122,19 @@ class CustomBuildPy(build_py):
                 "devtools/etdump/emitter.h",
                 "devtools/etdump/utils.h",
                 "devtools/etdump/data_sinks/",
-            ]:
+            ] + (
+                # The CUDA stream helper's public header, and the export macros it includes. Its library is
+                # shared so the process has one copy of the caller-stream state, and that is a handshake the
+                # caller takes part in, so a consumer needs the declarations to take part at all.
+                #
+                # Only when this wheel carries the CUDA delegate, and decided from the same CMake cache the
+                # libraries ship on. Keying it off the release row's CUDA version instead meant a build on
+                # an unrecognised toolkit shipped both CUDA libraries and both CMake components with no
+                # header, so a consumer got a component it could link and not include.
+                ["extension/cuda/caller_stream.h", "extension/cuda/export.h"]
+                if _cuda_libraries_built(cmake_cache_dir)
+                else []
+            ):
                 # A directory entry publishes everything under it, and a file entry publishes
                 # just that file. Some directories hold headers a consumer cannot compile
                 # against, so those are named individually rather than swept in.
@@ -1248,6 +1478,10 @@ class CustomBuild(build):
             if cmake_cache.is_enabled("EXECUTORCH_BUILD_CUDA"):
                 cmake_build_args += ["--target", "aoti_cuda_backend"]
                 cmake_build_args += ["--target", "aoti_common_shims_slim"]
+                if cmake_cache.is_enabled("EXECUTORCH_BUILD_SHARED"):
+                    # The stream helper ships as its own library so a process has one
+                    # of it. Named because nothing else in a wheel build links it.
+                    cmake_build_args += ["--target", "extension_cuda"]
 
             if cmake_cache.is_enabled("EXECUTORCH_BUILD_EXTENSION_MODULE"):
                 cmake_build_args += ["--target", "extension_module"]
@@ -1299,7 +1533,9 @@ if _is_minimal_build():
     setup_kwargs["packages"] = _minimal_packages()
     setup_kwargs["install_requires"] = _minimal_dependencies()
 else:
-    setup_kwargs["install_requires"] = _base_dependencies()
+    # A CUDA wheel links the CUDA runtime but does not bundle it, so the wheels that
+    # carry it are declared here. A CPU wheel adds nothing.
+    setup_kwargs["install_requires"] = _base_dependencies() + _cuda_dependencies()
 
 
 setup(
@@ -1386,6 +1622,28 @@ setup(
                     dependent_cmake_flags=[
                         "EXECUTORCH_BUILD_SHARED",
                         "EXECUTORCH_BUILD_KERNELS_OPTIMIZED",
+                    ],
+                ),
+                # The CUDA delegate and the process-wide CUDA stream helper, for a
+                # wheel built from a CUDA index. Only present when the build asks for
+                # CUDA, so packaging requires that rather than looking for files a
+                # CPU-only build never produced.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/backends/cuda/",
+                    src_name="libexecutorch_backend_cuda.so",
+                    dst="executorch/lib/libexecutorch_backend_cuda.so",
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_CUDA",
+                    ],
+                ),
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/extension/cuda/",
+                    src_name="libexecutorch_extension_cuda.so",
+                    dst="executorch/lib/libexecutorch_extension_cuda.so",
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_CUDA",
                     ],
                 ),
                 # The quantized kernels, as their own library rather than code

--- a/test/utils/OSSTestConfig.json
+++ b/test/utils/OSSTestConfig.json
@@ -97,6 +97,7 @@
     {
         "directory": "runtime/core/exec_aten/util/test",
         "sources": [
+            "device_copy_test.cpp",
             "dim_order_util_test.cpp",
             "operator_impl_example_test.cpp",
             "scalar_type_util_test.cpp",

--- a/tools/cmake/Codegen.cmake
+++ b/tools/cmake/Codegen.cmake
@@ -261,15 +261,26 @@ function(gen_custom_ops_aot_lib)
   executorch_target_link_options_shared_lib(${GEN_LIB_NAME})
   if(TARGET portable_lib)
     target_link_libraries(${GEN_LIB_NAME} PRIVATE portable_lib)
+  elseif(TARGET executorch_shared)
+    # Linked as a library rather than only retained, so this target also picks
+    # up the runtime's include directories and compile definitions. The
+    # retention helper below adds link options alone, which would leave a shared
+    # build without the pybind extension compiling against no runtime headers.
+    target_link_libraries(${GEN_LIB_NAME} PRIVATE executorch_shared)
   else()
     target_link_libraries(${GEN_LIB_NAME} PRIVATE executorch_core)
   endif()
+  executorch_target_link_shared_runtime(${GEN_LIB_NAME})
 endfunction()
 
 # Generate a runtime lib for registering operators in Executorch
+#
+# SHARED opts this library into being a shared object. It is opt-in because most
+# callers want the default static library, and only the one shipped in the wheel
+# needs to be shared so a process has a single copy of the kernels.
 function(gen_operators_lib)
   set(multi_arg_names LIB_NAME KERNEL_LIBS DEPS DTYPE_SELECTIVE_BUILD)
-  cmake_parse_arguments(GEN "" "" "${multi_arg_names}" ${ARGN})
+  cmake_parse_arguments(GEN "SHARED" "" "${multi_arg_names}" ${ARGN})
 
   message(STATUS "Generating operator lib:")
   message(STATUS "  LIB_NAME: ${GEN_LIB_NAME}")
@@ -282,7 +293,17 @@ function(gen_operators_lib)
     set(_opvariant_h ${_out_dir}/selected_op_variants.h)
   endif()
 
-  add_library(${GEN_LIB_NAME})
+  if(GEN_SHARED)
+    add_library(${GEN_LIB_NAME} SHARED)
+    # The caller names the library and sets its version, because the shipped
+    # name describes what the library provides rather than which generation
+    # target produced it, and only the caller knows that.
+    #
+    # Ships beside the runtime in the wheel's lib/ directory.
+    executorch_target_shipped_runtime_path(${GEN_LIB_NAME})
+  else()
+    add_library(${GEN_LIB_NAME})
+  endif()
 
   set(_srcs_list ${_out_dir}/RegisterCodegenUnboxedKernelsEverything.cpp
                  ${_out_dir}/Functions.h ${_out_dir}/NativeFunctions.h
@@ -292,6 +313,21 @@ function(gen_operators_lib)
   endif()
   target_sources(${GEN_LIB_NAME} PRIVATE ${_srcs_list})
   target_link_libraries(${GEN_LIB_NAME} PRIVATE ${GEN_DEPS})
+  # Resolve the runtime from the shared library rather than from the static core
+  # in GEN_DEPS. Linking the static core gives this library its own copy of the
+  # operator table, so its static initializer registers into a table nothing
+  # else reads and the operators appear missing at run time.
+  #
+  # Only when this target is itself shared. On a static target the retention
+  # helper cannot work: PRIVATE link options are dropped on a static library, so
+  # the --no-as-needed scope never reaches whatever links it, and the helper is
+  # fatal on that rather than pretending. A static operators library is
+  # extracted whole into its consumer, and the consumer is what retains the
+  # runtime, so there is nothing to do here. It still needs the runtime's
+  # headers, which come through GEN_DEPS.
+  if(GEN_SHARED)
+    executorch_target_link_shared_runtime(${GEN_LIB_NAME})
+  endif()
   set(portable_kernels_check "portable_kernels")
   if(GEN_KERNEL_LIBS)
 

--- a/tools/cmake/Utils.cmake
+++ b/tools/cmake/Utils.cmake
@@ -47,9 +47,64 @@ function(executorch_msvc_kernel_link_options target_name)
   )
 endfunction()
 
+# Bundle a static library's whole contents into a target.
+#
+# Deliberately a link option rather than the WHOLE_ARCHIVE link feature: that
+# feature refuses to coexist with the plain references other targets make to the
+# same archive, which the archives bundled here all have, until CMake 3.30. Link
+# options are also emitted before the ordered link libraries, which keeps a
+# bundled archive ahead of anything that would otherwise satisfy the same
+# symbols.
+function(executorch_target_whole_archive target_name archive_target)
+  # One self-contained option per archive. The path sits inside the option so
+  # its text is unique, which matters because CMake removes a duplicate option
+  # and that would leave every archive after the first outside the scope,
+  # silently dropping its registration objects.
+  #
+  # The cost, measured rather than assumed: CMake splits a comma-joined LINKER:
+  # list at every comma, so an archive whose path contains one reaches the
+  # linker as two broken arguments and the link fails. Accepted, because the
+  # alternative of giving the path its own option reintroduces the
+  # de-duplication problem above, and because this file's pre-existing
+  # SHELL:LINKER: helpers already break on a path containing a space, which is
+  # the more common case. Both fail loudly at link time rather than producing a
+  # binary whose registrations are quietly missing.
+  target_link_options(
+    ${target_name}
+    PRIVATE
+    "LINKER:--push-state,--whole-archive,$<TARGET_FILE:${archive_target}>,--pop-state"
+  )
+  # Also link it the ordinary way. A link option naming a file is not a build
+  # prerequisite, so on its own it lets the archive be rebuilt while the library
+  # bundling it keeps the previous contents, which is a stale registration
+  # rather than a build error.
+  target_link_libraries(${target_name} PRIVATE ${archive_target})
+endfunction()
+
 # Ensure that the load-time constructor functions run. By default, the linker
 # would remove them since there are no other references to them.
 function(executorch_target_link_options_shared_lib target_name)
+  # A shared library cannot be retained with --whole-archive: that flag only
+  # governs how an archive's members are pulled in, so the library is still
+  # subject to --as-needed and gets dropped along with its registration
+  # constructor. Export scoped --no-as-needed retention instead, which is what
+  # actually keeps a registration-only shared library on the link line.
+  get_target_property(_target_type ${target_name} TYPE)
+  if(_target_type STREQUAL "SHARED_LIBRARY" AND NOT (APPLE OR MSVC))
+    target_link_options(
+      ${target_name}
+      INTERFACE
+      # One option with the library inside it, for two reasons. A SHELL: string
+      # would split on spaces and break a path containing one, and separate
+      # options repeat identical text that CMake de-duplicates, which silently
+      # leaves every library after the first outside any --no-as-needed scope.
+      "LINKER:--push-state,--no-as-needed,$<TARGET_FILE:${target_name}>,--pop-state"
+    )
+    # Retention is fully handled above, and applying whole-archive to a shared
+    # library below would do nothing: that flag governs archive member
+    # extraction, and this target is not an archive.
+    return()
+  endif()
   if(APPLE)
     executorch_macos_kernel_link_options(${target_name})
   elseif(MSVC)
@@ -212,8 +267,127 @@ function(executorch_target_copy_mlx_metallib target)
   endif()
 endfunction()
 
+# Make a target resolve the ExecuTorch runtime from libexecutorch.so.
+#
+# Naming the shared runtime as an ordinary dependency is not enough. CMake
+# orders link libraries so that an archive precedes what it depends on, which
+# puts libexecutorch_core.a ahead of libexecutorch.so; the archive then
+# satisfies the runtime symbols first and the target ends up with a private copy
+# of the backend registry. Link options come before the ordered libraries, so
+# naming the runtime there leaves the archive with nothing left to resolve.
+#
+# On ELF platforms --no-as-needed is needed around it, because a shared library
+# with no already-referenced symbol at the point it appears can be dropped, and
+# the static archive further along the line would then supply the registry after
+# all. Other linkers keep the reference without it.
+function(executorch_target_link_shared_runtime target_name)
+  executorch_target_retain_shared_library(${target_name} executorch_shared)
+endfunction()
+
+# Put a shared library on a consumer's link line and keep it there.
+#
+# A library whose only purpose is to run a static initializer, such as a backend
+# or an operator registration library, has no symbol the consumer references
+# directly, so the linker is free to drop it from DT_NEEDED. Some linkers do
+# exactly that and the initializer never runs, which shows up at runtime as a
+# backend or kernel that is missing rather than as a link error.
+function(executorch_target_retain_shared_library target_name library_target)
+  if(NOT EXECUTORCH_BUILD_SHARED)
+    return()
+  endif()
+  # A target with no link step of its own cannot carry this. PRIVATE link
+  # options are dropped on both static and object libraries, because neither
+  # links, while PRIVATE link libraries still propagate to whatever consumes
+  # them as $<LINK_ONLY:...>. The consumer then gets the shared runtime with no
+  # --no-as-needed around it, which is the precise condition this function
+  # exists to prevent, and it fails silently: the build succeeds and the
+  # registrations land in a table nothing else reads.
+  #
+  # Written as the set of types that CAN link rather than a list of types to
+  # reject, so a target kind added later does not quietly escape.
+  get_target_property(_target_type ${target_name} TYPE)
+  if(NOT ${_target_type} MATCHES "^(SHARED_LIBRARY|MODULE_LIBRARY|EXECUTABLE)$")
+    message(
+      FATAL_ERROR
+        "executorch_target_retain_shared_library(${target_name}) cannot work on a "
+        "${_target_type}: it has no link step, so PRIVATE link options are dropped and "
+        "${library_target} would reach a consumer without --no-as-needed, leaving its "
+        "registrations in a private table. Make ${target_name} SHARED, or retain "
+        "${library_target} from the target that links it."
+    )
+  endif()
+  # The library being retained has to be one the loader can drop, or the option
+  # says nothing. Only checked when it is already defined: CMake resolves link
+  # libraries lazily, and a caller may legitimately name a library created later
+  # in the configure, which several call sites here do.
+  if(TARGET ${library_target})
+    get_target_property(_library_type ${library_target} TYPE)
+    if(NOT ${_library_type} STREQUAL "SHARED_LIBRARY")
+      message(
+        FATAL_ERROR
+          "executorch_target_retain_shared_library(${target_name} ${library_target}): "
+          "${library_target} is a ${_library_type}, and --no-as-needed only affects a shared "
+          "library. A static or object library is linked by extraction instead, "
+          "so use executorch_target_whole_archive."
+      )
+    endif()
+  endif()
+  # Scoped per library for the same reason as whole-archive above: unique option
+  # text, so nothing is de-duplicated out of the retention scope. Without this a
+  # registration-only library is dropped under the default --as-needed and its
+  # static initializer never runs.
+  target_link_options(
+    ${target_name}
+    PRIVATE
+    "LINKER:--push-state,--no-as-needed,$<TARGET_FILE:${library_target}>,--pop-state"
+  )
+  target_link_libraries(${target_name} PRIVATE ${library_target})
+endfunction()
+
+# Mark a library as one the wheel ships, so it finds its siblings wherever it
+# ends up. In the wheel all of these land in one directory, so "$ORIGIN" is the
+# whole answer.
+#
+# BUILD_WITH_INSTALL_RPATH is deliberately not used. It REPLACES the build-time
+# path with the install one, which drops the dependency directories CMake
+# records, and in the build tree these libraries are NOT siblings: the runtime
+# sits at the top while the others are in their own subdirectories. Those
+# recorded directories are what resolves them there, and packaging strips them
+# so nothing absolute ships.
+function(executorch_target_shipped_runtime_path target_name)
+  set_target_properties(
+    ${target_name} PROPERTIES BUILD_RPATH "$ORIGIN" INSTALL_RPATH "$ORIGIN"
+  )
+endfunction()
+
+# Apply the SONAME policy for a library the project ships.
+#
+# A distribution package needs a versioned SONAME: it installs
+# libexecutorch.so.1 into a system directory where independent packages link it,
+# and the version is what lets a later major coexist during an upgrade. That is
+# why the shared library support carries VERSION and SOVERSION.
+#
+# A wheel is the opposite case. The library and the only things that link it
+# ship in the same archive and are replaced together, so no version needs
+# pinning, and a versioned name actively hurts: `find_library(executorch)`
+# matches libexecutorch.so and not libexecutorch.so.1, so a consumer's
+# find_package could not locate it. The torch wheel ships plain names with
+# unversioned SONAMEs for the same reason. Offering an unversioned symlink
+# instead is not equivalent, because a wheel is a zip and the format has no
+# portable symlink support.
+function(executorch_target_soname_policy target_name)
+  if(EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
+    return()
+  endif()
+  set_target_properties(
+    ${target_name} PROPERTIES VERSION "${PROJECT_VERSION}"
+                              SOVERSION "${PROJECT_VERSION_MAJOR}"
+  )
+endfunction()
+
 # Create and install a shared library composed from dependency libraries. The
-# target links the provided dependencies and carries VERSION/SOVERSION.
+# target links the provided dependencies and carries the project's SONAME
+# policy.
 function(executorch_add_shared_library target_name)
   set(empty_source_name "${target_name}_empty.cpp")
   file(
@@ -224,15 +398,21 @@ function(executorch_add_shared_library target_name)
   add_library(
     ${target_name} SHARED "${CMAKE_CURRENT_BINARY_DIR}/${empty_source_name}"
   )
+  # The dependencies are linked plainly, without a retention option, because
+  # each one already carries its own INTERFACE whole-archive option and so pulls
+  # its registration objects in when linked. The empty source above exists only
+  # to give this library a translation unit.
+  #
+  # Nothing here can verify that invariant: CMake cannot tell at configure time
+  # whether every transitive dependency carries the option. It is checked where
+  # it is observable instead, by the release checks asserting exactly one owner
+  # per component in the shipped artifact, which is what fails if extraction
+  # stops working.
   if(ARGN)
     target_link_libraries(${target_name} PRIVATE ${ARGN})
   endif()
-  set_target_properties(
-    ${target_name}
-    PROPERTIES VERSION "${PROJECT_VERSION}"
-               SOVERSION "${PROJECT_VERSION_MAJOR}"
-               LINKER_LANGUAGE CXX
-  )
+  set_target_properties(${target_name} PROPERTIES LINKER_LANGUAGE CXX)
+  executorch_target_soname_policy(${target_name})
   install(
     TARGETS ${target_name}
     EXPORT ExecuTorchTargets

--- a/tools/cmake/executorch-wheel-config-version.cmake.in
+++ b/tools/cmake/executorch-wheel-config-version.cmake.in
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Version file for the wheel's CMake package, so `find_package(executorch 1.2)`
+# answers correctly instead of matching any version at all.
+#
+# Written by packaging rather than checked in, because the version is only known
+# when the wheel is built: version.txt gives the base, and BUILD_VERSION
+# overrides it for a nightly. A checked-in file would go stale the first time
+# either changed.
+#
+# The same shape as the torch wheel's TorchConfigVersion.cmake, which is the
+# file a consumer of this ecosystem will already have met.
+set(PACKAGE_VERSION "@EXECUTORCH_VERSION@")
+
+# The same version again, unabridged. find_package compares dotted integers
+# only, so the version above is read as its numeric release part and a consumer
+# cannot pin a nightly or a specific build through it: passing the full string
+# to find_package is a hard argument error. This variable is what a consumer
+# compares when an exact build pairing is required.
+set(EXECUTORCH_BUILD_VERSION "@EXECUTORCH_BUILD_VERSION@")
+
+# Any version at least as new as the one requested is compatible. ExecuTorch has
+# no stable ABI promise across majors yet, so this is deliberately permissive;
+# when it does, this is where the rule changes.
+if("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}")
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+  set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  if("${PACKAGE_VERSION}" VERSION_EQUAL "${PACKAGE_FIND_VERSION}")
+    set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()
+
+# A range request names an upper bound, and without this branch the check above
+# sees only the lower one, so find_package(executorch 1.0...<2.0) accepted 3.0.
+# CMake sets these variables only for a range, so a plain request is unaffected.
+if(PACKAGE_FIND_VERSION_RANGE AND PACKAGE_VERSION_COMPATIBLE)
+  if(PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE")
+    if("${PACKAGE_VERSION}" VERSION_GREATER "${PACKAGE_FIND_VERSION_MAX}")
+      set(PACKAGE_VERSION_COMPATIBLE FALSE)
+    endif()
+  elseif(NOT "${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION_MAX}")
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  endif()
+endif()

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -8,7 +8,23 @@
 # for this file and find ExecuTorch package if it is installed. Typical usage
 # is:
 #
+# ~~~
 # find_package(executorch REQUIRED)
+# target_link_libraries(my_app PRIVATE executorch::runtime)
+# ~~~
+#
+# This is the wheel's own contract, written by hand rather than generated,
+# because the wheel copies build products out of the build tree instead of
+# running an install step.
+#
+# It is NOT identical to the in-tree package config. That one exposes the
+# build's own bare target names, such as executorch and xnnpack_backend, while
+# this one exposes namespaced imported targets like executorch::runtime, because
+# a wheel consumer links prebuilt files rather than participating in the build.
+# Consumer code written against one therefore does not configure against the
+# other. The end state that removes the difference is a staged install whose
+# generated targets file the wheel ships, so the source and wheel contracts
+# become the same object rather than two things that must agree.
 # -------
 #
 # Finds the ExecuTorch library
@@ -17,12 +33,428 @@
 #
 # EXECUTORCH_FOUND        -- True if the system has the ExecuTorch library
 # EXECUTORCH_INCLUDE_DIRS -- The include directories for ExecuTorch
-# EXECUTORCH_LIBRARIES    -- Libraries to link against
+# EXECUTORCH_LIBRARIES    -- Libraries to link against. Includes the prebuilt
+# Python extension, whose Python symbols resolve inside an interpreter, so link
+# the imported targets below instead when building a standalone application.
+# EXECUTORCH_BUILD_VERSION -- The full version this package was built from,
+# including any prerelease suffix and local version label. Compare this when an
+# exact build pairing is required, since the CMake package version keeps only
+# the numeric part.
 #
+# and, when the prebuilt shared runtime is present, the imported target:
+#
+# executorch::runtime     -- The prebuilt C++ runtime (libexecutorch.so). Loads
+# and executes a program, and deliberately carries no operator kernels, so
+# running a model needs a kernel component as well.
+#
+# Component targets are defined only when the wheel ships that component, so the
+# set depends on which wheel is installed. Each one carries the runtime
+# dependency and, for a registration-only library, the link options that keep it
+# from being dropped. The names, when present, are:
+#
+# executorch::kernels_optimized -- The CPU operator kernels. Needed to run a
+# model. executorch::backend_xnnpack   -- The XNNPACK delegate.
+# executorch::threadpool        -- The shared thread pool. executorch::etdump --
+# The profiler.
+#
+# Check with if(TARGET executorch::<name>) rather than assuming one exists. A
+# namespaced name that was never defined is a configure-time error that names
+# the component, so a consumer who links one unconditionally gets a clear
+# failure rather than a broken build. Guarding is still worth doing, because a
+# component's absence is a legitimate state: a CPU-only wheel ships no
+# accelerator delegate, and a consumer that guards adapts instead of failing.
+#
+# The floor stays where it was, so a consumer that only wants the long-standing
+# variables and the prebuilt Python extension keeps working on the CMake it
+# already has. The shared-runtime targets below need more than this and check
+# for it themselves.
 cmake_minimum_required(VERSION 3.19)
 
-# Find prebuilt _portable_lib.<EXT_SUFFIX>.so. This file should be installed
-# under <site-packages>/executorch/share/cmake
+# The imported targets below export "$ORIGIN"-relative runtime paths as link
+# options, and CMake writes that token incorrectly before 3.28. Measured rather
+# than inferred, on a consumer linking such a target:
+#
+# ~~~
+#   3.24.3, 3.27.9   Makefiles double the dollar sign, Ninja drops the name
+#   3.28.4, 3.31.8   both write the token correctly
+# ~~~
+#
+# Either broken form leaves a consumer building and running in place, because
+# the absolute package directory is also recorded, then failing once it is
+# deployed somewhere else. Silently defining a target that behaves that way is
+# worse than not defining it, so the targets are skipped and a consumer that
+# asked for one gets a message naming the reason.
+if(CMAKE_VERSION VERSION_LESS 3.28)
+  set(_executorch_targets_supported FALSE)
+else()
+  set(_executorch_targets_supported TRUE)
+endif()
+
+# Everything is resolved relative to this file so the wheel stays relocatable:
+# no absolute path from the machine that built it is baked in here. The file is
+# installed both under share/cmake, which the historical contract uses, and
+# under lib/cmake/executorch, which a plain CMAKE_PREFIX_PATH pointed at the
+# package root can discover, so the root is located by a marker rather than a
+# fixed depth.
+#
+# Tested directly rather than through find_path. The root is a known relative
+# offset from this file, so a search adds nothing, and find_path applies the
+# consumer's find-root rules: under a cross-compiling toolchain that sets
+# CMAKE_FIND_ROOT_PATH_MODE_INCLUDE to ONLY it reroots these absolute paths into
+# the target sysroot, finds nothing, and reports a complete package as missing.
+set(_executorch_package_root "")
+foreach(_candidate
+        "${CMAKE_CURRENT_LIST_DIR}/.." "${CMAKE_CURRENT_LIST_DIR}/../.."
+        "${CMAKE_CURRENT_LIST_DIR}/../../.."
+)
+  # share/cmake identifies the package root and only exists there. A generic
+  # marker such as include/executorch can also appear one level down, in which
+  # case the search from lib/cmake/executorch would stop at lib/ and resolve the
+  # wrong root.
+  if(EXISTS "${_candidate}/share/cmake/executorch-config.cmake")
+    set(_executorch_package_root "${_candidate}")
+    break()
+  endif()
+endforeach()
+
+# Normalise the result before it is used to build paths. The search can return a
+# directory with a trailing separator, which then appears doubled in every path
+# derived from it and in the message reporting where the runtime was found.
+if(_executorch_package_root)
+  string(REGEX REPLACE "/+$" "" _executorch_package_root
+                       "${_executorch_package_root}"
+  )
+endif()
+
+# Both directories are needed for a usable package. The C10 compatibility
+# headers are not optional: core headers such as runtime/core/array_ref.h
+# include c10 unconditionally, so a package missing them cannot compile anything
+# that touches the runtime API.
+#
+# A missing directory is reported as not-found rather than raised here, so an
+# optional find_package gets a FALSE answer instead of a dead build. The
+# REQUIRED handling at the bottom of this file turns it into an error when the
+# caller asked for one.
+set(_executorch_c10_include
+    "${_executorch_package_root}/include/executorch/runtime/core/portable_type/c10"
+)
+# The full version this package was built from. It lives in the generated
+# version file, which CMake includes in a throwaway scope while deciding whether
+# the package is acceptable, so nothing assigned there reaches a consumer.
+# Reading that file here, from the config, is what makes the value visible. Both
+# files are installed side by side, so the path is fixed relative to this one.
+set(_executorch_version_file
+    "${CMAKE_CURRENT_LIST_DIR}/executorch-config-version.cmake"
+)
+if(EXISTS "${_executorch_version_file}")
+  file(STRINGS "${_executorch_version_file}" _executorch_version_lines
+       REGEX "^set\\(EXECUTORCH_BUILD_VERSION"
+  )
+  foreach(_line IN LISTS _executorch_version_lines)
+    if(_line MATCHES "\"([^\"]+)\"")
+      set(EXECUTORCH_BUILD_VERSION "${CMAKE_MATCH_1}")
+    endif()
+  endforeach()
+endif()
+unset(_executorch_version_file)
+
+set(EXECUTORCH_INCLUDE_DIRS "${_executorch_package_root}/include"
+                            "${_executorch_c10_include}"
+)
+foreach(_required_include ${EXECUTORCH_INCLUDE_DIRS})
+  if(NOT EXISTS "${_required_include}")
+    message(
+      STATUS "ExecuTorch package at ${_executorch_package_root} is missing "
+             "${_required_include}, so nothing can compile against it."
+    )
+    set(EXECUTORCH_INCLUDE_DIRS)
+    set(EXECUTORCH_LIBRARIES)
+    set(EXECUTORCH_FOUND OFF)
+    set(executorch_FOUND FALSE)
+    return()
+  endif()
+endforeach()
+
+set(EXECUTORCH_LIBRARIES)
+set(EXECUTORCH_FOUND OFF)
+
+# Locate one shipped library by base name.
+#
+# A wheel ships a single file per library, named for its SONAME, so the major is
+# read from the shipped names rather than hardcoded here. Sets <output> to the
+# full path, or to an empty string when the wheel does not carry that library.
+#
+# This depends on an invariant on the build side: every library the wheel ships
+# carries a VERSION and SOVERSION, so its file name ends in a major. A library
+# built without them ships as a bare .so, and while the glob below still finds
+# it, nothing then pins the major a consumer linked against, which is the
+# guarantee the SONAME exists to provide.
+function(_executorch_find_library _output _base_name)
+  set(${_output}
+      ""
+      PARENT_SCOPE
+  )
+  file(GLOB _matches "${_executorch_package_root}/lib/${_base_name}.so"
+       "${_executorch_package_root}/lib/${_base_name}.so.*"
+  )
+  list(LENGTH _matches _count)
+  if(_count EQUAL 0)
+    return()
+  endif()
+  # Highest major wins, so a package that somehow carries two does not silently
+  # select by string order. Natural ordering keeps .2 below .10.
+  list(
+    SORT _matches
+    COMPARE NATURAL
+    ORDER DESCENDING
+  )
+  list(GET _matches 0 _selected)
+  set(${_output}
+      "${_selected}"
+      PARENT_SCOPE
+  )
+endfunction()
+
+# The prebuilt runtime.
+_executorch_find_library(_executorch_runtime_library libexecutorch)
+if(_executorch_runtime_library AND NOT _executorch_targets_supported)
+  # The imported targets are skipped, but the libraries themselves are present
+  # and linkable by path, so the long-standing variables are still honoured.
+  # Leaving them empty here contradicted the message below and made a REQUIRED
+  # find_package fail on a package that carries a working runtime.
+  #
+  # The kernel libraries are listed too, not only the runtime. The runtime
+  # deliberately registers no operators, so a consumer given the runtime alone
+  # links successfully and then fails at run time with "Missing operator:
+  # aten::mul.out", which reads as a model problem rather than a missing
+  # library.
+  #
+  # Each one is wrapped in scoped retention, because a registration-only library
+  # exports nothing the application references and the linker discards it under
+  # --as-needed. Measured: without this the library reaches the link line and is
+  # absent from the binary's dependencies, so the registrations never run. The
+  # imported targets express the same thing through link options, which this
+  # older-CMake route cannot use.
+  set(EXECUTORCH_FOUND ON)
+  list(APPEND EXECUTORCH_LIBRARIES "${_executorch_runtime_library}")
+  foreach(_kernels IN ITEMS libexecutorch_kernels_optimized)
+    _executorch_find_library(_executorch_kernel_library "${_kernels}")
+    if(_executorch_kernel_library)
+      list(
+        APPEND
+        EXECUTORCH_LIBRARIES
+        "-Wl,--push-state,--no-as-needed,${_executorch_kernel_library},--pop-state"
+      )
+    endif()
+  endforeach()
+  unset(_executorch_kernel_library)
+  message(
+    STATUS
+      "executorch: the prebuilt runtime is present but its imported targets need CMake 3.28 or "
+      "newer, because older versions write the \$ORIGIN token in a runtime search path "
+      "incorrectly. EXECUTORCH_LIBRARIES carries the runtime and the kernel libraries by path "
+      "instead, so a consumer linking that variable still works, and the prebuilt Python extension "
+      "is unaffected."
+  )
+elseif(_executorch_runtime_library)
+  set(EXECUTORCH_FOUND ON)
+  message(STATUS "ExecuTorch runtime found at ${_executorch_runtime_library}")
+
+  # The documented contract is that a consumer can link ${EXECUTORCH_LIBRARIES}.
+  # Leaving it empty here would make find_package succeed while offering nothing
+  # linkable to anyone who has not moved to the imported target.
+  list(APPEND EXECUTORCH_LIBRARIES executorch::runtime)
+
+  # This file can be processed more than once in a single configure, for example
+  # when several subprojects each call find_package(executorch). Creating the
+  # target twice is an error, so only define it once and set the properties
+  # either way.
+  if(TARGET executorch::runtime)
+    # This file ran already in the same configure, because another subproject
+    # also called find_package. Redefining the target would be an error, so keep
+    # the one that is already there.
+    message(
+      STATUS "executorch: executorch::runtime is already defined, reusing it"
+    )
+  else()
+    add_library(executorch::runtime SHARED IMPORTED)
+    set_target_properties(
+      executorch::runtime
+      PROPERTIES IMPORTED_LOCATION "${_executorch_runtime_library}"
+                 INTERFACE_INCLUDE_DIRECTORIES "${EXECUTORCH_INCLUDE_DIRS}"
+                 INTERFACE_COMPILE_FEATURES cxx_std_17
+                 INTERFACE_COMPILE_DEFINITIONS
+                 C10_USING_CUSTOM_GENERATED_MACROS
+    )
+    # Consumers get the wheel's lib/ directory in their RUNPATH automatically,
+    # because CMake adds the imported library's directory. Also record
+    # $ORIGIN-relative entries so an application deployed next to a copy of the
+    # runtime keeps working without relinking or LD_LIBRARY_PATH. $ORIGIN is a
+    # loader token, so it belongs only in RUNPATH, never in IMPORTED_LOCATION.
+    #
+    # $ORIGIN is named before the wheel's own directory. An application deployed
+    # beside a copy of the runtime has to find that copy, and the loader takes
+    # the first match, so putting the install directory first would keep sending
+    # a relocated application back to the original wheel for as long as it
+    # remains installed. That also makes a relocation test that deletes the
+    # original pass for the wrong reason.
+    #
+    # The cost, measured rather than assumed: a library that merely shares this
+    # SONAME and sits in the application's own directory will win. That is what
+    # $ORIGIN means in every package that uses it, and a package cannot offer
+    # relocation while also refusing to honour what the user placed beside their
+    # binary. The consequence worth worrying about, a delegate pairing with a
+    # different registry, is caught directly by the single-registry checks,
+    # which inspect what the shipped libraries define instead of trusting the
+    # loader's choice.
+    #
+    # The absolute entry cannot simply be dropped to avoid the question: an
+    # application built against the installed package fails to start without it.
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      # $ORIGIN-relative entries so a relocated application keeps working. The
+      # package's own directory does not need to be added here: CMake already
+      # puts it in the consumer's runtime search path because the imported
+      # library is named by absolute path, which is also what makes an
+      # application built against the installed package start at all.
+      set_property(
+        TARGET executorch::runtime
+        APPEND
+        PROPERTY INTERFACE_LINK_OPTIONS "LINKER:-rpath,$ORIGIN"
+                 "LINKER:-rpath,$ORIGIN/../lib"
+      )
+    endif()
+  endif()
+endif()
+
+# Define an imported target for one shipped component library.
+#
+# A component is a prebuilt shared library next to the runtime, such as the CPU
+# kernels or a delegate backend. Without a target for each one, a consumer has
+# to find the file itself and decide how to keep it on the link line, which
+# means depending on the wheel's private layout. The retention part matters
+# most: a registration-only library has no symbol the application references, so
+# a normal link drops it and its registration never runs.
+#
+# Call as: executorch_define_component(<target suffix> <library base name>)
+function(executorch_define_component _suffix _library_name)
+  # Same reason the runtime target is skipped on older CMake: a component target
+  # exports an $ORIGIN-relative search path, and a version that writes it wrong
+  # produces a target that works in place and fails once deployed.
+  if(NOT _executorch_targets_supported)
+    return()
+  endif()
+  _executorch_find_library(_library "lib${_library_name}")
+  if(NOT _library)
+    return()
+  endif()
+
+  set(_target "executorch::${_suffix}")
+  if(TARGET ${_target})
+    # This file ran already in the same configure, because another subproject
+    # also called find_package. Redefining the target would be an error, so keep
+    # the one that is already there.
+    message(STATUS "executorch: ${_target} is already defined, reusing it")
+    # Still advertise it. This file runs again whenever another subproject calls
+    # find_package, and that run starts from an empty EXECUTORCH_LIBRARIES, so
+    # returning here would hand the second caller a list with the runtime but
+    # none of the components. A consumer linking that variable would then be
+    # missing its kernels and fail at load with an unregistered operator.
+    set(EXECUTORCH_LIBRARIES
+        ${EXECUTORCH_LIBRARIES} ${_target}
+        PARENT_SCOPE
+    )
+    return()
+  endif()
+  add_library(${_target} SHARED IMPORTED)
+  set_target_properties(
+    ${_target}
+    PROPERTIES IMPORTED_LOCATION "${_library}"
+               INTERFACE_INCLUDE_DIRECTORIES "${EXECUTORCH_INCLUDE_DIRS}"
+               INTERFACE_COMPILE_FEATURES cxx_std_17
+               INTERFACE_COMPILE_DEFINITIONS C10_USING_CUSTOM_GENERATED_MACROS
+  )
+  # Every component resolves the runtime from the same shared library, so record
+  # that rather than leaving a consumer to link both by hand.
+  if(TARGET executorch::runtime)
+    set_property(
+      TARGET ${_target}
+      APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES executorch::runtime
+    )
+  endif()
+  # Guarded on Linux because these are GNU linker options. A wheel only ships
+  # these components on Linux, so a consumer configured for another system is
+  # either cross-compiling from the wrong package or has nothing to retain.
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set_property(
+      TARGET ${_target}
+      APPEND
+      PROPERTY INTERFACE_LINK_OPTIONS
+               "LINKER:-rpath,$ORIGIN"
+               "LINKER:-rpath,$ORIGIN/../lib"
+               # One option per component rather than a shared push-state pair:
+               # CMake removes duplicate link options, so repeating the same
+               # push-state text for a second component silently drops its
+               # scoping and the library goes back to being --as-needed. Naming
+               # the library inside the same option keeps each one distinct.
+               #
+               # --no-as-needed applies only to what follows within the pushed
+               # state, so the pop restores whatever the consumer had.
+               "LINKER:--push-state,--no-as-needed,${_library},--pop-state"
+    )
+  endif()
+  set(EXECUTORCH_LIBRARIES
+      ${EXECUTORCH_LIBRARIES} ${_target}
+      PARENT_SCOPE
+  )
+endfunction()
+
+executorch_define_component(threadpool executorch_threadpool)
+
+# The merged CPU kernels. Documented as a component and asserted by the release
+# checks, so it has to be defined here or a consumer following the documentation
+# gets a bare name that CMake hands to the linker as a literal flag.
+executorch_define_component(kernels_optimized executorch_kernels_optimized)
+# The profiler. A C++ application could not record timing data from an installed
+# package before, because the implementation shipped only inside the Python
+# extension.
+executorch_define_component(etdump executorch_etdump)
+
+# The switch a source build sets, on the runtime rather than on the thread pool
+# target. The guarded declaration lives in a runtime header that every component
+# exposes, and it selects between an extern declaration and a local inline
+# definition. Putting it on the thread pool alone means a consumer with one
+# translation unit linking that component and another linking only the kernels
+# compiles two different definitions of the same function into one program, and
+# the serial one silently wins wherever it was inlined.
+#
+# Only when the thread pool actually shipped. Packaging gates that library on
+# the build flags it needs, so a wheel built without them has no thread pool,
+# and switching the declaration on there would leave a consumer calling a
+# function nothing defines.
+if(TARGET executorch::runtime AND TARGET executorch::threadpool)
+  set_property(
+    TARGET executorch::runtime
+    APPEND
+    PROPERTY INTERFACE_COMPILE_DEFINITIONS ET_USE_THREADPOOL
+  )
+  # The definition selects a declaration, and the thread pool library holds the
+  # only definition of what it declares, so a consumer linking just the runtime
+  # would fail to link. Carried on the runtime rather than left to the caller,
+  # since the caller cannot see which header a compile definition on an imported
+  # target switched.
+  set_property(
+    TARGET executorch::runtime
+    APPEND
+    PROPERTY INTERFACE_LINK_LIBRARIES executorch::threadpool
+  )
+endif()
+
+executorch_define_component(backend_xnnpack executorch_backend_xnnpack)
+
+# Find prebuilt _portable_lib.<EXT_SUFFIX>.so. This is the legacy contract used
+# to build custom-op extensions against the Python module, and is kept working
+# independently of the runtime target above.
 
 # Find python
 if(DEFINED ENV{CONDA_DEFAULT_ENV} AND NOT $ENV{CONDA_DEFAULT_ENV} STREQUAL
@@ -45,6 +477,20 @@ execute_process(
 
 if(SYSCONFIG_RESULT EQUAL 0)
   message(STATUS "Sysconfig extension suffix: ${EXT_SUFFIX}")
+elseif(_executorch_runtime_library) # Tested on the located library rather than
+                                    # the imported target, because the
+  # targets are not defined below the CMake version they need, and a C++
+  # application on an older CMake is exactly the case this branch exists to keep
+  # working. A C++ application linking only the shared runtime does not need
+  # Python at all, so a missing interpreter must not fail its configure. Skip
+  # locating the Python extension instead; the legacy _portable_lib target is
+  # simply not offered in that case.
+  message(
+    STATUS
+      "Python not usable, skipping the Python extension: ${SYSCONFIG_ERROR}"
+  )
+  set(EXT_SUFFIX "")
+  set(_portable_lib_LIBRARY "")
 else()
   message(
     FATAL_ERROR
@@ -52,66 +498,152 @@ else()
   )
 endif()
 
-find_library(
-  _portable_lib_LIBRARY
-  NAMES _portable_lib${EXT_SUFFIX}
-  PATHS "${CMAKE_CURRENT_LIST_DIR}/../../extension/pybindings/"
-)
+if(EXT_SUFFIX)
+  # Tested directly rather than through find_library, for the same reason as the
+  # package root: the path and the file name are both already known, so a search
+  # only adds the consumer's find-root rules, which reroot an absolute wheel
+  # path into a cross-compile sysroot and report a present extension as missing.
+  set(_portable_lib_candidate
+      "${_executorch_package_root}/extension/pybindings/_portable_lib${EXT_SUFFIX}"
+  )
+  if(EXISTS "${_portable_lib_candidate}")
+    set(_portable_lib_LIBRARY "${_portable_lib_candidate}")
+  else()
+    set(_portable_lib_LIBRARY "")
+  endif()
+endif()
 
-set(EXECUTORCH_LIBRARIES)
-set(EXECUTORCH_FOUND OFF)
+if(NOT _portable_lib_LIBRARY)
+  # The interpreter that answered above is whichever python3 is on PATH, which
+  # is not necessarily the one this wheel was built for. A cp310 wheel inspected
+  # by a 3.12 interpreter yields a suffix that names no file here, and the
+  # package then reported itself as not found on a complete install. The shipped
+  # extension carries its own suffix in its name, so take it from the package.
+  file(GLOB _portable_lib_matches
+       "${_executorch_package_root}/extension/pybindings/_portable_lib.*"
+  )
+  foreach(_candidate IN LISTS _portable_lib_matches)
+    if(_candidate MATCHES "\\.(so|pyd|dylib)$")
+      set(_portable_lib_LIBRARY "${_candidate}")
+      break()
+    endif()
+  endforeach()
+  unset(_portable_lib_matches)
+endif()
+
 if(_portable_lib_LIBRARY)
   set(EXECUTORCH_FOUND ON)
   message(
     STATUS "ExecuTorch portable library is found at ${_portable_lib_LIBRARY}"
   )
-  list(APPEND EXECUTORCH_LIBRARIES _portable_lib)
-  add_library(_portable_lib STATIC IMPORTED)
-  set(EXECUTORCH_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../../include)
+  # Only when nothing else is linkable. This is a Python extension, so it
+  # carries unresolved interpreter symbols, and a plain C++ application that
+  # links it fails with a page of PyUnicode_InternFromString style errors.
+  # Callers who want it ask for the _portable_lib target by name, which is the
+  # documented contract for building a custom operator against the bindings.
+  if(NOT EXECUTORCH_LIBRARIES)
+    list(APPEND EXECUTORCH_LIBRARIES _portable_lib)
+  endif()
+  if(TARGET _portable_lib)
+    # This file ran already in the same configure, because another subproject
+    # called find_package too. No in-tree target uses this name, so it can only
+    # be the imported one defined below, and re-setting its properties to the
+    # same values is harmless.
+    message(STATUS "executorch: _portable_lib is already defined, reusing it")
+  else()
+    add_library(_portable_lib STATIC IMPORTED)
+  endif()
+  # PyTorch requires C++20, so pybindings must be compiled with C++20.
   set_target_properties(
     _portable_lib
     PROPERTIES IMPORTED_LOCATION "${_portable_lib_LIBRARY}"
                INTERFACE_INCLUDE_DIRECTORIES "${EXECUTORCH_INCLUDE_DIRS}"
-               # PyTorch requires C++20, so anything linking this must compile
-               # as
-               # C++20. An interface requirement rather than CXX_STANDARD,
-               # because
-               # an imported target compiles nothing itself and CXX_STANDARD
-               # does
-               # not reach consumers, so a custom-op build could still compile
-               # as
-               # C++17 and fail against headers that need C++20.
+               # An interface requirement rather than CXX_STANDARD: an imported
+               # target compiles nothing itself, and CXX_STANDARD does not reach
+               # consumers, so a custom-op build linking this could still
+               # compile
+               # as C++17 and fail against headers that need C++20.
                INTERFACE_COMPILE_FEATURES cxx_std_20
+               # The same definition the runtime target carries. A custom-op
+               # build that links only this target still compiles against the
+               # same headers and needs it too.
+               INTERFACE_COMPILE_DEFINITIONS C10_USING_CUSTOM_GENERATED_MACROS
   )
-
   # The extension links the runtime rather than containing it, so it no longer
   # satisfies the runtime symbols a custom-op library references. Put the
   # shipped runtime on this target's interface, which is where the definitions
   # moved to, so an out-of-tree operator project keeps building and loading
-  # against the extension exactly as it did before.
-  find_library(
-    EXECUTORCH_RUNTIME_LIBRARY executorch
-    PATHS "${CMAKE_CURRENT_LIST_DIR}/../../lib"
-    NO_DEFAULT_PATH
-  )
-  if(EXECUTORCH_RUNTIME_LIBRARY)
+  # against the extension exactly as it did before. Without this a custom
+  # operator links and then fails to load with an undefined runtime symbol.
+  #
+  # The file path rather than executorch::runtime, because that target is only
+  # defined on CMake 3.28 or newer while this one has no such requirement.
+  if(_executorch_runtime_library)
     set_property(
       TARGET _portable_lib
       APPEND
-      PROPERTY INTERFACE_LINK_LIBRARIES "${EXECUTORCH_RUNTIME_LIBRARY}"
+      PROPERTY INTERFACE_LINK_LIBRARIES "${_executorch_runtime_library}"
     )
   endif()
 endif()
 
 # find_package checks <package name>_FOUND, which is case-sensitive and does not
 # match the EXECUTORCH_FOUND spelling this file documents. Without this, a
-# REQUIRED find_package succeeds even when nothing usable was located, and the
-# consumer goes on to link nothing.
+# REQUIRED find_package would succeed even when nothing usable was located.
 set(executorch_FOUND ${EXECUTORCH_FOUND})
 if(NOT executorch_FOUND AND executorch_FIND_REQUIRED)
   message(
     FATAL_ERROR
-      "Found the ExecuTorch package but could not locate the Python extension "
-      "inside it, so there is nothing to link."
+      "Found the ExecuTorch package but neither the shared runtime nor the Python "
+      "extension could be located inside it."
   )
+endif()
+
+# Component requests are answered from the targets that were actually defined
+# above, so a consumer asking for a component this wheel does not ship gets told
+# at configure time rather than at link or load time. Without this a REQUIRED
+# request for a missing component, or for a name that does not exist at all,
+# would configure and then fail much later.
+#
+# The check is written out rather than using check_required_components, which
+# comes from a module a package config cannot assume is already included.
+foreach(_component ${executorch_FIND_COMPONENTS})
+  if(TARGET executorch::${_component})
+    set(executorch_${_component}_FOUND TRUE)
+  else()
+    set(executorch_${_component}_FOUND FALSE)
+    if(executorch_FIND_REQUIRED_${_component})
+      set(executorch_FOUND FALSE)
+      # Naming the CMake version when that is the cause saves a consumer from
+      # concluding the component is missing from the package, which is the wrong
+      # thing to go looking for.
+      if(NOT _executorch_targets_supported)
+        # One string rather than several arguments. Several make a list, and
+        # message() joins a list with semicolons, which lands separators mid
+        # sentence.
+        string(
+          CONCAT
+            executorch_NOT_FOUND_MESSAGE
+            "the required component '${_component}' needs CMake 3.28 or newer, because older "
+            "versions write the \$ORIGIN token in a runtime search path incorrectly; this "
+            "package is otherwise usable through EXECUTORCH_LIBRARIES"
+        )
+      else()
+        # One string rather than several arguments. Several make a list, and
+        # message() joins a list with semicolons, which lands separators mid
+        # sentence.
+        string(
+          CONCAT
+            executorch_NOT_FOUND_MESSAGE
+            "this ExecuTorch package does not provide the required component "
+            "'${_component}'. The prebuilt libraries the components wrap are "
+            "built for Linux only, so a wheel for another platform installs "
+            "the headers and this package without them"
+        )
+      endif()
+    endif()
+  endif()
+endforeach()
+if(NOT executorch_FOUND AND executorch_FIND_REQUIRED)
+  message(FATAL_ERROR "${executorch_NOT_FOUND_MESSAGE}")
 endif()

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -68,11 +68,50 @@ if(_portable_lib_LIBRARY)
   list(APPEND EXECUTORCH_LIBRARIES _portable_lib)
   add_library(_portable_lib STATIC IMPORTED)
   set(EXECUTORCH_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../../include)
-  # PyTorch requires C++20, so pybindings must be compiled with C++20.
   set_target_properties(
     _portable_lib
     PROPERTIES IMPORTED_LOCATION "${_portable_lib_LIBRARY}"
                INTERFACE_INCLUDE_DIRECTORIES "${EXECUTORCH_INCLUDE_DIRS}"
-               CXX_STANDARD 20
+               # PyTorch requires C++20, so anything linking this must compile
+               # as
+               # C++20. An interface requirement rather than CXX_STANDARD,
+               # because
+               # an imported target compiles nothing itself and CXX_STANDARD
+               # does
+               # not reach consumers, so a custom-op build could still compile
+               # as
+               # C++17 and fail against headers that need C++20.
+               INTERFACE_COMPILE_FEATURES cxx_std_20
+  )
+
+  # The extension links the runtime rather than containing it, so it no longer
+  # satisfies the runtime symbols a custom-op library references. Put the
+  # shipped runtime on this target's interface, which is where the definitions
+  # moved to, so an out-of-tree operator project keeps building and loading
+  # against the extension exactly as it did before.
+  find_library(
+    EXECUTORCH_RUNTIME_LIBRARY executorch
+    PATHS "${CMAKE_CURRENT_LIST_DIR}/../../lib"
+    NO_DEFAULT_PATH
+  )
+  if(EXECUTORCH_RUNTIME_LIBRARY)
+    set_property(
+      TARGET _portable_lib
+      APPEND
+      PROPERTY INTERFACE_LINK_LIBRARIES "${EXECUTORCH_RUNTIME_LIBRARY}"
+    )
+  endif()
+endif()
+
+# find_package checks <package name>_FOUND, which is case-sensitive and does not
+# match the EXECUTORCH_FOUND spelling this file documents. Without this, a
+# REQUIRED find_package succeeds even when nothing usable was located, and the
+# consumer goes on to link nothing.
+set(executorch_FOUND ${EXECUTORCH_FOUND})
+if(NOT executorch_FOUND AND executorch_FIND_REQUIRED)
+  message(
+    FATAL_ERROR
+      "Found the ExecuTorch package but could not locate the Python extension "
+      "inside it, so there is nothing to link."
   )
 endif()

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -53,7 +53,8 @@
 # from being dropped. The names, when present, are:
 #
 # executorch::kernels_optimized -- The CPU operator kernels. Needed to run a
-# model. executorch::backend_xnnpack   -- The XNNPACK delegate.
+# model. executorch::kernels_quantized -- The quantized operator kernels, for a
+# quantized model. executorch::backend_xnnpack   -- The XNNPACK delegate.
 # executorch::threadpool        -- The shared thread pool. executorch::etdump --
 # The profiler.
 #
@@ -237,7 +238,9 @@ if(_executorch_runtime_library AND NOT _executorch_targets_supported)
   # older-CMake route cannot use.
   set(EXECUTORCH_FOUND ON)
   list(APPEND EXECUTORCH_LIBRARIES "${_executorch_runtime_library}")
-  foreach(_kernels IN ITEMS libexecutorch_kernels_optimized)
+  foreach(_kernels IN ITEMS libexecutorch_kernels_optimized
+                            libexecutorch_kernels_quantized
+  )
     _executorch_find_library(_executorch_kernel_library "${_kernels}")
     if(_executorch_kernel_library)
       list(
@@ -415,6 +418,9 @@ executorch_define_component(threadpool executorch_threadpool)
 # checks, so it has to be defined here or a consumer following the documentation
 # gets a bare name that CMake hands to the linker as a literal flag.
 executorch_define_component(kernels_optimized executorch_kernels_optimized)
+# The quantized kernels, optional in the same way: a wheel built without them
+# simply has no such library and the component is not defined.
+executorch_define_component(kernels_quantized executorch_kernels_quantized)
 # The profiler. A C++ application could not record timing data from an installed
 # package before, because the implementation shipped only inside the Python
 # extension.

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -457,6 +457,37 @@ if(TARGET executorch::runtime AND TARGET executorch::threadpool)
 endif()
 
 executorch_define_component(backend_xnnpack executorch_backend_xnnpack)
+# The CUDA delegate and its stream helper, present only in a wheel built from a
+# CUDA index. A CPU wheel defines neither, so a consumer asking for one is told
+# while configuring.
+executorch_define_component(backend_cuda executorch_backend_cuda)
+executorch_define_component(extension_cuda executorch_extension_cuda)
+# The stream helper's public header includes cuda_runtime.h, which this wheel
+# does not publish. No include directory is put on the target, because there is
+# no correct one to point at.
+#
+# The nvidia pip wheels this package declares as dependencies carry a flat
+# header tree, and their own cuda_runtime.h includes "crt/host_config.h", so
+# compiling against them fails on the very first include. They supply the
+# runtime library, not a usable header tree.
+#
+# find_package(CUDAToolkit) is not used either. It searches for a full toolkit
+# layout, which those wheels are not, so it silently resolves to whichever
+# system toolkit is installed instead. It also runs in the caller's scope, where
+# it deposits dozens of CUDA:: imported targets and a pinned CUDAToolkit_BIN_DIR
+# cache entry that makes a later find_package(CUDAToolkit) in the consumer's own
+# project resolve to that toolkit rather than the one it asked for.
+#
+# A consumer of this header is writing CUDA host code and creating streams, so
+# it already needs a toolkit of its own. Saying so is better than pointing at
+# something that does not work.
+if(TARGET executorch::extension_cuda)
+  message(
+    STATUS
+      "executorch: extension_cuda's header includes cuda_runtime.h, which this wheel does not "
+      "publish. Add a CUDA toolkit's include directory to any target that includes it."
+  )
+endif()
 
 # Find prebuilt _portable_lib.<EXT_SUFFIX>.so. This is the legacy contract used
 # to build custom-op extensions against the Python module, and is kept working

--- a/tools/cmake/preset/pybind.cmake
+++ b/tools/cmake/preset/pybind.cmake
@@ -104,6 +104,11 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     endif()
   endif()
   set_overridable_option(EXECUTORCH_BUILD_OPENVINO OFF)
+  # Ship one shared runtime that both the pybind extension and standalone C++
+  # consumers link, so a process has a single backend registry. Linux only:
+  # macOS C++ consumers are served by the Swift package distribution, and the
+  # runtime has no export annotations for a Windows DLL.
+  set_overridable_option(EXECUTORCH_BUILD_SHARED ON)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL
                                                "WIN32"
 )


### PR DESCRIPTION
Draft, for continuous integration coverage only. Do not land.

Combines the device-activation copy fix with the CUDA wheel rows so a wheel is built that contains the fix. Without this, the fix has no wheel to verify against: it targets main, which does not yet have CUDA wheel rows, so no wheel job runs on it.

The fix and the wheel work are reviewed separately in their own pull requests.
