### PR TITLE
Fix export_llama never passing enable_bf16 to the XNNPACK partitioner

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -1506,6 +1506,7 @@ def _export_llama(llm_config: LlmConfig) -> LLMEdgeManager:  # noqa: C901
             generate_etrecord=llm_config.debug.generate_etrecord,
             verbose=llm_config.debug.verbose,
             gen_tag_fn=gen_tag_fn,
+            enable_bf16=llm_config.model.dtype_override.value == "bf16",
         )
     elif llm_config.backend.openvino.enabled:
         builder = _to_edge_and_lower_llama_openvino(

--- a/examples/models/llama/tests/test_export_llama_lib.py
+++ b/examples/models/llama/tests/test_export_llama_lib.py
@@ -70,6 +70,29 @@ class ExportLlamaLibTest(unittest.TestCase):
         for op, _op_info in delegation_info.delegation_by_operator.items():
             self.assertTrue(op not in UNWANTED_OPS)
 
+    def test_bf16_xnnpack_delegates_linears(self):
+        """
+        bf16 linears only delegate when enable_bf16 reaches the partitioner,
+        so this guards the wiring from dtype_override to
+        get_xnnpack_partitioner. Some non-gemm subgraphs delegate either way,
+        so the assertion is on linears specifically.
+        """
+        parser = build_args_parser()
+        args = parser.parse_args([])
+        args.use_kv_cache = True
+        args.xnnpack = True
+        args.xnnpack_extended_ops = True
+        args.dtype_override = "bf16"
+
+        llm_config = LlmConfig.from_args(args)
+        builder = _export_llama(llm_config)
+        graph_module = builder.edge_manager.exported_program().graph_module
+        delegation_info = get_delegation_info(graph_module)
+
+        linear = delegation_info.delegation_by_operator["aten_linear_default"]
+        self.assertGreater(linear.delegated, 0)
+        self.assertEqual(linear.non_delegated, 0)
+
     @unittest.skipUnless(HAS_ARM_BACKEND, "ARM backend not available")
     def test_get_quantizer_and_quant_params_returns_tosa_quantizer(self):
         llm_config = LlmConfig()


### PR DESCRIPTION
Fixes #21859

## Problem

#21784 added `enable_bf16` and threaded it through `_to_edge_and_lower_llama_xnnpack` and `get_xnnpack_partitioner`, defaulting `False` at each layer, but the sole call site never set it:

```python
builder = _to_edge_and_lower_llama_xnnpack(
    ...
    xnnpack_extended_ops=llm_config.backend.xnnpack.extended_ops,
    generate_etrecord=llm_config.debug.generate_etrecord,
    verbose=llm_config.debug.verbose,
    gen_tag_fn=gen_tag_fn,
)
```

So the parameter stayed `False` on every path, and `--dtype-override bf16 -X` exports silently lost all XNNPACK delegation of their linears: exit 0, valid `.pte`, `Total delegated subgraphs: 0` visible only under `-v`. Full measurements in #21859.

## Fix

Derive the flag from the dtype override at the call site:

```python
enable_bf16=llm_config.model.dtype_override.value == "bf16",
```

This is the condition the parameter was added for, and it cannot change behavior for fp32 or fp16 exports. With it, the bf16 demo export delegates the same 21 subgraphs as the fp32 control (per-op table in #21859).

## Testing

New `test_bf16_xnnpack_delegates_linears` in test_export_llama_lib.py exports the no-checkpoint demo model with `dtype_override="bf16"` and XNNPACK on, and asserts every `aten_linear_default` is delegated. The assertion is on linears specifically, not a bare delegation count: measuring both states showed 12 non-gemm subgraphs delegate even without the flag, so a count-only assertion passes either way and cannot guard this wiring. With only the source change reverted and the test kept, the test fails (`linear.delegated=0, non_delegated=8`); with the fix it passes (`8, 0`).

lintrunner reports no issues on both changed files.

cc @GregoryComer @digantdesai @cbilgin @JakeStevens @larryliu0820 @mergennachin @cccclai @helunwencser @jackzhxng as requested in #21859
