### PR TITLE
Ship linkable libraries in the macOS wheel

### DIFF
--- a/.ci/scripts/wheel/test_cpp_sdk.py
+++ b/.ci/scripts/wheel/test_cpp_sdk.py
@@ -261,6 +261,38 @@ add_executable(consumer consumer.cpp)
 """
 
 
+def _dynamic_lib_suffix() -> str:
+    """The loadable library suffix on this platform, including the dot."""
+    return ".dylib" if sys.platform == "darwin" else ".so"
+
+
+def _library_file_name(base_name: str) -> str:
+    """The file name a library has on this platform."""
+    return f"{base_name}{_dynamic_lib_suffix()}"
+
+
+def _recorded_dependencies(binary) -> str:
+    """What a built binary records about its dependencies and search paths.
+
+    readelf prints the ELF dynamic section, otool -l the Mach-O load commands. Both
+    carry the same facts: a dependency entry and a runtime search path entry, named
+    NEEDED and RUNPATH on ELF, LC_LOAD_DYLIB and LC_RPATH on Mach-O.
+    """
+    if sys.platform == "darwin":
+        tool, args = _tool("otool"), ["-l"]
+        needed = "otool"
+    else:
+        tool, args = _tool("readelf"), ["-d"]
+        needed = "readelf"
+    assert tool is not None, f"{needed} is needed to read the runtime search path"
+    return subprocess.run(
+        [tool, *args, str(binary)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
 def _tool(name: str) -> str:
     """Locate a build tool, including one pip installed beside this interpreter.
 
@@ -560,14 +592,8 @@ def test_consumer_is_relocatable(work_dir: Path) -> None:
     model, reference = _export(work_dir, "plain")
     consumer = _build_consumer(work_dir, "relocate", ["runtime", "kernels_optimized"])
 
-    assert shutil.which("readelf") is not None, "readelf is needed to read the RUNPATH"
-    dynamic = subprocess.run(
-        [_tool("readelf"), "-d", str(consumer)],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout
-    assert "libexecutorch.so" in dynamic, (
+    dynamic = _recorded_dependencies(consumer)
+    assert _library_file_name("libexecutorch") in dynamic, (
         "the application records no dependency on the shipped runtime, so it is not "
         f"linking what the wheel ships:\n{dynamic}"
     )
@@ -591,7 +617,7 @@ def test_consumer_is_relocatable(work_dir: Path) -> None:
     deployed = work_dir / "deployed"
     deployed.mkdir(parents=True, exist_ok=True)
     shutil.copy2(consumer, deployed / "consumer")
-    for library in sorted((package_dir / "lib").glob("lib*.so*")):
+    for library in sorted((package_dir / "lib").glob(_library_file_name("lib*") + "*")):
         if library.is_file() and not library.is_symlink():
             shutil.copy2(library, deployed / library.name)
 
@@ -783,7 +809,9 @@ def test_profiler_component_is_usable(work_dir: Path) -> None:
     # Globbed, not an exact name: the library carries a version suffix outside a wheel build, and an exact
     # match would silently skip this check there. The profiler is required elsewhere in this suite, so its
     # absence is a fault rather than a reason to skip.
-    shipped = sorted((package_dir / "lib").glob("libexecutorch_etdump.so*"))
+    shipped = sorted(
+        (package_dir / "lib").glob(_library_file_name("libexecutorch_etdump") + "*")
+    )
     assert shipped, (
         f"the wheel ships no profiler library under {package_dir / 'lib'}, so the etdump component it "
         "advertises cannot be linked"
@@ -1019,7 +1047,7 @@ def test_shipped_headers_have_implementations(work_dir: Path) -> None:
                         "executorch_kernels_optimized",
                         "executorch_threadpool",
                     )
-                    if (library_dir / f"lib{name}.so").is_file()
+                    if (library_dir / f"lib{name}" + _dynamic_lib_suffix()).is_file()
                 ],
                 f"-Wl,-rpath,{library_dir}",
             ],
@@ -1229,10 +1257,8 @@ def test_pre_3_28_route_builds_a_consumer_through_variables(work_dir: Path) -> N
     # the only thing that carries them on this route. Reading the dynamic section rather
     # than running because running needs a model, which the modern-CMake tests above
     # cover once and this one only owns the variables path.
-    dependencies = subprocess.run(
-        ["readelf", "-d", str(consumer)], capture_output=True, text=True, check=True
-    ).stdout
-    assert "libexecutorch.so" in dependencies, (
+    dependencies = _recorded_dependencies(consumer)
+    assert _library_file_name("libexecutorch") in dependencies, (
         "a consumer built through EXECUTORCH_LIBRARIES on pre-3.28 CMake does not "
         f"depend on the runtime:\n{dependencies}"
     )
@@ -1262,7 +1288,11 @@ def test_quantized_kernels_component_runs_a_model(work_dir: Path) -> None:
     package_dir = _installed_package_dir()
     # Globbed for the same reason the profiler check is: the library carries a version suffix outside a
     # wheel build, and an exact name would skip this silently there rather than running it.
-    shipped = sorted((package_dir / "lib").glob("libexecutorch_kernels_quantized.so*"))
+    shipped = sorted(
+        (package_dir / "lib").glob(
+            _library_file_name("libexecutorch_kernels_quantized") + "*"
+        )
+    )
     assert shipped, (
         "the wheel ships no quantized kernels library. The preset that builds it enables "
         "them unconditionally, so this is a packaging or build regression rather than an "
@@ -1311,7 +1341,9 @@ def test_aggregate_variable_excludes_the_quantized_kernels(work_dir: Path) -> No
     # always enables these kernels, so their absence is a regression rather than a
     # configuration to tolerate, and skipping would report this as coverage.
     assert sorted(
-        (package_dir / "lib").glob("libexecutorch_kernels_quantized.so*")
+        (package_dir / "lib").glob(
+            _library_file_name("libexecutorch_kernels_quantized") + "*"
+        )
     ), "the wheel ships no quantized kernels library, so this check cannot run"
 
     source_dir = work_dir / "aggregate-only"
@@ -1346,9 +1378,7 @@ def test_aggregate_variable_excludes_the_quantized_kernels(work_dir: Path) -> No
         )
 
     consumer = build_dir / "consumer"
-    dependencies = subprocess.run(
-        ["readelf", "-d", str(consumer)], capture_output=True, text=True, check=True
-    ).stdout
+    dependencies = _recorded_dependencies(consumer)
     assert "libexecutorch_kernels_quantized" not in dependencies, (
         "an application that linked only ${EXECUTORCH_LIBRARIES} depends on the "
         "quantized kernels. That library collides with the export-time plugin, so it "

--- a/.ci/scripts/wheel/test_macos.py
+++ b/.ci/scripts/wheel/test_macos.py
@@ -6,11 +6,29 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import tempfile
+from pathlib import Path
+
 import test_base
+import test_cpp_sdk
+import test_shared_libraries
 from examples.models import Backend, Model
 
 if __name__ == "__main__":
     test_base.test_cmsis_nn_install()
+
+    # The wheel ships the runtime, the kernels, the delegate, the thread pool and
+    # the profiler as separate libraries here too, so check that each has exactly
+    # one owner and that all of them are loadable.
+    with tempfile.TemporaryDirectory() as work_dir:
+        test_shared_libraries.run_tests(Path(work_dir))
+
+    # And that a C++ application outside the wheel can actually use them. Nothing
+    # else covers this: the Python extension links those libraries itself, so it
+    # passes whether or not the package config names them or the shipped headers
+    # are complete.
+    with tempfile.TemporaryDirectory() as work_dir:
+        test_cpp_sdk.run_tests(Path(work_dir))
 
     test_base.run_tests(
         model_tests=[

--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -232,6 +232,83 @@ def _tool(name: str):
     return str(beside) if beside.is_file() else None
 
 
+def _dynamic_section(library) -> str | None:
+    """What a library records about its dependencies and search paths.
+
+    Returns None when no tool can read it, so a caller can tell "nothing recorded"
+    apart from "could not look", which are different verdicts.
+
+    readelf prints the ELF dynamic section. otool -l prints the Mach-O load commands,
+    which carry the same facts under different names: LC_LOAD_DYLIB for a dependency
+    where ELF has NEEDED, and LC_RPATH where ELF has RUNPATH.
+    """
+    if sys.platform == "darwin":
+        tool, args = _tool("otool"), ["-l"]
+    else:
+        tool, args = _tool("readelf"), ["-d"]
+    if tool is None:
+        return None
+    return subprocess.run(
+        [tool, *args, str(library)],
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout
+
+
+def _linked_libraries(library) -> str | None:
+    """The libraries this one resolves at load time, as text to search.
+
+    ldd resolves an ELF library's dependencies transitively. otool -L lists a Mach-O
+    library's direct dependencies without resolving them, which is weaker, so a macOS
+    result says which names are recorded rather than whether each one was found.
+    """
+    if sys.platform == "darwin":
+        tool, args = _tool("otool"), ["-L"]
+    else:
+        tool, args = _tool("ldd"), ["-r"]
+    if tool is None:
+        return None
+    result = subprocess.run(
+        [tool, *args, str(library)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout + result.stderr
+
+
+def _dynamic_lib_suffix() -> str:
+    """The loadable library suffix on this platform, including the dot."""
+    return ".dylib" if sys.platform == "darwin" else ".so"
+
+
+def _library_file_name(base_name: str) -> str:
+    """The file name a component's library has on this platform.
+
+    The component table names libraries without a suffix so one table serves both
+    platforms.
+    """
+    return f"{base_name}{_dynamic_lib_suffix()}"
+
+
+def _nm_defined_args():
+    """The nm flags that list what a library defines.
+
+    GNU nm reads the dynamic symbol table with -D. Mach-O has no separate dynamic
+    symbol table, so that flag fails outright there and -gU, global and defined, is
+    the equivalent question.
+    """
+    return ["-gU", "-C"] if sys.platform == "darwin" else ["-DC"]
+
+
+def _nm_undefined_args():
+    """The nm flags that list what a library needs from elsewhere."""
+    if sys.platform == "darwin":
+        return ["-gu", "-C"]
+    return ["-DC", "--undefined-only"]
+
+
 def _shipped_shared_objects(package_dir: Path):
     """Every shared object the wheel installed.
 
@@ -240,7 +317,7 @@ def _shipped_shared_objects(package_dir: Path):
     """
     found = [
         path
-        for path in sorted(package_dir.rglob("*.so*"))
+        for path in sorted(package_dir.rglob(f"*{_dynamic_lib_suffix()}*"))
         if path.is_file() and not path.is_symlink()
     ]
     assert (
@@ -285,7 +362,10 @@ def _defines_symbol(library: Path, symbol: str) -> bool:
     being visible at all.
     """
     result = subprocess.run(
-        [_tool("nm"), "-DC", str(library)], capture_output=True, text=True, check=False
+        [_tool("nm"), *_nm_defined_args(), str(library)],
+        capture_output=True,
+        text=True,
+        check=False,
     )
     if result.returncode != 0:
         # A file that is not an object file at all is not this check's concern: something whose
@@ -335,15 +415,10 @@ def _is_export_only(library: Path) -> bool:
         return False
     if library.name.endswith("_aot_lib.so"):
         return True
-    if _tool("readelf") is None:
+    dynamic = _dynamic_section(library)
+    if dynamic is None:
         return False
-    dynamic = subprocess.run(
-        [_tool("readelf"), "-d", str(library)],
-        capture_output=True,
-        text=True,
-        check=False,
-    ).stdout
-    return "libtorch.so" in dynamic
+    return _library_file_name("libtorch") in dynamic
 
 
 def _assert_single_definer(
@@ -470,26 +545,36 @@ _EXPECTED_CUDA_PACKAGES = {
 # one of them drift: it looked up its library with its own glob, which silently
 # stopped matching when the libraries were renamed while the others kept working.
 _OWNED_COMPONENTS = (
-    ("backend registry", _REGISTRY_SYMBOLS, "libexecutorch.so", True),
-    ("operator registry", _KERNEL_REGISTRY_SYMBOLS, "libexecutorch.so", True),
-    ("thread pool", _THREADPOOL_SYMBOLS, "libexecutorch_threadpool.so", True),
-    ("profiler", _ETDUMP_SYMBOLS, "libexecutorch_etdump.so", True),
+    ("backend registry", _REGISTRY_SYMBOLS, _library_file_name("libexecutorch"), True),
+    (
+        "operator registry",
+        _KERNEL_REGISTRY_SYMBOLS,
+        _library_file_name("libexecutorch"),
+        True,
+    ),
+    (
+        "thread pool",
+        _THREADPOOL_SYMBOLS,
+        _library_file_name("libexecutorch_threadpool"),
+        True,
+    ),
+    ("profiler", _ETDUMP_SYMBOLS, _library_file_name("libexecutorch_etdump"), True),
     (
         "XNNPACK delegate",
         _XNNPACK_SYMBOLS,
-        "libexecutorch_backend_xnnpack.so",
+        _library_file_name("libexecutorch_backend_xnnpack"),
         True,
     ),
     (
         "set of CPU kernels",
         _KERNEL_SYMBOLS,
-        "libexecutorch_kernels_optimized.so",
+        _library_file_name("libexecutorch_kernels_optimized"),
         False,
     ),
     (
         "set of quantized kernels",
         _QUANTIZED_KERNEL_SYMBOLS,
-        "libexecutorch_kernels_quantized.so",
+        _library_file_name("libexecutorch_kernels_quantized"),
         True,
     ),
     # The CUDA components. Required exactly when the wheel says it is a CUDA wheel,
@@ -500,19 +585,19 @@ _OWNED_COMPONENTS = (
     (
         "CUDA delegate",
         _CUDA_BACKEND_SYMBOLS,
-        "libexecutorch_backend_cuda.so",
+        _library_file_name("libexecutorch_backend_cuda"),
         _REQUIRED_ON_A_CUDA_WHEEL,
     ),
     (
         "CUDA stream helper",
         _CUDA_STREAM_SYMBOLS,
-        "libexecutorch_extension_cuda.so",
+        _library_file_name("libexecutorch_extension_cuda"),
         _REQUIRED_ON_A_CUDA_WHEEL,
     ),
     (
         "AOTI shim layer",
         _AOTI_SHIM_SYMBOLS,
-        "libaoti_cuda_shims.so",
+        _library_file_name("libaoti_cuda_shims"),
         _REQUIRED_ON_A_CUDA_WHEEL,
     ),
     # The third-party code these libraries bundle, checked separately from the
@@ -529,19 +614,19 @@ _OWNED_COMPONENTS = (
     (
         "bundled thread pool implementation",
         _BUNDLED_THREADPOOL_SYMBOLS,
-        "libexecutorch_threadpool.so",
+        _library_file_name("libexecutorch_threadpool"),
         True,
     ),
     (
         "bundled XNNPACK runtime",
         _BUNDLED_XNNPACK_SYMBOLS,
-        "libexecutorch_backend_xnnpack.so",
+        _library_file_name("libexecutorch_backend_xnnpack"),
         True,
     ),
     (
         "OpenVINO delegate",
         _OPENVINO_BACKEND_SYMBOLS,
-        "libexecutorch_backend_openvino.so",
+        _library_file_name("libexecutorch_backend_openvino"),
         False,
     ),
 )
@@ -1005,7 +1090,7 @@ def test_custom_op_compiles(work_dir: Path) -> None:
         "a custom operator does not compile or link against the shipped extension: "
         f"{(compiled.stderr or compiled.stdout).strip()[-800:]}"
     )
-    produced = list(build_dir.rglob("libcustom_op_check.so")) or list(
+    produced = list(build_dir.rglob(_library_file_name("libcustom_op_check"))) or list(
         build_dir.rglob("custom_op_check.dll")
     )
     assert produced, "the custom operator library was not produced"
@@ -1435,7 +1520,7 @@ def test_extension_contains_no_component() -> None:
     # UNDEFINED reference cannot be faked that way: it says the definition is not
     # here and has to come from a dependency.
     undefined = subprocess.run(
-        [_tool("nm"), "-DC", "--undefined-only", str(extension)],
+        [_tool("nm"), *_nm_undefined_args(), str(extension)],
         capture_output=True,
         text=True,
         check=False,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,17 +193,16 @@ if(DEFINED EXECUTORCH_BAREMETAL_SKIP_INSTALL
 endif()
 
 if(EXECUTORCH_BUILD_SHARED)
-  # Linux only, and said here rather than left to fail somewhere downstream. The
-  # shared build names libraries with an ELF soname, records $ORIGIN runtime
-  # paths, and uses GNU linker options to keep a registration-only library on a
-  # link line. None of that applies on Apple, which is served by the Swift
-  # package distribution, or on Windows, where the runtime carries no export
-  # annotations for a DLL. Enabling it elsewhere failed much later and less
-  # clearly, when packaging looked for a .so the build never emitted.
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  # Said here rather than left to fail somewhere downstream, where packaging
+  # looked for a library the build never emitted. Windows is still refused:
+  # there the runtime carries no export annotations, so a DLL would link against
+  # nothing, which is a missing capability rather than a different spelling of
+  # one.
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT APPLE)
     message(
-      FATAL_ERROR "EXECUTORCH_BUILD_SHARED is supported on Linux only, not "
-                  "${CMAKE_SYSTEM_NAME}."
+      FATAL_ERROR
+        "EXECUTORCH_BUILD_SHARED is supported on Linux and macOS only, not "
+        "${CMAKE_SYSTEM_NAME}."
     )
   endif()
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/setup.py
+++ b/setup.py
@@ -1728,8 +1728,8 @@ setup(
                 # what links it, which never happens inside a wheel.
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/",
-                    src_name="libexecutorch.so",
-                    dst="executorch/lib/libexecutorch.so",
+                    src_name=get_dynamic_lib_name("executorch"),
+                    dst="executorch/lib/" + get_dynamic_lib_name("executorch"),
                     dependent_cmake_flags=["EXECUTORCH_BUILD_SHARED"],
                 ),
                 # Install the profiler next to it, as its own library rather than
@@ -1737,8 +1737,8 @@ setup(
                 # it however many consumers load.
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/devtools/etdump/",
-                    src_name="libexecutorch_etdump.so",
-                    dst="executorch/lib/libexecutorch_etdump.so",
+                    src_name=get_dynamic_lib_name("executorch_etdump"),
+                    dst="executorch/lib/" + get_dynamic_lib_name("executorch_etdump"),
                     # Not gated on EXECUTORCH_BUILD_DEVTOOLS. The shared build adds
                     # the devtools subdirectory itself, so the library exists
                     # whenever the shared build does. The Python extension carries a
@@ -1751,8 +1751,9 @@ setup(
                 # component that uses it.
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/extension/threadpool/",
-                    src_name="libexecutorch_threadpool.so",
-                    dst="executorch/lib/libexecutorch_threadpool.so",
+                    src_name=get_dynamic_lib_name("executorch_threadpool"),
+                    dst="executorch/lib/"
+                    + get_dynamic_lib_name("executorch_threadpool"),
                     # The target only exists when both of its dependencies are
                     # enabled, so packaging has to require them too or a shared
                     # build with either turned off looks for a file that was
@@ -1767,8 +1768,9 @@ setup(
                 # registered once per process rather than once per component.
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/configurations/",
-                    src_name="libexecutorch_kernels_optimized.so",
-                    dst="executorch/lib/libexecutorch_kernels_optimized.so",
+                    src_name=get_dynamic_lib_name("executorch_kernels_optimized"),
+                    dst="executorch/lib/"
+                    + get_dynamic_lib_name("executorch_kernels_optimized"),
                     # The target is only created when the optimized kernels are
                     # enabled, so packaging has to require that too rather than
                     # looking for a file a shared build may never have produced.
@@ -1783,8 +1785,9 @@ setup(
                 # CPU-only build never produced.
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/backends/cuda/",
-                    src_name="libexecutorch_backend_cuda.so",
-                    dst="executorch/lib/libexecutorch_backend_cuda.so",
+                    src_name=get_dynamic_lib_name("executorch_backend_cuda"),
+                    dst="executorch/lib/"
+                    + get_dynamic_lib_name("executorch_backend_cuda"),
                     dependent_cmake_flags=[
                         "EXECUTORCH_BUILD_SHARED",
                         "EXECUTORCH_BUILD_CUDA",
@@ -1816,8 +1819,9 @@ setup(
                 # them before.
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/kernels/quantized/",
-                    src_name="libexecutorch_kernels_quantized.so",
-                    dst="executorch/lib/libexecutorch_kernels_quantized.so",
+                    src_name=get_dynamic_lib_name("executorch_kernels_quantized"),
+                    dst="executorch/lib/"
+                    + get_dynamic_lib_name("executorch_kernels_quantized"),
                     dependent_cmake_flags=[
                         "EXECUTORCH_BUILD_SHARED",
                         "EXECUTORCH_BUILD_KERNELS_QUANTIZED",
@@ -1839,8 +1843,9 @@ setup(
                 # copy of it instead of one per component that uses it.
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/backends/xnnpack/",
-                    src_name="libexecutorch_backend_xnnpack.so",
-                    dst="executorch/lib/libexecutorch_backend_xnnpack.so",
+                    src_name=get_dynamic_lib_name("executorch_backend_xnnpack"),
+                    dst="executorch/lib/"
+                    + get_dynamic_lib_name("executorch_backend_xnnpack"),
                     dependent_cmake_flags=[
                         "EXECUTORCH_BUILD_SHARED",
                         "EXECUTORCH_BUILD_XNNPACK",

--- a/tools/cmake/Utils.cmake
+++ b/tools/cmake/Utils.cmake
@@ -355,8 +355,15 @@ endfunction()
 # recorded directories are what resolves them there, and packaging strips them
 # so nothing absolute ships.
 function(executorch_target_shipped_runtime_path target_name)
+  # Mach-O spells the same idea @loader_path.
+  if(APPLE)
+    set(_origin "@loader_path")
+  else()
+    set(_origin "$ORIGIN")
+  endif()
   set_target_properties(
-    ${target_name} PROPERTIES BUILD_RPATH "$ORIGIN" INSTALL_RPATH "$ORIGIN"
+    ${target_name} PROPERTIES BUILD_RPATH "${_origin}" INSTALL_RPATH
+                                                       "${_origin}"
   )
 endfunction()
 
@@ -378,12 +385,21 @@ endfunction()
 function(executorch_target_shared_runtime_path target_name wheel_subdir
          install_destination
 )
-  if(NOT EXECUTORCH_BUILD_SHARED OR APPLE)
+  if(NOT EXECUTORCH_BUILD_SHARED)
     return()
+  endif()
+  # Mach-O spells the token differently and takes a list rather than a colon
+  # joined string, so both differ here while the mechanism does not.
+  if(APPLE)
+    set(_origin "@loader_path")
+    set(_separator ";")
+  else()
+    set(_origin "$ORIGIN")
+    set(_separator ":")
   endif()
   # Up out of the subdirectory, then into the package's lib/.
   string(REGEX REPLACE "[^/]+" ".." _up "${wheel_subdir}")
-  set(_paths "$ORIGIN/${_up}/lib")
+  set(_paths "${_origin}/${_up}/lib")
   # Made absolute lexically, so a destination that is already absolute, as a
   # ${CMAKE_INSTALL_LIBDIR} based one becomes, is handled the same as a prefix
   # relative one.
@@ -408,10 +424,10 @@ function(executorch_target_shared_runtime_path target_name wheel_subdir
   file(RELATIVE_PATH _to_libdir "${_installed_dir}"
        "${CMAKE_INSTALL_FULL_LIBDIR}"
   )
-  string(APPEND _paths ":$ORIGIN/${_to_libdir}")
+  string(APPEND _paths "${_separator}${_origin}/${_to_libdir}")
   get_target_property(_existing ${target_name} INSTALL_RPATH)
   if(_existing)
-    set(_paths "${_existing}:${_paths}")
+    set(_paths "${_existing}${_separator}${_paths}")
   endif()
   set_target_properties(
     ${target_name} PROPERTIES BUILD_RPATH "${_paths}" INSTALL_RPATH "${_paths}"
@@ -434,6 +450,14 @@ endfunction()
 # instead is not equivalent, because a wheel is a zip and the format has no
 # portable symlink support.
 function(executorch_target_soname_policy target_name)
+  # Mach-O records the path a library expects to live at, and a consumer copies
+  # that path verbatim, so a library shipped somewhere other than where it was
+  # built is unfindable unless the recorded name is relative to whoever loads
+  # it. Set that before the wheel check, because the wheel is exactly the case
+  # that relocates.
+  if(APPLE)
+    set_target_properties(${target_name} PROPERTIES INSTALL_NAME_DIR "@rpath")
+  endif()
   if(EXECUTORCH_BUILD_WHEEL_DO_NOT_USE)
     return()
   endif()

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -237,9 +237,18 @@ function(_executorch_find_library _output _base_name)
       ""
       PARENT_SCOPE
   )
-  file(GLOB _matches "${_executorch_package_root}/lib/${_base_name}.so"
-       "${_executorch_package_root}/lib/${_base_name}.so.*"
-  )
+  # Mach-O puts the version before the suffix, libfoo.1.dylib, where ELF puts it
+  # after, libfoo.so.1, so the versioned pattern differs and not just the
+  # suffix.
+  if(APPLE)
+    file(GLOB _matches "${_executorch_package_root}/lib/${_base_name}.dylib"
+         "${_executorch_package_root}/lib/${_base_name}.*.dylib"
+    )
+  else()
+    file(GLOB _matches "${_executorch_package_root}/lib/${_base_name}.so"
+         "${_executorch_package_root}/lib/${_base_name}.so.*"
+    )
+  endif()
   list(LENGTH _matches _count)
   if(_count EQUAL 0)
     return()

--- a/tools/cmake/preset/pybind.cmake
+++ b/tools/cmake/preset/pybind.cmake
@@ -42,6 +42,11 @@ endif()
 # TODO(larryliu0820): Temporarily disable building llm_runner for Windows wheel
 # due to the issue of tokenizer file path length limitation.
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  # Same reason as on Linux: one shared runtime so a process has a single
+  # backend registry, and a C++ consumer can link the wheel instead of building
+  # from source. The Swift package remains the better fit for an application
+  # bundle.
+  set_overridable_option(EXECUTORCH_BUILD_SHARED ON)
   set_overridable_option(EXECUTORCH_BUILD_VGF ${_executorch_pybind_enable_vgf})
   set_overridable_option(EXECUTORCH_BUILD_COREML ON)
   set_overridable_option(EXECUTORCH_BUILD_EXTENSION_TRAINING ON)
@@ -105,9 +110,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   endif()
   set_overridable_option(EXECUTORCH_BUILD_OPENVINO OFF)
   # Ship one shared runtime that both the pybind extension and standalone C++
-  # consumers link, so a process has a single backend registry. Linux only:
-  # macOS C++ consumers are served by the Swift package distribution, and the
-  # runtime has no export annotations for a Windows DLL.
+  # consumers link, so a process has a single backend registry. Not set on
+  # Windows, where the runtime has no export annotations for a DLL.
   set_overridable_option(EXECUTORCH_BUILD_SHARED ON)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL
                                                "WIN32"


### PR DESCRIPTION
The macOS wheel shipped one fused Python extension and no linkable libraries, so a C++ application got nothing from it: the headers and the CMake package were there, but every component a consumer asked for resolved to nothing. On Linux the same wheel ships the runtime, the kernels, the delegates, the thread pool and the profiler as separate libraries, and a C++ application links them directly.

### What was Linux only, and its Mach-O equivalent

```
runtime search path                  $ORIGIN          ->  @loader_path
keeping a registration-only library  --no-as-needed   ->  -force_load, already present
library identity                     ELF soname       ->  install name relative to @rpath
```

Windows is still refused, because there the runtime carries no export annotations for a DLL, which is a missing capability rather than a different spelling of one.

The packaging entries and the package config asked for a `.so` by name, so they would have looked for a file the build never emits. Both now derive the suffix from the platform, and the config also accounts for Mach-O putting the version before the suffix, `libfoo.1.dylib`, where ELF puts it after, `libfoo.so.1`.

### The tests are what make this real

The two wheel test suites now run on macOS too. Without them CI cannot tell a working split from a broken one: the Python extension links these libraries itself, so it passes whether or not the package config names them or the shipped headers are complete.

Porting them needed a suffix helper, the Mach-O spelling of the symbol queries, since `nm -D` asks for a dynamic symbol table that Mach-O does not have, and `otool` in place of `readelf`.

One check keeps a documented skip on macOS: `ldd` resolves dependencies transitively and reports undefined symbols, while `otool -L` only lists recorded names. Claiming equivalence there would weaken the check while appearing to strengthen coverage.

### Test Plan

Both platform branches of every changed helper were exercised.

CMake helpers, driven with real CMake and the Apple branch forced, so the macOS answers are checked rather than assumed:

```
shipped runtime path   Linux $ORIGIN                 macOS @loader_path
two entry path         Linux $ORIGIN/../../lib:...    macOS @loader_path/../../lib;...
library identity       Linux version only            macOS install name @rpath
```

Python helpers, loaded under each platform:

```
suffix              .so                       .dylib
defined symbols     nm -DC                    nm -gU -C
undefined symbols   nm -DC --undefined-only   nm -gu -C
library file name   libexecutorch.so          libexecutorch.dylib
```

The symbol queries and the load command reader were then run against a real Mach-O library on macOS: 137 defined and 133 undefined symbols listed, and the load commands read, including the dependency and search path entries and the torch dependency the libtorch check looks for.

Linux is unaffected, verified by building a wheel from this change and confirming it still ships the same six libraries.
