### PR TITLE
Qualcomm AI Engine Direct - [LLM QAT] Embedding + LM head W4 PCQ support

### DIFF
--- a/backends/qualcomm/quantizer/quant_recipe.py
+++ b/backends/qualcomm/quantizer/quant_recipe.py
@@ -18,6 +18,10 @@ from executorch.backends.qualcomm.quantizer.quantizer import (
     QuantizationConfig,
 )
 from executorch.backends.qualcomm.quantizer.rules import OpQuantRule
+from executorch.backends.qualcomm.utils.check_qnn_version import (
+    get_sdk_build_id,
+    is_qnn_sdk_version_less_than,
+)
 from tabulate import tabulate
 from torch._ops import OpOverload
 from torchao.quantization.pt2e import UniformQuantizationObserverBase
@@ -91,6 +95,7 @@ class QuantizationStrategy(ABC):
             is_qat=self.is_qat,
             is_conv_per_channel=True,
             is_linear_per_channel=True,
+            is_embedding_per_channel=True,
             act_observer=self.act_observer,
             act_symmetric=self.act_symmetric,
         )
@@ -108,6 +113,15 @@ class QuantizationStrategy(ABC):
         if self.granularity == QuantGranularity.PER_TENSOR:
             return self.quant_config.quant_config
         elif self.granularity == QuantGranularity.PER_CHANNEL:
+            if op == torch.ops.aten.embedding.default and is_qnn_sdk_version_less_than(
+                "2.48"
+            ):
+                raise RuntimeError(
+                    "Per-channel embedding quantization requires QNN SDK version "
+                    f">= 2.48. Current QNN SDK version: {get_sdk_build_id()}. Please "
+                    "upgrade your QNN SDK, or use QuantGranularity.PER_TENSOR for the "
+                    "embedding layer instead."
+                )
             ch_axis = self.quant_config.use_per_channel_weight_quant_ops.get(op)
             assert (
                 ch_axis is not None

--- a/examples/qualcomm/oss_scripts/llama/static_llm_quant_recipe.py
+++ b/examples/qualcomm/oss_scripts/llama/static_llm_quant_recipe.py
@@ -697,11 +697,7 @@ class Smollm2QuantRecipe(StaticLLMQuantRecipe):
 
 
 class Smollm2QATQuantRecipe(StaticLLMQATRecipe):
-    default_quant_dtype = QuantDtype.use_16a8w
-    frozen_param_patterns: List[str] = [
-        r"tok_embedding",  # Freeze token embeddings to prevent drift in the token space.
-        r"output\.conv",  # Freeze lm head to prevent drift in the token space.
-    ]
+    default_quant_dtype = QuantDtype.use_16a4w
 
     def __init__(self, verbose: bool = False):
         super().__init__()
@@ -725,14 +721,7 @@ class Smollm2QATQuantRecipe(StaticLLMQATRecipe):
             )
             .add_regex(
                 {r"tok_embeddings"},
-                QuantDtype.use_16a8w,
-                True,
-                act_observer=MovingAverageMinMaxObserver,
-                granularity=QuantGranularity.PER_TENSOR,
-            )
-            .add_regex(
-                {r"output\.conv"},
-                QuantDtype.use_16a8w,
+                QuantDtype.use_16a4w,
                 True,
                 act_observer=MovingAverageMinMaxObserver,
                 granularity=QuantGranularity.PER_CHANNEL,


### PR DESCRIPTION
### Summary
 - With W4 PCQ applied to the embedding and LM head, we can further compress the embedding size.
W4 PCQ.
- Note: PCQ for embeddings is supported only in `QNN SDK` 2.48 or later.

### E2E script
``` bash
python examples/qualcomm/oss_scripts/llama/llama.py --build_folder build-android --device ${SERIAL_NUM} --soc_model {SOC_MODEL} --decoder_model smollm2_135m --model_mode hybrid --max_seq_len 1024 --prompt "What dose it mean to edit written content?" --qat --train_hf_dataset "HuggingFaceTB/smol-smoltalk" --train_hf_limit 8000 --calib_hf_dataset "HuggingFaceTB/smol-smoltalk" --calib_hf_limit 8000 --batch_size 2 --grad_accum_steps 4
```

### Test plan
``` bash
python backends/qualcomm/tests/test_qnn_delegate.py TestExampleLLMScript.test_static_llm_qat --device ${SERIAL_NUM} --soc_model ${SOC_MODEL} -r . -a . --build_folder build-android
```