### PR TITLE
Arm backend: Preserve qparams for fused flow-offset sampling

### DIFF
--- a/backends/arm/quantizer/quantization_config.py
+++ b/backends/arm/quantizer/quantization_config.py
@@ -11,8 +11,7 @@ quantization specs consumed by the annotator.
 
 """
 
-
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Callable, cast, Optional
 
 import torch
@@ -26,6 +25,124 @@ from torchao.quantization.pt2e.quantizer import (
     QuantizationSpecBase,
     SharedQuantizationSpec,
 )
+
+
+def _is_canonical_flow_offset_grid_sampler(node: Node) -> bool:  # noqa: C901
+    if node.target != torch.ops.aten.grid_sampler.default or len(node.args) < 5:
+        return False
+    if tuple(node.args[2:5]) != (0, 1, True):
+        return False
+    image = node.args[0]
+    if not isinstance(image, Node):
+        return False
+    image_value = image.meta.get("val")
+    output_value = node.meta.get("val")
+    if (
+        not isinstance(image_value, torch.Tensor)
+        or len(image_value.shape) != 4
+        or int(image_value.shape[0]) != 1
+        or int(image_value.shape[1]) not in (3, 4)
+        or not isinstance(output_value, torch.Tensor)
+        or tuple(output_value.shape) != tuple(image_value.shape)
+    ):
+        return False
+    grid = node.args[1]
+    if not isinstance(grid, Node) or grid.target != torch.ops.aten.permute.default:
+        return False
+    permutation = grid.args[1]
+    if not isinstance(permutation, (list, tuple)) or list(permutation) != [0, 2, 3, 1]:
+        return False
+    add = grid.args[0]
+    if not isinstance(add, Node) or add.target != torch.ops.aten.add.Tensor:
+        return False
+    if len(add.args) > 2 and add.args[2] != 1:
+        return False
+    if add.kwargs.get("alpha", 1) != 1:
+        return False
+    for base_grid, flow_slice in (
+        (add.args[0], add.args[1]),
+        (add.args[1], add.args[0]),
+    ):
+        if not isinstance(flow_slice, Node) or flow_slice.target not in (
+            torch.ops.aten.slice.Tensor,
+            torch.ops.aten.slice_copy.Tensor,
+        ):
+            continue
+        flow, dim, start, end, *step = flow_slice.args
+        if dim != 1 or (start, end) not in ((0, 2), (2, 4)):
+            continue
+        if (
+            step not in ([], [1])
+            or flow_slice.kwargs.get("step", 1) != 1
+            or not isinstance(flow, Node)
+        ):
+            continue
+        flow_value = flow.meta.get("val")
+        while isinstance(base_grid, Node) and base_grid.target in (
+            torch.ops.aten.to.dtype,
+            torch.ops.aten.to.dtype_layout,
+            torch.ops.aten.alias.default,
+        ):
+            base_grid = base_grid.args[0]
+        if not isinstance(base_grid, Node):
+            continue
+        base_value = base_grid.meta.get("val")
+        if (
+            not isinstance(flow_value, torch.Tensor)
+            or len(flow_value.shape) != 4
+            or tuple(flow_value.shape[:2]) != (1, 4)
+        ):
+            continue
+        height, width = map(int, flow_value.shape[2:])
+        if height <= 1 or width <= 1:
+            continue
+        if tuple(image_value.shape[2:]) != (height, width):
+            continue
+        if not isinstance(base_value, torch.Tensor) or tuple(base_value.shape) != (
+            1,
+            2,
+            height,
+            width,
+        ):
+            continue
+        if base_grid.target != torch.ops.aten.cat.default or base_grid.args[1] != 1:
+            continue
+        axes = base_grid.args[0]
+        if not isinstance(axes, (list, tuple)) or len(axes) != 2:
+            continue
+
+        def matches_axis(axis_node, axis):
+            if not isinstance(axis_node, Node) or axis_node.target not in (
+                torch.ops.aten.expand.default,
+                torch.ops.aten.expand_copy.default,
+            ):
+                return False
+            view = axis_node.args[0]
+            if not isinstance(view, Node) or view.target not in (
+                torch.ops.aten.view.default,
+                torch.ops.aten.view_copy.default,
+            ):
+                return False
+            linspace = view.args[0]
+            if (
+                not isinstance(linspace, Node)
+                or linspace.target != torch.ops.aten.linspace.default
+            ):
+                return False
+            if linspace.kwargs.get("dtype") not in (None, torch.float32):
+                return False
+            extent = width if axis == 3 else height  # noqa: B023
+            expected_view = [1, 1, 1, width] if axis == 3 else [1, 1, height, 1]  # noqa: B023  # fmt: skip
+            expected_expand = [1, -1, height, -1] if axis == 3 else [1, -1, -1, width]  # noqa: B023  # fmt: skip
+            return (
+                tuple(linspace.args[:3]) == (-1.0, 1.0, extent)
+                and list(view.args[1]) == expected_view
+                and list(axis_node.args[1]) == expected_expand
+            )
+
+        if matches_axis(axes[0], 3) and matches_axis(axes[1], 2):
+            return True
+    return False
 
 
 @dataclass(eq=True, frozen=True)
@@ -156,7 +273,6 @@ class QuantizationConfig:
                 floating-point.
 
         """
-
         if self.bias is None or node is None:
             return None
 
@@ -363,7 +479,6 @@ class TOSAQuantizationConfig(QuantizationConfig):
         If node is a `to.dtype` operator, returns a fixed quantization spec if the input is integer and the output is float32.
 
         """
-
         if node is None:
             return super().get_output_act_qspec()
         # MLETORCH-1853: Fix lazy import when moving files around
@@ -421,4 +536,54 @@ class TOSAQuantizationConfig(QuantizationConfig):
 
 
 class VGFQuantizationConfig(TOSAQuantizationConfig):
+    """Configure quantization for VGF-specific lowering paths."""
+
     quantize_grid_sampler_grid = True
+
+    @staticmethod
+    def _snorm_compatible_qspec(
+        qspec: Optional[QuantizationSpecBase],
+    ) -> Optional[QuantizationSpecBase]:
+        if qspec is None:
+            return None
+        if not isinstance(qspec, QuantizationSpec):
+            raise ValueError("SNORM-compatible qparams require a QuantizationSpec.")
+        return replace(qspec, quant_min=-127, quant_max=127)
+
+    def get_input_act_qspec(self, node=None, input_node=None):
+        """Return the input activation spec for a VGF graph node.
+
+        Args:
+            node (Optional[Node]): Node whose input spec is requested.
+            input_node (Optional[Node]): Input node whose spec is requested.
+
+        Returns:
+            Optional[QuantizationSpecBase]: Input activation spec, or ``None``.
+
+        """
+        if (
+            node is not None
+            and input_node is not None
+            and _is_canonical_flow_offset_grid_sampler(node)
+            and input_node == node.args[0]
+        ):
+            qspec = QuantizationConfig.get_input_act_qspec(self, node, input_node)
+            if isinstance(qspec, QuantizationSpec) and qspec.dtype == torch.int8:
+                return self._snorm_compatible_qspec(qspec)
+        return super().get_input_act_qspec(node, input_node)
+
+    def get_output_act_qspec(self, node=None):
+        """Return the output activation spec for a VGF graph node.
+
+        Args:
+            node (Optional[Node]): Node whose output spec is requested.
+
+        Returns:
+            Optional[QuantizationSpecBase]: Output activation spec, or ``None``.
+
+        """
+        if node is not None and _is_canonical_flow_offset_grid_sampler(node):
+            qspec = QuantizationConfig.get_output_act_qspec(self, node)
+            if isinstance(qspec, QuantizationSpec) and qspec.dtype == torch.int8:
+                return self._snorm_compatible_qspec(qspec)
+        return super().get_output_act_qspec(node)

--- a/backends/arm/test/passes/test_fuse_grid_sampler_flow_offset_pass.py
+++ b/backends/arm/test/passes/test_fuse_grid_sampler_flow_offset_pass.py
@@ -13,6 +13,14 @@ from unittest.mock import Mock
 import pytest
 import torch
 from executorch.backends.arm._passes.quant_args import QuantArgs
+from executorch.backends.arm.quantizer.arm_quantizer import (
+    get_symmetric_a16w8_quantization_config,
+    get_symmetric_quantization_config,
+)
+from executorch.backends.arm.quantizer.quantization_config import (
+    _is_canonical_flow_offset_grid_sampler,
+    VGFQuantizationConfig,
+)
 from executorch.backends.arm.vgf._passes import fuse_grid_sampler_flow_offset
 from executorch.backends.arm.vgf._passes.fuse_grid_sampler_flow_offset import (
     _match_flow_offset_grid,
@@ -28,6 +36,10 @@ from executorch.backends.arm.vgf.shaders.grid_sampler import (
 )
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch.fx import Graph
+from torchao.quantization.pt2e.quantizer import (
+    FixedQParamsQuantizationSpec,
+    QuantizationSpec,
+)
 
 
 def _build_grid_axis(
@@ -198,6 +210,96 @@ def _arm_tensor_glslc():
         )
     if result.returncode != 0:
         pytest.skip("glslc does not support GL_ARM_tensors")
+
+
+def _build_aten_flow_offset_grid_sampler(
+    *,
+    padding=1,
+    height=8,
+    width=12,
+    image_shape=None,
+    flow_shape=None,
+    output_shape=None,
+    reverse_add_operands=False,
+    add_alpha=None,
+    slice_step=None,
+    linspace_dtype=None,
+):
+    graph = Graph()
+    image = graph.placeholder("image")
+    image.meta["val"] = torch.empty(image_shape or (1, 4, height, width))
+    flow = graph.placeholder("flow")
+    flow.meta["val"] = torch.empty(flow_shape or (1, 4, height, width))
+
+    linspace_kwargs = {} if linspace_dtype is None else {"dtype": linspace_dtype}
+
+    horizontal = graph.call_function(
+        torch.ops.aten.linspace.default,
+        args=(-1.0, 1.0, width),
+        kwargs=linspace_kwargs,
+    )
+    horizontal = graph.call_function(
+        torch.ops.aten.view.default,
+        args=(horizontal, [1, 1, 1, width]),
+    )
+    horizontal = graph.call_function(
+        torch.ops.aten.expand.default,
+        args=(horizontal, [1, -1, height, -1]),
+    )
+    vertical = graph.call_function(
+        torch.ops.aten.linspace.default,
+        args=(-1.0, 1.0, height),
+        kwargs=linspace_kwargs,
+    )
+    vertical = graph.call_function(
+        torch.ops.aten.view.default,
+        args=(vertical, [1, 1, height, 1]),
+    )
+    vertical = graph.call_function(
+        torch.ops.aten.expand.default,
+        args=(vertical, [1, -1, -1, width]),
+    )
+    base_grid = graph.call_function(
+        torch.ops.aten.cat.default,
+        args=([horizontal, vertical], 1),
+    )
+    base_grid.meta["val"] = torch.empty(1, 2, height, width)
+    flow_slice = graph.call_function(
+        torch.ops.aten.slice.Tensor,
+        args=(flow, 1, 0, 2),
+        kwargs={} if slice_step is None else {"step": slice_step},
+    )
+    add_args = (
+        (flow_slice, base_grid) if reverse_add_operands else (base_grid, flow_slice)
+    )
+    grid = graph.call_function(
+        torch.ops.aten.add.Tensor,
+        args=add_args,
+        kwargs={} if add_alpha is None else {"alpha": add_alpha},
+    )
+    grid = graph.call_function(
+        torch.ops.aten.permute.default,
+        args=(grid, [0, 2, 3, 1]),
+    )
+    grid_sampler = graph.call_function(
+        torch.ops.aten.grid_sampler.default,
+        args=(image, grid, 0, padding, True),
+    )
+    grid_sampler.meta["val"] = torch.empty(
+        output_shape or tuple(image.meta["val"].shape)
+    )
+    return grid_sampler, image
+
+
+def _vgf_quantization_config(config=None):
+    config = config or get_symmetric_quantization_config()
+    return VGFQuantizationConfig(
+        config.input_activation,
+        config.output_activation,
+        config.weight,
+        config.bias,
+        config.label,
+    )
 
 
 @pytest.mark.parametrize(
@@ -533,3 +635,81 @@ def test_build_flow_offset_grid_sampler_payload_rejects_invalid_contract(
 ):
     with pytest.raises(ValueError, match=error):
         _build_payload(**overrides)
+
+
+def test_vgf_quantization_uses_snorm_safe_observed_qparams_for_flow_offset_sampler():
+    grid_sampler, image = _build_aten_flow_offset_grid_sampler()
+    config = _vgf_quantization_config()
+
+    assert _is_canonical_flow_offset_grid_sampler(grid_sampler)
+    input_qspec = config.get_input_act_qspec(grid_sampler, image)
+    output_qspec = config.get_output_act_qspec(grid_sampler)
+    for qspec, configured_qspec in (
+        (input_qspec, config.input_activation),
+        (output_qspec, config.output_activation),
+    ):
+        assert isinstance(qspec, QuantizationSpec)
+        assert isinstance(configured_qspec, QuantizationSpec)
+        assert qspec.observer_or_fake_quant_ctr == (
+            configured_qspec.observer_or_fake_quant_ctr
+        )
+        assert qspec.quant_min == -127
+        assert qspec.quant_max == 127
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({}, id="canonical"),
+        pytest.param({"image_shape": (1, 3, 8, 12)}, id="three-channel-image"),
+        pytest.param({"reverse_add_operands": True}, id="reversed-add"),
+        pytest.param({"add_alpha": 1}, id="explicit-unit-alpha"),
+        pytest.param({"slice_step": 1}, id="explicit-unit-slice-step"),
+    ],
+)
+def test_vgf_quantization_matches_supported_flow_offset_variants(kwargs):
+    grid_sampler, _ = _build_aten_flow_offset_grid_sampler(**kwargs)
+
+    assert _is_canonical_flow_offset_grid_sampler(grid_sampler)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"padding": 0}, id="zero-padding"),
+        pytest.param({"add_alpha": 2}, id="non-unit-add-alpha"),
+        pytest.param({"slice_step": 2}, id="non-unit-slice-step"),
+        pytest.param({"linspace_dtype": torch.int8}, id="integer-linspace"),
+        pytest.param({"height": 1}, id="singleton-height"),
+        pytest.param({"width": 1}, id="singleton-width"),
+        pytest.param({"flow_shape": (1, 4)}, id="rank-two-flow"),
+        pytest.param({"flow_shape": (1, 4, 8)}, id="rank-three-flow"),
+        pytest.param({"flow_shape": (1, 4, 8, 12, 1)}, id="rank-five-flow"),
+        pytest.param({"image_shape": (2, 4, 8, 12)}, id="batched-image"),
+        pytest.param({"image_shape": (1, 2, 8, 12)}, id="two-channel-image"),
+        pytest.param({"image_shape": (1, 4, 7, 12)}, id="different-image-shape"),
+        pytest.param({"output_shape": (1, 4, 7, 12)}, id="different-output-shape"),
+    ],
+)
+def test_vgf_quantization_keeps_fixed_qparams_for_unsupported_variants(kwargs):
+    grid_sampler, image = _build_aten_flow_offset_grid_sampler(**kwargs)
+    config = _vgf_quantization_config()
+
+    assert not _is_canonical_flow_offset_grid_sampler(grid_sampler)
+    assert isinstance(
+        config.get_input_act_qspec(grid_sampler, image),
+        FixedQParamsQuantizationSpec,
+    )
+    assert isinstance(
+        config.get_output_act_qspec(grid_sampler),
+        FixedQParamsQuantizationSpec,
+    )
+
+
+def test_vgf_quantization_leaves_a16w8_flow_offset_sampler_unquantized():
+    grid_sampler, image = _build_aten_flow_offset_grid_sampler()
+    config = _vgf_quantization_config(get_symmetric_a16w8_quantization_config())
+
+    assert _is_canonical_flow_offset_grid_sampler(grid_sampler)
+    assert config.get_input_act_qspec(grid_sampler, image) is None
+    assert config.get_output_act_qspec(grid_sampler) is None


### PR DESCRIPTION
Use observed activation qparams for the image and output of the exact flow-offset pattern handled by the fused VGF shader. This preserves activation precision instead of forcing fixed grid-sampler qparams, reducing clipping and wasted int8 resolution.

Keep image and output ranges at [-127, 127] because Vulkan SNORM cannot distinguish -128 from -127. Keep flow at the full int8 range because the shader reads it directly as int8_t.

Align quantizer pattern matching with the fusion contract, including sampling modes, graph structure, shapes, slice semantics, and supported dtypes. Leave unsupported variants on the standard grid-sampler path.

Avoid unnecessary RESCALE operations and their additional rounding error between paired warps. Cover supported patterns, malformed shapes, near misses, fixed-qparams fallback, and A16W8 fallback.

Authored with Codex.

Change-Id: Icd9bc31e21c8f90fc1b7fa7265b532ff03a393b9

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani