### PR TITLE
Fix sliding-window over-attention in chunked prefill (#21857)

### DIFF
--- a/examples/models/llama/static_attention.py
+++ b/examples/models/llama/static_attention.py
@@ -205,10 +205,9 @@ class StaticAttentionMask:
             self.tensor[
                 :,
                 :,
-                max(
-                    0, self.cache_len - self.unmasked_len - new_unmasked_len
-                ) : self.cache_len
-                - self.unmasked_len,
+                max(0, self.cache_len - self.unmasked_len - new_unmasked_len) : max(
+                    0, self.cache_len - self.unmasked_len
+                ),
             ] = 0
 
         if self.style == "smart_mask":
@@ -274,6 +273,12 @@ class StaticAttentionIOManager:
             )
             for cl in set(cache_lens)
         }
+        # Global (full-attention) layers use the largest cache; local
+        # (sliding-window) layers use a strictly smaller cache. In a global-only
+        # model every layer shares the same cache, so this stays equal to it.
+        self._global_cache_len = max(
+            (mask.cache_len for mask in self._masks.values()), default=0
+        )
 
         if isinstance(config_or_model, ModelArgs):
             self._from_config(config_or_model, cache_lens_dict, batch_size, dtype)
@@ -421,6 +426,40 @@ class StaticAttentionIOManager:
         for mask in self._masks.values():
             mask.reset()
 
+    def _is_windowed_mask(self, mask: StaticAttentionMask) -> bool:
+        """
+        A mask belongs to a local (sliding-window) layer iff its cache is strictly
+        smaller than the global cache. A pure sliding-window model is
+        indistinguishable from a global one by cache_len alone and counts as global.
+        """
+        return 0 < mask.cache_len < self._global_cache_len
+
+    def _mask_cache_outside_window(self):
+        """
+        Rewrite the cache region of every windowed mask so each query row only sees
+        its own window. `unmask` fills the cache region identically for all rows,
+        which lets query row k attend to cache_len + k + 1 keys instead of cache_len.
+
+        With shift_pointer the valid cache entries are right aligned and ordered
+        oldest to newest, so with W = cache_len and v = min(pos, W) valid entries,
+        cache column c is visible to query row k iff c >= max(W - v, k + 1). This
+        holds for both prefill chunks and decode steps, and composes with the
+        in-chunk causal/window mask set by the caller.
+        """
+        for mask in self._masks.values():
+            if not self._is_windowed_mask(mask):
+                continue
+            w = mask.cache_len
+            first_valid = w - min(self.pos, w)
+            rows = torch.arange(self.input_len).unsqueeze(1)
+            cols = torch.arange(w).unsqueeze(0)
+            visible = cols >= torch.clamp(rows + 1, min=first_valid)
+            cache_mask = torch.full(
+                (self.input_len, w), mask.mask_val, dtype=mask.tensor.dtype
+            )
+            cache_mask[visible] = 0
+            mask.tensor[:, :, :w] = cache_mask
+
     def prefill(
         self,
         model: Callable[..., Any],
@@ -429,12 +468,6 @@ class StaticAttentionIOManager:
         if self.cache_full:
             raise RuntimeError("KV cache is full.")
 
-        # Global (full-attention) layers use the largest cache; local
-        # (sliding-window) layers use a strictly smaller cache. In a global-only
-        # model every layer shares the same cache, so this stays equal to it.
-        global_cache_len = max(
-            (mask.cache_len for mask in self._masks.values()), default=0
-        )
         for mask in self._masks.values():
             input_mask = torch.triu(
                 torch.full((1, self.input_len, self.input_len), self.mask_val),
@@ -448,10 +481,7 @@ class StaticAttentionIOManager:
             # windowed; a global layer is left full-causal even when its (nominal)
             # cache is smaller than the prompt. No-op for chunked prefill
             # (input_len <= cache_len).
-            if (
-                0 < mask.cache_len < self.input_len
-                and mask.cache_len < global_cache_len
-            ):
+            if self._is_windowed_mask(mask) and mask.cache_len < self.input_len:
                 input_mask = input_mask + torch.tril(
                     torch.full((1, self.input_len, self.input_len), self.mask_val),
                     diagonal=-mask.cache_len,
@@ -464,6 +494,7 @@ class StaticAttentionIOManager:
         logits = None
         all_logits = None
         for i in range(0, tokens.size(1), self.input_len):
+            self._mask_cache_outside_window()
             logits = self._run_once(model, tokens[:, i : i + self.input_len])[0]
             if self.generate_full_logits:
                 if all_logits is None:
@@ -497,6 +528,7 @@ class StaticAttentionIOManager:
         stop_tokens = stop_tokens or []
         new_tokens = [init_token]
         for _ in range(n):
+            self._mask_cache_outside_window()
             y = self._run_once(model, new_tokens[-1:])[0]
             if self.generate_full_logits:
                 new_tokens.append(y[:, :1, ...].argmax().item())

--- a/examples/models/llama/tests/test_static_attention.py
+++ b/examples/models/llama/tests/test_static_attention.py
@@ -258,6 +258,53 @@ class StaticAttentionTest(unittest.TestCase):
         ):
             test(*args)
 
+    def test_sliding_window_chunked_prefill(self):
+        prompt_len = 24
+        global_cache_len = 32
+
+        def sliding_window_mask(window):
+            causal = torch.tril(torch.ones(prompt_len, prompt_len, dtype=torch.bool))
+            return causal & torch.triu(
+                torch.ones(prompt_len, prompt_len, dtype=torch.bool),
+                diagonal=-(window - 1),
+            )
+
+        def test(window, chunk_len):
+            config = ModelArgs(
+                dim=64,
+                n_heads=4,
+                n_kv_heads=2,
+                max_seq_len=prompt_len,
+                max_context_len=global_cache_len + prompt_len,
+                n_layers=2,
+                vocab_size=128,
+                generate_full_logits=True,
+            )
+            mha_transformer, static_transformer, static_config = (
+                self._get_test_transformers(config)
+            )
+            # Layer 0 is the local (sliding-window) layer, layer 1 is global.
+            mha_transformer.layers[0].attention.mask[:prompt_len, :prompt_len] = (
+                sliding_window_mask(window)
+            )
+            x = torch.randint(config.vocab_size, (1, prompt_len))
+            expected = mha_transformer(x)
+
+            cache_lens = [window, global_cache_len]
+            single_chunk = StaticAttentionIOManager(
+                static_config, prompt_len, cache_lens
+            ).prefill(static_transformer, x)
+            chunked = StaticAttentionIOManager(
+                static_config, chunk_len, cache_lens
+            ).prefill(static_transformer, x)
+
+            msg = f"window={window}, chunk_len={chunk_len}"
+            self.assertTrue(torch.isclose(chunked, single_chunk, rtol=1e-3).all(), msg)
+            self.assertTrue(torch.isclose(chunked, expected, rtol=1e-3).all(), msg)
+
+        test(window=4, chunk_len=8)  # chunk longer than the window
+        test(window=12, chunk_len=6)  # chunk shorter than the window
+
     def test_lookahead_decode(self):
         config = ModelArgs(
             dim=64,


### PR DESCRIPTION
Summary:

Chunked prefill of a sliding-window (local) attention layer let every query row see more keys than the window allows, so multi-chunk prefill did not match single-chunk prefill. This makes the cache region of the attention mask per-query-row in `StaticAttentionIOManager`.

Reviewed By: billmguo

Differential Revision: D116080453


