### PR TITLE
Arm backend: Fuse canonical flow-offset grid sampling

### DIFF
--- a/backends/arm/BUCK
+++ b/backends/arm/BUCK
@@ -96,6 +96,7 @@ fbcode_target(
     srcs = [
         "vgf/__init__.py",
         "vgf/_passes/__init__.py",
+        "vgf/_passes/fuse_grid_sampler_flow_offset.py",
         "vgf/_passes/insert_grid_sampler_grid_dequant_pass.py",
         "vgf/_passes/rewrite_grid_sampler_to_tosa_custom.py",
         "vgf/backend.py",
@@ -107,6 +108,7 @@ fbcode_target(
         "vgf/shaders/grid_sampler.py",
     ],
     resources = [
+        "vgf/shaders/flow_offset_grid_sampler_int8_align_corners.glsl",
         "vgf/shaders/grid_sampler.glsl",
         "vgf/shaders/grid_sampler.spirv.b64",
         "vgf/shaders/grid_sampler_sampler.glsl",

--- a/backends/arm/test/passes/test_fuse_grid_sampler_flow_offset_pass.py
+++ b/backends/arm/test/passes/test_fuse_grid_sampler_flow_offset_pass.py
@@ -1,0 +1,535 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import base64
+import shutil
+import subprocess  # nosec B404 - fixed shader compiler invocation
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import torch
+from executorch.backends.arm._passes.quant_args import QuantArgs
+from executorch.backends.arm.vgf._passes import fuse_grid_sampler_flow_offset
+from executorch.backends.arm.vgf._passes.fuse_grid_sampler_flow_offset import (
+    _match_flow_offset_grid,
+    FuseGridSamplerFlowOffsetPass,
+)
+from executorch.backends.arm.vgf.shaders import grid_sampler as grid_sampler_shaders
+from executorch.backends.arm.vgf.shaders.grid_sampler import (
+    build_flow_offset_grid_sampler_payload,
+    decode_payload,
+    flow_offset_grid_sampler_operator_name,
+    GRID_SAMPLER_2D_QUANTIZED_GRID_VK_FORMAT,
+    GRID_SAMPLER_2D_SAMPLER_INT8_VK_FORMAT,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.fx import Graph
+
+
+def _build_grid_axis(
+    graph: Graph,
+    *,
+    steps: int,
+    view_shape: list[int],
+    expand_shape: list[int],
+) -> torch.fx.Node:
+    axis = graph.call_function(
+        exir_ops.edge.aten.linspace.default,
+        args=(-1.0, 1.0, steps),
+    )
+    axis = graph.call_function(
+        exir_ops.edge.aten.view_copy.default,
+        args=(axis, view_shape),
+    )
+    return graph.call_function(
+        exir_ops.edge.aten.expand_copy.default,
+        args=(axis, expand_shape),
+    )
+
+
+def _find_grid_sampler(graph: Graph) -> torch.fx.Node:
+    return next(
+        node
+        for node in graph.nodes
+        if node.target == exir_ops.edge.aten.grid_sampler_2d.default
+    )
+
+
+def _build_flow_offset_grid_sampler(
+    *,
+    flow_channel_offset=0,
+    interpolation=0,
+    padding=1,
+    align_corners=True,
+    height=8,
+    width=12,
+    reverse_add_operands=False,
+    add_alpha=None,
+    slice_step=None,
+    permutation=(0, 2, 3, 1),
+):
+    graph = Graph()
+    image = graph.placeholder("image")
+    image.meta["val"] = torch.empty(1, 4, height, width)
+    flow = graph.placeholder("flow")
+    flow.meta["val"] = torch.empty(1, 4, height, width)
+
+    horizontal = _build_grid_axis(
+        graph,
+        steps=width,
+        view_shape=[1, 1, 1, width],
+        expand_shape=[1, -1, height, -1],
+    )
+    vertical = _build_grid_axis(
+        graph,
+        steps=height,
+        view_shape=[1, 1, height, 1],
+        expand_shape=[1, -1, -1, width],
+    )
+    base_grid = graph.call_function(
+        exir_ops.edge.aten.cat.default,
+        args=([horizontal, vertical], 1),
+    )
+    base_grid = graph.call_function(
+        exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+        args=(base_grid, 0.01, 0, -128, 127, torch.int8),
+    )
+    base_grid = graph.call_function(
+        exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+        args=(base_grid, 0.01, 0, -128, 127, torch.int8),
+    )
+    flow_slice = graph.call_function(
+        exir_ops.edge.aten.slice_copy.Tensor,
+        args=(flow, 1, flow_channel_offset, flow_channel_offset + 2),
+        kwargs={} if slice_step is None else {"step": slice_step},
+    )
+    add_args = (
+        (flow_slice, base_grid) if reverse_add_operands else (base_grid, flow_slice)
+    )
+    add_kwargs = {} if add_alpha is None else {"alpha": add_alpha}
+    grid = graph.call_function(
+        exir_ops.edge.aten.add.Tensor, args=add_args, kwargs=add_kwargs
+    )
+    grid = graph.call_function(
+        exir_ops.edge.aten.permute_copy.default,
+        args=(grid, list(permutation)),
+    )
+    grid_sampler = graph.call_function(
+        exir_ops.edge.aten.grid_sampler_2d.default,
+        args=(image, grid, interpolation, padding, align_corners),
+    )
+    grid_sampler.meta["val"] = torch.empty(1, 4, height, width)
+    return grid_sampler, flow
+
+
+def _build_quantized_flow_offset_graph_module(
+    *, image_channels=4, flow_channel_offset=0
+):
+    grid_sampler, flow = _build_flow_offset_grid_sampler(
+        flow_channel_offset=flow_channel_offset
+    )
+    image = grid_sampler.args[0]
+    assert isinstance(image, torch.fx.Node)
+
+    image_qparams = QuantArgs(0.02, -3, -127, 127, torch.int8)
+    flow_qparams = QuantArgs(0.04, -5, -128, 127, torch.int8)
+    output_qparams = QuantArgs(0.03, 4, -127, 127, torch.int8)
+
+    image.meta["val"] = torch.empty(1, image_channels, 8, 12, dtype=torch.int8)
+    flow.meta["val"] = torch.empty(1, 4, 8, 12, dtype=torch.int8)
+    flow.meta["output_qparams"] = {0: flow_qparams}
+    grid_sampler.meta["val"] = torch.empty(1, image_channels, 8, 12, dtype=torch.int8)
+    grid_sampler.meta["input_qparams"] = {0: image_qparams}
+    grid_sampler.meta["output_qparams"] = {0: output_qparams}
+    grid_sampler.graph.output(grid_sampler)
+
+    graph_module = torch.fx.GraphModule(torch.nn.Module(), grid_sampler.graph)
+    return (
+        graph_module,
+        flow,
+        image_qparams,
+        flow_qparams,
+        output_qparams,
+    )
+
+
+def _build_payload(**overrides):
+    kwargs = {
+        "input_shape": (1, 4, 8, 12),
+        "output_shape": (1, 4, 8, 12),
+        "flow_shape": (1, 4, 8, 12),
+        "input_scale": 0.02,
+        "input_zero_point": -3,
+        "output_scale": 0.03,
+        "output_zero_point": 4,
+        "flow_scale": 0.04,
+        "flow_zero_point": -5,
+        "flow_channel_offset": 0,
+    }
+    kwargs.update(overrides)
+    return build_flow_offset_grid_sampler_payload(**kwargs)
+
+
+@pytest.fixture(scope="module")
+def _arm_tensor_glslc():
+    glslc = shutil.which("glslc")
+    if glslc is None:
+        pytest.skip("glslc not found")
+    source = (
+        "#version 450\n"
+        "#extension GL_ARM_tensors : require\n"
+        "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n"
+        "layout(set = 0, binding = 0) uniform tensorARM<int8_t, 4> value;\n"
+        "layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;\n"
+        "void main() {}\n"
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source_path = Path(tmpdir) / "arm_tensor_probe.glsl"
+        spirv_path = Path(tmpdir) / "arm_tensor_probe.spv"
+        source_path.write_text(source, encoding="utf-8")
+        result = subprocess.run(  # nosec B603 - glslc path is resolved from PATH.
+            [glslc, "-fshader-stage=compute", str(source_path), "-o", str(spirv_path)],
+            check=False,
+            capture_output=True,
+        )
+    if result.returncode != 0:
+        pytest.skip("glslc does not support GL_ARM_tensors")
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_offset"),
+    [
+        pytest.param({}, 0, id="first-flow-pair"),
+        pytest.param({"flow_channel_offset": 2}, 2, id="second-flow-pair"),
+        pytest.param({"reverse_add_operands": True}, 0, id="reversed-add"),
+        pytest.param({"add_alpha": 1}, 0, id="explicit-unit-alpha"),
+        pytest.param({"slice_step": 1}, 0, id="explicit-unit-slice-step"),
+    ],
+)
+def test_match_flow_offset_grid_accepts_supported_variants(kwargs, expected_offset):
+    grid_sampler, flow = _build_flow_offset_grid_sampler(**kwargs)
+
+    assert _match_flow_offset_grid(grid_sampler) == (flow, expected_offset)
+
+
+def test_match_flow_offset_grid_accepts_identity_base_grid_requantization():
+    grid_sampler, flow = _build_flow_offset_grid_sampler()
+    quantize = next(
+        node
+        for node in grid_sampler.graph.nodes
+        if node.target == exir_ops.edge.quantized_decomposed.quantize_per_tensor.default
+    )
+    dequantize = quantize.args[0]
+    quantize.update_arg(1, 0.007842528633773327)
+    quantize.update_arg(2, -1)
+    dequantize.update_arg(1, 0.007842586375772953)
+    dequantize.update_arg(2, -1)
+
+    assert _match_flow_offset_grid(grid_sampler) == (flow, 0)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"interpolation": 1}, id="nearest-interpolation"),
+        pytest.param({"padding": 0}, id="zero-padding"),
+        pytest.param({"align_corners": False}, id="unaligned-corners"),
+        pytest.param({"flow_channel_offset": 1}, id="non-pair-flow-slice"),
+        pytest.param({"slice_step": 2}, id="non-unit-slice-step"),
+        pytest.param({"add_alpha": 2}, id="non-unit-add-alpha"),
+        pytest.param({"height": 1}, id="singleton-height"),
+        pytest.param({"width": 1}, id="singleton-width"),
+        pytest.param({"permutation": (0, 3, 2, 1)}, id="wrong-permutation"),
+    ],
+)
+def test_match_flow_offset_grid_rejects_unsupported_variants(kwargs):
+    grid_sampler, _ = _build_flow_offset_grid_sampler(**kwargs)
+
+    assert _match_flow_offset_grid(grid_sampler) is None
+
+
+@pytest.mark.parametrize(
+    ("start", "kwargs"),
+    [
+        pytest.param(-0.5, {}, id="wrong-start"),
+        pytest.param(-1.0, {"dtype": torch.int8}, id="integer-dtype"),
+    ],
+)
+def test_match_flow_offset_grid_rejects_noncanonical_linspace(start, kwargs):
+    grid_sampler, _ = _build_flow_offset_grid_sampler()
+    horizontal = next(
+        node
+        for node in grid_sampler.graph.nodes
+        if node.target == exir_ops.edge.aten.linspace.default
+    )
+    horizontal.update_arg(0, start)
+    horizontal.kwargs = kwargs
+
+    assert _match_flow_offset_grid(grid_sampler) is None
+
+
+@pytest.mark.parametrize(
+    ("arg_index", "value"),
+    [
+        (1, 0.02),
+        (2, 1),
+        (3, -127),
+        (4, 126),
+        (5, torch.int16),
+    ],
+)
+def test_match_flow_offset_grid_rejects_requantized_base_grid(arg_index, value):
+    grid_sampler, _ = _build_flow_offset_grid_sampler()
+    quantize = next(
+        node
+        for node in grid_sampler.graph.nodes
+        if node.target == exir_ops.edge.quantized_decomposed.quantize_per_tensor.default
+    )
+    quantize.update_arg(arg_index, value)
+
+    assert _match_flow_offset_grid(grid_sampler) is None
+
+
+@pytest.mark.parametrize("image_shape", [(2, 4, 8, 12), (1, 2, 8, 12)])
+def test_match_flow_offset_grid_rejects_unsupported_image_shape(image_shape):
+    grid_sampler, _ = _build_flow_offset_grid_sampler()
+    image = grid_sampler.args[0]
+    assert isinstance(image, torch.fx.Node)
+    image.meta["val"] = torch.empty(image_shape)
+
+    assert _match_flow_offset_grid(grid_sampler) is None
+
+
+@pytest.mark.parametrize("value_name", ["input", "output"])
+def test_match_flow_offset_grid_rejects_different_spatial_shape(value_name):
+    grid_sampler, _ = _build_flow_offset_grid_sampler()
+    value_node = grid_sampler.args[0] if value_name == "input" else grid_sampler
+    assert isinstance(value_node, torch.fx.Node)
+    value_node.meta["val"] = torch.empty(1, 4, 7, 12)
+
+    assert _match_flow_offset_grid(grid_sampler) is None
+
+
+def test_match_flow_offset_grid_rejects_non_4d_flow():
+    grid_sampler, flow = _build_flow_offset_grid_sampler()
+    flow.meta["val"] = torch.empty(1, 4, 8)
+
+    assert _match_flow_offset_grid(grid_sampler) is None
+
+
+@pytest.mark.parametrize(("image_channels", "flow_channel_offset"), [(3, 0), (4, 2)])
+def test_fuse_flow_offset_grid_sampler_rewrites_image_paths(
+    monkeypatch, image_channels, flow_channel_offset
+):
+    (
+        graph_module,
+        flow,
+        image_qparams,
+        flow_qparams,
+        output_qparams,
+    ) = _build_quantized_flow_offset_graph_module(
+        image_channels=image_channels,
+        flow_channel_offset=flow_channel_offset,
+    )
+    monkeypatch.setattr(
+        fuse_grid_sampler_flow_offset,
+        "build_flow_offset_grid_sampler_payload",
+        lambda **kwargs: kwargs,
+    )
+
+    result = FuseGridSamplerFlowOffsetPass()(graph_module)
+    nodes = list(result.graph_module.graph.nodes)
+
+    assert result.modified
+    assert not any(
+        node.target == exir_ops.edge.aten.grid_sampler_2d.default for node in nodes
+    )
+    custom_node = next(
+        node for node in nodes if node.target == exir_ops.backend.tosa.CUSTOM.default
+    )
+    assert custom_node.args[0][1] is flow
+    payload = decode_payload(custom_node.kwargs["implementation_attrs"])
+    assert payload["input_scale"] == image_qparams.get_scale_per_tensor()
+    assert payload["input_zero_point"] == image_qparams.get_zp_per_tensor()
+    assert payload["flow_scale"] == flow_qparams.get_scale_per_tensor()
+    assert payload["flow_zero_point"] == flow_qparams.get_zp_per_tensor()
+    assert payload["output_scale"] == output_qparams.get_scale_per_tensor()
+    assert payload["output_zero_point"] == output_qparams.get_zp_per_tensor()
+    assert payload["flow_channel_offset"] == flow_channel_offset
+
+    pad_nodes = [
+        node
+        for node in nodes
+        if node.target == exir_ops.edge.aten.constant_pad_nd.default
+    ]
+    slice_count = sum(
+        node.target == exir_ops.edge.aten.slice_copy.Tensor for node in nodes
+    )
+    if image_channels == 3:
+        assert len(pad_nodes) == 1
+        assert pad_nodes[0].meta["input_qparams"] == {0: image_qparams}
+        assert pad_nodes[0].meta["output_qparams"] == {0: image_qparams}
+        assert slice_count == 1
+    else:
+        assert not pad_nodes
+        assert slice_count == 0
+    assert tuple(result.graph_module.graph.output_node().args[0].meta["val"].shape) == (
+        1,
+        image_channels,
+        8,
+        12,
+    )
+
+
+@pytest.mark.parametrize(
+    "unsupported_qparams",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param(
+            QuantArgs(0.02, 0, -32768, 32767, torch.int16),
+            id="non-int8",
+        ),
+    ],
+)
+@pytest.mark.parametrize("qparams_name", ["image", "flow", "output"])
+def test_fuse_flow_offset_grid_sampler_leaves_unsupported_qparams_unfused(
+    qparams_name, unsupported_qparams
+):
+    graph_module, flow, *_ = _build_quantized_flow_offset_graph_module()
+    grid_sampler = _find_grid_sampler(graph_module.graph)
+    if qparams_name == "image":
+        qparams_node, qparams_key = grid_sampler, "input_qparams"
+    elif qparams_name == "flow":
+        qparams_node, qparams_key = flow, "output_qparams"
+    else:
+        qparams_node, qparams_key = grid_sampler, "output_qparams"
+    if unsupported_qparams is None:
+        del qparams_node.meta[qparams_key]
+    else:
+        qparams_node.meta[qparams_key] = {0: unsupported_qparams}
+
+    result = FuseGridSamplerFlowOffsetPass()(graph_module)
+
+    assert not result.modified
+    assert any(
+        node.target == exir_ops.edge.aten.grid_sampler_2d.default
+        for node in result.graph_module.graph.nodes
+    )
+
+
+@pytest.mark.parametrize(
+    ("qparams_name", "qmin", "qmax"),
+    [
+        ("image", -128, 127),
+        ("image", -127, 126),
+        ("output", -128, 127),
+        ("output", -127, 126),
+    ],
+)
+def test_fuse_flow_offset_grid_sampler_leaves_non_snorm_qparams_unfused(
+    qparams_name, qmin, qmax
+):
+    graph_module, *_ = _build_quantized_flow_offset_graph_module()
+    grid_sampler = _find_grid_sampler(graph_module.graph)
+    unsupported_qparams = QuantArgs(0.02, -3, qmin, qmax, torch.int8)
+    qparams_key = "input_qparams" if qparams_name == "image" else "output_qparams"
+    grid_sampler.meta[qparams_key] = {0: unsupported_qparams}
+
+    result = FuseGridSamplerFlowOffsetPass()(graph_module)
+
+    assert not result.modified
+    assert any(
+        node.target == exir_ops.edge.aten.grid_sampler_2d.default
+        for node in result.graph_module.graph.nodes
+    )
+
+
+@pytest.mark.parametrize("compiler_failure", ["missing", "compile"])
+def test_fuse_flow_offset_grid_sampler_leaves_compiler_failure_unfused(
+    monkeypatch, compiler_failure
+):
+    graph_module, *_ = _build_quantized_flow_offset_graph_module(image_channels=3)
+    if compiler_failure == "missing":
+        monkeypatch.setattr(grid_sampler_shaders.shutil, "which", lambda _: None)
+    else:
+        monkeypatch.setattr(
+            grid_sampler_shaders.shutil, "which", lambda _: "/usr/bin/glslc"
+        )
+        monkeypatch.setattr(
+            grid_sampler_shaders.subprocess,
+            "run",
+            Mock(side_effect=subprocess.CalledProcessError(1, ["glslc"])),
+        )
+
+    result = FuseGridSamplerFlowOffsetPass()(graph_module)
+    nodes = list(result.graph_module.graph.nodes)
+
+    assert not result.modified
+    assert any(
+        node.target == exir_ops.edge.aten.grid_sampler_2d.default for node in nodes
+    )
+    assert not any(
+        node.target == exir_ops.edge.aten.constant_pad_nd.default for node in nodes
+    )
+
+
+@pytest.mark.parametrize("flow_channel_offset", [0, 2])
+def test_build_flow_offset_grid_sampler_payload(monkeypatch, flow_channel_offset):
+    compiled_shader = base64.b64encode(b"\x03\x02\x23\x07").decode("ascii")
+    monkeypatch.setattr(
+        grid_sampler_shaders,
+        "_compile_flow_offset_grid_sampler_shader",
+        lambda **_: compiled_shader,
+    )
+    payload = _build_payload(flow_channel_offset=flow_channel_offset)
+
+    assert payload["operator_name"] == flow_offset_grid_sampler_operator_name()
+    assert payload["flow_channel_offset"] == flow_channel_offset
+    assert payload["input_0_vkformat"] == GRID_SAMPLER_2D_SAMPLER_INT8_VK_FORMAT
+    assert payload["input_1_vkformat"] == GRID_SAMPLER_2D_QUANTIZED_GRID_VK_FORMAT
+    assert payload["output_0_vkformat"] == GRID_SAMPLER_2D_SAMPLER_INT8_VK_FORMAT
+    assert payload["shader_code"] == compiled_shader
+
+
+@pytest.mark.usefixtures("_arm_tensor_glslc")
+@pytest.mark.parametrize("flow_channel_offset", [0, 2])
+def test_compile_flow_offset_grid_sampler_shader(flow_channel_offset):
+    payload = _build_payload(flow_channel_offset=flow_channel_offset)
+
+    assert base64.b64decode(payload["shader_code"])[:4] == b"\x03\x02\x23\x07"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error"),
+    [
+        ({"input_shape": (1, 3, 8, 12)}, "expected static NCHW.*input"),
+        ({"output_shape": (1, 3, 8, 12)}, "expected static NCHW.*output"),
+        ({"flow_shape": (1, 2, 8, 12)}, "expected static NCHW.*flow"),
+        (
+            {"output_shape": (1, 4, 7, 12)},
+            "input and output spatial shapes must match",
+        ),
+        (
+            {"flow_shape": (1, 4, 7, 12)},
+            "flow and output spatial shapes must match",
+        ),
+        (
+            {
+                "input_shape": (1, 4, 1, 12),
+                "output_shape": (1, 4, 1, 12),
+                "flow_shape": (1, 4, 1, 12),
+            },
+            "requires H and W greater than 1",
+        ),
+        ({"flow_channel_offset": 1}, "flow_channel_offset must be 0 or 2"),
+    ],
+)
+def test_build_flow_offset_grid_sampler_payload_rejects_invalid_contract(
+    overrides, error
+):
+    with pytest.raises(ValueError, match=error):
+        _build_payload(**overrides)

--- a/backends/arm/vgf/_passes/__init__.py
+++ b/backends/arm/vgf/_passes/__init__.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .fuse_grid_sampler_flow_offset import FuseGridSamplerFlowOffsetPass  # noqa
 from .insert_grid_sampler_grid_dequant_pass import (  # noqa
     InsertGridSamplerGridDequantPass,
 )

--- a/backends/arm/vgf/_passes/fuse_grid_sampler_flow_offset.py
+++ b/backends/arm/vgf/_passes/fuse_grid_sampler_flow_offset.py
@@ -1,0 +1,521 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Fuse canonical quantized flow-offset grid sampling for VGF.
+
+The pass matches Edge-dialect graphs equivalent to::
+
+    base_grid = cat(expand(linspace_x), expand(linspace_y))
+    grid = permute(base_grid + flow[:, i:i + 2], [0, 2, 3, 1])
+    output = grid_sample(image, grid, bilinear, border, align_corners=True)
+
+The base grid may pass through an identity dequantize/quantize pair. Images
+must have shape ``[1, 3|4, H, W]``, flow must have shape ``[1, 4, H, W]``,
+and ``i`` must be zero or two. Image and output quantization ranges must be
+``[-127, 127]`` because the custom shader stores them in SNORM images. The
+flow tensor may use the full int8 range because the shader reads it directly.
+
+"""
+
+import logging
+import math
+import operator
+from typing import TypeGuard
+
+import torch
+from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import (
+    get_input_qparams,
+    get_output_qparams,
+)
+from executorch.backends.arm._passes.quant_args import QuantArgs
+from executorch.backends.arm.constants import NHWC_INVERSE_ORDER, NHWC_ORDER
+from executorch.backends.arm.tosa.dialect.ops.custom import register_fake_tosa
+from executorch.backends.arm.vgf._passes.rewrite_grid_sampler_to_tosa_custom import (
+    _set_fake_tensor_meta,
+    RewriteGridSamplerToTosaCustomPass,
+)
+from executorch.backends.arm.vgf.shaders.grid_sampler import (
+    _FlowOffsetShaderCompilationError,
+    build_flow_offset_grid_sampler_payload,
+    CUSTOM_SHADER_DOMAIN_NAME,
+    encode_payload,
+    flow_offset_grid_sampler_operator_name,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import PassResult
+from torch.fx import GraphModule, Node
+
+logger = logging.getLogger(__name__)
+
+
+def _flow_offset_grid_sampler_fake_impl(
+    inputs, operator_name, domain_name, implementation_attrs
+) -> list[torch.Tensor]:
+    _ = (operator_name, domain_name, implementation_attrs)
+    return [torch.empty_like(inputs[0])]
+
+
+register_fake_tosa(flow_offset_grid_sampler_operator_name())(
+    _flow_offset_grid_sampler_fake_impl
+)
+
+
+def _target_is(node: object, target: str) -> TypeGuard[Node]:
+    return isinstance(node, Node) and target in str(node.target).replace("::", ".")
+
+
+def _literal_list(value: object) -> list[int] | None:
+    if not isinstance(value, (list, tuple)):
+        return None
+    if not all(isinstance(item, int) for item in value):
+        return None
+    return [item for item in value if isinstance(item, int)]
+
+
+def _is_identity_requantization(
+    source_qparams: tuple[object, ...], destination_qparams: tuple[object, ...]
+) -> bool:
+    """Return whether requantization preserves every source integer value.
+
+    Requantization is affine, so checking that both source range endpoints
+    remain within half a quantization unit proves that rounding preserves all
+    intermediate values. The destination range must also contain the source
+    range to prevent clipping.
+
+    Args:
+        source_qparams (tuple[object, ...]): Source per-tensor quantization
+            parameters.
+        destination_qparams (tuple[object, ...]): Destination per-tensor
+            quantization parameters.
+
+    Returns:
+        bool: Whether requantization is an identity for the source range.
+
+    """
+    if len(source_qparams) != 5 or len(destination_qparams) != 5:
+        return False
+    source_scale, source_zp, source_qmin, source_qmax, source_dtype = source_qparams
+    (
+        destination_scale,
+        destination_zp,
+        destination_qmin,
+        destination_qmax,
+        destination_dtype,
+    ) = destination_qparams
+    if (
+        not isinstance(source_scale, (int, float))
+        or not isinstance(destination_scale, (int, float))
+        or not isinstance(source_zp, int)
+        or not isinstance(destination_zp, int)
+        or not isinstance(source_qmin, int)
+        or not isinstance(source_qmax, int)
+        or not isinstance(destination_qmin, int)
+        or not isinstance(destination_qmax, int)
+        or source_dtype != destination_dtype
+        or not math.isfinite(source_scale)
+        or not math.isfinite(destination_scale)
+        or source_scale <= 0
+        or destination_scale <= 0
+        or source_qmin > source_qmax
+        or destination_qmin > source_qmin
+        or destination_qmax < source_qmax
+    ):
+        return False
+
+    # QAT scales may drift slightly while the requantization remains an identity.
+    for value in (source_qmin, source_qmax):
+        destination_value = (
+            value - source_zp
+        ) * source_scale / destination_scale + destination_zp
+        if abs(destination_value - value) >= 0.5:
+            return False
+    return True
+
+
+def _unwrap_quantized_base_grid(node: Node) -> Node | None:
+    """Unwrap an identity dequantize-quantize pair around a base grid.
+
+    Args:
+        node (Node): Candidate quantize node.
+
+    Returns:
+        Node | None: Unwrapped base-grid node, or ``None`` when the wrapper
+        changes integer values or has an unsupported form.
+
+    """
+    if not _target_is(node, "quantized_decomposed.quantize_per_tensor.default"):
+        return None
+    dequantize = node.args[0]
+    if not _target_is(dequantize, "quantized_decomposed.dequantize_per_tensor.default"):
+        return None
+    if (
+        len(node.args) != 6
+        or len(dequantize.args) != 6
+        or not _is_identity_requantization(
+            tuple(dequantize.args[1:]), tuple(node.args[1:])
+        )
+        or dequantize.kwargs.get("out_dtype") not in (None, torch.float32)
+    ):
+        return None
+    base_grid = dequantize.args[0]
+    return base_grid if isinstance(base_grid, Node) else None
+
+
+def _matches_linspace_axis(
+    node: object,
+    *,
+    steps: int,
+    view_shape: list[int],
+    expand_shape: list[int],
+) -> bool:
+    """Match one expanded ``linspace(-1, 1)`` canonical-grid axis.
+
+    Args:
+        node (object): Candidate expand node.
+        steps (int): Expected number of linspace steps.
+        view_shape (list[int]): Expected shape before expansion.
+        expand_shape (list[int]): Expected expanded shape.
+
+    Returns:
+        bool: Whether the node matches the expected axis construction.
+
+    """
+    if not _target_is(node, "aten.expand_copy.default"):
+        return False
+    view = node.args[0]
+    actual_expand_shape = _literal_list(node.args[1])
+    if not _target_is(view, "aten.view_copy.default"):
+        return False
+    linspace = view.args[0]
+    actual_view_shape = _literal_list(view.args[1])
+    if not _target_is(linspace, "aten.linspace.default"):
+        return False
+    if linspace.kwargs.get("dtype") not in (None, torch.float32):
+        return False
+    if tuple(linspace.args[:3]) != (-1.0, 1.0, steps):
+        return False
+    return actual_view_shape == view_shape and actual_expand_shape == expand_shape
+
+
+def _matches_canonical_base_grid(node: Node, *, height: int, width: int) -> bool:
+    """Match a quantized canonical XY grid built from two linspace axes.
+
+    Args:
+        node (Node): Candidate quantized base-grid node.
+        height (int): Expected grid height.
+        width (int): Expected grid width.
+
+    Returns:
+        bool: Whether the node constructs the expected canonical base grid.
+
+    """
+    base_grid = _unwrap_quantized_base_grid(node)
+    if not _target_is(base_grid, "aten.cat.default"):
+        return False
+    tensors = base_grid.args[0]
+    cat_dim = base_grid.args[1]
+    return (
+        isinstance(tensors, (list, tuple))
+        and len(tensors) == 2
+        and isinstance(cat_dim, int)
+        and cat_dim == 1
+        and _matches_linspace_axis(
+            tensors[0],
+            steps=width,
+            view_shape=[1, 1, 1, width],
+            expand_shape=[1, -1, height, -1],
+        )
+        and _matches_linspace_axis(
+            tensors[1],
+            steps=height,
+            view_shape=[1, 1, height, 1],
+            expand_shape=[1, -1, -1, width],
+        )
+    )
+
+
+def _match_flow_offset_add(
+    add: Node,
+    *,
+    spatial_shape: tuple[int, int],
+) -> tuple[Node, int] | None:
+    """Match ``base_grid + flow[:, i:i + 2]`` in either operand order.
+
+    Args:
+        add (Node): Candidate addition node.
+        spatial_shape (tuple[int, int]): Expected flow height and width.
+
+    Returns:
+        tuple[Node, int] | None: Flow node and first selected channel, or
+        ``None`` when the addition is unsupported.
+
+    """
+    for base_grid, flow_slice in (
+        (add.args[0], add.args[1]),
+        (add.args[1], add.args[0]),
+    ):
+        if not _target_is(flow_slice, "aten.slice_copy.Tensor"):
+            continue
+        flow, dim, start, end, *step = flow_slice.args
+        if (
+            not isinstance(flow, Node)
+            or dim != 1
+            or step not in ([], [1])
+            or flow_slice.kwargs.get("step", 1) != 1
+        ):
+            continue
+        if not isinstance(start, int) or not isinstance(end, int):
+            continue
+        if (start, end) not in ((0, 2), (2, 4)):
+            continue
+        flow_value = flow.meta.get("val")
+        if (
+            not isinstance(flow_value, torch.Tensor)
+            or len(flow_value.shape) != 4
+            or tuple(flow_value.shape[:2]) != (1, 4)
+        ):
+            continue
+        height, width = map(int, flow_value.shape[2:])
+        if height <= 1 or width <= 1:
+            continue
+        if spatial_shape != (height, width):
+            continue
+        if isinstance(base_grid, Node) and _matches_canonical_base_grid(
+            base_grid, height=height, width=width
+        ):
+            return flow, int(start)
+    return None
+
+
+def _match_flow_offset_grid(node: Node) -> tuple[Node, int] | None:
+    """Match a grid sampler that adds flow to a canonical base grid.
+
+    The supported sampler uses bilinear interpolation, border padding, and
+    ``align_corners=True``. Its grid is the NHWC permutation of a canonical
+    base grid plus flow channels zero-to-one or two-to-three.
+
+    Args:
+        node (Node): Candidate ``aten.grid_sampler_2d`` node.
+
+    Returns:
+        tuple[Node, int] | None: Flow node and first selected channel, or
+        ``None`` when the complete pattern is unsupported.
+
+    """
+    if node.target != exir_ops.edge.aten.grid_sampler_2d.default:
+        return None
+    input_tensor, grid, interpolation, padding, align_corners = node.args
+    if (interpolation, padding, align_corners) != (0, 1, True):
+        return None
+    if not isinstance(input_tensor, Node):
+        return None
+    input_value = input_tensor.meta.get("val")
+    output_value = node.meta.get("val")
+    if (
+        not isinstance(input_value, torch.Tensor)
+        or len(input_value.shape) != 4
+        or int(input_value.shape[0]) != 1
+        or int(input_value.shape[1]) not in (3, 4)
+        or not isinstance(output_value, torch.Tensor)
+        or tuple(output_value.shape) != tuple(input_value.shape)
+    ):
+        return None
+    if not _target_is(grid, "aten.permute_copy.default"):
+        return None
+    if _literal_list(grid.args[1]) != [0, 2, 3, 1]:
+        return None
+    add = grid.args[0]
+    if not _target_is(add, "aten.add.Tensor"):
+        return None
+    if len(add.args) > 2 and add.args[2] != 1:
+        return None
+    if add.kwargs.get("alpha", 1) != 1:
+        return None
+
+    return _match_flow_offset_add(
+        add,
+        spatial_shape=(
+            int(input_value.shape[2]),
+            int(input_value.shape[3]),
+        ),
+    )
+
+
+def _is_per_tensor_int8(qparams: QuantArgs | None) -> TypeGuard[QuantArgs]:
+    return (
+        qparams is not None and not qparams.per_channel and qparams.dtype == torch.int8
+    )
+
+
+def _get_flow_offset_qparams(
+    node: Node, flow: Node
+) -> tuple[QuantArgs, QuantArgs, QuantArgs] | None:
+    """Get qparams supported by the fused shader.
+
+    Image and output qparams must use the SNORM-safe ``[-127, 127]`` range.
+    Flow may use the full int8 range because it is read as a tensor rather than
+    sampled as an image.
+
+    Args:
+        node (Node): Matched grid-sampler node.
+        flow (Node): Matched four-channel flow tensor.
+
+    Returns:
+        tuple[QuantArgs, QuantArgs, QuantArgs] | None: Image, flow, and output
+        qparams, or ``None`` when any qparams are unsupported.
+
+    """
+    try:
+        image_qparams = get_input_qparams(node).get(0)
+        flow_qparams = next(iter(get_output_qparams(flow).values()), None)
+        output_qparams = next(iter(get_output_qparams(node).values()), None)
+    except ValueError:
+        return None
+    if not _is_per_tensor_int8(image_qparams):
+        return None
+    if (image_qparams.qmin, image_qparams.qmax) != (-127, 127):
+        return None
+    if not _is_per_tensor_int8(flow_qparams):
+        return None
+    if not _is_per_tensor_int8(output_qparams):
+        return None
+    if (output_qparams.qmin, output_qparams.qmax) != (-127, 127):
+        return None
+    return image_qparams, flow_qparams, output_qparams
+
+
+class FuseGridSamplerFlowOffsetPass(RewriteGridSamplerToTosaCustomPass):
+    """Fuse ``grid_sample(canonical_grid + flow)`` into one custom shader."""
+
+    targeted_ops = ()  # type: ignore[assignment]
+    _passes_required_after = set()
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        modified = False
+        for node in list(graph_module.graph.nodes):
+            if node.op != "call_function":
+                continue
+            match = _match_flow_offset_grid(node)
+            if match is None:
+                continue
+            flow, flow_channel_offset = match
+            qparams = _get_flow_offset_qparams(node, flow)
+            if qparams is None:
+                continue
+            rewritten = self._rewrite_flow_offset(
+                graph_module,
+                node,
+                flow,
+                flow_channel_offset,
+                *qparams,
+            )
+            modified = rewritten or modified
+
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.graph.lint()
+            graph_module.recompile()
+        return PassResult(graph_module, modified)
+
+    def _rewrite_flow_offset(
+        self,
+        graph_module: GraphModule,
+        node: Node,
+        flow: Node,
+        flow_channel_offset: int,
+        image_qparams: QuantArgs,
+        flow_qparams: QuantArgs,
+        output_qparams: QuantArgs,
+    ) -> bool:
+        input_tensor = node.args[0]
+        if not isinstance(input_tensor, Node):
+            raise RuntimeError("grid sampler image input must be a tensor node")
+        input_value = input_tensor.meta["val"]
+        output_value = node.meta["val"]
+        flow_value = flow.meta["val"]
+        if tuple(input_value.shape[2:]) != tuple(output_value.shape[2:]) or tuple(
+            flow_value.shape[2:]
+        ) != tuple(output_value.shape[2:]):
+            raise RuntimeError("flow-offset fusion requires equal input/output H/W")
+
+        custom_shape = list(input_value.shape)
+        custom_shape[1] = 4
+        try:
+            payload = build_flow_offset_grid_sampler_payload(
+                input_shape=tuple(custom_shape),
+                output_shape=tuple(custom_shape),
+                flow_shape=tuple(flow_value.shape),
+                input_scale=float(image_qparams.get_scale_per_tensor()),
+                input_zero_point=int(image_qparams.get_zp_per_tensor()),
+                output_scale=float(output_qparams.get_scale_per_tensor()),
+                output_zero_point=int(output_qparams.get_zp_per_tensor()),
+                flow_scale=float(flow_qparams.get_scale_per_tensor()),
+                flow_zero_point=int(flow_qparams.get_zp_per_tensor()),
+                flow_channel_offset=flow_channel_offset,
+            )
+        except _FlowOffsetShaderCompilationError as error:
+            logger.warning("Skipping flow-offset grid sampler fusion: %s", error)
+            return False
+
+        graph = graph_module.graph
+        with graph.inserting_before(node):
+            custom_input = (
+                self._pad_c3_input_to_c4(
+                    graph_module, input_tensor, input_qparams=image_qparams
+                )
+                if int(input_value.shape[1]) == 3
+                else input_tensor
+            )
+            nhwc_input = graph.call_function(
+                exir_ops.edge.aten.permute_copy.default,
+                args=(custom_input, list(NHWC_ORDER)),
+            )
+            nhwc_input.meta = dict(custom_input.meta)
+            _set_fake_tensor_meta(
+                nhwc_input,
+                exir_ops.edge.aten.permute_copy.default(
+                    custom_input.meta["val"], list(NHWC_ORDER)
+                ),
+            )
+            custom_node = graph.call_function(
+                exir_ops.backend.tosa.CUSTOM.default,
+                args=([nhwc_input, flow],),
+                kwargs={
+                    "operator_name": flow_offset_grid_sampler_operator_name(),
+                    "domain_name": CUSTOM_SHADER_DOMAIN_NAME,
+                    "implementation_attrs": encode_payload(payload),
+                },
+            )
+            custom_node.meta = dict(node.meta)
+            if "input_qparams" in custom_node.meta:
+                custom_node.meta["input_qparams"] = {
+                    0: custom_node.meta["input_qparams"][0]
+                }
+
+        with graph.inserting_after(custom_node):
+            getitem = graph.call_function(operator.getitem, args=(custom_node, 0))
+            custom_output = torch.empty_like(nhwc_input.meta["val"])
+            _set_fake_tensor_meta(custom_node, [custom_output])
+            getitem.meta = dict(node.meta)
+            _set_fake_tensor_meta(getitem, custom_output)
+        with graph.inserting_after(getitem):
+            output = graph.call_function(
+                exir_ops.edge.aten.permute_copy.default,
+                args=(getitem, list(NHWC_INVERSE_ORDER)),
+            )
+            output.meta = dict(node.meta)
+            _set_fake_tensor_meta(
+                output,
+                exir_ops.edge.aten.permute_copy.default(
+                    custom_output, list(NHWC_INVERSE_ORDER)
+                ),
+            )
+        if int(input_value.shape[1]) == 3:
+            with graph.inserting_after(output):
+                replacement = self._slice_c4_output_to_c3(graph_module, output, node)
+        else:
+            replacement = output
+        node.replace_all_uses_with(replacement)
+        graph.erase_node(node)
+        return True

--- a/backends/arm/vgf/backend.py
+++ b/backends/arm/vgf/backend.py
@@ -21,7 +21,11 @@ import tempfile
 from dataclasses import dataclass
 from typing import Any, final, List
 
-from executorch.backends.arm._passes import DecomposeQuantNodesPass, RewriteConvPass
+from executorch.backends.arm._passes import (
+    DecomposeQuantNodesPass,
+    InsertRescaleInt32Pass,
+    RewriteConvPass,
+)
 from executorch.backends.arm._passes.arm_pass_manager import (
     _registered_pass_insertions,
     PassInsertions,
@@ -32,6 +36,7 @@ from executorch.backends.arm.tosa.backend import (  # type: ignore[import-not-fo
     TOSABackend,
 )
 from executorch.backends.arm.vgf._passes import (  # type: ignore[import-not-found]
+    FuseGridSamplerFlowOffsetPass,
     InsertGridSamplerGridDequantPass,
     RewriteGridSamplerToTosaCustomPass,
 )
@@ -159,6 +164,10 @@ def _register_pass_before(target_pass_type: type, pass_: ExportPass) -> None:
 def _register_vgf_rewrite_passes() -> None:
     """Register VGF-only custom shader lowering passes."""
     _register_pass_before(DecomposeQuantNodesPass, InsertGridSamplerGridDequantPass())
+    _register_pass_before(
+        InsertRescaleInt32Pass,
+        FuseGridSamplerFlowOffsetPass(),
+    )
     _register_pass_before(RewriteConvPass, RewriteGridSamplerToTosaCustomPass())
 
 
@@ -324,7 +333,6 @@ def vgf_compile(
 
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-
         # We currently write out a flatbuffer as input to the converter
         tosaname = f"output_{tag_name}.tosa"
         tosa_path = os.path.join(tmpdir, tosaname)

--- a/backends/arm/vgf/shaders/flow_offset_grid_sampler_int8_align_corners.glsl
+++ b/backends/arm/vgf/shaders/flow_offset_grid_sampler_int8_align_corners.glsl
@@ -1,0 +1,60 @@
+// Copyright 2026 Arm Limited and/or its affiliates.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#version 450
+#extension GL_ARM_tensors : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+
+layout(set = 0, binding = 0) uniform sampler2D inputImage;
+layout(set = 0, binding = 1) uniform tensorARM<int8_t, 4> flow;
+layout(set = 0, binding = 2, rgba8_snorm) uniform writeonly image2D outImage;
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+const float FLOW_SCALE = @FLOW_SCALE@;
+const int FLOW_ZERO_POINT = @FLOW_ZERO_POINT@;
+const float INPUT_SCALE = @INPUT_SCALE@;
+const int INPUT_ZERO_POINT = @INPUT_ZERO_POINT@;
+const float OUTPUT_SCALE = @OUTPUT_SCALE@;
+const int OUTPUT_ZERO_POINT = @OUTPUT_ZERO_POINT@;
+const uint FLOW_X_CHANNEL = @FLOW_X_CHANNEL@;
+const uint FLOW_Y_CHANNEL = @FLOW_Y_CHANNEL@;
+
+float readFlow(ivec2 p, uint channel) {
+  uint coords[4] = uint[](0u, channel, uint(p.y), uint(p.x));
+  int8_t value[1];
+  tensorReadARM(flow, coords, value);
+  return (float(value[0]) - float(FLOW_ZERO_POINT)) * FLOW_SCALE;
+}
+
+vec2 alignCornersUvFromFlowOffset(ivec2 p) {
+  vec2 inputSize = vec2(textureSize(inputImage, 0));
+  vec2 flowOffset = vec2(
+      readFlow(p, FLOW_X_CHANNEL), readFlow(p, FLOW_Y_CHANNEL));
+  vec2 baseGrid =
+      (vec2(p) * vec2(2.0) / (inputSize - vec2(1.0))) - vec2(1.0);
+  vec2 texel =
+      (baseGrid + flowOffset + vec2(1.0)) * vec2(0.5) *
+      (inputSize - vec2(1.0));
+  return (texel + vec2(0.5)) / inputSize;
+}
+
+void main() {
+  ivec2 outSize = imageSize(outImage);
+  ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
+  if (gid.x >= outSize.x || gid.y >= outSize.y) {
+    return;
+  }
+
+  vec4 inputRaw =
+      texture(inputImage, alignCornersUvFromFlowOffset(gid)) * 127.0;
+  vec4 inputDequantized =
+      (inputRaw - vec4(float(INPUT_ZERO_POINT))) * INPUT_SCALE;
+  vec4 outputRaw =
+      roundEven(inputDequantized / OUTPUT_SCALE) +
+      vec4(float(OUTPUT_ZERO_POINT));
+  outputRaw = clamp(outputRaw, vec4(-127.0), vec4(127.0));
+  imageStore(outImage, gid, outputRaw / 127.0);
+}

--- a/backends/arm/vgf/shaders/grid_sampler.py
+++ b/backends/arm/vgf/shaders/grid_sampler.py
@@ -3,8 +3,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import base64
 import json
+import shutil
+import subprocess  # nosec B404 - fixed shader compiler invocation
+import tempfile
 from importlib.resources import files
+from pathlib import Path
 from typing import Any, Sequence
 
 CUSTOM_SHADER_DOMAIN_NAME = "com.arm.VulkanCustomShader"
@@ -34,6 +39,15 @@ GRID_SAMPLER_2D_SAMPLER_INT8_ALIGN_CORNERS_SHADER_BINARY = (
 GRID_SAMPLER_2D_SAMPLER_VK_FORMAT = "VK_FORMAT_R32G32B32A32_SFLOAT"
 GRID_SAMPLER_2D_SAMPLER_INT8_VK_FORMAT = "VK_FORMAT_R8G8B8A8_SNORM"
 GRID_SAMPLER_2D_QUANTIZED_GRID_VK_FORMAT = "VK_FORMAT_R8_SINT"
+FLOW_OFFSET_GRID_SAMPLER_OPERATOR_NAME = "torch.nn.functional.grid_sample.flow_offset"
+FLOW_OFFSET_GRID_SAMPLER_SHADER_SOURCE = (
+    "flow_offset_grid_sampler_int8_align_corners.glsl"
+)
+
+
+class _FlowOffsetShaderCompilationError(RuntimeError):
+    pass
+
 
 _INTERPOLATION_MODE_NAMES = {
     0: "bilinear",
@@ -245,8 +259,7 @@ def build_grid_sampler_2d_payload(
 def _dispatch_shape_for_output_shape(output_shape: tuple[int, ...]) -> list[int]:
     if len(output_shape) != 4:
         raise ValueError(
-            "grid_sampler output_shape must be rank 4 NCHW, "
-            f"got shape {output_shape}"
+            f"grid_sampler output_shape must be rank 4 NCHW, got shape {output_shape}"
         )
     output_batch = int(output_shape[0])
     output_height = int(output_shape[2])
@@ -257,6 +270,157 @@ def _dispatch_shape_for_output_shape(output_shape: tuple[int, ...]) -> list[int]
         (output_height + group_y - 1) // group_y,
         (output_batch + group_z - 1) // group_z,
     ]
+
+
+def flow_offset_grid_sampler_operator_name() -> str:
+    """Return the custom operator name for fused flow-offset sampling.
+
+    Returns:
+        str: Fully qualified custom operator name.
+
+    """
+    return FLOW_OFFSET_GRID_SAMPLER_OPERATOR_NAME
+
+
+def _format_float(value: float) -> str:
+    return format(float(value), ".9g")
+
+
+def _compile_flow_offset_grid_sampler_shader(
+    *,
+    input_scale: float,
+    input_zero_point: int,
+    output_scale: float,
+    output_zero_point: int,
+    flow_scale: float,
+    flow_zero_point: int,
+    flow_channel_offset: int,
+) -> str:
+    source = (
+        files(__package__)
+        .joinpath(FLOW_OFFSET_GRID_SAMPLER_SHADER_SOURCE)
+        .read_text(encoding="utf-8")
+        .replace("@INPUT_SCALE@", _format_float(input_scale))
+        .replace("@INPUT_ZERO_POINT@", str(int(input_zero_point)))
+        .replace("@OUTPUT_SCALE@", _format_float(output_scale))
+        .replace("@OUTPUT_ZERO_POINT@", str(int(output_zero_point)))
+        .replace("@FLOW_SCALE@", _format_float(flow_scale))
+        .replace("@FLOW_ZERO_POINT@", str(int(flow_zero_point)))
+        .replace("@FLOW_X_CHANNEL@", f"{int(flow_channel_offset)}u")
+        .replace("@FLOW_Y_CHANNEL@", f"{int(flow_channel_offset) + 1}u")
+    )
+    glslc = shutil.which("glslc")
+    if glslc is None:
+        raise _FlowOffsetShaderCompilationError(
+            "glslc is required for fused flow-offset grid sampling"
+        )
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_path = Path(tmpdir) / "flow_offset_grid_sampler.glsl"
+            spirv_path = Path(tmpdir) / "flow_offset_grid_sampler.spv"
+            source_path.write_text(source, encoding="utf-8")
+            subprocess.run(  # nosec B603 - glslc path is resolved from PATH.
+                [
+                    glslc,
+                    "-fshader-stage=compute",
+                    str(source_path),
+                    "-o",
+                    str(spirv_path),
+                ],
+                check=True,
+            )
+            return base64.b64encode(spirv_path.read_bytes()).decode("ascii")
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise _FlowOffsetShaderCompilationError(
+            "failed to compile fused flow-offset grid sampler shader"
+        ) from error
+
+
+def build_flow_offset_grid_sampler_payload(
+    *,
+    input_shape: tuple[int, ...],
+    output_shape: tuple[int, ...],
+    flow_shape: tuple[int, ...],
+    input_scale: float,
+    input_zero_point: int,
+    output_scale: float,
+    output_zero_point: int,
+    flow_scale: float,
+    flow_zero_point: int,
+    flow_channel_offset: int,
+) -> dict[str, Any]:
+    """Build custom shader metadata for fused flow-offset grid sampling.
+
+    Args:
+        input_shape (tuple[int, ...]): Static NCHW image input shape.
+        output_shape (tuple[int, ...]): Static NCHW output shape.
+        flow_shape (tuple[int, ...]): Static NCHW four-channel flow shape.
+        input_scale (float): Image input quantization scale.
+        input_zero_point (int): Image input quantization zero point.
+        output_scale (float): Output quantization scale.
+        output_zero_point (int): Output quantization zero point.
+        flow_scale (float): Flow input quantization scale.
+        flow_zero_point (int): Flow input quantization zero point.
+        flow_channel_offset (int): First flow channel, either zero or two.
+
+    Returns:
+        dict[str, Any]: Vulkan custom shader metadata payload.
+
+    """
+    if len(input_shape) != 4 or tuple(input_shape[:2]) != (1, 4):
+        raise ValueError(f"expected static NCHW [1,4,H,W] input, got {input_shape}")
+    if len(output_shape) != 4 or tuple(output_shape[:2]) != (1, 4):
+        raise ValueError(f"expected static NCHW [1,4,H,W] output, got {output_shape}")
+    if len(flow_shape) != 4 or tuple(flow_shape[:2]) != (1, 4):
+        raise ValueError(f"expected static NCHW [1,4,H,W] flow, got {flow_shape}")
+    if tuple(input_shape[2:]) != tuple(output_shape[2:]):
+        raise ValueError("input and output spatial shapes must match")
+    if tuple(flow_shape[2:]) != tuple(output_shape[2:]):
+        raise ValueError("flow and output spatial shapes must match")
+    if any(int(dim) <= 1 for dim in output_shape[2:]):
+        raise ValueError("flow-offset grid sampling requires H and W greater than 1")
+    if flow_channel_offset not in (0, 2):
+        raise ValueError("flow_channel_offset must be 0 or 2")
+
+    sampler_vk_format = GRID_SAMPLER_2D_SAMPLER_INT8_VK_FORMAT
+    return {
+        "entry_point": GRID_SAMPLER_2D_SHADER_ENTRY_POINT,
+        "workgroup_sizes": _dispatch_shape_for_output_shape(output_shape),
+        "shader_language": GRID_SAMPLER_2D_SHADER_LANGUAGE,
+        "shader_code": _compile_flow_offset_grid_sampler_shader(
+            input_scale=input_scale,
+            input_zero_point=input_zero_point,
+            output_scale=output_scale,
+            output_zero_point=output_zero_point,
+            flow_scale=flow_scale,
+            flow_zero_point=flow_zero_point,
+            flow_channel_offset=flow_channel_offset,
+        ),
+        "operator_name": FLOW_OFFSET_GRID_SAMPLER_OPERATOR_NAME,
+        "input_scale": input_scale,
+        "input_zero_point": input_zero_point,
+        "output_scale": output_scale,
+        "output_zero_point": output_zero_point,
+        "flow_scale": flow_scale,
+        "flow_zero_point": flow_zero_point,
+        "flow_channel_offset": flow_channel_offset,
+        "input_0_binding": 0,
+        "input_0_descriptorset": 0,
+        "input_0_type": "Image",
+        "input_0_vkformat": sampler_vk_format,
+        "input_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER",
+        "input_0_sampler": _sampler_config(interpolation_mode=0, padding_mode=1),
+        "input_1_binding": 1,
+        "input_1_descriptorset": 0,
+        "input_1_type": "Tensor",
+        "input_1_vkformat": GRID_SAMPLER_2D_QUANTIZED_GRID_VK_FORMAT,
+        "input_1_vkdescriptortype": "VK_DESCRIPTOR_TYPE_TENSOR_ARM",
+        "output_0_binding": 2,
+        "output_0_descriptorset": 0,
+        "output_0_type": "Image",
+        "output_0_vkformat": sampler_vk_format,
+        "output_0_vkdescriptortype": "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE",
+    }
 
 
 def _sampler_vk_format(input_dtype: Any | None, output_dtype: Any | None) -> str | None:


### PR DESCRIPTION
Recognize grid_sample calls that add a two-channel flow slice to an align-corners base grid:

    base_grid ---------\
                         add -> permute -> grid_sample(image, grid)
    flow[:, i:i+2] ----/

Replace the complete expression with:

    image, flow -> fused flow-offset custom shader

This avoids materializing the normalized sampling grid at runtime.

Require SNORM-compatible image and output quantization ranges. Vulkan's signed normalized 8-bit image format maps both -128 and -127 to -1.0, so only fuse tensors using the range [-127, 127]. The flow tensor keeps the full int8 range because the shader reads it directly as a tensor.

If glslc is unavailable or compilation fails, leave the graph unchanged for generic grid-sampler lowering.

Cover supported rewrites, invalid patterns, SNORM ranges, and compiler fallback behavior.

Authored with Codex.

Change-Id: Ia19b4387c169bd24f8db837a5bfee7c91d4e55ce

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani