### PR TITLE
Remove torchao spinquant usage from llama example wrapper

### DIFF
--- a/examples/qualcomm/oss_scripts/llama/wrappers/llm_wrappers.py
+++ b/examples/qualcomm/oss_scripts/llama/wrappers/llm_wrappers.py
@@ -10,7 +10,6 @@ import inspect
 import json
 import logging
 import re
-import types
 
 from functools import partial
 from typing import Any, Dict, List
@@ -106,7 +105,6 @@ from executorch.exir.passes.memory_planning_pass import MemoryPlanningPass
 from executorch.extension.llm.custom_ops import model_sharding
 from executorch.extension.llm.export.builder import DType
 from torch.utils.data import DataLoader
-from torchao.prototype.spinquant import apply_spinquant
 from torchao.quantization.pt2e import MinMaxObserver
 from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
 from transformers import AutoModel, AutoModelForSpeechSeq2Seq
@@ -290,21 +288,10 @@ class TextDecoder(Component):
 
         decoder.load_state_dict(state_dict, strict=True, assign=True)
 
-        # apply spin quant if required
         if any([self.config.r1, self.config.r2]):
-            decoder.config = types.SimpleNamespace(
-                dim=decoder.dim,
-                head_dim=decoder.dim // decoder.n_heads,
-                n_local_heads=decoder.n_heads,
-                intermediate_size=4 * decoder.dim,
-            )
-            apply_spinquant(
-                decoder,
-                use_r1=self.config.r1,
-                use_r2=self.config.r2,
-                use_r4=False,
-                pretrained_rotation_path=None,
-                qkv_split=True,
+            raise RuntimeError(
+                "SpinQuant (r1/r2) is no longer supported: the "
+                "torchao.prototype.spinquant module has been deleted."
             )
 
         # perform model transformation


### PR DESCRIPTION
Summary:
We are deprecating and deleting `torchao.prototype.spinquant` from OSS
torchao. The only ExecuTorch consumer is the Qualcomm llama example wrapper
`llm_wrappers.py`, which imported `apply_spinquant` and invoked it when the
`r1`/`r2` rotation configs were set.

This removes that dependency: the `apply_spinquant` import and call site are
deleted, along with the now-unused `import types` (its only use was building
the `types.SimpleNamespace` fed to `apply_spinquant`). To avoid silently
ignoring a caller who requests SpinQuant, the `r1`/`r2` config path now raises
a `RuntimeError` stating that SpinQuant has been removed, rather than being a
no-op.

The `r1`/`r2`/`r3` fields on `LLMModelConfig` are intentionally left in place
for now; they are simply no longer consumed here.

This unblocks the follow-up deletion of `torchao.prototype.spinquant` from OSS
torchao.

Authored with AI (Claude Code).

Differential Revision: D115234575


