### PR TITLE
Treat an empty LLM data path as absent

### DIFF
--- a/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleConfigTest.kt
+++ b/extension/android/executorch_android/src/androidTest/java/org/pytorch/executorch/LlmModuleConfigTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package org.pytorch.executorch
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.pytorch.executorch.extension.llm.LlmModuleConfig
+
+/** Tests for [LlmModuleConfig]. */
+@RunWith(AndroidJUnit4::class)
+class LlmModuleConfigTest {
+
+  @Test
+  fun testDataPathDefaultsToNull() {
+    // An empty default reaches the runner as a real path, which then fails to open and takes the
+    // whole load down. Absent has to be null.
+    val config =
+        LlmModuleConfig.create().modulePath("/model.pte").tokenizerPath("/tokenizer.json").build()
+    assertNull(config.dataPath)
+  }
+
+  @Test
+  fun testDataPathRoundTrips() {
+    val config =
+        LlmModuleConfig.create()
+            .modulePath("/model.pte")
+            .tokenizerPath("/tokenizer.json")
+            .dataPath("/weights.ptd")
+            .build()
+    assertEquals("/weights.ptd", config.dataPath)
+  }
+
+  @Test
+  fun testDefaults() {
+    val config =
+        LlmModuleConfig.create().modulePath("/model.pte").tokenizerPath("/tokenizer.json").build()
+    assertEquals("/model.pte", config.modulePath)
+    assertEquals("/tokenizer.json", config.tokenizerPath)
+    assertEquals(LlmModuleConfig.MODEL_TYPE_TEXT, config.modelType)
+    assertEquals(LlmModuleConfig.LOAD_MODE_MMAP, config.loadMode)
+  }
+}

--- a/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModuleConfig.kt
+++ b/extension/android/executorch_android/src/main/java/org/pytorch/executorch/extension/llm/LlmModuleConfig.kt
@@ -65,7 +65,7 @@ private constructor(
     private var modulePath: String? = null
     private var tokenizerPath: String? = null
     private var temperature: Float = 0.8f
-    private var dataPath: String? = ""
+    private var dataPath: String? = null
     private var modelType: Int = MODEL_TYPE_TEXT
     private var numBos: Int = 0
     private var numEos: Int = 0

--- a/extension/llm/runner/llm_runner_helper.cpp
+++ b/extension/llm/runner/llm_runner_helper.cpp
@@ -189,7 +189,10 @@ std::unique_ptr<TextLLMRunner> create_text_llm_runner(
     float temperature,
     const std::string& method_name,
     Module::LoadMode load_mode) {
-  if (data_path.has_value()) {
+  // An empty path is not a path. Callers that build the optional from a
+  // language whose "no value" is an empty string would otherwise reach the
+  // loader with "", which fails to open and takes the whole load down with it.
+  if (data_path.has_value() && !data_path.value().empty()) {
     std::vector<std::string> data_files;
     data_files.push_back(data_path.value());
     return create_text_llm_runner(
@@ -355,7 +358,7 @@ std::unique_ptr<MultimodalRunner> create_multimodal_runner(
 
   // Create the Module
   std::unique_ptr<Module> module;
-  if (data_path.has_value()) {
+  if (data_path.has_value() && !data_path.value().empty()) {
     module = std::make_unique<Module>(model_path, data_path.value(), load_mode);
   } else {
     module = std::make_unique<Module>(model_path, load_mode);


### PR DESCRIPTION
`LlmModuleConfig.Builder` defaults `dataPath` to `""`, and `create_text_llm_runner` takes whatever the optional holds — the empty string included. So an Android caller that never asked for a separate data file still reaches the loader with `""`:

```
[llm_runner_helper.cpp:255] Reading metadata from model
[mmap_data_loader.cpp:94] Failed to open : No such file or directory (2)
[llm_runner_helper.cpp:105] Failed reading method names
[llm_runner_helper.cpp:258] Failed to get metadata from model
```

Because `LlmModule.load()` reports failure through `throwExecutorchException`, this comes out as `Fatal signal 6 (SIGABRT)` with abort message `'ptr'` and the process dies, rather than an error the app can catch. That is what makes it hard to place: nothing in the message points at a data path, and the same `.pte` and tokenizer work everywhere else.

Reproducing it takes only the documented builder call — no data file, no unusual model:

```kotlin
LlmModule(
    LlmModuleConfig.create()
        .modulePath(model)
        .tokenizerPath(tokenizer)
        .modelType(LlmModuleConfig.MODEL_TYPE_TEXT)
        .build())
    .load()
```

Passing `.dataPath(null)` explicitly is the workaround.

## The change

The builder default becomes `null`, and both runner factories ignore an empty path so a caller in any language whose "no value" is an empty string lands on the no-data-file branch rather than a failed mmap. Three files: the Kotlin default, the two `data_path.has_value()` checks, and a test for the default.

I kept the guard in C++ as well as fixing the Kotlin default, because the optional is public API and an empty string will keep arriving from bindings that have no null.

## Verification

On a Pixel 8a, arm64, LFM2.5-350M exported to XNNPACK 8da4w:

- before: abort during `load()`, every time
- after: loads in ~2.0 s and generates, prefill 23.8 tok/s / decode 11.9 tok/s

Those rates are low because the phone was locked while measuring, which parks the app on the little cluster — not a property of this change.

I also confirmed the failure is not the model or the tokenizer: the `.pte` exposes the full metadata method set the runner expects, and the tokenizer loads and encodes identically on the same device through a standalone harness.

This PR was authored with Claude.


cc @kirklandsign @cbilgin @larryliu0820 @mergennachin @cccclai @helunwencser @jackzhxng @digantdesai