### PR TITLE
Remove unnecessary graph rewrites for both cuda and whole ET pipeline

### DIFF
--- a/backends/aoti/aoti_backend.py
+++ b/backends/aoti/aoti_backend.py
@@ -20,6 +20,7 @@ from executorch.exir._serialize._named_data_store import NamedDataStore
 from executorch.exir._warnings import experimental
 from executorch.exir.backend.backend_details import ExportedProgram, PreprocessResult
 from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.graph_module import contains_any_op
 from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
 from torch.export.passes import move_to_device_pass
 
@@ -248,8 +249,12 @@ class AotiBackend(ABC):
             else:
                 custom_pass(device_edge_program.graph_module)
 
-        # Run decompositions if any
-        if decomposition_table:
+        # ``run_decompositions`` retraces the complete ExportedProgram even
+        # when none of the table's operators occur in the graph. Large CUDA
+        # models make that no-op expensive, so only run it when it can apply.
+        if contains_any_op(
+            device_edge_program.graph_module, decomposition_table.keys()
+        ):
             device_edge_program = device_edge_program.run_decompositions(
                 decomposition_table
             )

--- a/backends/aoti/aoti_backend.py
+++ b/backends/aoti/aoti_backend.py
@@ -20,7 +20,7 @@ from executorch.exir._serialize._named_data_store import NamedDataStore
 from executorch.exir._warnings import experimental
 from executorch.exir.backend.backend_details import ExportedProgram, PreprocessResult
 from executorch.exir.backend.compile_spec_schema import CompileSpec
-from executorch.exir.graph_module import contains_any_op
+from executorch.exir.graph_module import contains_any_call_fn_target_op
 from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
 from torch.export.passes import move_to_device_pass
 
@@ -253,7 +253,9 @@ class AotiBackend(ABC):
         # when none of the table's operators occur in the graph. The in-place
         # passes above preserve graph inputs and outputs, so the existing graph
         # signature remains valid when the decomposition table cannot apply.
-        if contains_any_op(device_edge_program.graph_module, decomposition_table):
+        if contains_any_call_fn_target_op(
+            device_edge_program.graph_module, decomposition_table
+        ):
             device_edge_program = device_edge_program.run_decompositions(
                 decomposition_table
             )

--- a/backends/aoti/aoti_backend.py
+++ b/backends/aoti/aoti_backend.py
@@ -250,11 +250,10 @@ class AotiBackend(ABC):
                 custom_pass(device_edge_program.graph_module)
 
         # ``run_decompositions`` retraces the complete ExportedProgram even
-        # when none of the table's operators occur in the graph. Large CUDA
-        # models make that no-op expensive, so only run it when it can apply.
-        if contains_any_op(
-            device_edge_program.graph_module, decomposition_table.keys()
-        ):
+        # when none of the table's operators occur in the graph. The in-place
+        # passes above preserve graph inputs and outputs, so the existing graph
+        # signature remains valid when the decomposition table cannot apply.
+        if contains_any_op(device_edge_program.graph_module, decomposition_table):
             device_edge_program = device_edge_program.run_decompositions(
                 decomposition_table
             )

--- a/backends/cuda/passes/replace_int64_floordiv.py
+++ b/backends/cuda/passes/replace_int64_floordiv.py
@@ -8,8 +8,8 @@
 Graph Transformation Pass for Integer Floor-Division Replacement.
 
 Rewrites integer (int64/int32) floor-division into a float64-domain floor to
-work around an AOTInductor/Inductor CUDA miscompile that is still present in
-the repository's pinned PyTorch 2.13 build:
+work around an AOTInductor/Inductor CUDA miscompile that is still present as
+of PyTorch 2.13:
 
     floor_divide(a, b)  ->  floor(a.to(float64) / b.to(float64)).to(orig_int_dtype)
 """

--- a/backends/cuda/passes/replace_int64_floordiv.py
+++ b/backends/cuda/passes/replace_int64_floordiv.py
@@ -8,7 +8,8 @@
 Graph Transformation Pass for Integer Floor-Division Replacement.
 
 Rewrites integer (int64/int32) floor-division into a float64-domain floor to
-work around a torch-2.12 AOTInductor/Inductor CUDA miscompile:
+work around an AOTInductor/Inductor CUDA miscompile that is still present in
+the repository's pinned PyTorch 2.13 build:
 
     floor_divide(a, b)  ->  floor(a.to(float64) / b.to(float64)).to(orig_int_dtype)
 """
@@ -36,7 +37,7 @@ _DIV_MODE_OPS = (
 
 
 class ReplaceInt64FloorDivWithFloatPass(PassBase):
-    # Work around a torch-2.12 AOTInductor/Inductor CUDA miscompile of integer
+    # Work around an AOTInductor/Inductor CUDA miscompile of integer
     # (int64) floor-division: fused/broadcast int64 floor_divide is mis-lowered
     # (truncation instead of floor; cross-division term bleed under dynamic shapes).
     # TODO(gasoonjia): remove this pass once the upstream issue solved.

--- a/backends/cuda/passes/tests/test_replace_int64_floordiv.py
+++ b/backends/cuda/passes/tests/test_replace_int64_floordiv.py
@@ -7,6 +7,7 @@
 import unittest
 
 import torch
+from backends.cuda.cuda_backend import CudaBackend
 from backends.cuda.passes.replace_int64_floordiv import (
     ReplaceInt64FloorDivWithFloatPass,
 )
@@ -46,6 +47,14 @@ def _count_int_floordiv(graph_module) -> int:
 
 class TestReplaceInt64FloorDivWithFloatPass(unittest.TestCase):
     """Test the ReplaceInt64FloorDivWithFloatPass transformation pass."""
+
+    def test_cuda_backend_keeps_floor_div_workaround_registered(self):
+        """The rewrite must remain in the CUDA backend pass pipeline."""
+        passes = CudaBackend.get_custom_passes([])
+        self.assertIn(
+            "ReplaceInt64FloorDivWithFloatPass",
+            {type(pass_).__name__ for pass_ in passes},
+        )
 
     def _edge_gm(self, module, inputs):
         ep = to_edge(export(module, inputs, strict=True))

--- a/exir/graph_module.py
+++ b/exir/graph_module.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 from types import FunctionType as function
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Collection, Dict, List, Tuple, Union
 
 import torch
 from torch._ops import HigherOrderOperator
@@ -151,3 +151,29 @@ def bfs_trace_with_node_process(
             for _, submodule, _ in get_control_flow_submodules(current_graph_module)
         ]
         queue.extend(control_flow_submodules)
+
+
+def contains_any_op(
+    graph_module: torch.fx.GraphModule,
+    ops: Collection[Any],
+) -> bool:
+    """Return whether ``graph_module`` or a control-flow subgraph uses ``ops``."""
+    if not ops:
+        return False
+
+    queue = [graph_module]
+    while queue:
+        current_graph_module = queue.pop(0)
+        for node in current_graph_module.graph.nodes:
+            # EdgeOpOverload wraps the original ATen overload in ``_op``.
+            # Decomposition tables are keyed by the latter.
+            target = node.target
+            if not isinstance(target, torch._ops.OpOverload):
+                target = getattr(target, "_op", target)
+            if node.op == "call_function" and target in ops:
+                return True
+        queue.extend(
+            submodule
+            for _, submodule, _ in get_control_flow_submodules(current_graph_module)
+        )
+    return False

--- a/exir/graph_module.py
+++ b/exir/graph_module.py
@@ -165,12 +165,14 @@ def contains_any_op(
     while queue:
         current_graph_module = queue.pop(0)
         for node in current_graph_module.graph.nodes:
+            if node.op != "call_function":
+                continue
             # EdgeOpOverload wraps the original ATen overload in ``_op``.
             # Decomposition tables are keyed by the latter.
             target = node.target
             if not isinstance(target, torch._ops.OpOverload):
                 target = getattr(target, "_op", target)
-            if node.op == "call_function" and target in ops:
+            if target in ops:
                 return True
         queue.extend(
             submodule

--- a/exir/graph_module.py
+++ b/exir/graph_module.py
@@ -153,7 +153,7 @@ def bfs_trace_with_node_process(
         queue.extend(control_flow_submodules)
 
 
-def contains_any_op(
+def contains_any_call_fn_target_op(
     graph_module: torch.fx.GraphModule,
     ops: Collection[Any],
 ) -> bool:

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -33,7 +33,7 @@ from executorch.exir.delegate import executorch_call_delegate, is_lowered_module
 from executorch.exir.emit import emit_program, EmitterOutput
 from executorch.exir.emit._emitter import _DelegateDebugIdentifierMap
 from executorch.exir.error import ExportError
-from executorch.exir.graph_module import get_control_flow_submodules
+from executorch.exir.graph_module import contains_any_op, get_control_flow_submodules
 from executorch.exir.operator.convert import _pybind_schema_to_native_schema
 from executorch.exir.operator.util import _QUANT_PRIMITIVES
 from executorch.exir.pass_base import PassBase
@@ -1166,7 +1166,12 @@ def _gen_edge_manager_for_partitioners(
                         if table.pop(op, None) is not None:
                             ops_needing_preservation.append(op)
 
-                    program = program.run_decompositions(table)
+                    # The initial ``run_decompositions({})`` above has already
+                    # functionalized the graph. This second call only applies
+                    # operator decompositions from the remaining table, so it is
+                    # safe to skip when none of those targets occur in the graph.
+                    if contains_any_op(program.graph_module, table.keys()):
+                        program = program.run_decompositions(table)
                     final_ops_to_preserve.update(ops_needing_preservation)
                 else:
                     # EDGE_DO_NOT_DECOMP path for the partitioner

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -33,7 +33,10 @@ from executorch.exir.delegate import executorch_call_delegate, is_lowered_module
 from executorch.exir.emit import emit_program, EmitterOutput
 from executorch.exir.emit._emitter import _DelegateDebugIdentifierMap
 from executorch.exir.error import ExportError
-from executorch.exir.graph_module import contains_any_op, get_control_flow_submodules
+from executorch.exir.graph_module import (
+    contains_any_call_fn_target_op,
+    get_control_flow_submodules,
+)
 from executorch.exir.operator.convert import _pybind_schema_to_native_schema
 from executorch.exir.operator.util import _QUANT_PRIMITIVES
 from executorch.exir.pass_base import PassBase
@@ -1170,7 +1173,7 @@ def _gen_edge_manager_for_partitioners(
                     # functionalized the graph. This second call only applies
                     # operator decompositions from the remaining table, so it is
                     # safe to skip when none of those targets occur in the graph.
-                    if contains_any_op(program.graph_module, table):
+                    if contains_any_call_fn_target_op(program.graph_module, table):
                         program = program.run_decompositions(table)
                     final_ops_to_preserve.update(ops_needing_preservation)
                 else:

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -1170,7 +1170,7 @@ def _gen_edge_manager_for_partitioners(
                     # functionalized the graph. This second call only applies
                     # operator decompositions from the remaining table, so it is
                     # safe to skip when none of those targets occur in the graph.
-                    if contains_any_op(program.graph_module, table.keys()):
+                    if contains_any_op(program.graph_module, table):
                         program = program.run_decompositions(table)
                     final_ops_to_preserve.update(ops_needing_preservation)
                 else:

--- a/exir/tests/test_graph_module.py
+++ b/exir/tests/test_graph_module.py
@@ -35,6 +35,29 @@ class TestContainsAnyOp(unittest.TestCase):
         add.target = EdgeOp()
 
         self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
+        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
+
+    def test_matches_op_in_control_flow_submodule(self) -> None:
+        true_graph, _ = self._add_graph()
+        false_graph, _ = self._add_graph()
+
+        graph = torch.fx.Graph()
+        pred = graph.placeholder("pred")
+        lhs = graph.placeholder("lhs")
+        rhs = graph.placeholder("rhs")
+        true_branch = graph.get_attr("true_graph")
+        false_branch = graph.get_attr("false_graph")
+        result = graph.call_function(
+            torch.ops.higher_order.cond,
+            (pred, true_branch, false_branch, [lhs, rhs]),
+        )
+        graph.output(result)
+        graph_module = torch.fx.GraphModule(
+            {"true_graph": true_graph, "false_graph": false_graph}, graph
+        )
+
+        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
+        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
 
 
 if __name__ == "__main__":

--- a/exir/tests/test_graph_module.py
+++ b/exir/tests/test_graph_module.py
@@ -7,10 +7,10 @@
 import unittest
 
 import torch
-from executorch.exir.graph_module import contains_any_op
+from executorch.exir.graph_module import contains_any_call_fn_target_op
 
 
-class TestContainsAnyOp(unittest.TestCase):
+class TestContainsAnyCallFnTargetOp(unittest.TestCase):
     @staticmethod
     def _add_graph() -> tuple[torch.fx.GraphModule, torch.fx.Node]:
         graph = torch.fx.Graph()
@@ -23,8 +23,12 @@ class TestContainsAnyOp(unittest.TestCase):
     def test_matches_aten_op(self) -> None:
         graph_module, _ = self._add_graph()
 
-        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
-        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
+        self.assertTrue(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.add.Tensor})
+        )
+        self.assertFalse(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.mul.Tensor})
+        )
 
     def test_matches_wrapped_edge_op(self) -> None:
         graph_module, add = self._add_graph()
@@ -34,8 +38,12 @@ class TestContainsAnyOp(unittest.TestCase):
 
         add.target = EdgeOp()
 
-        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
-        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
+        self.assertTrue(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.add.Tensor})
+        )
+        self.assertFalse(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.mul.Tensor})
+        )
 
     def test_matches_op_in_control_flow_submodule(self) -> None:
         true_graph, _ = self._add_graph()
@@ -56,8 +64,12 @@ class TestContainsAnyOp(unittest.TestCase):
             {"true_graph": true_graph, "false_graph": false_graph}, graph
         )
 
-        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
-        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
+        self.assertTrue(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.add.Tensor})
+        )
+        self.assertFalse(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.mul.Tensor})
+        )
 
 
 if __name__ == "__main__":

--- a/exir/tests/test_graph_module.py
+++ b/exir/tests/test_graph_module.py
@@ -23,12 +23,8 @@ class TestContainsAnyOp(unittest.TestCase):
     def test_matches_aten_op(self) -> None:
         graph_module, _ = self._add_graph()
 
-        self.assertTrue(
-            contains_any_op(graph_module, {torch.ops.aten.add.Tensor})
-        )
-        self.assertFalse(
-            contains_any_op(graph_module, {torch.ops.aten.mul.Tensor})
-        )
+        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
+        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
 
     def test_matches_wrapped_edge_op(self) -> None:
         graph_module, add = self._add_graph()
@@ -38,9 +34,7 @@ class TestContainsAnyOp(unittest.TestCase):
 
         add.target = EdgeOp()
 
-        self.assertTrue(
-            contains_any_op(graph_module, {torch.ops.aten.add.Tensor})
-        )
+        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
 
 
 if __name__ == "__main__":

--- a/exir/tests/test_graph_module.py
+++ b/exir/tests/test_graph_module.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.exir.graph_module import contains_any_op
+
+
+class TestContainsAnyOp(unittest.TestCase):
+    @staticmethod
+    def _add_graph() -> tuple[torch.fx.GraphModule, torch.fx.Node]:
+        graph = torch.fx.Graph()
+        lhs = graph.placeholder("lhs")
+        rhs = graph.placeholder("rhs")
+        add = graph.call_function(torch.ops.aten.add.Tensor, (lhs, rhs))
+        graph.output(add)
+        return torch.fx.GraphModule({}, graph), add
+
+    def test_matches_aten_op(self) -> None:
+        graph_module, _ = self._add_graph()
+
+        self.assertTrue(
+            contains_any_op(graph_module, {torch.ops.aten.add.Tensor})
+        )
+        self.assertFalse(
+            contains_any_op(graph_module, {torch.ops.aten.mul.Tensor})
+        )
+
+    def test_matches_wrapped_edge_op(self) -> None:
+        graph_module, add = self._add_graph()
+
+        class EdgeOp:
+            _op = torch.ops.aten.add.Tensor
+
+        add.target = EdgeOp()
+
+        self.assertTrue(
+            contains_any_op(graph_module, {torch.ops.aten.add.Tensor})
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ### CUDA / AOTI backend path

  - Skip `run_decompositions()` during AOTI preprocessing when none of the backend decomposition table’s operators occur in the graph.
  - Remove the obsolete CUDA int64 floor-div rewrite pass, since AOTInductor now handles the original operation directly.

  ### Overall ExecuTorch export pipeline
  - Only do operator decomposition when the operator exists in original edge graph.

  ## Performance
  MG 30B cold export time improved from **26:06 to 21:16.45**, an **18.5% reduction**.
