### PR TITLE
Fix the KeywordSpotting arena and reconcile it with the README

### DIFF
--- a/examples/arduino/README.md
+++ b/examples/arduino/README.md
@@ -497,6 +497,15 @@ RAM is the binding constraint, not flash. Zephyr reserves 32 KB of main stack
 and a 32 KB heap out of 128 KB before the sketch gets any, and the arena the
 sketch hands to `MemoryManager` comes out of what remains. KeywordSpotting's
 DS-CNN plans 16 KB of buffers but needs considerably more for the method's own
-structures: a 28 KB arena fails `load_method` with `MemoryAllocationFailed`
-(0x21), and a 64 KB one loads but then fails `execute` with `InvalidProgram`
-(0x23), which is memory being overrun rather than a malformed program.
+structures, which leaves a usable band rather than a floor to clear:
+
+| Arena | Result |
+|-------|--------|
+| 28 KB | `load_method` fails, `MemoryAllocationFailed` (0x21), 180 B short |
+| 40 KB | Works. 46,068 bytes of globals (35%) — what the table above measures |
+| 64 KB | Pushes globals to 70,644 and past Zephyr's reservation; may appear to run, but it is overrunning memory |
+
+The sketch ships 40 KB for that reason. Growing it is not automatically safer:
+`arduino-cli` reports RAM against the full 131,072 bytes and knows nothing about
+Zephyr's stack and heap, so a 64 KB arena still reports a comfortable 53% while
+already overlapping reserved memory. Read the arena as bounded on both sides.

--- a/examples/arduino/examples/KeywordSpotting/KeywordSpotting.ino
+++ b/examples/arduino/examples/KeywordSpotting/KeywordSpotting.ino
@@ -54,7 +54,13 @@ static const char* kLabels[] = {
     "silence", "unknown", "yes", "no", "up", "down",
     "left", "right", "on", "off", "stop", "go"};
 
-alignas(16) static uint8_t method_pool[28 * 1024];
+// 28 KB fails load_method with MemoryAllocationFailed (0x21), and going the
+// other way is not free: Zephyr takes a 32 KB stack and a 32 KB heap out of the
+// board's 128 KB before the sketch sees any, so an arena large enough to push
+// globals past ~64 KB overruns that reservation. arduino-cli's RAM figure does
+// not account for it and will look comfortable either way. See "Memory" in
+// ../../README.md.
+alignas(16) static uint8_t method_pool[40 * 1024];
 
 // ExecuTorch logs go to a weak hook so the library does not depend on Serial.
 // Without this the runtime's own diagnostics -- allocation failures, operator


### PR DESCRIPTION
Fix the KeywordSpotting arena and reconcile it with the README

The sketch shipped a 28 KB arena, which fails on hardware at load_method:

  ET| E [ET:memory_allocator.h:105] Memory allocation failed: 180B requested
       (adjusted for alignment), 4B available
  FAIL: method 0x21

The README already documented that 28 KB fails, and its measured table
(46,068 bytes of RAM, 10/10 keywords) corresponds to a 40 KB arena. The sketch
and the documentation were out of sync; the documentation was the correct one.

Set the arena to 40 KB. Verified on an Arduino UNO Q: RAM comes out at 46,068
bytes (35%), exactly reproducing the README's figure, and mfcc_yes.h scores
"yes" at 8.95 against -10.80 to -0.46 for the other eleven classes.

Not simply raising it further, which was my first instinct and was wrong.
Zephyr reserves a 32 KB stack and a 32 KB heap out of the board's 128 KB, so a
64 KB arena pushes globals to 70,644 bytes and overlaps that reservation.
It ran and printed the right answer when I tried it, which is exactly the
problem: arduino-cli reports RAM against the full 131,072 bytes, knows nothing
about Zephyr's reservations, and calls that build a comfortable 53%. The arena
is bounded on both sides, so the README section now gives the band as a table
rather than describing a floor.

Authored with assistance from Claude Code.

