### PR TITLE
Reject non-default dim order in the portable kernels that copy by block

### DIFF
--- a/kernels/portable/cpu/op_cat.cpp
+++ b/kernels/portable/cpu/op_cat.cpp
@@ -28,11 +28,9 @@ Tensor& cat_out(
 
   ET_KERNEL_CHECK(ctx, check_cat_args(tensors, dim, out), InvalidArgument, out);
 
+  // check_cat_args already requires every input to share out's dim order, so
+  // checking out is enough to force all of them to the default.
   ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(out), InvalidArgument, out);
-  for (size_t i = 0; i < tensors.size(); ++i) {
-    ET_KERNEL_CHECK(
-        ctx, tensor_is_default_dim_order(tensors[i]), InvalidArgument, out);
-  }
 
   Tensor::SizesType expected_out_size[kTensorDimensionLimit];
   size_t expected_out_dim = 0;

--- a/kernels/portable/cpu/op_cat.cpp
+++ b/kernels/portable/cpu/op_cat.cpp
@@ -28,6 +28,12 @@ Tensor& cat_out(
 
   ET_KERNEL_CHECK(ctx, check_cat_args(tensors, dim, out), InvalidArgument, out);
 
+  ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(out), InvalidArgument, out);
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    ET_KERNEL_CHECK(
+        ctx, tensor_is_default_dim_order(tensors[i]), InvalidArgument, out);
+  }
+
   Tensor::SizesType expected_out_size[kTensorDimensionLimit];
   size_t expected_out_dim = 0;
   get_cat_out_target_size(tensors, dim, expected_out_size, &expected_out_dim);

--- a/kernels/portable/cpu/op_constant_pad_nd.cpp
+++ b/kernels/portable/cpu/op_constant_pad_nd.cpp
@@ -252,6 +252,8 @@ Tensor& constant_pad_nd_out(
   ET_KERNEL_CHECK(
       ctx, tensors_have_same_dim_order(in, out), InvalidArgument, out);
 
+  ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(in), InvalidArgument, out);
+
   // resize out tensor for dynamic shapes
   ET_KERNEL_CHECK_MSG(
       ctx,

--- a/kernels/portable/cpu/op_cumsum.cpp
+++ b/kernels/portable/cpu/op_cumsum.cpp
@@ -103,6 +103,8 @@ Tensor& cumsum_out(
   ET_KERNEL_CHECK(
       ctx, tensors_have_same_dim_order(self, out), InvalidArgument, out);
 
+  ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(self), InvalidArgument, out);
+
   ET_KERNEL_CHECK(
       ctx, resize_tensor(out, self.sizes()) == Error::Ok, InvalidArgument, out);
 

--- a/kernels/portable/cpu/op_pixel_unshuffle.cpp
+++ b/kernels/portable/cpu/op_pixel_unshuffle.cpp
@@ -81,6 +81,11 @@ Tensor& pixel_unshuffle_out(
       InvalidArgument,
       out);
 
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_dim_order(in, out), InvalidArgument, out);
+
+  ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(in), InvalidArgument, out);
+
   // @lint-ignore CLANGTIDY facebook-hte-CArray
   Tensor::SizesType expected_out_size[kTensorDimensionLimit];
   size_t expected_out_dim = 0;

--- a/kernels/portable/cpu/op_slice_scatter.cpp
+++ b/kernels/portable/cpu/op_slice_scatter.cpp
@@ -42,7 +42,7 @@ Tensor& slice_scatter_out(
       out);
 
   ET_KERNEL_CHECK(
-      ctx, tensors_have_same_dim_order(input, out), InvalidArgument, out);
+      ctx, tensors_have_same_dim_order(input, src, out), InvalidArgument, out);
 
   ET_KERNEL_CHECK(
       ctx, tensor_is_default_dim_order(input), InvalidArgument, out);

--- a/kernels/portable/cpu/op_slice_scatter.cpp
+++ b/kernels/portable/cpu/op_slice_scatter.cpp
@@ -44,6 +44,9 @@ Tensor& slice_scatter_out(
   ET_KERNEL_CHECK(
       ctx, tensors_have_same_dim_order(input, out), InvalidArgument, out);
 
+  ET_KERNEL_CHECK(
+      ctx, tensor_is_default_dim_order(input), InvalidArgument, out);
+
   if (input.numel() == 0) {
     return out;
   }

--- a/kernels/portable/cpu/op_split_copy.cpp
+++ b/kernels/portable/cpu/op_split_copy.cpp
@@ -49,6 +49,8 @@ void split_copy_Tensor_out(
   for (size_t i = 0; i < out.size(); ++i) {
     ET_KERNEL_CHECK(
         ctx, tensors_have_same_dim_order(input, out[i]), InvalidArgument, );
+    ET_KERNEL_CHECK(
+        ctx, tensor_is_default_dim_order(out[i]), InvalidArgument, );
   }
 
   const size_t leading_dims = getLeadingDims(input, dim);

--- a/kernels/portable/cpu/op_split_with_sizes_copy.cpp
+++ b/kernels/portable/cpu/op_split_with_sizes_copy.cpp
@@ -43,6 +43,8 @@ void split_with_sizes_copy_out(
   for (const auto i : c10::irange(out.size())) {
     ET_KERNEL_CHECK(
         ctx, tensors_have_same_dim_order(in, out[i]), InvalidArgument, );
+    ET_KERNEL_CHECK(
+        ctx, tensor_is_default_dim_order(out[i]), InvalidArgument, );
   }
 
   // If out is empty, then nothing needs to be done after checking the args.

--- a/kernels/portable/cpu/op_topk.cpp
+++ b/kernels/portable/cpu/op_topk.cpp
@@ -170,6 +170,14 @@ std::tuple<Tensor&, Tensor&> topk_values(
   ET_KERNEL_CHECK(
       ctx, check_topk_args(in, k, dim, values, indices), InvalidArgument, out);
 
+  ET_KERNEL_CHECK(
+      ctx,
+      tensors_have_same_dim_order(in, values, indices),
+      InvalidArgument,
+      out);
+
+  ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(in), InvalidArgument, out);
+
   if (dim < 0) {
     dim += nonzero_dim(in);
   }

--- a/kernels/test/CMakeLists.txt
+++ b/kernels/test/CMakeLists.txt
@@ -261,6 +261,7 @@ set(all_test_sources
     "op_pdist_forward_test.cpp"
     "op_permute_copy_test.cpp"
     "op_pixel_shuffle_test.cpp"
+    "op_pixel_unshuffle_test.cpp"
     "op_prod_test.cpp"
     "op_rand_test.cpp"
     "op_randn_test.cpp"

--- a/kernels/test/op_cat_test.cpp
+++ b/kernels/test/op_cat_test.cpp
@@ -468,12 +468,12 @@ TEST_F(OpCatOutTest, DynamicShapeUnbound) {
 TEST_F(OpCatOutTest, NonDefaultDimOrderDies) {
   TensorFactory<ScalarType::Float> tf;
 
-  Tensor a = tf.channels_last_like(
+  Tensor x = tf.channels_last_like(
       tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
-  Tensor b = tf.channels_last_like(
+  Tensor y = tf.channels_last_like(
       tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
   Tensor out = tf.zeros_channels_last({1, 6, 2, 2});
-  std::vector<Tensor> inputs = {a, b};
+  std::vector<Tensor> inputs = {x, y};
 
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_cat_out(TensorList(inputs.data(), inputs.size()), 1, out));

--- a/kernels/test/op_cat_test.cpp
+++ b/kernels/test/op_cat_test.cpp
@@ -475,6 +475,10 @@ TEST_F(OpCatOutTest, NonDefaultDimOrderDies) {
   Tensor out = tf.zeros_channels_last({1, 6, 2, 2});
   std::vector<Tensor> inputs = {x, y};
 
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_cat_out(TensorList(inputs.data(), inputs.size()), 1, out));
 }

--- a/kernels/test/op_cat_test.cpp
+++ b/kernels/test/op_cat_test.cpp
@@ -464,3 +464,17 @@ TEST_F(OpCatOutTest, DynamicShapeUnbound) {
   op_cat_out(x, 0, out);
   EXPECT_TENSOR_EQ(out, expected);
 }
+
+TEST_F(OpCatOutTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  Tensor a = tf.channels_last_like(
+      tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+  Tensor b = tf.channels_last_like(
+      tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+  Tensor out = tf.zeros_channels_last({1, 6, 2, 2});
+  std::vector<Tensor> inputs = {a, b};
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_, op_cat_out(TensorList(inputs.data(), inputs.size()), 1, out));
+}

--- a/kernels/test/op_constant_pad_nd_test.cpp
+++ b/kernels/test/op_constant_pad_nd_test.cpp
@@ -493,6 +493,10 @@ TEST_F(OpConstantPadNDOutTest, NonDefaultDimOrderDies) {
   Tensor out = tf.zeros_channels_last({1, 3, 2, 4});
   const std::vector<int64_t> padding = {1, 1};
 
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
   ET_EXPECT_KERNEL_FAILURE(
       context_,
       op_constant_pad_nd_out(

--- a/kernels/test/op_constant_pad_nd_test.cpp
+++ b/kernels/test/op_constant_pad_nd_test.cpp
@@ -484,3 +484,17 @@ TEST_F(OpConstantPadNDOutTest, IncorrectOutputShapeFail) {
 }
 
 GENERATE_SCALAR_OVERFLOW_TESTS(OpConstantPadNDOutTest)
+
+TEST_F(OpConstantPadNDOutTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  Tensor self = tf.channels_last_like(
+      tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+  Tensor out = tf.zeros_channels_last({1, 3, 2, 4});
+  const std::vector<int64_t> padding = {1, 1};
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_constant_pad_nd_out(
+          self, IntArrayRef(padding.data(), padding.size()), 0.0, out));
+}

--- a/kernels/test/op_cumsum_test.cpp
+++ b/kernels/test/op_cumsum_test.cpp
@@ -290,10 +290,10 @@ TEST_F(OpCumSumOutTest, DISABLED_DynamicShapeUnbound) {
 TEST_F(OpCumSumOutTest, NonDefaultDimOrderDies) {
   TensorFactory<ScalarType::Float> tf;
 
-  Tensor self = tf.channels_last_like(
+  Tensor in = tf.channels_last_like(
       tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
   Tensor out = tf.zeros_channels_last({1, 3, 2, 2});
 
   ET_EXPECT_KERNEL_FAILURE(
-      context_, op_cumsum_out(self, 1, ScalarType::Float, out));
+      context_, op_cumsum_out(in, 1, ScalarType::Float, out));
 }

--- a/kernels/test/op_cumsum_test.cpp
+++ b/kernels/test/op_cumsum_test.cpp
@@ -294,6 +294,10 @@ TEST_F(OpCumSumOutTest, NonDefaultDimOrderDies) {
       tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
   Tensor out = tf.zeros_channels_last({1, 3, 2, 2});
 
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_cumsum_out(in, 1, ScalarType::Float, out));
 }

--- a/kernels/test/op_cumsum_test.cpp
+++ b/kernels/test/op_cumsum_test.cpp
@@ -286,3 +286,14 @@ TEST_F(OpCumSumOutTest, DISABLED_DynamicShapeUnbound) {
   Tensor ret = op_cumsum_out(x, 1, ScalarType::Float, out);
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
+
+TEST_F(OpCumSumOutTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  Tensor self = tf.channels_last_like(
+      tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+  Tensor out = tf.zeros_channels_last({1, 3, 2, 2});
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_, op_cumsum_out(self, 1, ScalarType::Float, out));
+}

--- a/kernels/test/op_pixel_unshuffle_test.cpp
+++ b/kernels/test/op_pixel_unshuffle_test.cpp
@@ -141,3 +141,19 @@ TEST_F(OpPixelUnshuffleOutTest, NonDefaultDimOrderDies) {
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_unshuffle_out(a, 2, out));
 }
+
+TEST_F(OpPixelUnshuffleOutTest, MixedDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  // Only out has a non-default dim order, so the same dim order check shall be
+  // what rejects it.
+  Tensor a = tf.make(
+      {1, 1, 4, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+  Tensor out = tf.zeros_channels_last({1, 4, 2, 2});
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
+  ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_unshuffle_out(a, 2, out));
+}

--- a/kernels/test/op_pixel_unshuffle_test.cpp
+++ b/kernels/test/op_pixel_unshuffle_test.cpp
@@ -130,9 +130,9 @@ TEST_F(OpPixelUnshuffleOutTest, NegativeUpscaleFactorDies) {
 TEST_F(OpPixelUnshuffleOutTest, NonDefaultDimOrderDies) {
   TensorFactory<ScalarType::Float> tf;
 
-  Tensor in = tf.channels_last_like(tf.make(
+  Tensor a = tf.channels_last_like(tf.make(
       {1, 1, 4, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}));
   Tensor out = tf.zeros_channels_last({1, 4, 2, 2});
 
-  ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_unshuffle_out(in, 2, out));
+  ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_unshuffle_out(a, 2, out));
 }

--- a/kernels/test/op_pixel_unshuffle_test.cpp
+++ b/kernels/test/op_pixel_unshuffle_test.cpp
@@ -9,6 +9,7 @@
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
 #include <executorch/kernels/test/supported_features.h>
+#include <executorch/kernels/test/supported_features_skip.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -133,6 +134,10 @@ TEST_F(OpPixelUnshuffleOutTest, NonDefaultDimOrderDies) {
   Tensor a = tf.channels_last_like(tf.make(
       {1, 1, 4, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}));
   Tensor out = tf.zeros_channels_last({1, 4, 2, 2});
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
 
   ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_unshuffle_out(a, 2, out));
 }

--- a/kernels/test/op_pixel_unshuffle_test.cpp
+++ b/kernels/test/op_pixel_unshuffle_test.cpp
@@ -126,3 +126,13 @@ TEST_F(OpPixelUnshuffleOutTest, NegativeUpscaleFactorDies) {
   // Using a negative upscale factor should exit with an error code.
   ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_unshuffle_out(a, -3, out));
 }
+
+TEST_F(OpPixelUnshuffleOutTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  Tensor in = tf.channels_last_like(tf.make(
+      {1, 1, 4, 4}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}));
+  Tensor out = tf.zeros_channels_last({1, 4, 2, 2});
+
+  ET_EXPECT_KERNEL_FAILURE(context_, op_pixel_unshuffle_out(in, 2, out));
+}

--- a/kernels/test/op_slice_scatter_test.cpp
+++ b/kernels/test/op_slice_scatter_test.cpp
@@ -888,13 +888,13 @@ TEST_F(OpSliceScatterTensorOutTest, LargeEndValue) {
 TEST_F(OpSliceScatterTensorOutTest, NonDefaultDimOrderDies) {
   TensorFactory<ScalarType::Float> tf;
 
-  Tensor self = tf.channels_last_like(
+  Tensor input = tf.channels_last_like(
       tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
   Tensor src = tf.zeros_channels_last({1, 1, 2, 2});
   Tensor out = tf.zeros_channels_last({1, 3, 2, 2});
 
   ET_EXPECT_KERNEL_FAILURE(
-      context_, op_slice_scatter_out(self, src, 1, 0, 1, 1, out));
+      context_, op_slice_scatter_out(input, src, 1, 0, 1, 1, out));
 }
 
 TEST_F(OpSliceScatterTensorOutTest, MixedDimOrderDies) {

--- a/kernels/test/op_slice_scatter_test.cpp
+++ b/kernels/test/op_slice_scatter_test.cpp
@@ -893,6 +893,10 @@ TEST_F(OpSliceScatterTensorOutTest, NonDefaultDimOrderDies) {
   Tensor src = tf.zeros_channels_last({1, 1, 2, 2});
   Tensor out = tf.zeros_channels_last({1, 3, 2, 2});
 
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_slice_scatter_out(input, src, 1, 0, 1, 1, out));
 }
@@ -908,6 +912,10 @@ TEST_F(OpSliceScatterTensorOutTest, MixedDimOrderDies) {
   Tensor src = tf.channels_last_like(
       tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
   Tensor out = tf.zeros({1, 3, 2, 4});
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
 
   ET_EXPECT_KERNEL_FAILURE(
       context_,

--- a/kernels/test/op_slice_scatter_test.cpp
+++ b/kernels/test/op_slice_scatter_test.cpp
@@ -896,3 +896,21 @@ TEST_F(OpSliceScatterTensorOutTest, NonDefaultDimOrderDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_, op_slice_scatter_out(self, src, 1, 0, 1, 1, out));
 }
+
+TEST_F(OpSliceScatterTensorOutTest, MixedDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  // Only src has a non-default dim order, so the same dim order check shall be
+  // what rejects it.
+  Tensor input =
+      tf.make({1, 3, 2, 4}, {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11,
+                             12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23});
+  Tensor src = tf.channels_last_like(
+      tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+  Tensor out = tf.zeros({1, 3, 2, 4});
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_slice_scatter_out(
+          input, src, /*dim=*/3, /*start=*/0, /*end=*/2, /*step=*/1, out));
+}

--- a/kernels/test/op_slice_scatter_test.cpp
+++ b/kernels/test/op_slice_scatter_test.cpp
@@ -884,3 +884,15 @@ TEST_F(OpSliceScatterTensorOutTest, LargeEndValue) {
   EXPECT_TENSOR_EQ(ret, out);
   EXPECT_TENSOR_EQ(ret, expected);
 }
+
+TEST_F(OpSliceScatterTensorOutTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  Tensor self = tf.channels_last_like(
+      tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+  Tensor src = tf.zeros_channels_last({1, 1, 2, 2});
+  Tensor out = tf.zeros_channels_last({1, 3, 2, 2});
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_, op_slice_scatter_out(self, src, 1, 0, 1, 1, out));
+}

--- a/kernels/test/op_split_copy_test.cpp
+++ b/kernels/test/op_split_copy_test.cpp
@@ -586,6 +586,10 @@ TEST_F(OpSplitCopyTensorOutTest, NonDefaultDimOrderDies) {
       tf.zeros_channels_last({1, 2, 2, 2}),
       tf.zeros_channels_last({1, 2, 2, 2})};
 
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
   ET_EXPECT_KERNEL_FAILURE(
       context_,
       op_split_copy_tensor_out(

--- a/kernels/test/op_split_copy_test.cpp
+++ b/kernels/test/op_split_copy_test.cpp
@@ -580,7 +580,7 @@ TEST_F(OpSplitCopyTensorOutTest, DISABLED_DynamicShapeUnbound) {
 TEST_F(OpSplitCopyTensorOutTest, NonDefaultDimOrderDies) {
   TensorFactory<ScalarType::Float> tf;
 
-  Tensor self = tf.channels_last_like(tf.make(
+  Tensor input = tf.channels_last_like(tf.make(
       {1, 4, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}));
   std::vector<Tensor> outs = {
       tf.zeros_channels_last({1, 2, 2, 2}),
@@ -589,5 +589,5 @@ TEST_F(OpSplitCopyTensorOutTest, NonDefaultDimOrderDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_,
       op_split_copy_tensor_out(
-          self, 2, 1, TensorList(outs.data(), outs.size())));
+          input, 2, 1, TensorList(outs.data(), outs.size())));
 }

--- a/kernels/test/op_split_copy_test.cpp
+++ b/kernels/test/op_split_copy_test.cpp
@@ -576,3 +576,18 @@ TEST_F(OpSplitCopyTensorOutTest, DISABLED_DynamicShapeUnbound) {
   test_dynamic_shape(
       {1, 1}, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND);
 }
+
+TEST_F(OpSplitCopyTensorOutTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  Tensor self = tf.channels_last_like(tf.make(
+      {1, 4, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}));
+  std::vector<Tensor> outs = {
+      tf.zeros_channels_last({1, 2, 2, 2}),
+      tf.zeros_channels_last({1, 2, 2, 2})};
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_split_copy_tensor_out(
+          self, 2, 1, TensorList(outs.data(), outs.size())));
+}

--- a/kernels/test/op_split_with_sizes_copy_test.cpp
+++ b/kernels/test/op_split_with_sizes_copy_test.cpp
@@ -9,6 +9,7 @@
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
 #include <executorch/kernels/test/supported_features.h>
+#include <executorch/kernels/test/supported_features_skip.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -126,6 +127,10 @@ TEST_F(OpSplitWithSizesCopyOutTest, NonDefaultDimOrderDies) {
       tf.zeros_channels_last({1, 2, 2, 2}),
       tf.zeros_channels_last({1, 2, 2, 2})};
   const std::vector<int64_t> split_sizes = {2, 2};
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
 
   ET_EXPECT_KERNEL_FAILURE(
       context_,

--- a/kernels/test/op_split_with_sizes_copy_test.cpp
+++ b/kernels/test/op_split_with_sizes_copy_test.cpp
@@ -115,3 +115,24 @@ TEST_F(OpSplitWithSizesCopyOutTest, DynamicShape) {
   test_tensor_shape_dynamism(
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND);
 }
+
+TEST_F(OpSplitWithSizesCopyOutTest, NonDefaultDimOrderDies) {
+  torch::executor::testing::TensorFactory<executorch::aten::ScalarType::Float>
+      tf;
+
+  executorch::aten::Tensor self = tf.channels_last_like(tf.make(
+      {1, 4, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}));
+  std::vector<executorch::aten::Tensor> outs = {
+      tf.zeros_channels_last({1, 2, 2, 2}),
+      tf.zeros_channels_last({1, 2, 2, 2})};
+  const std::vector<int64_t> split_sizes = {2, 2};
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_split_with_sizes_copy_out(
+          self,
+          executorch::aten::ArrayRef<int64_t>(
+              split_sizes.data(), split_sizes.size()),
+          1,
+          executorch::aten::TensorList(outs.data(), outs.size())));
+}

--- a/kernels/test/op_topk_test.cpp
+++ b/kernels/test/op_topk_test.cpp
@@ -8,6 +8,8 @@
 
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
+#include <executorch/kernels/test/supported_features_skip.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
@@ -182,6 +184,10 @@ TEST_F(OpTopkValuesTest, NonDefaultDimOrderDies) {
       {1, 4, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}));
   Tensor values = tf.zeros_channels_last({1, 2, 2, 2});
   Tensor indices = tf_long.zeros_channels_last({1, 2, 2, 2});
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
 
   TempMemoryAllocator allocator = TempMemoryAllocator();
   executorch::ET_RUNTIME_NAMESPACE::KernelRuntimeContext context(

--- a/kernels/test/op_topk_test.cpp
+++ b/kernels/test/op_topk_test.cpp
@@ -197,3 +197,27 @@ TEST_F(OpTopkValuesTest, NonDefaultDimOrderDies) {
 
   EXPECT_NE(context.failure_state(), torch::executor::Error::Ok);
 }
+
+TEST_F(OpTopkValuesTest, MixedDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+  TensorFactory<ScalarType::Long> tf_long;
+
+  // Only values has a non-default dim order, so the same dim order check shall
+  // be what rejects it.
+  Tensor in = tf.make(
+      {1, 4, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
+  Tensor values = tf.zeros_channels_last({1, 2, 2, 2});
+  Tensor indices = tf_long.zeros({1, 2, 2, 2});
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
+  TempMemoryAllocator allocator = TempMemoryAllocator();
+  executorch::ET_RUNTIME_NAMESPACE::KernelRuntimeContext context(
+      nullptr, &allocator);
+  torch::executor::aten::topk_outf(
+      context, in, 2, 1, true, true, values, indices);
+
+  EXPECT_NE(context.failure_state(), torch::executor::Error::Ok);
+}

--- a/kernels/test/op_topk_test.cpp
+++ b/kernels/test/op_topk_test.cpp
@@ -173,3 +173,21 @@ TEST_F(OpTopkValuesTest, NonPartialSort) {
     EXPECT_TENSOR_EQ(indices, indices_expected);
   }
 }
+
+TEST_F(OpTopkValuesTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+  TensorFactory<ScalarType::Long> tf_long;
+
+  Tensor in = tf.channels_last_like(tf.make(
+      {1, 4, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}));
+  Tensor values = tf.zeros_channels_last({1, 2, 2, 2});
+  Tensor indices = tf_long.zeros_channels_last({1, 2, 2, 2});
+
+  TempMemoryAllocator allocator = TempMemoryAllocator();
+  executorch::ET_RUNTIME_NAMESPACE::KernelRuntimeContext context(
+      nullptr, &allocator);
+  torch::executor::aten::topk_outf(
+      context, in, 2, 1, true, true, values, indices);
+
+  EXPECT_NE(context.failure_state(), torch::executor::Error::Ok);
+}


### PR DESCRIPTION
### Summary

Follow-up to #21828, which fixes the coordinate-indexed half of the same defect. These two PRs touch no files in common and can land in either order.

Five portable kernels accept a channels-last input and return wrong data without erroring. Three more share the defect but are currently masked by an unrelated check. Checked against eager PyTorch with only the memory format differing:

| kernel | contiguous input | channels-last input |
|---|---|---|
| `aten.cat` | matches | wrong, max abs diff 4.141 |
| `aten.pixel_unshuffle` | matches | wrong, max abs diff 3.941 |
| `aten.slice_scatter` | matches | wrong, max abs diff 3.376 |
| `aten.topk` | matches | wrong, max abs diff 2.581 |
| `aten.constant_pad_nd` | matches | wrong, max abs diff 2.526 |
| `aten.cumsum` | matches | rejected, status 0x12 |
| `aten.split_copy` | matches | rejected, status 0x12 |
| `aten.split_with_sizes_copy` | matches | rejected, status 0x12 |

The check that masks the last three is `tensors_have_same_dim_order`, and it fires only because the exported graph gives them differing dim orders. Nothing guards the arithmetic itself, so the unit tests below reach those kernels directly.

These kernels copy in blocks, taking `getLeadingDims` and `getTrailingDims` around the operating dim as the length of a contiguous run:

```cpp
const size_t outer = getLeadingDims(out, dim);
const size_t dim_stride = getTrailingDims(out, dim);
```

That run only exists in the default dim order. Under channels-last the elements after `dim` are not adjacent, so the arithmetic walks the wrong bytes.

This is the same assumption as #21828, but it needs a different fix. There the kernels index element by element, so reading the tensor's strides is enough. Here the algorithm depends on contiguity itself, and supporting the layout would mean restructuring each loop. So this adds the guard that `op_addmm`, `op_bmm` and `op_avg_pool2d` already use:

```cpp
ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(in), InvalidArgument, out);
```

`cat` needed it on each input as well as the output, since it had no dim order check at all. `slice_scatter` needed `src` in its same dim order check as well, since the kernel reads `src` as one contiguous run and only `input` and `out` were covered. `pixel_shuffle` already carries this exact pair of checks, so `pixel_unshuffle` missing them looks like an oversight rather than a decision.

Note: `cat` and `split` appear in nearly every model, so a channels-last program that runs today would start failing instead of returning wrong numbers. That still seems better than silent corruption, but happy to restructure the loops to support the layout instead if that's preferred.

`native_batch_norm` uses the same helpers but is not affected, since it checks `is_contiguous_dim_order` on the input directly. `select_scatter` and `unfold_copy` are affected and are left to a follow-up. `select_scatter` carries only the same dim order check, which passes when a rank-5 input and a rank-4 `src` are both channels-last, because `is_channels_last_dim_order` accepts 4 and 5 dims. `unfold_copy` has no dim order check at all. The same block arithmetic appears in the optimized `layer_norm`, fixed in #21866, and in the quantized `dequantize`, which #21517 covers.

### Test plan

A `NonDefaultDimOrderDies` test per kernel. Each passes a uniformly channels-last set of tensors, so the existing same dim order check passes and only the new guard can reject. Reverting the eight kernel sources while keeping the tests fails all eight.

This also adds `op_pixel_unshuffle_test.cpp` to `kernels/test/CMakeLists.txt`. It is registered in `targets.bzl` but missing from the CMake list, so those tests do not run in a CMake build and the new one would not either. Ten other op tests are missing the same way, and I have left those alone to keep this to one change.



cc @larryliu0820 @manuelcandales @JakeStevens