### PR TITLE
Carry a tensor's device when wrapping it for PyTorch

### DIFF
--- a/extension/aten_util/aten_bridge.cpp
+++ b/extension/aten_util/aten_bridge.cpp
@@ -134,6 +134,22 @@ c10::ScalarType executorch_to_torch_scalar_type(
   return static_cast<c10::ScalarType>(intermediate);
 }
 
+c10::Device executorch_to_torch_device(
+    executorch::runtime::etensor::Device device) {
+  switch (device.type()) {
+    case executorch::runtime::etensor::DeviceType::CPU:
+      return c10::Device(c10::DeviceType::CPU);
+    case executorch::runtime::etensor::DeviceType::CUDA:
+      return c10::Device(c10::DeviceType::CUDA, device.index());
+  }
+  // Aborting on an unknown device rather than falling back to CPU: a wrong
+  // label made the host read accelerator memory and segfault.
+  ET_CHECK_MSG(
+      false,
+      "Tensor reports device type %d, which this build cannot map to a PyTorch device",
+      static_cast<int>(device.type()));
+}
+
 /*
  * Following makes two assumptions:
  * 1. aten_tensor's lifetime is longer than the liftime within which mutable_et
@@ -167,11 +183,14 @@ at::Tensor alias_attensor_to_etensor(const torch::executor::Tensor& etensor) {
   std::vector<int64_t> at_tensor_strides(
       etensor.strides().begin(), etensor.strides().end());
 
-  at::Tensor t = at::from_blob(
-      etensor.mutable_data_ptr(),
-      at_tensor_sizes,
-      at_tensor_strides,
-      at::TensorOptions(dtype));
+  // Both are needed: the dispatch key comes from options, and target_device
+  // skips the pointer inspection that rejects an empty tensor's null pointer.
+  const c10::Device device = executorch_to_torch_device(etensor.device());
+  at::Tensor t = at::for_blob(etensor.mutable_data_ptr(), at_tensor_sizes)
+                     .strides(at_tensor_strides)
+                     .options(at::TensorOptions(dtype).device(device))
+                     .target_device(device)
+                     .make_tensor();
 
   check_tensor_meta(t, etensor);
   return t;

--- a/extension/aten_util/aten_bridge.h
+++ b/extension/aten_util/aten_bridge.h
@@ -10,6 +10,7 @@
 
 #include <executorch/extension/tensor/tensor.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
+#include <executorch/runtime/core/portable_type/device.h>
 
 #include <ATen/Functions.h> // @manual=//caffe2/aten:ATen-cpu
 #include <ATen/Tensor.h> // @manual=//caffe2/aten:ATen-core
@@ -27,6 +28,9 @@ torch::executor::ScalarType torch_to_executorch_scalar_type(
 
 c10::ScalarType executorch_to_torch_scalar_type(
     torch::executor::ScalarType type);
+
+c10::Device executorch_to_torch_device(
+    executorch::runtime::etensor::Device device);
 
 /*
  * @param[in] aten_tensor Input at::Tensor

--- a/extension/aten_util/test/aten_bridge_test.cpp
+++ b/extension/aten_util/test/aten_bridge_test.cpp
@@ -296,3 +296,61 @@ TEST(ATenBridgeTest, AliasETensorToATenTensorFailUnsupportedDimOrder) {
   torch::executor::Tensor etensor(&tensor_impl);
   ET_EXPECT_DEATH(alias_etensor_to_attensor(at_tensor, etensor), "");
 }
+
+TEST(ATenBridgeTest, DeviceMapping) {
+  // Needs no accelerator: only the mapping is under test.
+  using executorch::runtime::etensor::Device;
+  using executorch::runtime::etensor::DeviceType;
+
+  EXPECT_EQ(
+      executorch_to_torch_device(Device(DeviceType::CPU)).type(),
+      c10::DeviceType::CPU);
+  EXPECT_EQ(
+      executorch_to_torch_device(Device(DeviceType::CUDA, 1)).type(),
+      c10::DeviceType::CUDA);
+  EXPECT_EQ(executorch_to_torch_device(Device(DeviceType::CUDA, 1)).index(), 1);
+}
+
+TEST(ATenBridgeTest, DeviceMappingAbortsOnUnknownType) {
+  using executorch::runtime::etensor::Device;
+  using executorch::runtime::etensor::DeviceType;
+  ET_EXPECT_DEATH(
+      (void)executorch_to_torch_device(Device(static_cast<DeviceType>(99))),
+      "");
+}
+
+TEST(ATenBridgeTest, AliasATTensorToETensorHandlesAnEmptyTensor) {
+  // An empty tensor has a null data pointer, so this is the only case that
+  // distinguishes dropping the device, passing it through options alone (which
+  // raises), and passing target_device. Needs no accelerator: nothing
+  // allocates.
+  auto at_tensor = at::empty({0});
+  std::vector<Tensor::SizesType> sizes(
+      at_tensor.sizes().begin(), at_tensor.sizes().end());
+  auto dim_order = get_default_dim_order(at_tensor);
+  std::vector<Tensor::StridesType> strides(
+      at_tensor.strides().begin(), at_tensor.strides().end());
+  auto dtype = torchToExecuTorchScalarType(at_tensor.options().dtype());
+  torch::executor::TensorImpl tensor_impl(
+      dtype,
+      at_tensor.dim(),
+      sizes.data(),
+      /*data=*/nullptr,
+      dim_order.data(),
+      strides.data(),
+      executorch::runtime::TensorShapeDynamism::STATIC,
+      executorch::runtime::etensor::DeviceType::CUDA,
+      0);
+  torch::executor::Tensor etensor(&tensor_impl);
+
+  auto aliased = alias_attensor_to_etensor(etensor);
+  EXPECT_EQ(aliased.numel(), 0);
+  EXPECT_EQ(aliased.device().type(), c10::DeviceType::CUDA);
+  EXPECT_EQ(aliased.device().index(), 0);
+  // The dispatch key too, not just the label. The key comes from the options
+  // while the label can come from target_device, so a call site that passes the
+  // device only as target_device still satisfies the checks above and produces
+  // a tensor that dispatches to CPU kernels.
+  EXPECT_TRUE(aliased.is_cuda());
+  EXPECT_TRUE(aliased.key_set().has(c10::DispatchKey::CUDA));
+}


### PR DESCRIPTION
Re-lands the change from #21722, which was merged into its stacked base branch rather than into main, so the fix never reached main.

Wrapping an ExecuTorch tensor for PyTorch dropped the device, so the resulting tensor carried no device label. A caller that reads the label then either fails with "tensor does not have a device" or, for accelerator memory, reads device memory from the host and faults.

Measured on an NVIDIA H100 with a CUDA delegated model whose activations stay on the GPU: before this change the Python path faults, and the same program run from C++ succeeds, which places the defect in the bindings rather than in the runtime. A CPU model is affected the same way, because the wrapped tensor has no device of either kind.

Tests: extension/aten_util/test/aten_bridge_test.cpp covers the device mapping, the abort on an unknown device type, and an empty CUDA labelled tensor, which is the case that distinguishes a correct implementation from one that only sets the label or only sets the target device.