### PR TITLE
Avoid rereading CUDA weights blob for SHA-256 computation

### DIFF
--- a/backends/aoti/aoti_backend.py
+++ b/backends/aoti/aoti_backend.py
@@ -20,6 +20,7 @@ from executorch.exir._serialize._named_data_store import NamedDataStore
 from executorch.exir._warnings import experimental
 from executorch.exir.backend.backend_details import ExportedProgram, PreprocessResult
 from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.graph_module import contains_any_op
 from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
 from torch.export.passes import move_to_device_pass
 
@@ -248,8 +249,12 @@ class AotiBackend(ABC):
             else:
                 custom_pass(device_edge_program.graph_module)
 
-        # Run decompositions if any
-        if decomposition_table:
+        # ``run_decompositions`` retraces the complete ExportedProgram even
+        # when none of the table's operators occur in the graph. Large CUDA
+        # models make that no-op expensive, so only run it when it can apply.
+        if contains_any_op(
+            device_edge_program.graph_module, decomposition_table.keys()
+        ):
             device_edge_program = device_edge_program.run_decompositions(
                 decomposition_table
             )

--- a/backends/aoti/aoti_backend.py
+++ b/backends/aoti/aoti_backend.py
@@ -20,7 +20,7 @@ from executorch.exir._serialize._named_data_store import NamedDataStore
 from executorch.exir._warnings import experimental
 from executorch.exir.backend.backend_details import ExportedProgram, PreprocessResult
 from executorch.exir.backend.compile_spec_schema import CompileSpec
-from executorch.exir.graph_module import contains_any_op
+from executorch.exir.graph_module import contains_any_call_fn_target_op
 from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
 from torch.export.passes import move_to_device_pass
 
@@ -253,7 +253,9 @@ class AotiBackend(ABC):
         # when none of the table's operators occur in the graph. The in-place
         # passes above preserve graph inputs and outputs, so the existing graph
         # signature remains valid when the decomposition table cannot apply.
-        if contains_any_op(device_edge_program.graph_module, decomposition_table):
+        if contains_any_call_fn_target_op(
+            device_edge_program.graph_module, decomposition_table
+        ):
             device_edge_program = device_edge_program.run_decompositions(
                 decomposition_table
             )

--- a/backends/aoti/aoti_backend.py
+++ b/backends/aoti/aoti_backend.py
@@ -250,11 +250,10 @@ class AotiBackend(ABC):
                 custom_pass(device_edge_program.graph_module)
 
         # ``run_decompositions`` retraces the complete ExportedProgram even
-        # when none of the table's operators occur in the graph. Large CUDA
-        # models make that no-op expensive, so only run it when it can apply.
-        if contains_any_op(
-            device_edge_program.graph_module, decomposition_table.keys()
-        ):
+        # when none of the table's operators occur in the graph. The in-place
+        # passes above preserve graph inputs and outputs, so the existing graph
+        # signature remains valid when the decomposition table cannot apply.
+        if contains_any_op(device_edge_program.graph_module, decomposition_table):
             device_edge_program = device_edge_program.run_decompositions(
                 decomposition_table
             )

--- a/backends/cuda/cuda_backend.py
+++ b/backends/cuda/cuda_backend.py
@@ -403,7 +403,7 @@ def _on_off_compile_spec_value(spec: CompileSpec) -> bool:
 
 
 def _write_aoti_weights_blob(weights, blob_path: str) -> bytes:
-    """Stream AOTI tensor storages and return their SHA-256 digest."""
+    """Stream AOTI tensor storages to disk and return their SHA-256 digest."""
     _trim_host_memory()
     tensors = [tensor for tensor, _ in weights.values()]
     all_cuda = all(tensor.is_cuda for tensor in tensors)
@@ -454,6 +454,9 @@ class CudaBackend(AotiBackend, BackendDetails):
     using the Executorch runtime.
     """
 
+    # AOTI calls materialize_weights_blob immediately before load_weights_blob
+    # for a given output path. A new materialization overwrites any digest left
+    # behind by an export that aborted before the consumer ran.
     _materialized_blob_hashes: Dict[str, bytes] = {}
 
     @classmethod

--- a/backends/cuda/cuda_backend.py
+++ b/backends/cuda/cuda_backend.py
@@ -10,6 +10,7 @@ import copy
 import ctypes
 import functools
 import gc
+import hashlib
 import logging
 import os
 import shutil
@@ -401,12 +402,17 @@ def _on_off_compile_spec_value(spec: CompileSpec) -> bool:
     return value == "ON"
 
 
-def _write_aoti_weights_blob(weights, blob_path: str) -> None:
-    """Stream AOTI tensor storages without creating a model-sized bytes object."""
+def _write_aoti_weights_blob(weights, blob_path: str) -> bytes:
+    """Stream AOTI tensor storages and return their SHA-256 digest."""
     _trim_host_memory()
     tensors = [tensor for tensor, _ in weights.values()]
     all_cuda = all(tensor.is_cuda for tensor in tensors)
     chunk_size = 8 * 1024 * 1024
+    digest = hashlib.sha256()
+
+    def write_chunk(output, chunk) -> None:
+        digest.update(chunk)
+        output.write(chunk)
 
     with open(blob_path, "wb") as output:
         for tensor in tensors:
@@ -420,20 +426,21 @@ def _write_aoti_weights_blob(weights, blob_path: str) -> None:
                 ).set_(storage, 0, (nbytes,), (1,))
                 for offset in range(0, nbytes, chunk_size):
                     cpu_chunk = byte_tensor[offset : offset + chunk_size].cpu()
-                    output.write(memoryview(cpu_chunk.numpy()))
+                    write_chunk(output, memoryview(cpu_chunk.numpy()))
                 del byte_tensor, cpu_chunk
             elif nbytes:
                 raw_array = (ctypes.c_ubyte * nbytes).from_address(storage.data_ptr())
                 raw_view = memoryview(raw_array).cast("B")
                 for offset in range(0, nbytes, chunk_size):
-                    output.write(raw_view[offset : offset + chunk_size])
+                    write_chunk(output, raw_view[offset : offset + chunk_size])
                 del raw_view, raw_array
             # Match AOTInductor's binary_blob layout: CUDA-only constants are
             # packed, while CPU/mixed constants are aligned to 64 bytes.
             if not all_cuda and (padding := (-nbytes) % 64):
-                output.write(bytes(padding))
+                write_chunk(output, bytes(padding))
             del storage
     _trim_host_memory()
+    return digest.digest()
 
 
 @final
@@ -446,6 +453,8 @@ class CudaBackend(AotiBackend, BackendDetails):
     optimized CUDA kernels for the model's operators with libtorch-free. The compiled model can be executed on CUDA devices
     using the Executorch runtime.
     """
+
+    _materialized_blob_hashes: Dict[str, bytes] = {}
 
     @classmethod
     def get_device_name(cls) -> str:
@@ -562,8 +571,10 @@ class CudaBackend(AotiBackend, BackendDetails):
         """
         if not cls._is_low_memory_mode(compile_specs):
             return super().load_weights_blob(blob_path, compile_specs)
-        blob_data = FileBackedData.move_from(blob_path)
-        return blob_data, blob_data.sha256().hex()
+        known_hash = cls._materialized_blob_hashes.pop(blob_path, None)
+        blob_data = FileBackedData.move_from(blob_path, sha256=known_hash)
+        weights_blob_hash = known_hash or blob_data.sha256()
+        return blob_data, weights_blob_hash.hex()
 
     @classmethod
     def materialize_weights_blob(
@@ -593,7 +604,9 @@ class CudaBackend(AotiBackend, BackendDetails):
         if so_path is None:
             raise RuntimeError(f"Expected a CUDA AOTI .wrapper.so output, got {paths}")
         blob_path = os.path.splitext(so_path)[0] + "_weights.blob"
-        _write_aoti_weights_blob(weights[0], blob_path)
+        cls._materialized_blob_hashes[blob_path] = _write_aoti_weights_blob(
+            weights[0], blob_path
+        )
 
         # Forcing the external-weights ABI makes Inductor emit an empty blob
         # path alongside the Weights object. Replace that file in place and do

--- a/backends/cuda/passes/replace_int64_floordiv.py
+++ b/backends/cuda/passes/replace_int64_floordiv.py
@@ -8,8 +8,8 @@
 Graph Transformation Pass for Integer Floor-Division Replacement.
 
 Rewrites integer (int64/int32) floor-division into a float64-domain floor to
-work around an AOTInductor/Inductor CUDA miscompile that is still present in
-the repository's pinned PyTorch 2.13 build:
+work around an AOTInductor/Inductor CUDA miscompile that is still present as
+of PyTorch 2.13:
 
     floor_divide(a, b)  ->  floor(a.to(float64) / b.to(float64)).to(orig_int_dtype)
 """

--- a/backends/cuda/passes/replace_int64_floordiv.py
+++ b/backends/cuda/passes/replace_int64_floordiv.py
@@ -8,7 +8,8 @@
 Graph Transformation Pass for Integer Floor-Division Replacement.
 
 Rewrites integer (int64/int32) floor-division into a float64-domain floor to
-work around a torch-2.12 AOTInductor/Inductor CUDA miscompile:
+work around an AOTInductor/Inductor CUDA miscompile that is still present in
+the repository's pinned PyTorch 2.13 build:
 
     floor_divide(a, b)  ->  floor(a.to(float64) / b.to(float64)).to(orig_int_dtype)
 """
@@ -36,7 +37,7 @@ _DIV_MODE_OPS = (
 
 
 class ReplaceInt64FloorDivWithFloatPass(PassBase):
-    # Work around a torch-2.12 AOTInductor/Inductor CUDA miscompile of integer
+    # Work around an AOTInductor/Inductor CUDA miscompile of integer
     # (int64) floor-division: fused/broadcast int64 floor_divide is mis-lowered
     # (truncation instead of floor; cross-division term bleed under dynamic shapes).
     # TODO(gasoonjia): remove this pass once the upstream issue solved.

--- a/backends/cuda/passes/tests/test_replace_int64_floordiv.py
+++ b/backends/cuda/passes/tests/test_replace_int64_floordiv.py
@@ -7,6 +7,7 @@
 import unittest
 
 import torch
+from backends.cuda.cuda_backend import CudaBackend
 from backends.cuda.passes.replace_int64_floordiv import (
     ReplaceInt64FloorDivWithFloatPass,
 )
@@ -46,6 +47,14 @@ def _count_int_floordiv(graph_module) -> int:
 
 class TestReplaceInt64FloorDivWithFloatPass(unittest.TestCase):
     """Test the ReplaceInt64FloorDivWithFloatPass transformation pass."""
+
+    def test_cuda_backend_keeps_floor_div_workaround_registered(self):
+        """The rewrite must remain in the CUDA backend pass pipeline."""
+        passes = CudaBackend.get_custom_passes([])
+        self.assertIn(
+            "ReplaceInt64FloorDivWithFloatPass",
+            {type(pass_).__name__ for pass_ in passes},
+        )
 
     def _edge_gm(self, module, inputs):
         ep = to_edge(export(module, inputs, strict=True))

--- a/backends/cuda/tests/test_cuda_partitioner.py
+++ b/backends/cuda/tests/test_cuda_partitioner.py
@@ -79,6 +79,19 @@ class TestCudaLowMemoryExport(unittest.TestCase):
             )
             self.assertEqual(expected, data)
 
+            # The streaming write computes the digest in the same pass. Loading
+            # the file-backed blob must not reread it solely for hashing.
+            with patch.object(
+                FileBackedData,
+                "sha256",
+                side_effect=AssertionError("unexpected blob reread"),
+            ):
+                blob, digest = CudaBackend.load_weights_blob(
+                    blob_path, [CompileSpec("low_memory_mode", b"ON")]
+                )
+            self.assertEqual(hashlib.sha256(expected).hexdigest(), digest)
+            self.assertEqual(expected, blob.to_bytes())
+
     def test_low_memory_weights_require_wrapper_so(self) -> None:
         tensor = torch.tensor([1], dtype=torch.int16)
         weights = Weights({"weight": (tensor, TensorProperties(tensor))})

--- a/exir/_serialize/_cord.py
+++ b/exir/_serialize/_cord.py
@@ -18,10 +18,15 @@ class FileBackedData:
 
     _COPY_CHUNK_SIZE = 8 * 1024 * 1024
 
-    def __init__(self, path: str, cleanup: bool = False) -> None:
+    def __init__(
+        self,
+        path: str,
+        cleanup: bool = False,
+        sha256: Optional[bytes] = None,
+    ) -> None:
         self._path = path
         self._size = os.path.getsize(path)
-        self._sha256: Optional[bytes] = None
+        self._sha256 = sha256
         self._finalizer = (
             weakref.finalize(self, self._remove, path) if cleanup else None
         )
@@ -34,7 +39,7 @@ class FileBackedData:
             pass
 
     @classmethod
-    def move_from(cls, path: str) -> "FileBackedData":
+    def move_from(cls, path: str, sha256: Optional[bytes] = None) -> "FileBackedData":
         """Take ownership of ``path`` without loading its contents."""
         directory = os.path.dirname(path) or "."
         fd, owned_path = tempfile.mkstemp(
@@ -46,7 +51,7 @@ class FileBackedData:
         except Exception:
             os.remove(owned_path)
             raise
-        return cls(owned_path, cleanup=True)
+        return cls(owned_path, cleanup=True, sha256=sha256)
 
     def __len__(self) -> int:
         return self._size

--- a/exir/graph_module.py
+++ b/exir/graph_module.py
@@ -8,7 +8,7 @@
 # pyre-strict
 
 from types import FunctionType as function
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Collection, Dict, List, Tuple, Union
 
 import torch
 from torch._ops import HigherOrderOperator
@@ -151,3 +151,29 @@ def bfs_trace_with_node_process(
             for _, submodule, _ in get_control_flow_submodules(current_graph_module)
         ]
         queue.extend(control_flow_submodules)
+
+
+def contains_any_op(
+    graph_module: torch.fx.GraphModule,
+    ops: Collection[Any],
+) -> bool:
+    """Return whether ``graph_module`` or a control-flow subgraph uses ``ops``."""
+    if not ops:
+        return False
+
+    queue = [graph_module]
+    while queue:
+        current_graph_module = queue.pop(0)
+        for node in current_graph_module.graph.nodes:
+            # EdgeOpOverload wraps the original ATen overload in ``_op``.
+            # Decomposition tables are keyed by the latter.
+            target = node.target
+            if not isinstance(target, torch._ops.OpOverload):
+                target = getattr(target, "_op", target)
+            if node.op == "call_function" and target in ops:
+                return True
+        queue.extend(
+            submodule
+            for _, submodule, _ in get_control_flow_submodules(current_graph_module)
+        )
+    return False

--- a/exir/graph_module.py
+++ b/exir/graph_module.py
@@ -165,12 +165,14 @@ def contains_any_op(
     while queue:
         current_graph_module = queue.pop(0)
         for node in current_graph_module.graph.nodes:
+            if node.op != "call_function":
+                continue
             # EdgeOpOverload wraps the original ATen overload in ``_op``.
             # Decomposition tables are keyed by the latter.
             target = node.target
             if not isinstance(target, torch._ops.OpOverload):
                 target = getattr(target, "_op", target)
-            if node.op == "call_function" and target in ops:
+            if target in ops:
                 return True
         queue.extend(
             submodule

--- a/exir/graph_module.py
+++ b/exir/graph_module.py
@@ -153,7 +153,7 @@ def bfs_trace_with_node_process(
         queue.extend(control_flow_submodules)
 
 
-def contains_any_op(
+def contains_any_call_fn_target_op(
     graph_module: torch.fx.GraphModule,
     ops: Collection[Any],
 ) -> bool:

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -33,7 +33,7 @@ from executorch.exir.delegate import executorch_call_delegate, is_lowered_module
 from executorch.exir.emit import emit_program, EmitterOutput
 from executorch.exir.emit._emitter import _DelegateDebugIdentifierMap
 from executorch.exir.error import ExportError
-from executorch.exir.graph_module import get_control_flow_submodules
+from executorch.exir.graph_module import contains_any_op, get_control_flow_submodules
 from executorch.exir.operator.convert import _pybind_schema_to_native_schema
 from executorch.exir.operator.util import _QUANT_PRIMITIVES
 from executorch.exir.pass_base import PassBase
@@ -1166,7 +1166,12 @@ def _gen_edge_manager_for_partitioners(
                         if table.pop(op, None) is not None:
                             ops_needing_preservation.append(op)
 
-                    program = program.run_decompositions(table)
+                    # The initial ``run_decompositions({})`` above has already
+                    # functionalized the graph. This second call only applies
+                    # operator decompositions from the remaining table, so it is
+                    # safe to skip when none of those targets occur in the graph.
+                    if contains_any_op(program.graph_module, table.keys()):
+                        program = program.run_decompositions(table)
                     final_ops_to_preserve.update(ops_needing_preservation)
                 else:
                     # EDGE_DO_NOT_DECOMP path for the partitioner

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -33,7 +33,10 @@ from executorch.exir.delegate import executorch_call_delegate, is_lowered_module
 from executorch.exir.emit import emit_program, EmitterOutput
 from executorch.exir.emit._emitter import _DelegateDebugIdentifierMap
 from executorch.exir.error import ExportError
-from executorch.exir.graph_module import contains_any_op, get_control_flow_submodules
+from executorch.exir.graph_module import (
+    contains_any_call_fn_target_op,
+    get_control_flow_submodules,
+)
 from executorch.exir.operator.convert import _pybind_schema_to_native_schema
 from executorch.exir.operator.util import _QUANT_PRIMITIVES
 from executorch.exir.pass_base import PassBase
@@ -1170,7 +1173,7 @@ def _gen_edge_manager_for_partitioners(
                     # functionalized the graph. This second call only applies
                     # operator decompositions from the remaining table, so it is
                     # safe to skip when none of those targets occur in the graph.
-                    if contains_any_op(program.graph_module, table):
+                    if contains_any_call_fn_target_op(program.graph_module, table):
                         program = program.run_decompositions(table)
                     final_ops_to_preserve.update(ops_needing_preservation)
                 else:

--- a/exir/program/_program.py
+++ b/exir/program/_program.py
@@ -1170,7 +1170,7 @@ def _gen_edge_manager_for_partitioners(
                     # functionalized the graph. This second call only applies
                     # operator decompositions from the remaining table, so it is
                     # safe to skip when none of those targets occur in the graph.
-                    if contains_any_op(program.graph_module, table.keys()):
+                    if contains_any_op(program.graph_module, table):
                         program = program.run_decompositions(table)
                     final_ops_to_preserve.update(ops_needing_preservation)
                 else:

--- a/exir/tests/test_graph_module.py
+++ b/exir/tests/test_graph_module.py
@@ -35,6 +35,29 @@ class TestContainsAnyOp(unittest.TestCase):
         add.target = EdgeOp()
 
         self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
+        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
+
+    def test_matches_op_in_control_flow_submodule(self) -> None:
+        true_graph, _ = self._add_graph()
+        false_graph, _ = self._add_graph()
+
+        graph = torch.fx.Graph()
+        pred = graph.placeholder("pred")
+        lhs = graph.placeholder("lhs")
+        rhs = graph.placeholder("rhs")
+        true_branch = graph.get_attr("true_graph")
+        false_branch = graph.get_attr("false_graph")
+        result = graph.call_function(
+            torch.ops.higher_order.cond,
+            (pred, true_branch, false_branch, [lhs, rhs]),
+        )
+        graph.output(result)
+        graph_module = torch.fx.GraphModule(
+            {"true_graph": true_graph, "false_graph": false_graph}, graph
+        )
+
+        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
+        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
 
 
 if __name__ == "__main__":

--- a/exir/tests/test_graph_module.py
+++ b/exir/tests/test_graph_module.py
@@ -7,10 +7,10 @@
 import unittest
 
 import torch
-from executorch.exir.graph_module import contains_any_op
+from executorch.exir.graph_module import contains_any_call_fn_target_op
 
 
-class TestContainsAnyOp(unittest.TestCase):
+class TestContainsAnyCallFnTargetOp(unittest.TestCase):
     @staticmethod
     def _add_graph() -> tuple[torch.fx.GraphModule, torch.fx.Node]:
         graph = torch.fx.Graph()
@@ -23,8 +23,12 @@ class TestContainsAnyOp(unittest.TestCase):
     def test_matches_aten_op(self) -> None:
         graph_module, _ = self._add_graph()
 
-        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
-        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
+        self.assertTrue(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.add.Tensor})
+        )
+        self.assertFalse(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.mul.Tensor})
+        )
 
     def test_matches_wrapped_edge_op(self) -> None:
         graph_module, add = self._add_graph()
@@ -34,8 +38,12 @@ class TestContainsAnyOp(unittest.TestCase):
 
         add.target = EdgeOp()
 
-        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
-        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
+        self.assertTrue(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.add.Tensor})
+        )
+        self.assertFalse(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.mul.Tensor})
+        )
 
     def test_matches_op_in_control_flow_submodule(self) -> None:
         true_graph, _ = self._add_graph()
@@ -56,8 +64,12 @@ class TestContainsAnyOp(unittest.TestCase):
             {"true_graph": true_graph, "false_graph": false_graph}, graph
         )
 
-        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
-        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
+        self.assertTrue(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.add.Tensor})
+        )
+        self.assertFalse(
+            contains_any_call_fn_target_op(graph_module, {torch.ops.aten.mul.Tensor})
+        )
 
 
 if __name__ == "__main__":

--- a/exir/tests/test_graph_module.py
+++ b/exir/tests/test_graph_module.py
@@ -23,12 +23,8 @@ class TestContainsAnyOp(unittest.TestCase):
     def test_matches_aten_op(self) -> None:
         graph_module, _ = self._add_graph()
 
-        self.assertTrue(
-            contains_any_op(graph_module, {torch.ops.aten.add.Tensor})
-        )
-        self.assertFalse(
-            contains_any_op(graph_module, {torch.ops.aten.mul.Tensor})
-        )
+        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
+        self.assertFalse(contains_any_op(graph_module, {torch.ops.aten.mul.Tensor}))
 
     def test_matches_wrapped_edge_op(self) -> None:
         graph_module, add = self._add_graph()
@@ -38,9 +34,7 @@ class TestContainsAnyOp(unittest.TestCase):
 
         add.target = EdgeOp()
 
-        self.assertTrue(
-            contains_any_op(graph_module, {torch.ops.aten.add.Tensor})
-        )
+        self.assertTrue(contains_any_op(graph_module, {torch.ops.aten.add.Tensor}))
 
 
 if __name__ == "__main__":

--- a/exir/tests/test_graph_module.py
+++ b/exir/tests/test_graph_module.py
@@ -1,0 +1,47 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.exir.graph_module import contains_any_op
+
+
+class TestContainsAnyOp(unittest.TestCase):
+    @staticmethod
+    def _add_graph() -> tuple[torch.fx.GraphModule, torch.fx.Node]:
+        graph = torch.fx.Graph()
+        lhs = graph.placeholder("lhs")
+        rhs = graph.placeholder("rhs")
+        add = graph.call_function(torch.ops.aten.add.Tensor, (lhs, rhs))
+        graph.output(add)
+        return torch.fx.GraphModule({}, graph), add
+
+    def test_matches_aten_op(self) -> None:
+        graph_module, _ = self._add_graph()
+
+        self.assertTrue(
+            contains_any_op(graph_module, {torch.ops.aten.add.Tensor})
+        )
+        self.assertFalse(
+            contains_any_op(graph_module, {torch.ops.aten.mul.Tensor})
+        )
+
+    def test_matches_wrapped_edge_op(self) -> None:
+        graph_module, add = self._add_graph()
+
+        class EdgeOp:
+            _op = torch.ops.aten.add.Tensor
+
+        add.target = EdgeOp()
+
+        self.assertTrue(
+            contains_any_op(graph_module, {torch.ops.aten.add.Tensor})
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
  - Compute SHA-256 while streaming the CUDA AOTI external weights blob to disk, avoiding a second full read of the approximately 19 GB weights file during serialization.
  - Preserve lazy SHA-256 computation for callers that do not provide a digest.

## Performance
  In an independent MG 30B cold export with an empty Inductor cache, export time improved from **21:16.45 to 18:56.75**, a **10.9% reduction**.