### PR TITLE
Add a PyTorch to ExecuTorch device mapping

### DIFF
--- a/extension/aten_util/aten_bridge.cpp
+++ b/extension/aten_util/aten_bridge.cpp
@@ -150,6 +150,20 @@ c10::Device executorch_to_torch_device(
       static_cast<int>(device.type()));
 }
 
+std::optional<executorch::runtime::etensor::Device> torch_to_executorch_device(
+    c10::Device device) {
+  switch (device.type()) {
+    case c10::DeviceType::CPU:
+      return executorch::runtime::etensor::Device(
+          executorch::runtime::etensor::DeviceType::CPU);
+    case c10::DeviceType::CUDA:
+      return executorch::runtime::etensor::Device(
+          executorch::runtime::etensor::DeviceType::CUDA, device.index());
+    default:
+      return std::nullopt;
+  }
+}
+
 /*
  * Following makes two assumptions:
  * 1. aten_tensor's lifetime is longer than the liftime within which mutable_et

--- a/extension/aten_util/aten_bridge.h
+++ b/extension/aten_util/aten_bridge.h
@@ -18,6 +18,7 @@
 #include <c10/core/ScalarTypeToTypeMeta.h> // @manual=//caffe2/c10:c10
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace executorch {
@@ -31,6 +32,16 @@ c10::ScalarType executorch_to_torch_scalar_type(
 
 c10::Device executorch_to_torch_device(
     executorch::runtime::etensor::Device device);
+
+/**
+ * Maps a PyTorch device onto the ExecuTorch device naming the same location.
+ *
+ * Returns nothing for a device this runtime has no type for. That is a valid
+ * thing for a caller to ask, so it is reported rather than fatal, and the
+ * caller adds the context it has before failing.
+ */
+std::optional<executorch::runtime::etensor::Device> torch_to_executorch_device(
+    c10::Device device);
 
 /*
  * @param[in] aten_tensor Input at::Tensor

--- a/extension/aten_util/test/aten_bridge_test.cpp
+++ b/extension/aten_util/test/aten_bridge_test.cpp
@@ -319,6 +319,30 @@ TEST(ATenBridgeTest, DeviceMappingAbortsOnUnknownType) {
       "");
 }
 
+TEST(ATenBridgeTest, ReverseDeviceMapping) {
+  // Needs no accelerator: only the mapping is under test.
+  using executorch::runtime::etensor::DeviceType;
+
+  const auto cpu =
+      torch_to_executorch_device(c10::Device(c10::DeviceType::CPU));
+  ASSERT_TRUE(cpu.has_value());
+  EXPECT_EQ(cpu->type(), DeviceType::CPU);
+
+  const auto cuda =
+      torch_to_executorch_device(c10::Device(c10::DeviceType::CUDA, 7));
+  ASSERT_TRUE(cuda.has_value());
+  EXPECT_EQ(cuda->type(), DeviceType::CUDA);
+  EXPECT_EQ(cuda->index(), 7);
+}
+
+TEST(ATenBridgeTest, ReverseDeviceMappingReportsAnUnrepresentableDevice) {
+  // Reported rather than fatal, unlike the other direction: a caller can hand
+  // in any device PyTorch supports, and the caller is the one holding the
+  // context worth putting in the error.
+  EXPECT_FALSE(torch_to_executorch_device(c10::Device(c10::DeviceType::Meta))
+                   .has_value());
+}
+
 TEST(ATenBridgeTest, AliasATTensorToETensorHandlesAnEmptyTensor) {
   // An empty tensor has a null data pointer, so this is the only case that
   // distinguishes dropping the device, passing it through options alone (which


### PR DESCRIPTION
The reverse mapping already exists in this header, and the scalar type conversions live
here as a matched pair in both directions. The direction that turns a PyTorch device
into an ExecuTorch one was missing, so a caller converting an incoming tensor had
nowhere to get it and had to write the two entry table itself.

Returns nothing for a device this runtime has no type for. That is a valid thing for a
caller to ask about, so it is reported rather than fatal, and the caller adds the
context it has, such as which input and which method, before failing. The opposite
direction aborts instead, because an unknown ExecuTorch device is an internal invariant
failure rather than something a user can cause.

Test Plan: extension/aten_util/test/aten_bridge_test.cpp gains two cases, mirroring the
pair that covers the opposite direction three lines above.

  ReverseDeviceMapping                             CPU maps, CUDA maps, and the device
                                                   index is preserved
  ReverseDeviceMappingReportsAnUnrepresentableDevice
                                                   a device with no runtime equivalent
                                                   reports rather than aborts

Neither needs an accelerator: only the mapping is under test, which is why the CUDA arm
and the index can be covered on a machine without one. Both were compiled and run
directly.

Worth knowing when reading this: the test directory here carries no CMake build file, so
these two cases are not compiled by the public continuous integration. They run in the
internal build and when run by hand. The behaviour they cover is also exercised indirectly
by the change above this one, which calls this mapping on every input.