### PR TITLE
Arm backend: Avoid requantization around fused flow sampling

### DIFF
--- a/backends/arm/quantizer/__init__.py
+++ b/backends/arm/quantizer/__init__.py
@@ -16,6 +16,7 @@ from .arm_quantizer import (  # noqa
     get_symmetric_a16w8_quantization_config,
     get_symmetric_quantization_config,
     get_uint8_io_quantization_config,
+    get_vgf_snorm_quantization_config,
     TOSAQuantizer,
     VgfQuantizer,
 )

--- a/backends/arm/quantizer/arm_quantizer.py
+++ b/backends/arm/quantizer/arm_quantizer.py
@@ -108,6 +108,7 @@ __all__ = [
     "get_symmetric_a16w8_quantization_config",
     "get_symmetric_quantization_config",
     "get_uint8_io_quantization_config",
+    "get_vgf_snorm_quantization_config",
 ]
 
 logger = logging.getLogger(__name__)
@@ -311,6 +312,48 @@ def get_symmetric_quantization_config(
         weight_quantization_spec,
         bias_quantization_spec,
         label,
+    )
+
+
+@functools.lru_cache
+def get_vgf_snorm_quantization_config(
+    is_per_channel: bool = True,
+    is_qat: bool = False,
+    weight_qmin: int = -127,
+    weight_qmax: int = 127,
+    eps: float = 2**-16,
+) -> VGFQuantizationConfig:
+    """Create a VGF config compatible with signed normalized sampled images.
+
+    Args:
+        is_per_channel (bool): Whether to use per-channel quantization for
+            weights.
+        is_qat (bool): Whether the configuration targets quantization aware
+            training.
+        weight_qmin (int): Minimum weight quantization value.
+        weight_qmax (int): Maximum weight quantization value.
+        eps (float): Minimum scale value used by observers.
+
+    Returns:
+        VGFQuantizationConfig: VGF quantization settings using the SNORM-safe
+        activation range ``[-127, 127]``.
+
+    """
+    config = get_symmetric_quantization_config(
+        is_per_channel=is_per_channel,
+        is_qat=is_qat,
+        act_qmin=-127,
+        act_qmax=127,
+        weight_qmin=weight_qmin,
+        weight_qmax=weight_qmax,
+        eps=eps,
+    )
+    return VGFQuantizationConfig(
+        config.input_activation,
+        config.output_activation,
+        config.weight,
+        config.bias,
+        config.label,
     )
 
 

--- a/backends/arm/quantizer/quantization_config.py
+++ b/backends/arm/quantizer/quantization_config.py
@@ -548,6 +548,8 @@ class VGFQuantizationConfig(TOSAQuantizationConfig):
             return None
         if not isinstance(qspec, QuantizationSpec):
             raise ValueError("SNORM-compatible qparams require a QuantizationSpec.")
+        if qspec.quant_min == -127 and qspec.quant_max == 127:
+            return qspec
         return replace(qspec, quant_min=-127, quant_max=127)
 
     def get_input_act_qspec(self, node=None, input_node=None):

--- a/backends/arm/test/quantizer/test_vgf_snorm_quantization.py
+++ b/backends/arm/test/quantizer/test_vgf_snorm_quantization.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn.functional as F
+from executorch.backends.arm.quantizer import (
+    get_vgf_snorm_quantization_config,
+    VgfQuantizer,
+)
+from executorch.backends.arm.quantizer.quantization_config import (
+    _is_canonical_flow_offset_grid_sampler,
+    VGFQuantizationConfig,
+)
+from executorch.backends.arm.vgf import VgfCompileSpec
+from torch.export import export
+from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
+from torchao.quantization.pt2e.quantizer import QuantizationSpec
+
+
+class FlowOffsetSamplerChain(torch.nn.Module):
+    def forward(self, image: torch.Tensor, flow: torch.Tensor) -> torch.Tensor:
+        image = torch.relu(image)
+        height, width = image.shape[-2:]
+        horizontal = torch.linspace(
+            -1.0, 1.0, width, device=image.device, dtype=image.dtype
+        ).view(1, 1, 1, width)
+        vertical = torch.linspace(
+            -1.0, 1.0, height, device=image.device, dtype=image.dtype
+        ).view(1, 1, height, 1)
+        base_grid = torch.cat(
+            (
+                horizontal.expand(1, -1, height, -1),
+                vertical.expand(1, -1, -1, width),
+            ),
+            dim=1,
+        )
+        grid = (base_grid + flow[:, :2]).permute(0, 2, 3, 1)
+        sampled = F.grid_sample(
+            image,
+            grid,
+            mode="bilinear",
+            padding_mode="border",
+            align_corners=True,
+        )
+        return torch.relu(sampled)
+
+
+def test_vgf_snorm_quantization_avoids_requantization_boundaries():
+    inputs = (
+        torch.randn(1, 4, 8, 12),
+        torch.randn(1, 4, 8, 12) * 0.01,
+    )
+    exported = export(FlowOffsetSamplerChain(), inputs, strict=True).module()
+    grid_sampler = next(
+        node
+        for node in exported.graph.nodes
+        if node.target == torch.ops.aten.grid_sampler.default
+    )
+    assert _is_canonical_flow_offset_grid_sampler(grid_sampler)
+
+    config = get_vgf_snorm_quantization_config(is_per_channel=False)
+    assert isinstance(config, VGFQuantizationConfig)
+    for qspec in (config.input_activation, config.output_activation):
+        assert isinstance(qspec, QuantizationSpec)
+        assert (qspec.quant_min, qspec.quant_max) == (-127, 127)
+
+    quantizer = VgfQuantizer(
+        VgfCompileSpec()._set_preserve_io_quantization(True),
+        use_composable_quantizer=True,
+    )
+    quantizer.set_global(config)
+    quantizer.set_io(config)
+    prepared = prepare_pt2e(exported, quantizer)
+    prepared(*inputs)
+    converted = convert_pt2e(prepared)
+
+    quantize = torch.ops.quantized_decomposed.quantize_per_tensor.default
+    dequantize = torch.ops.quantized_decomposed.dequantize_per_tensor.default
+    requantize_nodes = [
+        node
+        for node in converted.graph.nodes
+        if node.target == quantize
+        and isinstance(node.args[0], torch.fx.Node)
+        and node.args[0].target == dequantize
+    ]
+    assert not requantize_nodes

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -52,6 +52,7 @@ def define_arm_tests():
     test_files += [
         "quantizer/test_generic_annotater.py",
         "quantizer/test_uint8_io_quantization.py",
+        "quantizer/test_vgf_snorm_quantization.py",
     ]
 
     # Misc tests

--- a/examples/arm/QAT_example/README.md
+++ b/examples/arm/QAT_example/README.md
@@ -52,6 +52,11 @@ The output directory contains:
 - `metrics.csv`: tabular per-sample metrics.
 - `quantization_coverage/`: PTQ and QAT graph coverage details.
 
+The flow uses the VGF SNORM-safe activation range `[-127, 127]`. Keeping this
+range consistent across the graph avoids requantization boundaries around the
+fused flow-offset samplers while ensuring sampled images never use the
+ambiguous SNORM value `-128`.
+
 ## Smoke Runs
 
 Small random or short QAT runs are useful only for checking that the flow runs.

--- a/examples/arm/QAT_example/qat_loop.py
+++ b/examples/arm/QAT_example/qat_loop.py
@@ -51,8 +51,8 @@ EXECUTORCH_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(EXECUTORCH_ROOT))
 
 from executorch.backends.arm.quantizer import (  # noqa: E402
-    get_symmetric_quantization_config,
     get_uint8_io_quantization_config,
+    get_vgf_snorm_quantization_config,
     VgfQuantizer,
 )
 from executorch.backends.arm.vgf import VgfCompileSpec, VgfPartitioner  # noqa: E402
@@ -663,7 +663,7 @@ def make_quantizer(
         VgfCompileSpec, VgfCompileSpec()._set_preserve_io_quantization(True)
     )
     quantizer = VgfQuantizer(compile_spec, use_composable_quantizer=True)
-    global_config = get_symmetric_quantization_config(is_qat=is_qat)
+    global_config = get_vgf_snorm_quantization_config(is_qat=is_qat)
     quantizer.set_global(global_config)
 
     if io_quantization == "int8":


### PR DESCRIPTION
Use a consistent SNORM-safe activation range for VGF PTQ and QAT models that use fused flow-offset grid sampling.

The pattern-specific VGF config gives fused samplers observed [-127, 127] qparams. Surrounding operators otherwise use the default [-128, 127] range, which creates DQ-to-Q requantization boundaries before and after each sampler:

    ReLU [-128, 127]
      -> DQ -> Q [-127, 127]
      -> fused grid sampler
      -> DQ -> Q [-128, 127]
      -> ReLU

Add get_vgf_snorm_quantization_config() and use [-127, 127] for all activations in this flow. Reuse qspec objects that already use the SNORM-safe range. PT2E can then keep the producer, sampler, and consumer edges in one quantization domain:

    ReLU [-127, 127]
      -> fused grid sampler [-127, 127]
      -> ReLU [-127, 127]

For the RIFE QAT export, this removes 22 DQ/Q boundary pairs. The TOSA graph has 22 fewer RESCALE and 88 fewer CONST ops. Model conversion also removes four RESCALE-only VGF GRAPH segments. All 18 custom-shader COMPUTE segments remain.

This range also avoids the ambiguous -128 SNORM value. Vulkan signed normalized 8-bit images map both -128 and -127 to -1.0.

Update the VGF QAT example and documentation, and add a converted-graph regression test covering the sampler chain.

Authored with Codex.

Change-Id: I570b598de00d5893b5494377033ebdec8491e94f

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani