### PR TITLE
Vulkan: accept a SymInt delegate arg as a plain Int EValue

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -748,12 +748,26 @@ class VulkanBackend final : public ::executorch::runtime::BackendInterface {
             args[i]->toTensor().numel(),
             equivalent_scalar_type(args[i]->toTensor().scalar_type()));
       } else if (compute_graph->val_is_symint(iref)) {
-        VK_CHECK_COND(
-            args[i]->isTensor(),
-            "Cannot handle symint arg to graph that is not derived from a "
-            "scalar tensor at the moment.");
-        bool was_updated = maybe_update_scalar_tensor(
-            compute_graph, iref, args[i]->toTensor());
+        // A SymInt input may arrive either as a scalar tensor (the convention
+        // when the value was lifted from one) or as a plain Int EValue, which
+        // is what the emitter produces when the Method's schema declares the
+        // argument as SymInt. Accept both.
+        bool was_updated = false;
+        if (args[i]->isTensor()) {
+          was_updated = maybe_update_scalar_tensor(
+              compute_graph, iref, args[i]->toTensor());
+        } else if (args[i]->isInt()) {
+          const int32_t cur_val = compute_graph->read_symint(iref);
+          const int32_t new_val = static_cast<int32_t>(args[i]->toInt());
+          if (new_val != cur_val) {
+            compute_graph->set_symint(iref, new_val);
+            was_updated = true;
+          }
+        } else {
+          VK_THROW(
+              "Could not handle symint arg: caller's EValue is neither "
+              "a scalar tensor nor an Int.");
+        }
         // Since symint inputs may impact tensor's sizes, trigger a resize if
         // any symbolic integer shapes are updated.
         should_propagate_resize = should_propagate_resize || was_updated;
@@ -830,6 +844,32 @@ class VulkanBackend final : public ::executorch::runtime::BackendInterface {
             args[o]->toTensor().mutable_data_ptr(),
             args[o]->toTensor().numel(),
             equivalent_scalar_type(args[o]->toTensor().scalar_type()));
+      } else if (compute_graph->val_is_symint(oref)) {
+        // Mirror of the input path: write the graph's current SymInt value
+        // into the caller's slot, which may be either a scalar tensor or a
+        // plain Int EValue.
+        const int32_t out_val = compute_graph->read_symint(oref);
+        if (args[o]->isTensor()) {
+          executorch::aten::Tensor& dst = args[o]->toTensor();
+          const auto dtype = dst.scalar_type();
+          if (dtype == executorch::aten::ScalarType::Int) {
+            *dst.mutable_data_ptr<int32_t>() = out_val;
+          } else if (dtype == executorch::aten::ScalarType::Long) {
+            *dst.mutable_data_ptr<int64_t>() = static_cast<int64_t>(out_val);
+          } else {
+            VK_THROW(
+                "Could not handle symint output with destination tensor dtype ",
+                static_cast<int>(dtype));
+          }
+        } else if (args[o]->isInt()) {
+          // Overwrite the EValue's int payload in place. EValue stores its int
+          // as int64_t, so a SymInt fits without truncation.
+          *args[o] = EValue(static_cast<int64_t>(out_val));
+        } else {
+          VK_THROW(
+              "Could not handle symint output: caller's EValue is neither "
+              "a scalar tensor nor an Int.");
+        }
       }
       // TensorRef values represent constant tensors which will not have been
       // modified by the graph execution. Therefore, if a constant tensor is


### PR DESCRIPTION
### Summary

`VulkanBackend::execute` required every SymInt input to arrive as a scalar
tensor:

```cpp
VK_CHECK_COND(
    args[i]->isTensor(),
    "Cannot handle symint arg to graph that is not derived from a "
    "scalar tensor at the moment.");
```

That holds when the value was lifted from a scalar tensor, but not when the
Method's schema declares the argument as `SymInt` — the emitter then passes a
plain `Int` EValue and the delegate rejects it. A dynamic-shape export whose
sequence length crosses the delegate boundary as a SymInt hits this.

This PR accepts both forms on the way in, and adds the mirrored handling on the
way out, which was missing entirely: the output loop knew about tensors and
TensorRefs but not SymInts, so a graph returning one fell through to
`"Could not handle output with type"`. An output SymInt is now written into the
caller's slot whether that slot is a scalar tensor (`Int` or `Long`) or an `Int`
EValue.

Behaviour for the existing scalar-tensor path is unchanged.

### Test plan

- Existing `backends/vulkan/test/test_vulkan_delegate.py` suite.
- On device (Galaxy S26 Ultra, Adreno): Gemma 4 and LFM2.5-VL exports whose
  decoder takes a dynamic sequence length pass the SymInt across the delegate
  boundary as a plain `Int` and generate correctly. Without this change the
  delegate aborts at the `VK_CHECK_COND` above during the first `execute()`.

Originally written by @Nklockiewicz and Mateusz Kopciński as part of Gemma 4
Vulkan enablement; extracted here as a standalone change.


cc @SS-JIA @manuelcandales @digantdesai @cbilgin

Fixes #21877
