### PR TITLE
Fuse mul into dequant when the multiplier is a lifted constant

### DIFF
--- a/backends/cadence/aot/fuse_ops.py
+++ b/backends/cadence/aot/fuse_ops.py
@@ -876,12 +876,45 @@ class FuseMulTensorIntoQuantPass(RemoveOrReplacePassInterface):
         return True
 
 
+def get_constant_scalar_from_node(node: torch.fx.Node) -> Optional[Number]:
+    """Return the compile-time scalar produced by ``node``, or None.
+
+    A single-valued multiplier reaches the graph in more than one spelling.
+    ``aten.full`` carries its fill value inline, but ``to_edge`` lifts a literal
+    operand into a constant placeholder instead, holding the value on the
+    FakeTensor (``meta["val"].constant``) or as a module attribute. Recognising
+    only the ``aten.full`` form silently misses the lifted ones.
+    """
+    if node.target == exir_ops.edge.aten.full.default:
+        value = node.args[1]
+        return value if isinstance(value, Number) else None
+
+    if node.op not in ("placeholder", "get_attr"):
+        return None
+
+    tensor = getattr(node.meta.get("val"), "constant", None)
+    target = node.target
+    if tensor is None and isinstance(target, str):
+        obj: object = node.graph.owning_module
+        for part in target.split("."):
+            if obj is None:
+                break
+            obj = getattr(obj, part, None)
+        tensor = obj
+    if isinstance(tensor, torch.nn.Parameter):
+        tensor = tensor.data
+    if not isinstance(tensor, torch.Tensor) or tensor.numel() != 1:
+        return None
+    return tensor.item()
+
+
 @register_cadence_pass(CadencePassAttribute(opt_level=1))
 class FuseMulTensorIntoDequantPass(RemoveOrReplacePassInterface):
     """
     Looks for the pattern where aten.mul is multiplying the outputs of dequantize
-    and aten.full, or vice versa. If found, updates the dequant scale to reflect
-    the multiplication and removes the full and mul nodes.
+    and a single-valued constant (an aten.full node or a lifted constant
+    placeholder), or vice versa. If found, updates the dequant scale to reflect
+    the multiplication and removes the mul node.
     """
 
     @property
@@ -889,7 +922,8 @@ class FuseMulTensorIntoDequantPass(RemoveOrReplacePassInterface):
         return [exir_ops.edge.aten.mul.Tensor]
 
     def maybe_remove_or_replace(self, node: torch.fx.Node) -> bool:
-        # Ensure that one of the args to mul is dequantize and the other is aten.full
+        # Ensure that one of the args to mul is dequantize and the other is a
+        # compile-time scalar.
         dequant_nodes = [
             arg
             for arg in node.args
@@ -905,7 +939,7 @@ class FuseMulTensorIntoDequantPass(RemoveOrReplacePassInterface):
             arg
             for arg in node.args
             if isinstance(arg, torch.fx.Node)
-            and arg.target == exir_ops.edge.aten.full.default
+            and get_constant_scalar_from_node(arg) is not None
         ]
 
         if len(dequant_nodes) != 1 or len(multiplier_nodes) != 1:
@@ -914,15 +948,16 @@ class FuseMulTensorIntoDequantPass(RemoveOrReplacePassInterface):
         deq_node = dequant_nodes[0]
         mplier_node = multiplier_nodes[0]
 
-        # Ensure that dequant and full don't have any other users
+        # Ensure that dequant and the multiplier don't have any other users
         if len(deq_node.users) > 1 or len(mplier_node.users) > 1:
             return False
 
+        multiplier = get_constant_scalar_from_node(mplier_node)
         new_deq_args = list(deq_node.args)
         assert isinstance(deq_node.args[1], Number)
-        assert isinstance(mplier_node.args[1], Number)
+        assert isinstance(multiplier, Number)
         # pyre-ignore[58]: Unsupported operand *
-        new_deq_args[1] = deq_node.args[1] * mplier_node.args[1]
+        new_deq_args[1] = deq_node.args[1] * multiplier
 
         logging.debug(
             f"Fused {node} and {mplier_node} into {deq_node}. Updated scale from {deq_node.args[1]} to {new_deq_args[1]}"
@@ -933,9 +968,12 @@ class FuseMulTensorIntoDequantPass(RemoveOrReplacePassInterface):
         # Update the dequant node's args with the new scale
         deq_node.args = tuple(new_deq_args)
 
-        # Erase the mul and full nodes
         node.graph.erase_node(node)
-        node.graph.erase_node(mplier_node)
+        # Only the full node is ours to erase. A placeholder is part of the
+        # ExportedProgram's input signature, so removing it here would desync
+        # the signature from the graph; leave it dangling for the owner to drop.
+        if mplier_node.op == "call_function":
+            node.graph.erase_node(mplier_node)
 
         return True
 

--- a/backends/cadence/aot/tests/test_fusion_ops_passes.py
+++ b/backends/cadence/aot/tests/test_fusion_ops_passes.py
@@ -739,6 +739,107 @@ class TestFusionPasses(TestFusionPassesBase):
                 deq_scale = node.args[1]
         self.assertEqual(deq_scale, DEQUANT_SCALE * FULL_VALUE)
 
+    def test_fuse_mul_into_dequant_lifted_constant_multiplier(self) -> None:
+        """`to_edge` lifts a literal mul operand into a constant placeholder
+        rather than an `aten.full`, so the pass must fold that spelling too."""
+        INPUT_SHAPE: Final[List[int]] = [4, 32]
+        DEQUANT_SCALE: Final[float] = 1.5
+        CONST_VALUE: Final[float] = 0.7071067811865476
+
+        builder = GraphBuilder()
+        x_input = torch.randint(low=0, high=255, size=INPUT_SHAPE, dtype=torch.uint8)
+        x = builder.placeholder("x", x_input)
+        # 0-d constant, matching what to_edge produces for a scalar operand.
+        const_input = torch.tensor(CONST_VALUE)
+        const = builder.placeholder("lifted_constant", const_input)
+        dequant = builder.call_operator(
+            op=exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+            args=(x, DEQUANT_SCALE, 0, 0, 255, torch.uint8),
+        )
+        mul = builder.call_operator(
+            op=exir_ops.edge.aten.mul.Tensor,
+            args=(dequant, const),
+        )
+        builder.output([mul])
+        original_graph = builder.get_graph_module()
+        # Export marks lifted constants by hanging the real tensor off the
+        # placeholder's FakeTensor; GraphBuilder does not, so set it here.
+        for node in original_graph.graph.find_nodes(op="placeholder"):
+            if node.name == "lifted_constant":
+                node.meta["val"].constant = const_input
+        gm_before = copy.deepcopy(original_graph)
+
+        result = cast(PassResult, FuseMulTensorIntoDequantPass()(original_graph))
+        self.assertTrue(result.modified)
+        converted_graph = result.graph_module
+
+        validate_numerics(
+            gm_before,
+            converted_graph,
+            (x_input, const_input),
+            "FuseMulTensorIntoDequantPass",
+        )
+
+        self.check_op_counts(
+            converted_graph,
+            expected_op_counts={
+                exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default: 1,
+                exir_ops.edge.aten.mul.Tensor: 0,
+            },
+        )
+
+        dequant_nodes = converted_graph.graph.find_nodes(
+            op="call_function",
+            target=exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+        )
+        self.assertEqual(len(dequant_nodes), 1)
+        # The constant is fp32, so the folded scale carries its fp32 value --
+        # not the fp64 literal it was built from.
+        self.assertEqual(dequant_nodes[0].args[1], DEQUANT_SCALE * const_input.item())
+
+        # The placeholder is part of the input signature; erasing it would
+        # desync the signature, so it must survive as an unused input.
+        self.assertEqual(
+            len(
+                [
+                    n
+                    for n in converted_graph.graph.find_nodes(op="placeholder")
+                    if n.name == "lifted_constant"
+                ]
+            ),
+            1,
+        )
+
+    def test_fuse_mul_into_dequant_rejects_non_scalar_constant(self) -> None:
+        """A multi-element constant cannot be folded into a per-tensor scale."""
+        INPUT_SHAPE: Final[List[int]] = [4, 32]
+
+        builder = GraphBuilder()
+        x_input = torch.randint(low=0, high=255, size=INPUT_SHAPE, dtype=torch.uint8)
+        x = builder.placeholder("x", x_input)
+        const_input = torch.full(INPUT_SHAPE, 3.0)
+        const = builder.placeholder("lifted_constant", const_input)
+        dequant = builder.call_operator(
+            op=exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+            args=(x, 1.5, 0, 0, 255, torch.uint8),
+        )
+        mul = builder.call_operator(
+            op=exir_ops.edge.aten.mul.Tensor,
+            args=(dequant, const),
+        )
+        builder.output([mul])
+        original_graph = builder.get_graph_module()
+        for node in original_graph.graph.find_nodes(op="placeholder"):
+            if node.name == "lifted_constant":
+                node.meta["val"].constant = const_input
+
+        result = cast(PassResult, FuseMulTensorIntoDequantPass()(original_graph))
+        self.assertFalse(result.modified)
+        self.check_op_counts(
+            result.graph_module,
+            expected_op_counts={exir_ops.edge.aten.mul.Tensor: 1},
+        )
+
     def test_fuse_mul_into_dequant_no_match(self) -> None:
         """
         Test that FuseMulTensorIntoDequantPass does NOT modify the graph


### PR DESCRIPTION
Summary:
`FuseMulTensorIntoDequantPass` only recognised `aten.full.default` as a compile-time scalar, but `to_edge` lifts a literal `mul` operand into a constant placeholder instead. The multiplier filter matched nothing, so the mul survived lowering: on the Gemma4 E2B decoder, `dequantize -> mul(x, 0.7071067811865476) -> 35x select_copy` reached `partitioned.dot` intact.

Adds `get_constant_scalar_from_node` to resolve the other spellings (`meta["val"].constant`, module attribute), guarded on `numel() == 1` so a multi-element constant cannot collapse into a single scale. Erasure now skips placeholders, which belong to the ExportedProgram input signature.

Buffer-backed multipliers (`b_`-prefixed) still need `graph_signature.inputs_to_buffers`; left for a follow-up.

Differential Revision: D115317359


