### PR TITLE
support forward and decoder method

### DIFF
--- a/extension/llm/runner/constants.h
+++ b/extension/llm/runner/constants.h
@@ -25,4 +25,11 @@ inline constexpr auto kAudioEncoderMethod = "audio_encoder";
 inline constexpr auto kTokenEmbeddingMethod = "token_embedding";
 inline constexpr auto kTextModelMethod = "text_decoder";
 
+// Text method name conventions. A single-method PTE exports kForwardMethod; a
+// two-method PTE exports kPrefillMethod and kDecodeMethod instead, and is run
+// with a dedicated decoder runner per stage.
+inline constexpr auto kForwardMethod = "forward";
+inline constexpr auto kPrefillMethod = "prefill";
+inline constexpr auto kDecodeMethod = "decode";
+
 } // namespace executorch::extension::llm

--- a/extension/llm/runner/llm_runner_helper.cpp
+++ b/extension/llm/runner/llm_runner_helper.cpp
@@ -273,14 +273,45 @@ std::unique_ptr<TextLLMRunner> create_text_llm_runner(
 
   auto stats = std::make_unique<Stats>();
 
+  auto method_names_result = module->method_names();
+  const std::unordered_set<std::string> method_names = method_names_result.ok()
+      ? method_names_result.get()
+      : std::unordered_set<std::string>{};
+
+  // A two-method PTE exports kPrefillMethod/kDecodeMethod instead of a single
+  // forward method, so fall back to kPrefillMethod when the requested method is
+  // absent. An explicitly requested method that does exist always wins.
+  std::string prefill_method_name = method_name;
+  if (method_names.count(prefill_method_name) == 0 &&
+      method_names.count(kPrefillMethod) > 0) {
+    prefill_method_name = kPrefillMethod;
+  }
+
   // Create text_decoder_runner
-  ET_LOG(Info, "Using method: %s", method_name.c_str());
+  ET_LOG(Info, "Using method: %s", prefill_method_name.c_str());
   auto text_decoder_runner = std::make_unique<TextDecoderRunner>(
       module.get(),
       io_manager.get(),
-      method_name,
+      prefill_method_name,
       std::move(sampler),
       stats.get());
+
+  // The decode stage gets its own decoder runner when the PTE exports a
+  // separate decode method; otherwise both stages share text_decoder_runner.
+  std::unique_ptr<TextDecoderRunner> decode_text_decoder_runner;
+  if (method_names.count(kDecodeMethod) > 0 &&
+      prefill_method_name != kDecodeMethod) {
+    ET_LOG(Info, "Using decode method: %s", kDecodeMethod);
+    decode_text_decoder_runner = std::make_unique<TextDecoderRunner>(
+        module.get(),
+        io_manager.get(),
+        kDecodeMethod,
+        std::make_unique<Sampler>(vocab_size, init_temp),
+        stats.get());
+  }
+  TextDecoderRunner* decode_runner = decode_text_decoder_runner
+      ? decode_text_decoder_runner.get()
+      : text_decoder_runner.get();
 
   // Create text_prefiller
   auto text_prefiller = std::make_unique<TextPrefiller>(
@@ -292,7 +323,7 @@ std::unique_ptr<TextLLMRunner> create_text_llm_runner(
   // Create text_token_generator with stats
   auto text_token_generator = std::make_unique<TextTokenGenerator>(
       tokenizer.get(),
-      text_decoder_runner.get(),
+      decode_runner,
       metadata.at(kUseKVCache),
       std::move(eos_ids),
       stats.get());
@@ -307,7 +338,8 @@ std::unique_ptr<TextLLMRunner> create_text_llm_runner(
       std::move(io_manager),
       std::move(text_token_generator),
       std::move(stats),
-      temperature);
+      temperature,
+      std::move(decode_text_decoder_runner));
 }
 
 std::unique_ptr<MultimodalRunner> create_multimodal_runner(

--- a/extension/llm/runner/llm_runner_helper.h
+++ b/extension/llm/runner/llm_runner_helper.h
@@ -108,7 +108,7 @@ ET_EXPERIMENTAL std::unique_ptr<TextLLMRunner> create_text_llm_runner(
     std::unique_ptr<::tokenizers::Tokenizer> tokenizer,
     std::optional<const std::string> data_path,
     float temperature = -1.0f,
-    const std::string& method_name = "forward",
+    const std::string& method_name = kForwardMethod,
     Module::LoadMode load_mode = Module::LoadMode::MmapUseMlockIgnoreErrors);
 
 /**
@@ -124,7 +124,10 @@ ET_EXPERIMENTAL std::unique_ptr<TextLLMRunner> create_text_llm_runner(
  * @param temperature Optional temperature parameter for controlling randomness
  * (deprecated)
  * @param event_tracer Optional event tracer for profiling
- * @param method_name Name of the method to execute in the model
+ * @param method_name Name of the method to execute in the model. Falls back to
+ * kPrefillMethod when absent from the model. When the model also exports
+ * kDecodeMethod, the resolved method drives prefill only and kDecodeMethod
+ * drives decode.
  * @param load_mode Loading strategy for the model file. Defaults to
  * MmapUseMlockIgnoreErrors which uses mmap to avoid loading the entire
  * model into RAM and attempts to pin pages with mlock for lower inference
@@ -138,7 +141,7 @@ ET_EXPERIMENTAL std::unique_ptr<TextLLMRunner> create_text_llm_runner(
     std::vector<std::string> data_files = {},
     float temperature = -1.0f,
     std::unique_ptr<::executorch::runtime::EventTracer> event_tracer = nullptr,
-    const std::string& method_name = "forward",
+    const std::string& method_name = kForwardMethod,
     Module::LoadMode load_mode = Module::LoadMode::MmapUseMlockIgnoreErrors);
 
 /**

--- a/extension/llm/runner/text_llm_runner.cpp
+++ b/extension/llm/runner/text_llm_runner.cpp
@@ -35,20 +35,19 @@ TextLLMRunner::TextLLMRunner(
     std::unique_ptr<IOManager> io_manager,
     std::unique_ptr<TextTokenGenerator> text_token_generator,
     std::unique_ptr<Stats> stats,
-    float temperature)
+    float temperature,
+    std::unique_ptr<TextDecoderRunner> decode_text_decoder_runner)
     : tokenizer_(std::move(tokenizer)),
       metadata_(std::move(metadata)),
       module_(std::move(module)),
       text_decoder_runner_(std::move(text_decoder_runner)),
+      decode_text_decoder_runner_(std::move(decode_text_decoder_runner)),
       text_prefiller_(std::move(text_prefiller)),
       io_manager_(std::move(io_manager)),
       text_token_generator_(std::move(text_token_generator)),
       stats_(std::move(stats)),
       temperature_(temperature),
-      pos_(0) {
-  // Note: This constructor assumes that text_prefiller and text_token_generator
-  // already have references to the Module and TextDecoderRunner they need
-}
+      pos_(0) {}
 
 bool TextLLMRunner::is_loaded() const {
   return text_prefiller_->is_loaded() && text_token_generator_->is_loaded();

--- a/extension/llm/runner/text_llm_runner.h
+++ b/extension/llm/runner/text_llm_runner.h
@@ -53,6 +53,8 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
    * @param stats Statistics tracking object for performance monitoring
    * @param temperature Temperature parameter for controlling randomness in
    * generation (deprecated). Please use GenerationConfig.temperature instead.
+   * @param decode_text_decoder_runner Decoder runner for the decode stage of a
+   * two-method PTE. When null, text_decoder_runner drives both stages.
    */
   explicit TextLLMRunner(
       std::unordered_map<std::string, int64_t> metadata,
@@ -63,7 +65,8 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
       std::unique_ptr<IOManager> io_manager,
       std::unique_ptr<TextTokenGenerator> text_token_generator,
       std::unique_ptr<Stats> stats,
-      float temperature = -1.0f);
+      float temperature = -1.0f,
+      std::unique_ptr<TextDecoderRunner> decode_text_decoder_runner = nullptr);
 
   /**
    * @brief Checks if the model is loaded and ready for inference
@@ -171,6 +174,10 @@ class ET_EXPERIMENTAL TextLLMRunner : public IRunner {
       text_decoder_runner_; // Manage text_decoder_runner_'s lifecycle, make
                             // sure it outlives text_prefiller_ &
                             // text_token_generator_.
+  std::unique_ptr<TextDecoderRunner>
+      decode_text_decoder_runner_; // Null unless the PTE exports a separate
+                                   // decode method, in which case
+                                   // text_decoder_runner_ drives prefill only.
   std::unique_ptr<TextPrefiller> text_prefiller_;
   std::unique_ptr<IOManager> io_manager_;
   std::unique_ptr<TextTokenGenerator> text_token_generator_;


### PR DESCRIPTION
Summary:
Enable a two-method PTE — one exporting separate `prefill` and `decode` methods — in the OSS `TextLLMRunner`, so the decode stage runs its own graph instead of being forced through the prefill graph.

The method names are derived from the PTE's own method table rather than plumbed down from user space:

- `create_text_llm_runner` reads `module->method_names()` (already fetched by `get_llm_metadata`, so no extra cost) and resolves the prefill method: the caller's `method_name` wins when the PTE exports it, otherwise it falls back to `kPrefillMethod`.
- When the PTE also exports `kDecodeMethod`, a second `TextDecoderRunner` is built for it and handed to `TextTokenGenerator`. Otherwise both stages share one runner and behavior is byte-identical to before.

This follows the convention already used by the multimodal path, where `constants.h` declares `kVisionEncoderMethod` / `kTokenEmbeddingMethod` / `kTextModelMethod` and `MultimodalPrefiller::load()` probes `method_names()` to decide what is present. `kForwardMethod`, `kPrefillMethod`, and `kDecodeMethod` are added alongside that block.

Deriving rather than plumbing means no new public API. An earlier revision of this diff added a third `create_text_llm_runner` overload, a second `TextLLMRunner` constructor, a second `create_llama_runner` overload, and two `llama_main` gflags. All four are gone; the single `TextLLMRunner` constructor gained a trailing `decode_text_decoder_runner = nullptr`, and `examples/models/llama/{main.cpp,runner/runner.h,runner/runner.cpp}` are untouched.

Collapsing onto one code path also fixes three things the separate two-method factory had silently dropped relative to the original:

- the 10 MB `CPUCachingAllocator` used as the Module's temp memory allocator
- the `Sampler`, without which `logits_to_token()` falls through to the free function instead of `sample_from_logits(..., *sampler_)`
- the `Stats*`, without which `on_model_execution_begin()` / `on_model_execution_end()` never fire — so the two-method path recorded no per-token execution timings at all, which would have quietly broken the decode-throughput measurement this change exists to enable

Note for reviewers: the two-method PTE exports `prefill` and `decode`, with no `forward` method at all. Hardcoding `forward` as the prefill method does not work; see the PTE inspection in the test plan.

Differential Revision: D96962421


