### PR TITLE
Cortex-M backend: supply a zero bias for grouped convolutions

### DIFF
--- a/backends/cortex_m/passes/aten_to_cortex_m_pass.py
+++ b/backends/cortex_m/passes/aten_to_cortex_m_pass.py
@@ -538,6 +538,19 @@ def _get_convolution_replacement(
         weight_permuted = param_weight_tensor.permute(0, 2, 3, 1).contiguous()
 
     with node.graph.inserting_after(weight):
+        if bias is None and groups > 1:
+            # CMSIS-NN's grouped kernels offset the bias per group, and the MVE
+            # depthwise one per channel block, so they need a real pointer rather
+            # than null. Supplied for both paths on every target: which depthwise
+            # kernel a convolution reaches is not predictable from the graph.
+            bias = create_constant_placeholder(
+                exported_program,
+                node.graph,
+                node.name + "_zero_bias",
+                InputKind.PARAMETER,
+                torch.zeros(out_channels, dtype=torch.int32),
+            )
+
         weight_nhwc = create_constant_placeholder(
             exported_program,
             node.graph,

--- a/backends/cortex_m/test/ops/test_conv.py
+++ b/backends/cortex_m/test/ops/test_conv.py
@@ -359,22 +359,19 @@ def test_implementation_conv2d(test_case, cortex_m_target):
 
 
 @parametrize(
-    "case_name",
-    {
-        "conv2d_groups": ("conv2d_groups", "quantized_conv2d"),
-        "depthwise_conv2d": ("depthwise_conv2d", "quantized_depthwise_conv2d"),
-    },
+    "test_case",
+    {name: test_cases[name] for name in ("conv2d_groups", "depthwise_conv2d")},
 )
-def test_grouped_conv2d_bias_is_populated(case_name, cortex_m_target):
+def test_grouped_conv2d_bias_is_populated(test_case, cortex_m_target):
     """Assert a bias-less grouped convolution reaches the kernel with a bias.
+
     The numeric cases only cover this on the FVP leg and only while their
-    reference output stays clear of saturation, and the depthwise kernel offsets
-    the bias by whole channel blocks, so it takes hundreds of channels before a
-    missing bias shows up at all — far more than any case here."""
-    case_key, op_name = case_name
-    case = test_cases[case_key]
+    reference output stays clear of saturation, and the depthwise kernel
+    offsets the bias by whole channel blocks, so it takes hundreds of channels
+    before a missing bias shows up at all -- far more than any case here.
+    """
     tester = CortexMTester(
-        case.model, case.example_inputs, target_config=cortex_m_target
+        test_case.model, test_case.example_inputs, target_config=cortex_m_target
     )
     tester.quantize()
     tester.export()
@@ -382,8 +379,13 @@ def test_grouped_conv2d_bias_is_populated(case_name, cortex_m_target):
     tester.run_passes()
 
     module = tester.get_artifact(StageType.RUN_PASSES).exported_program().module()
-    target = getattr(exir_ops.edge.cortex_m, op_name).default
+    grouped_convs = (
+        exir_ops.edge.cortex_m.quantized_conv2d.default,
+        exir_ops.edge.cortex_m.quantized_depthwise_conv2d.default,
+    )
     [conv_node] = [
-        n for n in module.graph.nodes if n.op == "call_function" and n.target == target
+        n
+        for n in module.graph.nodes
+        if n.op == "call_function" and n.target in grouped_convs
     ]
     assert conv_node.args[2] is not None

--- a/backends/cortex_m/test/ops/test_conv.py
+++ b/backends/cortex_m/test/ops/test_conv.py
@@ -11,6 +11,8 @@ from executorch.backends.cortex_m.test.tester import (
     McuTestCase,
     ramp_tensor,
 )
+from executorch.backends.test.harness.stages import StageType
+from executorch.exir.dialects._ops import ops as exir_ops
 
 
 class CortexMConv1D(torch.nn.Module):
@@ -181,10 +183,21 @@ test_cases = {
             ramp_tensor(0, 10, (3, 1, 8, 8)).to(memory_format=torch.channels_last),
         ),
     ),
+    # A bias-less grouped convolution is what needs a bias synthesized for it, so
+    # keep this case bias-less, keep groups > 1, and keep the reference output
+    # away from saturation: the previous 1x1-output version summed an
+    # all-positive ramp straight to qmax, where a wrong result is
+    # indistinguishable from the correct one.
     "conv2d_groups": McuTestCase(
-        model=CortexMConv2D(4, 4, 1, groups=2),
+        model=CortexMConv2D(4, 4, 3, padding=1, groups=2),
         example_inputs=(
-            ramp_tensor(0, 10, (1, 4, 1, 1)).to(memory_format=torch.channels_last),
+            ramp_tensor(-5, 5, (1, 4, 8, 8)).to(memory_format=torch.channels_last),
+        ),
+    ),
+    "conv2d_groups_bias": McuTestCase(
+        model=CortexMConv2DBias(4, 4, 3, padding=1, groups=2),
+        example_inputs=(
+            ramp_tensor(-5, 5, (1, 4, 8, 8)).to(memory_format=torch.channels_last),
         ),
     ),
     "conv2d_bias_ch_out_1": McuTestCase(
@@ -343,3 +356,34 @@ def test_implementation_conv2d(test_case, cortex_m_target):
         test_case.model, test_case.example_inputs, target_config=cortex_m_target
     )
     tester.test_implementation(qtol=2)
+
+
+@parametrize(
+    "case_name",
+    {
+        "conv2d_groups": ("conv2d_groups", "quantized_conv2d"),
+        "depthwise_conv2d": ("depthwise_conv2d", "quantized_depthwise_conv2d"),
+    },
+)
+def test_grouped_conv2d_bias_is_populated(case_name, cortex_m_target):
+    """Assert a bias-less grouped convolution reaches the kernel with a bias.
+    The numeric cases only cover this on the FVP leg and only while their
+    reference output stays clear of saturation, and the depthwise kernel offsets
+    the bias by whole channel blocks, so it takes hundreds of channels before a
+    missing bias shows up at all — far more than any case here."""
+    case_key, op_name = case_name
+    case = test_cases[case_key]
+    tester = CortexMTester(
+        case.model, case.example_inputs, target_config=cortex_m_target
+    )
+    tester.quantize()
+    tester.export()
+    tester.to_edge()
+    tester.run_passes()
+
+    module = tester.get_artifact(StageType.RUN_PASSES).exported_program().module()
+    target = getattr(exir_ops.edge.cortex_m, op_name).default
+    [conv_node] = [
+        n for n in module.graph.nodes if n.op == "call_function" and n.target == target
+    ]
+    assert conv_node.args[2] is not None


### PR DESCRIPTION
### Summary
CMSIS-NN's grouped convolutions index the bias per group rather than from a fixed base, so they need a real bias pointer: arm_convolve_s8 advances it once per group in every build, and the MVE arm_depthwise_conv_s8_opt offsets it per channel block. Leaving it null means those kernels read from an offset null pointer, and on Corstone-300 the affected output channels come back pinned at the int8 ceiling. Lower a zero bias for convolutions that do not have one.

Both paths get it on every target. Strictly only the MVE depthwise kernel needs it, since the DSP and scalar depthwise kernels re-base per row, but which depthwise kernel a convolution reaches depends on channel multiplier, batch, dilation, kernel size and padding, and that is not worth predicting from the graph. It costs nothing on the models in tree, where every convolution already carries a folded bias.

The existing conv2d_groups test missed this because its all-positive ramp summed straight to qmax, where a wrong result is indistinguishable from the correct one; it now convolves 3x3 over 8x8 with a signed input. A grouped case that does carry a bias is added next to it, and a structural test asserts the bias slot is populated for both the grouped and depthwise ops, since the numeric cases only cover this on the FVP leg and cannot reach the depthwise channel counts at all.

### Test plan
Verified on Corstone-300 for scalar (cortex-m0plus), DSP (cortex-m7) and MVE (cortex-m55).
