### PR TITLE
Stop defining STANDALONE_TORCH_HEADER (#21745)

### DIFF
--- a/runtime/core/portable_type/c10/c10/targets.bzl
+++ b/runtime/core/portable_type/c10/c10/targets.bzl
@@ -1,9 +1,8 @@
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def get_preprocessor_flags(is_fbcode):
-    flags = ["-DSTANDALONE_TORCH_HEADER"]
     if runtime.is_oss:
-        return flags
+        return []
     # AT_BUILD_ARM_VEC256_WITH_SLEEF is off on Windows because Sleef
     # is off on Windows per get_sleef_deps below.
     arm64_flags = select({
@@ -31,7 +30,7 @@ def get_preprocessor_flags(is_fbcode):
         "ovr_config//cpu:arm64": arm64_flags,
         "DEFAULT": default_flags,
     })
-    return flags + ["-DET_USE_PYTORCH_HEADERS=ET_HAS_EXCEPTIONS"] + (fbcode_flags if is_fbcode else non_fbcode_flags)
+    return ["-DET_USE_PYTORCH_HEADERS=ET_HAS_EXCEPTIONS"] + (fbcode_flags if is_fbcode else non_fbcode_flags)
 
 def get_sleef_deps():
     if runtime.is_oss:


### PR DESCRIPTION
Summary:

This flag gives TORCH_CHECK two different expansions: with it, TORCH_CHECK
throws std::runtime_error; without it, c10::Error. It is an exported
preprocessor flag, so it propagates to everything that depends on
aten_headers_for_executorch, and any binary linking both libtorch and
ExecuTorch compiles the same header-inline functions two different ways. That
is an ODR violation.

The flag existed because ATen's vec headers, which ExecuTorch's optimized
kernels use, called TORCH_CHECK and so would have pulled in c10::Error and
libtorch. Three preceding changes in pytorch/pytorch converted all 45 of those
call sites to STD_TORCH_CHECK, which is header-only; they must land before
this one. Nothing reachable from ExecuTorch's include closure then needs
c10::Error, so the flag is no longer buying anything.

STD_TORCH_CHECK was suggested by janeyx99 in review of
https://github.com/pytorch/pytorch/pull/192264, an earlier attempt at the
same ODR problem that tried to make c10::Error itself header-only. That PR
was dismissed; this series takes the suggested approach instead.

Differential Revision: D115057173


