### PR TITLE
Fix Scalar float conversion source compatibility

### DIFF
--- a/runtime/core/portable_type/scalar.h
+++ b/runtime/core/portable_type/scalar.h
@@ -75,6 +75,18 @@ class Scalar {
     }
   }
 
+  float toFloat() const {
+    if (isFloatingPoint()) {
+      return static_cast<float>(v.as_double);
+    } else if (isIntegral(/*includeBool=*/false)) {
+      return static_cast<float>(v.as_int);
+    } else if (isBoolean()) {
+      return static_cast<float>(v.as_bool);
+    } else {
+      ET_CHECK_MSG(false, "Scalar cannot be converted to float.");
+    }
+  }
+
   double toFloatingPoint() const {
     ET_CHECK_MSG(isFloatingPoint(), "Scalar is not a Double.");
     return v.as_double;
@@ -106,6 +118,7 @@ class Scalar {
   }
 
 ET_DEFINE_SCALAR_TO_METHOD(double, Double)
+ET_DEFINE_SCALAR_TO_METHOD(float, Float)
 ET_DEFINE_SCALAR_TO_METHOD(int64_t, Int)
 ET_DEFINE_SCALAR_TO_METHOD(bool, Bool)
 #undef ET_DEFINE_SCALAR_TO_METHOD

--- a/runtime/core/portable_type/test/scalar_test.cpp
+++ b/runtime/core/portable_type/test/scalar_test.cpp
@@ -21,6 +21,17 @@ TEST(ScalarTest, ToScalarType) {
   EXPECT_EQ(s_b.to<bool>(), true);
 }
 
+TEST(ScalarTest, ToFloatMatchesC10ScalarConversions) {
+  Scalar s_d((double)3.25);
+  EXPECT_FLOAT_EQ(s_d.to<float>(), 3.25f);
+
+  Scalar s_i((int64_t)3);
+  EXPECT_FLOAT_EQ(s_i.to<float>(), 3.0f);
+
+  Scalar s_b(true);
+  EXPECT_FLOAT_EQ(s_b.to<float>(), 1.0f);
+}
+
 TEST(ScalarTest, ToIntForFalseScalarPasses) {
   Scalar s_b(false);
   EXPECT_FALSE(s_b.isIntegral(/*includeBool=*/false));


### PR DESCRIPTION
## Summary

Fixes #9500.

ExecuTorch's portable `Scalar` documents itself as a source-compatible subset of `c10::Scalar`, but `Scalar::to<float>()` was not defined. Code that is valid against `c10::Scalar` therefore fails to compile against the portable type.

This adds a focused `to<float>()` specialization. It accepts the scalar storage categories supported by the portable `Scalar` and mirrors `c10::Scalar` conversion behavior for double, integer, and boolean values.

## Testing

Added `ScalarTest.ToFloatMatchesC10ScalarConversions` covering:
- double to float;
- integer to float;
- bool to float.

## Scope

No existing `to<double>()`, `to<int64_t>()`, or `to<bool>()` behavior is changed.

cc @larryliu0820 @JacobSzwejbka @lucylq