### PR TITLE
Check dim order in the optimized layer_norm as the portable one does

### DIFF
--- a/kernels/optimized/cpu/op_native_layer_norm.cpp
+++ b/kernels/optimized/cpu/op_native_layer_norm.cpp
@@ -159,6 +159,22 @@ std::tuple<Tensor&, Tensor&, Tensor&> opt_native_layer_norm_out(
       InvalidArgument,
       ret_val);
 
+  if (weight.has_value()) {
+    ET_KERNEL_CHECK(
+        ctx,
+        tensors_have_same_dim_order(input, weight.value()),
+        InvalidArgument,
+        ret_val);
+  }
+
+  if (bias.has_value()) {
+    ET_KERNEL_CHECK(
+        ctx,
+        tensors_have_same_dim_order(input, bias.value()),
+        InvalidArgument,
+        ret_val);
+  }
+
   Tensor::SizesType mean_rstd_sizes[kTensorDimensionLimit];
   size_t mean_rstd_ndim = 0;
   get_layer_norm_out_target_size(

--- a/kernels/optimized/cpu/op_native_layer_norm.cpp
+++ b/kernels/optimized/cpu/op_native_layer_norm.cpp
@@ -149,6 +149,16 @@ std::tuple<Tensor&, Tensor&, Tensor&> opt_native_layer_norm_out(
       InvalidArgument,
       ret_val);
 
+  // Only support default dim order for now.
+  ET_KERNEL_CHECK(
+      ctx, tensor_is_default_dim_order(input), InvalidArgument, ret_val);
+
+  ET_KERNEL_CHECK(
+      ctx,
+      tensors_have_same_dim_order(input, out, mean_out, rstd_out),
+      InvalidArgument,
+      ret_val);
+
   Tensor::SizesType mean_rstd_sizes[kTensorDimensionLimit];
   size_t mean_rstd_ndim = 0;
   get_layer_norm_out_target_size(

--- a/kernels/test/op_native_layer_norm_test.cpp
+++ b/kernels/test/op_native_layer_norm_test.cpp
@@ -482,3 +482,65 @@ TEST_F(OpNativeLayerNormTest, NonDefaultDimOrderDies) {
           out1,
           out2));
 }
+
+TEST_F(OpNativeLayerNormTest, NonDefaultDimOrderWeightDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  // weight takes the shape of normalized_shape, so it has to be rank 4 to carry
+  // a channels-last dim order, which makes the input rank 5. Everything else is
+  // default, so the same dim order check on weight shall be what rejects.
+  Tensor input = tf.make({2, 2, 2, 2, 2}, std::vector<float>(32, 1));
+  Tensor weight = tf.make_with_dimorder(
+      {2, 2, 2, 2}, std::vector<float>(16, 1), {0, 2, 3, 1});
+  Tensor out0 = tf.zeros({2, 2, 2, 2, 2});
+  Tensor out1 = tf.zeros({2, 1, 1, 1, 1});
+  Tensor out2 = tf.zeros({2, 1, 1, 1, 1});
+  const std::vector<int64_t> normalized_shape = {2, 2, 2, 2};
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_native_layer_norm_out(
+          input,
+          IntArrayRef(normalized_shape.data(), normalized_shape.size()),
+          exec_aten::optional<Tensor>(weight),
+          exec_aten::optional<Tensor>(),
+          1e-5,
+          out0,
+          out1,
+          out2));
+}
+
+TEST_F(OpNativeLayerNormTest, NonDefaultDimOrderBiasDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  // bias takes the shape of normalized_shape, so it has to be rank 4 to carry
+  // a channels-last dim order, which makes the input rank 5. Everything else is
+  // default, so the same dim order check on bias shall be what rejects.
+  Tensor input = tf.make({2, 2, 2, 2, 2}, std::vector<float>(32, 1));
+  Tensor bias = tf.make_with_dimorder(
+      {2, 2, 2, 2}, std::vector<float>(16, 1), {0, 2, 3, 1});
+  Tensor out0 = tf.zeros({2, 2, 2, 2, 2});
+  Tensor out1 = tf.zeros({2, 1, 1, 1, 1});
+  Tensor out2 = tf.zeros({2, 1, 1, 1, 1});
+  const std::vector<int64_t> normalized_shape = {2, 2, 2, 2};
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_native_layer_norm_out(
+          input,
+          IntArrayRef(normalized_shape.data(), normalized_shape.size()),
+          exec_aten::optional<Tensor>(),
+          exec_aten::optional<Tensor>(bias),
+          1e-5,
+          out0,
+          out1,
+          out2));
+}

--- a/kernels/test/op_native_layer_norm_test.cpp
+++ b/kernels/test/op_native_layer_norm_test.cpp
@@ -466,6 +466,10 @@ TEST_F(OpNativeLayerNormTest, NonDefaultDimOrderDies) {
   Tensor out2 = tf.zeros_channels_last({1, 3, 2, 1});
   const std::vector<int64_t> normalized_shape = {2};
 
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
   ET_EXPECT_KERNEL_FAILURE(
       context_,
       op_native_layer_norm_out(

--- a/kernels/test/op_native_layer_norm_test.cpp
+++ b/kernels/test/op_native_layer_norm_test.cpp
@@ -452,3 +452,29 @@ TEST_F(OpNativeLayerNormTest, DynamicShapeUnbound) {
   test_dynamic_shape(
       {1, 1}, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND);
 }
+
+TEST_F(OpNativeLayerNormTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  // mean and rstd share the input's rank with the normalized dims set to 1.
+  // All four are channels-last so the same-dim-order check passes and only the
+  // default dim order check can reject.
+  Tensor input = tf.channels_last_like(
+      tf.make({1, 3, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+  Tensor out0 = tf.zeros_channels_last({1, 3, 2, 2});
+  Tensor out1 = tf.zeros_channels_last({1, 3, 2, 1});
+  Tensor out2 = tf.zeros_channels_last({1, 3, 2, 1});
+  const std::vector<int64_t> normalized_shape = {2};
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_native_layer_norm_out(
+          input,
+          IntArrayRef(normalized_shape.data(), normalized_shape.size()),
+          exec_aten::optional<Tensor>(),
+          exec_aten::optional<Tensor>(),
+          1e-5,
+          out0,
+          out1,
+          out2));
+}


### PR DESCRIPTION
### Summary

Related to #21828 and #21865 (same underlying assumption in the optimized kernel library).

`aten.native_layer_norm` returns wrong data on a channels-last input, off by 3.192 against eager PyTorch where it matches exactly on contiguous input. Nothing errors.

The portable kernel is fine. It carries this, with the reason written down:

```cpp
// Only support default dim order for now.
// TODO: Support other dim orders.
ET_KERNEL_CHECK(
    ctx, tensor_is_default_dim_order(input), InvalidArgument, ret_val);
```

The optimized kernel has neither that check nor the matching `tensors_have_same_dim_order`, and `native_layer_norm.out` is mapped to `torch::executor::opt_native_layer_norm_out` in `optimized.yaml`. So any build with `EXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON` gets the ungated one.

It needs the guard rather than stride-aware indexing, because it splits the buffer into `M` rows of `N` contiguous elements:

```cpp
const size_t M = getLeadingDims(input, dim);
const size_t N = getTrailingDims(input, dim) * dim_size;
```

That layout only exists in the default dim order. This copies the two checks across from the portable kernel so the two agree.

### Test plan

`OpNativeLayerNormTest.NonDefaultDimOrderDies` passes a channels-last input with `out`, `mean` and `rstd` all channels-last, so the same dim order check passes and only the default dim order check can reject. `mean` and `rstd` share the input's rank with the normalized dims set to 1, which the kernel requires before it reaches any dim order check.

The test file is shared by both kernel libraries, so it runs against the portable kernel too, where it already passes.

cc @larryliu0820 @manuelcandales @JakeStevens