### PR TITLE
Share selective prim-ops helper

### DIFF
--- a/backends/arm/cmake/ArmRunnerUtils.cmake
+++ b/backends/arm/cmake/ArmRunnerUtils.cmake
@@ -46,62 +46,6 @@ function(verify_targets_exist)
   endforeach()
 endfunction()
 
-# Private function to isolate logic for building prim ops library.
-function(_arm_runner_create_prim_ops_lib)
-  # Parse arguments.
-  set(options INCLUDE_ALL_OPS)
-  set(one_value_args LIB_NAME SELECTED_OPS_YAML)
-  set(multi_value_args DEPS)
-  cmake_parse_arguments(
-    ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
-  )
-
-  set(_out_dir "${CMAKE_CURRENT_BINARY_DIR}/${ARG_LIB_NAME}")
-  set(_sources ${EXECUTORCH_ROOT}/kernels/prim_ops/register_prim_ops.cpp)
-
-  # Generate selected operator list if needed.
-  if(NOT ARG_INCLUDE_ALL_OPS)
-    set(_selected_prim_ops_header "${_out_dir}/selected_prim_ops.h")
-    set(_gen_selected_prim_ops_script
-        "${EXECUTORCH_ROOT}/codegen/tools/gen_selected_prim_ops.py"
-    )
-    set(_gen_selected_prim_ops_command
-        "${PYTHON_EXECUTABLE}" -m codegen.tools.gen_selected_prim_ops
-        --op-selection-yaml-path=${ARG_SELECTED_OPS_YAML}
-        --output-dir=${_out_dir}
-    )
-    add_custom_command(
-      COMMENT "Generating selected_prim_ops.h for ${ARG_LIB_NAME}"
-      OUTPUT ${_selected_prim_ops_header}
-      COMMAND ${_gen_selected_prim_ops_command}
-      DEPENDS ${ARG_SELECTED_OPS_YAML} ${_gen_selected_prim_ops_script}
-      WORKING_DIRECTORY ${EXECUTORCH_ROOT}
-    )
-    list(APPEND _sources ${_selected_prim_ops_header})
-  endif()
-
-  # Add prim ops registration library.
-  add_library(${ARG_LIB_NAME} ${_sources})
-  target_include_directories(
-    ${ARG_LIB_NAME} PRIVATE ${EXECUTORCH_ROOT}/kernels/prim_ops ${_out_dir}
-  )
-  if(NOT ARG_INCLUDE_ALL_OPS)
-    target_compile_definitions(
-      ${ARG_LIB_NAME} PRIVATE ET_PRIM_OPS_SELECTIVE_BUILD
-                              EXECUTORCH_ENABLE_PRIM_OPS_SELECTIVE_BUILD
-    )
-  endif()
-  target_link_libraries(${ARG_LIB_NAME} PRIVATE ${ARG_DEPS})
-  executorch_target_link_options_shared_lib(${ARG_LIB_NAME})
-
-  # Add prim ops kernel library.
-  add_library(
-    ${ARG_LIB_NAME}_impl ${EXECUTORCH_ROOT}/kernels/prim_ops/et_copy_index.cpp
-                         ${EXECUTORCH_ROOT}/kernels/prim_ops/et_view.cpp
-  )
-  target_link_libraries(${ARG_LIB_NAME}_impl PRIVATE ${ARG_DEPS})
-endfunction()
-
 #[[
 Create a selected operator registration library for one operator family.
 
@@ -221,7 +165,7 @@ function(arm_runner_create_selected_ops_lib)
     if(_arm_runner_include_all_ops)
       list(APPEND _arm_runner_prim_ops_args INCLUDE_ALL_OPS)
     endif()
-    _arm_runner_create_prim_ops_lib(${_arm_runner_prim_ops_args})
+    gen_selected_prim_ops_lib(${_arm_runner_prim_ops_args})
     return()
   endif()
 

--- a/tools/cmake/Codegen.cmake
+++ b/tools/cmake/Codegen.cmake
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -148,6 +149,81 @@ function(gen_selected_max_kernel_num)
       ${_include_root}
       PARENT_SCOPE
   )
+endfunction()
+
+# Generate a prim ops registration library. By default the library includes only
+# operators from SELECTED_OPS_YAML. INCLUDE_ALL_OPS disables prim-op selective
+# build and registers every prim op.
+function(gen_selected_prim_ops_lib)
+  # Parse arguments.
+  set(options INCLUDE_ALL_OPS)
+  set(one_value_args LIB_NAME SELECTED_OPS_YAML)
+  set(multi_value_args DEPS)
+  cmake_parse_arguments(
+    GEN "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
+  )
+
+  message(STATUS "Generating selected prim ops lib:")
+  message(STATUS "  LIB_NAME: ${GEN_LIB_NAME}")
+  message(STATUS "  SELECTED_OPS_YAML: ${GEN_SELECTED_OPS_YAML}")
+  message(STATUS "  INCLUDE_ALL_OPS: ${GEN_INCLUDE_ALL_OPS}")
+  message(STATUS "  DEPS: ${GEN_DEPS}")
+
+  if(NOT GEN_LIB_NAME)
+    message(FATAL_ERROR "gen_selected_prim_ops_lib: LIB_NAME is required")
+  endif()
+  if(NOT GEN_INCLUDE_ALL_OPS AND NOT GEN_SELECTED_OPS_YAML)
+    message(
+      FATAL_ERROR
+        "gen_selected_prim_ops_lib: SELECTED_OPS_YAML is required unless INCLUDE_ALL_OPS is set"
+    )
+  endif()
+
+  set(_out_dir ${CMAKE_CURRENT_BINARY_DIR}/${GEN_LIB_NAME})
+  file(MAKE_DIRECTORY ${_out_dir})
+
+  # Generate selected operator list if needed.
+  set(_sources ${EXECUTORCH_ROOT}/kernels/prim_ops/register_prim_ops.cpp)
+  if(NOT GEN_INCLUDE_ALL_OPS)
+    set(_selected_prim_ops_header ${_out_dir}/selected_prim_ops.h)
+    set(_gen_selected_prim_ops_script
+        ${EXECUTORCH_ROOT}/codegen/tools/gen_selected_prim_ops.py
+    )
+    set(_gen_selected_prim_ops_command
+        "${PYTHON_EXECUTABLE}" -m codegen.tools.gen_selected_prim_ops
+        --op-selection-yaml-path=${GEN_SELECTED_OPS_YAML}
+        --output-dir=${_out_dir}
+    )
+    add_custom_command(
+      COMMENT "Generating selected_prim_ops.h for ${GEN_LIB_NAME}"
+      OUTPUT ${_selected_prim_ops_header}
+      COMMAND ${_gen_selected_prim_ops_command}
+      DEPENDS ${GEN_SELECTED_OPS_YAML} ${_gen_selected_prim_ops_script}
+      WORKING_DIRECTORY ${EXECUTORCH_ROOT}
+    )
+    list(APPEND _sources ${_selected_prim_ops_header})
+  endif()
+
+  # Add prim ops registration library.
+  add_library(${GEN_LIB_NAME} ${_sources})
+  target_include_directories(
+    ${GEN_LIB_NAME} PRIVATE ${EXECUTORCH_ROOT}/kernels/prim_ops ${_out_dir}
+  )
+  if(NOT GEN_INCLUDE_ALL_OPS)
+    target_compile_definitions(
+      ${GEN_LIB_NAME} PRIVATE ET_PRIM_OPS_SELECTIVE_BUILD
+                              EXECUTORCH_ENABLE_PRIM_OPS_SELECTIVE_BUILD
+    )
+  endif()
+  target_link_libraries(${GEN_LIB_NAME} PRIVATE ${GEN_DEPS})
+  executorch_target_link_options_shared_lib(${GEN_LIB_NAME})
+
+  # Add prim ops kernel library.
+  add_library(
+    ${GEN_LIB_NAME}_impl ${EXECUTORCH_ROOT}/kernels/prim_ops/et_copy_index.cpp
+                         ${EXECUTORCH_ROOT}/kernels/prim_ops/et_view.cpp
+  )
+  target_link_libraries(${GEN_LIB_NAME}_impl PRIVATE ${GEN_DEPS})
 endfunction()
 
 # Codegen for registering kernels. Kernels are defined in functions_yaml and


### PR DESCRIPTION
As pointed out in #21714, the helper is useful
for all builds. Therefore, move the helper
from ArmRunnerUtils to Codegen.cmake.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani