### PR TITLE
[executorch][cuda] Add Muse Glimmer export and runtime CI

### DIFF
--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -25,6 +25,7 @@ Arguments:
                  - nvidia/diar_streaming_sortformer_4spk-v2
                  - nvidia/parakeet-tdt
                  - facebook/dinov2-small-imagenet1k-1-layer
+                 - meta-models/Muse-Glimmer-30B-GGUF
 
   quant_name   Quantization type (optional, default: non-quantized)
                Options:
@@ -33,6 +34,8 @@ Arguments:
                  - quantized-int4-weight-only (CUDA only)
                  - quantized-int4-metal (Metal only)
                  - quantized-8da4w (XNNPACK only)
+                 - kquant-17gb (Muse Glimmer only)
+                 - kquant-dynamic (Muse Glimmer only)
 
   output_dir   Output directory for artifacts (optional, default: current directory)
 
@@ -40,6 +43,8 @@ Arguments:
                Supported modes:
                  - vr-streaming: Voxtral Realtime streaming mode
                  - vr-offline: Voxtral Realtime offline mode
+                 - solo-text: Muse Glimmer solo text mode
+                 - dflash-image: Muse Glimmer DFlash vision mode
 
 Examples:
   export_model_artifact.sh metal "openai/whisper-small"
@@ -53,6 +58,7 @@ Examples:
   export_model_artifact.sh xnnpack "nvidia/parakeet-tdt" "quantized-8da4w" "./output"
   export_model_artifact.sh xnnpack "mistralai/Voxtral-Mini-4B-Realtime-2602" "quantized-8da4w" "./output"
   export_model_artifact.sh xnnpack "mistralai/Voxtral-Mini-4B-Realtime-2602" "non-quantized" "./output" "vr-offline"
+  export_model_artifact.sh cuda "meta-models/Muse-Glimmer-30B-GGUF" "kquant-17gb" "./output" "solo-text"
 EOF
 }
 
@@ -89,9 +95,16 @@ if [ -n "$MODE" ]; then
         exit 1
       fi
       ;;
+    solo-text|dflash-image)
+      if [ "$HF_MODEL" != "meta-models/Muse-Glimmer-30B-GGUF" ]; then
+        echo "Error: Mode '$MODE' can only be used with Muse Glimmer model"
+        echo "Provided model: $HF_MODEL"
+        exit 1
+      fi
+      ;;
     *)
       echo "Error: Unsupported mode '$MODE'"
-      echo "Supported modes: vr-streaming, vr-offline"
+      echo "Supported modes: vr-streaming, vr-offline, solo-text, dflash-image"
       exit 1
       ;;
   esac
@@ -203,9 +216,17 @@ case "$HF_MODEL" in
     PREPROCESSOR_FEATURE_SIZE=""
     PREPROCESSOR_OUTPUT=""
     ;;
+  meta-models/Muse-Glimmer-30B-GGUF)
+    MODEL_NAME="muse_glimmer"
+    TASK=""
+    MAX_SEQ_LEN=""
+    EXTRA_PIP=""
+    PREPROCESSOR_FEATURE_SIZE=""
+    PREPROCESSOR_OUTPUT=""
+    ;;
   *)
     echo "Error: Unsupported model '$HF_MODEL'"
-    echo "Supported models: mistralai/Voxtral-Mini-3B-2507, mistralai/Voxtral-Mini-4B-Realtime-2602, openai/whisper-{small, medium, large, large-v2, large-v3, large-v3-turbo}, google/gemma-3-4b-it, Qwen/Qwen3-0.6B, nvidia/diar_streaming_sortformer_4spk-v2, nvidia/parakeet-tdt, facebook/dinov2-small-imagenet1k-1-layer, SocialLocalMobile/Qwen3.5-35B-A3B-HQQ-INT4, unsloth/gemma-4-31B-it-GGUF"
+    echo "Supported models: mistralai/Voxtral-Mini-3B-2507, mistralai/Voxtral-Mini-4B-Realtime-2602, openai/whisper-{small, medium, large, large-v2, large-v3, large-v3-turbo}, google/gemma-3-4b-it, Qwen/Qwen3-0.6B, nvidia/diar_streaming_sortformer_4spk-v2, nvidia/parakeet-tdt, facebook/dinov2-small-imagenet1k-1-layer, SocialLocalMobile/Qwen3.5-35B-A3B-HQQ-INT4, unsloth/gemma-4-31B-it-GGUF, meta-models/Muse-Glimmer-30B-GGUF"
     exit 1
     ;;
 esac
@@ -243,12 +264,35 @@ case "$QUANT_NAME" in
     fi
     EXTRA_ARGS="--qlinear 8da4w --qlinear_group_size 32 --qlinear_encoder 8da4w --qlinear_encoder_group_size 32"
     ;;
+  kquant-17gb|kquant-dynamic)
+    if [ "$HF_MODEL" != "meta-models/Muse-Glimmer-30B-GGUF" ]; then
+      echo "Error: Quantization '$QUANT_NAME' can only be used with Muse Glimmer model"
+      echo "Provided model: $HF_MODEL"
+      exit 1
+    fi
+    EXTRA_ARGS=""
+    ;;
   *)
     echo "Error: Unsupported quantization '$QUANT_NAME'"
-    echo "Supported quantizations: non-quantized, quantized-int4-tile-packed, quantized-int4-weight-only, quantized-int4-metal, quantized-8da4w"
+    echo "Supported quantizations: non-quantized, quantized-int4-tile-packed, quantized-int4-weight-only, quantized-int4-metal, quantized-8da4w, kquant-17gb, kquant-dynamic"
     exit 1
     ;;
 esac
+
+if [ "$MODEL_NAME" = "muse_glimmer" ]; then
+  if [ "$DEVICE" != "cuda" ]; then
+    echo "Error: Muse Glimmer is only supported with the cuda device"
+    exit 1
+  fi
+  if [ "$QUANT_NAME" != "kquant-17gb" ] && [ "$QUANT_NAME" != "kquant-dynamic" ]; then
+    echo "Error: Muse Glimmer requires quantization 'kquant-17gb' or 'kquant-dynamic'"
+    exit 1
+  fi
+  if [ "$MODE" != "solo-text" ] && [ "$MODE" != "dflash-image" ]; then
+    echo "Error: Muse Glimmer requires mode 'solo-text' or 'dflash-image'"
+    exit 1
+  fi
+fi
 
 echo "::group::Export $MODEL_NAME"
 
@@ -465,6 +509,68 @@ if [ "$MODEL_NAME" = "qwen3_5_moe" ]; then
 
   test -f "${OUTPUT_DIR}/model.pte"
   test -f "${OUTPUT_DIR}/aoti_cuda_blob.ptd"
+  ls -al "${OUTPUT_DIR}"
+
+  exit 0
+fi
+
+# Muse Glimmer: download the selected GGUFs and export the requested CUDA configuration.
+if [ "$MODEL_NAME" = "muse_glimmer" ]; then
+  pip install safetensors huggingface_hub gguf
+
+  LOCAL_MODEL_DIR=$(mktemp -d)
+  INDUCTOR_CACHE=$(mktemp -d "${RUNNER_TEMP:-/tmp}/inductor_cache_XXXXXX")
+  INDUCTOR_TMPDIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/tmpdir_XXXXXX")
+  trap 'rm -rf "$LOCAL_MODEL_DIR" "$INDUCTOR_CACHE" "$INDUCTOR_TMPDIR"' EXIT
+
+  case "$QUANT_NAME" in
+    kquant-17gb)
+      TARGET_GGUF_FILE="muse-glimmer-30B-kquant-17gb.gguf"
+      ;;
+    kquant-dynamic)
+      TARGET_GGUF_FILE="muse-glimmer-30B-kquant-dynamic.gguf"
+      ;;
+  esac
+
+  python -c "from huggingface_hub import hf_hub_download; hf_hub_download('${HF_MODEL}', '${TARGET_GGUF_FILE}', local_dir='${LOCAL_MODEL_DIR}')"
+  TARGET_GGUF_PATH="${LOCAL_MODEL_DIR}/${TARGET_GGUF_FILE}"
+
+  echo "::group::Export"
+  case "$MODE" in
+    solo-text)
+      TMPDIR="$INDUCTOR_TMPDIR" \
+      TORCHINDUCTOR_CACHE_DIR="$INDUCTOR_CACHE" \
+      python -m executorch.examples.models.muse_glimmer.export.export_solo \
+          --gguf "$TARGET_GGUF_PATH" \
+          --backend cuda \
+          --output-dir "${OUTPUT_DIR}"
+      ;;
+    dflash-image)
+      DRAFT_GGUF_FILE="dflash-kquant.gguf"
+      MMPROJ_GGUF_FILE="mmproj-kquant.gguf"
+      python -c "from huggingface_hub import hf_hub_download; hf_hub_download('${HF_MODEL}', '${DRAFT_GGUF_FILE}', local_dir='${LOCAL_MODEL_DIR}')"
+      python -c "from huggingface_hub import hf_hub_download; hf_hub_download('${HF_MODEL}', '${MMPROJ_GGUF_FILE}', local_dir='${LOCAL_MODEL_DIR}')"
+      TMPDIR="$INDUCTOR_TMPDIR" \
+      TORCHINDUCTOR_CACHE_DIR="$INDUCTOR_CACHE" \
+      python -m executorch.examples.models.muse_glimmer.export.export_dflash \
+          --target-gguf "$TARGET_GGUF_PATH" \
+          --draft-gguf "${LOCAL_MODEL_DIR}/${DRAFT_GGUF_FILE}" \
+          --mmproj "${LOCAL_MODEL_DIR}/${MMPROJ_GGUF_FILE}" \
+          --backend cuda \
+          --output-dir "${OUTPUT_DIR}"
+      ;;
+    *)
+      echo "Error: Muse Glimmer requires mode 'solo-text' or 'dflash-image'"
+      exit 1
+      ;;
+  esac
+  echo "::endgroup::"
+
+  test -f "${OUTPUT_DIR}/model.pte"
+  test -f "${OUTPUT_DIR}/aoti_cuda_blob.ptd"
+  if [ "$MODE" = "dflash-image" ]; then
+    test -f "${OUTPUT_DIR}/pos_embed.bin"
+  fi
   ls -al "${OUTPUT_DIR}"
 
   exit 0

--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -538,6 +538,7 @@ if [ "$MODEL_NAME" = "muse_glimmer" ]; then
   echo "::group::Export"
   case "$MODE" in
     solo-text)
+      EXPORT_START_SECONDS=$SECONDS
       TMPDIR="$INDUCTOR_TMPDIR" \
       TORCHINDUCTOR_CACHE_DIR="$INDUCTOR_CACHE" \
       python -m executorch.examples.models.muse_glimmer.export.export_solo \
@@ -550,6 +551,7 @@ if [ "$MODEL_NAME" = "muse_glimmer" ]; then
       MMPROJ_GGUF_FILE="mmproj-kquant.gguf"
       python -c "from huggingface_hub import hf_hub_download; hf_hub_download('${HF_MODEL}', '${DRAFT_GGUF_FILE}', local_dir='${LOCAL_MODEL_DIR}')"
       python -c "from huggingface_hub import hf_hub_download; hf_hub_download('${HF_MODEL}', '${MMPROJ_GGUF_FILE}', local_dir='${LOCAL_MODEL_DIR}')"
+      EXPORT_START_SECONDS=$SECONDS
       TMPDIR="$INDUCTOR_TMPDIR" \
       TORCHINDUCTOR_CACHE_DIR="$INDUCTOR_CACHE" \
       python -m executorch.examples.models.muse_glimmer.export.export_dflash \
@@ -564,6 +566,9 @@ if [ "$MODEL_NAME" = "muse_glimmer" ]; then
       exit 1
       ;;
   esac
+  EXPORT_DURATION_SECONDS=$((SECONDS - EXPORT_START_SECONDS))
+  EXPORT_DURATION_MINUTES=$(awk -v seconds="$EXPORT_DURATION_SECONDS" 'BEGIN {printf "%.2f", seconds / 60}')
+  echo "Muse Glimmer took ${EXPORT_DURATION_MINUTES} minutes to export."
   echo "::endgroup::"
 
   test -f "${OUTPUT_DIR}/model.pte"

--- a/.ci/scripts/test_model_e2e.sh
+++ b/.ci/scripts/test_model_e2e.sh
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Test CUDA/Metal/XNNPACK model end-to-end, need to run .ci/scripts/export_model_artifact.sh first
+# Test CUDA/Metal/XNNPACK models end-to-end, optionally exporting artifacts first.
 
 show_help() {
   cat << EOF
@@ -26,6 +26,7 @@ Arguments:
                 - nvidia/parakeet-tdt
                 - facebook/dinov2-small-imagenet1k-1-layer
                 - mistralai/Voxtral-Mini-4B-Realtime-2602
+                - meta-models/Muse-Glimmer-30B-GGUF
 
   quant_name  Quantization type (required)
               Options:
@@ -33,6 +34,8 @@ Arguments:
                 - quantized-int4-tile-packed
                 - quantized-int4-weight-only
                 - quantized-8da4w (XNNPACK only)
+                - kquant-17gb (Muse Glimmer only)
+                - kquant-dynamic (Muse Glimmer only)
 
   model_dir   Directory containing model artifacts (optional, default: current directory)
               Expected files: model.pte, aoti_cuda_blob.ptd (CUDA only)
@@ -42,6 +45,11 @@ Arguments:
               Supported modes:
                 - vr-streaming: Voxtral Realtime streaming mode
                 - vr-offline: Voxtral Realtime offline mode
+                - solo-text: Muse Glimmer solo text mode
+                - dflash-image: Muse Glimmer DFlash vision mode
+
+Environment:
+  RUN_EXPORT  Set to 1 to export artifacts with export_model_artifact.sh before testing
 
 Examples:
   test_model_e2e.sh metal "openai/whisper-small" "non-quantized"
@@ -51,6 +59,7 @@ Examples:
   test_model_e2e.sh xnnpack "nvidia/parakeet-tdt" "quantized-8da4w" "./model_output"
   test_model_e2e.sh metal "mistralai/Voxtral-Mini-4B-Realtime-2602" "non-quantized" "." "vr-streaming"
   test_model_e2e.sh xnnpack "mistralai/Voxtral-Mini-4B-Realtime-2602" "quantized-8da4w" "./model_output" "vr-offline"
+  RUN_EXPORT=1 test_model_e2e.sh cuda "meta-models/Muse-Glimmer-30B-GGUF" "kquant-17gb" "./model_output" "solo-text"
 EOF
 }
 
@@ -80,6 +89,17 @@ QUANT_NAME="$3"
 MODEL_DIR="${4:-.}"
 MODE="${5:-}"
 
+# Locate EXECUTORCH_ROOT from the directory of this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXECUTORCH_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RUN_EXPORT="${RUN_EXPORT:-0}"
+if [ "$RUN_EXPORT" = "1" ]; then
+  mkdir -p "$MODEL_DIR"
+fi
+if [ -d "$MODEL_DIR" ]; then
+  MODEL_DIR="$(cd "$MODEL_DIR" && pwd)"
+fi
+
 # Validate mode if specified
 if [ -n "$MODE" ]; then
   case "$MODE" in
@@ -91,15 +111,34 @@ if [ -n "$MODE" ]; then
         exit 1
       fi
       ;;
+    solo-text|dflash-image)
+      if [ "$HF_MODEL" != "meta-models/Muse-Glimmer-30B-GGUF" ]; then
+        echo "Error: Mode '$MODE' can only be used with Muse Glimmer model"
+        echo "Provided model: $HF_MODEL"
+        exit 1
+      fi
+      ;;
     *)
       echo "Error: Unsupported mode '$MODE'"
-      echo "Supported modes: vr-streaming, vr-offline"
+      echo "Supported modes: vr-streaming, vr-offline, solo-text, dflash-image"
       exit 1
       ;;
   esac
 fi
 
 echo "Testing model: $HF_MODEL (quantization: $QUANT_NAME)"
+
+if [ "$HF_MODEL" = "meta-models/Muse-Glimmer-30B-GGUF" ] && [ "$DEVICE" != "cuda" ]; then
+  echo "Error: Muse Glimmer is only supported with the cuda device"
+  exit 1
+fi
+
+if [ "$RUN_EXPORT" = "1" ]; then
+  (
+    cd "$EXECUTORCH_ROOT"
+    bash "$SCRIPT_DIR/export_model_artifact.sh" "$DEVICE" "$HF_MODEL" "$QUANT_NAME" "$MODEL_DIR" "$MODE"
+  )
+fi
 
 # Make sure model.pte exists
 if [ ! -f "$MODEL_DIR/model.pte" ]; then
@@ -111,10 +150,6 @@ if [ "$DEVICE" = "cuda" ] && [ ! -f "$MODEL_DIR/aoti_cuda_blob.ptd" ]; then
   echo "Error: aoti_cuda_blob.ptd not found in $MODEL_DIR"
   exit 1
 fi
-# Locate EXECUTORCH_ROOT from the directory of this script
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-EXECUTORCH_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-
 pushd "$EXECUTORCH_ROOT"
 
 # Determine model configuration based on HF model ID
@@ -240,9 +275,35 @@ case "$HF_MODEL" in
     AUDIO_FILE=""
     IMAGE_PATH=""
     ;;
+  meta-models/Muse-Glimmer-30B-GGUF)
+    MODEL_NAME="muse_glimmer"
+    RUNNER_PATH="muse-glimmer"
+    PREPROCESSOR=""
+    TOKENIZER_URL="https://huggingface.co/meta-models/Muse-Glimmer-30B/resolve/main" # @lint-ignore
+    TOKENIZER_FILE="tokenizer.json"
+    AUDIO_URL=""
+    AUDIO_FILE=""
+    IMAGE_PATH=""
+    case "$MODE" in
+      solo-text)
+        RUNNER_TARGET="solo_runner"
+        EXPECTED_OUTPUT="Paris"
+        IMAGE_URL=""
+        ;;
+      dflash-image)
+        RUNNER_TARGET="dflash_runner"
+        EXPECTED_OUTPUT="dog"
+        IMAGE_URL="https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+        ;;
+      *)
+        echo "Error: Muse Glimmer requires mode 'solo-text' or 'dflash-image'"
+        exit 1
+        ;;
+    esac
+    ;;
   *)
     echo "Error: Unsupported model '$HF_MODEL'"
-    echo "Supported models: mistralai/Voxtral-Mini-3B-2507, mistralai/Voxtral-Mini-4B-Realtime-2602, nvidia/diar_streaming_sortformer_4spk-v2, openai/whisper series (whisper-{small, medium, large, large-v2, large-v3, large-v3-turbo}), google/gemma-3-4b-it, Qwen/Qwen3-0.6B, nvidia/parakeet-tdt, facebook/dinov2-small-imagenet1k-1-layer, SocialLocalMobile/Qwen3.5-35B-A3B-HQQ-INT4, unsloth/gemma-4-31B-it-GGUF"
+    echo "Supported models: mistralai/Voxtral-Mini-3B-2507, mistralai/Voxtral-Mini-4B-Realtime-2602, nvidia/diar_streaming_sortformer_4spk-v2, openai/whisper series (whisper-{small, medium, large, large-v2, large-v3, large-v3-turbo}), google/gemma-3-4b-it, Qwen/Qwen3-0.6B, nvidia/parakeet-tdt, facebook/dinov2-small-imagenet1k-1-layer, SocialLocalMobile/Qwen3.5-35B-A3B-HQQ-INT4, unsloth/gemma-4-31B-it-GGUF, meta-models/Muse-Glimmer-30B-GGUF"
     exit 1
     ;;
 esac
@@ -382,6 +443,18 @@ EOF
     ;;
   gemma4_31b)
     RUNNER_ARGS="$RUNNER_ARGS --tokenizer_path ${MODEL_DIR}/$TOKENIZER_FILE --prompt 'What is the capital of France?' --max_new_tokens 128 --temperature 0 --cuda_graph"
+    ;;
+  muse_glimmer)
+    PROMPT_FILE="${MODEL_DIR}/muse_glimmer_prompt.txt"
+    if [ "$MODE" = "solo-text" ]; then
+      printf '%s' '<|start|>user<|message|>What is the capital of France?<|eot|><|start|>assistant' > "$PROMPT_FILE"
+    else
+      printf '%s' '<|start|>user<|message|>What animal is in this image? <img><|eot|><|start|>assistant' > "$PROMPT_FILE"
+    fi
+    RUNNER_ARGS="$RUNNER_ARGS --tokenizer_path ${MODEL_DIR}/$TOKENIZER_FILE --prompt_file \"$PROMPT_FILE\" --max_new_tokens 512 --cuda_graph"
+    if [ "$MODE" = "dflash-image" ]; then
+      RUNNER_ARGS="$RUNNER_ARGS --image_path ${MODEL_DIR}/test_image.jpg"
+    fi
     ;;
   voxtral_realtime)
     RUNNER_ARGS="--model_path ${MODEL_DIR}/model.pte --tokenizer_path ${MODEL_DIR}/$TOKENIZER_FILE --preprocessor_path ${MODEL_DIR}/$PREPROCESSOR --audio_path ${MODEL_DIR}/$AUDIO_FILE --temperature 0"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -25,6 +25,7 @@ on:
       - .ci/scripts/test-cuda-build.sh
       - .ci/scripts/export_model_artifact.sh
       - .ci/scripts/test_model_e2e.sh
+      - examples/models/muse-glimmer/**
   workflow_dispatch:
 
 concurrency:
@@ -565,6 +566,76 @@ jobs:
         mkdir -p "${HF_HOME}" 2>/dev/null || export HF_HOME=/tmp/hf_cache
         mkdir -p "${HF_HOME}"
         source .ci/scripts/test_model_e2e.sh cuda "${{ matrix.model.repo }}/${{ matrix.model.name }}" "${{ matrix.quant }}" "${RUNNER_ARTIFACT_DIR}"
+
+  test-muse-glimmer-cuda-e2e:
+    name: test-muse-glimmer-cuda-e2e-${{ matrix.variant }}-${{ matrix.mode }}
+    needs: [changed-files, run-decision]
+    if: |
+      contains(needs.changed-files.outputs.changed-files, 'backends/cuda') ||
+      contains(needs.changed-files.outputs.changed-files, 'backends/aoti') ||
+      contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda.yml') ||
+      contains(needs.changed-files.outputs.changed-files, '.ci/scripts/test-cuda-build.sh') ||
+      contains(needs.changed-files.outputs.changed-files, '.ci/scripts/export_model_artifact.sh') ||
+      contains(needs.changed-files.outputs.changed-files, '.ci/scripts/test_model_e2e.sh') ||
+      contains(needs.changed-files.outputs.changed-files, 'examples/models/muse-glimmer') ||
+      needs.run-decision.outputs.is-full-run == 'true'
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: kquant-17gb
+            mode: solo-text
+          - variant: kquant-17gb
+            mode: dflash-image
+          - variant: kquant-dynamic
+            mode: solo-text
+          - variant: kquant-dynamic
+            mode: dflash-image
+    with:
+      timeout: 240
+      runner: mt-l-x86iavx512-11-125-a100
+      gpu-arch-type: cuda
+      gpu-arch-version: "13.0"
+      use-custom-docker-registry: false
+      submodules: recursive
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      script: |
+        set -eux
+
+        # OSDC mounts HF_HOME read-only at /mnt/hf_cache; redirect to a writable dir
+        # (RUNNER_TEMP, or /tmp when RUNNER_TEMP isn't writable inside the container).
+        export HF_HOME="${RUNNER_TEMP:-/tmp}/hf_cache"
+        mkdir -p "${HF_HOME}" 2>/dev/null || export HF_HOME=/tmp/hf_cache
+        mkdir -p "${HF_HOME}"
+
+        echo "::group::Setup ExecuTorch"
+        # OSDC runners can't reach the public PyPI CDN that download.pytorch.org's
+        # transitive deps resolve to. Pre-install torch's pure-python deps from the
+        # in-cluster pypi-cache and drop the default cpu extra-index so the cuda
+        # torch wheel is the only candidate.
+        export PIP_EXTRA_INDEX_URL=
+        # fsspec is pinned to satisfy datasets' fsspec[http]<=2025.3.0 so the later
+        # examples install doesn't try to downgrade it from the public CDN.
+        pip install filelock typing-extensions "setuptools<82" sympy networkx jinja2 "fsspec[http]<=2025.3.0" numpy pillow
+        # Disable MKL to avoid duplicate target error when conda has multiple MKL installations
+        export USE_MKL=OFF
+        ./install_executorch.sh
+        echo "::endgroup::"
+
+        echo "::group::Fix libstdc++ GLIBCXX version"
+        conda install -y -c conda-forge 'libstdcxx-ng>=12'
+        export LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
+        echo "::endgroup::"
+
+        RUN_EXPORT=1 source .ci/scripts/test_model_e2e.sh cuda \
+          "meta-models/Muse-Glimmer-30B-GGUF" \
+          "${{ matrix.variant }}" \
+          "${RUNNER_TEMP}/muse_glimmer" \
+          "${{ matrix.mode }}"
 
   test-cuda-pybind:
     name: test-cuda-pybind

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@
 #
 # ==============================================================================
 
-.PHONY: voxtral-cuda voxtral-cpu voxtral-metal voxtral-mlx voxtral_realtime-cuda voxtral_realtime-cpu voxtral_realtime-metal voxtral_realtime-mlx voxtral_tts-cpu voxtral_tts-cuda whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal parakeet-mlx parakeet-vulkan dinov2-cuda dinov2-cuda-debug sortformer-cuda sortformer-cpu silero-vad-cpu llama-cuda llama-cuda-debug llama-cpu lfm_2_5-mlx llava-cpu gemma3-cuda gemma3-cpu gemma4_31b-cuda gemma4_31b-mlx qwen3_5_moe-cuda qwen3_5_moe-metal qwen3_5_moe-mlx clean help
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal voxtral-mlx voxtral_realtime-cuda voxtral_realtime-cpu voxtral_realtime-metal voxtral_realtime-mlx voxtral_tts-cpu voxtral_tts-cuda whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal parakeet-mlx parakeet-vulkan dinov2-cuda dinov2-cuda-debug sortformer-cuda sortformer-cpu silero-vad-cpu llama-cuda llama-cuda-debug llama-cpu lfm_2_5-mlx llava-cpu gemma3-cuda gemma3-cpu gemma4_31b-cuda gemma4_31b-mlx muse-glimmer-cuda qwen3_5_moe-cuda qwen3_5_moe-metal qwen3_5_moe-mlx clean help
 
 help:
 	@echo "This Makefile adds targets to build runners for various models on various backends. Run using \`make <target>\`. Available targets:"
@@ -129,6 +129,7 @@ help:
 	@echo "  gemma3-cpu          - Build Gemma3 runner with CPU backend"
 	@echo "  gemma4_31b-cuda     - Build Gemma 4 31B runner and worker with CUDA backend"
 	@echo "  gemma4_31b-mlx      - Build Gemma 4 31B runner and worker with MLX backend"
+	@echo "  muse-glimmer-cuda   - Build Muse Glimmer runners and worker with CUDA backend"
 	@echo "  qwen3_5_moe-cuda    - Build Qwen3.5 MoE runner with CUDA backend"
 	@echo "  qwen3_5_moe-metal   - Build Qwen3.5 MoE runner with Metal backend"
 	@echo "  qwen3_5_moe-mlx     - Build Qwen3.5 MoE runner with MLX backend"
@@ -440,6 +441,17 @@ qwen3_5_moe-cuda:
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/qwen3_5_moe/qwen3_5_moe_runner"
 	@echo "  Test:   cmake-out/examples/models/qwen3_5_moe/test_qwen35_moe_nobleed"
+
+muse-glimmer-cuda:
+	@echo "==> Building and installing ExecuTorch with CUDA..."
+	cmake --workflow --preset llm-release-cuda
+	@echo "==> Building Muse Glimmer runners and worker with CUDA..."
+	cd examples/models/muse-glimmer && cmake --workflow --preset muse-glimmer-cuda
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Solo runner:   cmake-out/examples/models/muse-glimmer/solo_runner"
+	@echo "  DFlash runner: cmake-out/examples/models/muse-glimmer/dflash_runner"
+	@echo "  Worker:        cmake-out/examples/models/muse-glimmer/muse_glimmer_worker"
 
 gemma4_31b-cuda:
 	@echo "==> Building and installing ExecuTorch with CUDA..."


### PR DESCRIPTION
Add self-contained CUDA coverage for representative Muse Glimmer text and vision configurations. Introduce an opt-in same-job export path so large-model CI can avoid artifact upload and download handoffs, and the time for executorch rebuild.

This is for basic output check and perf guard will be added afterwards

