### PR TITLE
Support extra quantizable ops in advance quant above def chain (#21757)

### DIFF
--- a/backends/cadence/aot/reorder_ops.py
+++ b/backends/cadence/aot/reorder_ops.py
@@ -258,13 +258,21 @@ class AdvanceQuantizeOpAboveDefChainPass(ExportPass):
        input individually.  A later pass can clean up any redundant
        dequant-quant pairs on the inputs.
 
+    3. Caller-supplied ops: advance the quantize above a value-preserving op by
+       quantizing selected direct floating-point tensor inputs. The caller is
+       responsible for supplying only inputs that support the quantized dtype.
+
     For the cat case, SplitDequantizedCatPass should run first to ensure
     each cat has at most one quantize consumer.
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        extra_quantizable_ops: dict[EdgeOpOverload, tuple[int, ...]] | None = None,
+    ) -> None:
         super().__init__()
         self.graph_module = None
+        self._extra_quantizable_ops = extra_quantizable_ops or {}
 
     # Return true if advancing the quantize node is feasible
     def advancing_feasible(self, quant_node: torch.fx.Node):
@@ -349,6 +357,56 @@ class AdvanceQuantizeOpAboveDefChainPass(ExportPass):
         quant_node.replace_all_uses_with(new_cat)
         graph.erase_node(quant_node)
 
+    def _advance_above_extra_quantizable_op(
+        self,
+        quant_node: torch.fx.Node,
+        op_node: torch.fx.Node,
+        quantizable_input_indices: tuple[int, ...],
+    ) -> bool:
+        graph = quant_node.graph
+        new_op_args = list(op_node.args)
+        quantized_input = False
+
+        for index in quantizable_input_indices:
+            assert 0 <= index < len(op_node.args)
+            arg = op_node.args[index]
+            assert isinstance(arg, torch.fx.Node)
+            value = arg.meta["val"]
+            assert isinstance(value, torch.Tensor)
+            if not value.dtype.is_floating_point:
+                continue
+
+            quant_args = list(quant_node.args)
+            quant_args[0] = arg
+            with graph.inserting_before(op_node):
+                new_quant = graph.call_function(
+                    # pyre-ignore[6]
+                    quant_node.target,
+                    args=tuple(quant_args),
+                    kwargs=quant_node.kwargs,
+                )
+                # We will correct the dtype when we run
+                # ExportPass call at the end.
+                new_quant.meta = arg.meta.copy()
+            new_op_args[index] = new_quant
+            quantized_input = True
+
+        if not quantized_input:
+            return False
+
+        with graph.inserting_before(quant_node):
+            new_op = graph.call_function(
+                # pyre-ignore[6]
+                op_node.target,
+                args=tuple(new_op_args),
+                kwargs=op_node.kwargs,
+            )
+            new_op.meta = quant_node.meta.copy()
+
+        quant_node.replace_all_uses_with(new_op)
+        graph.erase_node(quant_node)
+        return True
+
     def advance_quantize_op(self, graph_module: torch.fx.GraphModule) -> bool:
         graph = graph_module.graph
         modified = False
@@ -369,6 +427,19 @@ class AdvanceQuantizeOpAboveDefChainPass(ExportPass):
                 and len(inp.users) == 1
             ):
                 self._advance_above_cat(node, inp)
+                modified = True
+                continue
+
+            if (
+                isinstance(inp, torch.fx.Node)
+                and inp.target in self._extra_quantizable_ops
+                and len(inp.users) == 1
+                and self._advance_above_extra_quantizable_op(
+                    node,
+                    inp,
+                    self._extra_quantizable_ops[inp.target],
+                )
+            ):
                 modified = True
                 continue
 

--- a/backends/cadence/aot/tests/test_reorder_ops_passes.py
+++ b/backends/cadence/aot/tests/test_reorder_ops_passes.py
@@ -359,6 +359,73 @@ class TestReorderPasses(unittest.TestCase):
             < get_node_pos(converted_graph, exir_ops.edge.aten.permute_copy.default)
         )
 
+    def test_advance_quantize_above_extra_quantizable_op(self) -> None:
+        builder = GraphBuilder()
+        cache_data = torch.randint(-128, 127, (4, 8), dtype=torch.int8)
+        update_data = torch.randint(-128, 127, (2, 8), dtype=torch.int8)
+        cache = builder.placeholder("cache", cache_data)
+        update = builder.placeholder("update", update_data)
+        qparams = (0.25, 3, -128, 127, torch.int8)
+        cache_float = builder.call_operator(
+            op=exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+            args=(cache, *qparams),
+        )
+        update_float = builder.call_operator(
+            op=exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+            args=(update, *qparams),
+        )
+        slice_scatter = builder.call_operator(
+            op=exir_ops.edge.aten.slice_scatter.default,
+            args=(cache_float, update_float, 0, 1, 3, 1),
+        )
+        quantized = builder.call_operator(
+            op=exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+            args=(slice_scatter, *qparams),
+        )
+        builder.output([quantized])
+
+        result = transform_and_check_numerics(
+            builder.get_graph_module(),
+            (cache_data, update_data),
+            AdvanceQuantizeOpAboveDefChainPass(
+                extra_quantizable_ops={exir_ops.edge.aten.slice_scatter.default: (0, 1)}
+            ),
+        )
+
+        self.assertTrue(result.modified)
+        self.assertEqual(
+            2,
+            count_node(
+                result.graph_module,
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+            ),
+        )
+        scatter_nodes = result.graph_module.graph.find_nodes(
+            op="call_function", target=exir_ops.edge.aten.slice_scatter.default
+        )
+        self.assertEqual(1, len(scatter_nodes))
+        scatter_node = scatter_nodes[0]
+        self.assertEqual((0, 1, 3, 1), scatter_node.args[2:])
+        self.assertEqual(torch.int8, scatter_node.meta["val"].dtype)
+
+        for scatter_input in scatter_node.args[:2]:
+            self.assertIsInstance(scatter_input, torch.fx.Node)
+            scatter_input = cast(torch.fx.Node, scatter_input)
+            self.assertEqual(
+                exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+                scatter_input.target,
+            )
+            self.assertEqual(torch.int8, scatter_input.meta["val"].dtype)
+
+            quant_input = scatter_input.args[0]
+            self.assertIsInstance(quant_input, torch.fx.Node)
+            quant_input = cast(torch.fx.Node, quant_input)
+            self.assertEqual(torch.float32, quant_input.meta["val"].dtype)
+            dequant_input = quant_input.args[0]
+            self.assertIsInstance(dequant_input, torch.fx.Node)
+            dequant_input = cast(torch.fx.Node, dequant_input)
+            self.assertEqual(torch.int8, dequant_input.meta["val"].dtype)
+
     def test_postpone_dequantize1(self) -> None:
         builder = GraphBuilder()
         x_data = torch.randn(1, 16, 32, 6, dtype=torch.float32)


### PR DESCRIPTION
Summary:

Added additional support in advance quant for arbitrary ops. The user just needs to supply the op target and what the quantizable indices are.

Reviewed By: ethansfng

Differential Revision: D115632906


