### PR TITLE
Ship the OpenVINO delegate as its own library

### DIFF
--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -105,6 +105,10 @@ _XNNPACK_SYMBOLS = (
 # have exactly one owner while the bundled code underneath them does not. That is
 # the same failure the split exists to prevent, reached by a different route.
 _BUNDLED_THREADPOOL_SYMBOLS = ("pthreadpool_create", "cpuinfo_initialize")
+# The delegate's own entry points. A second definer means the delegate is compiled
+# into the Python extension as well, which would register it twice in one process.
+_OPENVINO_BACKEND_SYMBOLS = ("OpenvinoBackend",)
+
 _BUNDLED_XNNPACK_SYMBOLS = ("xnn_create_runtime_v4",)
 
 # A representative symbol from the profiler. A second definer means two event
@@ -533,6 +537,12 @@ _OWNED_COMPONENTS = (
         _BUNDLED_XNNPACK_SYMBOLS,
         "libexecutorch_backend_xnnpack.so",
         True,
+    ),
+    (
+        "OpenVINO delegate",
+        _OPENVINO_BACKEND_SYMBOLS,
+        "libexecutorch_backend_openvino.so",
+        False,
     ),
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1236,6 +1236,9 @@ if(EXECUTORCH_BUILD_PYBIND)
   endif()
 
   if(EXECUTORCH_BUILD_OPENVINO)
+    # Under a shared build this resolves to the shipped library rather than a
+    # static archive, so the delegate is not copied into the extension and the
+    # process registers it once.
     list(APPEND _dep_libs openvino_backend)
   endif()
 

--- a/backends/openvino/CMakeLists.txt
+++ b/backends/openvino/CMakeLists.txt
@@ -32,7 +32,12 @@ include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
 # there is no build-time dependency on the OpenVINO SDK.
 
 # Define OpenVINO backend as a static library
-add_library(openvino_backend STATIC)
+if(EXECUTORCH_BUILD_SHARED)
+  set(_openvino_backend_library_type SHARED)
+else()
+  set(_openvino_backend_library_type STATIC)
+endif()
+add_library(openvino_backend ${_openvino_backend_library_type})
 
 # Enable exceptions and RTTI for OpenVINO backend
 target_compile_options(openvino_backend PRIVATE -frtti -fexceptions)
@@ -48,6 +53,21 @@ target_include_directories(openvino_backend PRIVATE ${COMMON_INCLUDE_DIRS})
 
 # Link ExecuteTorch core and dynamic loading libraries
 target_link_libraries(openvino_backend PRIVATE executorch_core ${CMAKE_DL_LIBS})
+
+if(EXECUTORCH_BUILD_SHARED)
+  # Named after what the library provides rather than after the target that
+  # produces it, matching the other shipped delegates, so the file reads as
+  # libexecutorch_backend_openvino.so.
+  set_target_properties(
+    openvino_backend PROPERTIES OUTPUT_NAME executorch_backend_openvino
+  )
+  executorch_target_soname_policy(openvino_backend)
+  # Resolve the runtime from the shared library rather than from the static
+  # core, so the delegate registers into the one registry the process has.
+  target_link_libraries(openvino_backend PUBLIC executorch_shared)
+  # Ships beside the runtime in the wheel's lib/ directory.
+  executorch_target_shipped_runtime_path(openvino_backend)
+endif()
 
 executorch_target_link_options_shared_lib(openvino_backend)
 

--- a/docs/source/using-executorch-cpp.md
+++ b/docs/source/using-executorch-cpp.md
@@ -110,6 +110,8 @@ reported while CMake configures, rather than failing later at link time.
 | `executorch::kernels_optimized` | CPU operator kernels. Needed for any operator a delegate does not claim. |
 | `executorch::kernels_quantized` | quantized operator kernels, for a quantized model. Link it only when you need it: see the note below. |
 | `executorch::backend_xnnpack` | the XNNPACK delegate. |
+| `executorch::backend_openvino` | the OpenVINO delegate. Present only in a wheel built with OpenVINO, and it loads the OpenVINO runtime at run time, so install that separately. |
+| `executorch::backend_openvino` | the OpenVINO delegate. Present only in a wheel built with OpenVINO, and it loads the OpenVINO runtime at run time, so install that separately. |
 | `executorch::backend_cuda` | the CUDA delegate, in a CUDA wheel. |
 | `executorch::extension_cuda` | the CUDA stream helper, in a CUDA wheel. Lets you pick the CUDA stream a model runs on. |
 | `executorch::threadpool` | the shared thread pool. |

--- a/setup.py
+++ b/setup.py
@@ -1823,6 +1823,18 @@ setup(
                         "EXECUTORCH_BUILD_KERNELS_QUANTIZED",
                     ],
                 ),
+                # The OpenVINO delegate, so a C++ application can link it from the
+                # wheel. Only the adapter ships here: the OpenVINO runtime itself is
+                # loaded at run time and comes from the openvino extra.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/backends/openvino/%BUILD_TYPE%/",
+                    src_name="*executorch_backend_openvino" + _dynamic_lib_suffix(),
+                    dst="executorch/lib/",
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_OPENVINO",
+                    ],
+                ),
                 # Install the XNNPACK delegate beside them, so a process has one
                 # copy of it instead of one per component that uses it.
                 BuiltFile(

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -588,6 +588,7 @@ if(TARGET executorch::runtime AND TARGET executorch::threadpool)
 endif()
 
 _executorch_define_component(backend_xnnpack executorch_backend_xnnpack)
+_executorch_define_component(backend_openvino executorch_backend_openvino)
 # The CUDA delegate and its stream helper, present only in a wheel built from a
 # CUDA index. A CPU wheel defines neither, so a consumer asking for one is told
 # while configuring.


### PR DESCRIPTION
The OpenVINO delegate was compiled into the Python extension, so only Python could use it. A C++ application had no way to link it from the wheel, which is the same gap the other delegates had before they were split out.

It now builds as its own library and ships beside the runtime, so an application can ask for it:

```cmake
find_package(executorch REQUIRED COMPONENTS backend_openvino)
target_link_libraries(my_app PRIVATE executorch::backend_openvino)
```

Only the adapter ships here. The OpenVINO runtime itself is loaded at run time and is not part of the wheel, so the component's documentation says to install it separately, and the wheel does not grow meaningfully: the adapter is a few kilobytes.

The library resolves the runtime from the shared runtime library rather than from the static core, so the delegate registers into the one registry the process has instead of a second private one.

### Test Plan

Built a wheel with OpenVINO enabled on Linux x86_64 and inspected it.

```
executorch/lib/libexecutorch_backend_openvino.so        ships

OpenvinoBackend symbols in the library                  13
OpenvinoBackend symbols in the Python extension          0   (was 13)

the library's ExecuTorch dependency                     libexecutorch.so
its link dependency on OpenVINO                         none, loaded at run time
```

So the process has one copy and one registration, and the runtime is still loaded at run time rather than linked. Added an ownership row to the shared library test, so a future change that puts the delegate back into the extension fails there.
