### PR TITLE
Git-ignore CMakeUserPresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ xcuserdata/
 /src/executorch/share/
 /src/executorch/version.py
 *_etdump
+CMakeUserPresets.json
 
 # Android
 *.aar


### PR DESCRIPTION
CMakeUserPresets.json is intended for developer- and machine-specific configuration, such as local paths, toolchains, and IDE settings. Keep shared project configuration in CMakePresets.json and exclude user-specific presets from version control.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani