### PR TITLE
Reseed the Cortex-M test RNG before each test module is imported

### DIFF
--- a/backends/cortex_m/test/conftest.py
+++ b/backends/cortex_m/test/conftest.py
@@ -64,6 +64,17 @@ def pytest_configure(config):
         _set_random_seed(seed)
 
 
+def pytest_collectstart(collector):
+    """Reseed before each test module is imported. Model tests that build
+    calibration data at module scope draw during collection, so seeding only in
+    ``pytest_configure`` would leave their quantization dependent on how many
+    modules were imported first."""
+    if not isinstance(collector, pytest.Module):
+        return
+    if os.environ.get("TEST_RUNTIME_IS_NOT_OSS", "0") != "1":
+        _set_random_seed(collector.config._test_seed)
+
+
 @pytest.fixture(autouse=True)
 def set_random_seed(request):
     """Control random numbers in the Cortex-M test suite.


### PR DESCRIPTION
### Summary
Model tests that build calibration data or example inputs at module scope draw from the global RNG during pytest collection, not during the test. Seeding only in pytest_configure therefore left those draws dependent on how many other modules pytest happened to import first, so a test's quantization could change purely because a file was added elsewhere in the directory.

Adding a test_silero_vad import ahead of test_mobilenet_v2 moves mv2's first calibration sample sum from -310.9496 to -42.2950; the reverse order moves silero's input sum from 15.9070 to 7.8727. Reseeding in pytest_collectstart makes both stable, and leaves the existing per-test autouse fixture untouched.

The TEST_RUNTIME_IS_NOT_OSS guard mirrors the one already in pytest_configure, which in turn follows backends/arm/test/conftest.py.

Authored with assistance from Claude Code.