### PR TITLE
Test wheel installation and execution with uv

### DIFF
--- a/.ci/scripts/wheel/test_base.py
+++ b/.ci/scripts/wheel/test_base.py
@@ -6,10 +6,16 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import re
+import shlex
+import site
 import subprocess
 import sys
+import tempfile
+import textwrap
 from dataclasses import dataclass
 from functools import cache
+from pathlib import Path
 from typing import List
 
 
@@ -39,6 +45,166 @@ from examples.models import Backend, Model
 class ModelTest:
     model: Model
     backend: Backend
+
+
+def test_native_library_paths() -> None:
+    if sys.platform not in ("darwin", "linux"):
+        return
+
+    package_root = next(
+        Path(root) / "executorch"
+        for root in site.getsitepackages()
+        if (Path(root) / "executorch").is_dir()
+    )
+    torch_linked_libraries = (
+        "_portable_lib",
+        "_training_lib",
+        "_llm_runner",
+        "libcustom_ops_aot_lib",
+        "libquantized_ops_aot_lib",
+    )
+    binaries = [
+        binary
+        for suffix in ("*.so", "*.dylib")
+        for binary in package_root.rglob(suffix)
+        if binary.name.startswith(torch_linked_libraries)
+    ]
+    assert binaries, f"No Torch-linked native libraries found under {package_root}"
+    invalid_paths = []
+    for binary in binaries:
+        if sys.platform == "darwin":
+            output = subprocess.run(
+                ["otool", "-l", binary],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            paths = re.findall(
+                r"cmd LC_RPATH\s+cmdsize \d+\s+path (.+?) \(offset",
+                output,
+            )
+            expected_prefix = "@loader_path"
+        else:
+            output = subprocess.run(
+                ["readelf", "-d", binary],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            paths = [
+                path
+                for value in re.findall(r"Library (?:rpath|runpath): \[(.*?)\]", output)
+                for path in value.split(":")
+                if path
+            ]
+            expected_prefix = "$ORIGIN"
+
+        invalid_paths.extend(
+            f"{binary}: {path}"
+            for path in paths
+            if not path.startswith(expected_prefix)
+        )
+
+    assert not invalid_paths, "Invalid native library paths found:\n" + "\n".join(
+        invalid_paths
+    )
+
+
+def test_uv_wheel_install() -> None:
+    if sys.version_info[:2] != (3, 14):
+        print("Skipping uv wheel test; it runs once with Python 3.14")
+        return
+
+    repository_root = Path(_repository_root_dir())
+    wheels = list((repository_root / "dist").glob("*.whl"))
+    assert len(wheels) == 1, f"Expected one wheel, found: {wheels}"
+
+    torch_install = shlex.split(_unsafe_get_env("PIP_INSTALL_TORCH"))
+    assert torch_install[:2] == ["pip", "install"], torch_install
+
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "uv==0.12.3"],
+        check=True,
+    )
+    uv = [sys.executable, "-m", "uv"]
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        environment = temp_path / "environment"
+        subprocess.run(
+            [*uv, "venv", "--python", sys.executable, environment],
+            check=True,
+        )
+        if sys.platform == "win32":
+            environment_python = environment / "Scripts" / "python.exe"
+        else:
+            environment_python = environment / "bin" / "python"
+
+        subprocess.run(
+            [
+                *uv,
+                "pip",
+                "install",
+                "--python",
+                environment_python,
+                *torch_install[2:],
+            ],
+            check=True,
+        )
+        subprocess.run(
+            [
+                *uv,
+                "pip",
+                "install",
+                "--python",
+                environment_python,
+                wheels[0],
+            ],
+            check=True,
+        )
+
+        smoke_test = textwrap.dedent("""
+            import sys
+
+            if sys.platform == "win32":
+                import torch
+                from executorch.extension.pybindings.portable_lib import (
+                    _load_for_executorch_from_buffer,
+                )
+            else:
+                assert "torch" not in sys.modules
+                from executorch.extension.pybindings._portable_lib import (
+                    _load_for_executorch_from_buffer,
+                )
+                assert "torch" not in sys.modules
+                import torch
+
+            from executorch.exir import to_edge
+
+            class Add(torch.nn.Module):
+                def forward(self, x, y):
+                    return x + y
+
+            inputs = (torch.ones(2, 3), torch.full((2, 3), 2.0))
+            program = to_edge(torch.export.export(Add(), inputs)).to_executorch()
+            module = _load_for_executorch_from_buffer(program.buffer)
+            output = module.run_method("forward", inputs)[0]
+            torch.testing.assert_close(output, torch.full((2, 3), 3.0))
+            print("uv wheel runtime smoke test passed")
+            """)
+        env = os.environ.copy()
+        for key in list(env):
+            if (
+                key == "PYTHONPATH"
+                or key == "LD_LIBRARY_PATH"
+                or key.startswith("DYLD_")
+            ):
+                env.pop(key)
+        subprocess.run(
+            [environment_python, "-I", "-c", smoke_test],
+            check=True,
+            cwd=temp_path,
+            env=env,
+        )
 
 
 def test_cmsis_nn_install():

--- a/.ci/scripts/wheel/test_base.py
+++ b/.ci/scripts/wheel/test_base.py
@@ -162,7 +162,8 @@ def test_uv_wheel_install() -> None:
             check=True,
         )
 
-        smoke_test = textwrap.dedent("""
+        smoke_test = textwrap.dedent(
+            """
             import sys
 
             if sys.platform == "win32":
@@ -190,7 +191,8 @@ def test_uv_wheel_install() -> None:
             output = module.run_method("forward", inputs)[0]
             torch.testing.assert_close(output, torch.full((2, 3), 3.0))
             print("uv wheel runtime smoke test passed")
-            """)
+            """
+        )
         env = os.environ.copy()
         for key in list(env):
             if (

--- a/.ci/scripts/wheel/test_base.py
+++ b/.ci/scripts/wheel/test_base.py
@@ -111,7 +111,10 @@ def test_native_library_paths() -> None:
 
 
 def test_uv_wheel_install() -> None:
-    if sys.version_info[:2] != (3, 14):
+    if os.getenv("GITHUB_EVENT_NAME") != "pull_request" and sys.version_info[:2] != (
+        3,
+        14,
+    ):
         print("Skipping uv wheel test; it runs once with Python 3.14")
         return
 

--- a/.ci/scripts/wheel/test_linux.py
+++ b/.ci/scripts/wheel/test_linux.py
@@ -12,6 +12,9 @@ import test_base
 from examples.models import Backend, Model
 
 if __name__ == "__main__":
+    test_base.test_native_library_paths()
+    test_base.test_uv_wheel_install()
+
     if platform.system() == "Linux":
         from executorch.extension.pybindings.portable_lib import (
             _get_registered_backend_names,

--- a/.ci/scripts/wheel/test_macos.py
+++ b/.ci/scripts/wheel/test_macos.py
@@ -10,6 +10,8 @@ import test_base
 from examples.models import Backend, Model
 
 if __name__ == "__main__":
+    test_base.test_native_library_paths()
+    test_base.test_uv_wheel_install()
     test_base.test_cmsis_nn_install()
 
     test_base.run_tests(

--- a/.ci/scripts/wheel/test_windows.py
+++ b/.ci/scripts/wheel/test_windows.py
@@ -10,7 +10,6 @@ import platform
 from typing import List
 
 import test_base
-
 import torch
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
 from executorch.examples.models import Backend, Model, MODEL_NAME_TO_MODEL
@@ -68,6 +67,8 @@ def run_tests(model_tests: List[ModelTest]) -> None:
 
 
 if __name__ == "__main__":
+    test_base.test_uv_wheel_install()
+
     if platform.system() == "Windows":
         registered = _get_registered_backend_names()
         # Vulkan backend is optional: only present when the wheel was built with

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,16 +277,11 @@ endif()
 
 add_subdirectory(third-party)
 
-# On Apple, pybind11 SHARED extension modules must not link libpython directly.
-# When python_add_library creates a SHARED library, it links Python::Python (via
-# pybind11::embed) which pulls in libpython. This conflicts with pybind11
-# >=3.0's multi-phase module init — the duplicate Python runtime causes a GIL
-# state crash at import time. This function replaces pybind11::embed with
-# pybind11::module (which links Python::Module instead of Python::Python —
-# headers and ABI only, no libpython) and adds -undefined dynamic_lookup for
-# symbol resolution. No-op on non-Apple platforms.
+# Unix pybind extension modules resolve Python symbols from the running
+# interpreter rather than linking a build-environment libpython. On Apple,
+# dynamic_lookup is also required for those symbols.
 function(strip_python_lib target)
-  if(NOT APPLE)
+  if(WIN32)
     return()
   endif()
   get_target_property(_libs ${target} LINK_LIBRARIES)
@@ -295,7 +290,9 @@ function(strip_python_lib target)
     list(APPEND _libs pybind11::module)
     set_target_properties(${target} PROPERTIES LINK_LIBRARIES "${_libs}")
   endif()
-  target_link_options(${target} PRIVATE "LINKER:-undefined,dynamic_lookup")
+  if(APPLE)
+    target_link_options(${target} PRIVATE "LINKER:-undefined,dynamic_lookup")
+  endif()
 endfunction()
 
 # Size-optimized builds disable exceptions, RTTI, and unwind tables.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1060,9 +1060,11 @@ if(EXECUTORCH_BUILD_PYBIND)
 
   # RPATH for _portable_lib.so
   if(APPLE)
-    set(_portable_lib_rpath "@loader_path/../../../torch/lib")
+    set(_portable_lib_rpath
+        "@loader_path/../../../torch/lib;@loader_path/../../../../.."
+    )
   else()
-    set(_portable_lib_rpath "$ORIGIN/../../../torch/lib")
+    set(_portable_lib_rpath "$ORIGIN/../../../torch/lib:$ORIGIN/../../../../..")
   endif()
 
   if(EXECUTORCH_BUILD_EXTENSION_MODULE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1174,13 +1174,14 @@ if(EXECUTORCH_BUILD_PYBIND)
   target_compile_options(portable_lib PUBLIC ${_pybind_compile_options})
   target_link_libraries(portable_lib PRIVATE ${_dep_libs})
 
-  # setup.py packages the library directly from the CMake build tree. Build it
-  # with its install RPATH so paths from the build environment are not embedded
-  # in the wheel.
   set_target_properties(
-    portable_lib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                            INSTALL_RPATH "${_portable_lib_rpath}"
+    portable_lib PROPERTIES INSTALL_RPATH "${_portable_lib_rpath}"
   )
+  if(NOT APPLE)
+    set_target_properties(
+      portable_lib PROPERTIES BUILD_RPATH "${_portable_lib_rpath}"
+    )
+  endif()
 
   install(
     TARGETS portable_lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1059,7 +1059,11 @@ if(EXECUTORCH_BUILD_PYBIND)
   endif()
 
   # RPATH for _portable_lib.so
-  set(_portable_lib_rpath "$ORIGIN/../../../torch/lib")
+  if(APPLE)
+    set(_portable_lib_rpath "@loader_path/../../../torch/lib")
+  else()
+    set(_portable_lib_rpath "$ORIGIN/../../../torch/lib")
+  endif()
 
   if(EXECUTORCH_BUILD_EXTENSION_MODULE)
     # Always use static linking for pybindings to avoid runtime symbol
@@ -1168,22 +1172,13 @@ if(EXECUTORCH_BUILD_PYBIND)
   target_compile_options(portable_lib PUBLIC ${_pybind_compile_options})
   target_link_libraries(portable_lib PRIVATE ${_dep_libs})
 
-  # Set RPATH to find PyTorch and backend libraries relative to the installation
-  # location. This goes from executorch/extension/pybindings up to
-  # site-packages, then to torch/lib. If QNN is enabled, also add
-  # backends/qualcomm/. Don't do this to APPLE, as it will error out on the
-  # following error:
-  #
-  if(APPLE)
-    # Skip setting @loader_path for APPLE, since it causes error like ld:
-    # duplicate LC_RPATH '@loader_path' in '<site-packages>/torch/lib/
-    # libtorch_cpu.dylib'
-  else()
-    set_target_properties(
-      portable_lib PROPERTIES BUILD_RPATH "${_portable_lib_rpath}"
-                              INSTALL_RPATH "${_portable_lib_rpath}"
-    )
-  endif()
+  # setup.py packages the library directly from the CMake build tree. Build it
+  # with its install RPATH so paths from the build environment are not embedded
+  # in the wheel.
+  set_target_properties(
+    portable_lib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                            INSTALL_RPATH "${_portable_lib_rpath}"
+  )
 
   install(
     TARGETS portable_lib

--- a/extension/llm/custom_ops/CMakeLists.txt
+++ b/extension/llm/custom_ops/CMakeLists.txt
@@ -149,10 +149,7 @@ if(EXECUTORCH_BUILD_KERNELS_LLM_AOT)
         "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib:$ORIGIN/../../../../../.."
     )
   endif()
-  set_target_properties(
-    custom_ops_aot_lib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
-                                                                "${RPATH}"
-  )
+  set_target_properties(custom_ops_aot_lib PROPERTIES INSTALL_RPATH "${RPATH}")
   if(TARGET portable_lib)
     # If we have portable_lib built, custom_ops_aot_lib gives the ability to use
     # the ops in PyTorch and ExecuTorch through pybind

--- a/extension/llm/custom_ops/CMakeLists.txt
+++ b/extension/llm/custom_ops/CMakeLists.txt
@@ -141,11 +141,16 @@ if(EXECUTORCH_BUILD_KERNELS_LLM_AOT)
   # TODO: This only works if we install portable_lib.so to
   # <site-packages>/executorch/extension/pybindings/.
   if(APPLE)
-    set(RPATH "@loader_path/../../pybindings")
+    set(RPATH
+        "@loader_path/../../pybindings;@loader_path/../../../../torch/lib"
+    )
   else()
-    set(RPATH "$ORIGIN/../../pybindings")
+    set(RPATH "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib")
   endif()
-  set_target_properties(custom_ops_aot_lib PROPERTIES INSTALL_RPATH ${RPATH})
+  set_target_properties(
+    custom_ops_aot_lib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
+                                                                "${RPATH}"
+  )
   if(TARGET portable_lib)
     # If we have portable_lib built, custom_ops_aot_lib gives the ability to use
     # the ops in PyTorch and ExecuTorch through pybind

--- a/extension/llm/custom_ops/CMakeLists.txt
+++ b/extension/llm/custom_ops/CMakeLists.txt
@@ -142,10 +142,12 @@ if(EXECUTORCH_BUILD_KERNELS_LLM_AOT)
   # <site-packages>/executorch/extension/pybindings/.
   if(APPLE)
     set(RPATH
-        "@loader_path/../../pybindings;@loader_path/../../../../torch/lib"
+        "@loader_path/../../pybindings;@loader_path/../../../../torch/lib;@loader_path/../../../../../.."
     )
   else()
-    set(RPATH "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib")
+    set(RPATH
+        "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib:$ORIGIN/../../../../../.."
+    )
   endif()
   set_target_properties(
     custom_ops_aot_lib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -133,10 +133,12 @@ if(EXECUTORCH_BUILD_PYBIND)
   )
   if(APPLE)
     set(RPATH
-        "@loader_path/../../pybindings;@loader_path/../../../../torch/lib"
+        "@loader_path/../../pybindings;@loader_path/../../../../torch/lib;@loader_path/../../../../../.."
     )
   else()
-    set(RPATH "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib")
+    set(RPATH
+        "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib:$ORIGIN/../../../../../.."
+    )
   endif()
   set_target_properties(
     _llm_runner PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -141,8 +141,7 @@ if(EXECUTORCH_BUILD_PYBIND)
     )
   endif()
   set_target_properties(
-    _llm_runner PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
-                                                         "${RPATH}"
+    _llm_runner PROPERTIES BUILD_RPATH "${RPATH}" INSTALL_RPATH "${RPATH}"
   )
   # Add include directories
   target_include_directories(

--- a/extension/llm/runner/CMakeLists.txt
+++ b/extension/llm/runner/CMakeLists.txt
@@ -139,7 +139,8 @@ if(EXECUTORCH_BUILD_PYBIND)
     set(RPATH "$ORIGIN/../../pybindings:$ORIGIN/../../../../torch/lib")
   endif()
   set_target_properties(
-    _llm_runner PROPERTIES BUILD_RPATH "${RPATH}" INSTALL_RPATH "${RPATH}"
+    _llm_runner PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE INSTALL_RPATH
+                                                         "${RPATH}"
   )
   # Add include directories
   target_include_directories(

--- a/extension/training/CMakeLists.txt
+++ b/extension/training/CMakeLists.txt
@@ -82,6 +82,16 @@ if(EXECUTORCH_BUILD_PYBIND)
   )
   target_link_libraries(_training_lib PRIVATE ${_pybind_training_dep_libs})
 
+  if(APPLE)
+    set(_training_lib_rpath "@loader_path/../../../../torch/lib")
+  else()
+    set(_training_lib_rpath "$ORIGIN/../../../../torch/lib")
+  endif()
+  set_target_properties(
+    _training_lib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                             INSTALL_RPATH "${_training_lib_rpath}"
+  )
+
   install(TARGETS _training_lib
           LIBRARY DESTINATION executorch/extension/training/pybindings
   )

--- a/extension/training/CMakeLists.txt
+++ b/extension/training/CMakeLists.txt
@@ -92,8 +92,7 @@ if(EXECUTORCH_BUILD_PYBIND)
     )
   endif()
   set_target_properties(
-    _training_lib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                             INSTALL_RPATH "${_training_lib_rpath}"
+    _training_lib PROPERTIES INSTALL_RPATH "${_training_lib_rpath}"
   )
 
   install(TARGETS _training_lib

--- a/extension/training/CMakeLists.txt
+++ b/extension/training/CMakeLists.txt
@@ -83,9 +83,13 @@ if(EXECUTORCH_BUILD_PYBIND)
   target_link_libraries(_training_lib PRIVATE ${_pybind_training_dep_libs})
 
   if(APPLE)
-    set(_training_lib_rpath "@loader_path/../../../../torch/lib")
+    set(_training_lib_rpath
+        "@loader_path/../../../../torch/lib;@loader_path/../../../../../.."
+    )
   else()
-    set(_training_lib_rpath "$ORIGIN/../../../../torch/lib")
+    set(_training_lib_rpath
+        "$ORIGIN/../../../../torch/lib:$ORIGIN/../../../../../.."
+    )
   endif()
   set_target_properties(
     _training_lib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -128,13 +128,17 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode"
       # installed location of our _portable_lib.so file. To see these LC_*
       # values, run `otool -l libquantized_ops_lib.dylib`.
       if(APPLE)
-        set(RPATH "@loader_path/../../extensions/pybindings")
+        set(RPATH
+            "@loader_path/../../extension/pybindings;@loader_path/../../../torch/lib"
+        )
       else()
-        set(RPATH "$ORIGIN/../../extensions/pybindings")
+        set(RPATH
+            "$ORIGIN/../../extension/pybindings:$ORIGIN/../../../torch/lib"
+        )
       endif()
       set_target_properties(
-        quantized_ops_aot_lib PROPERTIES BUILD_RPATH ${RPATH} INSTALL_RPATH
-                                                              ${RPATH}
+        quantized_ops_aot_lib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+                                         INSTALL_RPATH "${RPATH}"
       )
     endif()
   endif()

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -129,11 +129,11 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode"
       # values, run `otool -l libquantized_ops_lib.dylib`.
       if(APPLE)
         set(RPATH
-            "@loader_path/../../extension/pybindings;@loader_path/../../../torch/lib"
+            "@loader_path/../../extension/pybindings;@loader_path/../../../torch/lib;@loader_path/../../../../.."
         )
       else()
         set(RPATH
-            "$ORIGIN/../../extension/pybindings:$ORIGIN/../../../torch/lib"
+            "$ORIGIN/../../extension/pybindings:$ORIGIN/../../../torch/lib:$ORIGIN/../../../../.."
         )
       endif()
       set_target_properties(

--- a/kernels/quantized/CMakeLists.txt
+++ b/kernels/quantized/CMakeLists.txt
@@ -137,8 +137,8 @@ if(NOT CMAKE_GENERATOR STREQUAL "Xcode"
         )
       endif()
       set_target_properties(
-        quantized_ops_aot_lib PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                                         INSTALL_RPATH "${RPATH}"
+        quantized_ops_aot_lib PROPERTIES BUILD_RPATH "${RPATH}" INSTALL_RPATH
+                                                                "${RPATH}"
       )
     endif()
   endif()

--- a/setup.py
+++ b/setup.py
@@ -867,6 +867,11 @@ class CustomBuild(build):
             f"-DCMAKE_BUILD_TYPE={cmake_build_type}",
         ]
 
+        build_ext_command = self.distribution.get_command_obj("build_ext")
+        if not getattr(build_ext_command, "editable_mode", False):
+            # Wheel builds package libraries directly from the CMake build tree.
+            cmake_configuration_args += ["-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"]
+
         # Use ClangCL on Windows.
         if _is_windows():
             cmake_configuration_args += ["-T ClangCL"]


### PR DESCRIPTION
## Summary

This fixes packaged Torch-linked native libraries so macOS and Linux use install-relative search paths to both Torch and the environment library directory rather than retaining conda and CMake build-tree paths. It then adds wheel validation that rejects non-relative native library paths and installs the built wheel into a separate `uv` environment on macOS, Linux, and Windows.

The `uv` smoke test runs against the single wheel selected for pull requests. In nightly and release matrices it runs once per platform on Python 3.14. It installs the same Torch build used by wheel CI, installs the newly built ExecuTorch wheel, verifies Unix can load the native runtime before importing Torch, and exports and executes a portable tensor-add model outside the source checkout.

For review, the first commit contains the packaging fix and the subsequent commits contain the CI coverage.

## Test Plan

`git diff --check`, Python compilation, `ufmt`, `flake8`, and `cmake-format` pass. The native-path regression test fails against the published 1.4.0 macOS wheel and passes against the fixed wheel. The complete isolated `uv` install and portable runtime smoke test passes locally on Python 3.14.

Authored with Codex.
