### PR TITLE
Store external Vela blocks in named data (#21893)

### DIFF
--- a/backends/arm/BUCK
+++ b/backends/arm/BUCK
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
 # Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -87,6 +89,7 @@ fbcode_target(
         ":arm_vela",
         "//executorch/backends/arm/tosa:specification",
         "//executorch/backends/arm/tosa:partitioner",
+        "//executorch/exir/_serialize:lib",
     ],
 )
 
@@ -162,6 +165,7 @@ fbcode_target(
     ],
     deps = [
         "fbsource//third-party/pypi/ethos-u-vela:ethos-u-vela",
+        "//executorch/exir/_serialize:lib",
     ],
 )
 fbcode_target(

--- a/backends/arm/CMakeLists.txt
+++ b/backends/arm/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
 # Copyright 2023, 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the

--- a/backends/arm/__init__.py
+++ b/backends/arm/__init__.py
@@ -23,6 +23,10 @@ LAZY_IMPORTS = {
     "EthosUBackend": ("executorch.backends.arm.ethosu", "EthosUBackend"),
     "EthosUCompileSpec": ("executorch.backends.arm.ethosu", "EthosUCompileSpec"),
     "EthosUPartitioner": ("executorch.backends.arm.ethosu", "EthosUPartitioner"),
+    "VelaExternalBlockPlacements": (
+        "executorch.backends.arm.ethosu",
+        "VelaExternalBlockPlacements",
+    ),
     "VgfBackend": ("executorch.backends.arm.vgf", "VgfBackend"),
     "VgfCompileSpec": ("executorch.backends.arm.vgf", "VgfCompileSpec"),
     "VgfPartitioner": ("executorch.backends.arm.vgf", "VgfPartitioner"),

--- a/backends/arm/arm_vela.py
+++ b/backends/arm/arm_vela.py
@@ -1,13 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
 # Copyright 2023-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 
+import hashlib
 import os
 import struct
 import tempfile
 
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import List
 
 import numpy as np
@@ -18,6 +23,33 @@ try:
     has_vela = True
 except ImportError:
     has_vela = False
+
+
+_BLOCK_NAME_LENGTH = 16
+_BLOCK_HEADER = struct.Struct(f"<{_BLOCK_NAME_LENGTH}sIB11s")
+_BLOCK_ALIGNMENT = 16
+_STREAM_HEADER = "vela_bin_stream"
+_STREAM_FOOTER = "vela_end_stream"
+_EXTERNAL_REFERENCE = 1
+_RESERVED_BYTES = b"\x00" * 11
+
+
+@dataclass(frozen=True)
+class VelaExternalBlock:
+    """Named-data payload emitted by Vela compilation."""
+
+    key: str
+    payload: bytes
+    alignment: int
+    placement: str
+
+
+@dataclass(frozen=True)
+class VelaCompileResult:
+    """Binary stream and external payloads produced by Vela."""
+
+    processed_bytes: bytes
+    external_blocks: tuple[VelaExternalBlock, ...] = ()
 
 
 def _as_int32(value, name: str) -> int:
@@ -65,7 +97,8 @@ def vela_compile(
     args: List[str],
     verbose: bool = False,
     intermediate_path: str | None = None,
-):
+    block_placements: Mapping[str, str] | None = None,
+) -> VelaCompileResult:
     """Compile a TOSA graph to a binary stream for ArmBackendEthosU using
     Vela.
     """
@@ -73,8 +106,9 @@ def vela_compile(
         raise RuntimeError(
             "ethos-u-vela pip package couldn't be imported. Make sure it's installed!"
         )
+    resolved_block_placements: Mapping[str, str] = block_placements or {}
 
-    def run(dir: str) -> bytes:
+    def run(dir: str) -> VelaCompileResult:
         tosaname = "out.tosa"
         tosa_path = os.path.join(dir, tosaname)
         with open(tosa_path, "wb") as f:
@@ -90,11 +124,10 @@ def vela_compile(
 
         np_path = os.path.join(dir, "output", "out_vela.npz")
 
-        blocks = b""
         with np.load(np_path, allow_pickle=False) as data:
             # Construct our modified output_blocks with data in a form easily
             # digested on the device side
-            bin_blocks = {"vela_bin_stream": b""}
+            bin_blocks = {_STREAM_HEADER: b""}
 
             # copy command data through unmodified
             bin_blocks["cmd_data"] = data["cmd_data"].tobytes()
@@ -114,28 +147,58 @@ def vela_compile(
             bin_blocks["inputs"] = vela_bin_pack_io("input", data)
             bin_blocks["outputs"] = vela_bin_pack_io("output", data)
 
-            bin_blocks["vela_end_stream"] = b""
+            bin_blocks[_STREAM_FOOTER] = b""
+
+            unknown_blocks = resolved_block_placements.keys() - bin_blocks.keys()
+            if unknown_blocks:
+                raise ValueError(
+                    "External Vela block placements reference blocks that were not "
+                    f"emitted: {sorted(unknown_blocks)}"
+                )
 
             # Emit the NPZ regions as:
             #  - 16 byte block name null terminated string (padded to 16 if name shorter)
-            #  - 4 bytes of int32 block length and 12 bytes of 0's
+            #  - 4 bytes of int32 block length, 1 byte external flag, and 11 reserved bytes
             #  - block data (padded to 16 byte alignment at end)
             # Repeat for all blocks
+            blocks = b""
+            external_blocks: list[VelaExternalBlock] = []
             for key in bin_blocks.keys():
                 block_name = bytes(key, "utf8")[:15]
                 block_name = block_name + b"\x00" * (16 - len(block_name))
+                block_data = bin_blocks[key]
+                placement = resolved_block_placements.get(key)
+                external_reference = 0
+                if placement is not None:
+                    digest = hashlib.sha256(
+                        placement.encode("ascii") + b"\0" + block_data
+                    ).hexdigest()
+                    external_blocks.append(
+                        VelaExternalBlock(
+                            key=digest,
+                            payload=block_data,
+                            alignment=_BLOCK_ALIGNMENT,
+                            placement=placement,
+                        )
+                    )
+                    block_data = digest.encode("ascii")
+                    external_reference = _EXTERNAL_REFERENCE
 
                 # We need the acual unpadded block lengths for hw setup
-                block_length_bytes = struct.pack("<iiii", len(bin_blocks[key]), 0, 0, 0)
+                block_header = _BLOCK_HEADER.pack(
+                    block_name,
+                    len(block_data),
+                    external_reference,
+                    _RESERVED_BYTES,
+                )
 
                 # Pad block data to multiple of 16 bytes
-                block_data = bin_blocks[key]
                 block_data = block_data + b"\x00" * (15 - (len(block_data) - 1) % 16)
 
-                block = block_name + block_length_bytes + block_data
+                block = block_header + block_data
                 blocks = blocks + block
 
-        return blocks
+            return VelaCompileResult(blocks, tuple(external_blocks))
 
     if intermediate_path is not None:
         return run(intermediate_path)

--- a/backends/arm/ethosu/__init__.py
+++ b/backends/arm/ethosu/__init__.py
@@ -5,7 +5,12 @@
 #
 
 from .backend import EthosUBackend  # noqa: F401
-from .compile_spec import EthosUCompileSpec  # noqa: F401
+from .compile_spec import EthosUCompileSpec, VelaExternalBlockPlacements  # noqa: F401
 from .partitioner import EthosUPartitioner  # noqa: F401
 
-__all__ = ["EthosUBackend", "EthosUPartitioner", "EthosUCompileSpec"]
+__all__ = [
+    "EthosUBackend",
+    "EthosUPartitioner",
+    "EthosUCompileSpec",
+    "VelaExternalBlockPlacements",
+]

--- a/backends/arm/ethosu/backend.py
+++ b/backends/arm/ethosu/backend.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
 # Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
@@ -14,10 +16,11 @@
 import logging
 from typing import final, List
 
-from executorch.backends.arm.arm_vela import vela_compile
+from executorch.backends.arm.arm_vela import vela_compile, VelaCompileResult
 from executorch.backends.arm.ethosu.compile_spec import EthosUCompileSpec
 
 from executorch.backends.arm.tosa.backend import TOSABackend
+from executorch.exir._serialize._named_data_store import NamedDataStore
 from executorch.exir.backend.backend_details import BackendDetails, PreprocessResult
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from torch.export.exported_program import ExportedProgram
@@ -37,8 +40,9 @@ class EthosUBackend(BackendDetails):
 
     @staticmethod
     def _compile_tosa_flatbuffer(
-        tosa_flatbuffer: bytes, compile_spec: EthosUCompileSpec
-    ) -> bytes:
+        tosa_flatbuffer: bytes,
+        compile_spec: EthosUCompileSpec,
+    ) -> VelaCompileResult:
         """Compile a TOSA flatbuffer into a target-specific binary stream.
 
         Args:
@@ -46,9 +50,8 @@ class EthosUBackend(BackendDetails):
                 ``TOSABackend``.
             compile_spec (EthosUCompileSpec): Compile specification providing
                 Vela flags and intermediate paths.
-
         Returns:
-            bytes: Target-specific binary stream produced by Vela.
+            VelaCompileResult: Binary stream and external payloads from Vela.
 
         """
         compile_flags = compile_spec.compiler_flags
@@ -70,13 +73,15 @@ class EthosUBackend(BackendDetails):
             )
 
         # Pass on the TOSA flatbuffer to the vela compiler.
-        binary = vela_compile(
+        return vela_compile(
             tosa_flatbuffer,
             compile_flags,
             verbose=logger.getEffectiveLevel() <= logging.INFO,
             intermediate_path=compile_spec._get_intermediate_path(),
+            block_placements=(
+                compile_spec.external_block_placements.to_block_placements()
+            ),
         )
-        return binary
 
     @staticmethod
     def preprocess(
@@ -108,8 +113,21 @@ class EthosUBackend(BackendDetails):
         # which can be passed on to next compilation step.
         tosa_preprocess = TOSABackend._preprocess(edge_program, tosa_compile_spec)
 
-        binary = EthosUBackend._compile_tosa_flatbuffer(
+        compile_result = EthosUBackend._compile_tosa_flatbuffer(
             tosa_preprocess.processed_bytes, compile_spec
         )
+        if not compile_result.external_blocks:
+            return PreprocessResult(processed_bytes=compile_result.processed_bytes)
 
-        return PreprocessResult(processed_bytes=binary)
+        data_store = NamedDataStore()
+        for external_block in compile_result.external_blocks:
+            data_store.add_named_data(
+                external_block.key,
+                external_block.payload,
+                alignment=external_block.alignment,
+                external_tag=external_block.placement,
+            )
+        return PreprocessResult(
+            processed_bytes=compile_result.processed_bytes,
+            data_store_output=data_store.get_named_data_store_output(),
+        )

--- a/backends/arm/ethosu/compile_spec.py
+++ b/backends/arm/ethosu/compile_spec.py
@@ -3,12 +3,54 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
+from dataclasses import dataclass
+
 from executorch.backends.arm.common.arm_compile_spec import ArmCompileSpec
 from executorch.backends.arm.common.pipeline_config import ArmPassPipelineConfig
 from executorch.backends.arm.tosa import (  # type: ignore[import-not-found]
     TosaSpecification,
 )
 from executorch.exir.backend.compile_spec_schema import CompileSpec
+
+
+@dataclass(frozen=True)
+class VelaExternalBlockPlacements:
+    """Placement tags for external Vela command and weight data.
+
+    Tags are arbitrary build-time identifiers used to group named data into
+    external PTD outputs. Deployment decides where those artifacts live and
+    supplies them to the runtime.
+
+    Attributes:
+        cmd_data: Placement tag for command data, or ``None`` to keep it inline.
+        weight_data: Placement tag for weight data, or ``None`` to keep it inline.
+
+    """
+
+    cmd_data: str | None = None
+    weight_data: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate placement tags."""
+        for placement in (self.cmd_data, self.weight_data):
+            if placement is not None and (
+                not isinstance(placement, str)
+                or not placement
+                or not placement.isascii()
+            ):
+                raise ValueError(f"Invalid external Vela placement: {placement!r}")
+
+    def to_block_placements(self) -> dict[str, str]:
+        """Return configured placement tags keyed by Vela block name."""
+        return {
+            name: placement
+            for name, placement in (
+                ("cmd_data", self.cmd_data),
+                ("weight_data", self.weight_data),
+            )
+            if placement is not None
+        }
 
 
 class EthosUCompileSpec(ArmCompileSpec):
@@ -25,10 +67,13 @@ class EthosUCompileSpec(ArmCompileSpec):
             Vela.
         config_ini (str | None): Path to a Vela .ini configuration file.
             Defaults to ``"Arm/vela.ini"``.
+        external_block_placements (VelaExternalBlockPlacements | None): Command
+            and weight data to emit as named data with their placement tags.
 
     """
 
     _TARGET_KEY = "target"
+    _EXTERNAL_BLOCK_PLACEMENTS_KEY = "external_block_placements"
 
     @staticmethod
     def _default_system_config_and_memory_mode(
@@ -99,8 +144,14 @@ class EthosUCompileSpec(ArmCompileSpec):
         memory_mode: str | None = None,
         extra_flags: list[str] | None = None,
         config_ini: str | None = "Arm/vela.ini",
+        external_block_placements: VelaExternalBlockPlacements | None = None,
     ):
         self.target = target
+        self.external_block_placements = (
+            VelaExternalBlockPlacements()
+            if external_block_placements is None
+            else external_block_placements
+        )
         target_lower = self.target.lower()
         resolved_config_ini = "Arm/vela.ini" if config_ini is None else config_ini
         resolved_system_config, resolved_memory_mode = (
@@ -125,12 +176,42 @@ class EthosUCompileSpec(ArmCompileSpec):
         """Return compile specs including the encoded Ethos-U target."""
         compile_specs = super()._to_list()
         compile_specs.append(CompileSpec(self._TARGET_KEY, self.target.encode()))
+        block_placements = self.external_block_placements.to_block_placements()
+        if block_placements:
+            # CompileSpec values are bytes, so use deterministic JSON to
+            # preserve the placement mapping through serialization.
+            compile_specs.append(
+                CompileSpec(
+                    self._EXTERNAL_BLOCK_PLACEMENTS_KEY,
+                    json.dumps(
+                        block_placements,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode(),
+                )
+            )
         return compile_specs
 
     @classmethod
     def _from_list_hook(cls, compile_spec, specs: dict[str, str]):
         """Restore target-specific metadata from serialized compile specs."""
         compile_spec.target = specs.get(cls._TARGET_KEY, None)
+        serialized_placements = specs.get(cls._EXTERNAL_BLOCK_PLACEMENTS_KEY)
+        if serialized_placements is None:
+            compile_spec.external_block_placements = VelaExternalBlockPlacements()
+            return
+        placements = json.loads(serialized_placements)
+        if not isinstance(placements, dict):
+            raise ValueError("External Vela block placements must be a mapping.")
+        unknown_blocks = placements.keys() - {"cmd_data", "weight_data"}
+        if unknown_blocks:
+            raise ValueError(
+                "Unsupported external Vela blocks: " f"{sorted(unknown_blocks)}"
+            )
+        compile_spec.external_block_placements = VelaExternalBlockPlacements(
+            cmd_data=placements.get("cmd_data"),
+            weight_data=placements.get("weight_data"),
+        )
 
     def _validate(self):
         """Validate the configuration against supported Ethos-U settings."""

--- a/backends/arm/public_api_manifests/api_manifest_running.toml
+++ b/backends/arm/public_api_manifests/api_manifest_running.toml
@@ -18,7 +18,7 @@ signature = "EthosUBackend.preprocess(edge_program: torch.export.exported_progra
 
 [python.EthosUCompileSpec]
 kind = "class"
-signature = "EthosUCompileSpec(target: str, system_config: str | None = None, memory_mode: str | None = None, extra_flags: list[str] | None = None, config_ini: str | None = 'Arm/vela.ini')"
+signature = "EthosUCompileSpec(target: str, system_config: str | None = None, memory_mode: str | None = None, extra_flags: list[str] | None = None, config_ini: str | None = 'Arm/vela.ini', external_block_placements: executorch.backends.arm.ethosu.compile_spec.VelaExternalBlockPlacements | None = None)"
 
 [python.EthosUCompileSpec.DebugMode]
 kind = "enum"
@@ -91,6 +91,38 @@ signature = "EthosUQuantizer.transform_for_annotation(self, model: 'GraphModule'
 [python.EthosUQuantizer.validate]
 kind = "function"
 signature = "EthosUQuantizer.validate(self, model: 'GraphModule') -> 'None'"
+
+[python.VelaExternalBlockPlacements]
+kind = "class"
+signature = "VelaExternalBlockPlacements(cmd_data: str | None = None, weight_data: str | None = None) -> None"
+
+[python.VelaExternalBlockPlacements.__delattr__]
+kind = "function"
+signature = "VelaExternalBlockPlacements.__delattr__(self, name)"
+
+[python.VelaExternalBlockPlacements.__eq__]
+kind = "function"
+signature = "VelaExternalBlockPlacements.__eq__(self, other)"
+
+[python.VelaExternalBlockPlacements.__hash__]
+kind = "function"
+signature = "VelaExternalBlockPlacements.__hash__(self)"
+
+[python.VelaExternalBlockPlacements.__post_init__]
+kind = "function"
+signature = "VelaExternalBlockPlacements.__post_init__(self) -> None"
+
+[python.VelaExternalBlockPlacements.__repr__]
+kind = "function"
+signature = "VelaExternalBlockPlacements.__repr__(self)"
+
+[python.VelaExternalBlockPlacements.__setattr__]
+kind = "function"
+signature = "VelaExternalBlockPlacements.__setattr__(self, name, value)"
+
+[python.VelaExternalBlockPlacements.to_block_placements]
+kind = "function"
+signature = "VelaExternalBlockPlacements.to_block_placements(self) -> dict[str, str]"
 
 [python.VgfBackend]
 kind = "class"

--- a/backends/arm/runtime/EthosUBackend.cpp
+++ b/backends/arm/runtime/EthosUBackend.cpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  * Copyright 2023-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -84,9 +86,19 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
       BackendInitContext& context,
       FreeableBuffer* processed,
       ArrayRef<CompileSpec> compile_specs) const override {
-    ET_LOG(Info, "data:%p", processed->data());
+#if defined(ET_EVENT_TRACER_ENABLED)
+    EventTracer* event_tracer = context.event_tracer();
+    EventTracerEntry event_tracer_local_scope;
+#endif
 
+    EXECUTORCH_PROF_START(
+        event_tracer,
+        event_tracer_local_scope,
+        "+EthosUBackend::init()processed_data");
     const char* data = static_cast<const char*>(processed->data());
+    EXECUTORCH_PROF_END(event_tracer, event_tracer_local_scope);
+
+    ET_LOG(Info, "data:%p", data);
     size_t size = processed->size();
 
     // Verify format of vela_bin
@@ -101,7 +113,18 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
       return Error::MemoryAllocationFailed;
     }
 
-    handle->processed = processed;
+    EXECUTORCH_PROF_START(
+        event_tracer,
+        event_tracer_local_scope,
+        "+EthosUBackend::init()vela_bin_read()");
+    const Error read_status = vela_bin_read(
+        data, size, context.get_named_data_map(), &handle->handles);
+    EXECUTORCH_PROF_END(event_tracer, event_tracer_local_scope);
+    if (read_status != Error::Ok) {
+      delete handle;
+      return read_status;
+    }
+
     handle->platform_state = platform_init(compile_specs, allocator);
 
     // Return the same buffer we were passed - this data will be
@@ -134,30 +157,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
 
     ExecutionHandle* execution_handle =
         static_cast<ExecutionHandle*>(input_handle);
-    VelaHandles handles;
-
-    // Command stream - we know at this point it's aligned
-    EXECUTORCH_PROF_START(
-        event_tracer,
-        event_tracer_local_scope,
-        "+EthosUBackend::execute()processed_data");
-    const char* data =
-        static_cast<const char*>(execution_handle->processed->data());
-    EXECUTORCH_PROF_END(event_tracer, event_tracer_local_scope);
-
-    ET_LOG(Debug, "data:%p", data);
-
-    EXECUTORCH_PROF_START(
-        event_tracer,
-        event_tracer_local_scope,
-        "+EthosUBackend::execute()vela_bin_read()");
-    // Read key sections from the vela_bin_stream
-    if (vela_bin_read(data, &handles, execution_handle->processed->size()) ==
-        false) {
-      ET_LOG(Error, "vela_read: error, invalid binary layout");
-      return Error::InvalidProgram;
-    }
-    EXECUTORCH_PROF_END(event_tracer, event_tracer_local_scope);
+    VelaHandles handles = execution_handle->handles;
 
     const int input_count = handles.inputs ? handles.inputs->count : 0;
     const int output_count = handles.outputs ? handles.outputs->count : 0;
@@ -300,6 +300,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
   // No platform-specific members.
 };
 
+// cppcheck-suppress unusedFunction
 Error copy_with_layout_adjustment(
     const VelaIO& output_io,
     int output_index,

--- a/backends/arm/runtime/EthosUBackend_Internal.h
+++ b/backends/arm/runtime/EthosUBackend_Internal.h
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  * Copyright 2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -66,8 +68,8 @@ namespace arm {
 struct PlatformState;
 
 struct ExecutionHandle {
-  executorch::runtime::FreeableBuffer* processed;
   PlatformState* platform_state;
+  VelaHandles handles{};
 };
 
 extern "C" {

--- a/backends/arm/runtime/VelaBinStream.cpp
+++ b/backends/arm/runtime/VelaBinStream.cpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  * Copyright 2023, 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -12,18 +14,55 @@
 
 #include <executorch/backends/arm/runtime/VelaBinStream.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
+#include <string_view>
 
 #include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/named_data_map.h>
 
 namespace executorch {
 namespace backends {
 namespace arm {
 
-// get next mul of 16 ptr, return n if already aligned
-static uintptr_t next_mul_16(uintptr_t n) {
-  return ((n - 1) | 15) + 1;
+namespace {
+
+using ::executorch::runtime::Error;
+using ::executorch::runtime::NamedDataMap;
+
+constexpr size_t kVelaExternalBlockKeySize = 64;
+
+constexpr uintptr_t next_mul_16(uintptr_t value) {
+  return ((value - 1) | 15) + 1;
 }
+
+struct VelaBlockPayload {
+  const char* data;
+  size_t size;
+};
+
+// Reads the key from block.data and its referenced payload from named_data_map.
+Error resolve_external_block(
+    const VelaBinBlock& block,
+    const NamedDataMap& named_data_map,
+    VelaBlockPayload& payload) {
+  const std::string_view key(block.data, block.size);
+  auto result = named_data_map.get_data(key);
+  if (!result.ok()) {
+    return result.error();
+  }
+  payload.data = static_cast<const char*>(result->data());
+  payload.size = result->size();
+  if (payload.data == nullptr ||
+      reinterpret_cast<uintptr_t>(payload.data) !=
+          next_mul_16(reinterpret_cast<uintptr_t>(payload.data))) {
+    return Error::InvalidProgram;
+  }
+  return Error::Ok;
+}
+
+} // namespace
 
 bool vela_bin_validate(const char* data, int size) {
   const char* foot = data + size - sizeof(VelaBinBlock);
@@ -51,54 +90,74 @@ bool vela_bin_validate(const char* data, int size) {
   return valid;
 }
 
-bool vela_bin_read(const char* data, VelaHandles* handles, int size) {
+Error vela_bin_read(
+    const char* data,
+    int size,
+    const NamedDataMap* named_data_map,
+    VelaHandles* handles) {
   const char* ptr = data;
 
   while (ptr - data < size) {
     VelaBinBlock* b = reinterpret_cast<VelaBinBlock*>(const_cast<char*>(ptr));
     ptr += sizeof(VelaBinBlock) + next_mul_16(b->size);
 
+    VelaBlockPayload payload{b->data, b->size};
+    if (b->external == kVelaExternalBlockReference) {
+      if (b->size != kVelaExternalBlockKeySize || named_data_map == nullptr) {
+        return Error::InvalidProgram;
+      }
+      const Error status = resolve_external_block(*b, *named_data_map, payload);
+      if (status != Error::Ok) {
+        return status;
+      }
+    }
     if (!strncmp(b->name, "vela_bin_stream", strlen("vela_bin_stream"))) {
       // expect vela_bin_stream first
       if (reinterpret_cast<char*>(b) !=
           reinterpret_cast<char*>(const_cast<char*>(data)))
-        return false;
+        return Error::InvalidProgram;
     } else if (!strncmp(b->name, "cmd_data", strlen("cmd_data"))) {
       // This driver magic header confirms a valid command stream in binary
-      if (strncmp(b->data, "COP1", strlen("COP1")) &&
-          strncmp(b->data, "COP2", strlen("COP2"))) {
-        return false;
+      if (strncmp(payload.data, "COP1", strlen("COP1")) &&
+          strncmp(payload.data, "COP2", strlen("COP2"))) {
+        return Error::InvalidProgram;
       }
-      handles->cmd_data = b->data;
-      handles->cmd_data_size = b->size;
+      handles->cmd_data = payload.data;
+      handles->cmd_data_size = payload.size;
     } else if (!strncmp(b->name, "weight_data", strlen("weight_data"))) {
-      handles->weight_data = b->data;
-      handles->weight_data_size = b->size;
+      handles->weight_data = payload.data;
+      handles->weight_data_size = payload.size;
     } else if (!strncmp(b->name, "scratch_size", strlen("scratch_size"))) {
       const uint32_t* scratch_size_ptr =
-          reinterpret_cast<const uint32_t*>(b->data);
+          reinterpret_cast<const uint32_t*>(payload.data);
       handles->scratch_data_size = *scratch_size_ptr;
     } else if (!strncmp(b->name, "inputs", strlen("inputs"))) {
-      handles->inputs = reinterpret_cast<VelaIOs*>(b->data);
+      handles->inputs =
+          reinterpret_cast<VelaIOs*>(const_cast<char*>(payload.data));
     } else if (!strncmp(b->name, "outputs", strlen("outputs"))) {
-      handles->outputs = reinterpret_cast<VelaIOs*>(b->data);
+      handles->outputs =
+          reinterpret_cast<VelaIOs*>(const_cast<char*>(payload.data));
     } else if (!strncmp(
                    b->name, "vela_end_stream", strlen("vela_end_stream"))) {
       // expect vela_end_stream last
       if (ptr - data != size) {
         ET_LOG(Error, "Expected vela binary to end with vela_end_stream");
-        return false;
+        return Error::InvalidProgram;
       }
-      return true;
+      return Error::Ok;
     } else {
       // Unrecognised block name
       ET_LOG(Error, "Invalid block name or malformed binary");
-      return false;
+      return Error::InvalidProgram;
     }
   }
 
   // We've fallen off the end without finding vela_end_stream
-  return false;
+  return Error::InvalidProgram;
+}
+
+bool vela_bin_read(const char* data, VelaHandles* handles, int size) {
+  return vela_bin_read(data, size, nullptr, handles) == Error::Ok;
 }
 
 } // namespace arm

--- a/backends/arm/runtime/VelaBinStream.h
+++ b/backends/arm/runtime/VelaBinStream.h
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  * Copyright 2023-2025 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -18,19 +20,26 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <executorch/runtime/core/error.h>
+
 namespace executorch {
+namespace runtime {
+class NamedDataMap;
+}
 namespace backends {
 namespace arm {
 
 // Standard block name size
 const uint32_t kVelaBlockNameLength = 16;
+constexpr uint8_t kVelaExternalBlockReference = 1;
 
 // Generic block within the vela_bin_stream encoded by the python vela_compile
 // step
 typedef struct {
   char name[kVelaBlockNameLength]; // string name, can be shorter or truncated
   uint32_t size; // unpadded size, BinBlock size will be rounded to next_mul_16
-  char _pad[12]; // Our data often need 16 byte alignemnt
+  uint8_t external;
+  uint8_t reserved[11]; // Header remains 32 bytes for 16-byte data alignment
   char data[]; // block.name specific format data
 } VelaBinBlock;
 
@@ -67,6 +76,13 @@ typedef struct {
  * output values.
  */
 bool vela_bin_read(const char* data, VelaHandles* handles, int size);
+
+// Reads inline payloads from data and external payloads from named_data_map.
+::executorch::runtime::Error vela_bin_read(
+    const char* data,
+    int size,
+    const ::executorch::runtime::NamedDataMap* named_data_map,
+    VelaHandles* handles);
 
 /* Does minimal validation of a vela_bin_stream to ensure the overall
  * structure is correct and so likely to contain valid binary data for launch

--- a/backends/arm/runtime/targets.bzl
+++ b/backends/arm/runtime/targets.bzl
@@ -6,8 +6,11 @@ def define_common_targets():
         srcs = ["VelaBinStream.cpp"],
         exported_headers = ["VelaBinStream.h"],
         visibility = ["PUBLIC"],
-        deps = [
+        exported_deps = [
             "//executorch/runtime/core:core",
+        ],
+        deps = [
+            "//executorch/runtime/core:named_data_map",
         ],
     )
     runtime.cxx_library(

--- a/backends/arm/runtime/tests/ethos-u/CMakeLists.txt
+++ b/backends/arm/runtime/tests/ethos-u/CMakeLists.txt
@@ -1,10 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
 # Copyright 2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 cmake_minimum_required(VERSION 3.19)
-project(arm_ethos_u_runtime_tests NONE)
+project(arm_ethos_u_runtime_tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 enable_testing()
 
@@ -14,6 +19,23 @@ if(NOT EXECUTORCH_ROOT)
   )
 endif()
 get_filename_component(EXECUTORCH_ROOT "${EXECUTORCH_ROOT}" ABSOLUTE)
+
+add_subdirectory(
+  "${EXECUTORCH_ROOT}" "${CMAKE_CURRENT_BINARY_DIR}/executorch"
+  EXCLUDE_FROM_ALL
+)
+
+find_package(GTest QUIET)
+if(NOT TARGET GTest::gtest_main)
+  set(INSTALL_GTEST
+      OFF
+      CACHE BOOL "" FORCE
+  )
+  add_subdirectory(
+    "${EXECUTORCH_ROOT}/third-party/googletest"
+    "${CMAKE_CURRENT_BINARY_DIR}/googletest" EXCLUDE_FROM_ALL
+  )
+endif()
 
 set(_ethos_u_runtime_tests_dir "${CMAKE_CURRENT_SOURCE_DIR}")
 set(_ethos_u_runtime_test_output_dir "${CMAKE_CURRENT_BINARY_DIR}/test_run")
@@ -29,6 +51,19 @@ message(
 message(
   STATUS
     "Run one test: ctest --test-dir ${CMAKE_CURRENT_BINARY_DIR} -R '^memory_allocation_planned_fast$' --output-on-failure"
+)
+
+add_executable(
+  vela_external_blocks_test
+  "${EXECUTORCH_ROOT}/backends/arm/runtime/VelaBinStream.cpp"
+  "${EXECUTORCH_ROOT}/backends/arm/test/vela_external_blocks_test.cpp"
+)
+target_link_libraries(
+  vela_external_blocks_test PRIVATE executorch_core GTest::gtest_main
+)
+add_test(NAME vela_external_blocks COMMAND vela_external_blocks_test)
+set_tests_properties(
+  vela_external_blocks PROPERTIES LABELS "arm;ethos-u;runtime"
 )
 
 add_test(

--- a/backends/arm/scripts/docgen/docgen.py
+++ b/backends/arm/scripts/docgen/docgen.py
@@ -9,7 +9,11 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from executorch.backends.arm.ethosu import EthosUCompileSpec, EthosUPartitioner
+from executorch.backends.arm.ethosu import (
+    EthosUCompileSpec,
+    EthosUPartitioner,
+    VelaExternalBlockPlacements,
+)
 from executorch.backends.arm.quantizer import EthosUQuantizer, VgfQuantizer
 from executorch.backends.arm.vgf.partitioner import VgfCompileSpec, VgfPartitioner
 
@@ -139,6 +143,7 @@ def generate_ethos_u_docs():
         EthosUCompileSpec,
         ("DebugMode", "to_list", "from_list"),
     )
+    compilespec_string += get_class_docstring(VelaExternalBlockPlacements)
     partitioner_string = get_class_docstring(EthosUPartitioner)
     quantizer_string = get_class_docstring(
         EthosUQuantizer, ("prepare_obs_or_fq_callback", "annotate", "validate")

--- a/backends/arm/test/misc/test_compile_spec.py
+++ b/backends/arm/test/misc/test_compile_spec.py
@@ -9,7 +9,10 @@ from executorch.backends.arm.common.pipeline_config import (
     LeakyReLULoweringConfig,
     SoftmaxDecompositionConfig,
 )
-from executorch.backends.arm.ethosu import EthosUCompileSpec
+from executorch.backends.arm.ethosu import (
+    EthosUCompileSpec,
+    VelaExternalBlockPlacements,
+)
 from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
 from executorch.backends.arm.vgf import VgfCompileSpec
 from pytest import raises, warns
@@ -17,13 +20,25 @@ from pytest import raises, warns
 
 def test_compile_spec_u55_INT():
     compile_spec = (
-        EthosUCompileSpec("ethos-u55", extra_flags=["--my-flag"])
+        EthosUCompileSpec(
+            "ethos-u55",
+            extra_flags=["--my-flag"],
+            external_block_placements=VelaExternalBlockPlacements(
+                cmd_data="mem1",
+                weight_data="mem2",
+            ),
+        )
         .dump_intermediate_artifacts_to("my_path")
         .dump_debug_info(EthosUCompileSpec.DebugMode.TOSA)
     )
     spec_list = compile_spec._to_list()
 
-    assert EthosUCompileSpec._from_list(spec_list) == compile_spec
+    roundtripped = EthosUCompileSpec._from_list(spec_list)
+    assert roundtripped == compile_spec
+    assert roundtripped.external_block_placements == VelaExternalBlockPlacements(
+        cmd_data="mem1",
+        weight_data="mem2",
+    )
     assert "--my-flag" in compile_spec.compiler_flags
     assert "--output-format=raw" in compile_spec.compiler_flags
     with raises(ValueError, match="Incorrect output format"):
@@ -54,7 +69,9 @@ def test_ethos_u85_defaults_to_masked_softmax_u85_INT():
     """Test that EthosUCompileSpec for U85 defaults to MASKED softmax config."""
     compile_spec = EthosUCompileSpec("ethos-u85-256")
     pipeline_config = compile_spec._get_pass_pipeline_config()
+    roundtripped = EthosUCompileSpec._from_list(compile_spec._to_list())
     assert pipeline_config.softmax == SoftmaxDecompositionConfig.MASKED
+    assert roundtripped.external_block_placements == VelaExternalBlockPlacements()
 
 
 def test_compile_spec_vgf_no_quant():

--- a/backends/arm/test/misc/test_external_vela_blocks.py
+++ b/backends/arm/test/misc/test_external_vela_blocks.py
@@ -1,0 +1,203 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import contextlib
+import hashlib
+import struct
+from unittest.mock import patch
+
+import numpy as np
+from executorch.backends.arm import arm_vela
+from executorch.backends.arm.arm_vela import (
+    _BLOCK_ALIGNMENT,
+    _BLOCK_HEADER,
+    _EXTERNAL_REFERENCE,
+    _RESERVED_BYTES,
+    VelaCompileResult,
+    VelaExternalBlock,
+)
+from executorch.backends.arm.ethosu import (
+    EthosUCompileSpec,
+    VelaExternalBlockPlacements,
+)
+from executorch.backends.arm.ethosu.backend import EthosUBackend
+from executorch.backends.arm.tosa.backend import TOSABackend
+from executorch.exir._serialize.padding import aligned_size
+from executorch.exir.backend.backend_details import PreprocessResult
+from pytest import raises
+
+
+_COMMAND_DATA = b"COP1" + b"\x00" * 12
+_WEIGHT_DATA = b"weights"
+
+
+def _compile_vela_blocks(
+    tmp_path,
+    block_placements,
+) -> VelaCompileResult:
+    data = {
+        "cmd_data": np.frombuffer(_COMMAND_DATA, dtype=np.uint8),
+        "weight_data": np.frombuffer(_WEIGHT_DATA, dtype=np.uint8),
+        "scratch_shape": np.array([32], dtype=np.int64),
+        "input_shape": np.empty((0, 6), dtype=np.int32),
+        "output_shape": np.empty((0, 6), dtype=np.int32),
+    }
+    with (
+        patch.object(arm_vela, "has_vela", True),
+        patch.object(arm_vela, "vela", create=True),
+        patch.object(
+            arm_vela.np,
+            "load",
+            return_value=contextlib.nullcontext(data),
+        ),
+    ):
+        return arm_vela.vela_compile(
+            b"tosa",
+            [],
+            intermediate_path=str(tmp_path),
+            block_placements=block_placements,
+        )
+
+
+def _parse_vela_blocks(
+    binary: bytes,
+) -> list[tuple[str, bytes, tuple[int, bytes]]]:
+    blocks: list[tuple[str, bytes, tuple[int, bytes]]] = []
+    offset = 0
+    while offset < len(binary):
+        encoded_name, size, external, reserved = _BLOCK_HEADER.unpack_from(
+            binary, offset
+        )
+        name = encoded_name.rstrip(b"\x00").decode()
+        payload_start = offset + _BLOCK_HEADER.size
+        blocks.append(
+            (name, binary[payload_start : payload_start + size], (external, reserved))
+        )
+        offset = payload_start + aligned_size(size, _BLOCK_ALIGNMENT)
+    return blocks
+
+
+def test_external_vela_blocks_rejects_invalid_placements():
+    with raises(ValueError, match="Invalid external Vela placement"):
+        EthosUCompileSpec(
+            "ethos-u85-256",
+            external_block_placements=VelaExternalBlockPlacements(cmd_data=""),
+        )
+
+
+def test_vela_compile_embeds_hash_key_and_writes_named_data(tmp_path):
+    result = _compile_vela_blocks(tmp_path, {"cmd_data": "mem1"})
+
+    blocks = _parse_vela_blocks(result.processed_bytes)
+    expected_key = hashlib.sha256(b"mem1\0" + _COMMAND_DATA).hexdigest()
+    assert [name for name, _, _ in blocks] == [
+        "vela_bin_stream",
+        "cmd_data",
+        "weight_data",
+        "scratch_size",
+        "inputs",
+        "outputs",
+        "vela_end_stream",
+    ]
+    assert blocks[1][1] == expected_key.encode("ascii")
+    assert blocks[1][2] == (_EXTERNAL_REFERENCE, _RESERVED_BYTES)
+    assert result.external_blocks == (
+        VelaExternalBlock(expected_key, _COMMAND_DATA, 16, "mem1"),
+    )
+
+
+def test_vela_compile_supports_any_selected_block(tmp_path):
+    payloads = {
+        "cmd_data": _COMMAND_DATA,
+        "weight_data": _WEIGHT_DATA,
+        "scratch_size": b"\x20\x00\x00\x00",
+        "inputs": b"\x00\x00\x00\x00",
+        "outputs": b"\x00\x00\x00\x00",
+    }
+    placements = {name: "mem2" for name in payloads}
+    placements["cmd_data"] = "mem1"
+
+    result = _compile_vela_blocks(tmp_path, placements)
+
+    blocks = _parse_vela_blocks(result.processed_bytes)
+    assert [name for name, _, _ in blocks] == [
+        "vela_bin_stream",
+        *payloads,
+        "vela_end_stream",
+    ]
+    for name, key, reserved in blocks[1:-1]:
+        expected_key = hashlib.sha256(
+            placements[name].encode() + b"\0" + payloads[name]
+        ).hexdigest()
+        assert key == expected_key.encode("ascii")
+        assert reserved == (_EXTERNAL_REFERENCE, _RESERVED_BYTES)
+    assert [
+        (block.payload, block.alignment, block.placement)
+        for block in result.external_blocks
+    ] == [(payloads[name], 16, placements[name]) for name in payloads]
+
+
+def test_vela_compile_rejects_unknown_selected_block(tmp_path):
+    with raises(ValueError, match="cmnd_data"):
+        _compile_vela_blocks(tmp_path, {"cmnd_data": "mem1"})
+
+
+def test_vela_compile_without_external_blocks_matches_existing_format(tmp_path):
+    result = _compile_vela_blocks(tmp_path, {})
+    expected = b""
+    for name, payload in {
+        "vela_bin_stream": b"",
+        "cmd_data": _COMMAND_DATA,
+        "weight_data": _WEIGHT_DATA,
+        "scratch_size": b"\x20\x00\x00\x00",
+        "inputs": b"\x00\x00\x00\x00",
+        "outputs": b"\x00\x00\x00\x00",
+        "vela_end_stream": b"",
+    }.items():
+        encoded_name = name.encode("utf8")[:15].ljust(16, b"\x00")
+        padded_payload = payload + b"\x00" * (15 - (len(payload) - 1) % 16)
+        expected += encoded_name + struct.pack("<iiii", len(payload), 0, 0, 0)
+        expected += padded_payload
+
+    assert result.processed_bytes == expected
+    assert result.external_blocks == ()
+
+
+def test_ethosu_preprocess_outputs_external_blocks_as_named_data(tmp_path):
+
+    def compile_tosa_flatbuffer(
+        _tosa_flatbuffer,
+        compile_spec,
+    ) -> VelaCompileResult:
+        return _compile_vela_blocks(
+            tmp_path,
+            compile_spec.external_block_placements.to_block_placements(),
+        )
+
+    compile_spec = EthosUCompileSpec(
+        "ethos-u85-256",
+        external_block_placements=VelaExternalBlockPlacements(cmd_data="mem1"),
+    )
+    with (
+        patch.object(
+            TOSABackend,
+            TOSABackend._preprocess.__name__,
+            return_value=PreprocessResult(processed_bytes=b"tosa"),
+        ),
+        patch.object(
+            EthosUBackend,
+            EthosUBackend._compile_tosa_flatbuffer.__name__,
+            side_effect=compile_tosa_flatbuffer,
+        ),
+    ):
+        result = EthosUBackend.preprocess(None, compile_spec._to_list())
+
+    assert result.data_store_output is not None
+    external_data = result.data_store_output.external_data
+    assert list(external_data) == ["mem1"]
+    key, entry = next(iter(external_data["mem1"].items()))
+    assert key == hashlib.sha256(b"mem1\0" + _COMMAND_DATA).hexdigest()
+    assert result.data_store_output.buffers[entry.buffer_index] == _COMMAND_DATA

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -58,6 +58,7 @@ def define_arm_tests():
     # Misc tests
     test_files += [
         "misc/test_compile_spec.py",
+        "misc/test_external_vela_blocks.py",
         # "misc/test_evaluate_model.py",
         "misc/test_pass_pipeline_config.py",
         "misc/tosa_dialect/test_tosa_dialect_cast_to_block_scaled.py",
@@ -151,6 +152,16 @@ def define_arm_tests():
                 "//executorch/backends/arm/scripts/docgen:generate_vgf_op_support",
             ] if test_file == "misc/test_docgen_op_support.py" else []),
         )
+
+    runtime.cxx_test(
+        name = "vela_external_blocks_test",
+        srcs = ["vela_external_blocks_test.cpp"],
+        deps = [
+            "//executorch/backends/arm/runtime:vela_bin_stream",
+            "//executorch/runtime/core:core",
+            "//executorch/runtime/core:named_data_map",
+        ],
+    )
 
     if not runtime.is_oss and _ENABLE_VGF:
         runtime.cxx_test(

--- a/backends/arm/test/vela_external_blocks_test.cpp
+++ b/backends/arm/test/vela_external_blocks_test.cpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/arm/runtime/VelaBinStream.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <initializer_list>
+#include <string_view>
+#include <vector>
+
+#include <executorch/runtime/core/freeable_buffer.h>
+#include <executorch/runtime/core/named_data_map.h>
+#include <executorch/runtime/core/tensor_layout.h>
+#include <executorch/runtime/platform/runtime.h>
+#include <gtest/gtest.h>
+
+using executorch::backends::arm::kVelaExternalBlockReference;
+using executorch::backends::arm::vela_bin_read;
+using executorch::backends::arm::VelaHandles;
+using executorch::backends::arm::VelaIOs;
+using executorch::runtime::Error;
+using executorch::runtime::FreeableBuffer;
+using executorch::runtime::NamedDataMap;
+using executorch::runtime::Result;
+using executorch::runtime::TensorLayout;
+
+namespace {
+
+constexpr std::string_view kExternalKey =
+    "g123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+constexpr std::string_view kSecondExternalKey =
+    "h123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+void append_u32(std::vector<uint8_t>& output, uint32_t value) {
+  for (size_t i = 0; i < sizeof(value); ++i) {
+    output.push_back((value >> (8 * i)) & 0xff);
+  }
+}
+
+void append_fixed_string(
+    std::vector<uint8_t>& output,
+    std::string_view value,
+    size_t size) {
+  output.insert(output.end(), value.begin(), value.end());
+  output.resize(output.size() + size - value.size(), 0);
+}
+
+void append_block(
+    std::vector<uint8_t>& output,
+    std::string_view name,
+    const std::vector<uint8_t>& payload = {},
+    uint8_t external = 0,
+    uint8_t reserved = 0) {
+  append_fixed_string(output, name, 16);
+  append_u32(output, static_cast<uint32_t>(payload.size()));
+  output.push_back(external);
+  output.resize(output.size() + 11, reserved);
+  output.insert(output.end(), payload.begin(), payload.end());
+  output.resize((output.size() + 15) & ~size_t{15}, 0);
+}
+
+std::vector<uint8_t> stream_with_external_key(
+    std::string_view block_name,
+    std::string_view key = kExternalKey) {
+  std::vector<uint8_t> output;
+  append_block(output, "vela_bin_stream");
+  append_block(
+      output,
+      block_name,
+      std::vector<uint8_t>(key.begin(), key.end()),
+      kVelaExternalBlockReference);
+  append_block(output, "vela_end_stream");
+  return output;
+}
+
+class FakeNamedDataMap final : public NamedDataMap {
+ public:
+  struct Entry {
+    std::string_view key;
+    const void* data;
+    size_t size;
+  };
+
+  FakeNamedDataMap(std::string_view key, const void* data, size_t size)
+      : entries_{{key, data, size}} {}
+
+  explicit FakeNamedDataMap(std::initializer_list<Entry> entries)
+      : entries_(entries) {}
+
+  Result<const TensorLayout> get_tensor_layout(
+      std::string_view) const override {
+    return Error::NotFound;
+  }
+
+  Result<FreeableBuffer> get_data(std::string_view key) const override {
+    const auto entry = std::find_if(
+        entries_.begin(), entries_.end(), [key](const Entry& candidate) {
+          return key == candidate.key;
+        });
+    if (entry == entries_.end()) {
+      return Error::NotFound;
+    }
+    return FreeableBuffer(entry->data, entry->size, nullptr);
+  }
+
+  Error load_data_into(std::string_view, void*, size_t) const override {
+    return Error::NotImplemented;
+  }
+
+  Result<uint32_t> get_num_keys() const override {
+    return static_cast<uint32_t>(entries_.size());
+  }
+
+  Result<const char*> get_key(uint32_t index) const override {
+    return index < entries_.size()
+        ? Result<const char*>(entries_[index].key.data())
+        : Result<const char*>(Error::NotFound);
+  }
+
+ private:
+  std::vector<Entry> entries_;
+};
+
+} // namespace
+
+TEST(VelaExternalBlocksTest, ReadsInlineAndExternalBlocksInOnePass) {
+  alignas(16) const std::array<uint8_t, 16> command{
+      'C', 'O', 'P', '1', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  const std::vector<uint8_t> weights{1, 2, 3, 4};
+  std::vector<uint8_t> stream;
+  append_block(stream, "vela_bin_stream");
+  append_block(
+      stream,
+      "cmd_data",
+      std::vector<uint8_t>(kExternalKey.begin(), kExternalKey.end()),
+      kVelaExternalBlockReference);
+  append_block(stream, "weight_data", weights);
+  append_block(stream, "vela_end_stream");
+  FakeNamedDataMap data_map(kExternalKey, command.data(), command.size());
+  VelaHandles handles{};
+
+  ASSERT_EQ(
+      vela_bin_read(
+          reinterpret_cast<const char*>(stream.data()),
+          stream.size(),
+          &data_map,
+          &handles),
+      Error::Ok);
+  EXPECT_EQ(handles.cmd_data, reinterpret_cast<const char*>(command.data()));
+  EXPECT_EQ(handles.cmd_data_size, command.size());
+  ASSERT_NE(handles.weight_data, nullptr);
+  EXPECT_EQ(handles.weight_data_size, weights.size());
+  EXPECT_EQ(
+      std::memcmp(handles.weight_data, weights.data(), weights.size()), 0);
+}
+
+TEST(VelaExternalBlocksTest, RejectsInvalidExternalCommandStream) {
+  alignas(16) const std::array<uint8_t, 4> opaque_command{'B', 'A', 'D', '1'};
+  const auto stream = stream_with_external_key("cmd_data");
+  FakeNamedDataMap data_map(
+      kExternalKey, opaque_command.data(), opaque_command.size());
+  VelaHandles handles{};
+
+  EXPECT_EQ(
+      vela_bin_read(
+          reinterpret_cast<const char*>(stream.data()),
+          stream.size(),
+          &data_map,
+          &handles),
+      Error::InvalidProgram);
+}
+
+TEST(VelaExternalBlocksTest, RejectsExternalKeyWithWrongSize) {
+  alignas(16) const std::array<uint8_t, 4> command{'C', 'O', 'P', '1'};
+  const auto stream = stream_with_external_key("cmd_data", "not-a-hash");
+  FakeNamedDataMap data_map("not-a-hash", command.data(), command.size());
+  VelaHandles handles{};
+
+  EXPECT_EQ(
+      vela_bin_read(
+          reinterpret_cast<const char*>(stream.data()),
+          stream.size(),
+          &data_map,
+          &handles),
+      Error::InvalidProgram);
+}
+
+TEST(VelaExternalBlocksTest, ReadsInlineBlocksWithoutNamedData) {
+  const std::vector<uint8_t> command{
+      'C', 'O', 'P', '1', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<uint8_t> stream;
+  append_block(stream, "vela_bin_stream");
+  append_block(stream, "cmd_data", command);
+  append_block(stream, "vela_end_stream");
+  VelaHandles handles{};
+
+  ASSERT_EQ(
+      vela_bin_read(
+          reinterpret_cast<const char*>(stream.data()),
+          stream.size(),
+          nullptr,
+          &handles),
+      Error::Ok);
+  ASSERT_NE(handles.cmd_data, nullptr);
+  EXPECT_EQ(handles.cmd_data_size, command.size());
+  EXPECT_EQ(std::memcmp(handles.cmd_data, command.data(), command.size()), 0);
+}
+
+TEST(VelaExternalBlocksTest, ResolvesEveryExternalBlockType) {
+  alignas(16) const std::array<uint8_t, 16> weight_data{
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  alignas(16) const std::array<uint8_t, 4> scratch_size{32, 0, 0, 0};
+  alignas(16) const std::array<uint8_t, 4> empty_ios{0, 0, 0, 0};
+  struct ExternalBlockCase {
+    std::string_view name;
+    const uint8_t* data;
+    size_t size;
+  };
+  const std::array<ExternalBlockCase, 4> cases{{
+      {"weight_data", weight_data.data(), weight_data.size()},
+      {"scratch_size", scratch_size.data(), scratch_size.size()},
+      {"inputs", empty_ios.data(), empty_ios.size()},
+      {"outputs", empty_ios.data(), empty_ios.size()},
+  }};
+
+  for (const auto& test_case : cases) {
+    const auto stream = stream_with_external_key(test_case.name);
+    FakeNamedDataMap data_map(kExternalKey, test_case.data, test_case.size);
+    VelaHandles handles{};
+    ASSERT_EQ(
+        vela_bin_read(
+            reinterpret_cast<const char*>(stream.data()),
+            stream.size(),
+            &data_map,
+            &handles),
+        Error::Ok)
+        << test_case.name;
+    if (test_case.name == "weight_data") {
+      EXPECT_EQ(
+          handles.weight_data, reinterpret_cast<const char*>(test_case.data));
+      EXPECT_EQ(handles.weight_data_size, test_case.size);
+    } else if (test_case.name == "scratch_size") {
+      EXPECT_EQ(handles.scratch_data_size, 32);
+    } else if (test_case.name == "inputs") {
+      ASSERT_NE(handles.inputs, nullptr);
+      EXPECT_EQ(handles.inputs->count, 0);
+    } else {
+      ASSERT_NE(handles.outputs, nullptr);
+      EXPECT_EQ(handles.outputs->count, 0);
+    }
+  }
+}
+
+TEST(VelaExternalBlocksTest, ResolvesMultipleExternalBlocksIndependently) {
+  alignas(16) std::array<uint8_t, 4> inputs_data{1, 0, 0, 0};
+  alignas(16) std::array<uint8_t, 4> outputs_data{2, 0, 0, 0};
+  std::vector<uint8_t> stream;
+  append_block(stream, "vela_bin_stream");
+  append_block(
+      stream,
+      "inputs",
+      std::vector<uint8_t>(kExternalKey.begin(), kExternalKey.end()),
+      kVelaExternalBlockReference);
+  append_block(
+      stream,
+      "outputs",
+      std::vector<uint8_t>(
+          kSecondExternalKey.begin(), kSecondExternalKey.end()),
+      kVelaExternalBlockReference);
+  append_block(stream, "vela_end_stream");
+  FakeNamedDataMap data_map({
+      {kExternalKey, inputs_data.data(), inputs_data.size()},
+      {kSecondExternalKey, outputs_data.data(), outputs_data.size()},
+  });
+  VelaHandles handles{};
+
+  ASSERT_EQ(
+      vela_bin_read(
+          reinterpret_cast<const char*>(stream.data()),
+          stream.size(),
+          &data_map,
+          &handles),
+      Error::Ok);
+  ASSERT_EQ(handles.inputs, reinterpret_cast<VelaIOs*>(inputs_data.data()));
+  EXPECT_EQ(handles.inputs->count, 1);
+  ASSERT_EQ(handles.outputs, reinterpret_cast<VelaIOs*>(outputs_data.data()));
+  EXPECT_EQ(handles.outputs->count, 2);
+}
+
+TEST(VelaExternalBlocksTest, RejectsUnknownExternalBlock) {
+  executorch::runtime::runtime_init();
+  alignas(16) const std::array<uint8_t, 4> payload{1, 2, 3, 4};
+  const auto stream = stream_with_external_key("unsupported");
+  FakeNamedDataMap data_map(kExternalKey, payload.data(), payload.size());
+  VelaHandles handles{};
+
+  EXPECT_EQ(
+      vela_bin_read(
+          reinterpret_cast<const char*>(stream.data()),
+          stream.size(),
+          &data_map,
+          &handles),
+      Error::InvalidProgram);
+}

--- a/docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md
+++ b/docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md
@@ -40,7 +40,7 @@ The main configuration point for the lowering is the `EthosUCompileSpec` consume
 The full user-facing API is documented below.
 
 ```python
-class EthosUCompileSpec(target: str, system_config: str | None = None, memory_mode: str | None = None, extra_flags: list[str] | None = None, config_ini: str | None = 'Arm/vela.ini')
+class EthosUCompileSpec(target: str, system_config: str | None = None, memory_mode: str | None = None, extra_flags: list[str] | None = None, config_ini: str | None = 'Arm/vela.ini', external_block_placements: executorch.backends.arm.ethosu.compile_spec.VelaExternalBlockPlacements | None = None)
 ```
 Normalise Ethos-U compile configuration and compiler flags.
 
@@ -55,6 +55,8 @@ Args:
         Vela.
 - **config_ini (str | None)**: Path to a Vela .ini configuration file.
         Defaults to ``"Arm/vela.ini"``.
+- **external_block_placements (VelaExternalBlockPlacements | None)**: Command
+        and weight data to emit as named data with their placement tags.
 
 ```python
 def EthosUCompileSpec.dump_debug_info(self, debug_mode: executorch.backends.arm.common.arm_compile_spec.ArmCompileSpec.DebugMode | None):
@@ -79,6 +81,24 @@ Set the configuration for the Arm pass pipeline.
 
 Args:
 - **config**: The custom ArmPassPipelineConfig to set.
+
+```python
+class VelaExternalBlockPlacements(cmd_data: str | None = None, weight_data: str | None = None) -> None
+```
+Placement tags for external Vela command and weight data.
+
+Tags are arbitrary build-time identifiers used to group named data into
+external PTD outputs. Deployment decides where those artifacts live and
+supplies them to the runtime.
+
+Attributes:
+- **cmd_data**: Placement tag for command data, or ``None`` to keep it inline.
+- **weight_data**: Placement tag for weight data, or ``None`` to keep it inline.
+
+```python
+def VelaExternalBlockPlacements.to_block_placements(self) -> dict[str, str]:
+```
+Return configured placement tags keyed by Vela block name.
 
 
 


### PR DESCRIPTION
Summary:

Store selected Ethos-U Vela block payloads in placement-tagged named data.

### Serialization

During `vela_compile()`, each selected payload is written as named data. Its stream block keeps the same name and position, stores a SHA-256 named-data key, and uses one byte of the existing 12-byte header tail as the external-reference flag. The other 11 bytes remain reserved. Any Vela block may be selected.

### Runtime

Initialization resolves external payloads through the `BackendInitContext` named-data map and borrows that storage without taking ownership. Named-data resolution treats the fixed-size key and resolved payload as opaque.

Inline and external payloads follow the same `vela_bin_read` block handling. The existing `COP1`/`COP2` check remains in the parser’s `cmd_data` branch and therefore applies once to either storage form.

The processed-data and Vela parsing profiling regions run during initialization with that work.

Differential Revision: D114240131


