### PR TITLE
Updating QNN backend owners list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,7 @@
 /backends/cortex_m @rascani
 /backends/example @JacobSzwejbka @larryliu0820
 /backends/mediatek @neuropilot-captain
-/backends/qualcomm @chunit-quic @haowhsu-quic @shewu-quic @winskuo-quic @abhinaykukkadapu @psiddh
+/backends/qualcomm @haowhsu-quic @shewu-quic @winskuo-quic @abhinaykukkadapu @psiddh @harshs-qti @qti-horodnic @qti-mmadhava
 /backends/test
 /backends/transforms @kimishpatel
 /backends/vulkan @SS-JIA


### PR DESCRIPTION
### Summary
Updating the QNN backend owners list with current list of engineers working on the project.
- Remove `@chunit-quic`; add `@harshs-qti`, `@qti-horodnic`, `@qti-mmadhava`.