### PR TITLE
Qualcomm AI Engine Direct - [GenAI Pipeline] PR4: Adapter interfaces, default implementations & dataset providers

### DIFF
--- a/backends/qualcomm/.coveragerc
+++ b/backends/qualcomm/.coveragerc
@@ -7,6 +7,7 @@ omit =
     */tests/*
     */__pycache__/*
     pipeline_types.py
+    */strategies/*/default_*_adapter.py
 
 [report]
 show_missing = True
@@ -16,3 +17,4 @@ omit =
     */tests/*
     */__pycache__/*
     pipeline_types.py
+    */strategies/*/default_*_adapter.py

--- a/backends/qualcomm/genai_pipeline/configs/model_preparation_output_config.py
+++ b/backends/qualcomm/genai_pipeline/configs/model_preparation_output_config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Optional, TYPE_CHECKING
+from typing import Any, Iterable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from torch import nn
@@ -18,16 +18,24 @@ if TYPE_CHECKING:
 class ModelPreparationOutputConfig:
     """Output produced by the model preparation stage.
 
+    All fields are ``Optional`` because ``GenAIPipeline._run_model_preparation``
+    returns an empty instance when the stage is skipped (e.g. compile-only flows
+    with a caller-supplied module). ``None`` is a "stage did not run" sentinel,
+    not a valid post-execution state: when the stage runs, ``model_module`` and
+    ``tokenizer`` are always populated.
+
     Attributes:
         model_module: The prepared nn.Module ready for quantization.
         tokenizer: The tokenizer instance for encoding/decoding text.
-        calibration_data: Dataset samples for calibration during quantization.
-        runtime_tokenizer_path: Path to runtime tokenizer for on-device inference.
+        calibration_data: Calibration samples. Any Iterable[Tuple[Tensor, ...]],
+            including a DataLoader with a custom collate_fn.
+        runtime_tokenizer_path: Path to the runtime tokenizer **file** (not the
+            containing directory) for on-device inference.
         chat_template: Optional chat template for instruct models.
     """
 
     model_module: Optional["nn.Module"] = None
     tokenizer: Any = None
-    calibration_data: Optional[List[Any]] = None
+    calibration_data: Optional[Iterable[Any]] = None
     runtime_tokenizer_path: Optional[Path] = None
     chat_template: Optional[str] = None

--- a/backends/qualcomm/genai_pipeline/configs/quantization_input_config.py
+++ b/backends/qualcomm/genai_pipeline/configs/quantization_input_config.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, Iterable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from executorch.backends.qualcomm.serialization.qc_schema import (
@@ -21,11 +21,26 @@ if TYPE_CHECKING:
 class QuantizationInputConfig:
     """Input configuration for the quantization stage.
 
+    ``model_module`` and ``calibration_data`` are ``Optional`` only because the
+    orchestrator builds this from the previous stage's output, which is empty
+    when model preparation is skipped. **Both are required once the quantization
+    stage executes**, and strategies should validate their presence.
+
+    Flows needing no quantization (FP16, GPU backends) skip the stage entirely
+    via ``GenAIPipeline.from_proxy(proxy, skip_stages={STAGE_QUANTIZATION})``
+    rather than entering it with a no-op strategy; the orchestrator then returns
+    an empty ``QuantizationOutputConfig()`` and compilation receives the
+    unquantized module.
+
     Attributes:
         soc_model: The target SoC (e.g., QcomChipset.SM8750). Required.
         backend_type: QNN backend type (HTP, GPU, LPAI, etc.). Required.
-        model_module: The nn.Module to quantize.
-        calibration_data: Calibration dataset samples.
+        model_module: The nn.Module to quantize. Required when the stage runs.
+        calibration_data: Calibration samples. Required when the stage runs. Any
+            Iterable[Tuple[Tensor, ...]], including a DataLoader.
+        training_data: Training dataset for quantization-aware training (QAT),
+            typically (features, labels) pairs. Mirrors ``qat_training_data`` in
+            ``build_executorch_binary``. ``None`` selects PTQ.
         quant_recipe: Quantization recipe (per-layer bit widths, group sizes, etc.).
         extra_options: Additional quantization-specific options.
     """
@@ -33,6 +48,7 @@ class QuantizationInputConfig:
     soc_model: "QcomChipset"
     backend_type: "QnnExecuTorchBackendType"
     model_module: Optional["nn.Module"] = None
-    calibration_data: Optional[List[Any]] = None
+    calibration_data: Optional[Iterable[Any]] = None
+    training_data: Optional[Iterable[Any]] = None
     quant_recipe: Any = None
     extra_options: Dict[str, Any] = field(default_factory=dict)

--- a/backends/qualcomm/genai_pipeline/datasets/__init__.py
+++ b/backends/qualcomm/genai_pipeline/datasets/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Dataset providers for the GenAI pipeline.
+
+Datasets are a **cross-stage** concern rather than a model-preparation detail:
+the same corpus feeds PTQ calibration during quantization and on-device result
+evaluation during inference (including pre-built ``.pte`` flows, where no model
+preparation runs at all). They therefore live here rather than under
+``strategies/model_preparation/``.
+"""
+
+from executorch.backends.qualcomm.genai_pipeline.datasets.calibration_data_adapter import (
+    CalibrationDataAdapter,
+)
+from executorch.backends.qualcomm.genai_pipeline.datasets.default_calibration_data_adapter import (
+    DefaultCalibrationDataAdapter,
+)
+from executorch.backends.qualcomm.genai_pipeline.datasets.default_training_data_adapter import (
+    DefaultTrainingDataAdapter,
+)
+from executorch.backends.qualcomm.genai_pipeline.datasets.training_data_adapter import (
+    TrainingDataAdapter,
+)
+
+__all__ = [
+    "CalibrationDataAdapter",
+    "DefaultCalibrationDataAdapter",
+    "DefaultTrainingDataAdapter",
+    "TrainingDataAdapter",
+]

--- a/backends/qualcomm/genai_pipeline/datasets/calibration_data_adapter.py
+++ b/backends/qualcomm/genai_pipeline/datasets/calibration_data_adapter.py
@@ -1,0 +1,54 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class CalibrationDataAdapter(Protocol):
+    """Protocol for calibration dataset construction.
+
+    Kept separate from :class:`ModelLoaderAdapter` because data sources
+    (HuggingFace prompts, ``lm_eval`` tasks, JSON prompt files, multimodal file
+    inputs, synthetic tokens) vary independently of how the model is loaded and
+    mostly depend only on the tokenizer. Swapping the source is therefore a
+    matter of injecting a different adapter.
+
+    The same calibration corpus is also consumed by the inference stage for
+    on-device result evaluation -- including pre-built ``.pte`` flows where model
+    preparation never runs -- which is why this lives in ``datasets/`` rather
+    than under a single stage.
+
+    For quantization-aware training, see :class:`TrainingDataAdapter`: training
+    data yields ``(features, labels)`` pairs rather than model-argument tuples,
+    so it is a distinct contract.
+    """
+
+    def generate_calibration_data(
+        self,
+        tokenizer: Any,
+        num_samples: int = 128,
+        seq_length: int = 1024,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> Iterable[Any]:
+        """Build the calibration dataset used for post-training quantization.
+
+        Args:
+            tokenizer: The tokenizer used to encode text samples.
+            num_samples: Number of calibration samples to produce.
+            seq_length: Sequence length for each sample.
+            extra_options: Implementation-specific options. Implementations may
+                support a ``dataset`` key accepting any
+                ``Iterable[Tuple[Tensor, ...]]`` (including a ``DataLoader``)
+                to use caller-supplied data directly.
+
+        Returns:
+            An iterable of calibration input tuples, each suitable for
+            ``model(*sample)``.
+        """
+        ...

--- a/backends/qualcomm/genai_pipeline/datasets/default_calibration_data_adapter.py
+++ b/backends/qualcomm/genai_pipeline/datasets/default_calibration_data_adapter.py
@@ -1,0 +1,89 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_NUM_SAMPLES = 128
+DEFAULT_SEQ_LENGTH = 1024
+DEFAULT_SEED = 42
+
+
+class DefaultCalibrationDataAdapter:
+    """Default calibration data provider using random token sequences.
+
+    Suitable for bring-up. For production quantization accuracy, pass a real
+    corpus via ``extra_options["dataset"]`` or inject a corpus-backed adapter
+    (HuggingFace prompts, ``lm_eval`` tasks, JSON prompt files, ...).
+    """
+
+    def generate_calibration_data(
+        self,
+        tokenizer: Any,
+        num_samples: int = DEFAULT_NUM_SAMPLES,
+        seq_length: int = DEFAULT_SEQ_LENGTH,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> Iterable[Any]:
+        """Generate calibration data as random token sequences.
+
+        Args:
+            tokenizer: The tokenizer to use. Only ``vocab_size`` is consulted.
+            num_samples: Number of calibration samples to generate.
+            seq_length: Sequence length for each sample.
+            extra_options: Additional options. Supported keys:
+                - ``dataset``: Caller-supplied calibration data to use instead
+                  of random data. Accepts any ``Iterable[Tuple[Tensor, ...]]``,
+                  including a ``DataLoader`` with a custom ``collate_fn``, which
+                  allows batched/streamed calibration without materializing the
+                  whole dataset.
+                - ``seed``: Random seed for reproducibility (default: 42).
+
+        Returns:
+            A list of ``(input_ids, attention_mask)`` tuples of shape
+            ``(1, seq_length)``.
+
+        Raises:
+            ValueError: If the tokenizer has no usable ``vocab_size`` and no
+                ``dataset`` was supplied.
+        """
+        import torch
+
+        extra_options = extra_options or {}
+
+        # A caller-supplied dataset takes precedence over random generation.
+        if "dataset" in extra_options:
+            logger.info("Using caller-supplied dataset for calibration")
+            return extra_options["dataset"]
+
+        seed = extra_options.get("seed", DEFAULT_SEED)
+        torch.manual_seed(seed)
+
+        logger.info(
+            "Generating %d random calibration samples (seq_length=%d, seed=%d)",
+            num_samples,
+            seq_length,
+            seed,
+        )
+
+        vocab_size = getattr(tokenizer, "vocab_size", None)
+        if vocab_size is None or vocab_size <= 0:
+            raise ValueError(
+                "Tokenizer does not have a valid vocab_size attribute. "
+                "Cannot generate random calibration data. Supply a dataset "
+                "via extra_options['dataset'] instead."
+            )
+
+        calibration_data: List[Any] = []
+        for _ in range(num_samples):
+            input_ids = torch.randint(0, vocab_size, (1, seq_length))
+            attention_mask = torch.ones(1, seq_length, dtype=torch.long)
+            calibration_data.append((input_ids, attention_mask))
+
+        return calibration_data

--- a/backends/qualcomm/genai_pipeline/datasets/default_training_data_adapter.py
+++ b/backends/qualcomm/genai_pipeline/datasets/default_training_data_adapter.py
@@ -1,0 +1,65 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_NUM_SAMPLES = 128
+DEFAULT_SEQ_LENGTH = 1024
+
+
+class DefaultTrainingDataAdapter:
+    """Pass-through QAT training data provider.
+
+    Training data is **not** synthesized: random tokens carry no learning
+    signal, so there is no meaningful default corpus. Callers enabling QAT must
+    supply their data via ``extra_options["training_data"]``, or inject a
+    corpus-backed :class:`TrainingDataAdapter`.
+    """
+
+    def generate_training_data(
+        self,
+        tokenizer: Any,
+        num_samples: int = DEFAULT_NUM_SAMPLES,
+        seq_length: int = DEFAULT_SEQ_LENGTH,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> Iterable[Tuple[Any, Any]]:
+        """Return caller-supplied QAT training data.
+
+        Args:
+            tokenizer: The tokenizer (unused by this implementation).
+            num_samples: Ignored; retained for protocol conformance.
+            seq_length: Ignored; retained for protocol conformance.
+            extra_options: Additional options. Supported keys:
+                - ``training_data``: ``(features, labels)`` pairs, or any
+                  ``Iterable`` yielding them (including a ``DataLoader``).
+
+        Returns:
+            The caller-supplied ``(features, labels)`` pairs.
+
+        Raises:
+            ValueError: If no ``training_data`` was supplied. QAT cannot proceed
+                without labels, so failing loudly is preferable to silently
+                degrading to PTQ.
+        """
+        extra_options = extra_options or {}
+
+        training_data = extra_options.get("training_data")
+        if training_data is None:
+            raise ValueError(
+                "No training data supplied. DefaultTrainingDataAdapter does not "
+                "synthesize labelled data; pass it via "
+                "extra_options['training_data'] or inject a corpus-backed "
+                "TrainingDataAdapter. For PTQ, skip QAT entirely and use "
+                "CalibrationDataAdapter instead."
+            )
+
+        logger.info("Using caller-supplied training data for QAT")
+        return training_data

--- a/backends/qualcomm/genai_pipeline/datasets/training_data_adapter.py
+++ b/backends/qualcomm/genai_pipeline/datasets/training_data_adapter.py
@@ -1,0 +1,44 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional, Protocol, runtime_checkable, Tuple
+
+
+@runtime_checkable
+class TrainingDataAdapter(Protocol):
+    """Protocol for quantization-aware training (QAT) dataset construction.
+
+    Separate from :class:`CalibrationDataAdapter` because the contracts differ:
+    calibration yields model-argument tuples that get splatted as
+    ``model(*sample)``, whereas training yields ``(features, labels)`` pairs --
+    labels are required to compute a loss and have no analogue in PTQ.
+    """
+
+    def generate_training_data(
+        self,
+        tokenizer: Any,
+        num_samples: int = 128,
+        seq_length: int = 1024,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> Iterable[Tuple[Any, Any]]:
+        """Build the training dataset used for quantization-aware training.
+
+        Args:
+            tokenizer: The tokenizer used to encode text samples.
+            num_samples: Number of training samples to produce.
+            seq_length: Sequence length for each sample.
+            extra_options: Implementation-specific options. Implementations may
+                support a ``training_data`` key accepting caller-supplied data
+                directly, including a ``DataLoader``.
+
+        Returns:
+            An iterable of ``(features, labels)`` pairs. ``features`` is a tuple
+            of model inputs; ``labels`` holds the ground truth. Mirrors the
+            ``qat_training_data`` contract in ``build_executorch_binary``.
+        """
+        ...

--- a/backends/qualcomm/genai_pipeline/strategies/compilation/__init__.py
+++ b/backends/qualcomm/genai_pipeline/strategies/compilation/__init__.py
@@ -7,8 +7,17 @@
 from executorch.backends.qualcomm.genai_pipeline.strategies.compilation.compilation_strategy import (
     CompilationStrategy,
 )
+from executorch.backends.qualcomm.genai_pipeline.strategies.compilation.compiler_adapter import (
+    CompilationResult,
+    CompilerAdapter,
+)
 from executorch.backends.qualcomm.genai_pipeline.strategies.compilation.executorch_compilation_strategy import (
     ExecuTorchCompilationStrategy,
 )
 
-__all__ = ["CompilationStrategy", "ExecuTorchCompilationStrategy"]
+__all__ = [
+    "CompilationResult",
+    "CompilationStrategy",
+    "CompilerAdapter",
+    "ExecuTorchCompilationStrategy",
+]

--- a/backends/qualcomm/genai_pipeline/strategies/compilation/compiler_adapter.py
+++ b/backends/qualcomm/genai_pipeline/strategies/compilation/compiler_adapter.py
@@ -1,0 +1,73 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+
+@dataclass
+class CompilationResult:
+    """Result of a compilation operation.
+
+    Attributes:
+        artifact_paths: Paths to the compiled .pte artifacts.
+        etrecord: Optional ETRecord for debugging.
+    """
+
+    artifact_paths: List[Path] = field(default_factory=list)
+    etrecord: Optional[Any] = None
+
+
+@runtime_checkable
+class CompilerAdapter(Protocol):
+    """Protocol for compilation operations.
+
+    Wraps external compilation APIs (ExportSession, to_edge_transform_and_lower_to_qnn)
+    behind an injectable interface for testability.
+
+    .. note::
+        ``compile_model`` lowers a **single graph**, mirroring the underlying
+        ``to_edge_transform_and_lower_to_qnn`` API. Models exported as several
+        graphs from the same weights (a hybrid decoder's AR-N prefill and AR-1
+        decode, plus an optional token-embedding graph) are looped over by the
+        **compilation strategy**; adapters that group them into one multi-method
+        ``.pte`` may return a single artifact path covering several methods.
+
+        Only *deployed* graphs reach this adapter. A hybrid decoder additionally
+        builds a full-auto-regressive calibration graph, but that exists purely
+        to source quantization encodings and is never lowered.
+    """
+
+    def compile_model(
+        self,
+        model: Any,
+        compile_specs: Any,
+        artifact_dir: Path,
+        file_name: str,
+        soc_model: Any,
+        backend_type: Any,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> CompilationResult:
+        """Compile the model to on-device .pte artifacts.
+
+        Args:
+            model: The model to compile (nn.Module or quantized model).
+            compile_specs: QNN compiler specifications for backend delegation.
+            artifact_dir: Directory to store compiled artifacts.
+            file_name: Base name for the output .pte file.
+            soc_model: Target SoC chipset.
+            backend_type: QNN backend type (HTP, GPU, LPAI).
+            extra_options: Additional compilation options.
+
+        Returns:
+            CompilationResult with artifact paths and optional etrecord. May hold
+            several artifact paths, or a single multi-method .pte, depending on
+            how the implementation groups graphs.
+        """
+        ...

--- a/backends/qualcomm/genai_pipeline/strategies/compilation/default_compiler_adapter.py
+++ b/backends/qualcomm/genai_pipeline/strategies/compilation/default_compiler_adapter.py
@@ -1,0 +1,73 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from executorch.backends.qualcomm.genai_pipeline.strategies.compilation.compiler_adapter import (
+    CompilationResult,
+)
+
+
+class DefaultCompilerAdapter:
+    """Default adapter delegating to the ExportSession recipe-based pipeline.
+
+    .. note::
+        The body is deliberately unimplemented **in this PR only**: this PR
+        establishes the adapter interfaces, and the compilation strategy that
+        drives this adapter lands in the following PR, so the implementation
+        ships alongside its caller rather than ahead of it.
+
+        The APIs it will delegate to -- ``ExportRecipe.get_recipe`` with
+        ``QNNRecipeType.FP16`` and ``ExportSession`` -- are already available
+        in-tree; nothing external is blocking it. Until the follow-up lands,
+        inject a custom ``CompilerAdapter`` implementation.
+    """
+
+    def compile_model(
+        self,
+        model: Any,
+        compile_specs: Any,
+        artifact_dir: Path,
+        file_name: str,
+        soc_model: Any,
+        backend_type: Any,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> CompilationResult:
+        """Compile the model using ExportSession.
+
+        Placeholder for the recipe-based compilation flow, which uses
+        ``ExportRecipe.get_recipe(QNNRecipeType.FP16, ...)`` combined with
+        ``ExportSession``. Implemented in the compilation-strategy PR.
+
+        Args:
+            model: The model to compile (nn.Module or quantized model).
+            compile_specs: QNN compiler specifications (currently unused when
+                using recipe-based flow; kept for future custom compile spec support).
+            artifact_dir: Directory to store compiled .pte artifacts.
+            file_name: Base name for the output .pte file.
+            soc_model: Target SoC chipset enum value.
+            backend_type: QNN backend type (HTP, GPU, LPAI).
+            extra_options: Additional compilation options. Supported keys:
+                - ``example_inputs``: Sample inputs for torch.export.
+                - ``generate_etrecord``: Whether to generate ETRecord.
+                - ``constant_methods``: Dict of constant methods.
+
+        Returns:
+            CompilationResult with artifact paths and optional etrecord.
+
+        Raises:
+            NotImplementedError: Always raised in this PR. The body lands with
+                the compilation strategy that drives it; inject a custom
+                CompilerAdapter until then.
+        """
+        raise NotImplementedError(
+            "DefaultCompilerAdapter is not implemented in this PR: the body "
+            "lands together with the compilation strategy that drives it. "
+            "Inject a custom CompilerAdapter implementation until then."
+        )

--- a/backends/qualcomm/genai_pipeline/strategies/inference/__init__.py
+++ b/backends/qualcomm/genai_pipeline/strategies/inference/__init__.py
@@ -4,6 +4,10 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from executorch.backends.qualcomm.genai_pipeline.strategies.inference.device_runner_adapter import (
+    DeviceRunnerAdapter,
+    InferenceResult,
+)
 from executorch.backends.qualcomm.genai_pipeline.strategies.inference.executorch_inference_strategy import (
     ExecuTorchInferenceStrategy,
 )
@@ -11,4 +15,9 @@ from executorch.backends.qualcomm.genai_pipeline.strategies.inference.inference_
     InferenceStrategy,
 )
 
-__all__ = ["ExecuTorchInferenceStrategy", "InferenceStrategy"]
+__all__ = [
+    "DeviceRunnerAdapter",
+    "ExecuTorchInferenceStrategy",
+    "InferenceResult",
+    "InferenceStrategy",
+]

--- a/backends/qualcomm/genai_pipeline/strategies/inference/default_device_runner_adapter.py
+++ b/backends/qualcomm/genai_pipeline/strategies/inference/default_device_runner_adapter.py
@@ -1,0 +1,146 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from executorch.backends.qualcomm.genai_pipeline.strategies.inference.device_runner_adapter import (
+    InferenceResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DefaultDeviceRunnerAdapter:
+    """Default adapter delegating to ``SimpleADB`` for on-device inference.
+
+    Wraps the ``SimpleADB`` class from ``export_utils.py`` to push artifacts,
+    execute models, and pull results from an Android device via ADB.
+
+    Args:
+        qnn_config: A ``QnnConfig`` instance for device communication.
+        workspace: Folder for storing artifacts on the Android device.
+    """
+
+    def __init__(
+        self,
+        qnn_config: Any,
+        workspace: str = "/data/local/tmp/genai_pipeline",
+    ) -> None:
+        self._qnn_config = qnn_config
+        self._workspace = workspace
+        self._adb: Any = None
+
+    def push_artifacts(
+        self,
+        artifact_paths: List[Path],
+        input_data: Optional[List[Any]] = None,
+        extra_files: Optional[List[str]] = None,
+    ) -> None:
+        """Push compiled artifacts and inputs to the device via ADB.
+
+        Args:
+            artifact_paths: Paths to compiled .pte artifacts.
+            input_data: Optional input data to push to device.
+            extra_files: Optional additional files to push.
+        """
+        from executorch.backends.qualcomm.export_utils import SimpleADB
+
+        if self._adb is not None:
+            logger.warning(
+                "Overwriting existing ADB session. Previous artifacts will be "
+                "replaced on device."
+            )
+
+        pte_paths = [str(p) for p in artifact_paths]
+
+        logger.info("Pushing artifacts to device: %s", pte_paths)
+        self._adb = SimpleADB(
+            qnn_config=self._qnn_config,
+            pte_path=pte_paths,
+            workspace=self._workspace,
+        )
+        self._adb.push(
+            inputs=input_data,
+            files=extra_files,
+        )
+
+    def execute(
+        self,
+        inference_options: Optional[Dict[str, Any]] = None,
+    ) -> InferenceResult:
+        """Execute the model on device via ADB.
+
+        Args:
+            inference_options: Engine-specific options. Supported keys:
+                - ``method_index``: Index of the method to execute (default 0).
+                - ``iteration``: Number of inference iterations (default 1).
+
+        Returns:
+            InferenceResult with output data and performance metrics.
+        """
+        if self._adb is None:
+            raise RuntimeError(
+                "No artifacts have been pushed. Call push_artifacts() first."
+            )
+
+        inference_options = inference_options or {}
+        method_index = inference_options.get("method_index", 0)
+        iteration = inference_options.get("iteration", 1)
+
+        logger.info(
+            "Executing on device: method_index=%d, iteration=%d",
+            method_index,
+            iteration,
+        )
+        self._adb.execute(
+            method_index=method_index,
+            iteration=iteration,
+        )
+
+        return InferenceResult(
+            output_data=None,
+            performance_metrics={
+                "method_index": method_index,
+                "iteration": iteration,
+            },
+        )
+
+    def pull_results(
+        self,
+        output_dir: Path,
+    ) -> List[Path]:
+        """Pull inference results from the device via ADB.
+
+        Args:
+            output_dir: Local directory to store pulled results.
+
+        Returns:
+            List of paths to pulled result files.
+        """
+        if self._adb is None:
+            raise RuntimeError(
+                "No artifacts have been pushed. Call push_artifacts() first."
+            )
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.info("Pulling results from device to %s", output_dir)
+        self._adb.pull(host_output_path=str(output_dir))
+
+        # adb pull of a directory creates a subdirectory locally;
+        # collect actual result files from pulled content
+        result_files = []
+        for item in output_dir.iterdir():
+            if item.is_dir():
+                result_files.extend(item.iterdir())
+            else:
+                result_files.append(item)
+        logger.info("Pulled %d result files", len(result_files))
+        return result_files

--- a/backends/qualcomm/genai_pipeline/strategies/inference/device_runner_adapter.py
+++ b/backends/qualcomm/genai_pipeline/strategies/inference/device_runner_adapter.py
@@ -1,0 +1,78 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+
+@dataclass
+class InferenceResult:
+    """Result of an on-device inference run.
+
+    Attributes:
+        output_data: Raw output data from the model execution.
+        performance_metrics: Performance data (e.g., TTFT, tokens/sec).
+        etdump: Optional ETDump for debugging.
+    """
+
+    output_data: Optional[List[Any]] = None
+    performance_metrics: Dict[str, Any] = field(default_factory=dict)
+    etdump: Optional[Any] = None
+
+
+@runtime_checkable
+class DeviceRunnerAdapter(Protocol):
+    """Protocol for on-device inference operations.
+
+    Wraps external device runner APIs (SimpleADB) behind an injectable
+    interface for testability.
+    """
+
+    def push_artifacts(
+        self,
+        artifact_paths: List[Path],
+        input_data: Optional[List[Any]] = None,
+        extra_files: Optional[List[str]] = None,
+    ) -> None:
+        """Push compiled artifacts and inputs to the device.
+
+        Args:
+            artifact_paths: Paths to compiled .pte artifacts.
+            input_data: Optional input data to push to device.
+            extra_files: Optional additional files to push.
+        """
+        ...
+
+    def execute(
+        self,
+        inference_options: Optional[Dict[str, Any]] = None,
+    ) -> InferenceResult:
+        """Execute the model on device.
+
+        Args:
+            inference_options: Engine-specific inference options.
+
+        Returns:
+            InferenceResult with output data and performance metrics.
+        """
+        ...
+
+    def pull_results(
+        self,
+        output_dir: Path,
+    ) -> List[Path]:
+        """Pull inference results from the device.
+
+        Args:
+            output_dir: Local directory to store pulled results.
+
+        Returns:
+            List of paths to pulled result files.
+        """
+        ...

--- a/backends/qualcomm/genai_pipeline/strategies/model_preparation/__init__.py
+++ b/backends/qualcomm/genai_pipeline/strategies/model_preparation/__init__.py
@@ -4,8 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from executorch.backends.qualcomm.genai_pipeline.strategies.model_preparation.model_loader_adapter import (
+    ModelLoaderAdapter,
+)
 from executorch.backends.qualcomm.genai_pipeline.strategies.model_preparation.model_preparation_strategy import (
     ModelPreparationStrategy,
 )
 
-__all__ = ["ModelPreparationStrategy"]
+__all__ = [
+    "ModelLoaderAdapter",
+    "ModelPreparationStrategy",
+]

--- a/backends/qualcomm/genai_pipeline/strategies/model_preparation/default_model_loader_adapter.py
+++ b/backends/qualcomm/genai_pipeline/strategies/model_preparation/default_model_loader_adapter.py
@@ -1,0 +1,133 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class DefaultModelLoaderAdapter:
+    """Default adapter delegating to HuggingFace transformers for model loading.
+
+    Wraps ``AutoModelForCausalLM`` and ``AutoTokenizer`` for production use.
+    Requires ``transformers`` to be installed.
+
+    .. note::
+        This adapter is designed for **text-only causal LM** models.
+        For multimodal models (vision/audio encoders), use a specialized adapter
+        (e.g., ``MultiModalModelLoaderAdapter``) that handles separate encoder/decoder
+        loading via ``AutoModel`` or ``AutoModelForSpeechSeq2Seq``.
+
+    .. note::
+        Calibration data is **not** produced here -- see
+        ``CalibrationDataAdapter``.
+    """
+
+    def load_model(
+        self,
+        model_name: str,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Load a causal LM model from HuggingFace hub or local path.
+
+        Args:
+            model_name: HuggingFace model ID or local path.
+            extra_options: Additional options. Supported keys:
+                - ``torch_dtype``: dtype for model weights (default: float32).
+                - ``device_map``: device placement strategy.
+                - ``attn_implementation``: attention implementation to use.
+
+        Returns:
+            The loaded nn.Module in eval mode.
+        """
+        import torch
+        from transformers import AutoModelForCausalLM
+
+        extra_options = extra_options or {}
+        torch_dtype = extra_options.get("torch_dtype", torch.float32)
+        device_map = extra_options.get("device_map", "cpu")
+        attn_impl = extra_options.get("attn_implementation")
+
+        logger.info("Loading model '%s' with dtype=%s", model_name, torch_dtype)
+
+        kwargs: Dict[str, Any] = {
+            "torch_dtype": torch_dtype,
+            "device_map": device_map,
+        }
+        if attn_impl:
+            kwargs["attn_implementation"] = attn_impl
+
+        model = AutoModelForCausalLM.from_pretrained(model_name, **kwargs)
+        model.eval()
+
+        logger.info("Model loaded successfully")
+        return model
+
+    def load_tokenizer(
+        self,
+        model_name: str,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Load the tokenizer for the given model.
+
+        Args:
+            model_name: HuggingFace model ID or local path.
+            extra_options: Additional tokenizer options.
+
+        Returns:
+            The loaded tokenizer instance.
+        """
+        from transformers import AutoTokenizer
+
+        extra_options = extra_options or {}
+
+        logger.info("Loading tokenizer for '%s'", model_name)
+        tokenizer = AutoTokenizer.from_pretrained(model_name, **extra_options)
+
+        logger.info("Tokenizer loaded successfully")
+        return tokenizer
+
+    def export_tokenizer(
+        self,
+        tokenizer: Any,
+        output_dir: Path,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> Path:
+        """Export tokenizer to disk and return the runtime tokenizer file.
+
+        ``save_pretrained`` writes several files and returns the tuple of paths
+        it wrote, with the tokenizer file last. Both ``llm::load_tokenizer`` and
+        ``pytorch_tokenizers.get_tokenizer`` expect that **single file**, not the
+        containing directory, so we return it -- mirroring the existing
+        ``TokenizerWrapper._from_hf`` flow.
+
+        Args:
+            tokenizer: The tokenizer instance to export.
+            output_dir: Directory to write the exported tokenizer artifacts to.
+            extra_options: Additional export options.
+
+        Returns:
+            Path to the runtime tokenizer file (e.g. ``tokenizer.json``).
+
+        Raises:
+            FileNotFoundError: If no tokenizer artifacts were written.
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        logger.info("Exporting tokenizer to %s", output_dir)
+        artifacts = tokenizer.save_pretrained(str(output_dir))
+        if not artifacts:
+            raise FileNotFoundError(
+                f"save_pretrained() reported no tokenizer artifacts in {output_dir}."
+            )
+
+        runtime_tokenizer_path = Path(artifacts[-1])
+        logger.info("Tokenizer exported to %s", runtime_tokenizer_path)
+        return runtime_tokenizer_path

--- a/backends/qualcomm/genai_pipeline/strategies/model_preparation/model_loader_adapter.py
+++ b/backends/qualcomm/genai_pipeline/strategies/model_preparation/model_loader_adapter.py
@@ -1,0 +1,105 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ModelLoaderAdapter(Protocol):
+    """Protocol for model and tokenizer loading operations.
+
+    Wraps external model loading APIs (HuggingFace ``AutoModelForCausalLM``,
+    ``AutoTokenizer``, etc.) behind an injectable interface for testability.
+
+    Scope is limited to acquiring the model and its tokenizer. Datasets are a
+    cross-stage concern and live in ``genai_pipeline.datasets``
+    (:class:`CalibrationDataAdapter`, :class:`TrainingDataAdapter`).
+
+    .. note::
+        Implementations vary by **loading mechanism**, not by model family.
+        ``DefaultModelLoaderAdapter`` covers every text-only causal LM reachable
+        via HuggingFace ``AutoModelForCausalLM``; a new implementation is only
+        warranted when the mechanism itself differs (multimodal models needing
+        ``AutoModel`` / ``AutoModelForSpeechSeq2Seq``, a GGUF loader, a local
+        checkpoint format, ...).
+
+        Per-model **graph and weight transformations** are deliberately *not*
+        expressed by subclassing this protocol -- overlapping transform sets
+        (e.g. Llama needing ``[A, B, C]`` while Gemma needs ``[B, C, D]``) would
+        be reimplemented in each subclass. They are instead declared as data on
+        the model registry entry, so each transform is implemented once and
+        shared, and adding a model is a registry row rather than a new class.
+
+        The exact shape of that declaration is intentionally left open here: the
+        transforms in the existing flow are not uniform -- some rewrite the
+        state dict before it is loaded, some need the constructed module, and
+        some replace the module -- and the ordering between those kinds matters.
+        Pinning a single flat transform list now would encode the wrong
+        contract, so the registry columns land with the transforms themselves
+        once each is extracted into a named, shared function.
+
+    A single call returns **one** model. Multi-graph export configurations of the
+    same weights (hybrid prefill/decode, a separate token-embedding graph) are
+    expanded by the quantization and compilation *strategies*, and genuinely
+    multi-module models (multimodal encoders) belong in a specialized adapter.
+    """
+
+    def load_model(
+        self,
+        model_name: str,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Load a model by name or path.
+
+        Args:
+            model_name: Model identifier (e.g., HuggingFace model ID or local path).
+            extra_options: Additional model loading options (dtype, device_map, etc.).
+
+        Returns:
+            The loaded nn.Module.
+        """
+        ...
+
+    def load_tokenizer(
+        self,
+        model_name: str,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Load the tokenizer for the given model.
+
+        Args:
+            model_name: Model identifier matching the model.
+            extra_options: Additional tokenizer options.
+
+        Returns:
+            The tokenizer instance.
+        """
+        ...
+
+    def export_tokenizer(
+        self,
+        tokenizer: Any,
+        output_dir: Path,
+        extra_options: Optional[Dict[str, Any]] = None,
+    ) -> Path:
+        """Export tokenizer for on-device runtime use.
+
+        Args:
+            tokenizer: The tokenizer instance to export.
+            output_dir: Directory to write the exported tokenizer artifacts to.
+            extra_options: Additional export options.
+
+        Returns:
+            Path to the exported runtime tokenizer **file** (not the containing
+            directory). The returned path must be directly loadable by
+            ``pytorch_tokenizers.get_tokenizer`` and the C++
+            ``llm::load_tokenizer`` runtime, both of which expect a single file
+            such as ``tokenizer.json`` or ``tokenizer.model``.
+        """
+        ...

--- a/backends/qualcomm/genai_pipeline/strategies/quantization/__init__.py
+++ b/backends/qualcomm/genai_pipeline/strategies/quantization/__init__.py
@@ -10,5 +10,12 @@ from executorch.backends.qualcomm.genai_pipeline.strategies.quantization.executo
 from executorch.backends.qualcomm.genai_pipeline.strategies.quantization.quantization_strategy import (
     QuantizationStrategy,
 )
+from executorch.backends.qualcomm.genai_pipeline.strategies.quantization.quantizer_adapter import (
+    QuantizerAdapter,
+)
 
-__all__ = ["ExecuTorchQuantizationStrategy", "QuantizationStrategy"]
+__all__ = [
+    "ExecuTorchQuantizationStrategy",
+    "QuantizationStrategy",
+    "QuantizerAdapter",
+]

--- a/backends/qualcomm/genai_pipeline/strategies/quantization/default_quantizer_adapter.py
+++ b/backends/qualcomm/genai_pipeline/strategies/quantization/default_quantizer_adapter.py
@@ -1,0 +1,144 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class DefaultQuantizerAdapter:
+    """Default adapter delegating to real ExecuTorch/QNN quantization APIs.
+
+    Wraps ``export_utils.make_quantizer``, ``torchao.quantization.pt2e.prepare_pt2e``,
+    and ``torchao.quantization.pt2e.convert_pt2e`` for production use.
+    """
+
+    def make_quantizer(
+        self,
+        quant_dtype: Any,
+        backend: Any,
+        soc_model: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Create a QNN quantizer via ``export_utils.make_quantizer``.
+
+        Args:
+            quant_dtype: Quantization data type.
+            backend: QNN backend type enum.
+            soc_model: Target SoC (string name like "SM8750" or QcomChipset enum).
+            **kwargs: Forwarded to ``make_quantizer``.
+
+        Returns:
+            A configured ``QnnQuantizer`` instance.
+        """
+        from executorch.backends.qualcomm.export_utils import (
+            make_quantizer as _make_quantizer,
+        )
+
+        # export_utils.make_quantizer expects soc_model as a string for
+        # getattr(QcomChipset, soc_model) lookup. Normalize enum → string.
+        soc_model_str = soc_model.name if hasattr(soc_model, "name") else str(soc_model)
+
+        logger.debug(
+            "Creating quantizer: dtype=%s, backend=%s, soc=%s",
+            quant_dtype,
+            backend,
+            soc_model_str,
+        )
+        return _make_quantizer(
+            quant_dtype=quant_dtype,
+            backend=backend,
+            soc_model=soc_model_str,
+            **kwargs,
+        )
+
+    def export_model(
+        self,
+        model: Any,
+        sample_input: Any,
+    ) -> Any:
+        """Export the model using ``torch.export.export``.
+
+        Args:
+            model: The nn.Module to export.
+            sample_input: Sample input tuple for tracing.
+
+        Returns:
+            The exported module (``ExportedProgram.module()``).
+        """
+        logger.debug("Exporting model via torch.export.export")
+        return torch.export.export(model, sample_input, strict=False).module()
+
+    def prepare_pt2e(
+        self,
+        model: Any,
+        quantizer: Any,
+    ) -> Any:
+        """Prepare the model for PT2E quantization.
+
+        Args:
+            model: The exported model.
+            quantizer: The configured quantizer.
+
+        Returns:
+            The annotated model with observers inserted.
+        """
+        from torchao.quantization.pt2e.quantize_pt2e import (
+            prepare_pt2e as _prepare_pt2e,
+        )
+
+        logger.debug("Preparing model for PT2E quantization")
+        return _prepare_pt2e(model, quantizer)
+
+    def calibrate(
+        self,
+        model: Any,
+        calibration_data: Iterable[Any],
+    ) -> Any:
+        """Run calibration data through the annotated model.
+
+        One forward pass per sample. Adapters needing a stateful procedure --
+        e.g. autoregressive LLM calibration, where each step's input depends on
+        the previous step's output and the KV cache mutates across steps --
+        should override this method rather than passing a callable as data.
+
+        Args:
+            model: The annotated model with observers.
+            calibration_data: Any ``Iterable[Tuple[Tensor, ...]]``, including a
+                plain list or a ``DataLoader``.
+
+        Returns:
+            The calibrated model.
+        """
+        logger.debug("Running calibration")
+        with torch.no_grad():
+            for data in calibration_data:
+                model(*data)
+        return model
+
+    def convert_pt2e(
+        self,
+        model: Any,
+    ) -> Any:
+        """Convert the calibrated model to a quantized model.
+
+        Args:
+            model: The calibrated model.
+
+        Returns:
+            The quantized model.
+        """
+        from torchao.quantization.pt2e.quantize_pt2e import (
+            convert_pt2e as _convert_pt2e,
+        )
+
+        logger.debug("Converting PT2E model to quantized form")
+        return _convert_pt2e(model)

--- a/backends/qualcomm/genai_pipeline/strategies/quantization/quantizer_adapter.py
+++ b/backends/qualcomm/genai_pipeline/strategies/quantization/quantizer_adapter.py
@@ -1,0 +1,120 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class QuantizerAdapter(Protocol):
+    """Protocol for quantization operations.
+
+    Wraps external quantization APIs (make_quantizer, prepare_pt2e, convert_pt2e)
+    behind an injectable interface for testability.
+
+    .. note::
+        These methods operate on a **single graph**, mirroring the underlying
+        ``torchao`` PT2E APIs, and adapters stay a thin 1:1 wrapper over them.
+
+        For models exported as several graphs from the same weights -- e.g. a
+        hybrid decoder -- only one graph is actually quantized: a dedicated
+        full-auto-regressive calibration graph, which yields the best activation
+        statistics but is never deployed. Its scales and zero points are then
+        propagated onto the deployed graphs (AR-N prefill, AR-1 decode), which do
+        not run PT2E themselves. That propagation is inherently cross-graph, so
+        it cannot live in a per-graph method here; the **quantization strategy**
+        sequences it via a separate reconciliation hook after this adapter
+        returns.
+    """
+
+    def make_quantizer(
+        self,
+        quant_dtype: Any,
+        backend: Any,
+        soc_model: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Create a QNN quantizer with the given configuration.
+
+        Args:
+            quant_dtype: Quantization data type (e.g., QuantDtype.use_8a8w).
+            backend: QNN backend type (HTP, GPU, LPAI).
+            soc_model: Target SoC chipset.
+            **kwargs: Additional quantizer options (per_channel, observers, etc.).
+
+        Returns:
+            A configured quantizer instance.
+        """
+        ...
+
+    def export_model(
+        self,
+        model: Any,
+        sample_input: Any,
+    ) -> Any:
+        """Export the model using torch.export.
+
+        Args:
+            model: The nn.Module to export.
+            sample_input: Sample input tuple for tracing.
+
+        Returns:
+            The exported model (e.g., ExportedProgram.module()).
+        """
+        ...
+
+    def prepare_pt2e(
+        self,
+        model: Any,
+        quantizer: Any,
+    ) -> Any:
+        """Prepare the model for PT2E quantization (insert observers).
+
+        Args:
+            model: The exported model.
+            quantizer: The configured quantizer.
+
+        Returns:
+            The annotated model with observers inserted.
+        """
+        ...
+
+    def calibrate(
+        self,
+        model: Any,
+        calibration_data: Iterable[Any],
+    ) -> Any:
+        """Run calibration data through the annotated model.
+
+        Implementations needing a non-trivial procedure -- e.g. autoregressive
+        LLM calibration, where each step's input depends on the previous step's
+        output -- should override this method rather than encoding the procedure
+        in ``calibration_data``.
+
+        Args:
+            model: The annotated model with observers.
+            calibration_data: Any ``Iterable[Tuple[Tensor, ...]]``, including a
+                plain list or a ``DataLoader``.
+
+        Returns:
+            The calibrated model.
+        """
+        ...
+
+    def convert_pt2e(
+        self,
+        model: Any,
+    ) -> Any:
+        """Convert the calibrated model to a quantized model.
+
+        Args:
+            model: The calibrated model.
+
+        Returns:
+            The quantized model with fake quantize nodes replaced.
+        """
+        ...

--- a/backends/qualcomm/genai_pipeline/tests/configs/test_quantization_input_config.py
+++ b/backends/qualcomm/genai_pipeline/tests/configs/test_quantization_input_config.py
@@ -24,6 +24,24 @@ class TestQuantizationInputConfig(unittest.TestCase):
         with self.assertRaises(TypeError):
             QuantizationInputConfig()
 
+    def test_optional_fields_default_to_none(self):
+        config = QuantizationInputConfig(
+            soc_model=MagicMock(), backend_type=MagicMock()
+        )
+        self.assertIsNone(config.model_module)
+        self.assertIsNone(config.calibration_data)
+        self.assertIsNone(config.training_data)
+        self.assertIsNone(config.quant_recipe)
+
+    def test_training_data_carries_qat_dataset(self):
+        training_data = [("features", "labels")]
+        config = QuantizationInputConfig(
+            soc_model=MagicMock(),
+            backend_type=MagicMock(),
+            training_data=training_data,
+        )
+        self.assertIs(config.training_data, training_data)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backends/qualcomm/genai_pipeline/tests/datasets/test_default_calibration_data_adapter.py
+++ b/backends/qualcomm/genai_pipeline/tests/datasets/test_default_calibration_data_adapter.py
@@ -1,0 +1,96 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from executorch.backends.qualcomm.genai_pipeline.datasets.default_calibration_data_adapter import (
+    DefaultCalibrationDataAdapter,
+)
+
+TEST_VOCAB_SIZE = 32000
+TEST_NUM_SAMPLES = 4
+TEST_SEQ_LENGTH = 16
+
+
+def _make_tokenizer(vocab_size=TEST_VOCAB_SIZE):
+    tokenizer = MagicMock()
+    tokenizer.vocab_size = vocab_size
+    return tokenizer
+
+
+class TestGenerateCalibrationData(unittest.TestCase):
+
+    def setUp(self):
+        self.adapter = DefaultCalibrationDataAdapter()
+
+    def test_generates_requested_number_of_samples(self):
+        data = self.adapter.generate_calibration_data(
+            _make_tokenizer(),
+            num_samples=TEST_NUM_SAMPLES,
+            seq_length=TEST_SEQ_LENGTH,
+        )
+        self.assertEqual(len(data), TEST_NUM_SAMPLES)
+
+    def test_sample_shape_and_dtype(self):
+        data = self.adapter.generate_calibration_data(
+            _make_tokenizer(), num_samples=1, seq_length=TEST_SEQ_LENGTH
+        )
+        input_ids, attention_mask = data[0]
+        self.assertEqual(input_ids.shape, (1, TEST_SEQ_LENGTH))
+        self.assertEqual(attention_mask.shape, (1, TEST_SEQ_LENGTH))
+        self.assertEqual(attention_mask.dtype, torch.long)
+
+    def test_tokens_within_vocab_range(self):
+        vocab_size = 128
+        data = self.adapter.generate_calibration_data(
+            _make_tokenizer(vocab_size),
+            num_samples=TEST_NUM_SAMPLES,
+            seq_length=TEST_SEQ_LENGTH,
+        )
+        for input_ids, _ in data:
+            self.assertGreaterEqual(int(input_ids.min()), 0)
+            self.assertLess(int(input_ids.max()), vocab_size)
+
+    def test_seed_makes_generation_reproducible(self):
+        kwargs = {
+            "num_samples": TEST_NUM_SAMPLES,
+            "seq_length": TEST_SEQ_LENGTH,
+            "extra_options": {"seed": 7},
+        }
+        first = self.adapter.generate_calibration_data(_make_tokenizer(), **kwargs)
+        second = self.adapter.generate_calibration_data(_make_tokenizer(), **kwargs)
+        for (ids_a, _), (ids_b, _) in zip(first, second):
+            self.assertTrue(torch.equal(ids_a, ids_b))
+
+    def test_provided_list_dataset_is_returned_unchanged(self):
+        dataset = [(torch.zeros(1, 4, dtype=torch.long),)]
+        result = self.adapter.generate_calibration_data(
+            _make_tokenizer(), extra_options={"dataset": dataset}
+        )
+        self.assertIs(result, dataset)
+
+    def test_provided_dataloader_is_returned_unchanged(self):
+        # A DataLoader is an Iterable, so it is accepted without materialization.
+        dataloader = torch.utils.data.DataLoader(
+            [(torch.zeros(4, dtype=torch.long),)], batch_size=1
+        )
+        result = self.adapter.generate_calibration_data(
+            _make_tokenizer(), extra_options={"dataset": dataloader}
+        )
+        self.assertIs(result, dataloader)
+
+    def test_unusable_vocab_size_raises(self):
+        for vocab_size in (None, 0):
+            with self.subTest(vocab_size=vocab_size):
+                with self.assertRaises(ValueError):
+                    self.adapter.generate_calibration_data(_make_tokenizer(vocab_size))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/qualcomm/genai_pipeline/tests/datasets/test_default_training_data_adapter.py
+++ b/backends/qualcomm/genai_pipeline/tests/datasets/test_default_training_data_adapter.py
@@ -1,0 +1,51 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from executorch.backends.qualcomm.genai_pipeline.datasets.default_training_data_adapter import (
+    DefaultTrainingDataAdapter,
+)
+
+
+class TestGenerateTrainingData(unittest.TestCase):
+
+    def setUp(self):
+        self.adapter = DefaultTrainingDataAdapter()
+        self.tokenizer = MagicMock()
+
+    def test_returns_provided_feature_label_pairs(self):
+        training_data = [((torch.zeros(1, 4),), torch.ones(1))]
+        result = self.adapter.generate_training_data(
+            self.tokenizer, extra_options={"training_data": training_data}
+        )
+        self.assertIs(result, training_data)
+
+    def test_accepts_a_dataloader(self):
+        dataloader = torch.utils.data.DataLoader(
+            [(torch.zeros(4), torch.ones(1))], batch_size=1
+        )
+        result = self.adapter.generate_training_data(
+            self.tokenizer, extra_options={"training_data": dataloader}
+        )
+        self.assertIs(result, dataloader)
+
+    def test_raises_when_no_training_data_supplied(self):
+        # Labelled data cannot be synthesized, so QAT must fail loudly rather
+        # than silently degrading to PTQ.
+        for extra_options in (None, {}, {"training_data": None}):
+            with self.subTest(extra_options=extra_options):
+                with self.assertRaises(ValueError):
+                    self.adapter.generate_training_data(
+                        self.tokenizer, extra_options=extra_options
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/qualcomm/genai_pipeline/tests/strategies/model_preparation/test_default_model_loader_adapter.py
+++ b/backends/qualcomm/genai_pipeline/tests/strategies/model_preparation/test_default_model_loader_adapter.py
@@ -1,0 +1,65 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from executorch.backends.qualcomm.genai_pipeline.strategies.model_preparation.default_model_loader_adapter import (
+    DefaultModelLoaderAdapter,
+)
+
+TEST_TOKENIZER_CONFIG = "tokenizer_config.json"
+TEST_SPECIAL_TOKENS_MAP = "special_tokens_map.json"
+TEST_TOKENIZER_JSON = "tokenizer.json"
+
+
+class TestExportTokenizer(unittest.TestCase):
+    """The runtime (llm::load_tokenizer / pytorch_tokenizers.get_tokenizer)
+    expects a single tokenizer *file*, never the containing directory."""
+
+    def setUp(self):
+        self.adapter = DefaultModelLoaderAdapter()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.output_dir = Path(self._tmp.name) / "tokenizer_out"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _make_tokenizer(self, artifacts):
+        tokenizer = MagicMock()
+        tokenizer.save_pretrained.return_value = artifacts
+        return tokenizer
+
+    def test_returns_tokenizer_file_not_the_directory(self):
+        artifacts = (
+            str(self.output_dir / TEST_TOKENIZER_CONFIG),
+            str(self.output_dir / TEST_SPECIAL_TOKENS_MAP),
+            str(self.output_dir / TEST_TOKENIZER_JSON),
+        )
+        result = self.adapter.export_tokenizer(
+            self._make_tokenizer(artifacts), self.output_dir
+        )
+        self.assertEqual(result, self.output_dir / TEST_TOKENIZER_JSON)
+        self.assertNotEqual(result, self.output_dir)
+
+    def test_creates_output_directory(self):
+        artifacts = (str(self.output_dir / TEST_TOKENIZER_JSON),)
+        self.adapter.export_tokenizer(self._make_tokenizer(artifacts), self.output_dir)
+        self.assertTrue(self.output_dir.is_dir())
+
+    def test_raises_when_no_artifacts_written(self):
+        for artifacts in (None, ()):
+            with self.subTest(artifacts=artifacts):
+                with self.assertRaises(FileNotFoundError):
+                    self.adapter.export_tokenizer(
+                        self._make_tokenizer(artifacts), self.output_dir
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/qualcomm/genai_pipeline/tests/strategies/quantization/test_default_quantizer_adapter.py
+++ b/backends/qualcomm/genai_pipeline/tests/strategies/quantization/test_default_quantizer_adapter.py
@@ -1,0 +1,58 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from executorch.backends.qualcomm.genai_pipeline.strategies.quantization.default_quantizer_adapter import (
+    DefaultQuantizerAdapter,
+)
+
+
+class TestCalibrate(unittest.TestCase):
+
+    def setUp(self):
+        self.adapter = DefaultQuantizerAdapter()
+
+    def test_runs_one_forward_pass_per_sample(self):
+        model = MagicMock()
+        data = [(torch.zeros(1, 2),), (torch.ones(1, 2),)]
+        self.adapter.calibrate(model, data)
+        self.assertEqual(model.call_count, len(data))
+
+    def test_unpacks_tuple_into_positional_args(self):
+        model = MagicMock()
+        input_ids, attention_mask = torch.zeros(1, 2), torch.ones(1, 2)
+        self.adapter.calibrate(model, [(input_ids, attention_mask)])
+        model.assert_called_once_with(input_ids, attention_mask)
+
+    def test_returns_the_model(self):
+        model = MagicMock()
+        self.assertIs(self.adapter.calibrate(model, []), model)
+
+    def test_accepts_a_dataloader(self):
+        # A DataLoader with a collate_fn that yields the sample tuple unchanged
+        # is consumed directly, with no re-wrapping by the caller.
+        model = MagicMock()
+        input_ids, attention_mask = torch.zeros(1, 2), torch.ones(1, 2)
+        dataloader = torch.utils.data.DataLoader(
+            [(input_ids, attention_mask)],
+            batch_size=1,
+            collate_fn=lambda batch: batch[0],
+        )
+        self.adapter.calibrate(model, dataloader)
+        model.assert_called_once_with(input_ids, attention_mask)
+
+    def test_empty_dataset_is_a_no_op(self):
+        model = MagicMock()
+        self.adapter.calibrate(model, [])
+        model.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/qualcomm/genai_pipeline/tests/test_pipeline_context.py
+++ b/backends/qualcomm/genai_pipeline/tests/test_pipeline_context.py
@@ -93,6 +93,30 @@ class TestPipelineContextBuilder(unittest.TestCase):
         )
         self.assertEqual(ctx.prompt, test_prompts)
 
+    def test_blank_string_prompt_raises(self):
+        for blank in ("", "   ", "\t\n"):
+            with self.subTest(prompt=repr(blank)):
+                with self.assertRaises(ValueError) as cm:
+                    PipelineContext.builder().with_prompt(blank)
+                self.assertIn("empty or blank", str(cm.exception))
+
+    def test_all_blank_list_prompt_raises(self):
+        for blanks in ([], ["", "  "], [None, 42]):
+            with self.subTest(prompt=blanks):
+                with self.assertRaises(ValueError) as cm:
+                    PipelineContext.builder().with_prompt(blanks)
+                self.assertIn("cannot be empty", str(cm.exception))
+
+    def test_blank_and_non_string_list_entries_are_dropped(self):
+        ctx = (
+            PipelineContext.builder()
+            .with_model("test")
+            .with_soc(TEST_SOC_MODEL)
+            .with_prompt(["keep me", "", "   ", None, 42, "and me"])
+            .build()
+        )
+        self.assertEqual(ctx.prompt, ["keep me", "and me"])
+
     def test_with_artifact_dir(self):
         custom_dir = "/custom/path"
         ctx = (


### PR DESCRIPTION
## Summary

This PR adds the __adapter layer__ that wraps external APIs (ExecuTorch, QNN SDK, HuggingFace) behind injectable Protocol interfaces for testability. Each strategy implementation (in subsequent PRs) delegates to these adapters rather than calling external APIs directly, enabling unit tests with mocked dependencies.

### What's included

#### Adapter Protocols (6 files):

- `QuantizerAdapter`: Protocol wrapping `make_quantizer`, `prepare_pt2e`, `calibrate`, `convert_pt2e`
- `CompilerAdapter`: Protocol wrapping `ExportSession` compilation flow + `CompilationResult` dataclass
- `DeviceRunnerAdapter`: Protocol wrapping `SimpleADB` push/execute/pull + `InferenceResult` dataclass
- `ModelLoaderAdapter`: Protocol wrapping HuggingFace model/tokenizer loading
- `CalibrationDataAdapter`: Protocol for calibration dataset construction
- `TrainingDataAdapter`: Protocol for QAT training data (yields (features, labels) pairs)

#### Default Implementations (6 files):

- `DefaultQuantizerAdapter`: Delegates to `export_utils.make_quantizer` + `torchao.quantization.pt2e`
- `DefaultCompilerAdapter`: Placeholder for recipe-based compilation (depends on `ExportRecipe`/`ExportSession` APIs not yet available). Raises `NotImplementedError` with guidance to inject a custom `CompilerAdapter` using `to_edge_transform_and_lower_to_qnn`.
- `DefaultDeviceRunnerAdapter`: Delegates to `SimpleADB` for on-device execution
- `DefaultModelLoaderAdapter`: Delegates to HuggingFace `AutoModelForCausalLM` + `AutoTokenizer`
- `DefaultCalibrationDataAdapter`: Random token sequences; accepts a caller-supplied dataset or DataLoader via extra_options["dataset"]
- `DefaultTrainingDataAdapter`: Pass-through for caller-supplied QAT data; raises ValueError if absent (labelled data can't be synthesized)

#### Configuration:

- `.coveragerc` updated to omit `default_*_adapter.py` files (integration-test-only, require real SDK/hardware)
- `__init__.py` files updated to export new adapter types

#### New `datasets/` package

Dataset providers are a __cross-stage__ concern, not a model-preparation detail — the same corpus feeds PTQ calibration during quantization *and* 
on-device result evaluation during inference (including pre-built `.pte` flows where model preparation never runs). 
They therefore live in a top-level `datasets/` package rather than under `strategies/model_preparation/`.

### PR Review Checklist

- All new classes follow single responsibility (one class per file) - Yes.
- All dependencies are injected via constructor with sensible defaults - Yes.
- All external calls are behind injectable interfaces - Yes (Protocol pattern).
- Unit tests cover every public method - Yes.
- No existing files are modified (Phase 1 constraint) - Yes (only existing files modified are those added in previous GenAI prs).
- Docstrings on all public classes and methods - Yes.
- Type annotations on all function signatures - Yes.
- Logging follows the strategy in the LLD - Yes (lazy imports, debug-level logging in defaults).

### Related PRs

- PR 1: Core data model, engine routing & exceptions: https://github.com/pytorch/executorch/pull/20409
- PR 2: Strategy interfaces & stage wrappers: https://github.com/pytorch/executorch/pull/20795
- PR 3: Pipeline orchestrator: https://github.com/pytorch/executorch/pull/21149
- PR 4: Adapter interfaces, default implementations & dataset providers: this pr.
- PR 5: Model preparation & quantization strategies: pending
- PR 6: Compilation & inference strategy implementations: pending.
- PR 7: Integration & E2E tests: pending.

## Test plan

```
python -m pytest \
  backends/qualcomm/genai_pipeline/tests/ \
  -v
```

All existing tests continue to pass (no regressions).

### Test Coverage

Command to run:

```
python -m pytest backends/qualcomm/genai_pipeline/tests/ \
  --cov=backends/qualcomm/genai_pipeline \
  --cov-config=backends/qualcomm/.coveragerc \
  --cov-report=term-missing
```

Result:

```
Name                                                                                                     Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------------------------------------------------------------------------------------
backends/qualcomm/genai_pipeline/configs/compilation_input_config.py                                        11      0      0      0   100%
backends/qualcomm/genai_pipeline/configs/compilation_output_config.py                                        8      0      0      0   100%
backends/qualcomm/genai_pipeline/configs/inference_input_config.py                                          12      0      0      0   100%
backends/qualcomm/genai_pipeline/configs/inference_output_config.py                                          9      0      0      0   100%
backends/qualcomm/genai_pipeline/configs/model_preparation_input_config.py                                   7      0      0      0   100%
backends/qualcomm/genai_pipeline/configs/model_preparation_output_config.py                                 11      0      0      0   100%
backends/qualcomm/genai_pipeline/configs/quantization_input_config.py                                       12      0      0      0   100%
backends/qualcomm/genai_pipeline/configs/quantization_output_config.py                                       5      0      0      0   100%
backends/qualcomm/genai_pipeline/datasets/calibration_data_adapter.py                                        5      0      0      0   100%
backends/qualcomm/genai_pipeline/datasets/default_calibration_data_adapter.py                               26      0      6      0   100%
backends/qualcomm/genai_pipeline/datasets/default_training_data_adapter.py                                  14      0      2      0   100%
backends/qualcomm/genai_pipeline/datasets/training_data_adapter.py                                           5      0      0      0   100%
backends/qualcomm/genai_pipeline/engine_proxy.py                                                            20      0      4      0   100%
backends/qualcomm/genai_pipeline/exceptions.py                                                              20      0      6      0   100%
backends/qualcomm/genai_pipeline/genai_pipeline.py                                                          99      7     12      1    93%   190-201
backends/qualcomm/genai_pipeline/pipeline_context.py                                                        52      0     14      0   100%
backends/qualcomm/genai_pipeline/pipeline_stage.py                                                           5      0      0      0   100%
backends/qualcomm/genai_pipeline/stages/compilation_stage.py                                                14      0      0      0   100%
backends/qualcomm/genai_pipeline/stages/inference_stage.py                                                  14      0      0      0   100%
backends/qualcomm/genai_pipeline/stages/model_preparation_stage.py                                          14      2      0      0    86%   30, 37
backends/qualcomm/genai_pipeline/stages/quantization_stage.py                                               14      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/compilation/compilation_strategy.py                              7      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/compilation/compiler_adapter.py                                 11      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/compilation/executorch_compilation_strategy.py                   7      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/inference/device_runner_adapter.py                              14      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/inference/executorch_inference_strategy.py                       7      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/inference/inference_strategy.py                                  7      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/model_preparation/executorch_model_preparation_strategy.py       7      1      0      0    86%   40
backends/qualcomm/genai_pipeline/strategies/model_preparation/model_loader_adapter.py                        8      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/model_preparation/model_preparation_strategy.py                  7      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/quantization/executorch_quantization_strategy.py                 7      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/quantization/quantization_strategy.py                            7      0      0      0   100%
backends/qualcomm/genai_pipeline/strategies/quantization/quantizer_adapter.py                                9      0      0      0   100%
----------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                      475     10     44      1    98%                                                                                                    417     10     30      1    98%
```