### PR TITLE
Add check for QNN_SDK_ROOT in hadamard pass (#21815)

### DIFF
--- a/backends/qualcomm/_passes/recompose_hadamard.py
+++ b/backends/qualcomm/_passes/recompose_hadamard.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+import os
 from operator import attrgetter
 
 import torch
@@ -156,7 +157,7 @@ class RecomposeHadamard(ExportPass):
     def call(self, graph_module: torch.fx.GraphModule):
         # HadamardTransform is only supported by QNN 2.47+. On older SDKs skip the
         # rewrite so the op keeps its normal lowering path.
-        if is_qnn_sdk_version_less_than("2.47"):
+        if not os.environ.get("QNN_SDK_ROOT") or is_qnn_sdk_version_less_than("2.47"):
             return PassResult(graph_module, False)
 
         graph = graph_module.graph


### PR DESCRIPTION
Summary:

PR  #21729 added HadamardTransform op support, gated on a qnn sdk version. The version check assumed QNN_SDK_ROOT was available, resulting in errors when it is not.

This PR matches other usage like op_embedding.py to fallback when SDK is absent.

Reviewed By: rascani

Differential Revision: D115881389


