### PR TITLE
Tell the runtime which device a Python input lives on

### DIFF
--- a/extension/aten_util/aten_bridge.cpp
+++ b/extension/aten_util/aten_bridge.cpp
@@ -134,6 +134,22 @@ c10::ScalarType executorch_to_torch_scalar_type(
   return static_cast<c10::ScalarType>(intermediate);
 }
 
+executorch::runtime::etensor::Device torch_to_executorch_device(
+    c10::Device device) {
+  using executorch::runtime::etensor::DeviceIndex;
+  using executorch::runtime::etensor::DeviceType;
+
+  if (device.is_cpu()) {
+    return executorch::runtime::etensor::Device(DeviceType::CPU);
+  }
+  ET_CHECK_MSG(
+      device.is_cuda(),
+      "Device type %s is not supported by the ExecuTorch runtime",
+      c10::DeviceTypeName(device.type()).c_str());
+  return executorch::runtime::etensor::Device(
+      DeviceType::CUDA, static_cast<DeviceIndex>(device.index()));
+}
+
 /*
  * Following makes two assumptions:
  * 1. aten_tensor's lifetime is longer than the liftime within which mutable_et

--- a/extension/aten_util/aten_bridge.h
+++ b/extension/aten_util/aten_bridge.h
@@ -28,6 +28,17 @@ torch::executor::ScalarType torch_to_executorch_scalar_type(
 c10::ScalarType executorch_to_torch_scalar_type(
     torch::executor::ScalarType type);
 
+/**
+ * Translates a PyTorch device into the runtime's own device description.
+ *
+ * Needed so a tensor handed in from Python is described as living where it actually lives. A device
+ * tensor labelled as host memory is copied with a host memcpy, which is undefined.
+ *
+ * Throws for a device type the runtime does not model, rather than silently reporting host memory.
+ */
+executorch::runtime::etensor::Device torch_to_executorch_device(
+    c10::Device device);
+
 /*
  * @param[in] aten_tensor Input at::Tensor
  * @param[in,out] mutable_et ETensor whose underlying memory now will alias to

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -103,6 +103,7 @@ using torch::executor::ETDumpGen;
 #ifndef USE_ATEN_LIB
 using ::executorch::extension::alias_attensor_to_etensor;
 using ::executorch::extension::alias_etensor_to_attensor;
+using ::executorch::extension::torch_to_executorch_device;
 using ::executorch::extension::torch_to_executorch_scalar_type;
 #endif // !USE_ATEN_LIB
 
@@ -1109,11 +1110,11 @@ struct PyMethod final {
         auto type =
             torch_to_executorch_scalar_type(at_tensor.options().dtype());
         size_t dim = at_tensor.dim();
-        // cant directly alias at::Tensor sizes and strides due to int64 vs
-        // int32 typing conflict
-        std::vector<int> sizes(
+        // Rebuilt rather than aliased, because an at::Tensor reports 64-bit sizes and strides while
+        // the runtime uses narrower types.
+        std::vector<aten::SizesType> sizes(
             at_tensor.sizes().begin(), at_tensor.sizes().end());
-        std::vector<int> strides(
+        std::vector<aten::StridesType> strides(
             at_tensor.strides().begin(), at_tensor.strides().end());
 
         // Only works for MemoryFormat::Contiguous or MemoryFormat::ChannelsLast
@@ -1133,14 +1134,18 @@ struct PyMethod final {
               " should be contiguous or channels-last.";
           throw std::runtime_error(error_msg);
         }
-        TensorPtr tensor = for_blob(
-                               mutable_tensor_data_ptr_no_cow(at_tensor),
-                               std::move(sizes),
-                               type)
-                               .strides(std::move(strides))
-                               .dim_order(std::move(dim_order))
-                               .dynamism(aten::TensorShapeDynamism::STATIC)
-                               .make_tensor_ptr();
+        // The device comes from the tensor the caller passed, so a program whose activations stay on
+        // an accelerator sees its input described as device memory. Defaulting to CPU labelled a GPU
+        // input as host memory, and the runtime then copied it with a host memcpy.
+        TensorPtr tensor = make_tensor_ptr(
+            std::move(sizes),
+            mutable_tensor_data_ptr_no_cow(at_tensor),
+            std::move(dim_order),
+            std::move(strides),
+            type,
+            aten::TensorShapeDynamism::STATIC,
+            nullptr,
+            torch_to_executorch_device(at_tensor.device()));
         input_tensors.push_back(tensor);
         EValue evalue(input_tensors.back());
 #endif


### PR DESCRIPTION
## The problem

When you pass a tensor to a model from Python, ExecuTorch builds its own description of
that tensor: the shape, the data type, and where the memory lives. That last part was
never filled in, so it always said main memory (the host):

```cpp
TensorPtr tensor = for_blob(data_ptr, sizes, type)
    .strides(...).dim_order(...).make_tensor_ptr();   // device silently defaults to CPU
```

For an ordinary model that is correct, since the tensor really is in main memory. It is
wrong for a model whose activations stay on the GPU, where you hand over memory that is
already on the GPU. The runtime reads this description to decide what to do with your
input, so it was being told the wrong thing, and nothing downstream could tell the
difference between a host tensor and a GPU one.

## The change

Pass the tensor's device through instead of letting it default:

```cpp
TensorPtr tensor = make_tensor_ptr(
    std::move(sizes), data_ptr, std::move(dim_order), std::move(strides), type,
    aten::TensorShapeDynamism::STATIC, nullptr,
    torch_to_executorch_device(at_tensor.device()));
```

The tensor factory already accepts a device, and its documentation describes exactly this
case, so nothing new had to be invented:

```
The `device` parameter sets the Tensor's device location only, no data is
allocated or copied. The caller is responsible for ensuring `data` already
lives on the requested device.
```

The one new piece is a small translator beside the existing scalar-type one, because
PyTorch and the ExecuTorch runtime describe devices with different types:

```cpp
executorch::runtime::etensor::Device torch_to_executorch_device(c10::Device device);
```

It raises an error for a device the runtime does not model, rather than quietly reporting
host memory. Quietly reporting host memory is what made the original problem invisible.

The size and stride vectors now use the runtime's own types, which the factory takes
directly, so no extra conversion happens at the call.

## Test plan

- ran a CPU model from Python and confirmed it still matches eager PyTorch exactly. Every
  existing caller goes through this code path, so this is the important check: the device
  of an ordinary tensor is the host, which is what the code used to assume.
- ran the Python binding test suite as a baseline. Two quantized-operator tests fail
  before this change as well, for an unrelated reason, and the remaining 35 pass.

Tested on Linux x86_64. Continuous integration builds and runs these bindings, which is
where the compiled result is exercised.

## Note

This describes the input correctly; it does not by itself make a GPU-activation program
run from Python. Such a program also has to be exported so the runtime shares the
caller's memory rather than reserving its own buffer for it.
