### PR TITLE
Drop executorch opt-out, stop type-checking OSS code

### DIFF
--- a/backends/cadence/aot/BUCK
+++ b/backends/cadence/aot/BUCK
@@ -128,7 +128,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "ref_implementations.py",
     ],
-    typing = True,
     deps = [
         "fbcode//caffe2:torch",
         "fbcode//executorch/backends/cadence/aot:utils",
@@ -175,7 +174,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_pass_filter.py",
     ],
-    typing = True,
     deps = [
         ":pass_utils",
         "//executorch/exir:pass_base",
@@ -187,7 +185,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_pass_utils.py",
     ],
-    typing = True,
     deps = [
         ":pass_utils",
         "//caffe2:torch",
@@ -199,7 +196,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "compiler_utils.py",
     ],
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/exir/dialects:lib",
@@ -211,7 +207,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "to_out_var_pass.py",
     ],
-    typing = True,
     deps = [
         ":ops_registrations",
         "//caffe2:torch",
@@ -225,7 +220,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "graph_builder.py",
     ],
-    typing = True,
     deps = [
         "//executorch/backends/test:graph_builder",
     ],
@@ -236,7 +230,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "program_builder.py",
     ],
-    typing = True,
     deps = [
         "//executorch/backends/test:program_builder",
     ],
@@ -247,7 +240,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_program_builder.py",
     ],
-    typing = True,
     deps = [
         "//executorch/backends/test:program_builder",
         "//caffe2:torch",
@@ -260,7 +252,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "fuse_ops.py",
     ],
-    typing = True,
     deps = [
         ":compiler_utils",
         ":ops_registrations",
@@ -285,7 +276,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "simplify_ops.py",
     ],
-    typing = True,
     deps = [
         ":pass_utils",
         ":utils",
@@ -300,7 +290,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "remove_ops.py",
     ],
-    typing = True,
     deps = [
         ":fuse_ops",
         ":ops_registrations",
@@ -321,7 +310,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "reorder_ops.py",
     ],
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:compiler_utils",
@@ -340,7 +328,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "replace_ops.py",
     ],
-    typing = True,
     deps = [
         ":pass_utils",
         "//caffe2:torch",
@@ -362,7 +349,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "decompose_ops.py",
     ],
-    typing = True,
     deps = [
         ":pass_utils",
         "//caffe2:torch",
@@ -379,7 +365,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "type_dispatch.py",
     ],
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:pass_utils",
@@ -394,7 +379,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_type_dispatch_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":ops_registrations",
         ":typing_stubs",
@@ -412,7 +396,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "typing_stubs.py",
     ],
-    typing = True,
     deps = [
         "fbsource//third-party/pypi/parameterized:parameterized",
     ],
@@ -423,7 +406,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "compiler_funcs.py",
     ],
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/transforms:permute_pass_utils",
@@ -437,7 +419,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_graph_builder.py",
     ],
-    typing = True,
     deps = [
         ":ops_registrations",
         "//caffe2:torch",
@@ -455,7 +436,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_replace_ops_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":compiler",
         ":typing_stubs",
@@ -476,7 +456,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_decompose_ops_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":compiler",
         ":decompose_ops",
@@ -497,7 +476,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_fusion_ops_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":compiler",
         ":typing_stubs",
@@ -518,7 +496,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_remove_ops_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         "fbsource//third-party/pypi/pyre-extensions:pyre-extensions",
         ":typing_stubs",
@@ -540,7 +517,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_remove_bn_tracking_pass.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:remove_ops",
@@ -556,7 +532,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_simplify_ops_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":typing_stubs",
         "//caffe2:torch",
@@ -574,7 +549,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_reorder_ops_passes.py",
     ],
-    typing = True,
     deps = [
         ":compiler",
         ":pass_utils",
@@ -644,7 +618,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_memory_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":compiler",
         ":memory_planning",
@@ -665,7 +638,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_idma_ops.py",
     ],
-    typing = True,
     deps = [
         "//executorch/backends/test:graph_builder",
         "//executorch/backends/cadence/aot:ops_registrations",
@@ -680,7 +652,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_ref_implementations.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":typing_stubs",
         "//executorch/backends/cadence/aot:ops_registrations",
@@ -693,7 +664,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_quantizer_ops.py",
     ],
-    typing = True,
     deps = [
         "fbsource//third-party/pypi/parameterized:parameterized",
         "//caffe2:torch",
@@ -709,7 +679,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_to_out_var_pass.py",
     ],
-    typing = True,
     deps = [
         ":ops_registrations",
         "//executorch/backends/test:program_builder",

--- a/backends/cadence/aot/quantizer/BUCK
+++ b/backends/cadence/aot/quantizer/BUCK
@@ -19,7 +19,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "pattern_utils.py",
     ],
-    typing = True,
     deps = [
         ":utils",
         "//caffe2:torch",
@@ -34,7 +33,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "patterns.py",
     ],
-    typing = True,
     deps = [
         ":pattern_utils",
         ":utils",
@@ -48,7 +46,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "quantizer.py",
     ],
-    typing = True,
     deps = [
         ":patterns",
         ":utils",

--- a/backends/cadence/aot/quantizer/passes/BUCK
+++ b/backends/cadence/aot/quantizer/passes/BUCK
@@ -8,7 +8,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "fuse_ops.py",
     ],
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:pass_utils",

--- a/backends/cadence/runtime/BUCK
+++ b/backends/cadence/runtime/BUCK
@@ -21,7 +21,6 @@ fbcode_target(_kind = runtime.python_library,
     ] + glob([
         "xtsc-cfg/**/*",
     ]),
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/devtools/bundled_program:config",

--- a/backends/cadence/utils/targets.bzl
+++ b/backends/cadence/utils/targets.bzl
@@ -12,7 +12,6 @@ def define_common_targets():
         srcs = [
             "facto_util.py",
         ],
-        typing = True,
         deps = [
             "fbcode//caffe2:torch",
             "fbcode//pytorch/facto:facto",

--- a/backends/native/BUCK
+++ b/backends/native/BUCK
@@ -13,7 +13,6 @@ runtime.export_file(
 fbcode_target(
     _kind = runtime.python_library,
     name = "lib",
-    typing = True,
     srcs = [
         "serialization/__init__.py",
         "serialization/graph_serialize.py",

--- a/backends/test/targets.bzl
+++ b/backends/test/targets.bzl
@@ -12,7 +12,6 @@ def define_common_targets(is_fbcode = False):
             srcs = [
                 "graph_builder.py",
             ],
-            typing = True,
             deps = [
                 "//caffe2:torch",
                 "//executorch/exir:pass_base",
@@ -24,7 +23,6 @@ def define_common_targets(is_fbcode = False):
             srcs = [
                 "program_builder.py",
             ],
-            typing = True,
             deps = [
                 ":graph_builder",
                 "//caffe2:torch",

--- a/backends/vulkan/_passes/targets.bzl
+++ b/backends/vulkan/_passes/targets.bzl
@@ -132,7 +132,6 @@ def define_common_targets(is_fbcode = False):
             "//executorch/exir:pass_base",
             "//executorch/exir/dialects:lib",
         ],
-        typing = True,
     )
 
     runtime.python_library(

--- a/backends/vulkan/partitioner/BUCK
+++ b/backends/vulkan/partitioner/BUCK
@@ -20,5 +20,4 @@ fbcode_target(_kind = runtime.python_library,
         "//executorch/exir/backend:utils",
         "//executorch/exir/backend/canonical_partitioners:canonical_partitioner_lib",
     ],
-    typing = True,
 )

--- a/backends/vulkan/patterns/BUCK
+++ b/backends/vulkan/patterns/BUCK
@@ -32,5 +32,4 @@ fbcode_target(_kind = runtime.python_library,
         "//executorch/backends/transforms:utils",
         "//executorch/backends/vulkan:utils_lib",
     ],
-    typing = True,
 )


### PR DESCRIPTION
Summary:

Removing internal type checking from executorch, since it causes issues syncing pyrefly versions. 

