### PR TITLE
Release intermediate export artifacts once they are consumed (#21748)

### DIFF
--- a/export/export.py
+++ b/export/export.py
@@ -300,8 +300,14 @@ class ExportSession:
         stage = None
         for stage_type in stages or self._get_default_pipeline():
             if stage_type == StageType.SOURCE_TRANSFORM:
+                source_transform_passes = None
+                if self._export_recipe.source_transform_passes is not None:
+                    source_transform_passes = list(
+                        self._export_recipe.source_transform_passes
+                    )
                 stage = SourceTransformStage(
                     self._quant_recipe,
+                    source_transform_passes=source_transform_passes,
                     in_place=self._export_recipe.source_transform_in_place,
                 )
             elif stage_type == StageType.QUANTIZE:
@@ -312,8 +318,13 @@ class ExportSession:
                     aten_transform_passes = list(
                         self._export_recipe.aten_transform_passes
                     )
+                pre_trace_hooks = None
+                if self._export_recipe.pre_trace_hooks is not None:
+                    pre_trace_hooks = list(self._export_recipe.pre_trace_hooks)
                 stage = TorchExportStage(
-                    aten_transform_passes, strict=self._export_recipe.strict
+                    aten_transform_passes,
+                    strict=self._export_recipe.strict,
+                    pre_trace_hooks=pre_trace_hooks,
                 )
             elif stage_type == StageType.TO_EDGE_TRANSFORM_AND_LOWER:
                 stage = EdgeTransformAndLowerStage.from_recipe(self._lowering_recipe)

--- a/export/export.py
+++ b/export/export.py
@@ -7,7 +7,7 @@
 
 import logging
 import time
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import torch
 from executorch.exir import EdgeProgramManager
@@ -233,6 +233,7 @@ class ExportSession:
         }
 
         self._stage_to_artifacts: Dict[StageType, PipelineArtifact] = {}
+        self._released_stages: Set[StageType] = set()
 
     def _detect_model_type(
         self, model: Union[nn.Module, GraphModule, ExportedProgram, Dict]
@@ -452,6 +453,8 @@ class ExportSession:
         )
 
         current_artifact = PipelineArtifact(data=self._model, context=self._run_context)
+        release = self._export_recipe.release_intermediate_artifacts
+        previous_stage_type = None
 
         # Execute stages from registry in the order specified by pipeline_stages
         for stage_type in self._pipeline_stages:
@@ -470,6 +473,30 @@ class ExportSession:
             logging.info(f"Stage {stage_type} execution done")
 
             self._stage_to_artifacts[stage_type] = current_artifact
+
+            # The stage that just ran has consumed its input, so the previous
+            # stage's output is now unreachable except through the two
+            # references we hold ourselves.
+            if release and previous_stage_type is not None:
+                self._release_stage(previous_stage_type)
+            previous_stage_type = stage_type
+
+    def _release_stage(self, stage_type: StageType) -> None:
+        self._stage_to_artifacts.pop(stage_type, None)
+        stage = self._stage_registry.get(stage_type)
+        if stage is not None:
+            stage.release_artifact()
+        self._released_stages.add(stage_type)
+        logging.info(f"Released artifact for stage: {stage_type}")
+
+    def _raise_if_released(self, *stage_types: StageType) -> None:
+        released = [s for s in stage_types if s in self._released_stages]
+        if released:
+            names = ", ".join(str(s) for s in released)
+            raise RuntimeError(
+                f"Artifact for {names} was released to free memory. Disable "
+                "release_intermediate_artifacts on the recipe to retain it."
+            )
 
     def export(self) -> None:
         """
@@ -501,6 +528,7 @@ class ExportSession:
             RuntimeError: If torch export stage has not been run
             KeyError: If the method name is not found in exported programs
         """
+        self._raise_if_released(StageType.TORCH_EXPORT)
         artifact = self._stage_to_artifacts.get(StageType.TORCH_EXPORT)
         if artifact is None or artifact.data is None:
             raise RuntimeError(
@@ -533,17 +561,19 @@ class ExportSession:
             RuntimeError: If no edge stage has been run
         """
         # Check stages in order of preference
-        for stage_type in [
+        edge_stages = [
             StageType.TO_EDGE_TRANSFORM_AND_LOWER,
             StageType.TO_BACKEND,
             StageType.EDGE_PROGRAM_MANAGER_TRANSFORM,
             StageType.TO_EDGE,
-        ]:
+        ]
+        for stage_type in edge_stages:
             artifact = self._stage_to_artifacts.get(stage_type)
             if artifact is not None and artifact.data is not None:
                 logging.info(f"Returning edge program manager from stage {stage_type}")
                 return artifact.data
 
+        self._raise_if_released(*edge_stages)
         raise RuntimeError(
             "Edge program manager is not available. "
             "Run one of the edge stages first: TO_EDGE_TRANSFORM_AND_LOWER, TO_EDGE, EDGE_PROGRAM_MANAGER_TRANSFORM, or TO_BACKEND."
@@ -679,13 +709,16 @@ class ExportSession:
             & {StageType.TO_EDGE_TRANSFORM_AND_LOWER, StageType.TO_BACKEND}
         )
         if not lowering_stage:
-            RuntimeError(
+            raise RuntimeError(
                 "No delegation info available, atleast one of the lowering stages should be present"
             )
 
         stage_artifact = self._stage_to_artifacts.get(lowering_stage[0])
         if stage_artifact is None:
-            RuntimeError("No delegation info available, run the lowering stage first")
+            self._raise_if_released(lowering_stage[0])
+            raise RuntimeError(
+                "No delegation info available, run the lowering stage first"
+            )
 
         delegation_info_by_method = stage_artifact.get_context(
             "delegation_info_by_method", None

--- a/export/export.py
+++ b/export/export.py
@@ -676,14 +676,26 @@ class ExportSession:
         if stage_artifact is None:
             RuntimeError("No delegation info available, run the lowering stage first")
 
-        # pyre-ignore
-        delegation_info = stage_artifact.get_context("delegation_info", None)
-        if delegation_info:
+        delegation_info_by_method = stage_artifact.get_context(
+            "delegation_info_by_method", None
+        )
+        if delegation_info_by_method:
+            delegation_infos = sorted(delegation_info_by_method.items())
+        else:
+            # pyre-ignore
+            delegation_info = stage_artifact.get_context("delegation_info", None)
+            delegation_infos = [(None, delegation_info)] if delegation_info else []
+
+        if not delegation_infos:
+            print("No delegation info available")
+            return
+
+        for method_name, delegation_info in delegation_infos:
+            if method_name is not None:
+                print(f"Delegation info for method '{method_name}':")
             print(delegation_info.get_summary())
             df = delegation_info.get_operator_delegation_dataframe()
             print(tabulate(df, headers="keys", tablefmt="fancy_grid"))
-        else:
-            print("No delegation info available")
 
     # Use Any instead of ETRecord as return type to avoid static dependency on etrecord
     def get_etrecord(self) -> Any:

--- a/export/recipe.py
+++ b/export/recipe.py
@@ -159,6 +159,16 @@ class ExportRecipe:
         quantization_recipe: Optional quantization recipe for model quantization
         aten_transform_passes: Optional list of functions to apply transformation passes to the program before edge lowering.
                                These callables are invoked to modify and return the transformed program.
+        source_transform_passes: Optional list of nn.Module transforms applied once
+                               during the SOURCE_TRANSFORM stage, before quantization.
+                               Each is applied once per distinct model object, so a
+                               model shared by several methods is transformed once.
+        pre_trace_hooks: Optional list of (method_name, model) callables invoked
+                               immediately before each method is traced. Use these for
+                               per-method state that must differ between traces; a
+                               SOURCE_TRANSFORM pass cannot express it, because that
+                               stage completes before any tracing and methods may share
+                               one model object.
         source_transform_in_place: Skip the defensive deepcopy in the SOURCE_TRANSFORM
                                stage and mutate the caller's model. Necessary for models
                                large enough that a second copy will not fit in memory.
@@ -181,6 +191,10 @@ class ExportRecipe:
     pipeline_stages: Optional[List[StageType]] = None
     mode: Mode = Mode.RELEASE
     strict: bool = True
+    source_transform_passes: Optional[
+        List[Callable[[torch.nn.Module], torch.nn.Module]]
+    ] = None
+    pre_trace_hooks: Optional[List[Callable[[str, torch.nn.Module], None]]] = None
 
     @classmethod
     def get_recipe(cls, recipe: "RecipeType", **kwargs) -> "ExportRecipe":
@@ -260,6 +274,8 @@ class ExportRecipe:
         all_quantizers = []
         all_ao_quantization_configs = []
         all_pre_edge_passes = []
+        all_source_transform_passes = []
+        all_pre_trace_hooks = []
         all_transform_passes = []
         combined_backend_config = None
 
@@ -267,6 +283,10 @@ class ExportRecipe:
             # Collect pre-edge transform passes
             if recipe.aten_transform_passes:
                 all_pre_edge_passes.extend(recipe.aten_transform_passes)
+            if recipe.source_transform_passes:
+                all_source_transform_passes.extend(recipe.source_transform_passes)
+            if recipe.pre_trace_hooks:
+                all_pre_trace_hooks.extend(recipe.pre_trace_hooks)
 
             # Collect partitioners from lowering recipes
             if recipe.lowering_recipe and recipe.lowering_recipe.partitioners:
@@ -347,6 +367,11 @@ class ExportRecipe:
             name=recipe_name,
             quantization_recipe=combined_quantization_recipe,
             aten_transform_passes=all_pre_edge_passes,
+            source_transform_passes=all_source_transform_passes or None,
+            pre_trace_hooks=all_pre_trace_hooks or None,
+            source_transform_in_place=any(
+                recipe.source_transform_in_place for recipe in backend_recipes
+            ),
             lowering_recipe=combined_lowering_recipe,
             executorch_backend_config=combined_backend_config,
         )

--- a/export/recipe.py
+++ b/export/recipe.py
@@ -8,7 +8,7 @@ import copy
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
-from typing import Callable, List, Optional
+from typing import Callable, Dict, List, Optional, Union
 
 import torch
 from executorch.exir import EdgeProgramManager, ExportedProgram
@@ -118,7 +118,10 @@ class LoweringRecipe:
     to backend-specific representations.
 
     Attributes:
-        partitioners: Optional list of partitioners for model partitioning
+        partitioners: Optional partitioners for model partitioning. Either a list
+                      applied to every method, or a dict mapping method names to
+                      per-method partitioner lists. Use the dict form when
+                      backends need per-method compile specs.
         edge_transform_passes: Optional list of callables that take (method_name: str, exported_program: ExportedProgram)
                                and return either List[PassType] or PassManager to be applied during edge lowering.
         edge_manager_transform_passes: Optional list of callables that take EdgeProgramManager as argument
@@ -126,7 +129,9 @@ class LoweringRecipe:
         edge_compile_config: Optional edge compilation configuration
     """
 
-    partitioners: Optional[List[Partitioner]] = None
+    partitioners: Optional[Union[List[Partitioner], Dict[str, List[Partitioner]]]] = (
+        None
+    )
     edge_transform_passes: (
         None | List[Callable[[str, ExportedProgram], List[PassType] | PassManager]]
     ) = None
@@ -251,6 +256,7 @@ class ExportRecipe:
         """
         # Extract components from individual recipes
         all_partitioners = []
+        all_partitioners_by_method = {}
         all_quantizers = []
         all_ao_quantization_configs = []
         all_pre_edge_passes = []
@@ -264,7 +270,14 @@ class ExportRecipe:
 
             # Collect partitioners from lowering recipes
             if recipe.lowering_recipe and recipe.lowering_recipe.partitioners:
-                all_partitioners.extend(recipe.lowering_recipe.partitioners)
+                partitioners = recipe.lowering_recipe.partitioners
+                if isinstance(partitioners, dict):
+                    for method_name, method_partitioners in partitioners.items():
+                        all_partitioners_by_method.setdefault(method_name, []).extend(
+                            method_partitioners
+                        )
+                else:
+                    all_partitioners.extend(partitioners)
 
             # Collect transform passes from lowering recipes
             if recipe.lowering_recipe and recipe.lowering_recipe.edge_transform_passes:
@@ -300,9 +313,16 @@ class ExportRecipe:
                 ),
             )
 
+        if all_partitioners and all_partitioners_by_method:
+            raise ValueError(
+                "Cannot combine recipes that mix list-valued and dict-valued "
+                "partitioners; convert the list-valued recipe to per-method form."
+            )
+        combined_partitioners = all_partitioners_by_method or all_partitioners
+
         # Create combined lowering recipe
         combined_lowering_recipe = None
-        if all_partitioners or all_transform_passes:
+        if combined_partitioners or all_transform_passes:
             edge_compile_config = None
             for recipe in backend_recipes:
                 if (
@@ -313,7 +333,7 @@ class ExportRecipe:
                     break
 
             combined_lowering_recipe = LoweringRecipe(
-                partitioners=all_partitioners if all_partitioners else None,
+                partitioners=combined_partitioners if combined_partitioners else None,
                 edge_transform_passes=(
                     all_transform_passes if all_transform_passes else None
                 ),

--- a/export/recipe.py
+++ b/export/recipe.py
@@ -172,6 +172,12 @@ class ExportRecipe:
         source_transform_in_place: Skip the defensive deepcopy in the SOURCE_TRANSFORM
                                stage and mutate the caller's model. Necessary for models
                                large enough that a second copy will not fit in memory.
+        release_intermediate_artifacts: Drop each stage's output once the next stage
+                               has consumed it, so only the final artifact stays
+                               resident. Necessary for models whose intermediates do
+                               not all fit in memory at once. Makes
+                               get_exported_program() and get_edge_program_manager()
+                               unavailable after export.
         lowering_recipe: Optional lowering recipe for model lowering and partitioning
         executorch_backend_config: Optional backend configuration for ExecuTorch
         pipeline_stages: Optional list of stages to execute, defaults to a standard pipeline.
@@ -195,6 +201,7 @@ class ExportRecipe:
         List[Callable[[torch.nn.Module], torch.nn.Module]]
     ] = None
     pre_trace_hooks: Optional[List[Callable[[str, torch.nn.Module], None]]] = None
+    release_intermediate_artifacts: bool = False
 
     @classmethod
     def get_recipe(cls, recipe: "RecipeType", **kwargs) -> "ExportRecipe":
@@ -371,6 +378,9 @@ class ExportRecipe:
             pre_trace_hooks=all_pre_trace_hooks or None,
             source_transform_in_place=any(
                 recipe.source_transform_in_place for recipe in backend_recipes
+            ),
+            release_intermediate_artifacts=any(
+                recipe.release_intermediate_artifacts for recipe in backend_recipes
             ),
             lowering_recipe=combined_lowering_recipe,
             executorch_backend_config=combined_backend_config,

--- a/export/stages.py
+++ b/export/stages.py
@@ -9,7 +9,8 @@ import copy
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional
+from itertools import zip_longest
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 from executorch.devtools.backend_debug import get_delegation_info
@@ -167,6 +168,36 @@ class TorchExportStage(Stage):
         self._artifact = artifact.copy_with_new_data(exported_programs)
 
 
+def _collect_delegation_info(
+    edge_program_manager: EdgeProgramManager,
+) -> Dict[str, Any]:
+    """
+    Delegation info for every method, keyed by method name.
+
+    `EdgeProgramManager.exported_program()` defaults to `forward`, which raises
+    KeyError for a multi-method program that has no method by that name.
+    """
+    return {
+        name: get_delegation_info(
+            edge_program_manager.exported_program(name).graph_module
+        )
+        for name in sorted(edge_program_manager.methods)
+    }
+
+
+def _add_delegation_info_context(
+    artifact: PipelineArtifact, edge_program_manager: EdgeProgramManager
+) -> None:
+    by_method = _collect_delegation_info(edge_program_manager)
+    artifact.add_context("delegation_info_by_method", by_method)
+    # `forward` when present, else the first method by name, so that
+    # single-method callers keep seeing the value they always have.
+    artifact.add_context(
+        "delegation_info",
+        by_method.get("forward", next(iter(by_method.values()), None)),
+    )
+
+
 class EdgeTransformAndLowerStage(Stage):
     """
     Second stage: Transform and lower to EdgeProgramManager.
@@ -174,7 +205,7 @@ class EdgeTransformAndLowerStage(Stage):
 
     def __init__(
         self,
-        partitioners: Optional[List[Any]] = None,
+        partitioners: Optional[Union[List[Any], Dict[str, List[Any]]]] = None,
         transform_passes: (
             None
             | List[
@@ -255,11 +286,8 @@ class EdgeTransformAndLowerStage(Stage):
                 generate_etrecord=generate_etrecord,
             )
 
-        delegation_info = get_delegation_info(
-            edge_program_manager.exported_program().graph_module
-        )
         self._artifact = artifact.copy_with_new_data(edge_program_manager)
-        self._artifact.add_context("delegation_info", delegation_info)
+        _add_delegation_info_context(self._artifact, edge_program_manager)
 
     @property
     def delegation_info(self) -> Any:
@@ -267,6 +295,13 @@ class EdgeTransformAndLowerStage(Stage):
         Returns the delegation info.
         """
         return self._artifact.get_context("delegation_info")
+
+    @property
+    def delegation_info_by_method(self) -> Dict[str, Any]:
+        """
+        Returns the delegation info for every method, keyed by method name.
+        """
+        return self._artifact.get_context("delegation_info_by_method")
 
 
 class ExecutorchStage(Stage):
@@ -641,7 +676,7 @@ class ToBackendStage(Stage):
 
     def __init__(
         self,
-        partitioners: Optional[List[Any]] = None,
+        partitioners: Optional[Union[List[Any], Dict[str, List[Any]]]] = None,
     ) -> None:
         super().__init__()
         self._partitioners = partitioners
@@ -687,17 +722,28 @@ class ToBackendStage(Stage):
         # Apply partitioners if available
         if self._partitioners is not None and len(self._partitioners) > 0:
             with validation_disabled():
-                # pyre-ignore
-                for partitioner in self._partitioners:
-                    edge_program_manager = edge_program_manager.to_backend(partitioner)
-
-        # Get delegation info
-        delegation_info = get_delegation_info(
-            edge_program_manager.exported_program().graph_module
-        )
+                if isinstance(self._partitioners, dict):
+                    method_names = list(self._partitioners)
+                    for partitioner_round in zip_longest(*self._partitioners.values()):
+                        partitioners_by_method = {
+                            method_name: partitioner
+                            for method_name, partitioner in zip(
+                                method_names, partitioner_round
+                            )
+                            if partitioner is not None
+                        }
+                        edge_program_manager = edge_program_manager.to_backend(
+                            partitioners_by_method
+                        )
+                else:
+                    # pyre-ignore
+                    for partitioner in self._partitioners:
+                        edge_program_manager = edge_program_manager.to_backend(
+                            partitioner
+                        )
 
         self._artifact = artifact.copy_with_new_data(edge_program_manager)
-        self._artifact.add_context("delegation_info", delegation_info)
+        _add_delegation_info_context(self._artifact, edge_program_manager)
 
     @property
     def delegation_info(self) -> Any:
@@ -705,3 +751,10 @@ class ToBackendStage(Stage):
         Returns the delegation info.
         """
         return self._artifact.get_context("delegation_info")
+
+    @property
+    def delegation_info_by_method(self) -> Dict[str, Any]:
+        """
+        Returns the delegation info for every method, keyed by method name.
+        """
+        return self._artifact.get_context("delegation_info_by_method")

--- a/export/stages.py
+++ b/export/stages.py
@@ -114,10 +114,12 @@ class TorchExportStage(Stage):
             List[Callable[[str, ExportedProgram], ExportedProgram]]
         ] = None,
         strict=True,
+        pre_trace_hooks: Optional[List[Callable[[str, nn.Module], None]]] = None,
     ) -> None:
         super().__init__()
         self._aten_transform_passes = aten_transform_passes
         self.strict = strict
+        self._pre_trace_hooks = pre_trace_hooks
 
     @property
     def stage_type(self) -> str:
@@ -146,6 +148,12 @@ class TorchExportStage(Stage):
                     )
 
                 method_dynamic_shapes = dynamic_shapes.get(method_name)
+
+                # Applied here, not in SOURCE_TRANSFORM, because methods may
+                # share one model object: a stage that ran to completion before
+                # any tracing would leave only the last method's state in place.
+                for hook in self._pre_trace_hooks or []:
+                    hook(method_name, model)
 
                 # Export the model
                 exported_programs[method_name] = torch.export.export(
@@ -353,9 +361,13 @@ class SourceTransformStage(Stage):
     def __init__(
         self,
         quantization_recipe: Optional[QuantizationRecipe],
+        source_transform_passes: Optional[
+            List[Callable[[nn.Module], nn.Module]]
+        ] = None,
         in_place: bool = False,
     ) -> None:
         self._quantization_recipe = quantization_recipe
+        self._source_transform_passes = source_transform_passes
         self._in_place = in_place
         self._transformed_models: Dict[str, nn.Module] = {}
 
@@ -375,37 +387,46 @@ class SourceTransformStage(Stage):
         """
         Apply source transformations to the model.
         """
-        if (
-            not self._quantization_recipe
-            or not self._quantization_recipe.ao_quantization_configs
-        ):
+        ao_configs = (
+            self._quantization_recipe.ao_quantization_configs
+            if self._quantization_recipe
+            else None
+        )
+        if not ao_configs and not self._source_transform_passes:
             logging.info(
-                "Quantization recipe is invalid to run SourceTransform, returning original artifact"
+                "No source transform passes and no AO quantization configs, returning original artifact"
             )
             self._artifact = artifact
             return
 
         assert isinstance(artifact.data, dict)
 
+        if ao_configs and len(ao_configs) > 1:
+            raise ValueError(
+                "AO quantization configs cannot be reliably composed together, multiple quantization configs are disallowed for source transform at this point"
+            )
+
         # A second copy of the model is not affordable for every caller, so
         # large models can opt out and have their own model mutated instead.
-        self._transformed_models = (
-            artifact.data if self._in_place else copy.deepcopy(artifact.data)
-        )
+        models = artifact.data if self._in_place else copy.deepcopy(artifact.data)
 
-        # Apply torchao quantize_ to each model
-        for _, model in self._transformed_models.items():
-            # pyre-ignore
-            if len(self._quantization_recipe.ao_quantization_configs) > 1:
-                raise ValueError(
-                    "AO quantization configs cannot be reliably composed together, multiple quantization configs are disallowed for source transform at this point"
-                )
+        # Several methods commonly share one model object. Transform each
+        # distinct object once, or a shared model is quantized once per method.
+        transformed_by_id: Dict[int, nn.Module] = {}
+        for method_name, model in list(models.items()):
+            original_id = id(model)
+            if original_id not in transformed_by_id:
+                for transform in self._source_transform_passes or []:
+                    model = transform(model)
+                if ao_configs:
+                    ao_config = ao_configs[0]
+                    quantize_(model, ao_config.ao_base_config, ao_config.filter_fn)
+                    unwrap_tensor_subclass(model)
+                transformed_by_id[original_id] = model
+            models[method_name] = transformed_by_id[original_id]
 
-            ao_config = self._quantization_recipe.ao_quantization_configs[0]
-            quantize_(model, ao_config.ao_base_config, ao_config.filter_fn)
-            unwrap_tensor_subclass(model)
-
-        self._artifact = artifact.copy_with_new_data(self._transformed_models)
+        self._transformed_models = models
+        self._artifact = artifact.copy_with_new_data(models)
 
 
 class QuantizeStage(Stage):

--- a/export/stages.py
+++ b/export/stages.py
@@ -63,6 +63,7 @@ class Stage(ABC):
         Initialize the stage.
         """
         self._artifact = None
+        self._artifact_released = False
 
     @property
     @abstractmethod
@@ -98,9 +99,26 @@ class Stage(ABC):
         pass
 
     def get_artifacts(self) -> "PipelineArtifact":
-        if self._artifact is None:
-            raise RuntimeError(f"Stage: {self.__class__.__name__} not executed")
-        return self._artifact
+        if self._artifact is not None:
+            self._artifact_released = False
+            return self._artifact
+        if self._artifact_released:
+            raise RuntimeError(
+                f"Stage: {self.__class__.__name__} artifact was released to free "
+                "memory. Disable release_intermediate_artifacts to retain it."
+            )
+        raise RuntimeError(f"Stage: {self.__class__.__name__} not executed")
+
+    def release_artifact(self) -> None:
+        """
+        Drop this stage's reference to its output.
+
+        The pipeline holds the only other reference, so releasing both lets a
+        stage's output be collected once the next stage has consumed it.
+        Subclasses that retain their own references must extend this.
+        """
+        self._artifact = None
+        self._artifact_released = True
 
 
 class TorchExportStage(Stage):
@@ -318,6 +336,7 @@ class ExecutorchStage(Stage):
     """
 
     def __init__(self, backend_config: Any) -> None:
+        super().__init__()
         self._backend_config = backend_config
 
     @property
@@ -366,10 +385,15 @@ class SourceTransformStage(Stage):
         ] = None,
         in_place: bool = False,
     ) -> None:
+        super().__init__()
         self._quantization_recipe = quantization_recipe
         self._source_transform_passes = source_transform_passes
         self._in_place = in_place
         self._transformed_models: Dict[str, nn.Module] = {}
+
+    def release_artifact(self) -> None:
+        super().release_artifact()
+        self._transformed_models = {}
 
     @property
     def stage_type(self) -> str:
@@ -435,6 +459,7 @@ class QuantizeStage(Stage):
     """
 
     def __init__(self, quantization_recipe: Optional[QuantizationRecipe]) -> None:
+        super().__init__()
         self._quantization_recipe = quantization_recipe
 
     @property

--- a/export/tests/test_export_recipe.py
+++ b/export/tests/test_export_recipe.py
@@ -8,6 +8,7 @@
 
 import unittest
 from typing import Any, Dict, Optional, Sequence
+from unittest.mock import Mock
 
 from executorch.export.recipe import ExportRecipe, RecipeType
 from executorch.export.recipe_provider import BackendRecipeProvider
@@ -129,3 +130,42 @@ class TestExportRecipeGetRecipe(unittest.TestCase):
         # Verify that the kwargs were passed to the backend provider's create_recipe method
         self.assertIsNotNone(self.provider.last_kwargs)
         self.assertEqual(self.provider.last_kwargs, kwargs)
+
+
+class TestExportRecipeCombine(unittest.TestCase):
+    def test_new_hooks_do_not_change_existing_positional_arguments(self) -> None:
+        recipe = ExportRecipe(None, None, None, True)
+
+        self.assertTrue(recipe.source_transform_in_place)
+        self.assertIsNone(recipe.source_transform_passes)
+        self.assertIsNone(recipe.pre_trace_hooks)
+
+    def test_preserves_source_transform_passes_and_pre_trace_hooks(self) -> None:
+        first_source_transform = Mock()
+        second_source_transform = Mock()
+        first_pre_trace_hook = Mock()
+        second_pre_trace_hook = Mock()
+
+        combined = ExportRecipe.combine(
+            [
+                ExportRecipe(
+                    source_transform_passes=[first_source_transform],
+                    pre_trace_hooks=[first_pre_trace_hook],
+                    source_transform_in_place=True,
+                ),
+                ExportRecipe(
+                    source_transform_passes=[second_source_transform],
+                    pre_trace_hooks=[second_pre_trace_hook],
+                ),
+            ]
+        )
+
+        self.assertEqual(
+            combined.source_transform_passes,
+            [first_source_transform, second_source_transform],
+        )
+        self.assertEqual(
+            combined.pre_trace_hooks,
+            [first_pre_trace_hook, second_pre_trace_hook],
+        )
+        self.assertTrue(combined.source_transform_in_place)

--- a/export/tests/test_export_recipe.py
+++ b/export/tests/test_export_recipe.py
@@ -140,6 +140,25 @@ class TestExportRecipeCombine(unittest.TestCase):
         self.assertIsNone(recipe.source_transform_passes)
         self.assertIsNone(recipe.pre_trace_hooks)
 
+    def test_release_option_does_not_change_existing_positional_arguments(
+        self,
+    ) -> None:
+        lowering_recipe = Mock()
+        recipe = ExportRecipe(None, None, None, False, lowering_recipe)
+
+        self.assertIs(recipe.lowering_recipe, lowering_recipe)
+        self.assertFalse(recipe.release_intermediate_artifacts)
+
+    def test_combine_preserves_release_intermediate_artifacts(self) -> None:
+        combined = ExportRecipe.combine(
+            [
+                ExportRecipe(release_intermediate_artifacts=True),
+                ExportRecipe(),
+            ]
+        )
+
+        self.assertTrue(combined.release_intermediate_artifacts)
+
     def test_preserves_source_transform_passes_and_pre_trace_hooks(self) -> None:
         first_source_transform = Mock()
         second_source_transform = Mock()

--- a/export/tests/test_export_session.py
+++ b/export/tests/test_export_session.py
@@ -7,8 +7,8 @@
 # pyre-strict
 
 import unittest
-from typing import List
-from unittest.mock import Mock
+from typing import Any, Dict, List
+from unittest.mock import call, Mock, patch
 
 import torch
 from executorch.export import ExportRecipe, ExportSession
@@ -817,6 +817,77 @@ class TestExportSessionExtendedInputTypes(unittest.TestCase):
 
         # Should not raise during validation
         session._validate_pipeline_sequence(recipe.pipeline_stages)
+
+
+class TestDelegationInfoReporting(unittest.TestCase):
+    def setUp(self) -> None:
+        self.session = ExportSession(
+            model=SimpleTestModel(),
+            example_inputs=[(torch.randn(2, 10),)],
+            export_recipe=ExportRecipe(),
+        )
+
+    def _set_delegation_context(self, context: Dict[str, Any]) -> None:
+        self.session._stage_to_artifacts[StageType.TO_EDGE_TRANSFORM_AND_LOWER] = (
+            PipelineArtifact(data=None, context=context)
+        )
+
+    @patch("executorch.export.export.tabulate")
+    @patch("builtins.print")
+    def test_print_delegation_info_for_every_method(
+        self, mock_print: Mock, mock_tabulate: Mock
+    ) -> None:
+        decode_info = Mock()
+        decode_info.get_summary.return_value = "decode-summary"
+        decode_info.get_operator_delegation_dataframe.return_value = "decode-data"
+        prefill_info = Mock()
+        prefill_info.get_summary.return_value = "prefill-summary"
+        prefill_info.get_operator_delegation_dataframe.return_value = "prefill-data"
+        mock_tabulate.side_effect = ["decode-table", "prefill-table"]
+        self._set_delegation_context(
+            {
+                "delegation_info_by_method": {
+                    "prefill": prefill_info,
+                    "decode": decode_info,
+                },
+                "delegation_info": decode_info,
+            }
+        )
+
+        self.session.print_delegation_info()
+
+        self.assertEqual(
+            mock_print.call_args_list,
+            [
+                call("Delegation info for method 'decode':"),
+                call("decode-summary"),
+                call("decode-table"),
+                call("Delegation info for method 'prefill':"),
+                call("prefill-summary"),
+                call("prefill-table"),
+            ],
+        )
+        self.assertEqual(mock_tabulate.call_count, 2)
+
+    @patch("executorch.export.export.tabulate", return_value="legacy-table")
+    @patch("builtins.print")
+    def test_print_delegation_info_legacy_fallback(
+        self, mock_print: Mock, mock_tabulate: Mock
+    ) -> None:
+        delegation_info = Mock()
+        delegation_info.get_summary.return_value = "legacy-summary"
+        delegation_info.get_operator_delegation_dataframe.return_value = "legacy-data"
+        self._set_delegation_context({"delegation_info": delegation_info})
+
+        self.session.print_delegation_info()
+
+        self.assertEqual(
+            mock_print.call_args_list,
+            [call("legacy-summary"), call("legacy-table")],
+        )
+        mock_tabulate.assert_called_once_with(
+            "legacy-data", headers="keys", tablefmt="fancy_grid"
+        )
 
 
 class TestIntermediateStateGetters(unittest.TestCase):

--- a/export/tests/test_export_session.py
+++ b/export/tests/test_export_session.py
@@ -107,6 +107,68 @@ class TestExportSessionCoreFlow(unittest.TestCase):
         self.assertEqual(len(session._stage_to_artifacts), 5)
         self.assertEqual(set(session._stage_to_artifacts.keys()), set(stage_types))
 
+    def _run_five_stage_pipeline(self, recipe: ExportRecipe) -> ExportSession:
+        stage_types = [
+            StageType.SOURCE_TRANSFORM,
+            StageType.QUANTIZE,
+            StageType.TORCH_EXPORT,
+            StageType.TO_EDGE_TRANSFORM_AND_LOWER,
+            StageType.TO_EXECUTORCH,
+        ]
+        session = ExportSession(
+            model=self.model,
+            example_inputs=self.example_inputs,
+            export_recipe=recipe,
+        )
+        for stage_type in stage_types:
+            session.register_stage(stage_type, self._create_mock_stage(stage_type))
+        session.export()
+        return session
+
+    def test_intermediate_artifacts_retained_by_default(self) -> None:
+        session = self._run_five_stage_pipeline(ExportRecipe(name="test"))
+        self.assertEqual(len(session._stage_to_artifacts), 5)
+        self.assertEqual(session._released_stages, set())
+
+    def test_release_intermediate_artifacts_keeps_only_the_last(self) -> None:
+        session = self._run_five_stage_pipeline(
+            ExportRecipe(name="test", release_intermediate_artifacts=True)
+        )
+
+        self.assertEqual(
+            set(session._stage_to_artifacts.keys()), {StageType.TO_EXECUTORCH}
+        )
+        # Every stage but the last had both of its references dropped.
+        for stage_type in [
+            StageType.SOURCE_TRANSFORM,
+            StageType.QUANTIZE,
+            StageType.TORCH_EXPORT,
+            StageType.TO_EDGE_TRANSFORM_AND_LOWER,
+        ]:
+            self.assertIn(stage_type, session._released_stages)
+            session.get_registered_stage(
+                stage_type
+            ).release_artifact.assert_called_once()
+
+    def test_released_accessors_explain_why(self) -> None:
+        session = self._run_five_stage_pipeline(
+            ExportRecipe(name="test", release_intermediate_artifacts=True)
+        )
+
+        for accessor in (
+            session.get_exported_program,
+            session.get_edge_program_manager,
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                accessor()
+            self.assertIn("released to free memory", str(cm.exception))
+
+    def test_release_does_not_touch_the_final_artifact(self) -> None:
+        session = self._run_five_stage_pipeline(
+            ExportRecipe(name="test", release_intermediate_artifacts=True)
+        )
+        self.assertIsNotNone(session.get_executorch_program_manager())
+
     def test_overriden_pipeline_execution_order(self) -> None:
         # Test when pipeline stages that are passed through recipe
         stage_types = [

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -159,6 +159,28 @@ class TestTorchExportStage(unittest.TestCase):
             str(cm.exception),
         )
 
+    def test_pre_trace_hooks_fire_per_method(self) -> None:
+        """Hooks fire once per method, immediately before that method's trace."""
+        calls = []
+        stage = TorchExportStage(
+            pre_trace_hooks=[lambda name, model: calls.append((name, model))]
+        )
+        artifact = PipelineArtifact(
+            data={"decode": self.model, "prefill": self.model},
+            context={
+                "example_inputs": {
+                    "decode": self.example_inputs,
+                    "prefill": self.example_inputs,
+                }
+            },
+        )
+        stage.run(artifact)
+
+        # Both methods share one model object, so a hook that ran in an earlier
+        # batch stage could only have left the last method's state in place.
+        self.assertEqual([name for name, _ in calls], ["decode", "prefill"])
+        self.assertTrue(all(model is self.model for _, model in calls))
+
 
 class TestEdgeTransformAndLowerStage(unittest.TestCase):
     def setUp(self) -> None:
@@ -355,24 +377,66 @@ class TestSourceTransformStage(unittest.TestCase):
         # verify the result model is NOT the same object as the original
         self.assertIsNot(result_artifact.data["forward"], self.model)
 
-    @patch("executorch.export.stages.quantize_")
-    @patch("executorch.export.stages.unwrap_tensor_subclass")
-    def test_run_in_place_does_not_copy_the_model(
-        self, mock_unwrap: Mock, mock_quantize: Mock
-    ) -> None:
-        from torchao.core.config import AOBaseConfig
+    def _no_quant_recipe(self) -> Mock:
+        recipe = Mock(spec=QuantizationRecipe)
+        recipe.ao_quantization_configs = None
+        return recipe
 
-        mock_recipe = Mock(spec=QuantizationRecipe)
-        mock_recipe.ao_quantization_configs = [
-            AOQuantizationConfig(ao_base_config=Mock(spec=AOBaseConfig))
-        ]
+    def test_source_transform_passes_run_without_quantization(self) -> None:
+        seen = []
 
-        stage = SourceTransformStage(mock_recipe, in_place=True)
+        def record(model: torch.nn.Module) -> torch.nn.Module:
+            seen.append(model)
+            return model
+
+        stage = SourceTransformStage(
+            self._no_quant_recipe(), source_transform_passes=[record], in_place=True
+        )
         stage.run(PipelineArtifact(data=self.models_dict, context={}))
 
-        # The caller's own model is quantized rather than a copy of it.
-        self.assertIs(mock_quantize.call_args[0][0], self.model)
+        self.assertEqual(seen, [self.model])
+        # in_place mutates the caller's own module rather than a copy
         self.assertIs(stage.get_artifacts().data["forward"], self.model)
+
+    def test_source_transform_passes_copy_by_default(self) -> None:
+        stage = SourceTransformStage(
+            self._no_quant_recipe(), source_transform_passes=[lambda m: m]
+        )
+        stage.run(PipelineArtifact(data=self.models_dict, context={}))
+
+        self.assertIsNot(stage.get_artifacts().data["forward"], self.model)
+
+    def test_source_transform_pass_applied_once_for_shared_model(self) -> None:
+        """Methods sharing one model object must not be transformed twice."""
+        calls = []
+
+        def record(model: torch.nn.Module) -> torch.nn.Module:
+            calls.append(model)
+            return model
+
+        stage = SourceTransformStage(
+            self._no_quant_recipe(), source_transform_passes=[record], in_place=True
+        )
+        stage.run(
+            PipelineArtifact(
+                data={"decode": self.model, "prefill": self.model}, context={}
+            )
+        )
+
+        self.assertEqual(len(calls), 1)
+        data = stage.get_artifacts().data
+        self.assertIs(data["decode"], data["prefill"])
+
+    def test_source_transform_pass_return_value_is_rebound(self) -> None:
+        replacement = SimpleTestModel()
+        stage = SourceTransformStage(
+            self._no_quant_recipe(),
+            source_transform_passes=[lambda m: replacement],
+            in_place=True,
+        )
+        stage.run(PipelineArtifact(data=self.models_dict, context={}))
+
+        self.assertIs(stage.get_artifacts().data["forward"], replacement)
 
 
 class TestQuantizeStage(unittest.TestCase):
@@ -595,7 +659,8 @@ class TestToBackendStage(unittest.TestCase):
         mock_get_delegation_info.side_effect = delegation_by_graph_module.__getitem__
 
         stage = ToBackendStage()
-        stage.run(PipelineArtifact(data=self.mock_edge_manager, context=self.context))
+        artifact = PipelineArtifact(data=self.mock_edge_manager, context=self.context)
+        stage.run(artifact)
 
         self.assertEqual(
             stage.delegation_info_by_method,

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -7,7 +7,7 @@
 # pyre-strict
 
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import call, Mock, patch
 
 import torch
 from executorch.exir.program import EdgeProgramManager, ExecutorchProgramManager
@@ -190,6 +190,7 @@ class TestEdgeTransformAndLowerStage(unittest.TestCase):
         mock_graph_module = Mock()
         mock_exported_program.graph_module = mock_graph_module
         mock_edge_program_manager.exported_program.return_value = mock_exported_program
+        mock_edge_program_manager.methods = {"forward"}
         mock_to_edge_transform_and_lower.return_value = mock_edge_program_manager
 
         stage = EdgeTransformAndLowerStage(
@@ -230,6 +231,39 @@ class TestEdgeTransformAndLowerStage(unittest.TestCase):
         self.assertEqual(
             result_artifact.get_context("delegation_info"), mock_delegation_info
         )
+
+    @patch("executorch.export.stages.to_edge_transform_and_lower")
+    @patch("executorch.export.stages.get_delegation_info")
+    def test_run_multi_method_without_forward(
+        self, mock_get_delegation_info: Mock, mock_to_edge_transform_and_lower: Mock
+    ) -> None:
+        """Delegation info is collected per method when there is no `forward`."""
+        programs = {name: Mock() for name in ("decode", "prefill")}
+        for program in programs.values():
+            program.graph_module = Mock()
+        delegation_by_graph_module = {
+            program.graph_module: f"{name}-info" for name, program in programs.items()
+        }
+
+        mock_edge_program_manager = Mock(spec=EdgeProgramManager)
+        mock_edge_program_manager.methods = set(programs)
+        mock_edge_program_manager.exported_program.side_effect = programs.__getitem__
+        mock_to_edge_transform_and_lower.return_value = mock_edge_program_manager
+        mock_get_delegation_info.side_effect = delegation_by_graph_module.__getitem__
+
+        stage = EdgeTransformAndLowerStage()
+        artifact = PipelineArtifact(
+            data={name: Mock(spec=ExportedProgram) for name in programs},
+            context=self.context,
+        )
+        stage.run(artifact)
+
+        self.assertEqual(
+            stage.delegation_info_by_method,
+            {"decode": "decode-info", "prefill": "prefill-info"},
+        )
+        # No `forward` method, so the first method by name is reported.
+        self.assertEqual(stage.delegation_info, "decode-info")
 
 
 class TestExecutorchStage(unittest.TestCase):
@@ -543,6 +577,68 @@ class TestToBackendStage(unittest.TestCase):
         self.assertEqual(
             result_artifact.get_context("delegation_info"), mock_delegation_info
         )
+
+    @patch("executorch.export.stages.get_delegation_info")
+    def test_run_multi_method_without_forward(
+        self, mock_get_delegation_info: Mock
+    ) -> None:
+        """Delegation info is collected per method when there is no `forward`."""
+        programs = {name: Mock() for name in ("decode", "prefill")}
+        for program in programs.values():
+            program.graph_module = Mock()
+        delegation_by_graph_module = {
+            program.graph_module: f"{name}-info" for name, program in programs.items()
+        }
+
+        self.mock_edge_manager.methods = set(programs)
+        self.mock_edge_manager.exported_program.side_effect = programs.__getitem__
+        mock_get_delegation_info.side_effect = delegation_by_graph_module.__getitem__
+
+        stage = ToBackendStage()
+        stage.run(PipelineArtifact(data=self.mock_edge_manager, context=self.context))
+
+        self.assertEqual(
+            stage.delegation_info_by_method,
+            {"decode": "decode-info", "prefill": "prefill-info"},
+        )
+        # No `forward` method, so the first method by name is reported.
+        self.assertEqual(stage.delegation_info, "decode-info")
+
+    @patch("executorch.export.stages.get_delegation_info")
+    def test_run_with_per_method_partitioners(
+        self, mock_get_delegation_info: Mock
+    ) -> None:
+        """A dict of partitioners lowers each method with its own partitioners."""
+        mock_get_delegation_info.return_value = {"delegation": "info"}
+        exported_program = Mock()
+        exported_program.graph_module = Mock()
+        self.mock_edge_manager.methods = {"decode", "prefill"}
+        self.mock_edge_manager.exported_program.return_value = exported_program
+        self.mock_edge_manager.to_backend.return_value = self.mock_edge_manager
+
+        decode_partitioner = Mock()
+        second_decode_partitioner = Mock()
+        prefill_partitioner = Mock()
+        stage = ToBackendStage(
+            partitioners={
+                "decode": [decode_partitioner, second_decode_partitioner],
+                "prefill": [prefill_partitioner],
+            }
+        )
+        stage.run(PipelineArtifact(data=self.mock_edge_manager, context=self.context))
+
+        self.mock_edge_manager.to_backend.assert_has_calls(
+            [
+                call(
+                    {
+                        "decode": decode_partitioner,
+                        "prefill": prefill_partitioner,
+                    }
+                ),
+                call({"decode": second_decode_partitioner}),
+            ]
+        )
+        self.assertEqual(self.mock_edge_manager.to_backend.call_count, 2)
 
     def test_run_edge_manager_none(self) -> None:
         stage = ToBackendStage()

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -6,7 +6,9 @@
 
 # pyre-strict
 
+import gc
 import unittest
+import weakref
 from unittest.mock import call, Mock, patch
 
 import torch
@@ -98,6 +100,21 @@ class TestTorchExportStage(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             stage.get_artifacts()
         self.assertIn("Stage: TorchExportStage not executed", str(cm.exception))
+
+    @patch("torch.export.export")
+    def test_run_after_artifact_release(self, mock_torch_export: Mock) -> None:
+        first_program = Mock(spec=ExportedProgram)
+        second_program = Mock(spec=ExportedProgram)
+        mock_torch_export.side_effect = [first_program, second_program]
+        stage = TorchExportStage()
+        artifact = PipelineArtifact(data=self.models_dict, context=self.context)
+
+        stage.run(artifact)
+        stage.release_artifact()
+        stage.run(artifact)
+
+        self.assertIs(stage.get_artifacts().data["forward"], second_program)
+        self.assertEqual(mock_torch_export.call_count, 2)
 
     @patch("torch.export.export")
     def test_export_stage_with_aten_transform_passes(
@@ -437,6 +454,51 @@ class TestSourceTransformStage(unittest.TestCase):
         stage.run(PipelineArtifact(data=self.models_dict, context={}))
 
         self.assertIs(stage.get_artifacts().data["forward"], replacement)
+
+
+class TestStageArtifactRelease(unittest.TestCase):
+    def test_release_makes_the_output_collectable(self) -> None:
+        """A released stage must not be what keeps its own output alive."""
+        stage = TorchExportStage()
+        payload = SimpleTestModel()
+        stage._artifact = PipelineArtifact(data=payload, context={})
+        ref = weakref.ref(payload)
+        del payload
+
+        gc.collect()
+        self.assertIsNotNone(ref())
+
+        stage.release_artifact()
+        gc.collect()
+        self.assertIsNone(ref())
+
+    def test_get_artifacts_after_release_explains_why(self) -> None:
+        stage = TorchExportStage()
+        stage._artifact = PipelineArtifact(data=Mock(), context={})
+        stage.release_artifact()
+
+        with self.assertRaises(RuntimeError) as cm:
+            stage.get_artifacts()
+        self.assertIn("released to free memory", str(cm.exception))
+
+    def test_source_transform_release_drops_transformed_models(self) -> None:
+        """SourceTransformStage holds a second reference that must go too."""
+        recipe = Mock(spec=QuantizationRecipe)
+        recipe.ao_quantization_configs = None
+        stage = SourceTransformStage(
+            recipe, source_transform_passes=[lambda m: m], in_place=True
+        )
+        model = SimpleTestModel()
+        stage.run(PipelineArtifact(data={"forward": model}, context={}))
+        ref = weakref.ref(model)
+        del model
+
+        gc.collect()
+        self.assertIsNotNone(ref())
+
+        stage.release_artifact()
+        gc.collect()
+        self.assertIsNone(ref())
 
 
 class TestQuantizeStage(unittest.TestCase):


### PR DESCRIPTION
Summary:

Add an opt-in `release_intermediate_artifacts` recipe setting that drops each stage’s output after the next stage consumes it, reducing peak memory usage for large models. Released artifacts produce descriptive accessor errors, and stages remain reusable across subsequent exports. Recipe combination and positional compatibility are preserved.

Authored with Codex.

Reviewed By: psiddh

Differential Revision: D115607218
