### PR TITLE
Record the input tensor's device when converting it for a method

### DIFF
--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -103,6 +103,7 @@ using torch::executor::ETDumpGen;
 #ifndef USE_ATEN_LIB
 using ::executorch::extension::alias_attensor_to_etensor;
 using ::executorch::extension::alias_etensor_to_attensor;
+using ::executorch::extension::torch_to_executorch_device;
 using ::executorch::extension::torch_to_executorch_scalar_type;
 #endif // !USE_ATEN_LIB
 
@@ -794,18 +795,35 @@ struct PyModule final {
             at_tensor.dim() == 4) {
           dim_order = decltype(dim_order)({0, 2, 3, 1});
         } else {
-          auto error_msg = "Input " + std::to_string(i) + "for method " +
+          auto error_msg = "Input " + std::to_string(i) + " for method " +
               method_name + " should be contiguous or channels-last.";
           throw std::runtime_error(error_msg);
         }
         input_dim_order.push_back(std::move(dim_order));
+        // The runtime has two device types, so a device outside that pair
+        // cannot be represented at all and the tensor would carry a label that
+        // does not describe its memory.
+        auto mapped_device = torch_to_executorch_device(at_tensor.device());
+        // An empty tensor has no buffer for a label to describe, so it is left
+        // alone rather than rejected for a device it never touches.
+        if (!mapped_device.has_value() && at_tensor.numel() != 0) {
+          throw std::runtime_error(
+              "Input " + std::to_string(i) + " for method " + method_name +
+              " is on device " + at_tensor.device().str() +
+              ", and only CPU and CUDA tensors can be passed to a method.");
+        }
+        const auto device = mapped_device.value_or(
+            torch::executor::Device(torch::executor::DeviceType::CPU));
         input_tensors.emplace_back(
             type,
             dim,
             input_sizes.back().data(),
             nullptr,
             input_dim_order.back().data(),
-            input_strides.back().data());
+            input_strides.back().data(),
+            torch::executor::TensorShapeDynamism::STATIC,
+            device.type(),
+            device.index());
 
         torch::executor::Tensor temp =
             torch::executor::Tensor(&input_tensors.back());
@@ -1128,11 +1146,26 @@ struct PyMethod final {
             at_tensor.dim() == 4) {
           dim_order = decltype(dim_order)({0, 2, 3, 1});
         } else {
-          auto error_msg = "Input " + std::to_string(i) + "for method " +
+          auto error_msg = "Input " + std::to_string(i) + " for method " +
               method_->method_meta().name() +
               " should be contiguous or channels-last.";
           throw std::runtime_error(error_msg);
         }
+        // Record where the buffer actually lives. The conversion copied every
+        // other property and left the device at CPU, so an accelerator buffer
+        // was described as host memory.
+        auto mapped_device = torch_to_executorch_device(at_tensor.device());
+        // An empty tensor has no buffer for a label to describe, so it is left
+        // alone rather than rejected for a device it never touches.
+        if (!mapped_device.has_value() && at_tensor.numel() != 0) {
+          throw std::runtime_error(
+              "Input " + std::to_string(i) + " for method " +
+              method_->method_meta().name() + " is on device " +
+              at_tensor.device().str() +
+              ", and only CPU and CUDA tensors can be passed to a method.");
+        }
+        const auto device =
+            mapped_device.value_or(aten::Device(aten::DeviceType::CPU));
         TensorPtr tensor = for_blob(
                                mutable_tensor_data_ptr_no_cow(at_tensor),
                                std::move(sizes),
@@ -1140,6 +1173,7 @@ struct PyMethod final {
                                .strides(std::move(strides))
                                .dim_order(std::move(dim_order))
                                .dynamism(aten::TensorShapeDynamism::STATIC)
+                               .device(device)
                                .make_tensor_ptr();
         input_tensors.push_back(tensor);
         EValue evalue(input_tensors.back());

--- a/extension/pybindings/test/test_pybindings.py
+++ b/extension/pybindings/test/test_pybindings.py
@@ -50,6 +50,9 @@ class PybindingsTest(unittest.TestCase):
                 print("can't load aten lib")
 
         assert kernel_mode is not None
+        # Only the portable build converts an incoming tensor, so a test for
+        # that conversion has to skip under the aten build.
+        self.kernel_mode = kernel_mode
         self.load_fn = runtime._load_for_executorch_from_buffer
         self.load_prog_fn = runtime._load_program_from_buffer
         self.runtime = runtime
@@ -733,3 +736,53 @@ class PybindingsTest(unittest.TestCase):
         )
         with self.assertRaises(RuntimeError):
             executorch_module_bundled_no_data.forward(inputs)
+
+    def test_method_rejects_input_on_unrepresentable_device(self):
+        # The conversion used to label every input CPU, so an input whose memory
+        # the host cannot read was described as host memory, and the failure
+        # surfaced later as a crash instead of an error naming the input.
+        if self.kernel_mode != "portable":
+            self.skipTest("only the portable build converts the input tensor")
+
+        exported_program, inputs = create_program(ModuleAdd())
+        executorch_module = self.load_fn(exported_program.buffer)
+
+        with self.assertRaises(RuntimeError) as caught:
+            executorch_module.forward([inputs[0].to("meta"), inputs[1]])
+        message = str(caught.exception)
+        # Asserts the device is named as Python spells it, since an uppercased or
+        # index-less name would not match what the caller passed.
+        self.assertIn("is on device meta", message)
+        self.assertIn("only CPU and CUDA tensors", message)
+
+    def test_method_accepts_a_cpu_input_after_the_device_check(self):
+        # The rejection tests above pass for a change that throws on every input, so this
+        # asserts the other half: an ordinary CPU input still converts and runs. Without it
+        # the pair does not distinguish "rejects what it cannot represent" from "rejects
+        # everything".
+        exported_program, inputs = create_program(ModuleAdd())
+        executorch_module = self.load_fn(exported_program.buffer)
+
+        executorch_output = executorch_module.forward(inputs)[0]
+
+        self.assertTrue(
+            torch.allclose(executorch_output, inputs[0] + inputs[1]),
+            "a CPU input must still reach the method and produce the same result",
+        )
+
+    def test_program_method_rejects_input_on_unrepresentable_device(self):
+        # The other conversion site, reached through a loaded program rather than a
+        # module. It got the same treatment, and without this it had no test: before
+        # the change this path aborted the process rather than raising.
+        if self.kernel_mode != "portable":
+            self.skipTest("only the portable build converts the input tensor")
+
+        exported_program, inputs = create_program(ModuleAdd())
+        program = self.load_prog_fn(exported_program.buffer)
+        method = program.load_method("forward")
+
+        with self.assertRaises(RuntimeError) as caught:
+            method.set_inputs([inputs[0].to("meta"), inputs[1]])
+        message = str(caught.exception)
+        self.assertIn("is on device meta", message)
+        self.assertIn("only CPU and CUDA tensors", message)


### PR DESCRIPTION
When a tensor is passed to a method, the bindings convert it into the runtime's own
tensor type. That conversion copied the shape, the strides, the dim order and the data
type, and left the device at CPU regardless of what the caller passed. A buffer on an
accelerator was therefore described as host memory.

Both entry points are fixed, because both did this. One is reached by loading a module
and calling a method on it, the other by loading a program and setting a method's inputs
directly. They had the same defect and only one of them would have been worth fixing
alone.

This records the device instead. A device the runtime has no type for is reported by
name, naming the two it does have, rather than being silently relabelled as CPU. An
empty tensor is left alone, because it has no buffer for a label to describe and
rejecting it would break a case that worked before.

One behaviour change worth naming: a non-empty tensor on any device other than CPU or
CUDA is now rejected where it was previously accepted and relabelled CPU. That includes a
device whose memory the host can read, such as one a private backend registers, which
would have happened to work. Nothing here passes such a tensor, and a silently wrong
label is worse than a named error, but the case is real and the error says which device
it saw.

What this does not do: for a CPU input the conversion is unchanged, so nothing about
that path is fixed here. And the label has no reader yet, so passing memory the host
cannot address still misbehaves downstream, because sharing a buffer between tensors of
this type does not compare devices the way sharing between the other tensor type does,
and copying compares them on neither side. Making the label meaningful means adding those
comparisons, which is a separate change. This one stops the conversion from discarding what the caller said.

Depends on the change that adds the device mapping, since there was previously no shared
way to express this and each site would have carried its own copy of the table.

Test Plan: extension/pybindings/test/test_pybindings.py gains a case per entry point,
each asserting the device is named as Python spells it, so an uppercased or index-less
name would not match.

  test_method_rejects_input_on_unrepresentable_device
  test_program_method_rejects_input_on_unrepresentable_device
  test_method_accepts_a_cpu_input_after_the_device_check

The first two are skipped under the ATen build, where the runtime uses the PyTorch tensor
type directly and no conversion happens. The third runs in both.

What these do not cover, stated plainly: none of them observes the recorded device. The
bindings expose no way to read a tensor's device from Python, so a change that dropped the
device again, or that stopped handling CUDA specifically, would leave this file green. The
tests here pin the error path and the CPU path. The device plumbing itself is covered by
the C++ tests in the two changes below this one, which can read the label directly.

Built a wheel from this change, installed it in a clean environment, and ran all three:
they pass. Against the code before this change the program one aborts the process rather
than raising, so that path was genuinely unprotected.

Also exported and ran three programs through the bindings, one using portable kernels,
one using quantized operators and one using XNNPACK, to confirm the ordinary path is
unaffected.

One unrelated fix carried along because it sits on the lines being edited: a missing space
in the neighbouring contiguity error, which printed "Input 0for method" at both sites.