### PR TITLE
NXP backend: handle tests of mlperf tiny classification

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -400,6 +400,7 @@ exclude_patterns = [
     'backends/cadence/utils/FACTO',
     'examples/cuda',
     'examples/qualcomm',
+    'examples/nxp',
     'kernels/portable',
     # File contains @generated
     'extension/llm/custom_ops/spinquant/fast_hadamard_transform_special.h',

--- a/backends/nxp/tests/calibration_dataset.py
+++ b/backends/nxp/tests/calibration_dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2025 NXP
+# Copyright 2025-2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -22,6 +22,53 @@ class CalibrationDataset(Dataset):
             )
         else:
             raise ValueError("Invalid file format, supported formats are .xz, .pt.")
+
+    def __len__(self):
+        return len(self.examples)
+
+    def __getitem__(self, i):
+        return self.examples[i]
+
+
+class RandomCalibrationDataset(Dataset):
+    def __init__(
+        self,
+        num_examples: int,
+        sample_shape,
+        num_classes: int,
+        balanced: bool = True,
+    ):
+        if balanced and num_examples % num_classes != 0:
+            raise ValueError(
+                f"RandomCalibrationDataset: `num_examples` ({num_examples}) must be divisible by "
+                f"`num_classes` ({num_classes}) when `balanced` is True."
+            )
+
+        self._num_examples = num_examples
+        self._shape = tuple(sample_shape)
+        self._num_classes = num_classes
+        self._balanced = balanced
+
+        labels = self._create_labels(num_examples, num_classes, balanced)
+
+        self.examples = []
+        for label in labels:
+            data = torch.rand(self._shape, dtype=torch.float32)
+            self.examples.append((data, label))
+
+    @staticmethod
+    def _create_labels(
+        num_examples: int, num_classes: int, balanced: bool
+    ) -> list[int]:
+        """Create the list of labels for the individual examples."""
+        if balanced:
+            examples_per_class = num_examples // num_classes
+            labels = torch.arange(num_classes).repeat_interleave(examples_per_class)
+            labels = labels[torch.randperm(num_examples)]
+        else:
+            labels = torch.randint(low=0, high=num_classes, size=(num_examples,))
+
+        return labels.tolist()
 
     def __len__(self):
         return len(self.examples)

--- a/backends/nxp/tests/generic_tests/test_aot_example.py
+++ b/backends/nxp/tests/generic_tests/test_aot_example.py
@@ -2,6 +2,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+import contextlib
 import os
 import subprocess
 import sys
@@ -14,11 +15,116 @@ from executorch.exir._serialize import _deserialize_pte_binary
 from executorch.exir.schema import DelegateCall, KernelCall
 
 
+EXECUTORCH_ROOT = test_config.PROJECT_DIR
+CMD_TIMEOUT = 300
+
+
+@contextlib.contextmanager
+def _cleanup_generated_files(
+    pte_file: Path | None = None, etrecord_file: Path | None = None
+):
+    """Delete the given generated files once the block finishes, whether the test passed or failed."""
+    try:
+        yield
+
+    finally:
+        if pte_file is not None and pte_file.exists():
+            pte_file.unlink()
+        if etrecord_file is not None and etrecord_file.exists():
+            etrecord_file.unlink()
+            parent = etrecord_file.parent
+            if not any(parent.iterdir()):
+                parent.rmdir()
+
+
+def _run_compile(cmd: str):
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=CMD_TIMEOUT,  # 5 minute timeout just in case. On 8-core x86 the test usually runs ~1 minute.
+        cwd=str(EXECUTORCH_ROOT),  # Run from executorch root (like run_aot_example.sh)
+    )
+
+    return result
+
+
+def _assert_delegation(
+    process_result: subprocess.CompletedProcess[str], pte_path: Path
+):
+    # Check script ran successfully
+    assert process_result.returncode == 0, (
+        f"Script failed with return code {process_result.returncode}\n"
+        f"STDOUT:\n{process_result.stdout}\n"
+        f"STDERR:\n{process_result.stderr}"
+    )
+
+    # Expected .pte file path
+    assert pte_path.exists(), f"PTE file not created at {pte_path}"
+
+    # Load and inspect the program to verify delegation
+    with open(pte_path, "rb") as f:
+        pte_data = f.read()
+
+    program = _deserialize_pte_binary(pte_data).program
+
+    # 1 execution plan (forward).
+    assert len(program.execution_plan) == 1
+    assert (forward := program.execution_plan[0]).name == "forward"
+
+    # The program only does: Quantize -> Delegate call -> Dequantize
+    assert len(ops := forward.operators) == 2  # Quantize and Dequantize
+    assert len(forward.chains) == 1
+    assert len(instructions := forward.chains[0].instructions) == 3
+    # Quantize (Can only check by string. There is no object.)
+    assert isinstance(instructions[0].instr_args, KernelCall)
+    assert (
+        instructions[0].instr_args.op_index == (q_idx := 0)
+        and ops[q_idx].name == "quantized_decomposed::quantize_per_tensor"
+    )
+    # Delegate call
+    assert isinstance(instructions[1].instr_args, DelegateCall)
+    assert len(forward.delegates) == 1
+    assert (
+        instructions[1].instr_args.delegate_index == 0
+        and forward.delegates[0].id == "NeutronBackend"
+    )
+    # Dequantize (Can only check by string. There is no object.)
+    assert isinstance(instructions[2].instr_args, KernelCall)
+    assert (
+        instructions[2].instr_args.op_index == (dq_idx := 1)
+        and ops[dq_idx].name == "quantized_decomposed::dequantize_per_tensor"
+    )
+
+
+def _assert_profiling(
+    process_result: subprocess.CompletedProcess[str],
+    pte_path: Path,
+    etrecord_path: Path,
+):
+    # Check script ran successfully.
+    assert process_result.returncode == 0, (
+        f"Script failed with return code {process_result.returncode}\n"
+        f"STDOUT:\n{process_result.stdout}\n"
+        f"STDERR:\n{process_result.stderr}"
+    )
+
+    # Check if delegated model was created and saved.
+    assert pte_path.exists(), f"PTE file not created at {pte_path}"
+
+    # Combine stdout and stderr to capture all subprocess output, including logs.
+    process_output = process_result.stdout + process_result.stderr
+
+    # Check if nonempty Neutron to Edge map was created.
+    assert "Neutron to Edge map was created:" in process_output
+
+    # Check if ETRecord was created and saved.
+    assert "The ETRecord for the model was saved to" in process_output
+    assert etrecord_path.exists(), f"ETRecord file not created at {etrecord_path}"
+
+
 def test_aot_example__mobilenet_v2():
     """Test that mobilenet can be lowered to Neutron backend via `aot_neutron_compile.py` and all ops are delegated."""
-
-    # Set the executorch root directory.
-    executorch_root = test_config.PROJECT_DIR
 
     # Run the compilation script as a module (like run_aot_example.sh does)
     cmd = [
@@ -35,75 +141,16 @@ def test_aot_example__mobilenet_v2():
     ]
 
     # Output file will be created in executorch_root
-    pte_file = Path(os.path.join(executorch_root, "mobilenetv2_nxp_delegate.pte"))
+    pte_file = Path(os.path.join(EXECUTORCH_ROOT, "mobilenetv2_nxp_delegate.pte"))
 
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=300,  # 5 minute timeout just in case. On 8-core x86 the test usually runs ~1 minute.
-            cwd=str(
-                executorch_root
-            ),  # Run from executorch root (like run_aot_example.sh)
-        )
-
-        # Check script ran successfully
-        assert result.returncode == 0, (
-            f"Script failed with return code {result.returncode}\n"
-            f"STDOUT:\n{result.stdout}\n"
-            f"STDERR:\n{result.stderr}"
-        )
-
-        # Expected .pte file path
-        assert pte_file.exists(), f"PTE file not created at {pte_file}"
-
-        # Load and inspect the program to verify delegation
-        with open(pte_file, "rb") as f:
-            pte_data = f.read()
-
-        program = _deserialize_pte_binary(pte_data).program
-
-        # 1 execution plan (forward).
-        assert len(program.execution_plan) == 1
-        assert (forward := program.execution_plan[0]).name == "forward"
-
-        # The program only does: Quantize -> Delegate call -> Dequantize
-        assert len(ops := forward.operators) == 2  # Quantize and Dequantize
-        assert len(forward.chains) == 1
-        assert len(instructions := forward.chains[0].instructions) == 3
-        # Quantize (Can only check by string. There is no object.)
-        assert isinstance(instructions[0].instr_args, KernelCall)
-        assert (
-            instructions[0].instr_args.op_index == (q_idx := 0)
-            and ops[q_idx].name == "quantized_decomposed::quantize_per_tensor"
-        )
-        # Delegate call
-        assert isinstance(instructions[1].instr_args, DelegateCall)
-        assert len(forward.delegates) == 1
-        assert (
-            instructions[1].instr_args.delegate_index == 0
-            and forward.delegates[0].id == "NeutronBackend"
-        )
-        # Dequantize (Can only check by string. There is no object.)
-        assert isinstance(instructions[2].instr_args, KernelCall)
-        assert (
-            instructions[2].instr_args.op_index == (dq_idx := 1)
-            and ops[dq_idx].name == "quantized_decomposed::dequantize_per_tensor"
-        )
-
-    finally:
-        # Clean up the generated file
-        if pte_file.exists():
-            pte_file.unlink()
+    with _cleanup_generated_files(pte_file):
+        result = _run_compile(cmd)
+        _assert_delegation(result, pte_file)
 
 
 def test_aot_example__mobilenet_v2__profiling():
     """Test that mobilenet_v2 can be lowered to Neutron backend via `aot_neutron_compile.py`, all ops are delegated,
     the output model is profilable and ETRecord is generated properly."""
-
-    # Set the executorch root directory.
-    executorch_root = test_config.PROJECT_DIR
 
     # Run the compilation script as a module (like run_aot_example.sh does)
     cmd = [
@@ -124,49 +171,81 @@ def test_aot_example__mobilenet_v2__profiling():
 
     # Output files will be created in executorch_root.
     pte_file = Path(
-        os.path.join(executorch_root, "mobilenetv2_nxp_delegate_profile.pte")
+        os.path.join(EXECUTORCH_ROOT, "mobilenetv2_nxp_delegate_profile.pte")
     )
     etrecord_file = Path(
-        os.path.join(executorch_root, "etrecord", "mobilenetv2_etrecord.bin")
+        os.path.join(EXECUTORCH_ROOT, "etrecord", "mobilenetv2_etrecord.bin")
     )
 
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=300,  # 5 minute timeout just in case. On 8-core x86 the test usually runs ~1 minute.
-            cwd=str(
-                executorch_root
-            ),  # Run from executorch root (like run_aot_example.sh)
+    with _cleanup_generated_files(pte_file, etrecord_file):
+        result = _run_compile(cmd)
+        _assert_profiling(result, pte_file, etrecord_file)
+
+
+def test_aot_example__mlperf_tiny_ic():
+    """Test that the MLPerf Tiny image classification model (ResNet-8) can be lowered to Neutron backend via
+    `aot_neutron_compile.py` and all ops are delegated."""
+
+    # Run the compilation script as a module (like run_aot_example.sh does).
+    # The calibration data of this model is generated randomly, so no dataset download is needed.
+    cmd = [
+        sys.executable,
+        "-m",
+        "examples.nxp.aot_neutron_compile",
+        "--model_name",
+        "mlperf_tiny_image_classification",
+        "--delegate",
+        "--quantize",
+        "--target",
+        "imxrt700",
+        "--use_random_dataset",
+    ]
+
+    # Output file will be created in executorch_root
+    pte_file = Path(
+        os.path.join(
+            EXECUTORCH_ROOT, "mlperf_tiny_image_classification_nxp_delegate.pte"
         )
+    )
 
-        # Check script ran successfully.
-        assert result.returncode == 0, (
-            f"Script failed with return code {result.returncode}\n"
-            f"STDOUT:\n{result.stdout}\n"
-            f"STDERR:\n{result.stderr}"
+    with _cleanup_generated_files(pte_file):
+        result = _run_compile(cmd)
+        _assert_delegation(result, pte_file)
+
+
+def test_aot_example__mlperf_tiny_ic__profiling():
+    """Test that the MLPerf Tiny image classification model (ResNet-8) can be lowered to Neutron backend via
+    `aot_neutron_compile.py` and all ops are delegated."""
+
+    # Run the compilation script as a module (like run_aot_example.sh does)
+    # Channels-last is buggy, so channels-first is used instead
+    cmd = [
+        sys.executable,
+        "-m",
+        "examples.nxp.aot_neutron_compile",
+        "--model_name",
+        "mlperf_tiny_image_classification",
+        "--delegate",
+        "--quantize",
+        "--target",
+        "imxrt700",
+        "--remove-quant-io-ops",
+        "--use_profiling",  # Generate profilable model and create ETRecord
+        "--use_random_dataset",  # Avoid downloading the dataset.
+    ]
+
+    # Output files will be created in executorch_root.
+    pte_file = Path(
+        os.path.join(
+            EXECUTORCH_ROOT, "mlperf_tiny_image_classification_nxp_delegate_profile.pte"
         )
+    )
+    etrecord_file = Path(
+        os.path.join(
+            EXECUTORCH_ROOT, "etrecord", "mlperf_tiny_image_classification_etrecord.bin"
+        )
+    )
 
-        # Check if delegated model was created and saved.
-        assert pte_file.exists(), f"PTE file not created at {pte_file}"
-
-        # Combine stdout and stderr to capture all subprocess output, including logs.
-        process_output = result.stdout + result.stderr
-
-        # Check if nonempty Neutron to Edge map was created.
-        assert "Neutron to Edge map was created:" in process_output
-
-        # Check if ETRecord was created and saved.
-        assert "The ETRecord for the model was saved to" in process_output
-        assert etrecord_file.exists(), f"ETRecord file not created at {etrecord_file}"
-
-    finally:
-        # Clean up the generated files.
-        if pte_file.exists():
-            pte_file.unlink()
-        if etrecord_file.exists():
-            etrecord_file.unlink()
-            parent = etrecord_file.parent
-            if not any(parent.iterdir()):
-                parent.rmdir()
+    with _cleanup_generated_files(pte_file, etrecord_file):
+        result = _run_compile(cmd)
+        _assert_profiling(result, pte_file, etrecord_file)

--- a/backends/nxp/tests/model_output_comparator.py
+++ b/backends/nxp/tests/model_output_comparator.py
@@ -139,6 +139,28 @@ def _default_postprocess_fn(outputs: np.ndarray, _: str):
     return np.argmax(outputs, axis=-1)
 
 
+def _parse_class_id_from_sample_dir(
+    sample_dir: str, inv_class_dict: dict[str, int]
+) -> int:
+    if not isinstance(sample_dir, str) or len(sample_dir.split("_")) < 3:
+        raise ValueError(
+            f"Sample dir format invalid. Expected format: 'example_classname_0', got {sample_dir}"
+        )
+
+    dir_parts = sample_dir.split("_")
+    first_numerical_index = next(
+        (i for i, s in enumerate(dir_parts) if s.isdigit()), -1
+    )
+
+    if first_numerical_index < 2:
+        raise ValueError(
+            f"Sample dir format invalid. Expected format: 'example_classname_0', got {sample_dir}"
+        )
+
+    class_name = "_".join(dir_parts[1:first_numerical_index])
+    return inv_class_dict[class_name]
+
+
 class ClassificationAccuracyOutputComparator(BaseOutputComparator):
 
     def __init__(
@@ -260,23 +282,7 @@ class ClassificationAccuracyOutputComparator(BaseOutputComparator):
         finetuned_correct_total = 0
         total_samples = 0
 
-        if not isinstance(sample_dir, str) or len(sample_dir.split("_")) < 3:
-            raise ValueError(
-                f"Sample dir format invalid. Expected format: 'example_classname_0', got {sample_dir}"
-            )
-
-        dir_parts = sample_dir.split("_")
-        first_numerical_index = next(
-            (i for i, s in enumerate(dir_parts) if s.isdigit()), -1
-        )
-
-        if first_numerical_index < 2:
-            raise ValueError(
-                f"Sample dir format invalid. Expected format: 'example_classname_0', got {sample_dir}"
-            )
-
-        class_name = "_".join(dir_parts[1:first_numerical_index])
-        class_id = self.inv_class_dict[class_name]
+        class_id = _parse_class_id_from_sample_dir(sample_dir, self.inv_class_dict)
 
         for idx in range(len(baseline_output_tensors)):
             (baseline_output_name, baseline_tensor) = baseline_output_tensors[idx]
@@ -313,6 +319,178 @@ class ClassificationAccuracyOutputComparator(BaseOutputComparator):
             )
 
         return finetuned_correct_total, baseline_correct_total, total_samples
+
+
+class GroundTruthAccuracyComparator(BaseOutputComparator):
+
+    def __init__(
+        self,
+        class_dict: dict[int, str],
+        max_accuracy_drop: float = 0.05,
+        postprocess_fn: Callable[
+            [np.ndarray, str], np.ndarray
+        ] = _default_postprocess_fn,
+        min_cpu_accuracy: float | None = None,
+        parse_class_id_fn: Callable[
+            [str, dict[str, int]], int
+        ] = _parse_class_id_from_sample_dir,
+    ):
+        """
+        Comparator that computes classification accuracy of both the non-delegated
+        (CPU) model and the delegated (NPU) model against the ground-truth annotations
+        encoded in the sample directory names, then fails if the accuracy drop caused
+        by delegation exceeds a configured threshold.
+
+        The ground-truth label is parsed from the sample directory name, which is
+        expected to follow the format produced by `FromCalibrationDataDatasetCreator`,
+        e.g. 'example_classname_0'.
+
+        :param class_dict: Dictionary mapping class indices to class names.
+        :param max_accuracy_drop: Maximum allowed accuracy drop (cpu_accuracy - npu_accuracy).
+                                    The test fails if the delegated (NPU) model accuracy is
+                                    lower than the non-delegated (CPU) model accuracy by more
+                                    than this value. Given as a fraction in the range [0, 1].
+        :param postprocess_fn: An optional callback for postprocessing model output into
+                                classification predictions.
+        :param min_cpu_accuracy: Optional lower bound on the non-delegated (CPU) model accuracy.
+                                    If provided and the CPU accuracy is below this value, the test
+                                    fails - this guards against a meaningless comparison where both
+                                    models are equally bad. Given as a fraction in the range [0, 1].
+        :param parse_class_id_fn: Callback used to derive the ground-truth class index for a sample.
+                                    It receives the sample directory basename and the inverse class
+                                    dictionary (class name to class index) and returns the class index.
+                                    Defaults to `_parse_class_id_from_sample_dir`.
+        """
+        self.postprocess_fn = postprocess_fn
+        self.max_accuracy_drop = max_accuracy_drop
+        self.min_cpu_accuracy = min_cpu_accuracy
+        self.parse_class_id_fn = parse_class_id_fn
+        self.inv_class_dict = {v: k for k, v in class_dict.items()}
+
+    def compare_results(self, cpu_results_dir, npu_results_dir, output_tensor_spec):
+        """
+        Estimate the prediction accuracy of both the non-delegated (CPU) results and the
+        delegated (NPU) results against the ground-truth labels, then fail if the accuracy
+        drop caused by delegation exceeds `max_accuracy_drop`.
+
+        :param cpu_results_dir: Path to directory with non-delegated (CPU) results.
+        :param npu_results_dir: Path to directory with delegated (NPU) results.
+        :param output_tensor_spec: List of output tensor specifications.
+        """
+        sample_dirs = [
+            os.path.join(cpu_results_dir, file) for file in os.listdir(cpu_results_dir)
+        ]
+        sample_dirs = [file for file in sample_dirs if os.path.isdir(file)]
+
+        assert len(sample_dirs), "No samples to compare."
+
+        cpu_num_correct = 0
+        npu_num_correct = 0
+        total_samples = 0
+
+        for sample_dir in sample_dirs:
+            cpu_sample_paths = []
+            npu_sample_paths = []
+
+            cpu_out_tensors = []
+            npu_out_tensors = []
+
+            for idx, out_tensor_name in enumerate(os.listdir(sample_dir)):
+                sample_dir = os.path.basename(sample_dir)
+                tensor_path = os.path.join(sample_dir, out_tensor_name)
+
+                cpu_tensor_path = os.path.join(cpu_results_dir, tensor_path)
+                npu_tensor_path = os.path.join(npu_results_dir, tensor_path)
+
+                tensor_spec = output_tensor_spec[idx]
+
+                cpu_tensor = np.fromfile(
+                    cpu_tensor_path,
+                    dtype=torch_type_to_numpy_type(tensor_spec.dtype),
+                )
+                cpu_tensor = np.reshape(cpu_tensor, tensor_spec.shape)
+                cpu_sample_paths.append(cpu_tensor_path)
+                cpu_out_tensors.append((out_tensor_name, cpu_tensor))
+
+                npu_tensor = np.fromfile(
+                    npu_tensor_path,
+                    dtype=torch_type_to_numpy_type(tensor_spec.dtype),
+                )
+                npu_tensor = np.reshape(npu_tensor, tensor_spec.shape)
+                npu_sample_paths.append(npu_tensor_path)
+                npu_out_tensors.append((out_tensor_name, npu_tensor))
+
+            cpu_correct, npu_correct, total = self.compare_sample(
+                sample_dir,
+                cpu_sample_paths,
+                cpu_out_tensors,
+                npu_sample_paths,
+                npu_out_tensors,
+            )
+
+            cpu_num_correct += cpu_correct
+            npu_num_correct += npu_correct
+            total_samples += total
+
+        cpu_accuracy = cpu_num_correct / total_samples
+        npu_accuracy = npu_num_correct / total_samples
+        accuracy_drop = cpu_accuracy - npu_accuracy
+
+        if self.min_cpu_accuracy is not None and cpu_accuracy < self.min_cpu_accuracy:
+            raise AssertionError(
+                f"Non-delegated (CPU) model accuracy ({cpu_accuracy:.4f}) is below the "
+                f"minimum required accuracy ({self.min_cpu_accuracy:.4f}). "
+                "The accuracy comparison is not meaningful when the reference model is inaccurate."
+            )
+
+        if accuracy_drop > self.max_accuracy_drop:
+            raise AssertionError(
+                f"Delegated (NPU) model accuracy ({npu_accuracy:.4f}) dropped by "
+                f"{accuracy_drop:.4f} relative to the non-delegated (CPU) model accuracy "
+                f"({cpu_accuracy:.4f}), which exceeds the maximum allowed drop "
+                f"({self.max_accuracy_drop:.4f})."
+            )
+
+    def compare_sample(
+        self,
+        sample_dir,
+        cpu_filepaths,
+        cpu_out_tensors,
+        npu_filepaths,
+        npu_out_tensors,
+    ) -> tuple[int, int, int]:
+        cpu_num_correct = 0
+        npu_num_correct = 0
+        total_samples = 0
+
+        class_id = self.parse_class_id_fn(sample_dir, self.inv_class_dict)
+
+        for idx in range(len(cpu_out_tensors)):
+
+            (cpu_out_name, cpu_tensor) = cpu_out_tensors[idx]
+            (npu_out_name, npu_tensor) = npu_out_tensors[idx]
+
+            assert cpu_out_name == npu_out_name
+            assert cpu_tensor.shape == npu_tensor.shape
+            assert np.any(
+                cpu_tensor
+            ), "Output tensor contains only zeros. This is suspicious."
+
+            cpu_class = self.postprocess_fn(cpu_tensor, cpu_filepaths[idx])
+            npu_class = self.postprocess_fn(npu_tensor, npu_filepaths[idx])
+
+            cpu_correct = cpu_class == class_id
+            npu_correct = npu_class == class_id
+
+            cpu_num_correct += (
+                cpu_correct if np.isscalar(cpu_correct) else sum(cpu_correct)
+            )
+            npu_num_correct += (
+                npu_correct if np.isscalar(npu_correct) else sum(npu_correct)
+            )
+            total_samples += 1 if np.isscalar(cpu_correct) else len(cpu_correct)
+
+        return cpu_num_correct, npu_num_correct, total_samples
 
 
 class NumericalStatsOutputComparator(BaseOutputComparator):

--- a/backends/nxp/tests/model_output_comparator.py
+++ b/backends/nxp/tests/model_output_comparator.py
@@ -89,11 +89,18 @@ class BaseOutputComparator(abc.ABC):
                     store_txt_input_tensor(npu_tensor_path, tensor_spec)
                     store_txt_input_tensor(diff_cpu_npu_tensor_path, tensor_spec)
 
-        # We need to archive the test_dir before comparison, as comparison can cause AssertionError exception
+            try:
+                self.compare_sample(sample_dir, cpu_output_tensors, npu_output_tensors)
+            except Exception as e:
+                # We need to archive the test_dir if comparison fails
+                test_dir = os.path.dirname(cpu_results_dir)
+                if logging.root.isEnabledFor(logging.DEBUG):
+                    archive_test_dir(test_dir)
+                raise e
+
         test_dir = os.path.dirname(cpu_results_dir)
         if logging.root.isEnabledFor(logging.DEBUG):
             archive_test_dir(test_dir)
-        self.compare_sample(sample_dir, cpu_output_tensors, npu_output_tensors)
 
     @abstractmethod
     def compare_sample(

--- a/backends/nxp/tests/models/test_mlperf_tiny_image_classification.py
+++ b/backends/nxp/tests/models/test_mlperf_tiny_image_classification.py
@@ -1,0 +1,131 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from functools import partial
+
+import numpy as np
+import torch
+from executorch.backends.nxp.tests.dataset_creator import (
+    FromCalibrationDataDatasetCreator,
+)
+from executorch.backends.nxp.tests.executorch_pipeline import ModelInputSpec
+from executorch.backends.nxp.tests.graph_verifier import BaseGraphVerifier
+from executorch.backends.nxp.tests.model_output_comparator import (
+    ClassificationAccuracyOutputComparator,
+    NumericalStatsOutputComparator,
+)
+
+from executorch.backends.nxp.tests.nsys_testing import (
+    lower_run_compare,
+    lower_run_compare_ptq_qat,
+    ReferenceModel,
+)
+from executorch.backends.nxp.tests.use_qat import *  # noqa F403
+import pytest
+from executorch.examples.nxp.models.mlperf_tiny.image_classification.mlperf_tiny_image_classification import (
+    MLPerfTinyImageClassification,
+)
+
+BOUNDS_MSE = {
+    "PTQ": {"channels-last": 1.859e-05, "channels-first": 7.432e-09},
+    "QAT": {"channels-last": 2.751e-07, "channels-first": 5.205e-06},
+}
+
+
+@pytest.fixture(autouse=True)
+def reseed_model_per_test_run():
+    torch.manual_seed(23)
+    np.random.seed(23)
+
+
+@pytest.mark.parametrize("channels_last", [False, True])
+def test_mlperf_tiny_classification_mse_cpu_vs_npu(
+    mocker, request, channels_last, use_qat
+):
+    # 10 samples per class
+    num_samples = 60
+
+    img_classification = MLPerfTinyImageClassification(
+        num_samples=num_samples, use_random_dataset=True
+    )
+    model = img_classification.get_eager_model()
+    dataset = img_classification.dataset
+    labels = img_classification.labels
+
+    dataset_creator = FromCalibrationDataDatasetCreator(
+        dataset, num_examples=num_samples, idx_to_label=labels
+    )
+
+    input_spec = ModelInputSpec(img_classification.input_shape)
+    if channels_last:
+        model.to(memory_format=torch.channels_last)
+        input_spec.dim_order = torch.channels_last
+
+    quant_type_key = "QAT" if use_qat else "PTQ"
+    dim_order_key = "channels-last" if channels_last else "channels-first"
+
+    mse = BOUNDS_MSE[quant_type_key][dim_order_key]
+    comparator = NumericalStatsOutputComparator(
+        max_mse_error=mse, use_softmax=True, is_classification_task=True
+    )
+    model_verifier = BaseGraphVerifier(1, [])
+    train_fn = (
+        partial(img_classification.train_model_fn, channels_last=channels_last)
+        if use_qat
+        else None
+    )
+
+    # This model does not work in channels-last format and QAT. See more information below.
+    # Github issue: https://github.com/pytorch/executorch/issues/22179
+    # NXP internal issue ID: EIEX-1065
+    ref_model = (
+        ReferenceModel.QUANTIZED_EDGE_PYTHON
+        if channels_last and use_qat
+        else ReferenceModel.QUANTIZED_EXECUTORCH_CPP
+    )
+
+    lower_run_compare(
+        model,
+        [input_spec],
+        model_verifier,
+        request,
+        dataset_creator=dataset_creator,
+        output_comparator=comparator,
+        reference_model=ref_model,
+        mocker=mocker,
+        use_qat=use_qat,
+        train_fn=train_fn,
+    )
+
+
+def test_mlperf_tiny_image_classification_ptq_qat_equivalence(request):
+    # 10 samples per class
+    num_samples = 60
+
+    img_classification = MLPerfTinyImageClassification(
+        num_samples=num_samples, use_random_dataset=True
+    )
+
+    model = img_classification.get_eager_model()
+    dataset = img_classification.dataset
+    labels = img_classification.labels
+
+    dataset_creator = FromCalibrationDataDatasetCreator(
+        dataset, num_examples=num_samples, idx_to_label=labels
+    )
+    comparator = ClassificationAccuracyOutputComparator(class_dict=labels)
+
+    input_spec = ModelInputSpec(img_classification.input_shape)
+    model_verifier = BaseGraphVerifier(1, [])
+
+    lower_run_compare_ptq_qat(
+        model,
+        [input_spec],
+        model_verifier,
+        request,
+        train_fn=img_classification.train_model_fn,
+        dataset_creator=dataset_creator,
+        output_comparator=comparator,
+    )

--- a/backends/nxp/tests/nsys_testing.py
+++ b/backends/nxp/tests/nsys_testing.py
@@ -34,6 +34,7 @@ from executorch.backends.nxp.tests.dataset_creator import (
 from executorch.backends.nxp.tests.executorch_pipeline import (
     get_calibration_inputs_fn_from_dataset_dir,
     ModelInputSpec,
+    to_edge_program,
     to_model_input_spec,
     to_quantized_edge_program,
     to_quantized_executorch_program,
@@ -230,6 +231,24 @@ def _run_non_delegated_executorch_program(
     execute_cmd(non_delegated_cmd)
 
     return non_delegated_program.exported_program()
+
+
+def _save_non_quantized_fp32_executorch_program(
+    model,
+    test_dir,
+    test_name,
+    input_spec,
+) -> ExportedProgram:
+    non_quantized_program = to_edge_program(model, input_spec).to_executorch()
+
+    nodes = list(non_quantized_program.exported_program().graph.nodes)
+    assert all(
+        not node.name.startswith("executorch_call_delegate") for node in nodes
+    ), "Delegated parts found in non-quantized FP32 program!"
+
+    save_pte_program(non_quantized_program, test_name + "_non_quantized", test_dir)
+
+    return non_quantized_program.exported_program()
 
 
 def read_prepared_samples(
@@ -457,6 +476,7 @@ def lower_run_compare(
 
     model_to_delegate = model
     model_to_not_delegate = deepcopy(model)
+    model_to_export_fp32 = deepcopy(model)
 
     test_name = get_test_name(request)
     test_dir = os.path.join(OUTPUTS_DIR, test_name)
@@ -474,6 +494,13 @@ def lower_run_compare(
 
     cpu_results_dir = os.path.join(test_dir, "results_cpu")
     npu_results_dir = os.path.join(test_dir, "results_npu")
+
+    _save_non_quantized_fp32_executorch_program(
+        model_to_export_fp32,
+        test_dir,
+        test_name,
+        input_spec,
+    )
 
     delegated_program, testing_dataset_dir = _run_delegated_executorch_program(
         model_to_delegate,

--- a/backends/nxp/tests/nsys_testing.py
+++ b/backends/nxp/tests/nsys_testing.py
@@ -782,13 +782,19 @@ def get_executorch_git_info() -> dict[str, str]:
 def dump_debug_test_summary(test_name: str, test_dir: str):
     git_info = get_executorch_git_info()
 
+    # During development, the NSYS in virtual env is not used.
+    nsys_version = (
+        "Internal build from executorch-integration"
+        if NSYS_PATH is not None
+        else version("eiq_nsys")
+    )
     summary = {
         "test_name": test_name,
         "date_time": datetime.datetime.now().isoformat(),
         "git_branch": git_info["git_branch"],
         "git_commit": git_info["git_commit"],
         "eiq_neutron_sdk_version": version("eiq_neutron_sdk"),
-        "eiq_nsys_version": version("eiq_nsys"),
+        "eiq_nsys_version": nsys_version,
     }
     with open(os.path.join(test_dir, "summary.yaml"), "w") as f:
         yaml.dump(summary, f)

--- a/backends/nxp/tests/nsys_testing.py
+++ b/backends/nxp/tests/nsys_testing.py
@@ -39,12 +39,15 @@ from executorch.backends.nxp.tests.executorch_pipeline import (
     to_quantized_edge_program,
     to_quantized_executorch_program,
 )
+from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.backends.nxp.tests.graph_verifier import GraphVerifier
 from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
+from executorch.backends.nxp.tests.ops_aliases import ExecutorchDelegateCall
 from executorch.backends.nxp.tests.outputs_dir_importer import outputs_dir
 from executorch.backends.nxp.tests.utils import save_pte_program, store_txt_input_tensor
+
 from executorch.devtools.visualization.visualization_utils import (
     visualize_with_clusters,
 )
@@ -146,9 +149,8 @@ def _run_delegated_executorch_program(
         raise
 
     exported_program = delegated_program.exported_program()
-    nodes = list(exported_program.graph.nodes)
-    assert any(
-        node.name.startswith("executorch_call_delegate") for node in nodes
+    assert graph_contains_any_of_ops(
+        exported_program.graph, [ExecutorchDelegateCall]
     ), "No delegated parts found in program delegated to NPU!"
     dlg_model_verifier.verify_graph(exported_program.graph)
 
@@ -214,9 +216,8 @@ def _run_non_delegated_executorch_program(
         remove_quant_io_ops=remove_quant_io_ops,
     )
 
-    nodes = list(non_delegated_program.exported_program().graph.nodes)
-    assert all(
-        not node.name.startswith("executorch_call_delegate") for node in nodes
+    assert not graph_contains_any_of_ops(
+        non_delegated_program.exported_program().graph, [ExecutorchDelegateCall]
     ), "Delegated parts found in program executed on CPU!"
 
     save_pte_program(non_delegated_program, test_name + "_non_delegated", test_dir)
@@ -241,9 +242,8 @@ def _save_non_quantized_fp32_executorch_program(
 ) -> ExportedProgram:
     non_quantized_program = to_edge_program(model, input_spec).to_executorch()
 
-    nodes = list(non_quantized_program.exported_program().graph.nodes)
-    assert all(
-        not node.name.startswith("executorch_call_delegate") for node in nodes
+    assert not graph_contains_any_of_ops(
+        non_quantized_program.exported_program().graph, [ExecutorchDelegateCall]
     ), "Delegated parts found in non-quantized FP32 program!"
 
     save_pte_program(non_quantized_program, test_name + "_non_quantized", test_dir)

--- a/examples/nxp/__init__.py
+++ b/examples/nxp/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -36,6 +36,16 @@ from executorch.devtools.visualization.visualization_utils import (
 )
 from executorch.examples.models import MODEL_NAME_TO_MODEL
 from executorch.examples.models.model_factory import EagerModelFactory
+
+from executorch.examples.nxp.experimental.cifar_net.cifar_net import (
+    CifarNet,
+    train_cifarnet_model,
+    verify_cifarnet_model,
+)
+from executorch.examples.nxp.models.mlperf_tiny.image_classification.mlperf_tiny_image_classification import (
+    MLPerfTinyImageClassification,
+)
+from executorch.examples.nxp.models.mobilenet_v2 import MobilenetV2
 from executorch.exir import (
     EdgeCompileConfig,
     ExecutorchBackendConfig,
@@ -49,18 +59,18 @@ from torchao.quantization.pt2e import (
 )
 from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_qat_pt2e
 
-from .experimental.cifar_net.cifar_net import (
-    CifarNet,
-    train_cifarnet_model,
-    verify_cifarnet_model,
-)
-from .models.mobilenet_v2 import MobilenetV2
+
+MODELS = {
+    "cifar10": CifarNet,
+    "mobilenetv2": MobilenetV2,
+    "mlperf_tiny_image_classification": MLPerfTinyImageClassification,
+}
 
 FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
 logging.basicConfig(level=logging.INFO, format=FORMAT)
 
 
-def print_ops_in_edge_program(edge_program):
+def _print_ops_in_edge_program(edge_program):
     """Find all ops used in the `edge_program` and print them out along with their occurrence counts."""
 
     ops_and_counts = defaultdict(
@@ -88,27 +98,39 @@ def print_ops_in_edge_program(edge_program):
         print(f"{op: <50} {count}x")
 
 
-def get_model_and_inputs_from_name(model_name: str, use_random_dataset: bool):
-    """Given the name of an example pytorch model, return it, example inputs and calibration inputs (can be None)
+def _get_model_info_from_name(
+    model_name: str, dataset_path: str | None, use_random_dataset: bool
+):
+    """Given the name of an example pytorch model and args, return the model, its class instance (can be None), example inputs and calibration inputs (can be None).
 
     Raises RuntimeError if there is no example model corresponding to the given name.
     """
 
     calibration_inputs = None
     # Case 1: Model is defined in this file
-    if model_name in models.keys():
-        if use_random_dataset:
-            if model_name != "mobilenetv2":
+    if model_name in MODELS.keys():
+        model_cls = MODELS[model_name]
+        # TODO: establish a common interface or a factory for all models
+        if model_cls is CifarNet:
+            if use_random_dataset:
                 raise NotImplementedError(
                     f"Random dataset for model {model_name} is not implemented."
                 )
-            m = models[model_name](use_random_dataset=use_random_dataset)
-        else:
-            m = models[model_name]()
+            model_cls_inst = model_cls()
 
-        model = m.get_eager_model()
-        example_inputs = m.get_example_inputs()
-        calibration_inputs = m.get_calibration_inputs(64)
+        elif model_cls is MLPerfTinyImageClassification:
+            model_cls_inst = model_cls(
+                dataset_path=dataset_path, use_random_dataset=use_random_dataset
+            )
+
+        else:
+            model_cls_inst = model_cls(use_random_dataset=use_random_dataset)
+
+        model = model_cls_inst.get_eager_model()
+        example_inputs = model_cls_inst.get_example_inputs()
+        calibration_inputs = model_cls_inst.get_calibration_inputs(64)
+
+        return model, example_inputs, calibration_inputs, model_cls_inst
     # Case 2: Model is defined in executorch/examples/models/
     elif model_name in MODEL_NAME_TO_MODEL.keys():
         logging.warning(
@@ -117,27 +139,21 @@ def get_model_and_inputs_from_name(model_name: str, use_random_dataset: bool):
         model, example_inputs, _, _ = EagerModelFactory.create_model(
             *MODEL_NAME_TO_MODEL[model_name]
         )
+
+        return model, example_inputs, calibration_inputs, None
     else:
         raise RuntimeError(
             f"Model '{model_name}' is not a valid name. Use --help for a list of available models."
         )
 
-    return model, example_inputs, calibration_inputs
 
-
-models = {
-    "cifar10": CifarNet,
-    "mobilenetv2": MobilenetV2,
-}
-
-
-if __name__ == "__main__":  # noqa C901
+def _get_arg_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-m",
         "--model_name",
         required=True,
-        help=f"Provide model name. Valid ones: {set(models.keys())}",
+        help=f"Provide model name. Valid ones: {set(MODELS.keys())}",
     )
     parser.add_argument(
         "-d",
@@ -180,7 +196,7 @@ if __name__ == "__main__":  # noqa C901
         "--so_library",
         required=False,
         default=None,
-        help="Path to custome kernel library",
+        help="Path to custom kernel library",
     )
     parser.add_argument(
         "--debug", action="store_true", help="Set the logging level to debug."
@@ -241,6 +257,13 @@ if __name__ == "__main__":  # noqa C901
         help="The calibration and testing datasets will be generated randomly instead of being downloaded.",
     )
     parser.add_argument(
+        "-dst",
+        "--dataset_path",
+        required=False,
+        default=None,
+        help="Path to custom dataset archive (.pt, .xz) to use for calibration.",
+    )
+    parser.add_argument(
         "--fetch_constants_to_sram",
         required=False,
         default=False,
@@ -248,7 +271,11 @@ if __name__ == "__main__":  # noqa C901
         help="This feature allows running models which do not fit into SRAM by offloading them to an external memory.",
     )
 
-    args = parser.parse_args()
+    return parser
+
+
+if __name__ == "__main__":  # noqa C901
+    args = _get_arg_parser().parse_args()
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG, format=FORMAT, force=True)
@@ -256,8 +283,10 @@ if __name__ == "__main__":  # noqa C901
     neutron_target_spec = NeutronTargetSpec(target=args.target)
 
     # 1. pick model from one of the supported lists
-    model, example_inputs, calibration_inputs = get_model_and_inputs_from_name(
-        args.model_name, args.use_random_dataset
+    model, example_inputs, calibration_inputs, model_cls_inst = (
+        _get_model_info_from_name(
+            args.model_name, args.dataset_path, args.use_random_dataset
+        )
     )
     model = model.eval()
 
@@ -286,18 +315,35 @@ if __name__ == "__main__":  # noqa C901
     if args.quantize:
         quantizer = NeutronQuantizer(neutron_target_spec, is_qat=args.use_qat)
         if args.use_qat:
-            match args.model_name:
-                case "cifar10":
-                    print("Starting two epochs of QAT training with CifarNet model...")
-                    module = prepare_qat_pt2e(module, quantizer)
-                    module = move_exported_model_to_train(module)
-                    module = train_cifarnet_model(module, num_epochs=2)
-                    module = move_exported_model_to_eval(module)
-                    module = convert_pt2e(module)
-                case _:
-                    raise ValueError(
-                        f"QAT training is not supported for model '{args.model_name}'"
-                    )
+            if not isinstance(
+                model_cls_inst, (CifarNet, MLPerfTinyImageClassification)
+            ):
+                raise ValueError(
+                    f"QAT training is not supported for model '{args.model_name}'"
+                )
+
+            if isinstance(model_cls_inst, CifarNet):
+                print("Starting two epochs of QAT training with CifarNet model...")
+                module = prepare_qat_pt2e(module, quantizer)
+                module = move_exported_model_to_train(module)
+                module = train_cifarnet_model(module, num_epochs=2)
+                module = move_exported_model_to_eval(module)
+                module = convert_pt2e(module)
+
+            else:
+                print(
+                    f"Starting two epochs of QAT training with {args.model_name} model..."
+                )
+                module = prepare_qat_pt2e(module, quantizer)
+                module = move_exported_model_to_train(module)
+                module = model_cls_inst.train_model_fn(
+                    module,
+                    num_epochs=2,
+                    channels_last=args.use_channels_last_dim_order,
+                )
+                module = move_exported_model_to_eval(module)
+                module = convert_pt2e(module)
+
         else:
             if calibration_inputs is None:
                 logging.warning(

--- a/examples/nxp/experimental/__init__.py
+++ b/examples/nxp/experimental/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/nxp/experimental/cifar_net/__init__.py
+++ b/examples/nxp/experimental/cifar_net/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/nxp/models/__init__.py
+++ b/examples/nxp/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/nxp/models/mlperf_tiny/__init__.py
+++ b/examples/nxp/models/mlperf_tiny/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/nxp/models/mlperf_tiny/image_classification/__init__.py
+++ b/examples/nxp/models/mlperf_tiny/image_classification/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/nxp/models/mlperf_tiny/image_classification/mlperf_tiny_image_classification.py
+++ b/examples/nxp/models/mlperf_tiny/image_classification/mlperf_tiny_image_classification.py
@@ -1,0 +1,108 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+from pathlib import Path
+
+import torch
+
+from executorch.backends.nxp.tests.calibration_dataset import (
+    CalibrationDataset,
+    RandomCalibrationDataset,
+)
+
+from executorch.examples.models.mlperf_tiny import ResNet8
+from executorch.examples.nxp.models.mlperf_tiny.mlperf_tiny_model import MLPerfTinyModel
+from torch.utils.data import Dataset
+from torchao.quantization.pt2e import disable_observer
+from tqdm import tqdm
+
+log = logging.getLogger(__name__)
+
+INPUT_SHAPE = (1, 3, 32, 32)
+IDX_TO_LABEL = {
+    0: "airplane",
+    1: "automobile",
+    2: "bird",
+    3: "cat",
+    4: "deer",
+    5: "dog",
+    6: "frog",
+    7: "horse",
+    8: "ship",
+    9: "truck",
+}
+
+
+class MLPerfTinyImageClassification(MLPerfTinyModel):
+    """MLPerf Tiny image classification model (ResNet-8)."""
+
+    def __init__(
+        self,
+        num_samples: int = 200,
+        dataset_path: Path | str | None = None,
+        use_random_dataset: bool = False,
+    ):
+        self._num_samples = num_samples
+        self._use_random_dataset = use_random_dataset
+        self._dataset_path = dataset_path
+
+        super().__init__()
+
+    @property
+    def input_shape(self):
+        return INPUT_SHAPE
+
+    @property
+    def labels(self):
+        return IDX_TO_LABEL
+
+    def _init_dataset(self) -> Dataset:
+        if self._use_random_dataset:
+            num_classes = len(self.labels)
+            sample_shape = tuple(self.input_shape)[1:]
+            return RandomCalibrationDataset(
+                self._num_samples, sample_shape, num_classes
+            )
+        else:
+            if self._dataset_path is None:
+                raise ValueError(
+                    "Path to dataset data cannot be empty. If you want to use random data, set `use_random_dataset = True`"
+                )
+            return CalibrationDataset(self._dataset_path)
+
+    def _init_eager_model(self) -> torch.nn.Module:
+        num_classes = len(self.labels)
+        return ResNet8(num_classes)
+
+    def train_model_fn(self, model, num_epochs=15, batch_size=20, channels_last=False):
+        torch.manual_seed(42)
+        torch.use_deterministic_algorithms(True)
+
+        optimizer = torch.optim.Adam(
+            params=model.parameters(),
+            lr=1e-5,
+            weight_decay=1e-4,
+        )
+        loss_fn = torch.nn.CrossEntropyLoss()
+
+        logging.warning("Starting training...")
+
+        data = self.get_qat_train_inputs(batch_size=batch_size)
+        for nepoch in range(num_epochs):
+            for images, labels in tqdm(data):
+                if channels_last:
+                    images = images.to(memory_format=torch.channels_last)
+
+                optimizer.zero_grad()
+                outputs = model(images)
+                loss = loss_fn(outputs, labels)
+                loss.backward()
+                optimizer.step()
+
+            if nepoch >= num_epochs / 3:
+                model.apply(disable_observer)
+
+        return model

--- a/examples/nxp/models/mlperf_tiny/mlperf_tiny_model.py
+++ b/examples/nxp/models/mlperf_tiny/mlperf_tiny_model.py
@@ -1,0 +1,81 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+from abc import abstractmethod
+from typing import Iterator
+
+import torch
+from executorch.examples.models import model_base
+from torch.utils.data import DataLoader, Dataset
+
+
+class MLPerfTinyModel(model_base.EagerModelBase):
+    """Base class of the MLPerf Tiny models."""
+
+    def __init__(self):
+        """Create the model wrapper along with the dataset it owns."""
+        self._num_workers = 4
+
+        self._eager_model = self._init_eager_model()
+        self.dataset = self._init_dataset()
+
+    @staticmethod
+    def _collate_fn(data: list[tuple]):
+        data, labels = zip(*data)
+        return torch.stack(list(data)), torch.tensor(list(labels))
+
+    @abstractmethod
+    def _init_dataset(self) -> Dataset:
+        pass
+
+    @abstractmethod
+    def _init_eager_model(self) -> torch.nn.Module:
+        pass
+
+    @property
+    @abstractmethod
+    def input_shape(self):
+        pass
+
+    @property
+    @abstractmethod
+    def labels(self):
+        pass
+
+    def get_qat_train_inputs(
+        self, batch_size: int = 5, dataset_portion: float = 0.1
+    ) -> Iterator[tuple[torch.Tensor]]:
+        """Return an iterator over a portion of the model dataset, to be used for QAT."""
+        reduced_dataset = torch.utils.data.Subset(
+            self.dataset, range(int(len(self.dataset) * dataset_portion))
+        )
+        reduced_loader = DataLoader(
+            reduced_dataset,
+            batch_size=batch_size,
+            collate_fn=self._collate_fn,
+            num_workers=self._num_workers,
+            pin_memory=True,
+        )
+        return iter(reduced_loader)
+
+    def get_calibration_inputs(
+        self, batch_size: int = 1
+    ) -> Iterator[tuple[torch.Tensor]]:
+        """Return an iterator over the model dataset, to be used for post training quantization."""
+        loader = DataLoader(
+            self.dataset,
+            batch_size=batch_size,
+            collate_fn=self._collate_fn,
+            num_workers=self._num_workers,
+            pin_memory=True,
+        )
+        return itertools.starmap(lambda data, _: (data,), iter(loader))
+
+    def get_eager_model(self):
+        return self._eager_model
+
+    def get_example_inputs(self) -> tuple[torch.Tensor]:
+        return (torch.randn(self.input_shape, dtype=torch.float32),)

--- a/src/executorch/examples/nxp
+++ b/src/executorch/examples/nxp
@@ -1,0 +1,1 @@
+../../../examples/nxp

--- a/src/executorch/examples/nxp/experimental
+++ b/src/executorch/examples/nxp/experimental
@@ -1,1 +1,0 @@
-../../../../examples/nxp/experimental/


### PR DESCRIPTION
### Summary

Enable and refactor MLPerf Tiny Classification tests.

### Test plan

tests can be manually run using `pytest -c /dev/null backends/nxp/tests/`

cc @robert-kalmar @JakeStevens @digantdesai @rascani @roman-janik-nxp 