### PR TITLE
NXP backend: Update docs with recent ops, rename SliceTensorConverter…

### DIFF
--- a/backends/nxp/backend/edge_program_converter.py
+++ b/backends/nxp/backend/edge_program_converter.py
@@ -60,7 +60,7 @@ functions_converters = {
     exir_ops.edge.aten.relu.default: ReLUConverter,  # noqa F405
     exir_ops.edge.aten.rsqrt.default: RsqrtConverter,  # noqa F405
     exir_ops.edge.aten.sigmoid.default: SigmoidConverter,  # noqa F405
-    exir_ops.edge.aten.slice_copy.Tensor: SliceTensorConverter,  # noqa F405
+    exir_ops.edge.aten.slice_copy.Tensor: SliceCopyTensorConverter,  # noqa F405
     exir_ops.edge.aten._softmax.default: SoftmaxConverter,  # noqa F405
     exir_ops.edge.aten.sub.Tensor: SubTensorConverter,  # noqa F405
     exir_ops.edge.aten.sum.dim_IntList: SumDimIntListConverter,  # noqa F405

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/__init__.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/__init__.py
@@ -101,8 +101,8 @@ from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters
 from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.sigmoid_converter import (
     SigmoidConverter,
 )
-from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.slice_tensor_converter import (
-    SliceTensorConverter,
+from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.slice_copy_tensor_converter import (
+    SliceCopyTensorConverter,
 )
 from executorch.backends.nxp.backend.ir.converter.node_converters.ops_converters.softmax_converter import (
     SoftmaxConverter,
@@ -163,7 +163,7 @@ __all__ = [
     "ReLUConverter",
     "RsqrtConverter",
     "SigmoidConverter",
-    "SliceTensorConverter",
+    "SliceCopyTensorConverter",
     "SoftmaxConverter",
     "SubTensorConverter",
     "SumDimIntListConverter",

--- a/backends/nxp/backend/ir/converter/node_converters/ops_converters/slice_copy_tensor_converter.py
+++ b/backends/nxp/backend/ir/converter/node_converters/ops_converters/slice_copy_tensor_converter.py
@@ -20,7 +20,7 @@ from torch.fx import Node
 from torch.nn import Parameter
 
 
-class SliceTensorConverter(NodeConverter):
+class SliceCopyTensorConverter(NodeConverter):
     @staticmethod
     def _is_supported_on_target(
         node: Node,
@@ -46,7 +46,7 @@ class SliceTensorConverter(NodeConverter):
         if len(args) != 4:
             return False
 
-        dim, start, end = SliceTensorConverter._get_clipped_slice_args(node)
+        dim, start, end = SliceCopyTensorConverter._get_clipped_slice_args(node)
         input_rank = len(input_tensor(node, 0).shape)
 
         # Check "dim" out of bounds

--- a/backends/nxp/neutron_partitioner.py
+++ b/backends/nxp/neutron_partitioner.py
@@ -234,7 +234,7 @@ supported_ops = {
     exir_ops.edge.aten.relu.default: ReLUConverter,  # noqa F405
     exir_ops.edge.aten.rsqrt.default: RsqrtConverter,  # noqa F405
     exir_ops.edge.aten.sigmoid.default: SigmoidConverter,  # noqa F405
-    exir_ops.edge.aten.slice_copy.Tensor: SliceTensorConverter,  # noqa F405
+    exir_ops.edge.aten.slice_copy.Tensor: SliceCopyTensorConverter,  # noqa F405
     exir_ops.edge.aten._softmax.default: SoftmaxConverter,  # noqa F405
     exir_ops.edge.aten.sub.Tensor: SubTensorConverter,  # noqa F405
     exir_ops.edge.aten.sum.dim_IntList: SumDimIntListConverter,  # noqa F405

--- a/backends/nxp/tests/ir/converter/node_converter/test_slice_copy_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_slice_copy_tensor_converter.py
@@ -24,7 +24,6 @@ from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 from executorch.backends.nxp.tests.ops_aliases import (
     Convolution,
     ExecutorchDelegateCall,
-    Slice,
     SliceCopy,
 )
 
@@ -35,7 +34,7 @@ def reseed_model_per_test_run():
     np.random.seed(23)
 
 
-class TestSliceTensorConverter:
+class TestSliceCopyTensorConverter:
     @staticmethod
     def _slice_id(prefix, input_shape, dims, starts, ends):
         return f"{prefix}rank={len(input_shape)}_dims={str(dims)}_starts={str(starts)}_ends={str(ends)}"
@@ -70,7 +69,7 @@ class TestSliceTensorConverter:
         assert not graph_contains_any_of_ops(
             delegated_ep.graph, [ExecutorchDelegateCall]
         )
-        assert not graph_contains_any_of_ops(delegated_ep.graph, [Slice, SliceCopy])
+        assert not graph_contains_any_of_ops(delegated_ep.graph, [SliceCopy])
 
     @staticmethod
     def assert_not_delegated(model, input_shape):
@@ -80,7 +79,7 @@ class TestSliceTensorConverter:
         assert not graph_contains_any_of_ops(
             delegated_ep.graph, [ExecutorchDelegateCall]
         )
-        assert graph_contains_any_of_ops(delegated_ep.graph, [Slice, SliceCopy])
+        assert graph_contains_any_of_ops(delegated_ep.graph, [SliceCopy])
 
     @pytest.mark.parametrize(
         "input_shape, dims, starts, ends",

--- a/docs/source/backends/nxp/nxp-quantization.md
+++ b/docs/source/backends/nxp/nxp-quantization.md
@@ -27,8 +27,8 @@ The Neutron delegate supports the following quantization schemes:
       - `aten.dropout.default`
       - `aten.exp.default`
       - `aten.flatten.using_ints`
-      - `aten.hardtanh.default`
-      - `aten.hardtanh_.default`
+      - `aten.hardswish.default` and `aten.hardswish_.default`
+      - `aten.hardtanh.default` and `aten.hardtanh_.default`
       - `aten.leaky_relu.default` and `aten.leaky_relu_.default`
       - `aten.linear.default`
       - `aten.log.default`
@@ -45,6 +45,7 @@ The Neutron delegate supports the following quantization schemes:
       - `aten.prelu.default`
       - `aten.relu.default` and `aten.relu_.default`
       - `aten.reshape.default`
+      - `aten.rsqrt.default`
       - `aten.sigmoid.default`
       - `aten.slice.Tensor`
       - `aten.softmax.int`

--- a/docs/source/backends/nxp/op-support.csv
+++ b/docs/source/backends/nxp/op-support.csv
@@ -13,7 +13,8 @@ aten.clamp.default,int8,static int8,"Bounds = (-1, 1) or (0, 1) or (0, 6) or (0,
 aten.clone.default,int8,static int8,"node has memory format specified"
 aten.constant_pad_nd.default,int8,static int8,"H or W padding only"
 aten.convolution.default,int8,static int8,"1D or 2D convolution, constant weights, groups=1 or groups=channels_count (depthwise)"
-aten.dim_order_ops._clone_dim_order.default,,, "See aten.clone.default"
+aten.convolution.out,int8,static int8,"1D or 2D convolution, constant weights, groups=1 or groups=channels_count (depthwise)"
+aten.dim_order_ops._clone_dim_order.default,,,"See aten.clone.default"
 aten.div.Tensor,int8,static int8,"divisor - static tensor or scalar value, one dimension must satisfy %8 = 0 or scalar division (all dims = 1)"
 aten.exp.default,int8,static int8,
 aten.hardswish.default,int8,static int8,
@@ -29,15 +30,17 @@ aten.minimum.default,int8,static int8,
 aten.mm.default,int8,static int8,"2D tensor only"
 aten.mul.Tensor,int8,static int8,
 aten.neg.default,int8,static int8,
-aten.permute_copy.default,int8, static int8, "Only specific transpositions supported, see backends/nxp/backend/ir/converter/node_converters/ops_converters/permute_copy_converter.py"
-aten.prelu.default,int8, static int8,
+aten.pad.default,int8,static int8,"Only reflect mode supported for torch.nn.functional.pad. Constant mode converted by aten.constant_pad_nd.default"
+aten.permute_copy.default,int8,static int8,"Only specific transpositions supported, see backends/nxp/backend/ir/converter/node_converters/ops_converters/permute_copy_converter.py"
+aten.prelu.default,int8,static int8,
 aten.relu.default,int8,static int8,
+aten.rsqrt.default,int8,static int8,
 aten.sigmoid.default,int8,static int8,
-aten.slice.Tensor,int8, static int8
-aten._softmax.default,int8, static int8, "rank > 1, channels % 8 = 0, channels < 2048, flat input size / channels <= 4096, flat input size <= 524288"
-aten.split.default,N/A, N/A, "transforming split -> getitem to slice, see aten.slice_copy.Tensor"
-aten.split.Tensor,N/A, N/A, "transforming split -> getitem to slice, see aten.slice_copy.Tensor"
-aten.split_with_sizes.default,N/A, N/A, "transforming split -> getitem to slice, see aten.slice_copy.Tensor"
+aten.slice_copy.Tensor,int8,static int8,
+aten._softmax.default,int8,static int8,"channels <= 2040, flat input size / channels <= 4096, flat input size <= 524288"
+aten.split.default,N/A,N/A,"transforming split -> getitem to slice, see aten.slice_copy.Tensor"
+aten.split.Tensor,N/A,N/A,"transforming split -> getitem to slice, see aten.slice_copy.Tensor"
+aten.split_with_sizes.default,N/A,N/A,"transforming split -> getitem to slice, see aten.slice_copy.Tensor"
 aten.squeeze.default,int8,static int8,
 aten.squeeze.dim,int8,static int8,
 aten.squeeze.dims,int8,static int8,


### PR DESCRIPTION
… to SliceCopyTensorConverter

### Summary
Update docs with recent ops, rename SliceTensorConverter to SliceCopyTensorConverter

### Test plan
Docs, rename updates only.

cc @robert-kalmar @JakeStevens @digantdesai @rascani