### PR TITLE
Clean up executorch type checking setup  (#21719)

### DIFF
--- a/backends/cadence/aot/BUCK
+++ b/backends/cadence/aot/BUCK
@@ -128,7 +128,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "ref_implementations.py",
     ],
-    typing = True,
     deps = [
         "fbcode//caffe2:torch",
         "fbcode//executorch/backends/cadence/aot:utils",
@@ -175,7 +174,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_pass_utils.py",
     ],
-    typing = True,
     deps = [
         ":pass_utils",
         "//caffe2:torch",
@@ -187,7 +185,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "compiler_utils.py",
     ],
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/exir/dialects:lib",
@@ -199,7 +196,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "to_out_var_pass.py",
     ],
-    typing = True,
     deps = [
         ":ops_registrations",
         "//caffe2:torch",
@@ -213,7 +209,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "graph_builder.py",
     ],
-    typing = True,
     deps = [
         "//executorch/backends/test:graph_builder",
     ],
@@ -224,7 +219,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "program_builder.py",
     ],
-    typing = True,
     deps = [
         "//executorch/backends/test:program_builder",
     ],
@@ -235,7 +229,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_program_builder.py",
     ],
-    typing = True,
     deps = [
         "//executorch/backends/test:program_builder",
         "//caffe2:torch",
@@ -248,7 +241,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "fuse_ops.py",
     ],
-    typing = True,
     deps = [
         ":compiler_utils",
         ":ops_registrations",
@@ -273,7 +265,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "simplify_ops.py",
     ],
-    typing = True,
     deps = [
         ":pass_utils",
         ":utils",
@@ -288,7 +279,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "remove_ops.py",
     ],
-    typing = True,
     deps = [
         ":fuse_ops",
         ":ops_registrations",
@@ -309,7 +299,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "reorder_ops.py",
     ],
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:compiler_utils",
@@ -328,7 +317,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "replace_ops.py",
     ],
-    typing = True,
     deps = [
         ":pass_utils",
         "//caffe2:torch",
@@ -350,7 +338,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "decompose_ops.py",
     ],
-    typing = True,
     deps = [
         ":pass_utils",
         "//caffe2:torch",
@@ -367,7 +354,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "type_dispatch.py",
     ],
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:pass_utils",
@@ -382,7 +368,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_type_dispatch_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":ops_registrations",
         ":typing_stubs",
@@ -400,7 +385,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "typing_stubs.py",
     ],
-    typing = True,
     deps = [
         "fbsource//third-party/pypi/parameterized:parameterized",
     ],
@@ -411,7 +395,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "compiler_funcs.py",
     ],
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/transforms:permute_pass_utils",
@@ -425,7 +408,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_graph_builder.py",
     ],
-    typing = True,
     deps = [
         ":ops_registrations",
         "//caffe2:torch",
@@ -443,7 +425,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_replace_ops_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":compiler",
         ":typing_stubs",
@@ -464,7 +445,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_decompose_ops_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":compiler",
         ":decompose_ops",
@@ -485,7 +465,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_fusion_ops_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":compiler",
         ":typing_stubs",
@@ -506,7 +485,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_remove_ops_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         "fbsource//third-party/pypi/pyre-extensions:pyre-extensions",
         ":typing_stubs",
@@ -528,7 +506,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_remove_bn_tracking_pass.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:remove_ops",
@@ -544,7 +521,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_simplify_ops_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":typing_stubs",
         "//caffe2:torch",
@@ -562,7 +538,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_reorder_ops_passes.py",
     ],
-    typing = True,
     deps = [
         ":compiler",
         ":pass_utils",
@@ -632,7 +607,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_memory_passes.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":compiler",
         ":memory_planning",
@@ -653,7 +627,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_idma_ops.py",
     ],
-    typing = True,
     deps = [
         "//executorch/backends/test:graph_builder",
         "//executorch/backends/cadence/aot:ops_registrations",
@@ -668,7 +641,6 @@ fbcode_target(_kind = python_unittest,
         "tests/test_ref_implementations.py",
     ],
     supports_static_listing = False,
-    typing = True,
     deps = [
         ":typing_stubs",
         "//executorch/backends/cadence/aot:ops_registrations",
@@ -681,7 +653,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_quantizer_ops.py",
     ],
-    typing = True,
     deps = [
         "fbsource//third-party/pypi/parameterized:parameterized",
         "//caffe2:torch",
@@ -697,7 +668,6 @@ fbcode_target(_kind = python_unittest,
     srcs = [
         "tests/test_to_out_var_pass.py",
     ],
-    typing = True,
     deps = [
         ":ops_registrations",
         "//executorch/backends/test:program_builder",

--- a/backends/cadence/aot/quantizer/BUCK
+++ b/backends/cadence/aot/quantizer/BUCK
@@ -19,7 +19,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "pattern_utils.py",
     ],
-    typing = True,
     deps = [
         ":utils",
         "//caffe2:torch",
@@ -34,7 +33,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "patterns.py",
     ],
-    typing = True,
     deps = [
         ":pattern_utils",
         ":utils",
@@ -48,7 +46,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "quantizer.py",
     ],
-    typing = True,
     deps = [
         ":patterns",
         ":utils",

--- a/backends/cadence/aot/quantizer/passes/BUCK
+++ b/backends/cadence/aot/quantizer/passes/BUCK
@@ -8,7 +8,6 @@ fbcode_target(_kind = runtime.python_library,
     srcs = [
         "fuse_ops.py",
     ],
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/backends/cadence/aot:pass_utils",

--- a/backends/cadence/runtime/BUCK
+++ b/backends/cadence/runtime/BUCK
@@ -21,7 +21,6 @@ fbcode_target(_kind = runtime.python_library,
     ] + glob([
         "xtsc-cfg/**/*",
     ]),
-    typing = True,
     deps = [
         "//caffe2:torch",
         "//executorch/devtools/bundled_program:config",

--- a/backends/cadence/utils/targets.bzl
+++ b/backends/cadence/utils/targets.bzl
@@ -12,7 +12,6 @@ def define_common_targets():
         srcs = [
             "facto_util.py",
         ],
-        typing = True,
         deps = [
             "fbcode//caffe2:torch",
             "fbcode//pytorch/facto:facto",

--- a/backends/native/BUCK
+++ b/backends/native/BUCK
@@ -13,7 +13,6 @@ runtime.export_file(
 fbcode_target(
     _kind = runtime.python_library,
     name = "lib",
-    typing = True,
     srcs = [
         "serialization/__init__.py",
         "serialization/graph_serialize.py",

--- a/backends/test/targets.bzl
+++ b/backends/test/targets.bzl
@@ -12,7 +12,6 @@ def define_common_targets(is_fbcode = False):
             srcs = [
                 "graph_builder.py",
             ],
-            typing = True,
             deps = [
                 "//caffe2:torch",
                 "//executorch/exir:pass_base",
@@ -24,7 +23,6 @@ def define_common_targets(is_fbcode = False):
             srcs = [
                 "program_builder.py",
             ],
-            typing = True,
             deps = [
                 ":graph_builder",
                 "//caffe2:torch",

--- a/backends/vulkan/_passes/targets.bzl
+++ b/backends/vulkan/_passes/targets.bzl
@@ -132,7 +132,6 @@ def define_common_targets(is_fbcode = False):
             "//executorch/exir:pass_base",
             "//executorch/exir/dialects:lib",
         ],
-        typing = True,
     )
 
     runtime.python_library(

--- a/backends/vulkan/partitioner/BUCK
+++ b/backends/vulkan/partitioner/BUCK
@@ -20,5 +20,4 @@ fbcode_target(_kind = runtime.python_library,
         "//executorch/exir/backend:utils",
         "//executorch/exir/backend/canonical_partitioners:canonical_partitioner_lib",
     ],
-    typing = True,
 )

--- a/backends/vulkan/patterns/BUCK
+++ b/backends/vulkan/patterns/BUCK
@@ -32,5 +32,4 @@ fbcode_target(_kind = runtime.python_library,
         "//executorch/backends/transforms:utils",
         "//executorch/backends/vulkan:utils_lib",
     ],
-    typing = True,
 )


### PR DESCRIPTION
Summary:
Removing the typing = True from these buck files to clear the way for a more stable, easy to configure type checking set up 


Reviewed By: shobhitmehro

Differential Revision: D115454520


