### PR TITLE
Arm backend: Delegate nearest upsample on U55

### DIFF
--- a/backends/arm/operator_support/ethos_u55_support.py
+++ b/backends/arm/operator_support/ethos_u55_support.py
@@ -209,7 +209,6 @@ class EthosU55NotSupported(OperatorSupportBase):
         exir_ops.edge.aten.scatter_reduce.two,
         exir_ops.edge.aten.scatter_add.default,
         exir_ops.edge.aten.unfold_copy.default,  # GATHER
-        exir_ops.edge.aten.upsample_nearest2d.vec,  # RESIZE
         exir_ops.edge.aten.upsample_bilinear2d.vec,  # RESIZE
         exir_ops.edge.aten.reflection_pad1d.default,  # REVERSE
         exir_ops.edge.aten.reflection_pad2d.default,  # REVERSE
@@ -244,6 +243,97 @@ class EthosU55NotSupported(OperatorSupportBase):
             return False
 
         return True
+
+
+class EthosU55ResizeCheck(OperatorSupportBase):
+    """Accept nearest-neighbor upscales supported by Ethos-U55.
+
+    Ethos-U55 supports nearest-neighbor TOSA RESIZE when both spatial dimensions
+    have batch size 1 and use the same power-of-two scale in the range 2x
+    through 8x.
+
+    """
+
+    def __init__(self, reporter: WhyNoPartitionReporter):
+        """Initialize the check with a reporter.
+
+        Args:
+            reporter (WhyNoPartitionReporter): Reporter for rejection reasons.
+
+        """
+        self.reporter = reporter
+
+    def is_node_supported(
+        self, submodules: typing.Mapping[str, torch.nn.Module], node: fx.Node
+    ) -> bool:
+        """Return True when a resize satisfies the U55 constraints.
+
+        Args:
+            submodules (typing.Mapping[str, torch.nn.Module]): Exported modules.
+            node (fx.Node): FX node to check.
+
+        Returns:
+            bool: True if supported; otherwise, False.
+
+        """
+        if node.target != exir_ops.edge.aten.upsample_nearest2d.vec:
+            return True
+
+        input_shape = get_first_fake_tensor(node.all_input_nodes[0]).shape
+        output_shape = get_first_fake_tensor(node).shape
+        input_batch = input_shape[0]
+        output_batch = output_shape[0]
+        if isinstance(input_batch, torch.SymInt) or isinstance(
+            output_batch, torch.SymInt
+        ):
+            self.reporter.report_reject(
+                node,
+                "U55 nearest-neighbor resize requires a static batch size of 1.",
+            )
+            return False
+        if input_batch != 1 or output_batch != 1:
+            self.reporter.report_reject(
+                node, "U55 nearest-neighbor resize requires batch size 1."
+            )
+            return False
+
+        scale_factors_arg = node.args[2]
+        if scale_factors_arg is not None:
+            scale_factors = typing.cast(typing.Sequence[float], scale_factors_arg)
+            if len(scale_factors) != 2 or not (
+                scale_factors[0] == scale_factors[1] and scale_factors[0] in (2, 4, 8)
+            ):
+                self.reporter.report_reject(
+                    node,
+                    "U55 nearest-neighbor resize requires equal 2x, 4x, or 8x "
+                    "scale factors.",
+                )
+                return False
+            return True
+
+        input_height, input_width = input_shape[-2:]
+        output_height, output_width = output_shape[-2:]
+        if any(
+            isinstance(dim, torch.SymInt)
+            for dim in (input_height, input_width, output_height, output_width)
+        ):
+            self.reporter.report_reject(
+                node,
+                "U55 nearest-neighbor resize with an explicit size requires "
+                "static spatial dimensions.",
+            )
+            return False
+        if any(
+            output_height == input_height * scale
+            and output_width == input_width * scale
+            for scale in (2, 4, 8)
+        ):
+            return True
+
+        self.reporter.report_reject(
+            node, "U55 nearest-neighbor resize requires a 2x, 4x, or 8x upscale."
+        )
+        return False
 
 
 class EthosU55CastCheck(OperatorSupportBase):

--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -40,6 +40,7 @@ from executorch.backends.arm.operator_support.ethos_u55_support import (
     EthosU55CastCheck,
     EthosU55DtypeSupport,
     EthosU55NotSupported,
+    EthosU55ResizeCheck,
 )
 from executorch.backends.arm.operator_support.tosa_profile_supported_op_lists import (
     TOSA_PRO_FP_SupportList,
@@ -363,6 +364,7 @@ def _negative_checks(
 
     if tosa_spec.is_U55_subset:
         checks.append(EthosU55NotSupported(reporter))
+        checks.append(EthosU55ResizeCheck(reporter))
         checks.append(EthosU55DtypeSupport(reporter))
         checks.append(EthosU55CastCheck(reporter))
 

--- a/backends/arm/test/ops/test_upsample_nearest2d.py
+++ b/backends/arm/test/ops/test_upsample_nearest2d.py
@@ -6,17 +6,24 @@
 from typing import Optional, Tuple
 
 import torch
+from executorch.backends.arm.operator_support.ethos_u55_support import (
+    EthosU55ResizeCheck,
+)
 from executorch.backends.arm.quantizer.arm_quantizer import (
     get_symmetric_a16w8_quantization_config,
 )
 from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.arm_tester import ArmTester
 
 from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
     OpNotSupportedPipeline,
     TosaPipelineFP,
     TosaPipelineINT,
     VgfPipeline,
 )
+from executorch.exir.backend.utils import WhyNoPartitionReporter
+from executorch.exir.dialects._ops import ops as exir_ops
 
 aten_op = "torch.ops.aten.upsample_nearest2d.vec"
 exir_op = "executorch_exir_dialects_edge__ops_aten_upsample_nearest2d_vec"
@@ -75,7 +82,15 @@ test_data_suite_fp16 = {
 }
 
 test_data_u55 = {
-    "rand_double_size": lambda: (torch.rand(2, 4, 8, 3), (16, 6), None, True),
+    "rand_double_scale": lambda: (torch.rand(1, 4, 8, 3), None, 2.0, True),
+    "rand_double_scale_different_shape": lambda: (
+        torch.rand(1, 2, 4, 3),
+        None,
+        2.0,
+        True,
+    ),
+    "rand_quadruple_size": lambda: (torch.rand(1, 4, 8, 3), (32, 12), None, True),
+    "rand_octuple_size": lambda: (torch.rand(1, 4, 8, 3), (64, 24), None, True),
 }
 
 test_data_suite_dynamic = {
@@ -447,56 +462,118 @@ def test_upsample_nearest2d_vec_vgf_quant_a16w8_interpolate(
 
 @common.parametrize("test_data", test_data_u55)
 @common.XfailIfNoCorstone300
-def test_upsample_nearest2d_vec_u55_INT_Upsample_not_delegated(
-    test_data: torch.Tensor,
-):
+def test_upsample_nearest2d_vec_u55_INT_Upsample(test_data: torch.Tensor):
     test_data, size, scale_factor, compare_outputs = test_data()
-    pipeline = OpNotSupportedPipeline[input_t1](
+    pipeline = EthosU55PipelineINT[input_t1](
         Upsample(size, scale_factor),
         (test_data,),
-        {exir_op: 1},
-        n_expected_delegates=0,
-        quantize=True,
-        u55_subset=True,
+        aten_op,
+        exir_op,
     )
-
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_u55)
 @common.XfailIfNoCorstone300
-def test_upsample_nearest2d_vec_u55_INT_Interpolate_not_delegated(
-    test_data: torch.Tensor,
-):
+def test_upsample_nearest2d_vec_u55_INT_Interpolate(test_data: torch.Tensor):
     test_data, size, scale_factor, compare_outputs = test_data()
-    pipeline = OpNotSupportedPipeline[input_t1](
+    pipeline = EthosU55PipelineINT[input_t1](
         Interpolate(size, scale_factor),
         (test_data,),
-        {exir_op: 1},
-        n_expected_delegates=0,
-        quantize=True,
-        u55_subset=True,
+        aten_op,
+        exir_op,
     )
-
     pipeline.run()
 
 
 @common.parametrize("test_data", test_data_u55)
 @common.XfailIfNoCorstone300
-def test_upsample_nearest2d_vec_u55_INT_UpsamplingBilinear2d_not_delegated(
+def test_upsample_nearest2d_vec_u55_INT_UpsamplingNearest2d(
     test_data: torch.Tensor,
 ):
     test_data, size, scale_factor, compare_outputs = test_data()
-    pipeline = OpNotSupportedPipeline[input_t1](
+    pipeline = EthosU55PipelineINT[input_t1](
         UpsamplingNearest2d(size, scale_factor),
+        (test_data,),
+        aten_op,
+        exir_op,
+    )
+    pipeline.run()
+
+
+def test_upsample_nearest2d_vec_u55_INT_unsupported_scale_not_delegated():
+    # 2.25 rounds a 2x2 input to 4x4, which looks like a supported 2x resize from shapes alone.
+    test_data = torch.rand(1, 4, 2, 2)
+    pipeline = OpNotSupportedPipeline[input_t1](
+        Interpolate(None, 2.25),
         (test_data,),
         {exir_op: 1},
         n_expected_delegates=0,
         quantize=True,
         u55_subset=True,
     )
-
     pipeline.run()
+
+
+def test_upsample_nearest2d_vec_u55_INT_unsupported_batch_not_delegated():
+    test_data = torch.rand(2, 4, 8, 3)
+    pipeline = OpNotSupportedPipeline[input_t1](
+        Interpolate(None, 2.0),
+        (test_data,),
+        {exir_op: 1},
+        n_expected_delegates=0,
+        quantize=True,
+        u55_subset=True,
+    )
+    pipeline.run()
+
+
+def test_upsample_nearest2d_vec_u55_INT_dynamic_batch_not_delegated():
+    test_data = torch.rand(2, 4, 8, 3)
+    batch = torch.export.Dim("batch", min=1, max=4)
+    tester = ArmTester(
+        Interpolate(None, 2.0),
+        (test_data,),
+        common.get_u55_compile_spec(),
+        dynamic_shapes={"x": {0: batch}},
+    )
+    tester.quantize().export().to_edge().partition()
+
+    targets = {
+        node.target
+        for node in tester.stages[tester.cur].artifact.exported_program().graph.nodes
+    }
+    assert exir_ops.edge.aten.upsample_nearest2d.vec in targets
+    assert torch.ops.higher_order.executorch_call_delegate not in targets
+
+
+def test_upsample_nearest2d_vec_u55_INT_dynamic_spatial_size_not_delegated():
+    test_data = torch.rand(1, 4, 8, 3)
+    input_height = torch.export.Dim("input_height", min=4, max=12)
+    input_width = torch.export.Dim("input_width", min=2, max=6)
+    tester = ArmTester(
+        Interpolate((16, 6), None),
+        (test_data,),
+        common.get_u55_compile_spec(),
+        dynamic_shapes={"x": {2: input_height, 3: input_width}},
+    )
+    tester.quantize().export().to_edge()
+    resize_node = next(
+        node
+        for node in tester.stages[tester.cur].artifact.exported_program().graph.nodes
+        if node.target == exir_ops.edge.aten.upsample_nearest2d.vec
+    )
+    assert not EthosU55ResizeCheck(WhyNoPartitionReporter()).is_node_supported(
+        {}, resize_node
+    )
+
+    tester.partition()
+    targets = {
+        node.target
+        for node in tester.stages[tester.cur].artifact.exported_program().graph.nodes
+    }
+    assert exir_ops.edge.aten.upsample_nearest2d.vec in targets
+    assert torch.ops.higher_order.executorch_call_delegate not in targets
 
 
 @common.parametrize("test_data", test_data_suite_dynamic)


### PR DESCRIPTION
Allow batch-size-1 nearest-neighbor upsampling with equal 2x, 4x, or 8x spatial scales to lower through TOSA RESIZE on Ethos-U55. Validate provided scale factors directly so fractional factors whose rounded output shapes resemble supported ratios continue to fall back to CPU.

Exercise supported scales through Upsample, interpolate, and UpsamplingNearest2d using the Ethos-U55 pipeline. Add fallback coverage for batch sizes greater than one and for scale factor 2.25, whose rounded 2x2-to-4x4 output previously appeared to be a supported 2x resize.

Authored with Codex.

Signed-off-by: Per Held <per.held@arm.com>

Change-Id: I37a8680d9b5bfe03e8d858f6a34b0afde81b9376


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani