### PR TITLE
Add source transform hooks to ExportRecipe (#21747)

### DIFF
--- a/export/export.py
+++ b/export/export.py
@@ -300,8 +300,14 @@ class ExportSession:
         stage = None
         for stage_type in stages or self._get_default_pipeline():
             if stage_type == StageType.SOURCE_TRANSFORM:
+                source_transform_passes = None
+                if self._export_recipe.source_transform_passes is not None:
+                    source_transform_passes = list(
+                        self._export_recipe.source_transform_passes
+                    )
                 stage = SourceTransformStage(
                     self._quant_recipe,
+                    source_transform_passes=source_transform_passes,
                     in_place=self._export_recipe.source_transform_in_place,
                 )
             elif stage_type == StageType.QUANTIZE:
@@ -312,8 +318,13 @@ class ExportSession:
                     aten_transform_passes = list(
                         self._export_recipe.aten_transform_passes
                     )
+                pre_trace_hooks = None
+                if self._export_recipe.pre_trace_hooks is not None:
+                    pre_trace_hooks = list(self._export_recipe.pre_trace_hooks)
                 stage = TorchExportStage(
-                    aten_transform_passes, strict=self._export_recipe.strict
+                    aten_transform_passes,
+                    strict=self._export_recipe.strict,
+                    pre_trace_hooks=pre_trace_hooks,
                 )
             elif stage_type == StageType.TO_EDGE_TRANSFORM_AND_LOWER:
                 stage = EdgeTransformAndLowerStage.from_recipe(self._lowering_recipe)

--- a/export/export.py
+++ b/export/export.py
@@ -676,14 +676,26 @@ class ExportSession:
         if stage_artifact is None:
             RuntimeError("No delegation info available, run the lowering stage first")
 
-        # pyre-ignore
-        delegation_info = stage_artifact.get_context("delegation_info", None)
-        if delegation_info:
+        delegation_info_by_method = stage_artifact.get_context(
+            "delegation_info_by_method", None
+        )
+        if delegation_info_by_method:
+            delegation_infos = sorted(delegation_info_by_method.items())
+        else:
+            # pyre-ignore
+            delegation_info = stage_artifact.get_context("delegation_info", None)
+            delegation_infos = [(None, delegation_info)] if delegation_info else []
+
+        if not delegation_infos:
+            print("No delegation info available")
+            return
+
+        for method_name, delegation_info in delegation_infos:
+            if method_name is not None:
+                print(f"Delegation info for method '{method_name}':")
             print(delegation_info.get_summary())
             df = delegation_info.get_operator_delegation_dataframe()
             print(tabulate(df, headers="keys", tablefmt="fancy_grid"))
-        else:
-            print("No delegation info available")
 
     # Use Any instead of ETRecord as return type to avoid static dependency on etrecord
     def get_etrecord(self) -> Any:

--- a/export/recipe.py
+++ b/export/recipe.py
@@ -159,6 +159,16 @@ class ExportRecipe:
         quantization_recipe: Optional quantization recipe for model quantization
         aten_transform_passes: Optional list of functions to apply transformation passes to the program before edge lowering.
                                These callables are invoked to modify and return the transformed program.
+        source_transform_passes: Optional list of nn.Module transforms applied once
+                               during the SOURCE_TRANSFORM stage, before quantization.
+                               Each is applied once per distinct model object, so a
+                               model shared by several methods is transformed once.
+        pre_trace_hooks: Optional list of (method_name, model) callables invoked
+                               immediately before each method is traced. Use these for
+                               per-method state that must differ between traces; a
+                               SOURCE_TRANSFORM pass cannot express it, because that
+                               stage completes before any tracing and methods may share
+                               one model object.
         source_transform_in_place: Skip the defensive deepcopy in the SOURCE_TRANSFORM
                                stage and mutate the caller's model. Necessary for models
                                large enough that a second copy will not fit in memory.
@@ -181,6 +191,10 @@ class ExportRecipe:
     pipeline_stages: Optional[List[StageType]] = None
     mode: Mode = Mode.RELEASE
     strict: bool = True
+    source_transform_passes: Optional[
+        List[Callable[[torch.nn.Module], torch.nn.Module]]
+    ] = None
+    pre_trace_hooks: Optional[List[Callable[[str, torch.nn.Module], None]]] = None
 
     @classmethod
     def get_recipe(cls, recipe: "RecipeType", **kwargs) -> "ExportRecipe":
@@ -260,6 +274,8 @@ class ExportRecipe:
         all_quantizers = []
         all_ao_quantization_configs = []
         all_pre_edge_passes = []
+        all_source_transform_passes = []
+        all_pre_trace_hooks = []
         all_transform_passes = []
         combined_backend_config = None
 
@@ -267,6 +283,10 @@ class ExportRecipe:
             # Collect pre-edge transform passes
             if recipe.aten_transform_passes:
                 all_pre_edge_passes.extend(recipe.aten_transform_passes)
+            if recipe.source_transform_passes:
+                all_source_transform_passes.extend(recipe.source_transform_passes)
+            if recipe.pre_trace_hooks:
+                all_pre_trace_hooks.extend(recipe.pre_trace_hooks)
 
             # Collect partitioners from lowering recipes
             if recipe.lowering_recipe and recipe.lowering_recipe.partitioners:
@@ -347,6 +367,11 @@ class ExportRecipe:
             name=recipe_name,
             quantization_recipe=combined_quantization_recipe,
             aten_transform_passes=all_pre_edge_passes,
+            source_transform_passes=all_source_transform_passes or None,
+            pre_trace_hooks=all_pre_trace_hooks or None,
+            source_transform_in_place=any(
+                recipe.source_transform_in_place for recipe in backend_recipes
+            ),
             lowering_recipe=combined_lowering_recipe,
             executorch_backend_config=combined_backend_config,
         )

--- a/export/recipe.py
+++ b/export/recipe.py
@@ -8,7 +8,7 @@ import copy
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional, Union
 
 import torch
 from executorch.exir import EdgeProgramManager, ExportedProgram
@@ -118,7 +118,10 @@ class LoweringRecipe:
     to backend-specific representations.
 
     Attributes:
-        partitioners: Optional list of partitioners for model partitioning
+        partitioners: Optional partitioners for model partitioning. Either a list
+                      applied to every method, or a dict mapping method names to
+                      per-method partitioner lists. Use the dict form when
+                      backends need per-method compile specs.
         edge_transform_passes: Optional list of callables that take (method_name: str, exported_program: ExportedProgram)
                                and return either List[PassType] or PassManager to be applied during edge lowering.
         edge_manager_transform_passes: Optional list of callables that take EdgeProgramManager as argument
@@ -126,7 +129,9 @@ class LoweringRecipe:
         edge_compile_config: Optional edge compilation configuration
     """
 
-    partitioners: Optional[List[Partitioner]] = None
+    partitioners: Optional[Union[List[Partitioner], Dict[str, List[Partitioner]]]] = (
+        None
+    )
     edge_transform_passes: (
         None | List[Callable[[str, ExportedProgram], List[PassType] | PassManager]]
     ) = None
@@ -251,6 +256,7 @@ class ExportRecipe:
         """
         # Extract components from individual recipes
         all_partitioners = []
+        all_partitioners_by_method = {}
         all_quantizers = []
         all_ao_quantization_configs = []
         all_pre_edge_passes = []
@@ -264,7 +270,14 @@ class ExportRecipe:
 
             # Collect partitioners from lowering recipes
             if recipe.lowering_recipe and recipe.lowering_recipe.partitioners:
-                all_partitioners.extend(recipe.lowering_recipe.partitioners)
+                partitioners = recipe.lowering_recipe.partitioners
+                if isinstance(partitioners, dict):
+                    for method_name, method_partitioners in partitioners.items():
+                        all_partitioners_by_method.setdefault(method_name, []).extend(
+                            method_partitioners
+                        )
+                else:
+                    all_partitioners.extend(partitioners)
 
             # Collect transform passes from lowering recipes
             if recipe.lowering_recipe and recipe.lowering_recipe.edge_transform_passes:
@@ -300,9 +313,16 @@ class ExportRecipe:
                 ),
             )
 
+        if all_partitioners and all_partitioners_by_method:
+            raise ValueError(
+                "Cannot combine recipes that mix list-valued and dict-valued "
+                "partitioners; convert the list-valued recipe to per-method form."
+            )
+        combined_partitioners = all_partitioners_by_method or all_partitioners
+
         # Create combined lowering recipe
         combined_lowering_recipe = None
-        if all_partitioners or all_transform_passes:
+        if combined_partitioners or all_transform_passes:
             edge_compile_config = None
             for recipe in backend_recipes:
                 if (
@@ -313,7 +333,7 @@ class ExportRecipe:
                     break
 
             combined_lowering_recipe = LoweringRecipe(
-                partitioners=all_partitioners if all_partitioners else None,
+                partitioners=combined_partitioners if combined_partitioners else None,
                 edge_transform_passes=(
                     all_transform_passes if all_transform_passes else None
                 ),

--- a/export/stages.py
+++ b/export/stages.py
@@ -9,7 +9,8 @@ import copy
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional
+from itertools import zip_longest
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 from executorch.devtools.backend_debug import get_delegation_info
@@ -167,6 +168,36 @@ class TorchExportStage(Stage):
         self._artifact = artifact.copy_with_new_data(exported_programs)
 
 
+def _collect_delegation_info(
+    edge_program_manager: EdgeProgramManager,
+) -> Dict[str, Any]:
+    """
+    Delegation info for every method, keyed by method name.
+
+    `EdgeProgramManager.exported_program()` defaults to `forward`, which raises
+    KeyError for a multi-method program that has no method by that name.
+    """
+    return {
+        name: get_delegation_info(
+            edge_program_manager.exported_program(name).graph_module
+        )
+        for name in sorted(edge_program_manager.methods)
+    }
+
+
+def _add_delegation_info_context(
+    artifact: PipelineArtifact, edge_program_manager: EdgeProgramManager
+) -> None:
+    by_method = _collect_delegation_info(edge_program_manager)
+    artifact.add_context("delegation_info_by_method", by_method)
+    # `forward` when present, else the first method by name, so that
+    # single-method callers keep seeing the value they always have.
+    artifact.add_context(
+        "delegation_info",
+        by_method.get("forward", next(iter(by_method.values()), None)),
+    )
+
+
 class EdgeTransformAndLowerStage(Stage):
     """
     Second stage: Transform and lower to EdgeProgramManager.
@@ -174,7 +205,7 @@ class EdgeTransformAndLowerStage(Stage):
 
     def __init__(
         self,
-        partitioners: Optional[List[Any]] = None,
+        partitioners: Optional[Union[List[Any], Dict[str, List[Any]]]] = None,
         transform_passes: (
             None
             | List[
@@ -255,11 +286,8 @@ class EdgeTransformAndLowerStage(Stage):
                 generate_etrecord=generate_etrecord,
             )
 
-        delegation_info = get_delegation_info(
-            edge_program_manager.exported_program().graph_module
-        )
         self._artifact = artifact.copy_with_new_data(edge_program_manager)
-        self._artifact.add_context("delegation_info", delegation_info)
+        _add_delegation_info_context(self._artifact, edge_program_manager)
 
     @property
     def delegation_info(self) -> Any:
@@ -267,6 +295,13 @@ class EdgeTransformAndLowerStage(Stage):
         Returns the delegation info.
         """
         return self._artifact.get_context("delegation_info")
+
+    @property
+    def delegation_info_by_method(self) -> Dict[str, Any]:
+        """
+        Returns the delegation info for every method, keyed by method name.
+        """
+        return self._artifact.get_context("delegation_info_by_method")
 
 
 class ExecutorchStage(Stage):
@@ -641,7 +676,7 @@ class ToBackendStage(Stage):
 
     def __init__(
         self,
-        partitioners: Optional[List[Any]] = None,
+        partitioners: Optional[Union[List[Any], Dict[str, List[Any]]]] = None,
     ) -> None:
         super().__init__()
         self._partitioners = partitioners
@@ -687,17 +722,28 @@ class ToBackendStage(Stage):
         # Apply partitioners if available
         if self._partitioners is not None and len(self._partitioners) > 0:
             with validation_disabled():
-                # pyre-ignore
-                for partitioner in self._partitioners:
-                    edge_program_manager = edge_program_manager.to_backend(partitioner)
-
-        # Get delegation info
-        delegation_info = get_delegation_info(
-            edge_program_manager.exported_program().graph_module
-        )
+                if isinstance(self._partitioners, dict):
+                    method_names = list(self._partitioners)
+                    for partitioner_round in zip_longest(*self._partitioners.values()):
+                        partitioners_by_method = {
+                            method_name: partitioner
+                            for method_name, partitioner in zip(
+                                method_names, partitioner_round
+                            )
+                            if partitioner is not None
+                        }
+                        edge_program_manager = edge_program_manager.to_backend(
+                            partitioners_by_method
+                        )
+                else:
+                    # pyre-ignore
+                    for partitioner in self._partitioners:
+                        edge_program_manager = edge_program_manager.to_backend(
+                            partitioner
+                        )
 
         self._artifact = artifact.copy_with_new_data(edge_program_manager)
-        self._artifact.add_context("delegation_info", delegation_info)
+        _add_delegation_info_context(self._artifact, edge_program_manager)
 
     @property
     def delegation_info(self) -> Any:
@@ -705,3 +751,10 @@ class ToBackendStage(Stage):
         Returns the delegation info.
         """
         return self._artifact.get_context("delegation_info")
+
+    @property
+    def delegation_info_by_method(self) -> Dict[str, Any]:
+        """
+        Returns the delegation info for every method, keyed by method name.
+        """
+        return self._artifact.get_context("delegation_info_by_method")

--- a/export/stages.py
+++ b/export/stages.py
@@ -114,10 +114,12 @@ class TorchExportStage(Stage):
             List[Callable[[str, ExportedProgram], ExportedProgram]]
         ] = None,
         strict=True,
+        pre_trace_hooks: Optional[List[Callable[[str, nn.Module], None]]] = None,
     ) -> None:
         super().__init__()
         self._aten_transform_passes = aten_transform_passes
         self.strict = strict
+        self._pre_trace_hooks = pre_trace_hooks
 
     @property
     def stage_type(self) -> str:
@@ -146,6 +148,12 @@ class TorchExportStage(Stage):
                     )
 
                 method_dynamic_shapes = dynamic_shapes.get(method_name)
+
+                # Applied here, not in SOURCE_TRANSFORM, because methods may
+                # share one model object: a stage that ran to completion before
+                # any tracing would leave only the last method's state in place.
+                for hook in self._pre_trace_hooks or []:
+                    hook(method_name, model)
 
                 # Export the model
                 exported_programs[method_name] = torch.export.export(
@@ -353,9 +361,13 @@ class SourceTransformStage(Stage):
     def __init__(
         self,
         quantization_recipe: Optional[QuantizationRecipe],
+        source_transform_passes: Optional[
+            List[Callable[[nn.Module], nn.Module]]
+        ] = None,
         in_place: bool = False,
     ) -> None:
         self._quantization_recipe = quantization_recipe
+        self._source_transform_passes = source_transform_passes
         self._in_place = in_place
         self._transformed_models: Dict[str, nn.Module] = {}
 
@@ -375,37 +387,46 @@ class SourceTransformStage(Stage):
         """
         Apply source transformations to the model.
         """
-        if (
-            not self._quantization_recipe
-            or not self._quantization_recipe.ao_quantization_configs
-        ):
+        ao_configs = (
+            self._quantization_recipe.ao_quantization_configs
+            if self._quantization_recipe
+            else None
+        )
+        if not ao_configs and not self._source_transform_passes:
             logging.info(
-                "Quantization recipe is invalid to run SourceTransform, returning original artifact"
+                "No source transform passes and no AO quantization configs, returning original artifact"
             )
             self._artifact = artifact
             return
 
         assert isinstance(artifact.data, dict)
 
+        if ao_configs and len(ao_configs) > 1:
+            raise ValueError(
+                "AO quantization configs cannot be reliably composed together, multiple quantization configs are disallowed for source transform at this point"
+            )
+
         # A second copy of the model is not affordable for every caller, so
         # large models can opt out and have their own model mutated instead.
-        self._transformed_models = (
-            artifact.data if self._in_place else copy.deepcopy(artifact.data)
-        )
+        models = artifact.data if self._in_place else copy.deepcopy(artifact.data)
 
-        # Apply torchao quantize_ to each model
-        for _, model in self._transformed_models.items():
-            # pyre-ignore
-            if len(self._quantization_recipe.ao_quantization_configs) > 1:
-                raise ValueError(
-                    "AO quantization configs cannot be reliably composed together, multiple quantization configs are disallowed for source transform at this point"
-                )
+        # Several methods commonly share one model object. Transform each
+        # distinct object once, or a shared model is quantized once per method.
+        transformed_by_id: Dict[int, nn.Module] = {}
+        for method_name, model in list(models.items()):
+            original_id = id(model)
+            if original_id not in transformed_by_id:
+                for transform in self._source_transform_passes or []:
+                    model = transform(model)
+                if ao_configs:
+                    ao_config = ao_configs[0]
+                    quantize_(model, ao_config.ao_base_config, ao_config.filter_fn)
+                    unwrap_tensor_subclass(model)
+                transformed_by_id[original_id] = model
+            models[method_name] = transformed_by_id[original_id]
 
-            ao_config = self._quantization_recipe.ao_quantization_configs[0]
-            quantize_(model, ao_config.ao_base_config, ao_config.filter_fn)
-            unwrap_tensor_subclass(model)
-
-        self._artifact = artifact.copy_with_new_data(self._transformed_models)
+        self._transformed_models = models
+        self._artifact = artifact.copy_with_new_data(models)
 
 
 class QuantizeStage(Stage):

--- a/export/tests/test_export_recipe.py
+++ b/export/tests/test_export_recipe.py
@@ -8,6 +8,7 @@
 
 import unittest
 from typing import Any, Dict, Optional, Sequence
+from unittest.mock import Mock
 
 from executorch.export.recipe import ExportRecipe, RecipeType
 from executorch.export.recipe_provider import BackendRecipeProvider
@@ -129,3 +130,42 @@ class TestExportRecipeGetRecipe(unittest.TestCase):
         # Verify that the kwargs were passed to the backend provider's create_recipe method
         self.assertIsNotNone(self.provider.last_kwargs)
         self.assertEqual(self.provider.last_kwargs, kwargs)
+
+
+class TestExportRecipeCombine(unittest.TestCase):
+    def test_new_hooks_do_not_change_existing_positional_arguments(self) -> None:
+        recipe = ExportRecipe(None, None, None, True)
+
+        self.assertTrue(recipe.source_transform_in_place)
+        self.assertIsNone(recipe.source_transform_passes)
+        self.assertIsNone(recipe.pre_trace_hooks)
+
+    def test_preserves_source_transform_passes_and_pre_trace_hooks(self) -> None:
+        first_source_transform = Mock()
+        second_source_transform = Mock()
+        first_pre_trace_hook = Mock()
+        second_pre_trace_hook = Mock()
+
+        combined = ExportRecipe.combine(
+            [
+                ExportRecipe(
+                    source_transform_passes=[first_source_transform],
+                    pre_trace_hooks=[first_pre_trace_hook],
+                    source_transform_in_place=True,
+                ),
+                ExportRecipe(
+                    source_transform_passes=[second_source_transform],
+                    pre_trace_hooks=[second_pre_trace_hook],
+                ),
+            ]
+        )
+
+        self.assertEqual(
+            combined.source_transform_passes,
+            [first_source_transform, second_source_transform],
+        )
+        self.assertEqual(
+            combined.pre_trace_hooks,
+            [first_pre_trace_hook, second_pre_trace_hook],
+        )
+        self.assertTrue(combined.source_transform_in_place)

--- a/export/tests/test_export_session.py
+++ b/export/tests/test_export_session.py
@@ -7,8 +7,8 @@
 # pyre-strict
 
 import unittest
-from typing import List
-from unittest.mock import Mock
+from typing import Any, Dict, List
+from unittest.mock import call, Mock, patch
 
 import torch
 from executorch.export import ExportRecipe, ExportSession
@@ -817,6 +817,77 @@ class TestExportSessionExtendedInputTypes(unittest.TestCase):
 
         # Should not raise during validation
         session._validate_pipeline_sequence(recipe.pipeline_stages)
+
+
+class TestDelegationInfoReporting(unittest.TestCase):
+    def setUp(self) -> None:
+        self.session = ExportSession(
+            model=SimpleTestModel(),
+            example_inputs=[(torch.randn(2, 10),)],
+            export_recipe=ExportRecipe(),
+        )
+
+    def _set_delegation_context(self, context: Dict[str, Any]) -> None:
+        self.session._stage_to_artifacts[StageType.TO_EDGE_TRANSFORM_AND_LOWER] = (
+            PipelineArtifact(data=None, context=context)
+        )
+
+    @patch("executorch.export.export.tabulate")
+    @patch("builtins.print")
+    def test_print_delegation_info_for_every_method(
+        self, mock_print: Mock, mock_tabulate: Mock
+    ) -> None:
+        decode_info = Mock()
+        decode_info.get_summary.return_value = "decode-summary"
+        decode_info.get_operator_delegation_dataframe.return_value = "decode-data"
+        prefill_info = Mock()
+        prefill_info.get_summary.return_value = "prefill-summary"
+        prefill_info.get_operator_delegation_dataframe.return_value = "prefill-data"
+        mock_tabulate.side_effect = ["decode-table", "prefill-table"]
+        self._set_delegation_context(
+            {
+                "delegation_info_by_method": {
+                    "prefill": prefill_info,
+                    "decode": decode_info,
+                },
+                "delegation_info": decode_info,
+            }
+        )
+
+        self.session.print_delegation_info()
+
+        self.assertEqual(
+            mock_print.call_args_list,
+            [
+                call("Delegation info for method 'decode':"),
+                call("decode-summary"),
+                call("decode-table"),
+                call("Delegation info for method 'prefill':"),
+                call("prefill-summary"),
+                call("prefill-table"),
+            ],
+        )
+        self.assertEqual(mock_tabulate.call_count, 2)
+
+    @patch("executorch.export.export.tabulate", return_value="legacy-table")
+    @patch("builtins.print")
+    def test_print_delegation_info_legacy_fallback(
+        self, mock_print: Mock, mock_tabulate: Mock
+    ) -> None:
+        delegation_info = Mock()
+        delegation_info.get_summary.return_value = "legacy-summary"
+        delegation_info.get_operator_delegation_dataframe.return_value = "legacy-data"
+        self._set_delegation_context({"delegation_info": delegation_info})
+
+        self.session.print_delegation_info()
+
+        self.assertEqual(
+            mock_print.call_args_list,
+            [call("legacy-summary"), call("legacy-table")],
+        )
+        mock_tabulate.assert_called_once_with(
+            "legacy-data", headers="keys", tablefmt="fancy_grid"
+        )
 
 
 class TestIntermediateStateGetters(unittest.TestCase):

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -159,6 +159,28 @@ class TestTorchExportStage(unittest.TestCase):
             str(cm.exception),
         )
 
+    def test_pre_trace_hooks_fire_per_method(self) -> None:
+        """Hooks fire once per method, immediately before that method's trace."""
+        calls = []
+        stage = TorchExportStage(
+            pre_trace_hooks=[lambda name, model: calls.append((name, model))]
+        )
+        artifact = PipelineArtifact(
+            data={"decode": self.model, "prefill": self.model},
+            context={
+                "example_inputs": {
+                    "decode": self.example_inputs,
+                    "prefill": self.example_inputs,
+                }
+            },
+        )
+        stage.run(artifact)
+
+        # Both methods share one model object, so a hook that ran in an earlier
+        # batch stage could only have left the last method's state in place.
+        self.assertEqual([name for name, _ in calls], ["decode", "prefill"])
+        self.assertTrue(all(model is self.model for _, model in calls))
+
 
 class TestEdgeTransformAndLowerStage(unittest.TestCase):
     def setUp(self) -> None:
@@ -355,24 +377,66 @@ class TestSourceTransformStage(unittest.TestCase):
         # verify the result model is NOT the same object as the original
         self.assertIsNot(result_artifact.data["forward"], self.model)
 
-    @patch("executorch.export.stages.quantize_")
-    @patch("executorch.export.stages.unwrap_tensor_subclass")
-    def test_run_in_place_does_not_copy_the_model(
-        self, mock_unwrap: Mock, mock_quantize: Mock
-    ) -> None:
-        from torchao.core.config import AOBaseConfig
+    def _no_quant_recipe(self) -> Mock:
+        recipe = Mock(spec=QuantizationRecipe)
+        recipe.ao_quantization_configs = None
+        return recipe
 
-        mock_recipe = Mock(spec=QuantizationRecipe)
-        mock_recipe.ao_quantization_configs = [
-            AOQuantizationConfig(ao_base_config=Mock(spec=AOBaseConfig))
-        ]
+    def test_source_transform_passes_run_without_quantization(self) -> None:
+        seen = []
 
-        stage = SourceTransformStage(mock_recipe, in_place=True)
+        def record(model: torch.nn.Module) -> torch.nn.Module:
+            seen.append(model)
+            return model
+
+        stage = SourceTransformStage(
+            self._no_quant_recipe(), source_transform_passes=[record], in_place=True
+        )
         stage.run(PipelineArtifact(data=self.models_dict, context={}))
 
-        # The caller's own model is quantized rather than a copy of it.
-        self.assertIs(mock_quantize.call_args[0][0], self.model)
+        self.assertEqual(seen, [self.model])
+        # in_place mutates the caller's own module rather than a copy
         self.assertIs(stage.get_artifacts().data["forward"], self.model)
+
+    def test_source_transform_passes_copy_by_default(self) -> None:
+        stage = SourceTransformStage(
+            self._no_quant_recipe(), source_transform_passes=[lambda m: m]
+        )
+        stage.run(PipelineArtifact(data=self.models_dict, context={}))
+
+        self.assertIsNot(stage.get_artifacts().data["forward"], self.model)
+
+    def test_source_transform_pass_applied_once_for_shared_model(self) -> None:
+        """Methods sharing one model object must not be transformed twice."""
+        calls = []
+
+        def record(model: torch.nn.Module) -> torch.nn.Module:
+            calls.append(model)
+            return model
+
+        stage = SourceTransformStage(
+            self._no_quant_recipe(), source_transform_passes=[record], in_place=True
+        )
+        stage.run(
+            PipelineArtifact(
+                data={"decode": self.model, "prefill": self.model}, context={}
+            )
+        )
+
+        self.assertEqual(len(calls), 1)
+        data = stage.get_artifacts().data
+        self.assertIs(data["decode"], data["prefill"])
+
+    def test_source_transform_pass_return_value_is_rebound(self) -> None:
+        replacement = SimpleTestModel()
+        stage = SourceTransformStage(
+            self._no_quant_recipe(),
+            source_transform_passes=[lambda m: replacement],
+            in_place=True,
+        )
+        stage.run(PipelineArtifact(data=self.models_dict, context={}))
+
+        self.assertIs(stage.get_artifacts().data["forward"], replacement)
 
 
 class TestQuantizeStage(unittest.TestCase):
@@ -595,7 +659,8 @@ class TestToBackendStage(unittest.TestCase):
         mock_get_delegation_info.side_effect = delegation_by_graph_module.__getitem__
 
         stage = ToBackendStage()
-        stage.run(PipelineArtifact(data=self.mock_edge_manager, context=self.context))
+        artifact = PipelineArtifact(data=self.mock_edge_manager, context=self.context)
+        stage.run(artifact)
 
         self.assertEqual(
             stage.delegation_info_by_method,

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import call, Mock, patch
 
 import torch
 from executorch.exir.program import EdgeProgramManager, ExecutorchProgramManager
@@ -190,6 +190,7 @@ class TestEdgeTransformAndLowerStage(unittest.TestCase):
         mock_graph_module = Mock()
         mock_exported_program.graph_module = mock_graph_module
         mock_edge_program_manager.exported_program.return_value = mock_exported_program
+        mock_edge_program_manager.methods = {"forward"}
         mock_to_edge_transform_and_lower.return_value = mock_edge_program_manager
 
         stage = EdgeTransformAndLowerStage(
@@ -230,6 +231,39 @@ class TestEdgeTransformAndLowerStage(unittest.TestCase):
         self.assertEqual(
             result_artifact.get_context("delegation_info"), mock_delegation_info
         )
+
+    @patch("executorch.export.stages.to_edge_transform_and_lower")
+    @patch("executorch.export.stages.get_delegation_info")
+    def test_run_multi_method_without_forward(
+        self, mock_get_delegation_info: Mock, mock_to_edge_transform_and_lower: Mock
+    ) -> None:
+        """Delegation info is collected per method when there is no `forward`."""
+        programs = {name: Mock() for name in ("decode", "prefill")}
+        for program in programs.values():
+            program.graph_module = Mock()
+        delegation_by_graph_module = {
+            program.graph_module: f"{name}-info" for name, program in programs.items()
+        }
+
+        mock_edge_program_manager = Mock(spec=EdgeProgramManager)
+        mock_edge_program_manager.methods = set(programs)
+        mock_edge_program_manager.exported_program.side_effect = programs.__getitem__
+        mock_to_edge_transform_and_lower.return_value = mock_edge_program_manager
+        mock_get_delegation_info.side_effect = delegation_by_graph_module.__getitem__
+
+        stage = EdgeTransformAndLowerStage()
+        artifact = PipelineArtifact(
+            data={name: Mock(spec=ExportedProgram) for name in programs},
+            context=self.context,
+        )
+        stage.run(artifact)
+
+        self.assertEqual(
+            stage.delegation_info_by_method,
+            {"decode": "decode-info", "prefill": "prefill-info"},
+        )
+        # No `forward` method, so the first method by name is reported.
+        self.assertEqual(stage.delegation_info, "decode-info")
 
 
 class TestExecutorchStage(unittest.TestCase):
@@ -543,6 +577,68 @@ class TestToBackendStage(unittest.TestCase):
         self.assertEqual(
             result_artifact.get_context("delegation_info"), mock_delegation_info
         )
+
+    @patch("executorch.export.stages.get_delegation_info")
+    def test_run_multi_method_without_forward(
+        self, mock_get_delegation_info: Mock
+    ) -> None:
+        """Delegation info is collected per method when there is no `forward`."""
+        programs = {name: Mock() for name in ("decode", "prefill")}
+        for program in programs.values():
+            program.graph_module = Mock()
+        delegation_by_graph_module = {
+            program.graph_module: f"{name}-info" for name, program in programs.items()
+        }
+
+        self.mock_edge_manager.methods = set(programs)
+        self.mock_edge_manager.exported_program.side_effect = programs.__getitem__
+        mock_get_delegation_info.side_effect = delegation_by_graph_module.__getitem__
+
+        stage = ToBackendStage()
+        stage.run(PipelineArtifact(data=self.mock_edge_manager, context=self.context))
+
+        self.assertEqual(
+            stage.delegation_info_by_method,
+            {"decode": "decode-info", "prefill": "prefill-info"},
+        )
+        # No `forward` method, so the first method by name is reported.
+        self.assertEqual(stage.delegation_info, "decode-info")
+
+    @patch("executorch.export.stages.get_delegation_info")
+    def test_run_with_per_method_partitioners(
+        self, mock_get_delegation_info: Mock
+    ) -> None:
+        """A dict of partitioners lowers each method with its own partitioners."""
+        mock_get_delegation_info.return_value = {"delegation": "info"}
+        exported_program = Mock()
+        exported_program.graph_module = Mock()
+        self.mock_edge_manager.methods = {"decode", "prefill"}
+        self.mock_edge_manager.exported_program.return_value = exported_program
+        self.mock_edge_manager.to_backend.return_value = self.mock_edge_manager
+
+        decode_partitioner = Mock()
+        second_decode_partitioner = Mock()
+        prefill_partitioner = Mock()
+        stage = ToBackendStage(
+            partitioners={
+                "decode": [decode_partitioner, second_decode_partitioner],
+                "prefill": [prefill_partitioner],
+            }
+        )
+        stage.run(PipelineArtifact(data=self.mock_edge_manager, context=self.context))
+
+        self.mock_edge_manager.to_backend.assert_has_calls(
+            [
+                call(
+                    {
+                        "decode": decode_partitioner,
+                        "prefill": prefill_partitioner,
+                    }
+                ),
+                call({"decode": second_decode_partitioner}),
+            ]
+        )
+        self.assertEqual(self.mock_edge_manager.to_backend.call_count, 2)
 
     def test_run_edge_manager_none(self) -> None:
         stage = ToBackendStage()


### PR DESCRIPTION
Summary:

Add recipe-configurable source transforms and per-method pre-trace hooks. Source transforms run once per distinct model, including shared models, while pre-trace hooks run immediately before each method is exported. Recipe combination preserves hooks and in-place behavior without breaking existing positional arguments.

Differential Revision: D115602123


