### PR TITLE
Cortex-M: check the output dim order in quantized_conv2d

### DIFF
--- a/backends/cortex_m/ops/op_quantized_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_conv2d.cpp
@@ -35,11 +35,6 @@ bool validate_conv2d_arguments(
 
   // Check for channels_last dim_order (NHWC: 0, 2, 3, 1)
   // Skip check if channels == 1, as dim_order is ambiguous in that case
-  constexpr executorch::aten::DimOrderType kChannelsLastDimOrder[] = {
-      0, 2, 3, 1};
-  executorch::aten::ArrayRef<executorch::aten::DimOrderType>
-      channels_last_order(kChannelsLastDimOrder, 4);
-
   if (input.size(1) > 1 && !is_channels_last_tensor(input)) {
     ET_LOG(
         Error,
@@ -48,7 +43,7 @@ bool validate_conv2d_arguments(
     return false;
   }
 
-  if (output.size(1) > 1 && !is_channels_last_tensor(input)) {
+  if (output.size(1) > 1 && !is_channels_last_tensor(output)) {
     ET_LOG(
         Error,
         "quantized_conv2d_out: output must have channels_last dim_order (NHWC)");


### PR DESCRIPTION
### Summary

The output channels_last guard tested the input tensor, so an NCHW output would reach arm_convolve_wrapper_s8 and produce silently transposed results. The depthwise and transpose-conv kernels already validate their own outputs.

Also drops the local kChannelsLastDimOrder/channels_last_order pair, which became dead when is_channels_last_tensor moved into cortex_m_ops_common.h and grew its own copy.

Authored with assistance from Claude Code.