### PR TITLE
Introduce CompileMode compatibility API (#21721)

### DIFF
--- a/backends/cadence/aot/compiler.py
+++ b/backends/cadence/aot/compiler.py
@@ -45,7 +45,12 @@ from executorch.exir.program._program import to_edge
 from torch.export.exported_program import ExportedProgram
 from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e
 
-from .pass_utils import EdgePassesConfig
+from .pass_utils import (
+    CompileMode,
+    EdgePassesConfig,
+    normalize_compile_mode,
+    resolve_opt_level,
+)
 from .passes import apply_exir_ops_passes, apply_torch_ops_passes
 from .utils import print_ops_info
 
@@ -364,15 +369,16 @@ def quantize_and_export_to_edge(
 def _lower_ep_to_cadence(
     program: ExportedProgram,
     dump_graphs: bool = False,
-    opt_level: int = 1,
+    mode: CompileMode | int | None = None,
     edge_passes_config: Optional[EdgePassesConfig] = None,
+    opt_level: Optional[int] = None,
 ) -> EdgeProgramManager:
     """
     Lower an existing ExportedProgram to edge IR and apply frontend optimization passes.
     """
     edge_prog_manager = _lower_ep_to_edge(program, dump_graphs=dump_graphs)
     cadence_prog_manager = apply_exir_ops_passes(
-        opt_level, edge_prog_manager, edge_passes_config
+        resolve_opt_level(mode, opt_level), edge_prog_manager, edge_passes_config
     )
     return cadence_prog_manager
 
@@ -381,12 +387,13 @@ def export_to_cadence(
     model: torch.nn.Module,
     inputs: tuple[object, ...],
     dump_graphs: bool = False,
-    opt_level: int = 1,
+    mode: CompileMode | int | None = None,
     edge_passes_config: Optional[EdgePassesConfig] = None,
+    opt_level: Optional[int] = None,
 ) -> EdgeProgramManager:
     edge_prog_manager = export_to_edge(model, inputs, dump_graphs=dump_graphs)
     cadence_prog_manager = apply_exir_ops_passes(
-        opt_level, edge_prog_manager, edge_passes_config
+        resolve_opt_level(mode, opt_level), edge_prog_manager, edge_passes_config
     )
     return cadence_prog_manager
 
@@ -395,8 +402,9 @@ def quantize_and_export_to_cadence(
     model: torch.nn.Module,
     inputs: tuple[object, ...],
     dump_graphs: bool = False,
-    opt_level: int = 1,
+    mode: CompileMode | int | None = None,
     edge_passes_config: Optional[EdgePassesConfig] = None,
+    opt_level: Optional[int] = None,
 ) -> EdgeProgramManager:
     """
     Trace, quantize, lower a model/inputs pair to edge IR and apply frontend
@@ -406,6 +414,7 @@ def quantize_and_export_to_cadence(
 
     return _lower_ep_to_cadence(
         quantized_model,
+        mode=mode,
         opt_level=opt_level,
         dump_graphs=dump_graphs,
         edge_passes_config=edge_passes_config,
@@ -416,17 +425,19 @@ def export_to_executorch_gen_etrecord(
     model: torch.nn.Module,
     inputs: tuple[object, ...],
     output_dir: Optional[str] = None,
-    opt_level: int = 1,
+    mode: CompileMode | int | None = None,
     mem_algo: int = 0,
     alloc_graph_input: bool = True,
     alloc_graph_output: bool = True,
     memory_config: Optional[MemoryConfig] = None,
     dump_graphs: bool = False,
+    opt_level: Optional[int] = None,
 ) -> ExecutorchProgramManager:
     ep = torch.export.export(model, inputs, strict=True)
     return _lower_ep_to_cadence_gen_etrecord(
         ep,
         output_dir=output_dir,
+        mode=mode,
         opt_level=opt_level,
         mem_algo=mem_algo,
         alloc_graph_input=alloc_graph_input,
@@ -442,15 +453,18 @@ def export_to_executorch_gen_etrecord(
 def _lower_ep_to_cadence_gen_etrecord(
     ep: ExportedProgram,
     output_dir: Optional[str] = None,
-    opt_level: int = 1,
+    mode: CompileMode | int | None = None,
     mem_algo: int = 0,
     alloc_graph_input: bool = True,
     alloc_graph_output: bool = True,
     memory_config: Optional[MemoryConfig] = None,
     dump_graphs: bool = False,
+    opt_level: Optional[int] = None,
 ) -> ExecutorchProgramManager:
+    normalized_mode = normalize_compile_mode(mode, opt_level)
+    resolved_opt_level = resolve_opt_level(normalized_mode)
     edge_prog_manager = _lower_ep_to_edge(ep, dump_graphs)
-    cadence_prog_manager = apply_exir_ops_passes(opt_level, edge_prog_manager)
+    cadence_prog_manager = apply_exir_ops_passes(resolved_opt_level, edge_prog_manager)
 
     # Print some information to terminal
     print_ops_info(
@@ -463,7 +477,7 @@ def _lower_ep_to_cadence_gen_etrecord(
 
     memory_planning_pass = CadenceMemoryPlanning(
         memory_config,
-        opt_level=opt_level,
+        mode=normalized_mode,
         mem_algo=mem_algo,
         alloc_graph_input=alloc_graph_input,
         alloc_graph_output=alloc_graph_output,
@@ -483,7 +497,7 @@ def _lower_ep_to_cadence_gen_etrecord(
     print_memory_planning_info(
         exec_prog,
         memory_config,
-        opt_level,
+        normalized_mode,
         alloc_graph_input,
         alloc_graph_output,
     )

--- a/backends/cadence/aot/memory_constraints.py
+++ b/backends/cadence/aot/memory_constraints.py
@@ -16,8 +16,11 @@ import torch
 import torch.fx
 from executorch.backends.cadence.aot.pass_utils import (
     CadencePassAttribute,
+    CompileMode,
     create_cadence_pass_filter,
+    normalize_compile_mode,
     register_cadence_pass,
+    resolve_opt_level,
 )
 from executorch.backends.cadence.aot.utils import get_shape, is_node_in_flattened_output
 from executorch.exir import memory
@@ -63,11 +66,16 @@ class MemConstraints:
 
     def __init__(
         self,
-        opt_level: int = 1,
+        mode: CompileMode | int | None = None,
         alloc_graph_input: bool = True,
         alloc_graph_output: bool = True,
+        opt_level: Optional[int] = None,
     ) -> None:
-        self.opt_level = opt_level
+        normalized_mode = normalize_compile_mode(mode, opt_level)
+        self.opt_level = resolve_opt_level(normalized_mode)
+        self.mode: Optional[CompileMode] = (
+            normalized_mode if isinstance(normalized_mode, CompileMode) else None
+        )
         self.alloc_graph_input = alloc_graph_input
         self.alloc_graph_output = alloc_graph_output
 

--- a/backends/cadence/aot/memory_planning.py
+++ b/backends/cadence/aot/memory_planning.py
@@ -19,6 +19,11 @@ from executorch.backends.cadence.aot.memory_planning_algo import (
     MemoryPlanningAlgo,
     MemoryPlanningState,
 )
+from executorch.backends.cadence.aot.pass_utils import (
+    CompileMode,
+    normalize_compile_mode,
+    resolve_opt_level,
+)
 from executorch.backends.cadence.aot.utils import (
     MemoryConfig,
     MemoryPlanningAlgoFailure,
@@ -287,13 +292,15 @@ def find_peak_memory_usage(
 def print_memory_planning_info(
     executorch_prog: ExecutorchProgramManager,
     memory_config: MemoryConfig,
-    opt_level: int,
-    alloc_graph_input: bool,
-    alloc_graph_output: bool,
+    mode: CompileMode | int | None = None,
+    alloc_graph_input: bool = True,
+    alloc_graph_output: bool = True,
     log_level=logging.INFO,
+    opt_level: Optional[int] = None,
 ) -> None:
     # Get the peak memory usages per memory space
     mem_constraints = MemConstraints(
+        mode=mode,
         opt_level=opt_level,
         alloc_graph_input=alloc_graph_input,
         alloc_graph_output=alloc_graph_output,
@@ -397,20 +404,25 @@ class CadenceMemoryPlanning:
     def __init__(
         self,
         memory_config: MemoryConfig,
-        opt_level: int,
-        mem_algo: int,
+        mode: CompileMode | int | None = None,
+        mem_algo: int = 0,
         alloc_graph_input: bool = True,
         alloc_graph_output: bool = True,
         additional_constraint_gen_passes: Optional[Sequence[ConstraintsGenPass]] = None,
+        opt_level: Optional[int] = None,
     ) -> None:
         self.memory_config = memory_config
-        self.opt_level = opt_level
+        normalized_mode = normalize_compile_mode(mode, opt_level)
+        self.opt_level = resolve_opt_level(normalized_mode)
+        self.mode: Optional[CompileMode] = (
+            normalized_mode if isinstance(normalized_mode, CompileMode) else None
+        )
         self.alloc_graph_input = alloc_graph_input
         self.alloc_graph_output = alloc_graph_output
 
         self.algo: MemoryPlanningAlgo = self.get_mem_algos(
             memory_config,
-            opt_level,
+            normalized_mode,
             alloc_graph_input,
             alloc_graph_output,
             additional_constraint_gen_passes,
@@ -419,22 +431,24 @@ class CadenceMemoryPlanning:
     @staticmethod
     def get_mem_algos(
         memory_config: MemoryConfig,
-        opt_level: int,
-        alloc_graph_input: bool,
-        alloc_graph_output: bool,
-        additional_constraint_gen_passes: Optional[Sequence[ConstraintsGenPass]],
+        mode: CompileMode | int | None = None,
+        alloc_graph_input: bool = True,
+        alloc_graph_output: bool = True,
+        additional_constraint_gen_passes: Optional[Sequence[ConstraintsGenPass]] = None,
+        opt_level: Optional[int] = None,
     ) -> list[MemoryPlanningAlgo]:
+        normalized_mode = normalize_compile_mode(mode, opt_level)
         return [
             PositionBasedGreedyWithHierarchy(
                 memory_config=memory_config,
-                opt_level=opt_level,
+                mode=normalized_mode,
                 alloc_graph_input=alloc_graph_input,
                 alloc_graph_output=alloc_graph_output,
                 additional_constraint_gen_passes=additional_constraint_gen_passes,
             ),
             GreedyWithHeuristic(
                 memory_config=memory_config,
-                opt_level=opt_level,
+                mode=normalized_mode,
                 alloc_graph_input=alloc_graph_input,
                 alloc_graph_output=alloc_graph_output,
                 additional_constraint_gen_passes=additional_constraint_gen_passes,

--- a/backends/cadence/aot/memory_planning_algo.py
+++ b/backends/cadence/aot/memory_planning_algo.py
@@ -15,6 +15,11 @@ from executorch.backends.cadence.aot.memory_constraints import (
     GenerateMemConstraints,
     MemConstraints,
 )
+from executorch.backends.cadence.aot.pass_utils import (
+    CompileMode,
+    normalize_compile_mode,
+    resolve_opt_level,
+)
 from executorch.backends.cadence.aot.utils import MemoryConfig
 from executorch.exir.memory_planning import Verifier
 from executorch.exir.tensor import TensorSpec
@@ -85,16 +90,21 @@ class MemoryPlanningAlgo(ABC):
     def __init__(
         self,
         memory_config: MemoryConfig,
-        opt_level: int = 1,
+        mode: CompileMode | int | None = None,
         alloc_graph_input: bool = True,
         alloc_graph_output: bool = True,
         additional_constraint_gen_passes: Optional[Sequence[ConstraintsGenPass]] = None,
+        opt_level: Optional[int] = None,
     ) -> None:
         self.memory_config: MemoryConfig = memory_config
         self.additional_constraint_gen_passes: Optional[
             Sequence[ConstraintsGenPass]
         ] = additional_constraint_gen_passes
-        self.opt_level: int = opt_level
+        normalized_mode = normalize_compile_mode(mode, opt_level)
+        self.opt_level: int = resolve_opt_level(normalized_mode)
+        self.mode: Optional[CompileMode] = (
+            normalized_mode if isinstance(normalized_mode, CompileMode) else None
+        )
         self.alloc_graph_input: bool = alloc_graph_input
         self.alloc_graph_output: bool = alloc_graph_output
         self.memory_id_is_valid: list[bool] = [True] * self.get_num_memories()

--- a/backends/cadence/aot/pass_utils.py
+++ b/backends/cadence/aot/pass_utils.py
@@ -7,7 +7,9 @@
 # pyre-strict
 
 import dataclasses
+import warnings
 from dataclasses import dataclass
+from enum import Enum
 from typing import Callable, List, Optional, Set, Type, Union
 
 import torch
@@ -23,6 +25,59 @@ from executorch.backends.transforms.permute_pass_utils import (  # noqa: F401
 from executorch.exir.dialects.edge._ops import EdgeOpOverload, EdgeOpOverloadPacket
 from executorch.exir.pass_base import PassBase, PassResult
 from torch._ops import OpOverloadPacket
+
+
+class CompileMode(Enum):
+    """Selects which pass pipeline the Cadence backend runs.
+
+    During migration, omitting ``mode`` preserves the legacy ``opt_level=1``
+    behavior, while explicitly passing ``DEFAULT`` selects the former O3
+    pipeline with all graph optimizations.
+    """
+
+    MINIMAL = "minimal"
+    DEFAULT = "default"
+    SIZE = "size"
+
+
+def opt_level_from_compile_mode(mode: CompileMode) -> int:
+    """Translate the new API to the legacy pass levels during migration."""
+    if mode is CompileMode.MINIMAL:
+        return 0
+    if mode is CompileMode.SIZE:
+        return 4
+    return 3
+
+
+def resolve_opt_level(
+    mode: CompileMode | int | None = None,
+    opt_level: Optional[int] = None,
+) -> int:
+    if opt_level is not None:
+        if mode is not None:
+            warnings.warn(
+                "Both mode and opt_level were provided; deprecated opt_level takes "
+                "precedence.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return opt_level
+    if mode is None:
+        return 1
+    if isinstance(mode, int):
+        return mode
+    return opt_level_from_compile_mode(mode)
+
+
+def normalize_compile_mode(
+    mode: CompileMode | int | None = None,
+    opt_level: Optional[int] = None,
+) -> CompileMode | int:
+    """Resolve compatibility arguments while preserving an explicit enum mode."""
+    resolved_opt_level = resolve_opt_level(mode, opt_level)
+    if opt_level is None and isinstance(mode, CompileMode):
+        return mode
+    return resolved_opt_level
 
 
 # Is an overlap in tensor lifetime and storage allowed at the current opt level?

--- a/backends/cadence/aot/passes.py
+++ b/backends/cadence/aot/passes.py
@@ -18,8 +18,10 @@ from executorch.backends.cadence.aot.fuse_ops import (
 )
 from executorch.backends.cadence.aot.pass_utils import (
     CadencePassAttribute,
+    CompileMode,
     create_cadence_pass_filter,
     EdgePassesConfig,
+    opt_level_from_compile_mode,
     register_cadence_pass,
 )
 
@@ -100,22 +102,38 @@ def get_passes_in_default_order() -> list[Type[ExportPass]]:
     return pytree.tree_flatten(passes)[0]
 
 
+def get_passes(
+    mode: CompileMode,
+    edge_passes_config: Optional[EdgePassesConfig] = None,
+) -> list[Type[ExportPass]]:
+    pass_filter = create_cadence_pass_filter(
+        opt_level_from_compile_mode(mode),
+        edge_passes_config=edge_passes_config,
+    )
+    return list(filter(pass_filter, get_passes_in_default_order()))
+
+
 def apply_exir_ops_passes(
-    opt_level: int,
+    opt_level: int | CompileMode,
     edge_prog_manager: EdgeProgramManager,
     edge_passes_config: Optional[EdgePassesConfig] = None,
 ) -> EdgeProgramManager:
-    passes = get_passes_in_default_order()
-    pass_filter = create_cadence_pass_filter(
-        opt_level, edge_passes_config=edge_passes_config
+    resolved_opt_level = (
+        opt_level_from_compile_mode(opt_level)
+        if isinstance(opt_level, CompileMode)
+        else opt_level
     )
+    pass_filter = create_cadence_pass_filter(
+        resolved_opt_level, edge_passes_config=edge_passes_config
+    )
+    passes = list(filter(pass_filter, get_passes_in_default_order()))
     cadence_passes = [
         (
             lambda graph_module, filtered_pass=filtered_pass: filtered_pass()(
                 graph_module
             )
         )
-        for filtered_pass in list(filter(pass_filter, passes))
+        for filtered_pass in passes
     ]
     cadence_prog_manager = edge_prog_manager.transform(
         cast(

--- a/backends/cadence/aot/tests/test_memory_passes.py
+++ b/backends/cadence/aot/tests/test_memory_passes.py
@@ -29,6 +29,7 @@ from executorch.backends.cadence.aot.memory_planning_algo import (
 )
 from executorch.backends.cadence.aot.pass_utils import (
     CadencePassAttribute,
+    CompileMode,
     count_node,
     register_cadence_pass,
 )
@@ -50,6 +51,54 @@ from executorch.exir.passes.spec_prop_pass import SpecPropPass
 from executorch.exir.tests.models import MultiLayerPerceptron
 from parameterized import parameterized
 from torch.fx import GraphModule
+
+
+class TestCompileModeNormalization(unittest.TestCase):
+    def test_enum_mode_is_preserved(self) -> None:
+        memory_planning = CadenceMemoryPlanning(
+            get_default_memory_config(), mode=CompileMode.MINIMAL
+        )
+
+        self.assertEqual(memory_planning.mode, CompileMode.MINIMAL)
+        self.assertEqual(memory_planning.opt_level, 0)
+        self.assertEqual(memory_planning.algo.mode, CompileMode.MINIMAL)
+
+    def test_legacy_level_warns_once_and_takes_precedence(self) -> None:
+        with self.assertWarns(DeprecationWarning) as warning:
+            memory_planning = CadenceMemoryPlanning(
+                get_default_memory_config(),
+                mode=CompileMode.MINIMAL,
+                opt_level=4,
+            )
+
+        self.assertEqual(len(warning.warnings), 1)
+        self.assertIsNone(memory_planning.mode)
+        self.assertEqual(memory_planning.opt_level, 4)
+        self.assertIsNone(memory_planning.algo.mode)
+        self.assertEqual(memory_planning.algo.opt_level, 4)
+
+    def test_mem_constraints_normalize_conflicting_arguments(self) -> None:
+        with self.assertWarns(DeprecationWarning) as warning:
+            constraints = MemConstraints(
+                mode=CompileMode.MINIMAL,
+                opt_level=4,
+            )
+
+        self.assertEqual(len(warning.warnings), 1)
+        self.assertIsNone(constraints.mode)
+        self.assertEqual(constraints.opt_level, 4)
+
+    def test_memory_algorithm_normalizes_conflicting_arguments(self) -> None:
+        with self.assertWarns(DeprecationWarning) as warning:
+            algorithm = PositionBasedGreedyWithHierarchy(
+                get_default_memory_config(),
+                mode=CompileMode.MINIMAL,
+                opt_level=4,
+            )
+
+        self.assertEqual(len(warning.warnings), 1)
+        self.assertIsNone(algorithm.mode)
+        self.assertEqual(algorithm.opt_level, 4)
 
 
 class TestMemPlanningPasses(unittest.TestCase):

--- a/backends/cadence/aot/tests/test_pass_filter.py
+++ b/backends/cadence/aot/tests/test_pass_filter.py
@@ -16,11 +16,26 @@ from executorch.backends.cadence.aot import pass_utils
 from executorch.backends.cadence.aot.pass_utils import (
     ALL_CADENCE_PASSES,
     CadencePassAttribute,
+    CompileMode,
     create_cadence_pass_filter,
     register_cadence_pass,
+    resolve_opt_level,
 )
 
 from executorch.exir.pass_base import ExportPass, PassBase
+
+
+class TestCompileModeCompatibility(unittest.TestCase):
+    def test_resolve_opt_level(self) -> None:
+        self.assertEqual(resolve_opt_level(), 1)
+        self.assertEqual(resolve_opt_level(CompileMode.MINIMAL), 0)
+        self.assertEqual(resolve_opt_level(CompileMode.DEFAULT), 3)
+        self.assertEqual(resolve_opt_level(CompileMode.SIZE), 4)
+        self.assertEqual(resolve_opt_level(2), 2)
+
+    def test_deprecated_opt_level_takes_precedence(self) -> None:
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(resolve_opt_level(CompileMode.MINIMAL, 4), 4)
 
 
 class TestBase(unittest.TestCase):


### PR DESCRIPTION
Summary:

Introduce the typed CompileMode API alongside the existing opt_level pass registry and integer memory-planning interfaces.

This compatibility layer lets downstream callers migrate to explicit MINIMAL, DEFAULT, and SIZE modes without changing legacy callers or pass behavior. Omitted mode values retain the former opt_level=1 default; explicitly supplied CompileMode values map to the equivalent legacy pipeline during the migration.

Reviewed By: ethansfng

Differential Revision: D115453091


