### PR TITLE
Disable code signing for iOS Device Farm artifacts

### DIFF
--- a/.ci/scripts/test_ios_ci.sh
+++ b/.ci/scripts/test_ios_ci.sh
@@ -80,7 +80,9 @@ xcodebuild build-for-testing \
   DEVELOPMENT_TEAM=78E7V7QP35 \
   CODE_SIGN_STYLE=Manual \
   PROVISIONING_PROFILE_SPECIFIER=ExecuTorchDemo \
-  CODE_SIGN_IDENTITY="iPhone Distribution"
+  CODE_SIGN_IDENTITY="iPhone Distribution" \
+  CODE_SIGNING_REQUIRED=No \
+  CODE_SIGNING_ALLOWED=No
 
 # The hack to figure out where the xctest package locates
 BUILD_DIR=$(xcodebuild -showBuildSettings -project "$APP_PATH.xcodeproj" -json | jq -r ".[0].buildSettings.BUILD_DIR")


### PR DESCRIPTION
## Summary

Disable code signing while packaging the iOS demo app and XCTest bundle for AWS Device Farm. Device Farm re-signs uploaded artifacts, and the existing benchmark packaging path already uses the same settings. This avoids failing the Apple workflow when the repository provisioning profile expires.

Fixes the failure in https://github.com/pytorch/executorch/actions/runs/32045215446/job/95431476785.

## Test plan

- `bash -n .ci/scripts/test_ios_ci.sh`
- `git diff --check`
- Confirmed the existing Device Farm benchmark packaging path uses `CODE_SIGNING_REQUIRED=No` and `CODE_SIGNING_ALLOWED=No`

This PR was authored with Codex (OpenAI).