### PR TITLE
Fix "Too many open files" in QNN DeepLabV3 example

### DIFF
--- a/examples/qualcomm/scripts/deeplab_v3.py
+++ b/examples/qualcomm/scripts/deeplab_v3.py
@@ -41,23 +41,19 @@ def get_dataset(data_size, dataset_dir, download):
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ]
     )
-    dataset = list(
-        datasets.VOCSegmentation(
-            root=os.path.join(dataset_dir, "voc_image"),
-            year="2012",
-            image_set="val",
-            transform=preprocess,
-            download=download,
-        )
+    dataset = datasets.VOCSegmentation(
+        root=os.path.join(dataset_dir, "voc_image"),
+        year="2012",
+        image_set="val",
+        transform=preprocess,
+        download=download,
     )
 
     # prepare input data
-    random.shuffle(dataset)
+    indices = random.sample(range(len(dataset)), min(data_size, len(dataset)))
     inputs, targets = [], []
-    for index, data in enumerate(dataset):
-        if index >= data_size:
-            break
-        image, target = data
+    for index in indices:
+        image, target = dataset[index]
         inputs.append((image.unsqueeze(0),))
         targets.append(np.array(target.resize(input_size)))
 


### PR DESCRIPTION
### Summary

Fixes #21870

Avoids exhausting the process limit of file descriptors by sampling indices, and loading only the sample. This avoids materializing the full VOC val dataset with `list(...)`.

### Test plan

Since this is just editing an example Python script, we tested it against a built executorch installed from pip too. With
CWD in a working copy pointed to this branch:

```sh
python3 -m venv /tmp/dlv3-venv
. /tmp/dlv3-venv/bin/activate
pip install \
    --index-url https://download.pytorch.org/whl/cpu \
    --extra-index-url https://pypi.org/simple \
     executorch==1.4.1 torchvision py-cpuinfo transformers pydot

# ulimit -n 1024   # Only needed to repro the error in a shell that has a different default soft limit
unset QNN_SDK_ROOT
export QNN_SDK_ROOT="$(python backends/qualcomm/scripts/download_qnn_sdk.py --print-sdk-path)"
export LD_LIBRARY_PATH="$QNN_SDK_ROOT/lib/x86_64-linux-clang:$LD_LIBRARY_PATH"

# Runs the example python script from this working copy
python ./examples/qualcomm/scripts/deeplab_v3.py \
    --build_folder build-x86 --soc_model SM8550 \
    --artifact ./dlv3 --compile_only --download
```

Run at the `main` branch (or with `python -m executorch.examples.qualcomm.scripts.deeplab_v3 ...` this fails with:

```
...
  File "/tmp/dlv3-venv/lib/python3.14/site-packages/torchvision/datasets/voc.py", line 155, in __getitem__
    img = Image.open(self.images[index]).convert("RGB")
          ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/tmp/dlv3-venv/lib/python3.14/site-packages/PIL/Image.py", line 3639, in open
    fp = builtins.open(filename, "rb")
OSError: [Errno 24] Too many open files: './dlv3/voc_image/VOCdevkit/VOC2012/JPEGImages/2010_001448.jpg'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mcollins/soft/executorch/./examples/qualcomm/scripts/deeplab_v3.py", line 200, in <module>
    raise Exception(e)
Exception: [Errno 24] Too many open files: './dlv3/voc_image/VOCdevkit/VOC2012/JPEGImages/2010_001448.jpg'
```

after this change it succeeds & writes the  `.pte` file:

```
python ./examples/qualcomm/scripts/deeplab_v3.py     --build_folder build-x86 --soc_model SM8550     --artifact ./dlv3 --compile_only --download
[QNN] Using QNN SDK at /home/mcollins/.cache/executorch/qnn/sdk-2.37.0.250724 (from QNN_SDK_ROOT)
W0815 21:36:10.026000 308359 torch/utils/_pytree.py:630] <enum 'KernelPreference'> is an Enum subclass and is now natively supported by torch.compile as an opaque value type. Calling register_constant() on Enum subclasses is deprecated and will be an error in a future release.
[WARNING 2026-08-15 21:36:11,241 backend_opinfo_adapter.py:67] The backend_opinfo module couldn't be imported, so the abstract implementation will be used instead. This might be because $QNN_SDK_ROOT/lib/python isn't included in your PYTHONPATH, or the `BackendOpInfo` API isn't available in your QNN SDK version. Note that the `BackendOpInfo` API is supported starting from QNN SDK 2.41 and above.
[INFO 2026-08-15 21:36:11,786 export_utils.py:172] Using parser's config
[INFO 2026-08-15 21:36:43,104 model.py:41] loading deeplabv3_resnet101 model
[INFO 2026-08-15 21:36:43,636 model.py:45] loaded deeplabv3_resnet101 model
[WARNING 2026-08-15 21:36:44,895 pass_manager.py:57] PassManager is deprecated. Please use ExportedProgramPassManager instead.
No quant config is implemented for op, aten.dropout.default
No quant config is implemented for op, aten.dropout.default
/usr/lib/python3.14/copyreg.py:104: FutureWarning: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.
  return cls.__new__(cls, *args)
Quantizing(PTQ) the model...
...
[INFO 2026-08-15 21:29:47,581 qnn_preprocess.py:78] Visiting: aten_permute_copy_default_2, aten.permute_copy.default
[INFO 2026-08-15 21:29:47,581 qnn_preprocess.py:78] Visiting: quantized_decomposed_dequantize_per_tensor_default_1, quantized_decomposed.dequantize_per_tensor.default

====== DDR bandwidth summary ======
spill_bytes=6553600
fill_bytes=6553600
write_total_bytes=14983168
read_total_bytes=68526080

[INFO] [Qnn ExecuTorch]: Destroy Qnn context
[WARNING 2026-08-15 21:29:48,878 _program.py:1029] Op aten.unbind.int was requested for preservation by partitioner.  This request is ignored because it aliases output.
[INFO] [Qnn ExecuTorch]: Destroy Qnn device
[INFO] [Qnn ExecuTorch]: Destroy Qnn backend
```

cc @mergennachin @iseeyuan @lucylq @helunwencser @tarun292 @kimishpatel @jackzhxng @cbilgin @psiddh