### PR TITLE
Optimize the custom SDPA kernel for BF16 (#21789)

### DIFF
--- a/extension/llm/custom_ops/op_sdpa_impl.h
+++ b/extension/llm/custom_ops/op_sdpa_impl.h
@@ -71,7 +71,8 @@ void _q_at_k_gemm(
     const int64_t q_stride_m,
     const MaybeQuantizedMatrixData& k_data,
     const int64_t k_stride_n,
-    accum_t* qk_data) {
+    accum_t* qk_data,
+    accum_t* widen_scratch) {
   ET_CHECK_MSG(q_data.dtype == k_data.dtype, "q and k must have same dtype");
   ET_CHECK_MSG(
       q_data.dtype == ScalarType::Char || q_data.dtype == ScalarType::Float ||
@@ -109,6 +110,45 @@ void _q_at_k_gemm(
       q_data.dtype == ScalarType::BFloat16 ||
       q_data.dtype == ScalarType::Half) {
     if constexpr (std::is_same<accum_t, float>::value) {
+      if (widen_scratch != nullptr && q_data.dtype == ScalarType::BFloat16) {
+        // Reduction is headSize here, short enough that a per-output dot pays
+        // a cross-lane reduction it cannot amortize, while a packed BLAS can.
+        // BLAS has no bf16 entry point, so widen and use the fp32 one; the
+        // conversion is O(mk + nk) against O(mnk) of multiply.
+        accum_t* k_f32 = widen_scratch;
+        accum_t* q_f32 = widen_scratch + k_n * qk_k;
+        const auto* k_src =
+            static_cast<const ::executorch::aten::BFloat16*>(k_data.data);
+        const auto* q_src =
+            static_cast<const ::executorch::aten::BFloat16*>(q_data.data);
+        for (int64_t i = 0; i < k_n; ++i) {
+          for (int64_t l = 0; l < qk_k; ++l) {
+            k_f32[i * qk_k + l] =
+                static_cast<accum_t>(k_src[i * k_stride_n + l]);
+          }
+        }
+        for (int64_t j = 0; j < q_m; ++j) {
+          for (int64_t l = 0; l < qk_k; ++l) {
+            q_f32[j * qk_k + l] =
+                static_cast<accum_t>(q_src[j * q_stride_m + l]);
+          }
+        }
+        ::executorch::cpublas::gemm(
+            ::executorch::cpublas::TransposeType::Transpose,
+            ::executorch::cpublas::TransposeType::NoTranspose,
+            k_n,
+            q_m,
+            qk_k,
+            static_cast<accum_t>(1),
+            k_f32,
+            qk_k,
+            q_f32,
+            qk_k,
+            static_cast<accum_t>(0),
+            qk_data,
+            k_n);
+        return;
+      }
       auto do_gemm = [&](auto rt_tag) {
         using rt = decltype(rt_tag);
         ::executorch::cpublas::gemm(
@@ -289,7 +329,8 @@ void _qk_at_v_gemm(
     accum_t* o_data,
     const int64_t o_stride_m,
     const accum_t beta,
-    accum_t* buf_qdq_ptr) {
+    accum_t* buf_qdq_ptr,
+    const bool widen_v) {
   if (v_data.dtype == ScalarType::Char) {
     if constexpr (std::is_same<accum_t, float>::value) {
       const float* qk = static_cast<const float*>(qk_data);
@@ -339,6 +380,37 @@ void _qk_at_v_gemm(
     // qk has been cast to the activation dtype (see qk_reduced_data); both
     // operands are reduced precision and accumulate into the float output.
     if constexpr (std::is_same<accum_t, float>::value) {
+      if (widen_v) {
+        ET_CHECK_MSG(
+            v_data.dtype == ScalarType::BFloat16,
+            "widen_v requires BFloat16 V data");
+        // Weights are still accum_t, so widen V to match and let BLAS do the
+        // multiply. buf_qdq_ptr is free here: per-thread, ctx-allocated, the
+        // right size, and only the quantized branch above uses it.
+        const auto* v_src =
+            static_cast<const ::executorch::aten::BFloat16*>(v_data.data);
+        for (int64_t kk = 0; kk < k; ++kk) {
+          for (int64_t nn = 0; nn < n; ++nn) {
+            buf_qdq_ptr[kk * n + nn] =
+                static_cast<accum_t>(v_src[kk * v_stride_n + nn]);
+          }
+        }
+        ::executorch::cpublas::gemm(
+            ::executorch::cpublas::TransposeType::NoTranspose,
+            ::executorch::cpublas::TransposeType::NoTranspose,
+            n,
+            m,
+            k,
+            static_cast<accum_t>(1),
+            buf_qdq_ptr,
+            n,
+            static_cast<const accum_t*>(qk_data),
+            qk_stride_m,
+            beta,
+            o_data,
+            o_stride_m);
+        return;
+      }
       auto do_gemm = [&](auto rt_tag) {
         using rt = decltype(rt_tag);
         ::executorch::cpublas::gemm(
@@ -848,6 +920,34 @@ void cpu_flash_attention(
       buf_reduced = scratch_reduced.get();
     }
   }
+  // Widening only pays for a short reduction feeding many output columns; both
+  // bounds are empirical.
+  constexpr int64_t kMaxHeadSizeForWidenedQK = 128;
+  constexpr int64_t kMinQBlockForWidenedQK = 32;
+  // Scratch for widening q@K.T to fp32 (see _q_at_k_gemm): one K block plus one
+  // q block. qBlockSize cannot exceed qSplitSize, so include the runtime bounds
+  // that determine whether any block can use the widened path.
+  const bool widen_qk =
+      std::is_same<scalar_t, ::executorch::aten::BFloat16>::value &&
+      ::executorch::cpublas::gemm_uses_blas() &&
+      headSize <= kMaxHeadSizeForWidenedQK &&
+      qSplitSize >= kMinQBlockForWidenedQK;
+  int64_t size_per_thread_widen =
+      widen_qk ? (kvSplitSize + qSplitSize) * headSize : 0;
+  std::unique_ptr<char[]> allocated_buf_widen;
+  accum_t* widen_buf = nullptr;
+  if (widen_qk) {
+    int64_t size_widen_bytes =
+        size_per_thread_widen * num_thread * sizeof(accum_t);
+    Result<void*> scratch_widen = ctx.allocate_temp(size_widen_bytes, 64);
+    if (!scratch_widen.ok()) {
+      allocated_buf_widen = std::make_unique<char[]>(size_widen_bytes);
+      widen_buf = reinterpret_cast<accum_t*>(allocated_buf_widen.get());
+    } else {
+      widen_buf = reinterpret_cast<accum_t*>(scratch_widen.get());
+    }
+  }
+
   int64_t size_per_thread_qdq_vec = kvSplitSize * headSize;
   // Lets align size_per_thread_qdq_vec to 64 bytes, for coalesced cache reads,
   // by padding with right number of per thread elements
@@ -891,6 +991,8 @@ void cpu_flash_attention(
         : nullptr;
     accum_t* buf_qdq_ptr =
         scratch_for_quant_dequant + ompIdx * size_per_thread_qdq_vec;
+    accum_t* widen_ptr =
+        widen_buf ? widen_buf + ompIdx * size_per_thread_widen : nullptr;
 
     for (int64_t z = begin; z < end; z++) {
       int64_t m = k * qSplitSize;
@@ -987,7 +1089,9 @@ void cpu_flash_attention(
             qStrideM,
             k_sub_matrix_data,
             kStrideN,
-            qk_data);
+            qk_data,
+            (widen_qk && qBlockSize >= kMinQBlockForWidenedQK) ? widen_ptr
+                                                               : nullptr);
 
         // There are 4 cases that is_causal has to cover to fill
         // not-attendable-position with -inf
@@ -1139,9 +1243,17 @@ void cpu_flash_attention(
         // For reduced-precision activations the attention weights are cast to
         // the activation dtype so that Softmax(q @ k.T) @ v runs as a
         // reduced-in/float-out gemm matching the value matrix.
+        // Casting the weights down only pays when the bf16 attn@V kernel is
+        // the one that runs. Above kMinQBlockForWidenedAV it is faster to keep
+        // them in accum_t, widen V and let BLAS multiply -- also one rounding
+        // step fewer. Below it the widening stops amortizing.
+        constexpr int64_t kMinQBlockForWidenedAV = 64;
+        const bool widen_v = is_reduced_type && !is_quantized_sdpa &&
+            std::is_same<scalar_t, ::executorch::aten::BFloat16>::value &&
+            qBlockSize >= kMinQBlockForWidenedAV;
         const void* qk_gemm_data = qk_data;
         if constexpr (is_reduced_type) {
-          if (!is_quantized_sdpa) {
+          if (!is_quantized_sdpa && !widen_v) {
             vec::convert<accum_t, scalar_t>(
                 qk_data, qk_reduced_data, qBlockSize * kvBlockSize);
             qk_gemm_data = qk_reduced_data;
@@ -1159,7 +1271,8 @@ void cpu_flash_attention(
             dst_data,
             headSize,
             n == 0 ? static_cast<accum_t>(0) : static_cast<accum_t>(1),
-            buf_qdq_ptr);
+            buf_qdq_ptr,
+            widen_v);
       }
       // dst <- dst / sum[row]
       // reorder MHA output with strides

--- a/kernels/optimized/blas/BlasKernel.cpp
+++ b/kernels/optimized/blas/BlasKernel.cpp
@@ -19,9 +19,15 @@
 #include <c10/util/Unroll.h>
 #include <c10/util/irange.h>
 
+#include <algorithm>
+#include <array>
+
 #ifdef __aarch64__
 #include <arm_neon.h>
 #include <cpuinfo.h>
+#elif defined(__x86_64__) && !defined(_MSC_VER)
+#include <cpuinfo.h>
+#include <immintrin.h>
 #endif
 
 namespace vec = at::vec;
@@ -104,19 +110,33 @@ float reduce(vec::VectorizedN<float, kF32RegistersPerIteration>& x) {
 #if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE) && \
     defined(__clang__) && __clang_major__ > 15
 // https://godbolt.org/z/z8P4Yncra
-#define COMPILER_SUPPORTS_BF16_TARGET 1
+#define COMPILER_SUPPORTS_ARM_BF16_TARGET 1
 #elif defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE) && \
     !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 10
 // https://gcc.gnu.org/gcc-10/changes.html
 // https://godbolt.org/z/cdGG7vn8o
-#define COMPILER_SUPPORTS_BF16_TARGET 1
+#define COMPILER_SUPPORTS_ARM_BF16_TARGET 1
 #else // defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE) &&
       // defined(__clang__) && __clang_major__ > 15
-#define COMPILER_SUPPORTS_BF16_TARGET 0
+#define COMPILER_SUPPORTS_ARM_BF16_TARGET 0
 #endif // defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE) &&
        // defined(__clang__) && __clang_major__ > 15
 
-#if COMPILER_SUPPORTS_BF16_TARGET
+// GCC 10 / Clang 9 are the first versions with both the target("avx512bf16")
+// function attribute and _mm512_dpbf16_ps. clang-cl does not expose the
+// AVX-512 intrinsic types unless they are enabled for the whole translation
+// unit, so use the portable path for the MSVC ABI.
+#if defined(__x86_64__) && !defined(_MSC_VER) && defined(__clang__) && \
+    __clang_major__ >= 9
+#define COMPILER_SUPPORTS_X86_BF16_TARGET 1
+#elif defined(__x86_64__) && !defined(_MSC_VER) && !defined(__clang__) && \
+    defined(__GNUC__) && __GNUC__ >= 10
+#define COMPILER_SUPPORTS_X86_BF16_TARGET 1
+#else
+#define COMPILER_SUPPORTS_X86_BF16_TARGET 0
+#endif
+
+#if COMPILER_SUPPORTS_ARM_BF16_TARGET
 #define TARGET_ARM_BF16_ATTRIBUTE __attribute__((target("arch=armv8.2-a+bf16")))
 
 TARGET_ARM_BF16_ATTRIBUTE C10_ALWAYS_INLINE void
@@ -155,7 +175,7 @@ dot_with_fp32_arith_vectorized_tail_inner_loop_bfdot(
 
 #else
 #define TARGET_ARM_BF16_ATTRIBUTE
-#endif // COMPILER_SUPPORTS_BF16_TARGET
+#endif // COMPILER_SUPPORTS_ARM_BF16_TARGET
 
 namespace {
 
@@ -233,7 +253,7 @@ C10_ALWAYS_INLINE auto dot_with_fp32_arith_main_loop_no_bfdot(
   return reduce(sum);
 }
 
-#if COMPILER_SUPPORTS_BF16_TARGET
+#if COMPILER_SUPPORTS_ARM_BF16_TARGET
 template <int n>
 struct ForcedUnrollTargetBFloat16 {
   template <typename Func>
@@ -271,7 +291,7 @@ dot_with_fp32_arith_main_loop_bfdot(
   }
   return reduce(sum);
 }
-#endif // COMPILER_SUPPORTS_BF16_TARGET
+#endif // COMPILER_SUPPORTS_ARM_BF16_TARGET
 
 static_assert(
     (vec::Vectorized<BFloat16>::size() &
@@ -308,7 +328,7 @@ static_assert(
   }                                                                            \
   return reduced_sum
 
-#if COMPILER_SUPPORTS_BF16_TARGET
+#if COMPILER_SUPPORTS_ARM_BF16_TARGET
 TARGET_ARM_BF16_ATTRIBUTE float dot_with_fp32_arith_bfdot(
     const BFloat16* vec1,
     const BFloat16* vec2,
@@ -316,7 +336,7 @@ TARGET_ARM_BF16_ATTRIBUTE float dot_with_fp32_arith_bfdot(
   auto reduced_sum = dot_with_fp32_arith_main_loop_bfdot(vec1, vec2, len);
   DOT_WITH_FP32_ARITH_TAIL_AFTER_MAIN_LOOP_BODY(_bfdot);
 }
-#endif // COMPILER_SUPPORTS_BF16_TARGET
+#endif // COMPILER_SUPPORTS_ARM_BF16_TARGET
 
 template <typename T>
 C10_ALWAYS_INLINE float
@@ -328,17 +348,536 @@ dot_with_fp32_arith_no_bfdot(const T* vec1, const T* vec2, int64_t len) {
 
 } // namespace
 
-float bf16_dot_with_fp32_arith(
-    const at::BFloat16* vec1,
-    const at::BFloat16* vec2,
-    int64_t len) {
-#if COMPILER_SUPPORTS_BF16_TARGET
-  if (cpuinfo_has_arm_bf16()) {
+#if COMPILER_SUPPORTS_ARM_BF16_TARGET
+// Four dots against a shared vec1: the cross-lane reduction is paid once per
+// four results rather than per result, which matters when callers reduce over
+// headSize while producing a whole tile of outputs.
+TARGET_ARM_BF16_ATTRIBUTE static void dot4_with_fp32_arith_bfdot(
+    const BFloat16* vec1,
+    const BFloat16* vec2,
+    int64_t stride2,
+    int64_t len,
+    float* out) {
+  constexpr int64_t kElementsPerIteration = 8;
+  float32x4_t acc[4] = {
+      vdupq_n_f32(0.0f),
+      vdupq_n_f32(0.0f),
+      vdupq_n_f32(0.0f),
+      vdupq_n_f32(0.0f)};
+  int64_t idx = 0;
+  for (; idx + kElementsPerIteration <= len; idx += kElementsPerIteration) {
+    // See NOTE[Intrinsics in bfdot variant] above.
+    const auto v1 = vld1q_bf16(reinterpret_cast<const bfloat16_t*>(&vec1[idx]));
+    for (int64_t j = 0; j < 4; ++j) {
+      const auto v2 = vld1q_bf16(
+          reinterpret_cast<const bfloat16_t*>(&vec2[j * stride2 + idx]));
+      acc[j] = vbfdotq_f32(acc[j], v1, v2);
+    }
+  }
+  const float32x4_t sums =
+      vpaddq_f32(vpaddq_f32(acc[0], acc[1]), vpaddq_f32(acc[2], acc[3]));
+  vst1q_f32(out, sums);
+  for (; idx < len; ++idx) {
+    for (int64_t j = 0; j < 4; ++j) {
+      out[j] += static_cast<float>(vec1[idx]) *
+          static_cast<float>(vec2[j * stride2 + idx]);
+    }
+  }
+}
+#endif // COMPILER_SUPPORTS_ARM_BF16_TARGET
+
+#if defined(__aarch64__)
+template <int64_t kRegisterPairs>
+C10_ALWAYS_INLINE void gemv_notrans_block_neon(
+    int64_t output_offset,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const BFloat16* b,
+    float beta,
+    float* c) {
+  float32x4_t acc[kRegisterPairs * 2];
+#pragma unroll
+  for (int64_t r = 0; r < kRegisterPairs * 2; ++r) {
+    if (beta == 0.0f) {
+      acc[r] = vdupq_n_f32(0.0f);
+    } else {
+      acc[r] = vld1q_f32(c + output_offset + r * 4);
+      if (beta != 1.0f) {
+        acc[r] = vmulq_n_f32(acc[r], beta);
+      }
+    }
+  }
+
+  for (int64_t l = 0; l < k; ++l) {
+    const float b_val = static_cast<float>(b[l]) * alpha;
+    const auto* a_col =
+        reinterpret_cast<const uint16_t*>(a + l * lda + output_offset);
+#pragma unroll
+    for (int64_t r = 0; r < kRegisterPairs; ++r) {
+      const uint16x8_t a_bf16 = vld1q_u16(a_col + r * 8);
+      const float32x4_t a_low =
+          vreinterpretq_f32_u32(vshll_n_u16(vget_low_u16(a_bf16), 16));
+      const float32x4_t a_high =
+          vreinterpretq_f32_u32(vshll_n_u16(vget_high_u16(a_bf16), 16));
+      acc[r * 2] = vfmaq_n_f32(acc[r * 2], a_low, b_val);
+      acc[r * 2 + 1] = vfmaq_n_f32(acc[r * 2 + 1], a_high, b_val);
+    }
+  }
+
+#pragma unroll
+  for (int64_t r = 0; r < kRegisterPairs * 2; ++r) {
+    vst1q_f32(c + output_offset + r * 4, acc[r]);
+  }
+}
+
+static void gemv_notrans_neon(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const BFloat16* b,
+    float beta,
+    float* c) {
+  int64_t i = 0;
+  for (; i + 64 <= m; i += 64) {
+    gemv_notrans_block_neon<8>(i, k, alpha, a, lda, b, beta, c);
+  }
+  for (; i + 32 <= m; i += 32) {
+    gemv_notrans_block_neon<4>(i, k, alpha, a, lda, b, beta, c);
+  }
+  for (; i + 16 <= m; i += 16) {
+    gemv_notrans_block_neon<2>(i, k, alpha, a, lda, b, beta, c);
+  }
+  for (; i + 8 <= m; i += 8) {
+    gemv_notrans_block_neon<1>(i, k, alpha, a, lda, b, beta, c);
+  }
+  for (; i < m; ++i) {
+    float acc = beta == 0.0f ? 0.0f : beta * c[i];
+    for (int64_t l = 0; l < k; ++l) {
+      acc += static_cast<float>(a[l * lda + i]) *
+          (static_cast<float>(b[l]) * alpha);
+    }
+    c[i] = acc;
+  }
+}
+
+static bool use_arm_bf16() {
+#if COMPILER_SUPPORTS_ARM_BF16_TARGET
+  static const bool supported = cpuinfo_initialize() && cpuinfo_has_arm_bf16();
+  return supported;
+#else
+  return false;
+#endif // COMPILER_SUPPORTS_ARM_BF16_TARGET
+}
+
+static float
+platform_bf16_dot(const BFloat16* vec1, const BFloat16* vec2, int64_t len) {
+#if COMPILER_SUPPORTS_ARM_BF16_TARGET
+  if (use_arm_bf16()) {
     return dot_with_fp32_arith_bfdot(vec1, vec2, len);
-  } else
-#endif // COMPILER_SUPPORTS_BF16_TARGET
-  {
-    return dot_with_fp32_arith_no_bfdot(vec1, vec2, len);
+  }
+#endif // COMPILER_SUPPORTS_ARM_BF16_TARGET
+  return dot_with_fp32_arith_no_bfdot(vec1, vec2, len);
+}
+
+#if COMPILER_SUPPORTS_ARM_BF16_TARGET
+static bool platform_supports_bf16_dot4() {
+  return use_arm_bf16();
+}
+
+static void platform_bf16_dot4(
+    const BFloat16* vec1,
+    const BFloat16* vec2,
+    int64_t stride2,
+    int64_t len,
+    float* out) {
+  dot4_with_fp32_arith_bfdot(vec1, vec2, stride2, len, out);
+}
+#endif // COMPILER_SUPPORTS_ARM_BF16_TARGET
+
+static bool platform_supports_bf16_gemv_notrans() {
+  return true;
+}
+
+static void platform_bf16_gemv_notrans(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const BFloat16* b,
+    float beta,
+    float* c) {
+  gemv_notrans_neon(m, k, alpha, a, lda, b, beta, c);
+}
+
+#if COMPILER_SUPPORTS_ARM_BF16_TARGET
+static bool platform_supports_bf16_gemv_transa() {
+  return false;
+}
+
+static void platform_bf16_gemv_transa(
+    int64_t,
+    int64_t,
+    float,
+    const BFloat16*,
+    int64_t,
+    const BFloat16*,
+    float,
+    float*) {}
+#endif // COMPILER_SUPPORTS_ARM_BF16_TARGET
+
+#elif COMPILER_SUPPORTS_X86_BF16_TARGET
+
+// GCC drops vector type attributes on direct std::array<__m512, ...>
+// instantiations and promotes that warning to an error in CI.
+struct M512Accumulator {
+  __m512 value;
+};
+
+// Native x86 bf16 dot using AVX512-BF16's vdpbf16ps (_mm512_dpbf16_ps),
+// which computes bf16 x bf16 -> fp32 accumulate in a single instruction.
+__attribute__((target("avx512f,avx512bw,avx512vl,avx512bf16"))) static float
+dot_with_fp32_arith_x86bfdot(
+    const BFloat16* vec1,
+    const BFloat16* vec2,
+    int64_t len) {
+  constexpr int kBF16PerRegister = 32;
+  constexpr int kAccumulators = 4;
+  constexpr int kBF16PerIteration = kBF16PerRegister * kAccumulators;
+
+  std::array<M512Accumulator, kAccumulators> acc{};
+  for (int i = 0; i < kAccumulators; ++i) {
+    acc[i].value = _mm512_setzero_ps();
+  }
+
+  int64_t j = 0;
+  const int64_t len_main = len - (len % kBF16PerIteration);
+  for (; j < len_main; j += kBF16PerIteration) {
+    for (int i = 0; i < kAccumulators; ++i) {
+      const int64_t off = j + i * kBF16PerRegister;
+      const __m512bh a =
+          (__m512bh)_mm512_loadu_si512((const void*)(vec1 + off));
+      const __m512bh b =
+          (__m512bh)_mm512_loadu_si512((const void*)(vec2 + off));
+      acc[i].value = _mm512_dpbf16_ps(acc[i].value, a, b);
+    }
+  }
+
+  const int64_t len_vec = len - (len % kBF16PerRegister);
+  for (; j < len_vec; j += kBF16PerRegister) {
+    const __m512bh a = (__m512bh)_mm512_loadu_si512((const void*)(vec1 + j));
+    const __m512bh b = (__m512bh)_mm512_loadu_si512((const void*)(vec2 + j));
+    acc[0].value = _mm512_dpbf16_ps(acc[0].value, a, b);
+  }
+
+  float reduced_sum = 0;
+  for (int i = 0; i < kAccumulators; ++i) {
+    reduced_sum += _mm512_reduce_add_ps(acc[i].value);
+  }
+  for (; j < len; ++j) {
+    const float x1 = vec1[j];
+    const float x2 = vec2[j];
+    reduced_sum += x1 * x2;
+  }
+  return reduced_sum;
+}
+
+// x86 counterpart of dot4_with_fp32_arith_bfdot. The single-dot path above
+// carries four accumulators for ILP, but at len == headSize it never enters
+// its 128-wide main loop: it fills one accumulator and then reduces all four,
+// so three of every four reductions are over zeros. Here each accumulator
+// holds a distinct output instead, so the same four reductions do four times
+// the work.
+__attribute__((target("avx512f,avx512bw,avx512vl,avx512bf16"))) static void
+dot4_with_fp32_arith_x86bfdot(
+    const BFloat16* vec1,
+    const BFloat16* vec2,
+    int64_t stride2,
+    int64_t len,
+    float* out) {
+  constexpr int64_t kBF16PerRegister = 32;
+  std::array<M512Accumulator, 4> acc{};
+  for (int i = 0; i < 4; ++i) {
+    acc[i].value = _mm512_setzero_ps();
+  }
+
+  int64_t j = 0;
+  const int64_t len_vec = len - (len % kBF16PerRegister);
+  for (; j < len_vec; j += kBF16PerRegister) {
+    const __m512bh a = (__m512bh)_mm512_loadu_si512((const void*)(vec1 + j));
+    for (int i = 0; i < 4; ++i) {
+      const __m512bh b =
+          (__m512bh)_mm512_loadu_si512((const void*)(vec2 + i * stride2 + j));
+      acc[i].value = _mm512_dpbf16_ps(acc[i].value, a, b);
+    }
+  }
+
+  for (int i = 0; i < 4; ++i) {
+    out[i] = _mm512_reduce_add_ps(acc[i].value);
+  }
+
+  // Scalar fp32 tail, matching the numerics of the no_bfdot path.
+  for (; j < len; ++j) {
+    const float x1 = vec1[j];
+    for (int i = 0; i < 4; ++i) {
+      out[i] += x1 * static_cast<float>(vec2[i * stride2 + j]);
+    }
+  }
+}
+
+template <int64_t kRegisters>
+__attribute__((
+    target("avx512f,avx512bw,avx512vl,avx512bf16,fma"))) C10_ALWAYS_INLINE void
+gemv_notrans_block_x86bf16(
+    int64_t output_offset,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const BFloat16* b,
+    float beta,
+    float* c) {
+  std::array<M512Accumulator, kRegisters> acc{};
+  for (int64_t r = 0; r < kRegisters; ++r) {
+    if (beta == 0.0f) {
+      acc[r].value = _mm512_setzero_ps();
+    } else {
+      acc[r].value = _mm512_loadu_ps(c + output_offset + r * 16);
+      if (beta != 1.0f) {
+        acc[r].value = _mm512_mul_ps(acc[r].value, _mm512_set1_ps(beta));
+      }
+    }
+  }
+
+  for (int64_t l = 0; l < k; ++l) {
+    const __m512 b_vec = _mm512_set1_ps(static_cast<float>(b[l]) * alpha);
+    const BFloat16* a_col = a + l * lda + output_offset;
+    for (int64_t r = 0; r < kRegisters; ++r) {
+      const __m256i a_bf16 =
+          _mm256_loadu_si256(reinterpret_cast<const __m256i*>(a_col + r * 16));
+      // GCC 10 and 11 support AVX512-BF16 dot products but do not expose
+      // _mm512_cvtpbh_ps. Widen the bit patterns with AVX-512F instead.
+      const __m512 a_vec = _mm512_castsi512_ps(
+          _mm512_slli_epi32(_mm512_cvtepu16_epi32(a_bf16), 16));
+      acc[r].value = _mm512_fmadd_ps(a_vec, b_vec, acc[r].value);
+    }
+  }
+
+  for (int64_t r = 0; r < kRegisters; ++r) {
+    _mm512_storeu_ps(c + output_offset + r * 16, acc[r].value);
+  }
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl,avx512bf16,fma"))) static void
+gemv_notrans_x86bf16(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const BFloat16* b,
+    float beta,
+    float* c) {
+  int64_t i = 0;
+  for (; i + 128 <= m; i += 128) {
+    gemv_notrans_block_x86bf16<8>(i, k, alpha, a, lda, b, beta, c);
+  }
+  for (; i + 64 <= m; i += 64) {
+    gemv_notrans_block_x86bf16<4>(i, k, alpha, a, lda, b, beta, c);
+  }
+  for (; i + 32 <= m; i += 32) {
+    gemv_notrans_block_x86bf16<2>(i, k, alpha, a, lda, b, beta, c);
+  }
+  for (; i + 16 <= m; i += 16) {
+    gemv_notrans_block_x86bf16<1>(i, k, alpha, a, lda, b, beta, c);
+  }
+  for (; i < m; ++i) {
+    float acc = beta == 0.0f ? 0.0f : beta * c[i];
+    for (int64_t l = 0; l < k; ++l) {
+      acc += static_cast<float>(a[l * lda + i]) *
+          (static_cast<float>(b[l]) * alpha);
+    }
+    c[i] = acc;
+  }
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl,avx512bf16"))) static void
+gemv_transa_x86bfdot(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const BFloat16* b,
+    float beta,
+    float* c) {
+  int64_t i = 0;
+  for (; i + 4 <= m; i += 4) {
+    std::array<float, 4> dots{};
+    dot4_with_fp32_arith_x86bfdot(b, a + i * lda, lda, k, dots.data());
+    for (int64_t d = 0; d < 4; ++d) {
+      c[i + d] =
+          beta == 0.0f ? alpha * dots[d] : beta * c[i + d] + alpha * dots[d];
+    }
+  }
+  for (; i < m; ++i) {
+    const float dot = dot_with_fp32_arith_x86bfdot(a + i * lda, b, k);
+    c[i] = beta == 0.0f ? alpha * dot : beta * c[i] + alpha * dot;
+  }
+}
+
+static bool use_x86_bf16() {
+  static const bool supported =
+      cpuinfo_initialize() && cpuinfo_has_x86_avx512bf16();
+  return supported;
+}
+
+static float
+platform_bf16_dot(const BFloat16* vec1, const BFloat16* vec2, int64_t len) {
+  return use_x86_bf16() ? dot_with_fp32_arith_x86bfdot(vec1, vec2, len)
+                        : dot_with_fp32_arith_no_bfdot(vec1, vec2, len);
+}
+
+static bool platform_supports_bf16_dot4() {
+  return use_x86_bf16();
+}
+
+static void platform_bf16_dot4(
+    const BFloat16* vec1,
+    const BFloat16* vec2,
+    int64_t stride2,
+    int64_t len,
+    float* out) {
+  dot4_with_fp32_arith_x86bfdot(vec1, vec2, stride2, len, out);
+}
+
+static bool platform_supports_bf16_gemv_notrans() {
+  return use_x86_bf16();
+}
+
+static void platform_bf16_gemv_notrans(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const BFloat16* b,
+    float beta,
+    float* c) {
+  gemv_notrans_x86bf16(m, k, alpha, a, lda, b, beta, c);
+}
+
+static bool platform_supports_bf16_gemv_transa() {
+  return use_x86_bf16();
+}
+
+static void platform_bf16_gemv_transa(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const BFloat16* b,
+    float beta,
+    float* c) {
+  gemv_transa_x86bfdot(m, k, alpha, a, lda, b, beta, c);
+}
+
+#else
+
+static float
+platform_bf16_dot(const BFloat16* vec1, const BFloat16* vec2, int64_t len) {
+  return dot_with_fp32_arith_no_bfdot(vec1, vec2, len);
+}
+
+#endif // defined(__aarch64__)
+
+float bf16_dot_with_fp32_arith(
+    const BFloat16* vec1,
+    const BFloat16* vec2,
+    int64_t len) {
+  return platform_bf16_dot(vec1, vec2, len);
+}
+
+void bf16_dot4_with_fp32_arith(
+    const BFloat16* vec1,
+    const BFloat16* vec2,
+    int64_t stride2,
+    int64_t len,
+    float* out) {
+#if COMPILER_SUPPORTS_ARM_BF16_TARGET || COMPILER_SUPPORTS_X86_BF16_TARGET
+  if (platform_supports_bf16_dot4()) {
+    platform_bf16_dot4(vec1, vec2, stride2, len, out);
+    return;
+  }
+#endif
+  for (int64_t j = 0; j < 4; ++j) {
+    out[j] = bf16_dot_with_fp32_arith(vec1, vec2 + j * stride2, len);
+  }
+}
+
+void bf16_gemv_notrans_with_fp32_arith(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const BFloat16* b,
+    float beta,
+    float* c) {
+#if defined(__aarch64__) || COMPILER_SUPPORTS_X86_BF16_TARGET
+  if (platform_supports_bf16_gemv_notrans()) {
+    platform_bf16_gemv_notrans(m, k, alpha, a, lda, b, beta, c);
+    return;
+  }
+#endif
+  if (beta == 0.0f) {
+    std::fill(c, c + m, 0.0f);
+  } else if (beta != 1.0f) {
+    for (int64_t i = 0; i < m; ++i) {
+      c[i] *= beta;
+    }
+  }
+  for (int64_t l = 0; l < k; ++l) {
+    const BFloat16* a_col = a + l * lda;
+    const float b_val = static_cast<float>(b[l]) * alpha;
+    for (int64_t i = 0; i < m; ++i) {
+      c[i] += static_cast<float>(a_col[i]) * b_val;
+    }
+  }
+}
+
+void bf16_gemv_transa_with_fp32_arith(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const BFloat16* b,
+    float beta,
+    float* c) {
+#if COMPILER_SUPPORTS_ARM_BF16_TARGET || COMPILER_SUPPORTS_X86_BF16_TARGET
+  if (platform_supports_bf16_gemv_transa()) {
+    platform_bf16_gemv_transa(m, k, alpha, a, lda, b, beta, c);
+    return;
+  }
+#endif
+  int64_t i = 0;
+  for (; i + 4 <= m; i += 4) {
+    std::array<float, 4> dots{};
+    bf16_dot4_with_fp32_arith(b, a + i * lda, lda, k, dots.data());
+    for (int64_t d = 0; d < 4; ++d) {
+      c[i + d] =
+          beta == 0.0f ? alpha * dots[d] : beta * c[i + d] + alpha * dots[d];
+    }
+  }
+  for (; i < m; ++i) {
+    const float dot = bf16_dot_with_fp32_arith(a + i * lda, b, k);
+    c[i] = beta == 0.0f ? alpha * dot : beta * c[i] + alpha * dot;
   }
 }
 

--- a/kernels/optimized/blas/BlasKernel.h
+++ b/kernels/optimized/blas/BlasKernel.h
@@ -15,6 +15,7 @@
 #include <executorch/runtime/kernel/thread_parallel_interface.h>
 
 #include <array>
+#include <vector>
 
 namespace executorch {
 namespace cpublas {
@@ -138,7 +139,123 @@ float bf16_dot_with_fp32_arith(
     const torch::executor::BFloat16* vec1,
     const torch::executor::BFloat16* vec2,
     int64_t len);
+// Four dots of vec1 against vec2, vec2 + stride2, ... into out[0..3].
+void bf16_dot4_with_fp32_arith(
+    const torch::executor::BFloat16* vec1,
+    const torch::executor::BFloat16* vec2,
+    int64_t stride2,
+    int64_t len,
+    float* out);
+void bf16_gemv_notrans_with_fp32_arith(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const torch::executor::BFloat16* a,
+    int64_t lda,
+    const torch::executor::BFloat16* b,
+    float beta,
+    float* c);
+void bf16_gemv_transa_with_fp32_arith(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const torch::executor::BFloat16* a,
+    int64_t lda,
+    const torch::executor::BFloat16* b,
+    float beta,
+    float* c);
 } // namespace internal
+
+// Used by custom SDPA's attn@V. Serial on purpose: SDPA already parallelizes
+// its outer head loop, and executorch's threadpool deadlocks on a nested
+// parallel_for.
+// clang-format off
+template <>
+inline typename std::enable_if<
+    !std::is_same<torch::executor::BFloat16, float>::value,
+    void>::type
+gemm_notrans_<torch::executor::BFloat16, float, float>(
+    int64_t m, int64_t n, int64_t k,
+    float alpha,
+    const torch::executor::BFloat16 *a, int64_t lda,
+    const torch::executor::BFloat16 *b, int64_t ldb,
+    float beta,
+    float *c, int64_t ldc) {
+  if (n == 1) {
+    internal::bf16_gemv_notrans_with_fp32_arith(
+        m, k, alpha, a, lda, b, beta, c);
+    return;
+  }
+
+  // bf16_dot_with_fp32_arith needs a contiguous k-vector, but a is strided by
+  // lda in k, so the dot path must gather each row first. On aarch64 the
+  // gather-free form wins for small n; x86 uses the dot path from n == 2.
+  // The crossover is empirical and only visible with runtime-valued
+  // dimensions: constant-folded ones let the gather-free loop unroll.
+#if defined(__aarch64__) && !defined(CPU_CAPABILITY_SVE)
+  constexpr int64_t kMinColsForGather = 32;
+#else
+  constexpr int64_t kMinColsForGather = 2;
+#endif
+  const bool use_dot = n >= kMinColsForGather;
+
+  if (!use_dot) {
+    for (int64_t j = 0; j < n; ++j) {
+      float *c_col = c + j * ldc;
+      if (beta == 0) {
+        for (int64_t i = 0; i < m; ++i) {
+          c_col[i] = 0.0f;
+        }
+      } else if (beta != 1.0f) {
+        for (int64_t i = 0; i < m; ++i) {
+          c_col[i] *= beta;
+        }
+      }
+    }
+    // l outermost so a's column is loaded once and reused across c's columns.
+    for (int64_t l = 0; l < k; ++l) {
+      const torch::executor::BFloat16 *a_col = a + l * lda;
+      for (int64_t j = 0; j < n; ++j) {
+        const float b_val = static_cast<float>(b[l + j * ldb]) * alpha;
+        float *c_col = c + j * ldc;
+        // Unrolled for the same reason the fp32 specialization above is: the
+        // bf16->fp32 conversion does not vectorize from the rolled form.
+        int64_t i = 0;
+        for (; i + 4 <= m; i += 4) {
+          c_col[i + 0] += static_cast<float>(a_col[i + 0]) * b_val;
+          c_col[i + 1] += static_cast<float>(a_col[i + 1]) * b_val;
+          c_col[i + 2] += static_cast<float>(a_col[i + 2]) * b_val;
+          c_col[i + 3] += static_cast<float>(a_col[i + 3]) * b_val;
+        }
+        for (; i < m; ++i) {
+          c_col[i] += static_cast<float>(a_col[i]) * b_val;
+        }
+      }
+    }
+    return;
+  }
+
+  // This path runs once per SDPA tile. Reuse storage across calls so gathering
+  // a row does not allocate in the tile loop.
+  /* library-local */ thread_local std::vector<torch::executor::BFloat16> a_row;
+  a_row.resize(k);
+  for (int64_t i = 0; i < m; ++i) {
+    for (int64_t l = 0; l < k; ++l) {
+      a_row[l] = a[l * lda + i];
+    }
+    const torch::executor::BFloat16 *b_ = b;
+    for (int64_t j = 0; j < n; ++j) {
+      const float dot = internal::bf16_dot_with_fp32_arith(a_row.data(), b_, k);
+      b_ += ldb;
+      if (beta == 0) {
+        c[j * ldc + i] = alpha * dot;
+      } else {
+        c[j * ldc + i] = beta * c[j * ldc + i] + alpha * dot;
+      }
+    }
+  }
+}
+// clang-format on
 
 // clang-format off
 template <typename scalar_t, typename opmath_t, typename out_t = scalar_t>
@@ -208,6 +325,46 @@ inline void gemm_transa_<torch::executor::BFloat16, torch::executor::BFloat16, t
       a_ += lda;
     }
   });
+}
+
+// Used by custom SDPA's q@k.T; both k-dimensions are already contiguous.
+// Serial for the same reason as the gemm_notrans_ specialization above.
+template <>
+inline void gemm_transa_<torch::executor::BFloat16, float, float>(
+    int64_t m, int64_t n, int64_t k,
+    float alpha,
+    const torch::executor::BFloat16 *a, int64_t lda,
+    const torch::executor::BFloat16 *b, int64_t ldb,
+    float beta,
+    float *c, int64_t ldc) {
+  if (n == 1) {
+    internal::bf16_gemv_transa_with_fp32_arith(
+        m, k, alpha, a, lda, b, beta, c);
+    return;
+  }
+
+  // Four columns at a time: k is headSize here, short enough that each dot's
+  // cross-lane reduction is a large share of its cost, and this tile produces
+  // m*n of them.
+  const auto *a_ = a;
+  for (int64_t i = 0; i < m; ++i) {
+    int64_t j = 0;
+    for (; j + 4 <= n; j += 4) {
+      std::array<float, 4> dots{};
+      internal::bf16_dot4_with_fp32_arith(
+          a_, b + j * ldb, ldb, k, dots.data());
+      for (int64_t d = 0; d < 4; ++d) {
+        float *dst = c + (j + d) * ldc + i;
+        *dst = (beta == 0) ? alpha * dots[d] : beta * *dst + alpha * dots[d];
+      }
+    }
+    for (; j < n; ++j) {
+      const float dot = internal::bf16_dot_with_fp32_arith(a_, b + j * ldb, k);
+      float *dst = c + j * ldc + i;
+      *dst = (beta == 0) ? alpha * dot : beta * *dst + alpha * dot;
+    }
+    a_ += lda;
+  }
 }
 // clang-format on
 

--- a/kernels/optimized/blas/CPUBlas.cpp
+++ b/kernels/optimized/blas/CPUBlas.cpp
@@ -47,6 +47,14 @@ inline CBLAS_TRANSPOSE to_cblas_transpose(TransposeType trans) {
 #endif // ET_BUILD_FOR_APPLE
 #endif // ET_BUILD_WITH_BLAS
 
+bool gemm_uses_blas() {
+#ifdef ET_BUILD_WITH_BLAS
+  return true;
+#else
+  return false;
+#endif
+}
+
 // clang-format off
 void normalize_last_dims(
     TransposeType transa, TransposeType transb,

--- a/kernels/optimized/blas/CPUBlas.h
+++ b/kernels/optimized/blas/CPUBlas.h
@@ -43,6 +43,13 @@ inline char to_blas(TransposeType trans) {
   return 'N';
 }
 
+// Whether gemm() dispatches to a BLAS implementation rather than the portable
+// fallback. Callers that can restructure a shape BLAS handles better -- by
+// widening a reduced-precision operand, say -- need this to know whether that
+// is worth doing. Answered here because the build flag is only visible inside
+// this library.
+bool gemm_uses_blas();
+
 // clang-format off
 template <typename scalar_t, typename opmath_t, typename out_t = scalar_t>
 void gemm_impl(

--- a/kernels/optimized/test/libblas_test.cpp
+++ b/kernels/optimized/test/libblas_test.cpp
@@ -11,6 +11,12 @@
 #include <executorch/kernels/optimized/blas/CPUBlas.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <utility>
 #include <vector>
 
 #define TEST_FORALL_SUPPORTED_CTYPES(_, N)   \
@@ -44,6 +50,85 @@ bool check_all_equal_to(std::vector<T>& arr, const float value) {
   }
   return true;
 }
+
+template <typename T>
+std::vector<T> make_values(size_t n, uint32_t seed) {
+  std::vector<T> v(n);
+  uint32_t state = seed;
+  for (size_t i = 0; i < n; ++i) {
+    state = state * 1664525u + 1013904223u;
+    v[i] = static_cast<T>(
+        static_cast<float>(state >> 8) / static_cast<float>(1 << 23) - 1.0f);
+  }
+  return v;
+}
+
+template <typename T>
+float reference_dot(const T* a, const T* b, int64_t len) {
+  float sum = 0;
+  for (int64_t i = 0; i < len; ++i) {
+    sum += static_cast<float>(a[i]) * static_cast<float>(b[i]);
+  }
+  return sum;
+}
+
+// Column-major c = beta * c + alpha * (op(a) @ b), accumulated in fp32, mirror-
+// ing the generic gemm_{transa,notrans}_ templates the bf16 specializations
+// replace.
+template <typename T>
+void reference_gemm(
+    bool transa,
+    int64_t m,
+    int64_t n,
+    int64_t k,
+    float alpha,
+    const T* a,
+    int64_t lda,
+    const T* b,
+    int64_t ldb,
+    float beta,
+    std::vector<float>& c,
+    int64_t ldc) {
+  for (int64_t i = 0; i < m; ++i) {
+    for (int64_t j = 0; j < n; ++j) {
+      float dot = 0;
+      for (int64_t l = 0; l < k; ++l) {
+        const float av = transa ? static_cast<float>(a[i * lda + l])
+                                : static_cast<float>(a[l * lda + i]);
+        dot += av * static_cast<float>(b[j * ldb + l]);
+      }
+      c[j * ldc + i] =
+          beta == 0 ? alpha * dot : beta * c[j * ldc + i] + alpha * dot;
+    }
+  }
+}
+
+void expect_near_relative(float actual, float expected, const char* context) {
+  EXPECT_NEAR(actual, expected, 1e-4f * std::max(1.0f, std::abs(expected)))
+      << context;
+}
+
+// Straddle the vectorized main-loop, cleanup-loop and scalar-tail boundaries of
+// the bfdot paths: 128 and 32 bf16 per iteration on x86, 32 and 8 on ARM.
+constexpr std::array<int64_t, 18> kDotLengths{
+    0,
+    1,
+    7,
+    8,
+    15,
+    16,
+    31,
+    32,
+    33,
+    63,
+    64,
+    96,
+    127,
+    128,
+    129,
+    160,
+    255,
+    257};
 
 } // namespace
 
@@ -79,4 +164,187 @@ void test_matmul_ones() {
 
 TEST(BlasTest, MatmulOnes) {
   TEST_FORALL_SUPPORTED_CTYPES(test_matmul_ones, 25);
+}
+
+// bf16_dot_with_fp32_arith has three implementations -- ARM bfdot, x86
+// AVX512-BF16 and the portable fp32 fallback -- selected by compile-time
+// support and runtime cpuinfo. Only the one this host dispatches to is covered
+// by a given run.
+TEST(BlasTest, BF16DotMatchesScalarAccumulation) {
+  using torch::executor::BFloat16;
+
+  for (const int64_t len : kDotLengths) {
+    const auto a = make_values<BFloat16>(len, 1);
+    const auto b = make_values<BFloat16>(len, 2);
+
+    const float actual =
+        executorch::cpublas::internal::bf16_dot_with_fp32_arith(
+            a.data(), b.data(), len);
+
+    expect_near_relative(
+        actual,
+        reference_dot(a.data(), b.data(), len),
+        ("len=" + std::to_string(len)).c_str());
+  }
+}
+
+// The bf16-in/float-out gemm specializations used by custom SDPA.
+TEST(BlasTest, BF16FloatGemmMatchesScalarAccumulation) {
+  using executorch::aten::BFloat16;
+  using executorch::cpublas::TransposeType;
+
+  constexpr int64_t kM = 3;
+  constexpr int64_t kN = 5;
+
+  for (const bool transa : {false, true}) {
+    for (const int64_t k : kDotLengths) {
+      if (k == 0) {
+        continue;
+      }
+      // Pad the leading dimensions so a stride bug can't hide behind tightly
+      // packed operands.
+      const int64_t lda = (transa ? k : kM) + 2;
+      const int64_t ldb = k + 3;
+      const int64_t ldc = kM + 1;
+
+      const auto a = make_values<BFloat16>(lda * (transa ? kM : k), 3);
+      const auto b = make_values<BFloat16>(ldb * kN, 4);
+
+      for (const float alpha : {1.0f, -0.5f}) {
+        for (const float beta : {0.0f, 1.0f, 0.25f}) {
+          auto c = make_values<float>(ldc * kN, 5);
+          auto expected = c;
+
+          // clang-format off
+          reference_gemm(
+              transa,
+              kM, kN, k,
+              alpha,
+              a.data(), lda,
+              b.data(), ldb,
+              beta,
+              expected, ldc);
+
+          executorch::cpublas::gemm(
+              transa ? TransposeType::Transpose : TransposeType::NoTranspose,
+              TransposeType::NoTranspose,
+              kM, kN, k,
+              alpha,
+              a.data(), lda,
+              b.data(), ldb,
+              beta,
+              c.data(), ldc);
+          // clang-format on
+
+          const std::string context = "transa=" + std::to_string(transa) +
+              " k=" + std::to_string(k) + " alpha=" + std::to_string(alpha) +
+              " beta=" + std::to_string(beta);
+          for (int64_t j = 0; j < kN; ++j) {
+            for (int64_t i = 0; i < kM; ++i) {
+              expect_near_relative(
+                  c[j * ldc + i], expected[j * ldc + i], context.c_str());
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(BlasTest, BF16FloatGemmDecodeShapesMatchScalarAccumulation) {
+  using executorch::aten::BFloat16;
+  using executorch::cpublas::TransposeType;
+
+  struct Shape {
+    bool transa;
+    int64_t m;
+    int64_t k;
+  };
+  constexpr std::array<Shape, 7> kShapes{
+      Shape{false, 64, 511},
+      Shape{false, 96, 511},
+      Shape{false, 128, 512},
+      Shape{false, 130, 513},
+      Shape{true, 512, 64},
+      Shape{true, 515, 128},
+      Shape{true, 513, 130},
+  };
+
+  for (const Shape shape : kShapes) {
+    constexpr int64_t kN = 1;
+    const int64_t lda = (shape.transa ? shape.k : shape.m) + 3;
+    const int64_t ldb = shape.k;
+    const int64_t ldc = shape.m;
+    const auto a =
+        make_values<BFloat16>(lda * (shape.transa ? shape.m : shape.k), 8);
+    const auto b = make_values<BFloat16>(shape.k, 9);
+
+    for (const auto [alpha, beta] :
+         {std::pair{1.0f, 0.0f}, std::pair{-0.5f, 0.25f}}) {
+      auto c = make_values<float>(shape.m, 10);
+      auto expected = c;
+
+      // clang-format off
+      reference_gemm(
+          shape.transa,
+          shape.m, kN, shape.k,
+          alpha,
+          a.data(), lda,
+          b.data(), ldb,
+          beta,
+          expected, ldc);
+
+      executorch::cpublas::gemm(
+          shape.transa ? TransposeType::Transpose : TransposeType::NoTranspose,
+          TransposeType::NoTranspose,
+          shape.m, kN, shape.k,
+          alpha,
+          a.data(), lda,
+          b.data(), ldb,
+          beta,
+          c.data(), ldc);
+      // clang-format on
+
+      const std::string context = "transa=" + std::to_string(shape.transa) +
+          " m=" + std::to_string(shape.m) + " k=" + std::to_string(shape.k) +
+          " alpha=" + std::to_string(alpha) + " beta=" + std::to_string(beta);
+      for (int64_t i = 0; i < shape.m; ++i) {
+        expect_near_relative(c[i], expected[i], context.c_str());
+      }
+    }
+  }
+}
+
+// beta == 0 must overwrite c rather than read it, so uninitialized garbage in
+// the output cannot poison the result.
+TEST(BlasTest, BF16FloatGemmBetaZeroIgnoresOutput) {
+  using executorch::aten::BFloat16;
+  using executorch::cpublas::TransposeType;
+
+  constexpr int64_t kM = 3;
+  constexpr int64_t kN = 5;
+  constexpr int64_t kK = 40;
+
+  const auto a = make_values<BFloat16>(kK * kM, 6);
+  const auto b = make_values<BFloat16>(kK * kN, 7);
+
+  for (const bool transa : {false, true}) {
+    std::vector<float> c(kM * kN, std::numeric_limits<float>::quiet_NaN());
+
+    // clang-format off
+    executorch::cpublas::gemm(
+        transa ? TransposeType::Transpose : TransposeType::NoTranspose,
+        TransposeType::NoTranspose,
+        kM, kN, kK,
+        1.0f,
+        a.data(), transa ? kK : kM,
+        b.data(), kK,
+        0.0f,
+        c.data(), kM);
+    // clang-format on
+
+    for (const float v : c) {
+      EXPECT_FALSE(std::isnan(v)) << "transa=" << transa;
+    }
+  }
 }


### PR DESCRIPTION
Summary:
Optimizes end-to-end bf16 custom SDPA for both prefill and decode. It adds bf16-input/fp32-output kernels for Q@K and attn@V, four-output dot tiling, native AVX512-BF16 and Arm BFDOT dispatch, and dedicated n == 1 GEMV paths on x86 and NEON.

For larger blocks, operands are widened once and routed through optimized fp32 BLAS, amortizing conversion while keeping attention weights and accumulation in fp32. Decode avoids that materialization: Q@K uses native bf16 reductions, while attn@V widens lanes to fp32 before FMA because each output lane must remain independent. Portable fallbacks, feature detection, tails, and alpha/beta behavior are covered by tests.


Verified on a Genoa server and M4 mac with Llama 3.2 1B instruct


Reviewed By: digantdesai

Differential Revision: D116040710

Pulled By: JakeStevens


