### PR TITLE
Cortex-M: stop xfailing test_implementation_mv2

### DIFF
--- a/backends/cortex_m/test/models/test_mobilenet_v2.py
+++ b/backends/cortex_m/test/models/test_mobilenet_v2.py
@@ -71,12 +71,7 @@ def test_dialect_mv2(test_case):
     assert torch.argmax(ref) == torch.argmax(result), "Mismatch in model outputs"
 
 
-@parametrize(
-    "test_case",
-    test_cases,
-    xfails={"mobilenet_v2": "MLETORCH-XXX - Investigate mobilenet_v2 flakiness"},
-    strict=False,
-)
+@parametrize("test_case", test_cases)
 def test_implementation_mv2(test_case):
     inputs = test_case.get_example_inputs()
     tester = CortexMTester(test_case.model, inputs)


### PR DESCRIPTION
### Summary
The xfail was precautionary rather than observed. #17300 added it "for potential flakiness in the serialization/runtime path", and because strict=False suppresses XPASS reporting, CI has never been able to tell us whether the test actually fails.

It does not. Running it with --runxfail over TEST_SEED=0..7 on the Corstone-300 FVP passes 8/8 seeds, both the dialect and the implementation test, so the xfail is removed along with its placeholder MLETORCH-XXX ticket reference.

Authored with assistance from Claude Code.