### PR TITLE
Qualcomm AI Engine Direct - Change transpose output from NCH1 to NC1W before conv

### DIFF
--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -168,11 +168,20 @@ def convert_linear_to_conv2d(module: torch.nn.Module):
 
         def forward(self, x):
             rank = x.dim()
-            x = x.reshape(*x.shape, 1) if rank == 3 else x.reshape(1, *x.shape, 1)
-            x = torch.transpose(x, 1, 2)
+            if rank == 3:
+                bsz, dim0, dim1 = x.size()
+                x = torch.reshape(x, (bsz, dim0, 1, dim1))
+            else:
+                dim0, dim1 = x.size()
+                x = torch.reshape(x, (1, dim0, 1, dim1))
+            x = torch.transpose(x, 1, 3)
             res = self.conv(x)
-            res = torch.transpose(res, 1, 2)
-            res = res.squeeze(-1) if rank == 3 else res.reshape(*res.shape[1:3])
+            res = res.permute(0, 3, 1, 2)
+            res = (
+                res.squeeze(-1)
+                if rank == 3
+                else res.reshape(dim0, self.conv.weight.shape[0])
+            )
             return res
 
     def replace_linear(module: torch.nn.Module):


### PR DESCRIPTION
### Summary
This memory layout has better performance on the HTP backend, and lead to better performance on prefill model.
 
#### Prefill performance of third partitioned graph:
| Model               | w/o      | w/       |
|---------------------|:--------:|:--------:|
| llama3.2 3b instruct| 55924    | 35774    |



cc @cbilgin @psiddh