### PR TITLE
Let TensorPtrMaker carry the device its buffer lives on

### DIFF
--- a/extension/tensor/tensor_ptr_maker.h
+++ b/extension/tensor/tensor_ptr_maker.h
@@ -93,6 +93,22 @@ class TensorPtrMaker final {
   }
 
   /**
+   * Labels the tensor with the device where its buffer already lives.
+   *
+   * No data is moved, matching the corresponding `make_tensor_ptr` parameter.
+   *
+   * @param device The device on which the data buffer resides. Give the index
+   * explicitly: a device constructed without one is index 0 in this build and
+   * -1 in the ATen build, where it then compares unequal to the same device
+   * carrying an explicit index.
+   * @return Rvalue to this TensorPtrMaker for method chaining.
+   */
+  TensorPtrMaker&& device(executorch::aten::Device device) {
+    device_ = device;
+    return std::move(*this);
+  }
+
+  /**
    * Creates and returns a TensorPtr instance using the properties set in this
    * TensorPtrMaker.
    *
@@ -106,7 +122,8 @@ class TensorPtrMaker final {
         std::move(strides_),
         type_,
         dynamism_,
-        std::move(deleter_));
+        std::move(deleter_),
+        device_);
   }
 
   /**
@@ -141,6 +158,8 @@ class TensorPtrMaker final {
   executorch::aten::ScalarType type_ = executorch::aten::ScalarType::Float;
   executorch::aten::TensorShapeDynamism dynamism_ =
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND;
+  executorch::aten::Device device_ =
+      executorch::aten::Device(executorch::aten::DeviceType::CPU);
 };
 
 /**

--- a/extension/tensor/test/tensor_ptr_maker_test.cpp
+++ b/extension/tensor/test/tensor_ptr_maker_test.cpp
@@ -506,3 +506,54 @@ TEST_F(TensorPtrMakerTest, CreateRandnTensorWithIntType) {
     EXPECT_EQ(val, 0);
   }
 }
+
+TEST_F(TensorPtrMakerTest, ForBlobDefaultsToCPU) {
+  float data[8] = {};
+  auto tensor = for_blob(data, {2, 4}, executorch::aten::ScalarType::Float)
+                    .make_tensor_ptr();
+
+  // Type only: the default index is 0 in one build mode and -1 in the other, so
+  // asserting it would pass in one and fail in the other.
+  EXPECT_EQ(tensor->device().type(), executorch::aten::DeviceType::CPU);
+}
+
+TEST_F(TensorPtrMakerTest, ForBlobCarriesTheDeviceItIsGiven) {
+  float data[8] = {};
+  auto tensor = for_blob(data, {2, 4}, executorch::aten::ScalarType::Float)
+                    .device(executorch::aten::Device(
+                        executorch::aten::DeviceType::CUDA, 3))
+                    .make_tensor_ptr();
+
+  EXPECT_EQ(tensor->device().type(), executorch::aten::DeviceType::CUDA);
+  EXPECT_EQ(tensor->device().index(), 3);
+}
+
+TEST_F(TensorPtrMakerTest, ForBlobDeviceSurvivesLaterSetters) {
+  float data[8] = {};
+  auto tensor = for_blob(data, {2, 4}, executorch::aten::ScalarType::Float)
+                    .device(executorch::aten::Device(
+                        executorch::aten::DeviceType::CUDA, 0))
+                    .dim_order({1, 0})
+                    .strides({1, 2})
+                    .make_tensor_ptr();
+
+  // The strides are asserted with a value a contiguous tensor would not have,
+  // so a setter that silently ignored its argument would fail here rather than
+  // pass.
+  EXPECT_EQ(tensor->device().type(), executorch::aten::DeviceType::CUDA);
+  EXPECT_EQ(tensor->device().index(), 0);
+  EXPECT_EQ(tensor->strides()[0], 1);
+  EXPECT_EQ(tensor->strides()[1], 2);
+}
+
+TEST_F(TensorPtrMakerTest, ForBlobDeviceAcceptsANamedBuilder) {
+  float data[8] = {};
+  auto maker = for_blob(data, {2, 4}, executorch::aten::ScalarType::Float);
+  maker.device(executorch::aten::Device(executorch::aten::DeviceType::CUDA, 1));
+  auto tensor = std::move(maker).make_tensor_ptr();
+
+  // Choosing a device at run time and applying it to a named builder is the
+  // case this setter exists for, and an rvalue-only qualifier would reject it.
+  EXPECT_EQ(tensor->device().type(), executorch::aten::DeviceType::CUDA);
+  EXPECT_EQ(tensor->device().index(), 1);
+}


### PR DESCRIPTION
TensorPtrMaker could express every property of a tensor except where its data resides.
make_tensor_ptr already takes a device as its last parameter, defaulting to CPU, and the
builder never passed one, so for_blob(...).make_tensor_ptr() always produced a CPU
labelled tensor.

A caller wrapping accelerator memory therefore got a tensor claiming to be on the host.
Nothing rejects that at the boundary, so the label is simply wrong, and whatever reads
it next acts on the wrong answer. For memory the host cannot address, that means the
host follows a pointer it must not.

The setter is unqualified, matching the five setters already on this builder, so a
caller can pick a device at run time and apply it to a named builder before finishing
it.

Test Plan: extension/tensor/test/tensor_ptr_maker_test.cpp gains four cases. The file
had no device coverage at all, which is why the missing setter went unnoticed.

  ForBlobDefaultsToCPU                    the default is still CPU, so existing
                                          callers are unaffected. Type only: the
                                          default index is 0 in one build mode and -1
                                          in the other
  ForBlobCarriesTheDeviceItIsGiven        an explicitly set device type and index
                                          reach the tensor
  ForBlobDeviceSurvivesLaterSetters       a setter running after it does not drop it,
                                          asserted with a non contiguous stride so the
                                          case fails rather than passing for an
                                          unrelated reason
  ForBlobDeviceAcceptsANamedBuilder       the run time choice above, which an rvalue
                                          only qualifier would have rejected

Compiled and ran all four against the shipped headers on Linux x86_64. The wheel build
sets EXECUTORCH_BUILD_TESTS=OFF, so these do not run there; they run in the unit test
build. Three of the four do not compile without this change, no member named 'device', so they
are not vacuous. The default case is the exception: it only reads the accessor, which
already existed, and would compile against the old builder while reporting CPU.