### PR TITLE
Retire attention-mask custom operator

### DIFF
--- a/backends/cadence/aot/ops_registrations.py
+++ b/backends/cadence/aot/ops_registrations.py
@@ -747,12 +747,6 @@ aten_lib.define(
     "_cat_nop.out(Tensor[] tensors, int dim=0, *, Tensor(a!) out) -> Tensor(a!)"
 )
 
-# Custom ops with cadence_nn_ops namespace
-jarvis_nn_lib = Library("jarvis_nn_ops", "DEF")
-jarvis_nn_lib.define(
-    "attention_mask.out(Tensor input, Tensor start, Tensor stop, *, Tensor(a!) out) -> Tensor(a!)"
-)
-
 # Custom ops in aten namespace. RMSNorm is usually decomposed, so having
 # an out-variant is non-standard
 

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -85,12 +85,12 @@ def define_common_targets():
         ],
         exported_deps = [
             ":broadcast_indexes_range",
+            "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],
         deps = [
             ":repeat_util",
             "//executorch/runtime/kernel:kernel_includes",
             "//executorch/runtime/core/exec_aten/util:tensor_shape_to_c_string",
-            "//executorch/runtime/core/exec_aten/util:tensor_util",
         ],
         visibility = ["PUBLIC"],
     )
@@ -424,10 +424,10 @@ def define_common_targets():
             exported_headers = ["reduce_util.h"],
             deps = [
                 "//executorch/runtime/kernel:kernel_includes{}".format(suffix),
-                "//executorch/runtime/core/exec_aten/util:tensor_util{}".format(suffix),
             ],
             exported_deps = [
                 "//executorch/extension/threadpool:threadpool",
+                "//executorch/runtime/core/exec_aten/util:tensor_util{}".format(suffix),
             ],
             exported_preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
             visibility = ["PUBLIC"],


### PR DESCRIPTION
Summary:
Retire the Jarvis attention-mask custom operator and all confirmed dead scaffolding.

Remove both the ExecuTorch `jarvis_nn_ops::attention_mask.out` runtime path and the unused eager `jarvis_nn_ops::attention_mask` wrapper. Delete their generic and HiFi kernels, tests, build targets, registrations, dependencies, and documentation.

Differential Revision: D115805406


