### PR TITLE
Fix prebuilt PTE download and serving instructions for Muse Glimmer

### DIFF
--- a/examples/models/muse-glimmer/README.md
+++ b/examples/models/muse-glimmer/README.md
@@ -18,6 +18,11 @@ CPU export is not supported. For general environment setup, follow the
 
 ## Model assets
 
+The GGUF checkpoints below are the inputs to [Export](#export). To run a
+published export instead, skip to
+[Prebuilt PTE artifacts](#prebuilt-pte-artifacts); that download is
+self-contained and needs nothing else from this section.
+
 Download the GGUF checkpoints and Hugging Face tokenizer metadata from the
 [`meta-models/Muse-Glimmer-30B-GGUF`](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF)
 and [`meta-models/Muse-Glimmer-30B`](https://huggingface.co/meta-models/Muse-Glimmer-30B),
@@ -62,23 +67,46 @@ BACKEND=cuda  # use mlx on macOS
 
 Ready-to-run exports for Apple silicon and NVIDIA GPUs are published in
 [`meta-models/Muse-Glimmer-30B-ExecuTorch-PTE`](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE).
+A prebuilt export needs neither the GGUF checkpoints nor the [Export](#export)
+step, and the repository serves the tokenizer metadata and chat template at its
+root, so it is the only download required.
+
 Each subdirectory is one export, named after its quantization, context length,
-modalities, decoding mode (`solo` or `dflash`), and target hardware, for example
-`muse_glimmer_k_quant_17G_128K_text_solo_metal`. Browse the repository, pick the
-subdirectory that matches your setup, and download only that one:
+modalities, decoding mode (`solo` or `dflash`), and target backend (`metal` for
+Apple silicon, `sm80+ptx` for NVIDIA), for example
+`muse-glimmer-k-quant-17G-128K-text-solo-metal`. Its artifacts repeat that
+directory name rather than the `model.pte` and `aoti_cuda_blob.ptd` filenames a
+local export writes:
+
+| Artifact | Present |
+|---|---|
+| `<subdirectory>.pte` | Always |
+| `<subdirectory>.ptd` | `sm80+ptx` only, and it holds the weights, so a CUDA export needs both files |
+| `pos_embed.bin` | `text-image` only |
+
+Browse the repository, pick the subdirectory that matches your setup, and
+download just that one alongside the shared tokenizer metadata:
 
 ```bash
-EXPORT_DIR=<subdirectory from the repository>
+PTE_REPO=meta-models/Muse-Glimmer-30B-ExecuTorch-PTE
+EXPORT_DIR=muse-glimmer-k-quant-17G-128K-text-solo-metal
 
-hf download meta-models/Muse-Glimmer-30B-ExecuTorch-PTE \
+hf download "$PTE_REPO" \
   --include "$EXPORT_DIR/*" \
+  --include tokenizer.json \
+  --include tokenizer_config.json \
+  --include chat_template.jinja \
   --local-dir exports
 ```
 
-The repository holds many exports, so avoid downloading it in full.
+`--include` takes one pattern per flag, and adding positional filenames makes
+`hf` ignore every `--include`. The repository holds many exports, so avoid
+downloading it in full; `--dry-run` reports the file list and total size before
+the transfer starts.
 
 With a prebuilt export, skip the [Export](#export) section and use
-`exports/$EXPORT_DIR` as the artifact directory in the sections below.
+`exports/$EXPORT_DIR` as the artifact directory and `exports` as the tokenizer
+directory in the sections below.
 
 ## Export
 
@@ -185,6 +213,31 @@ For MLX, use the MLX `model.pte` and omit `--data-path`. For DFlash, replace
 `exports/solo` with `exports/dflash` in both artifact paths; the server detects
 the exported method contract. For vision, also pass
 `--pos-embed-path <export-dir>/pos_embed.bin`.
+
+Serving a prebuilt export instead follows the same shape, with both artifacts
+named after their subdirectory and the tokenizer metadata taken from the
+download root:
+
+```bash
+EXPORT_DIR=muse-glimmer-k-quant-17G-128K-text-solo-sm80+ptx
+
+python -m executorch.examples.models.muse_glimmer.serving.serve \
+  --model-path "exports/$EXPORT_DIR/$EXPORT_DIR.pte" \
+  --data-path "exports/$EXPORT_DIR/$EXPORT_DIR.ptd" \
+  --tokenizer-path exports/tokenizer.json \
+  --hf-tokenizer exports \
+  --worker-bin cmake-out/examples/models/muse-glimmer/muse_glimmer_worker \
+  --model-id muse-glimmer-30B \
+  --tool-parser atem \
+  --host 127.0.0.1 \
+  --port 8000
+```
+
+`--dflash-block-length` defaults to 4, the largest block the CUDA export
+supports. The MLX export carries the drafter's native block size of 16, so pass
+`--dflash-block-length 0` there to select the exported maximum; `0` for
+`--dflash-n-draft` likewise resolves to `block_length - 1`. On `sm80+ptx`,
+`--dflash-n-draft` must stay at 3 or below.
 
 Smoke test:
 


### PR DESCRIPTION
## Why

Following the **Prebuilt PTE artifacts** section as written does not produce a working setup. I hit each of these while setting up a Metal vision export on an M4 Max, and verified every claim below against the live [`meta-models/Muse-Glimmer-30B-ExecuTorch-PTE`](https://huggingface.co/meta-models/Muse-Glimmer-30B-ExecuTorch-PTE) repository and against the export/serve code in this repo.

**1. The example subdirectory name doesn't exist.** The README shows `muse_glimmer_k_quant_17G_128K_text_solo_metal`; the published directories are hyphenated, e.g. `muse-glimmer-k-quant-17G-128K-text-solo-metal`. Since the snippet feeds that name straight into `--include "$EXPORT_DIR/*"`, a copy-paste downloads zero files.

**2. The serving commands name artifacts that aren't in the repo.** `model.pte` and `aoti_cuda_blob.ptd` are what a local `export_solo` run writes. Every published export names its artifacts after its own directory:

| Artifact | Present |
|---|---|
| `<subdirectory>.pte` | always |
| `<subdirectory>.ptd` | `sm80+ptx` only |
| `pos_embed.bin` | `text-image` only |

So the section tells you to skip **Export**, then hands you a serve command pointing at files that only exist if you *didn't* skip it. This also matters more than a rename: on CUDA the `.pte` is ~16 MB of graph and the `.ptd` holds all ~20 GB of weights, so grabbing only the `.pte` looks like a successful download and then fails at load.

**3. Prebuilt users are routed through a download they never use.** **Model assets** presents the GGUF checkpoints unconditionally, and only after that does **Prebuilt PTE artifacts** say to skip **Export** — by which point you've pulled tens of gigabytes of GGUFs that are export inputs only. The PTE repository publishes `tokenizer.json`, `tokenizer_config.json`, and `chat_template.jinja` at its root, so the prebuilt path needs nothing from that section.

**4. `--dflash-block-length` defaults to the CUDA ceiling, silently penalizing MLX.** Unrelated to filenames, but found while reading the same flow. `serve.py` defaults it to `4`. That's the max the CUDA export supports — `_export_dflash_cuda` sets `exported_block_size = min(draft_config.block_size, 4)` — while `_export_dflash_mlx` exports the drafter's native `block_size = 16`. The engine treats `0` as "use the exported maximum". An MLX user taking the defaults runs a quarter of the block their artifact supports, with nothing surfacing that.

## What changed

Docs only, `examples/models/muse-glimmer/README.md`:

- Corrected the example subdirectory to the published hyphenated form, and documented the three artifact-naming rules, including that a CUDA export needs both files.
- Added a working download command that also fetches the tokenizer metadata, plus the two `hf download` traps (`--include` is one pattern per flag; adding positional filenames makes `hf` ignore every `--include`).
- Added a pointer at the top of **Model assets** so prebuilt users skip the GGUF download.
- Added a prebuilt serving example with the correct `$EXPORT_DIR/$EXPORT_DIR.pte` / `.ptd` paths and `--hf-tokenizer exports`.
- Documented the `--dflash-block-length` backend split and the `sm80+ptx` `--dflash-n-draft ≤ 3` limit.

## Verification

The new download snippet was run as written:

```
[dry-run] Will download 4 files (out of 4) totalling 18.0G.
chat_template.jinja                                                          10.0K
muse-glimmer-k-quant-17G-128K-text-solo-metal/...-text-solo-metal.pte         17.9G
tokenizer.json                                                               28.1M
tokenizer_config.json                                                        79.9K
```

18.0 GB matches the 17.9 GB published for that variant. The `sm80+ptx` paths were checked against the repository tree (`.pte` 16.2 MB, `.ptd` 19.8 GB), confirming the weights split. `sm80+ptx` also expands correctly unquoted in the shell, since `+` isn't special in bash word context.

Source claims trace to `export/export_dflash.py` (`exported_block_size`, `Dim("block_len", min=2, max=...)`), `serving/serve.py` (flag defaults), and `runtime/engine/` (`config.dflash_block_length == 0` → exported max; `kCudaDFlashHiddenRows = 4` → `n_draft ≤ 3`).

No markdown linter is configured for this path; I checked the `ETCAPITAL` pattern from `.lintrunner.toml` manually along with trailing whitespace, tabs, and EOF newline. The one new line over 100 columns is a table row, matching three pre-existing long rows in the same file.

Authored with Copilot CLI.