### PR TITLE
Arm backend: Fix Cortex-M55 CPU cycle measurements

### DIFF
--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -300,7 +300,7 @@ unsigned char __attribute__((
 constexpr size_t FAST_MEMORY_REGION_INDEX = 2;
 
 [[maybe_unused]] void et_pal_init(void) {
-#if defined(__ARM_ARCH_8_1M_MAIN__)
+#if defined(__PMU_PRESENT) && (__PMU_PRESENT == 1U)
   // Armv8.1-M Mainline cores (M55, M85) have the optional PMU extension.
   // Pre-Armv8.1-M cores lack ARM_PMU_*; et_pal_current_ticks() returns 0.
   ARM_PMU_Enable();
@@ -327,7 +327,7 @@ constexpr size_t FAST_MEMORY_REGION_INDEX = 2;
 }
 
 [[maybe_unused]] et_timestamp_t et_pal_current_ticks(void) {
-#if defined(__ARM_ARCH_8_1M_MAIN__)
+#if defined(__PMU_PRESENT) && (__PMU_PRESENT == 1U)
   return ARM_PMU_Get_CCNTR();
 #else
   return 0;

--- a/examples/arm/executor_runner/arm_perf_monitor.cpp
+++ b/examples/arm/executor_runner/arm_perf_monitor.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024-2025 Arm Limited and/or its affiliates.
+/* Copyright 2024-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -18,7 +18,7 @@ namespace {
 
 // Returns the Armv8.1-M PMU cycle counter; 0 on cores without it.
 static inline uint64_t arm_pmu_cycles() {
-#if defined(__ARM_ARCH_8_1M_MAIN__)
+#if defined(__PMU_PRESENT) && (__PMU_PRESENT == 1U)
   return ARM_PMU_Get_CCNTR();
 #else
   return 0;
@@ -139,7 +139,7 @@ void StartMeasurements() {
 }
 
 void StopMeasurements(int num_inferences) {
-#if defined(__ARM_ARCH_8_1M_MAIN__)
+#if defined(__PMU_PRESENT) && (__PMU_PRESENT == 1U)
   ARM_PMU_CNTR_Disable(
       PMU_CNTENCLR_CCNTR_ENABLE_Msk | PMU_CNTENCLR_CNT0_ENABLE_Msk |
       PMU_CNTENCLR_CNT1_ENABLE_Msk);


### PR DESCRIPTION
The affected GCC Arm Cortex-M55 build defines __ARM_ARCH_8M_MAIN__, so the existing __ARM_ARCH_8_1M_MAIN__ guard excludes PMU initialization and counter reads. Consequently, inference runtime is always reported as zero CPU cycles on the Cortex-M55 FPGA.

Guard PMU access using the CMSIS __PMU_PRESENT device capability. This describes the hardware requirement directly and avoids relying on architecture macros or a list of specific processor names.



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @Sebastian-Larsson @robell @rascani