### PR TITLE
Update Muse Glimmer GGUF filenames to canonical names

### DIFF
--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -525,10 +525,10 @@ if [ "$MODEL_NAME" = "muse_glimmer" ]; then
 
   case "$QUANT_NAME" in
     kquant-17gb)
-      TARGET_GGUF_FILE="muse-glimmer-30B-kquant-17gb.gguf"
+      TARGET_GGUF_FILE="Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf"
       ;;
     kquant-dynamic)
-      TARGET_GGUF_FILE="muse-glimmer-30B-kquant-dynamic.gguf"
+      TARGET_GGUF_FILE="Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf"
       ;;
   esac
 
@@ -547,8 +547,8 @@ if [ "$MODEL_NAME" = "muse_glimmer" ]; then
           --output-dir "${OUTPUT_DIR}"
       ;;
     dflash-image)
-      DRAFT_GGUF_FILE="dflash-kquant.gguf"
-      MMPROJ_GGUF_FILE="mmproj-kquant.gguf"
+      DRAFT_GGUF_FILE="dflash-Muse-Glimmer-30B-Q4_K_M.gguf"
+      MMPROJ_GGUF_FILE="mmproj-Muse-Glimmer-30B-Q4_K_M.gguf"
       python -c "from huggingface_hub import hf_hub_download; hf_hub_download('${HF_MODEL}', '${DRAFT_GGUF_FILE}', local_dir='${LOCAL_MODEL_DIR}')"
       python -c "from huggingface_hub import hf_hub_download; hf_hub_download('${HF_MODEL}', '${MMPROJ_GGUF_FILE}', local_dir='${LOCAL_MODEL_DIR}')"
       EXPORT_START_SECONDS=$SECONDS

--- a/examples/models/muse-glimmer/README.md
+++ b/examples/models/muse-glimmer/README.md
@@ -44,17 +44,17 @@ the serving path uses it to render prompts and tools.
 
 | File | Use |
 |---|---|
-| `muse-glimmer-30B-kquant-17gb.gguf` | Recommended target checkpoint |
-| `muse-glimmer-30B-kquant-dynamic.gguf` | Dynamic K-quant target checkpoint |
-| `mmproj-kquant.gguf` | Optional vision projector |
-| `dflash-kquant.gguf` | Optional DFlash draft checkpoint |
+| `Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf` | Recommended target checkpoint |
+| `Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf` | Dynamic K-quant target checkpoint |
+| `mmproj-Muse-Glimmer-30B-Q4_K_M.gguf` | Optional vision projector |
+| `dflash-Muse-Glimmer-30B-Q4_K_M.gguf` | Optional DFlash draft checkpoint |
 
 Set paths once for the commands below:
 
 ```bash
-TARGET="$(find assets/quant -type f -name 'muse-glimmer-30B-kquant-17gb.gguf' -print -quit)"
-DRAFT="$(find assets/quant -type f -name 'dflash-kquant.gguf' -print -quit)"
-MMPROJ="$(find assets/quant -type f -name 'mmproj-kquant.gguf' -print -quit)"
+TARGET="$(find assets/quant -type f -name 'Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf' -print -quit)"
+DRAFT="$(find assets/quant -type f -name 'dflash-Muse-Glimmer-30B-Q4_K_M.gguf' -print -quit)"
+MMPROJ="$(find assets/quant -type f -name 'mmproj-Muse-Glimmer-30B-Q4_K_M.gguf' -print -quit)"
 BACKEND=cuda  # use mlx on macOS
 ```
 

--- a/examples/models/muse-glimmer/export/export_dflash.py
+++ b/examples/models/muse-glimmer/export/export_dflash.py
@@ -716,7 +716,7 @@ def main() -> None:
     target_src.add_argument(
         "--target-gguf",
         default=None,
-        help="Path to target GGUF (e.g. muse-glimmer-30B-kquant-17gb.gguf).",
+        help="Path to target GGUF (e.g. Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf).",
     )
     target_src.add_argument(
         "--target-mlx",
@@ -728,7 +728,7 @@ def main() -> None:
     draft_src.add_argument(
         "--draft-gguf",
         default=None,
-        help="Path to draft DFlash GGUF (e.g. dflash-kquant.gguf).",
+        help="Path to draft DFlash GGUF (e.g. dflash-Muse-Glimmer-30B-Q4_K_M.gguf).",
     )
     draft_src.add_argument(
         "--draft-mlx",

--- a/examples/models/muse-glimmer/export/export_solo.py
+++ b/examples/models/muse-glimmer/export/export_solo.py
@@ -526,7 +526,7 @@ def main() -> None:
     src.add_argument(
         "--gguf",
         default=None,
-        help="Path to a GGUF file (e.g. muse-glimmer-30B-kquant-17gb.gguf). Streams and "
+        help="Path to a GGUF file (e.g. Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf). Streams and "
         "converts weights for the target backend, preserving quant bit-widths.",
     )
     src.add_argument(
@@ -592,7 +592,7 @@ def main() -> None:
         "--mmproj",
         default=None,
         help="Optional path to the vision projector GGUF "
-        "(e.g. mmproj-kquant.gguf). When given (CUDA or "
+        "(e.g. mmproj-Muse-Glimmer-30B-Q4_K_M.gguf). When given (CUDA or "
         "MLX backend), a `vision_encoder` method is exported and the runner can "
         "take image input. Omit to export the text-only (TITO) model.",
     )


### PR DESCRIPTION
## Summary

The [`meta-models/Muse-Glimmer-30B-GGUF`](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF) repo standardized its GGUF filenames to canonical Q4_K names. The old-named files are being removed, so this updates ExecuTorch to reference the canonical names.

## Rename map

| Old | New |
|---|---|
| `muse-glimmer-30B-kquant-17gb.gguf` | `Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf` |
| `muse-glimmer-30B-kquant-dynamic.gguf` | `Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf` |
| `dflash-kquant.gguf` | `dflash-Muse-Glimmer-30B-Q4_K_M.gguf` |
| `mmproj-kquant.gguf` | `mmproj-Muse-Glimmer-30B-Q4_K_M.gguf` |

## Files changed

- `.ci/scripts/export_model_artifact.sh` — the `hf_hub_download` target/draft/mmproj filenames (the `kquant-17gb` / `kquant-dynamic` **quant-mode CLI args** are unchanged — only the downloaded `.gguf` filenames)
- `examples/models/muse-glimmer/README.md` — file table + `find` snippets
- `examples/models/muse-glimmer/export/export_solo.py` — `--gguf` / `--mmproj` help text examples
- `examples/models/muse-glimmer/export/export_dflash.py` — `--target-gguf` / `--draft-gguf` help text examples

## Notes

- Pure string rename — no logic changes. All 4 new names verified to exist on the HF repo (case-sensitive exact match).
- The README download step uses `--include '*.gguf'`, so it already fetches the canonical files; no change needed there.
