### PR TITLE
Support multi-method models in the export pipeline (#21723)

### DIFF
--- a/export/export.py
+++ b/export/export.py
@@ -680,14 +680,26 @@ class ExportSession:
         if stage_artifact is None:
             RuntimeError("No delegation info available, run the lowering stage first")
 
-        # pyre-ignore
-        delegation_info = stage_artifact.get_context("delegation_info", None)
-        if delegation_info:
+        delegation_info_by_method = stage_artifact.get_context(
+            "delegation_info_by_method", None
+        )
+        if delegation_info_by_method:
+            delegation_infos = sorted(delegation_info_by_method.items())
+        else:
+            # pyre-ignore
+            delegation_info = stage_artifact.get_context("delegation_info", None)
+            delegation_infos = [(None, delegation_info)] if delegation_info else []
+
+        if not delegation_infos:
+            print("No delegation info available")
+            return
+
+        for method_name, delegation_info in delegation_infos:
+            if method_name is not None:
+                print(f"Delegation info for method '{method_name}':")
             print(delegation_info.get_summary())
             df = delegation_info.get_operator_delegation_dataframe()
             print(tabulate(df, headers="keys", tablefmt="fancy_grid"))
-        else:
-            print("No delegation info available")
 
     # Use Any instead of ETRecord as return type to avoid static dependency on etrecord
     def get_etrecord(self) -> Any:

--- a/export/recipe.py
+++ b/export/recipe.py
@@ -9,7 +9,7 @@ import dataclasses
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional, Union
 
 import torch
 from executorch.exir import EdgeProgramManager, ExportedProgram
@@ -159,7 +159,10 @@ class LoweringRecipe:
     to backend-specific representations.
 
     Attributes:
-        partitioners: Optional list of partitioners for model partitioning
+        partitioners: Optional partitioners for model partitioning. Either a list
+                      applied to every method, or a dict mapping method names to
+                      per-method partitioner lists. Use the dict form when
+                      backends need per-method compile specs.
         edge_transform_passes: Optional list of callables that take (method_name: str, exported_program: ExportedProgram)
                                and return either List[PassType] or PassManager to be applied during edge lowering.
         edge_manager_transform_passes: Optional list of callables that take EdgeProgramManager as argument
@@ -167,7 +170,9 @@ class LoweringRecipe:
         edge_compile_config: Optional edge compilation configuration
     """
 
-    partitioners: Optional[List[Partitioner]] = None
+    partitioners: Optional[Union[List[Partitioner], Dict[str, List[Partitioner]]]] = (
+        None
+    )
     edge_transform_passes: (
         None | List[Callable[[str, ExportedProgram], List[PassType] | PassManager]]
     ) = None
@@ -303,6 +308,7 @@ class ExportRecipe:
 
         # Extract components from individual recipes
         all_partitioners = []
+        all_partitioners_by_method = {}
         all_quantizers = []
         all_ao_quantization_configs = []
         all_pre_edge_passes = []
@@ -316,7 +322,14 @@ class ExportRecipe:
 
             # Collect partitioners from lowering recipes
             if recipe.lowering_recipe and recipe.lowering_recipe.partitioners:
-                all_partitioners.extend(recipe.lowering_recipe.partitioners)
+                partitioners = recipe.lowering_recipe.partitioners
+                if isinstance(partitioners, dict):
+                    for method_name, method_partitioners in partitioners.items():
+                        all_partitioners_by_method.setdefault(method_name, []).extend(
+                            method_partitioners
+                        )
+                else:
+                    all_partitioners.extend(partitioners)
 
             # Collect transform passes from lowering recipes
             if recipe.lowering_recipe and recipe.lowering_recipe.edge_transform_passes:
@@ -352,6 +365,13 @@ class ExportRecipe:
                 ),
             )
 
+        if all_partitioners and all_partitioners_by_method:
+            raise ValueError(
+                "Cannot combine recipes that mix list-valued and dict-valued "
+                "partitioners; convert the list-valued recipe to per-method form."
+            )
+        combined_partitioners = all_partitioners_by_method or all_partitioners
+
         # By value, not identity: every provider builds a fresh config object,
         # so asking for the same thing twice is not a conflict.
         distinct: List[tuple[str, EdgeCompileConfig]] = []
@@ -375,9 +395,9 @@ class ExportRecipe:
         edge_compile_config = copy.deepcopy(distinct[0][1]) if distinct else None
 
         combined_lowering_recipe = None
-        if all_partitioners or all_transform_passes or edge_compile_config:
+        if combined_partitioners or all_transform_passes or edge_compile_config:
             combined_lowering_recipe = LoweringRecipe(
-                partitioners=all_partitioners if all_partitioners else None,
+                partitioners=combined_partitioners if combined_partitioners else None,
                 edge_transform_passes=(
                     all_transform_passes if all_transform_passes else None
                 ),

--- a/export/stages.py
+++ b/export/stages.py
@@ -9,7 +9,8 @@ import copy
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional
+from itertools import zip_longest
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 from executorch.devtools.backend_debug import get_delegation_info
@@ -173,6 +174,36 @@ class TorchExportStage(Stage):
         self._artifact = artifact.copy_with_new_data(exported_programs)
 
 
+def _collect_delegation_info(
+    edge_program_manager: EdgeProgramManager,
+) -> Dict[str, Any]:
+    """
+    Delegation info for every method, keyed by method name.
+
+    `EdgeProgramManager.exported_program()` defaults to `forward`, which raises
+    KeyError for a multi-method program that has no method by that name.
+    """
+    return {
+        name: get_delegation_info(
+            edge_program_manager.exported_program(name).graph_module
+        )
+        for name in sorted(edge_program_manager.methods)
+    }
+
+
+def _add_delegation_info_context(
+    artifact: PipelineArtifact, edge_program_manager: EdgeProgramManager
+) -> None:
+    by_method = _collect_delegation_info(edge_program_manager)
+    artifact.add_context("delegation_info_by_method", by_method)
+    # `forward` when present, else the first method by name, so that
+    # single-method callers keep seeing the value they always have.
+    artifact.add_context(
+        "delegation_info",
+        by_method.get("forward", next(iter(by_method.values()), None)),
+    )
+
+
 class EdgeTransformAndLowerStage(Stage):
     """
     Second stage: Transform and lower to EdgeProgramManager.
@@ -180,7 +211,7 @@ class EdgeTransformAndLowerStage(Stage):
 
     def __init__(
         self,
-        partitioners: Optional[List[Any]] = None,
+        partitioners: Optional[Union[List[Any], Dict[str, List[Any]]]] = None,
         transform_passes: (
             None
             | List[
@@ -262,11 +293,8 @@ class EdgeTransformAndLowerStage(Stage):
                 generate_etrecord=generate_etrecord,
             )
 
-        delegation_info = get_delegation_info(
-            edge_program_manager.exported_program().graph_module
-        )
         self._artifact = artifact.copy_with_new_data(edge_program_manager)
-        self._artifact.add_context("delegation_info", delegation_info)
+        _add_delegation_info_context(self._artifact, edge_program_manager)
 
     @property
     def delegation_info(self) -> Any:
@@ -274,6 +302,13 @@ class EdgeTransformAndLowerStage(Stage):
         Returns the delegation info.
         """
         return self._artifact.get_context("delegation_info")
+
+    @property
+    def delegation_info_by_method(self) -> Dict[str, Any]:
+        """
+        Returns the delegation info for every method, keyed by method name.
+        """
+        return self._artifact.get_context("delegation_info_by_method")
 
 
 class ExecutorchStage(Stage):
@@ -647,7 +682,7 @@ class ToBackendStage(Stage):
 
     def __init__(
         self,
-        partitioners: Optional[List[Any]] = None,
+        partitioners: Optional[Union[List[Any], Dict[str, List[Any]]]] = None,
     ) -> None:
         super().__init__()
         self._partitioners = partitioners
@@ -693,17 +728,28 @@ class ToBackendStage(Stage):
         # Apply partitioners if available
         if self._partitioners is not None and len(self._partitioners) > 0:
             with validation_disabled():
-                # pyre-ignore
-                for partitioner in self._partitioners:
-                    edge_program_manager = edge_program_manager.to_backend(partitioner)
-
-        # Get delegation info
-        delegation_info = get_delegation_info(
-            edge_program_manager.exported_program().graph_module
-        )
+                if isinstance(self._partitioners, dict):
+                    method_names = list(self._partitioners)
+                    for partitioner_round in zip_longest(*self._partitioners.values()):
+                        partitioners_by_method = {
+                            method_name: partitioner
+                            for method_name, partitioner in zip(
+                                method_names, partitioner_round
+                            )
+                            if partitioner is not None
+                        }
+                        edge_program_manager = edge_program_manager.to_backend(
+                            partitioners_by_method
+                        )
+                else:
+                    # pyre-ignore
+                    for partitioner in self._partitioners:
+                        edge_program_manager = edge_program_manager.to_backend(
+                            partitioner
+                        )
 
         self._artifact = artifact.copy_with_new_data(edge_program_manager)
-        self._artifact.add_context("delegation_info", delegation_info)
+        _add_delegation_info_context(self._artifact, edge_program_manager)
 
     @property
     def delegation_info(self) -> Any:
@@ -711,3 +757,10 @@ class ToBackendStage(Stage):
         Returns the delegation info.
         """
         return self._artifact.get_context("delegation_info")
+
+    @property
+    def delegation_info_by_method(self) -> Dict[str, Any]:
+        """
+        Returns the delegation info for every method, keyed by method name.
+        """
+        return self._artifact.get_context("delegation_info_by_method")

--- a/export/tests/test_export_session.py
+++ b/export/tests/test_export_session.py
@@ -6,9 +6,10 @@
 
 # pyre-strict
 
+import importlib
 import unittest
-from typing import List
-from unittest.mock import Mock
+from typing import Any, Dict, List
+from unittest.mock import call, Mock, patch
 
 import torch
 from executorch.export import ExportRecipe, ExportSession
@@ -19,6 +20,9 @@ from executorch.export.recipe import (
 )
 from executorch.export.stages import PipelineArtifact, Stage
 from executorch.export.types import StageType
+
+
+export_module = importlib.import_module("executorch.export.export")
 
 
 class SimpleTestModel(torch.nn.Module):
@@ -817,6 +821,77 @@ class TestExportSessionExtendedInputTypes(unittest.TestCase):
 
         # Should not raise during validation
         session._validate_pipeline_sequence(recipe.pipeline_stages)
+
+
+class TestDelegationInfoReporting(unittest.TestCase):
+    def setUp(self) -> None:
+        self.session = ExportSession(
+            model=SimpleTestModel(),
+            example_inputs=[(torch.randn(2, 10),)],
+            export_recipe=ExportRecipe(),
+        )
+
+    def _set_delegation_context(self, context: Dict[str, Any]) -> None:
+        self.session._stage_to_artifacts[StageType.TO_EDGE_TRANSFORM_AND_LOWER] = (
+            PipelineArtifact(data=None, context=context)
+        )
+
+    @patch.object(export_module, "tabulate")
+    @patch("builtins.print")
+    def test_print_delegation_info_for_every_method(
+        self, mock_print: Mock, mock_tabulate: Mock
+    ) -> None:
+        decode_info = Mock()
+        decode_info.get_summary.return_value = "decode-summary"
+        decode_info.get_operator_delegation_dataframe.return_value = "decode-data"
+        prefill_info = Mock()
+        prefill_info.get_summary.return_value = "prefill-summary"
+        prefill_info.get_operator_delegation_dataframe.return_value = "prefill-data"
+        mock_tabulate.side_effect = ["decode-table", "prefill-table"]
+        self._set_delegation_context(
+            {
+                "delegation_info_by_method": {
+                    "prefill": prefill_info,
+                    "decode": decode_info,
+                },
+                "delegation_info": decode_info,
+            }
+        )
+
+        self.session.print_delegation_info()
+
+        self.assertEqual(
+            mock_print.call_args_list,
+            [
+                call("Delegation info for method 'decode':"),
+                call("decode-summary"),
+                call("decode-table"),
+                call("Delegation info for method 'prefill':"),
+                call("prefill-summary"),
+                call("prefill-table"),
+            ],
+        )
+        self.assertEqual(mock_tabulate.call_count, 2)
+
+    @patch.object(export_module, "tabulate", return_value="legacy-table")
+    @patch("builtins.print")
+    def test_print_delegation_info_legacy_fallback(
+        self, mock_print: Mock, mock_tabulate: Mock
+    ) -> None:
+        delegation_info = Mock()
+        delegation_info.get_summary.return_value = "legacy-summary"
+        delegation_info.get_operator_delegation_dataframe.return_value = "legacy-data"
+        self._set_delegation_context({"delegation_info": delegation_info})
+
+        self.session.print_delegation_info()
+
+        self.assertEqual(
+            mock_print.call_args_list,
+            [call("legacy-summary"), call("legacy-table")],
+        )
+        mock_tabulate.assert_called_once_with(
+            "legacy-data", headers="keys", tablefmt="fancy_grid"
+        )
 
 
 class TestIntermediateStateGetters(unittest.TestCase):

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import call, Mock, patch
 
 import torch
 from executorch.exir.program import EdgeProgramManager, ExecutorchProgramManager
@@ -191,6 +191,7 @@ class TestEdgeTransformAndLowerStage(unittest.TestCase):
         mock_graph_module = Mock()
         mock_exported_program.graph_module = mock_graph_module
         mock_edge_program_manager.exported_program.return_value = mock_exported_program
+        mock_edge_program_manager.methods = {"forward"}
         mock_to_edge_transform_and_lower.return_value = mock_edge_program_manager
 
         stage = EdgeTransformAndLowerStage(
@@ -231,6 +232,39 @@ class TestEdgeTransformAndLowerStage(unittest.TestCase):
         self.assertEqual(
             result_artifact.get_context("delegation_info"), mock_delegation_info
         )
+
+    @patch("executorch.export.stages.to_edge_transform_and_lower")
+    @patch("executorch.export.stages.get_delegation_info")
+    def test_run_multi_method_without_forward(
+        self, mock_get_delegation_info: Mock, mock_to_edge_transform_and_lower: Mock
+    ) -> None:
+        """Delegation info is collected per method when there is no `forward`."""
+        programs = {name: Mock() for name in ("decode", "prefill")}
+        for program in programs.values():
+            program.graph_module = Mock()
+        delegation_by_graph_module = {
+            program.graph_module: f"{name}-info" for name, program in programs.items()
+        }
+
+        mock_edge_program_manager = Mock(spec=EdgeProgramManager)
+        mock_edge_program_manager.methods = set(programs)
+        mock_edge_program_manager.exported_program.side_effect = programs.__getitem__
+        mock_to_edge_transform_and_lower.return_value = mock_edge_program_manager
+        mock_get_delegation_info.side_effect = delegation_by_graph_module.__getitem__
+
+        stage = EdgeTransformAndLowerStage()
+        artifact = PipelineArtifact(
+            data={name: Mock(spec=ExportedProgram) for name in programs},
+            context=self.context,
+        )
+        stage.run(artifact)
+
+        self.assertEqual(
+            stage.delegation_info_by_method,
+            {"decode": "decode-info", "prefill": "prefill-info"},
+        )
+        # No `forward` method, so the first method by name is reported.
+        self.assertEqual(stage.delegation_info, "decode-info")
 
 
 class TestExecutorchStage(unittest.TestCase):
@@ -545,6 +579,68 @@ class TestToBackendStage(unittest.TestCase):
             result_artifact.get_context("delegation_info"), mock_delegation_info
         )
 
+    @patch("executorch.export.stages.get_delegation_info")
+    def test_run_multi_method_without_forward(
+        self, mock_get_delegation_info: Mock
+    ) -> None:
+        """Delegation info is collected per method when there is no `forward`."""
+        programs = {name: Mock() for name in ("decode", "prefill")}
+        for program in programs.values():
+            program.graph_module = Mock()
+        delegation_by_graph_module = {
+            program.graph_module: f"{name}-info" for name, program in programs.items()
+        }
+
+        self.mock_edge_manager.methods = set(programs)
+        self.mock_edge_manager.exported_program.side_effect = programs.__getitem__
+        mock_get_delegation_info.side_effect = delegation_by_graph_module.__getitem__
+
+        stage = ToBackendStage()
+        stage.run(PipelineArtifact(data=self.mock_edge_manager, context=self.context))
+
+        self.assertEqual(
+            stage.delegation_info_by_method,
+            {"decode": "decode-info", "prefill": "prefill-info"},
+        )
+        # No `forward` method, so the first method by name is reported.
+        self.assertEqual(stage.delegation_info, "decode-info")
+
+    @patch("executorch.export.stages.get_delegation_info")
+    def test_run_with_per_method_partitioners(
+        self, mock_get_delegation_info: Mock
+    ) -> None:
+        """A dict of partitioners lowers each method with its own partitioners."""
+        mock_get_delegation_info.return_value = {"delegation": "info"}
+        exported_program = Mock()
+        exported_program.graph_module = Mock()
+        self.mock_edge_manager.methods = {"decode", "prefill"}
+        self.mock_edge_manager.exported_program.return_value = exported_program
+        self.mock_edge_manager.to_backend.return_value = self.mock_edge_manager
+
+        decode_partitioner = Mock()
+        second_decode_partitioner = Mock()
+        prefill_partitioner = Mock()
+        stage = ToBackendStage(
+            partitioners={
+                "decode": [decode_partitioner, second_decode_partitioner],
+                "prefill": [prefill_partitioner],
+            }
+        )
+        stage.run(PipelineArtifact(data=self.mock_edge_manager, context=self.context))
+
+        self.mock_edge_manager.to_backend.assert_has_calls(
+            [
+                call(
+                    {
+                        "decode": decode_partitioner,
+                        "prefill": prefill_partitioner,
+                    }
+                ),
+                call({"decode": second_decode_partitioner}),
+            ]
+        )
+        self.assertEqual(self.mock_edge_manager.to_backend.call_count, 2)
+
     def test_run_edge_manager_none(self) -> None:
         stage = ToBackendStage()
         artifact = PipelineArtifact(data=None, context=self.context)
@@ -592,7 +688,9 @@ class TestEmptyPassDictIsNotApplied(unittest.TestCase):
     def test_lower_stage_passes_none_not_empty_dict(
         self, mock_lower: Mock, mock_delegation_info: Mock
     ) -> None:
-        mock_lower.return_value = Mock(spec=EdgeProgramManager)
+        mock_edge_program_manager = Mock(spec=EdgeProgramManager)
+        mock_edge_program_manager.methods = {"forward"}
+        mock_lower.return_value = mock_edge_program_manager
         mock_delegation_info.return_value = {}
         stage = EdgeTransformAndLowerStage()
         stage.run(


### PR DESCRIPTION
Summary:

Current export recipe implementation only supports single method export, defaulting to "forward"

LLMs typically have "prefill" and "decode" or similar, which fails on the current setup.

This PR adds multi method support

Reviewed By: rascani

Differential Revision: D115479160


