### PR TITLE
Skip the Core ML wheel test on Python 3.14

### DIFF
--- a/.ci/scripts/wheel/test_linux.py
+++ b/.ci/scripts/wheel/test_linux.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import platform
+import sys
 
 import test_base
 from examples.models import Backend, Model
@@ -41,15 +42,22 @@ if __name__ == "__main__":
 
         test_base.test_cmsis_nn_install()
 
-    test_base.run_tests(
-        model_tests=[
-            test_base.ModelTest(
-                model=Model.Mv3,
-                backend=Backend.XnnpackQuantizationDelegation,
-            ),
+    model_tests = [
+        test_base.ModelTest(
+            model=Model.Mv3,
+            backend=Backend.XnnpackQuantizationDelegation,
+        ),
+    ]
+    # The wheel declares coremltools only below 3.14, because that release publishes no build for
+    # it, so on 3.14 this case would fail on the missing import rather than exercise Core ML.
+    if sys.version_info < (3, 14):
+        model_tests.append(
             test_base.ModelTest(
                 model=Model.Mv3,
                 backend=Backend.CoreMlExportOnly,
-            ),
-        ]
-    )
+            )
+        )
+    else:
+        print("Skipping the Core ML case: coremltools has no Python 3.14 build")
+
+    test_base.run_tests(model_tests=model_tests)

--- a/.ci/scripts/wheel/test_macos.py
+++ b/.ci/scripts/wheel/test_macos.py
@@ -6,21 +6,30 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import sys
+
 import test_base
 from examples.models import Backend, Model
 
 if __name__ == "__main__":
     test_base.test_cmsis_nn_install()
 
-    test_base.run_tests(
-        model_tests=[
-            test_base.ModelTest(
-                model=Model.Mv3,
-                backend=Backend.XnnpackQuantizationDelegation,
-            ),
+    model_tests = [
+        test_base.ModelTest(
+            model=Model.Mv3,
+            backend=Backend.XnnpackQuantizationDelegation,
+        ),
+    ]
+    # The wheel declares coremltools only below 3.14, because that release publishes no build for
+    # it, so on 3.14 this case would fail on the missing import rather than exercise Core ML.
+    if sys.version_info < (3, 14):
+        model_tests.append(
             test_base.ModelTest(
                 model=Model.Mv3,
                 backend=Backend.CoreMlExportAndTest,
-            ),
-        ]
-    )
+            )
+        )
+    else:
+        print("Skipping the Core ML case: coremltools has no Python 3.14 build")
+
+    test_base.run_tests(model_tests=model_tests)


### PR DESCRIPTION
## The problem

The Python 3.14 wheel jobs on Linux x86_64 and macOS fail in their smoke test with:

```
ModuleNotFoundError: No module named 'coremltools'
```

The reason is that the wheel does not declare `coremltools` on Python 3.14, because that release
publishes no build for it. The declaration in `setup.py` already says so:

```
coremltools==9.0; (platform_system == 'Darwin' or platform_system == 'Linux') and python_version < '3.14'
```

But the two wheel smoke tests run a Core ML case unconditionally:

```
.ci/scripts/wheel/test_linux.py    backend=Backend.CoreMlExportOnly
.ci/scripts/wheel/test_macos.py    backend=Backend.CoreMlExportAndTest
```

So on 3.14 that case fails on the missing import rather than testing Core ML at all. The other
platforms are unaffected, because no other wheel test script runs a Core ML case.

The pin cannot simply be raised. The first `coremltools` release with any Python 3.14 file is a
development release, which pip will not choose unless it is explicitly asked for pre-releases.

## The fix

Skip that one case on Python 3.14 and print why, leaving the rest of the smoke test in place:

```python
if sys.version_info < (3, 14):
    model_tests.append(
        test_base.ModelTest(model=Model.Mv3, backend=Backend.CoreMlExportOnly)
    )
else:
    print("Skipping the Core ML case: coremltools has no Python 3.14 build")
```

The XNNPACK case still runs on every version, so the wheel is still exercised on 3.14. This is the
smallest change that matches what the wheel actually installs.

## Testing

Verified:
- Read the failing job logs and confirmed the missing `coremltools` import is what stops the test.
- Confirmed `setup.py` already excludes `coremltools` on 3.14, so the test was asking for something
  the wheel does not ship.
- Confirmed no wheel test script other than these two names a Core ML backend, which matches the
  aarch64 and Windows jobs getting past this stage.
- Both files parse, and lint and formatting are clean.

Not verified:
- A full wheel build or its smoke tests on Python 3.14.
