### PR TITLE
change submit -> update in arduino lint call

### DIFF
--- a/.github/workflows/_test_arduino_library.yml
+++ b/.github/workflows/_test_arduino_library.yml
@@ -89,4 +89,4 @@ jobs:
         cp ../../LICENSE arduino_lib/ExecuTorch/LICENSE
         cp README.md arduino_lib/ExecuTorch/README.md
         (cd arduino_lib/ExecuTorch && arduino-lint \
-          --project-type library --library-manager submit --compliance strict)
+          --project-type library --library-manager update --compliance strict)


### PR DESCRIPTION
Summary: `submit` results in the error "Library name ExecuTorch is in use by a library in the Library Manager index" now that it is in the index. Per linter rule LP017, switch to update now.

Differential Revision: D115880353


