### PR TITLE
Arm backend: Support memory planning in arm_executor_runner

### DIFF
--- a/backends/arm/test/assets/export_memory_planning_mem_id_3.py
+++ b/backends/arm/test/assets/export_memory_planning_mem_id_3.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+import executorch.exir as exir
+import torch
+from executorch.exir import to_edge
+from executorch.exir.memory_planning import greedy, MemoryPlanningAlgorithmSuite
+from executorch.exir.pass_base import PassResult
+from executorch.exir.passes import MemoryPlanningPass
+from torch.export import export
+from torch.export.exported_program import ExportGraphSignature
+from torch.fx import GraphModule
+
+
+class CustomPoolMemoryPlanningPass(MemoryPlanningPass):
+    def call(self, graph_module: GraphModule) -> PassResult:
+        for subgm in graph_module.modules():
+            if not isinstance(subgm, GraphModule):
+                continue
+            for node in subgm.graph.nodes:
+                if node.op == "placeholder":
+                    node.meta["spec"].mem_id = 1
+                    continue
+
+                if node.op != "call_function":
+                    continue
+
+                if node.target == torch.ops.aten.add.out:
+                    node.meta["spec"].mem_id = 3
+                elif node.target == torch.ops.aten.mul.out:
+                    node.meta["spec"].mem_id = 1
+
+        return super().run(graph_module)
+
+    def run(
+        self,
+        graph_module: GraphModule,
+        graph_signature: Optional[ExportGraphSignature] = None,
+    ) -> PassResult:
+        return self.call(graph_module)
+
+
+class MultiplePoolsToyModel(torch.nn.Module):
+    def forward(self, a: torch.Tensor) -> torch.Tensor:
+        b = a + a
+        c = a * b
+        d = c + b
+        e = c * d
+        return e
+
+
+def export_pte(output_path: Path) -> None:
+    edge_program = to_edge(
+        export(MultiplePoolsToyModel(), (torch.ones(1),), strict=True)
+    )
+    mem_algo = MemoryPlanningAlgorithmSuite(algo_list=[greedy])
+    executorch_program = edge_program.to_executorch(
+        exir.ExecutorchBackendConfig(
+            memory_planning_pass=CustomPoolMemoryPlanningPass(
+                memory_planning_algo=mem_algo,
+                alignment=1,
+            ),
+        )
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("wb") as output_file:
+        executorch_program.write_to_file(output_file)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Export a portable .pte with mem_id=3 planned tensor storage."
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path to the .pte file to write.",
+    )
+    args = parser.parse_args()
+
+    export_pte(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/backends/arm/test/test_arm_backend.sh
+++ b/backends/arm/test/test_arm_backend.sh
@@ -482,6 +482,32 @@ test_memory_allocation() {
             --require "Total DRAM used" "<= 0.06 KiB"
 
     _test_runner_size_optimization
+
+    echo "${TEST_SUITE_NAME}: Test planned slow and fast memory allocation"
+    local plan_dir="arm_test/test_run/memory_planning"
+    local pte_file="${plan_dir}/memory_planning_mem_id_3.pte"
+    local runner_dir="${plan_dir}/cmake-out"
+    local planned_log="${plan_dir}/planned.log"
+    mkdir -p "${plan_dir}"
+
+    python3 "${et_root_dir}/backends/arm/test/assets/export_memory_planning_mem_id_3.py" \
+        --output="${pte_file}"
+
+    backends/arm/scripts/build_executor_runner.sh \
+        --pte="${pte_file}" \
+        --target=ethos-u55-128 \
+        --output="${runner_dir}" \
+        --select_ops_list="aten::add.out,aten::mul.out" \
+        --extra_build_flags="-DFETCH_ETHOS_U_CONTENT=OFF -DET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=0x180000 -DET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE=0x1000"
+
+    backends/arm/scripts/run_fvp.sh \
+        --elf="${runner_dir}/arm_executor_runner" \
+        --target=ethos-u55-128 \
+        &> "${planned_log}"
+
+    python3 backends/arm/test/test_memory_allocator_log.py --log "${planned_log}" \
+            --require "method_allocator_planned" "== 8 B" \
+            --require "planned_fast_used" "== 8 B"
     echo "${TEST_SUITE_NAME}: PASS"
 }
 

--- a/examples/arm/ethos-u-porting-guide.md
+++ b/examples/arm/ethos-u-porting-guide.md
@@ -89,6 +89,7 @@ way, depending on the `ETHOSU_ARENA` parameter, the linker knows whether the inp
 its value is derived based on the memory mode parameter that is passed to the `examples/arm/run.sh` shell script. Then, at link time, the .ddr.bss section is always placed in the external memory and the .sram.bss is always placed in the SRAM.
 Finally, note that in the `examples/arm/executor_runner/arm_executor_runner.cpp` application code, we place the buffers for the Ethos-u scratch and the neural network in the correct symbol from the linker script. For instance,
 the Ethos-u scratch buffer corresponds to the the `.bss.tensor_arena` input section in the linker script, In the application code, when we allocate memory for the Ethos-u scratch buffer, we place this array in the .bss.tensor_arena section in the memory map.
+The same runner also supports ExecuTorch memory-planned tensors in `SLOW_MEMORY_REGION` for `mem_id=1` and `mem_id=2`, and in `FAST_MEMORY_REGION` for `mem_id=3`, backed by the `.fast_memory` input section in `.sram.bss` and sized with `ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE`.
 
 ```
 unsigned char __attribute__((

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -101,6 +101,11 @@ option(
   "Set ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE to specify memory alloction pool size"
   OFF
 )
+set(ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE
+    ""
+    CACHE STRING
+          "Size of the SRAM-backed planned fast memory pool used for mem_id=3"
+)
 
 if(NOT DEFINED PYTHON_EXECUTABLE)
   find_package(
@@ -201,6 +206,10 @@ message(
 message(
   STATUS
     "ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE = ${ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE}"
+)
+message(
+  STATUS
+    "ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE = ${ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE}"
 )
 
 # Dependencies from the Ethos-U Core This is the platform target of
@@ -676,6 +685,14 @@ if(DEFINED ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
     arm_executor_runner
     PUBLIC
       ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=${ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE}
+  )
+endif()
+
+if(ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE)
+  target_compile_definitions(
+    arm_executor_runner
+    PUBLIC
+      ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE=${ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE}
   )
 endif()
 

--- a/examples/arm/executor_runner/Corstone-300.ld
+++ b/examples/arm/executor_runner/Corstone-300.ld
@@ -230,6 +230,8 @@ SECTIONS
     *(.bss.tensor_arena)
 #endif
     . = ALIGN(16);
+    *(.fast_memory)
+    . = ALIGN(16);
     *(.bss.ethosu_scratch);
   } > SRAM :null
 

--- a/examples/arm/executor_runner/Corstone-320.ld
+++ b/examples/arm/executor_runner/Corstone-320.ld
@@ -236,6 +236,8 @@ SECTIONS
     *(.bss.tensor_arena)
 #endif
     . = ALIGN(16);
+    *(.fast_memory)
+    . = ALIGN(16);
     *(.bss.ethosu_scratch);
   } > SRAM :null
 

--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -94,6 +94,9 @@
  * ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE - Size of memory area
  *                                                          used when running
  *                                                          inferences
+ * ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE              - Size of the fast
+ *                                                          planned memory area
+ *                                                          for mem_id = 3
  */
 
 #include <errno.h>
@@ -288,6 +291,15 @@ dedicated_sram[ET_ARM_BAREMETAL_FAST_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE];
 unsigned char* ethosu_fast_scratch = dedicated_sram;
 }
 #endif
+
+#if defined(ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE)
+const size_t planned_fast_memory_pool_size =
+    ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE;
+unsigned char __attribute__((
+    section(".fast_memory"),
+    aligned(16))) planned_fast_memory_pool[planned_fast_memory_pool_size];
+#endif
+constexpr size_t FAST_MEMORY_REGION_INDEX = 2;
 
 [[maybe_unused]] void et_pal_init(void) {
 #if defined(__ARM_ARCH_8_1M_MAIN__)
@@ -581,6 +593,7 @@ struct RunnerContext {
   Box<BufferDataLoader> loader;
   Box<Program> program;
   Box<ArmMemoryAllocator> method_allocator;
+  Box<ArmMemoryAllocator> planned_fast_allocator;
   Box<ArmMemoryAllocator> temp_allocator;
   std::vector<Span<uint8_t>> planned_spans;
   Box<HierarchicalAllocator> planned_memory;
@@ -672,6 +685,15 @@ void runner_init(
   ctx.method_allocator.reset(
       method_allocation_pool_size, method_allocation_pool);
 
+#if defined(ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE)
+  ET_LOG(
+      Info,
+      "Setup planned FAST_MEMORY_REGION pool. Size: %lu bytes.",
+      static_cast<unsigned long>(planned_fast_memory_pool_size));
+  ctx.planned_fast_allocator.reset(
+      planned_fast_memory_pool_size, planned_fast_memory_pool);
+#endif
+
   ctx.planned_spans.clear();
   size_t num_memory_planned_buffers = method_meta->num_memory_planned_buffers();
   ctx.planned_spans.reserve(num_memory_planned_buffers);
@@ -680,20 +702,49 @@ void runner_init(
   for (size_t id = 0; id < num_memory_planned_buffers; ++id) {
     size_t buffer_size =
         static_cast<size_t>(method_meta->memory_planned_buffer_size(id).get());
+
     ET_LOG(
         Info,
-        "Setting up planned buffer %lu, size %lu.",
-        static_cast<unsigned long>(id),
+        "Setting up planned buffer with mem_id=%lu, size %lu.",
+        static_cast<unsigned long>(id + 1),
         static_cast<unsigned long>(buffer_size));
+    if (buffer_size == 0) {
+      ctx.planned_spans.push_back(Span<uint8_t>(
+          static_cast<uint8_t*>(nullptr), static_cast<size_t>(0)));
+      continue;
+    }
 
-    /* Move to it's own allocator when MemoryPlanner is in place. */
-    /* Ethos-U driver requires 16 bit alignment. */
-    uint8_t* buffer = reinterpret_cast<uint8_t*>(
-        ctx.method_allocator->allocate(buffer_size, 16UL));
+    uint8_t* buffer = nullptr;
+    const char* memory_region = nullptr;
+    switch (id) {
+      case FAST_MEMORY_REGION_INDEX:
+        memory_region = "FAST_MEMORY_REGION";
+#if defined(ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE)
+        buffer = reinterpret_cast<uint8_t*>(
+            ctx.planned_fast_allocator->allocate(buffer_size, 16UL));
+#else
+        ET_CHECK_MSG(
+            false,
+            "Planned buffer %lu uses mem_id=%lu/FAST_MEMORY_REGION, but "
+            "ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE is not set",
+            static_cast<unsigned long>(id),
+            static_cast<unsigned long>(id + 1));
+#endif
+        break;
+      default:
+        memory_region = "SLOW_MEMORY_REGION";
+        /* Ethos-U driver requires 16 bit alignment. */
+        buffer = reinterpret_cast<uint8_t*>(
+            ctx.method_allocator->allocate(buffer_size, 16UL));
+        break;
+    }
     ET_CHECK_MSG(
         buffer != nullptr,
-        "Could not allocate memory for memory planned buffer size %lu",
-        static_cast<unsigned long>(buffer_size));
+        "Could not allocate memory for planned buffer with mem_id=%lu, size "
+        "%lu in %s",
+        static_cast<unsigned long>(id + 1),
+        static_cast<unsigned long>(buffer_size),
+        memory_region);
     ctx.planned_spans.push_back({buffer, buffer_size});
   }
 
@@ -916,6 +967,23 @@ void log_mem_status(RunnerContext& ctx) {
         Info,
         "method_allocator_planned:  %lu bytes",
         static_cast<unsigned long>(ctx.planned_buffer_memsize));
+#if defined(ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE)
+    if (ctx.planned_fast_allocator->size() > 0) {
+      ET_LOG(
+          Info,
+          "planned_fast_allocator:    %lu / %lu free: %lu ( used: %lu %% ) ",
+          static_cast<unsigned long>(ctx.planned_fast_allocator->used_size()),
+          static_cast<unsigned long>(ctx.planned_fast_allocator->size()),
+          static_cast<unsigned long>(ctx.planned_fast_allocator->free_size()),
+          static_cast<unsigned long>(
+              100 * ctx.planned_fast_allocator->used_size() /
+              ctx.planned_fast_allocator->size()));
+      ET_LOG(
+          Info,
+          "planned_fast_used:         %lu bytes",
+          static_cast<unsigned long>(ctx.planned_fast_allocator->used_size()));
+    }
+#endif
     ET_LOG(
         Info,
         "method_allocator_loaded:   %lu bytes",


### PR DESCRIPTION
Support explicitly tagging tensors with mem_id = 2 for putting them in a SLOW_MEMORY_REGION and mem_id = 3 for putting in FAST_MEMORY_REGION. Keep default mem_id = 1 in SLOW_MEMORY_REGION. This gives users more flexibility in memory planning their programs.

Add a new .fast_memory input section in .sram.bss that backs the fast memory allocator. The size of the memory area is set by a new cmake flag
ET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE. The slow memory region can still be allocated like planned et tensors are currently.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani