### PR TITLE
Add U65 specific support (#21888)

### DIFF
--- a/backends/arm/test/ops/test_add.py
+++ b/backends/arm/test/ops/test_add.py
@@ -184,7 +184,7 @@ def test_add_tensor_u55_INT(test_data: input_t1):
 
 
 @common.parametrize("test_data", Add.test_data)
-@common.XfailIfNoCorstone300
+@common.XfailIfNoCorstone300_u65
 def test_add_tensor_u65_INT(test_data: input_t1):
     pipeline = EthosU65PipelineINT[input_t1](
         Add(),


### PR DESCRIPTION
Summary:

The add test compiles for `Ethos_U65_256` but the runtime did not match (using a U55, 128 MAC config).

Update appropriately.

Since now we have U55/U65/U85, `is_u85` is replaced by a `target` at all callsites.

Differential Revision: D116303719


