### PR TITLE
zephyr: support renamed Ethos-U Kconfig symbol

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -57,7 +57,9 @@ if(CONFIG_EXECUTORCH)
   if(CONFIG_CPU_CORTEX_A)
     set(EXECUTORCH_BUILD_XNNPACK ON)
   endif()
-  if(CONFIG_ETHOS_U)
+  # Zephyr renamed these symbols to ARM_ETHOS_U in 4.3. Keep compatibility with
+  # SDK releases on either side of that rename.
+  if(CONFIG_ETHOS_U OR CONFIG_ARM_ETHOS_U)
     set(EXECUTORCH_BUILD_ARM_BAREMETAL ON)
   endif()
 


### PR DESCRIPTION
Accept ARM_ETHOS_U while retaining compatibility with SDKs that still define ETHOS_U.

AI-assisted by Codex.

Change-Id: I7749387bc209defef779f875dbe2c562a30f3812

### Summary


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani