### PR TITLE
Lint only what a PR adds: diff the link checks from the merge base

### DIFF
--- a/.ci/scripts/tests/test_link_check_diff_selection.py
+++ b/.ci/scripts/tests/test_link_check_diff_selection.py
@@ -1,0 +1,161 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Fixture content, not real references. The linters under test would otherwise find
+# their own bait here and check it against this repo.
+BAD = "[broken](sub/missing.md)\nhttps://example.invalid/dead\n"  # @lint-ignore
+GOOD = "[fine](sub/present.md)\nhttps://example.invalid/live\n"  # @lint-ignore
+
+OVERSIZED = "x" * (1024 * 1024 + 1)
+
+CURL_STUB = """#!/bin/sh
+for arg in "$@"; do url=$arg; done
+case "$url" in *dead*) echo 404 ;; *) echo 200 ;; esac
+"""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="The scripts under test need bash")
+class TestLinkCheckDiffSelection(unittest.TestCase):
+    """A branch cut before recent base commits keeps the base branch's old lines. Those
+    are not the branch's to answer for, so the linters must diff from the merge base.
+
+    Each fixture file pins a different part of that: base_only.md the file selection,
+    both_sides.md the per-file diff, big.bin the file size range, feature_only.md that
+    the branch's own additions are still checked at all.
+    """
+
+    def setUp(self):
+        self.repo = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.repo, ignore_errors=True)
+        self.git("init", "-q")
+        self.git("symbolic-ref", "HEAD", "refs/heads/main")
+        self.git("config", "user.email", "test@example.com")
+        self.git("config", "user.name", "test")
+
+        self.write("sub/present.md", "target\n")
+        self.write("base_only.md", BAD)
+        self.write("both_sides.md", BAD)
+        self.write("big.bin", OVERSIZED)
+        self.commit("initial")
+        self.git("branch", "feature")
+
+        self.write("base_only.md", GOOD)
+        self.write("both_sides.md", GOOD)
+        self.write("big.bin", "small\n")
+        self.commit("main repairs the links and shrinks the file")
+
+        self.git("checkout", "-q", "feature")
+        self.write("both_sides.md", BAD + GOOD)
+        self.write("feature_only.md", GOOD)
+        self.commit("feature edits one file and adds another")
+
+    def env(self, **extra):
+        # A developer's git config and any inherited GIT_DIR must not reach the fixture.
+        env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+        env["GIT_CONFIG_GLOBAL"] = os.devnull
+        env["GIT_CONFIG_SYSTEM"] = os.devnull
+        env.update(extra)
+        return env
+
+    def git(self, *args):
+        subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            env=self.env(),
+        )
+
+    def write(self, relpath, text):
+        path = self.repo / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+    def commit(self, message):
+        self.git("add", "-A")
+        self.git("commit", "-q", "-m", message)
+
+    def add_on_feature(self, relpath, text):
+        self.write(relpath, text)
+        self.commit(f"feature adds {relpath}")
+
+    def lint(self, script, **env):
+        return subprocess.run(
+            ["bash", str(REPO_ROOT / "scripts" / script), "main", "feature"],
+            cwd=self.repo,
+            capture_output=True,
+            text=True,
+            env=self.env(**env),
+        )
+
+    def assert_scoped_to_feature(self, result):
+        output = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 0, output)
+        self.assertIn("feature_only.md", result.stdout)
+        self.assertIn("both_sides.md", result.stdout)
+        self.assertNotIn("base_only.md", output)
+
+    def curl_stub(self):
+        stub_dir = self.repo / "stub"
+        stub_dir.mkdir()
+        stub = stub_dir / "curl"
+        stub.write_text(CURL_STUB)
+        stub.chmod(0o755)
+        return {"PATH": f"{stub_dir}{os.pathsep}{os.environ['PATH']}"}
+
+    def test_lint_urls_ignores_lines_the_branch_only_lacks(self):
+        self.assert_scoped_to_feature(self.lint("lint_urls.sh", **self.curl_stub()))
+
+    def test_lint_xrefs_ignores_lines_the_branch_only_lacks(self):
+        self.assert_scoped_to_feature(self.lint("lint_xrefs.sh"))
+
+    def test_lint_file_size_ignores_files_the_branch_only_lacks(self):
+        result = self.lint("lint_file_size.sh")
+        output = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 0, output)
+        self.assertIn("feature_only.md", result.stdout)
+        self.assertNotIn("big.bin", output)
+
+    def test_lint_urls_still_catches_a_url_the_branch_adds(self):
+        self.add_on_feature("feature_bad.md", BAD)
+        result = self.lint("lint_urls.sh", **self.curl_stub())
+        output = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 1, output)
+        self.assertIn("example.invalid/dead", output)
+
+    def test_lint_xrefs_still_catches_a_reference_the_branch_adds(self):
+        self.add_on_feature("feature_bad.md", BAD)
+        result = self.lint("lint_xrefs.sh")
+        output = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 1, output)
+        self.assertIn("sub/missing.md", output)
+
+    def test_lint_file_size_still_catches_a_file_the_branch_adds(self):
+        self.add_on_feature("feature_big.bin", OVERSIZED)
+        result = self.lint("lint_file_size.sh")
+        output = result.stdout + result.stderr
+        self.assertEqual(result.returncode, 1, output)
+        self.assertIn("feature_big.bin", output)
+
+    def test_lint_urls_survives_a_colorizing_git_config(self):
+        config = self.repo / "colorful.gitconfig"
+        config.write_text("[color]\n\tui = always\n")
+        result = self.lint(
+            "lint_urls.sh", GIT_CONFIG_GLOBAL=str(config), **self.curl_stub()
+        )
+        self.assert_scoped_to_feature(result)

--- a/.github/workflows/_link_check.yml
+++ b/.github/workflows/_link_check.yml
@@ -5,7 +5,9 @@ on:
         type: string
         required: true
       base_ref:
-        description: Commit to diff against. Empty, or all zeros, means check the whole tree.
+        description: >
+          Base branch commit. Pull requests lint from its merge base with ref, pushes
+          lint from it directly. Empty, or all zeros, means check the whole tree.
         type: string
         required: false
         default: ''
@@ -21,16 +23,31 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          # Only the merge base path needs history, and it costs ~25s. Quote the
+          # branches: bare 0 is falsy, so `&& 0 || 1` would always yield 1.
+          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
       - name: Lint URLs
         env:
           BASE_REF: ${{ inputs.base_ref }}
           HEAD_REF: ${{ inputs.ref }}
+          FROM_MERGE_BASE: ${{ github.event_name == 'pull_request' }}
         run: |
           args=()
           # A push creating a tag or branch reports an all zero SHA no remote can serve.
           if [ -n "$BASE_REF" ] && [ "$BASE_REF" != "0000000000000000000000000000000000000000" ]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF"
-            args=("$BASE_REF" "$HEAD_REF")
+            if [ "$FROM_MERGE_BASE" = "true" ]; then
+              git fetch --no-tags origin "$BASE_REF"
+              # Where the branch left the base branch, not the base branch tip, or a
+              # branch cut before recent commits is blamed for every line it merely
+              # lacks. No merge base means no usable range, so leave args empty for a
+              # whole tree scan: the scripts treat a bad range as nothing to check.
+              if merge_base=$(git merge-base "$BASE_REF" "$HEAD_REF"); then
+                args=("$merge_base" "$HEAD_REF")
+              fi
+            else
+              git fetch --no-tags --depth=1 origin "$BASE_REF"
+              args=("$BASE_REF" "$HEAD_REF")
+            fi
           fi
           ./scripts/lint_urls.sh "${args[@]}" || {
             echo
@@ -50,16 +67,31 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          # Only the merge base path needs history, and it costs ~25s. Quote the
+          # branches: bare 0 is falsy, so `&& 0 || 1` would always yield 1.
+          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
       - name: Lint cross-references
         env:
           BASE_REF: ${{ inputs.base_ref }}
           HEAD_REF: ${{ inputs.ref }}
+          FROM_MERGE_BASE: ${{ github.event_name == 'pull_request' }}
         run: |
           args=()
           # A push creating a tag or branch reports an all zero SHA no remote can serve.
           if [ -n "$BASE_REF" ] && [ "$BASE_REF" != "0000000000000000000000000000000000000000" ]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF"
-            args=("$BASE_REF" "$HEAD_REF")
+            if [ "$FROM_MERGE_BASE" = "true" ]; then
+              git fetch --no-tags origin "$BASE_REF"
+              # Where the branch left the base branch, not the base branch tip, or a
+              # branch cut before recent commits is blamed for every line it merely
+              # lacks. No merge base means no usable range, so leave args empty for a
+              # whole tree scan: the scripts treat a bad range as nothing to check.
+              if merge_base=$(git merge-base "$BASE_REF" "$HEAD_REF"); then
+                args=("$merge_base" "$HEAD_REF")
+              fi
+            else
+              git fetch --no-tags --depth=1 origin "$BASE_REF"
+              args=("$BASE_REF" "$HEAD_REF")
+            fi
           fi
           ./scripts/lint_xrefs.sh "${args[@]}" || {
             echo
@@ -79,16 +111,31 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          # Only the merge base path needs history, and it costs ~25s. Quote the
+          # branches: bare 0 is falsy, so `&& 0 || 1` would always yield 1.
+          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
       - name: Lint file sizes
         env:
           BASE_REF: ${{ inputs.base_ref }}
           HEAD_REF: ${{ inputs.ref }}
+          FROM_MERGE_BASE: ${{ github.event_name == 'pull_request' }}
         run: |
           args=()
           # A push creating a tag or branch reports an all zero SHA no remote can serve.
           if [ -n "$BASE_REF" ] && [ "$BASE_REF" != "0000000000000000000000000000000000000000" ]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF"
-            args=("$BASE_REF" "$HEAD_REF")
+            if [ "$FROM_MERGE_BASE" = "true" ]; then
+              git fetch --no-tags origin "$BASE_REF"
+              # Where the branch left the base branch, not the base branch tip, or a
+              # branch cut before recent commits is blamed for every line it merely
+              # lacks. No merge base means no usable range, so leave args empty for a
+              # whole tree scan: the scripts treat a bad range as nothing to check.
+              if merge_base=$(git merge-base "$BASE_REF" "$HEAD_REF"); then
+                args=("$merge_base" "$HEAD_REF")
+              fi
+            else
+              git fetch --no-tags --depth=1 origin "$BASE_REF"
+              args=("$BASE_REF" "$HEAD_REF")
+            fi
           fi
           chmod +x ./scripts/lint_file_size.sh
           ./scripts/lint_file_size.sh "${args[@]}" || {

--- a/scripts/lint_file_size.sh
+++ b/scripts/lint_file_size.sh
@@ -40,8 +40,8 @@ is_exception() {
 if [ $# -eq 2 ]; then
   base=$1
   head=$2
-  echo "Checking changed files between $base..$head"
-  files=$(git diff --name-only "$base..$head")
+  echo "Checking changed files between $base...$head"
+  files=$(git diff --no-color --name-only "$base...$head")
 else
   echo "Checking all files in repository"
   files=$(git ls-files)

--- a/scripts/lint_urls.sh
+++ b/scripts/lint_urls.sh
@@ -70,8 +70,10 @@ done < <(
     ':(exclude,glob)**/third_party/**'
   )
   if [ $# -eq 2 ]; then
-    for filename in $(git diff --name-only --unified=0 "$1..$2"); do
-      git diff --unified=0 "$1..$2" -- "$filename" "${excludes[@]}" \
+    # Three dots, not two. Against the base branch tip, a branch cut before recent
+    # commits looks like it is adding back every line those commits touched.
+    for filename in $(git diff --no-color --name-only --unified=0 "$1...$2"); do
+      git diff --no-color --unified=0 "$1...$2" -- "$filename" "${excludes[@]}" \
         | grep -E '^\+' \
         | grep -Ev '^\+\+\+' \
         | perl -nle 'print for m#'"$pattern"'#g' \

--- a/scripts/lint_xrefs.sh
+++ b/scripts/lint_xrefs.sh
@@ -35,8 +35,10 @@ done < <(
     ':(exclude,glob)**/third_party/**'
   )
   if [ $# -eq 2 ]; then
-    for filename in $(git diff --name-only --unified=0 "$1..$2"); do
-      git diff --unified=0 "$1..$2" -- "$filename" "${excludes[@]}" \
+    # Three dots, not two. Against the base branch tip, a branch cut before recent
+    # commits looks like it is adding back every line those commits touched.
+    for filename in $(git diff --no-color --name-only --unified=0 "$1...$2"); do
+      git diff --no-color --unified=0 "$1...$2" -- "$filename" "${excludes[@]}" \
         | grep -E '^\+' \
         | grep -Ev '^\+\+\+' \
         | perl -nle 'print for m#'"$pattern"'#g' \


### PR DESCRIPTION
### Summary

The URL, xref, and file-size linters diffed `base..head`, where `base` is the **tip** of the base branch rather than the point the branch left it. A branch cut before recent commits still carries the lines those commits replaced, so against the newer tip its old copies read as additions, and the branch gets blamed for links someone else already repaired.

#21729 failed exactly this way. It touches 18 files and adds no URLs at all, but the two-dot diff scoped the lint to 143 files and flagged nine links that #21694 had already fixed or `@lint-ignore`d. #21707 is starker: one Python file with no URLs in it, 199 files linted, the same nine failures.

```
base..head    143 files   <- what CI linted
base...head    18 files   <- what the PR actually changes
```

The stray `jq: parse error` lines in #21729's log are the same symptom from the other direction: the job runs the branch's own pre-#21694 copy of `lint_urls.sh`.

### Fix

The workflow resolves the merge base and passes it down. That is the half that matters for branches already open: on a `pull_request` the reusable workflow resolves from the merge commit, so it carries this fix even though `scripts/` still comes from the branch itself. The scripts also switch to three-dot ranges so `./scripts/lint_urls.sh main HEAD` by hand behaves the same. `lint_xrefs.sh` and `lint_file_size.sh` had the identical bug and get the identical change.

**Cost, stated plainly.** A merge base needs real history, so this restores `fetch-depth: 0` on the `pull_request` path — line for line what #17682 removed in February for speed. Measured on this branch, that is ~25s of added wall clock and ~79s of runner time across the three concurrent jobs. #17682's 6min → 10s was mostly the runner and Docker change rather than the fetch depth, though the commit changes both at once and I can't fully separate them. Pushes and the nightly whole-tree scan cannot use a merge base and stay shallow:

```yaml
fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
```

The quotes matter — bare `0` is falsy in GitHub expressions, so `&& 0 || 1` always yields `1` and would silently disable the fix.

**No silent fallback.** When there is no merge base there is no usable range, so the range is left unset and the linters scan the whole tree. Substituting the base tip instead produces a range the scripts fail on quietly: verified against unrelated histories, `lint_urls.sh` and `lint_xrefs.sh` both exit **0** having checked nothing, while `lint_file_size.sh` exits 128 and the wrapper reports "some files exceed the 1 MB limit", which is not what happened. Unset args are loud instead — verified rc=1 on a tree containing a dead link.

**`--no-color`.** Both `git diff` calls now pass it, matching the `git grep --no-color` two lines below. With `color.ui = always` in a developer's config, added lines arrive wrapped in escape sequences, `grep -E '^\+'` matches nothing, and the check passes having found nothing (measured: 2 matches → 0).

### Test plan

`.ci/scripts/tests/test_link_check_diff_selection.py` builds a diverged history where `main` repairs bad links and shrinks an oversized file while the feature branch simply predates all of it. Four fixture files each pin a different part, and `curl` is stubbed so there is no network:

| Fixture | Pins |
|---|---|
| `both_sides.md` — edited on both branches | the per-file diff range |
| `big.bin` — oversized at the branch point, shrunk on main | `lint_file_size.sh`'s range |
| `colorful.gitconfig` — `color.ui = always` | `--no-color` |
| `base_only.md` / `feature_only.md` | that main-only changes stay invisible and the branch's own additions are still checked |

```
pytest .ci/scripts/tests/test_link_check_diff_selection.py   # 4 passed
```

Mutating each changed line individually:

```
inner per-file range -> ..     3 failed   caught
lint_file_size range -> ..     1 failed   caught
drop --no-color                1 failed   caught
file-selection range -> ..     4 passed   equivalent mutant, see below
```

The file-selection range is not pinned because it cannot be: with the per-file diff at three dots, the extra files it selects produce empty diffs. Replayed against #21707's real 199-file range, both variants emit byte-identical output. It is changed for consistency, not behaviour.

**Narrowing the scope must not blunt the check**, so each linter also has a positive control where the branch itself adds the bad thing:

```
lint_urls      adds a dead URL         -> rc=1, reports example.invalid/dead
lint_xrefs     adds a broken reference -> rc=1, reports sub/missing.md
lint_file_size adds a 1MB+ file        -> rc=1, reports feature_big.bin
```

End to end on real content: a synthetic commit on top of `main` that puts #21694's nine repaired links back, as if a PR had added them, gives `rc=1` with 9 FAIL and 5 OK against the live network. Incidentally `musl.cc` answered this time where CI saw `000`, and `pybind/cmake_example` now 404s where CI saw `301` — which is the retry-then-WARN path earning its keep.

Also replayed #21729's and #21707's exact CI refs through the fixed scripts (exit 0 each), and ran all three linters plus `lintrunner` against this PR's own diff.

### Known limitations

- The checkout is `head.sha`, so references still resolve against the branch tree rather than the merge result — the mirror image of the bug fixed here. Pre-existing and not worsened by this PR.
- The whole-tree branch swallows a `git grep` failure and exits 0, so on a git built without PCRE the scan silently checks nothing. Reachable locally, not on the runners, which is why the nightly scan works. Pre-existing; worth a follow-up rather than widening this PR.

### Rollout

This does **not** repair a currently red run. A rerun keeps the original `GITHUB_SHA`, and advancing the base alone does not fire `synchronize`, so an already-open PR picks the fix up only on its next newly triggered pull-request run — any push, or close/reopen. That is still cheaper than a content rebase: no history rewrite, no conflicts, nothing to re-review.

Supersedes #21762, which fixes the same bug but leaves the checkout shallow and misses `lint_urls.sh`. Its reviewer's shallow-checkout point is exactly right: a `--depth=1` fetch writes a shallow graft even into an otherwise complete clone, after which `git merge-base` fails and `A...B` is fatal, so the two halves of this change are a pair. The regression test here is adapted from that PR.

Authored with Claude Code (Claude Opus 5).
