### PR TITLE
Arm backend: Move memory pools into NOLOAD section

### DIFF
--- a/examples/arm/executor_runner/Corstone-300.ld
+++ b/examples/arm/executor_runner/Corstone-300.ld
@@ -254,14 +254,6 @@ SECTIONS
     __asan_shadow_end = .;
   } > DDR :null
 
-  .ddr.bss (NOLOAD) :
-  {
-#if (ETHOSU_ARENA == 1)
-    . = ALIGN(32);
-    *(.bss.tensor_arena)
-#endif
-  } > DDR :null
-
   __eddr_data = ALIGN(4);
   .sram.data :
   {
@@ -280,6 +272,17 @@ SECTIONS
     . = ALIGN(4);
     __rodata_end__ = .;
   } > DTCM AT >DDR :rom_dram
+
+  .ddr.bss (NOLOAD) :
+  {
+    . = ALIGN(16);
+    *(input_file_allocator_sec)
+    *(method_allocator_sec)
+#if (ETHOSU_ARENA == 1)
+    . = ALIGN(32);
+    *(.bss.tensor_arena)
+#endif
+  } > DDR :null
 
   .bss :
   {

--- a/examples/arm/executor_runner/Corstone-320.ld
+++ b/examples/arm/executor_runner/Corstone-320.ld
@@ -261,6 +261,9 @@ SECTIONS
 
   .ddr.bss (NOLOAD) :
   {
+    . = ALIGN(16);
+    *(input_file_allocator_sec)
+    *(method_allocator_sec)
 #if (ETHOSU_ARENA == 1)
     . = ALIGN(32);
     *(.bss.tensor_arena)

--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -150,9 +150,7 @@ using printf_size_t = unsigned long;
  * e.g. the input file data and the pte file data
  * In our unit test flow, we have the capability to provide an enitre model to
  * the Corstone-3xx FVP using semi hosting. Hence, the input file allocation
- * pool needs to be large enough to take an entire model and input. On the FVP,
- * input_data_sec is linked to the DDR, which is large (256MB on
- * Corstone-300).
+ * pool needs to be large enough to take an entire model and input.
  * If you use semihosting on your HW this can be lowered to fit your
  * files/memory
  */
@@ -163,7 +161,7 @@ using printf_size_t = unsigned long;
 const size_t input_file_allocation_pool_size =
     ET_ARM_BAREMETAL_SEMIHOSTING_FILE_ALLOCATOR_POOL_SIZE;
 unsigned char __attribute__((
-    section("input_data_sec"),
+    section("input_file_allocator_sec"),
     aligned(16))) input_file_allocation_pool[input_file_allocation_pool_size];
 #endif
 
@@ -231,7 +229,7 @@ using torch::executor::etdump_result;
 const size_t method_allocation_pool_size =
     ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE;
 unsigned char __attribute__((
-    section("input_data_sec"),
+    section("method_allocator_sec"),
     aligned(16))) method_allocation_pool[method_allocation_pool_size];
 
 #if defined(ET_BUNDLE_IO)

--- a/examples/arm/image_classification_example_ethos_u/runtime/main.cpp
+++ b/examples/arm/image_classification_example_ethos_u/runtime/main.cpp
@@ -85,7 +85,7 @@ constexpr const char* labels[] = {
 
 const size_t method_allocation_pool_size = 1 * 1024 * 1024;
 unsigned char __attribute__((
-    section("input_data_sec"),
+    section("method_allocator_sec"),
     aligned(16))) method_allocation_pool[method_allocation_pool_size];
 
 /*

--- a/examples/arm/mobilesam_prompt_segmentation_example_ethos_u/runtime/main.cpp
+++ b/examples/arm/mobilesam_prompt_segmentation_example_ethos_u/runtime/main.cpp
@@ -46,7 +46,7 @@ using executorch::runtime::Span;
 const size_t method_allocation_pool_size =
     ET_SEGMENTATION_METHOD_ALLOCATOR_POOL_SIZE;
 unsigned char __attribute__((
-    section("input_data_sec"),
+    section("method_allocator_sec"),
     aligned(16))) method_allocation_pool[method_allocation_pool_size];
 
 const size_t temp_allocation_pool_size =


### PR DESCRIPTION
In the arm_executor_runner, the two large memory pools (60MiB by default) input_file_allocation_pool and
memory_allocation_pool were put into the input_data_sec section. While the pools contain uninitialized memory, this section is also used for embedding data into the runner and can thus not be NOLOAD.

Instead, introduce two new input sections,
input_file_allocator_sec and method_allocator_sec, that are put into .ddr.bss which is already NOLOAD.

Additionally, for Corstone-300 the .ddr.bss output section is placed after the DDR-backed scatter-load payloads to avoid creating a large file-backed hole in the ELF.

This saves binary size, since the pools
will only be initialized at runtime. It also has the benefit of making the placement of these pools more explicit.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani