### PR TITLE
Arm backend: Add .bss prefix to bss sections

### DIFF
--- a/examples/arm/executor_runner/Corstone-300.ld
+++ b/examples/arm/executor_runner/Corstone-300.ld
@@ -278,8 +278,8 @@ SECTIONS
   .ddr.bss (NOLOAD) :
   {
     . = ALIGN(16);
-    *(input_file_allocator_sec)
-    *(method_allocator_sec)
+    *(.bss.input_file_allocator_sec)
+    *(.bss.method_allocator_sec)
 #if (ETHOSU_ARENA == 1)
     . = ALIGN(32);
     *(.bss.tensor_arena)

--- a/examples/arm/executor_runner/Corstone-320.ld
+++ b/examples/arm/executor_runner/Corstone-320.ld
@@ -264,6 +264,8 @@ SECTIONS
   .ddr.bss (NOLOAD) :
   {
     . = ALIGN(16);
+    *(.bss.input_file_allocator_sec)
+    *(.bss.method_allocator_sec)
     *(input_file_allocator_sec)
     *(method_allocator_sec)
 #if (ETHOSU_ARENA == 1)

--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -164,7 +164,7 @@ using printf_size_t = unsigned long;
 const size_t input_file_allocation_pool_size =
     ET_ARM_BAREMETAL_SEMIHOSTING_FILE_ALLOCATOR_POOL_SIZE;
 unsigned char __attribute__((
-    section("input_file_allocator_sec"),
+    section(".bss.input_file_allocator_sec"),
     aligned(16))) input_file_allocation_pool[input_file_allocation_pool_size];
 #endif
 
@@ -232,7 +232,7 @@ using torch::executor::etdump_result;
 const size_t method_allocation_pool_size =
     ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE;
 unsigned char __attribute__((
-    section("method_allocator_sec"),
+    section(".bss.method_allocator_sec"),
     aligned(16))) method_allocation_pool[method_allocation_pool_size];
 
 #if defined(ET_BUNDLE_IO)


### PR DESCRIPTION
Even though the .ld file ensured the final elf
did not include a large chunk of 0 data,
the object file did. By prefixing sections  with
.bss, the compiler will pick it up and fix
it already when compiling the object file.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani