### PR TITLE
remove deleted file from buck

### DIFF
--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -76,10 +76,6 @@ def define_arm_tests():
         # "misc/test_dim_order.py", (TODO - T238390249)
     ]
 
-    # Deprecation tests
-    test_files += [
-        "deprecation/test_arm_compile_spec_deprecation.py",
-    ]
 
     # These import the top-level executorch.backends.arm package, whose
     # __init__ eagerly imports torch. Pulling that into pytest collection fails


### PR DESCRIPTION
Summary: output_order_workaround was removed, and the file `deprecation/test_arm_compile_spec_deprecation.py` was deleted. But, it was kept in this .bzl file resulting in an incorrect BUCK target

Differential Revision: D115755844




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani