### PR TITLE
Carry a tensor's device when wrapping it for PyTorch

### DIFF
--- a/extension/aten_util/aten_bridge.cpp
+++ b/extension/aten_util/aten_bridge.cpp
@@ -134,6 +134,22 @@ c10::ScalarType executorch_to_torch_scalar_type(
   return static_cast<c10::ScalarType>(intermediate);
 }
 
+c10::Device executorch_to_torch_device(
+    executorch::runtime::etensor::Device device) {
+  switch (device.type()) {
+    case executorch::runtime::etensor::DeviceType::CPU:
+      return c10::Device(c10::DeviceType::CPU);
+    case executorch::runtime::etensor::DeviceType::CUDA:
+      return c10::Device(c10::DeviceType::CUDA, device.index());
+  }
+  // Aborting on an unknown device rather than falling back to CPU: a wrong
+  // label made the host read accelerator memory and segfault.
+  ET_CHECK_MSG(
+      false,
+      "Tensor reports device type %d, which this build cannot map to a PyTorch device",
+      static_cast<int>(device.type()));
+}
+
 /*
  * Following makes two assumptions:
  * 1. aten_tensor's lifetime is longer than the liftime within which mutable_et
@@ -167,11 +183,14 @@ at::Tensor alias_attensor_to_etensor(const torch::executor::Tensor& etensor) {
   std::vector<int64_t> at_tensor_strides(
       etensor.strides().begin(), etensor.strides().end());
 
-  at::Tensor t = at::from_blob(
-      etensor.mutable_data_ptr(),
-      at_tensor_sizes,
-      at_tensor_strides,
-      at::TensorOptions(dtype));
+  // Both are needed: the dispatch key comes from options, and target_device
+  // skips the pointer inspection that rejects an empty tensor's null pointer.
+  const c10::Device device = executorch_to_torch_device(etensor.device());
+  at::Tensor t = at::for_blob(etensor.mutable_data_ptr(), at_tensor_sizes)
+                     .strides(at_tensor_strides)
+                     .options(at::TensorOptions(dtype).device(device))
+                     .target_device(device)
+                     .make_tensor();
 
   check_tensor_meta(t, etensor);
   return t;

--- a/extension/aten_util/aten_bridge.h
+++ b/extension/aten_util/aten_bridge.h
@@ -10,6 +10,7 @@
 
 #include <executorch/extension/tensor/tensor.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/portable_type/device.h>
 
 #include <ATen/Functions.h> // @manual=//caffe2/aten:ATen-cpu
 #include <ATen/Tensor.h> // @manual=//caffe2/aten:ATen-core
@@ -27,6 +28,9 @@ torch::executor::ScalarType torch_to_executorch_scalar_type(
 
 c10::ScalarType executorch_to_torch_scalar_type(
     torch::executor::ScalarType type);
+
+c10::Device executorch_to_torch_device(
+    executorch::runtime::etensor::Device device);
 
 /*
  * @param[in] aten_tensor Input at::Tensor

--- a/extension/aten_util/test/aten_bridge_test.cpp
+++ b/extension/aten_util/test/aten_bridge_test.cpp
@@ -296,3 +296,61 @@ TEST(ATenBridgeTest, AliasETensorToATenTensorFailUnsupportedDimOrder) {
   torch::executor::Tensor etensor(&tensor_impl);
   ET_EXPECT_DEATH(alias_etensor_to_attensor(at_tensor, etensor), "");
 }
+
+TEST(ATenBridgeTest, DeviceMapping) {
+  // Needs no accelerator: only the mapping is under test.
+  using executorch::runtime::etensor::Device;
+  using executorch::runtime::etensor::DeviceType;
+
+  EXPECT_EQ(
+      executorch_to_torch_device(Device(DeviceType::CPU)).type(),
+      c10::DeviceType::CPU);
+  EXPECT_EQ(
+      executorch_to_torch_device(Device(DeviceType::CUDA, 1)).type(),
+      c10::DeviceType::CUDA);
+  EXPECT_EQ(executorch_to_torch_device(Device(DeviceType::CUDA, 1)).index(), 1);
+}
+
+TEST(ATenBridgeTest, DeviceMappingAbortsOnUnknownType) {
+  using executorch::runtime::etensor::Device;
+  using executorch::runtime::etensor::DeviceType;
+  ET_EXPECT_DEATH(
+      (void)executorch_to_torch_device(Device(static_cast<DeviceType>(99))),
+      "");
+}
+
+TEST(ATenBridgeTest, AliasATTensorToETensorHandlesAnEmptyTensor) {
+  // An empty tensor has a null data pointer, so this is the only case that
+  // distinguishes dropping the device, passing it through options alone (which
+  // raises), and passing target_device. Needs no accelerator: nothing
+  // allocates.
+  auto at_tensor = at::empty({0});
+  std::vector<Tensor::SizesType> sizes(
+      at_tensor.sizes().begin(), at_tensor.sizes().end());
+  auto dim_order = get_default_dim_order(at_tensor);
+  std::vector<Tensor::StridesType> strides(
+      at_tensor.strides().begin(), at_tensor.strides().end());
+  auto dtype = torchToExecuTorchScalarType(at_tensor.options().dtype());
+  torch::executor::TensorImpl tensor_impl(
+      dtype,
+      at_tensor.dim(),
+      sizes.data(),
+      /*data=*/nullptr,
+      dim_order.data(),
+      strides.data(),
+      executorch::runtime::TensorShapeDynamism::STATIC,
+      executorch::runtime::etensor::DeviceType::CUDA,
+      0);
+  torch::executor::Tensor etensor(&tensor_impl);
+
+  auto aliased = alias_attensor_to_etensor(etensor);
+  EXPECT_EQ(aliased.numel(), 0);
+  EXPECT_EQ(aliased.device().type(), c10::DeviceType::CUDA);
+  EXPECT_EQ(aliased.device().index(), 0);
+  // The dispatch key too, not just the label. The key comes from the options
+  // while the label can come from target_device, so a call site that passes the
+  // device only as target_device still satisfies the checks above and produces
+  // a tensor that dispatches to CPU kernels.
+  EXPECT_TRUE(aliased.is_cuda());
+  EXPECT_TRUE(aliased.key_set().has(c10::DispatchKey::CUDA));
+}


### PR DESCRIPTION
## The problem

ExecuTorch can run a model on a GPU and keep the intermediate results (the
"activations") in GPU memory the whole way through, so nothing is copied back and forth
across the host boundary. A caller passes GPU tensors in and gets a GPU tensor back.

Reading that result from Python crashed:

```
Fatal Python error: Segmentation fault
  File "run.py", line 16 in <module>     # module.forward(inputs)
```

The model and the GPU delegate are both fine. The fault is in the small layer that wraps
an ExecuTorch tensor as a PyTorch tensor.

An ExecuTorch tensor records which device its data lives on. That wrapper ignored it:

```cpp
at::from_blob(etensor.mutable_data_ptr(), sizes, strides,
              at::TensorOptions(dtype));   // no device, so it defaults to CPU
```

So a tensor whose storage is GPU memory came back labelled CPU, and anything that then
touched it on the host read GPU memory directly. The Python bindings do exactly that:
they clone each output before returning it, and that clone is a host memory copy. The
backtrace lands in a vectorized CPU copy kernel:

```
at::native::AVX2::direct_copy_kernel(at::TensorIteratorBase&)
at::native::copy_impl(at::Tensor&, at::Tensor const&, bool)
at::native::clone(at::Tensor const&, std::optional<c10::MemoryFormat>)
```

## The change

Take the device from the tensor being wrapped instead of assuming CPU. The construction
uses the ATen fluent builder:

```cpp
const c10::Device device = executorch_to_torch_device(etensor.device());
at::Tensor t = at::for_blob(etensor.mutable_data_ptr(), sizes)
                   .strides(strides)
                   .options(at::TensorOptions(dtype).device(device))
                   .target_device(device)
                   .make_tensor();
```

A device the build has no mapping for is rejected rather than reported as CPU, because
treating an unreadable pointer as host memory is what caused the crash.

Both parts of the device argument are load-bearing:

- The device must go through `TensorOptions`. The tensor's dispatch key set is derived
  from options, not from `target_device`, so passing the device only as `target_device`
  produces a `cuda:0`-labelled tensor with a CPU dispatch key.
- `target_device` must also be present. Without it, ATen infers the device by inspecting
  the data pointer, and an empty tensor has no pointer to inspect: the runtime sets it
  to null when a tensor has no elements. `tensor_parser_aten.cpp` had already hit this
  and solved it the same way, so this follows that precedent.

This is a labelling fix, not a copy. The data pointer is unchanged, so a program exported
to keep activations on the device still hands the delegate the caller's own buffer.

## Test plan

- Ran a GPU model exported with device-resident activations on an NVIDIA GPU. Before this
  change the process died with a segmentation fault; after it, the output matches eager
  PyTorch exactly (largest absolute difference 0).
- Checked the mechanism directly against real device memory: the old wrapping reports
  `cpu` and dies with signal 11 when cloned, the new one reports `cuda:0`, clones and the
  values match.
- Confirmed no copying is introduced. A device-activation program contains no copy
  operators, its method inputs report as not memory planned so the runtime shares the
  caller's buffer, and the caller's pointers are unchanged across the call. A
  host-activation program still shows its copy operators and still matches eager PyTorch.
- Verified the dispatch-key point directly. Constructing the wrapper with only
  `target_device(cuda:0)` (no device on `TensorOptions`) yields a tensor whose device
  reports `cuda:0` but whose key set is `DispatchKeySet(CPU, ...)`. Constructing with the
  device on both options and `target_device` yields the correct
  `DispatchKeySet(CUDA, ...)`.
- Added three unit tests and verified with a mutation harness that the empty-tensor test
  (`AliasATTensorToETensorHandlesAnEmptyTensor`) fails under both plausible regressions:
  restoring the old options-only call, and passing the device only via options without
  `target_device`. The other two tests (`DeviceMapping`,
  `DeviceMappingAbortsOnUnknownType`) cover the mapping helper on its own.

Not covered: no open-source continuous integration job builds this test file. It is
compiled only where PyTorch and ATen are available, which the C++ test job does not
enable, so the tests here are verified locally and by the internal build. Wiring that up
means enabling the Python bindings in that job, which is a change to shared test
infrastructure and belongs on its own.

Left for later, all pre-existing and none of them regressions from this change:
`alias_tensor_ptr_to_attensor` and the `type_convert` helpers in the same directory drop
the device the same way. `make_tensor_ptr` already accepts a device, so what is missing
is only a `torch_to_executorch_device` conversion in the opposite direction to feed it.