### PR TITLE
Synchronize the CUDA stream before returning from execute

### DIFF
--- a/backends/cuda/runtime/cuda_backend.cpp
+++ b/backends/cuda/runtime/cuda_backend.cpp
@@ -829,6 +829,15 @@ class ET_EXPERIMENTAL CudaBackend final
       slim_outputs[i] = nullptr;
     }
 
+    // The kernels above and the D2D landing copies are asynchronous, so the
+    // outputs are not readable yet. Whoever consumes them next may run on a
+    // different stream, such as another backend's delegate or a portable kernel
+    // on the default stream, with no event linking the two, so returning here
+    // would hand out buffers that are still being written. The CUDA graph replay
+    // and capture paths already synchronize before returning; this path must do
+    // the same.
+    ET_CUDA_CHECK_OR_RETURN_ERROR(cudaStreamSynchronize(cuda_stream));
+
     return Error::Ok;
   }
 


### PR DESCRIPTION
## The problem

The CUDA delegate finishes its work on the GPU **asynchronously**, then returns without waiting for it to finish. GPU work is queued on a "stream" (an ordered queue of operations), and work on one stream is not visible to a reader on a different stream unless the producer waits for it first.

So whoever runs next can read an output buffer that is still being written. The result is wrong numbers rather than an error, and the same wrong numbers on every run, which makes it look like a modeling bug rather than a race.

The delegate's own helper already documents the rule being broken:

```
// NOTE: In the fast path the copy is asynchronous. The caller must synchronize
// the stream before consuming the ETensor data.
```

Nothing on the normal execution path does that.

## Why it is reachable

The normal path launches the kernels and, when AOTInductor hands back its own output buffer, an asynchronous device-to-device copy into the planned buffer. Then it returns.

That is only safe while every consumer happens to run on the same stream. It is not safe when the output is consumed by:

- a delegate from a **different backend**, which selects its own stream and has no event ordering it after this one, or
- a portable kernel on the default stream.

The two CUDA graph paths in the same function already synchronize before returning (replay and capture). Only the normal path does not, so this change makes it consistent with its neighbours.

## The fix

One synchronize at the end of the normal path, mirroring what the graph paths already do:

```cpp
    ET_CUDA_CHECK_OR_RETURN_ERROR(cudaStreamSynchronize(cuda_stream));

    return Error::Ok;
```

Nine added lines, no deletions, one file.

## Testing

Found while running a program that interleaves this backend with another backend's delegate in one method. The failure scales with the number of handoffs between the two: with a couple of handoffs the timing happened to work out, and with more it was consistently wrong.

The check that isolates it is an A/B on one unchanged program, where the only difference is whether the GPU is forced to run everything in order:

```
default                    first token 13377, then 0 0 0 0 0 0 0 0   (dead)
CUDA_LAUNCH_BLOCKING=1     first token  3854, then 13 13 17 13 ...   (alive)
with this change           first token  3854, then 13 13 17 13 ...   (identical)
```

Serialising all GPU work and adding the missing synchronize produce **byte-identical** output, which is what a correctly fixed ordering hazard looks like. Also confirmed this does not disturb a program that was already correct: a longer-sequence variant of the same model still produces its previous, verified output.

## A note on a regression test

I did not include one, and I would rather say why than ship something that does not actually test this.

A genuine test needs a consumer reading on a **different stream**, which in practice means a second backend in the same method. I could not find an existing test that runs two different delegates in one method and checks numerics, so there is no natural place to extend.

I tried two versions and discarded both:

1. A C++ unit test asserting cross-stream visibility. It verified CUDA's own documented semantics, so it passed with and without the change. A tautology, not a regression test.
2. A Python test lowering a multi-output model to this backend and comparing against eager, following the pattern of the existing `test_output_stride_rearrange.py`. It crashed in the pybindings loader in my environment, and so did that pre-existing test unchanged, so I could not validate any result from it.

Happy to add a test if a maintainer can point me at the right harness for a two-backend numeric check.
