### PR TITLE
Channels last: add single-output max pool

### DIFF
--- a/backends/transforms/channels_last_ops.py
+++ b/backends/transforms/channels_last_ops.py
@@ -99,6 +99,19 @@ def _max_pool2d_with_indices(
     return values, indices
 
 
+def _max_pool2d(
+    input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False
+):
+    if stride is None:
+        stride = []  # Default value of max_pool2d.
+
+    nchw = input.permute(0, 3, 1, 2)
+    out = torch.ops.aten.max_pool2d.default(
+        nchw, kernel_size, stride, padding, dilation, ceil_mode
+    )
+    return out.permute(0, 2, 3, 1).contiguous()
+
+
 def _grid_sampler_2d(input, grid, interpolation_mode, padding_mode, align_corners):
     nchw = input.permute(0, 3, 1, 2)
     out = torch.ops.aten.grid_sampler_2d(
@@ -154,6 +167,13 @@ lib.impl(
 register_fake(
     "channels_last::max_pool2d_with_indices", _max_pool2d_with_indices, lib=lib
 )
+
+lib.define(
+    "max_pool2d(Tensor input, int[2] kernel_size, int[2] stride=[], "
+    "int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor"
+)
+lib.impl("max_pool2d", _max_pool2d, "CompositeExplicitAutograd")
+register_fake("channels_last::max_pool2d", _max_pool2d, lib=lib)
 
 lib.define(
     "grid_sampler_2d(Tensor input, Tensor grid, int interpolation_mode, "

--- a/backends/transforms/decompose_channels_last_pass.py
+++ b/backends/transforms/decompose_channels_last_pass.py
@@ -56,7 +56,10 @@ class DecomposeChannelsLastPass(ExportPass):
                 {},
                 meta,
             )
-        if op == exir_ops.edge.channels_last.max_pool2d_with_indices.default:
+        if op in (
+            exir_ops.edge.channels_last.max_pool2d.default,
+            exir_ops.edge.channels_last.max_pool2d_with_indices.default,
+        ):
             nchw_in = super().call_operator(
                 exir_ops.edge.aten.permute_copy.default,
                 (args[0], _NHWC_TO_NCHW),
@@ -70,21 +73,23 @@ class DecomposeChannelsLastPass(ExportPass):
                 meta,
             )
             values = super().call_operator(operator.getitem, (pooled, 0), {}, meta)
-            indices = super().call_operator(operator.getitem, (pooled, 1), {}, meta)
-            return (
-                super().call_operator(
-                    exir_ops.edge.aten.permute_copy.default,
-                    (values, _NCHW_TO_NHWC),
-                    {},
-                    meta,
-                ),
-                super().call_operator(
-                    exir_ops.edge.aten.permute_copy.default,
-                    (indices, _NCHW_TO_NHWC),
-                    {},
-                    meta,
-                ),
+            values = super().call_operator(
+                exir_ops.edge.aten.permute_copy.default,
+                (values, _NCHW_TO_NHWC),
+                {},
+                meta,
             )
+            if op == exir_ops.edge.channels_last.max_pool2d.default:
+                return values
+
+            indices = super().call_operator(operator.getitem, (pooled, 1), {}, meta)
+            indices = super().call_operator(
+                exir_ops.edge.aten.permute_copy.default,
+                (indices, _NCHW_TO_NHWC),
+                {},
+                meta,
+            )
+            return values, indices
         if op == exir_ops.edge.channels_last.permute_copy.default:
             return super().call_operator(
                 exir_ops.edge.aten.permute_copy.default, args, kwargs, meta

--- a/backends/transforms/replace_ops_with_channels_last_variants.py
+++ b/backends/transforms/replace_ops_with_channels_last_variants.py
@@ -63,7 +63,7 @@ class ChannelsLastOpSpec:
     # Positional arg indices of tensor inputs that should be permuted NCHW→NHWC.
     input_indices: list[int]
 
-    # Indices of the outputs that should be permuted NCHW→NHWC.
+    # Indices of the outputs that should be permuted NHWC→NCHW.
     output_indices: list[int]
 
     # If provided, this function must return True for a node to be replaced.
@@ -99,6 +99,14 @@ _DEFAULT_OP_MAP: dict[Target, ChannelsLastOpSpec] = {
         target=exir_ops.edge.channels_last.max_pool2d_with_indices.default,
         input_indices=[0],
         output_indices=[0, 1],
+        filter_fn=_requires_rank([3, 4]),
+    ),
+    # RemoveGetItemPass turns max_pool2d_with_indices + getitem(0) into this
+    # single-output operator before backend layout lowering.
+    exir_ops.edge.aten.max_pool2d.default: ChannelsLastOpSpec(
+        target=exir_ops.edge.channels_last.max_pool2d.default,
+        input_indices=[0],
+        output_indices=[0],
         filter_fn=_requires_rank([3, 4]),
     ),
     exir_ops.edge.aten.upsample_bilinear2d.vec: ChannelsLastOpSpec(

--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -504,6 +504,7 @@ def define_common_targets():
         deps = [
             "//caffe2:torch",
             ":channels_last_ops",
+            ":remove_getitem_op",
             ":replace_ops_with_channels_last_variants",
             "//executorch/exir:lib",
             "fbsource//third-party/pypi/pytest:pytest",

--- a/backends/transforms/test/test_channels_last_ops.py
+++ b/backends/transforms/test/test_channels_last_ops.py
@@ -191,6 +191,22 @@ def test_max_pool2d_with_indices_matches_aten():
     assert torch.equal(act_i, expected_i)
 
 
+def test_max_pool2d_matches_aten():
+    torch.manual_seed(0)
+    nchw = torch.randn(2, 3, 8, 8)
+    nhwc = _to_nhwc(nchw)
+
+    expected = _to_nhwc(
+        torch.ops.aten.max_pool2d.default(nchw, [2, 2], [2, 2], [0, 0], [1, 1], False)
+    )
+    actual = torch.ops.channels_last.max_pool2d(
+        nhwc, [2, 2], [2, 2], [0, 0], [1, 1], False
+    )
+
+    assert actual.shape == expected.shape
+    assert torch.equal(actual, expected)
+
+
 def test_grid_sampler_2d_matches_aten():
     torch.manual_seed(0)
     nchw = torch.randn(2, 3, 8, 8)

--- a/backends/transforms/test/test_decompose_channels_last_pass.py
+++ b/backends/transforms/test/test_decompose_channels_last_pass.py
@@ -81,6 +81,13 @@ class _MaxPoolModule(torch.nn.Module):
         )
 
 
+class _MaxPoolValuesModule(torch.nn.Module):
+    def forward(self, x):
+        return torch.ops.channels_last.max_pool2d(
+            x, [2, 2], [2, 2], [0, 0], [1, 1], False
+        )
+
+
 class _PermuteModule(torch.nn.Module):
     def forward(self, x):
         return torch.ops.channels_last.permute_copy(x, [0, 3, 1, 2])
@@ -141,6 +148,13 @@ _CASES = [
         (torch.randn(2, 8, 8, 3), torch.rand(2, 6, 6, 2) * 2 - 1),
         exir_ops.edge.channels_last.grid_sampler_2d.default,
         exir_ops.edge.aten.grid_sampler_2d.default,
+        2,
+    ),
+    (
+        _MaxPoolValuesModule(),
+        (torch.randn(2, 8, 8, 3),),
+        exir_ops.edge.channels_last.max_pool2d.default,
+        exir_ops.edge.aten.max_pool2d_with_indices.default,
         2,
     ),
     (

--- a/backends/transforms/test/test_replace_ops_with_channels_last_variants.py
+++ b/backends/transforms/test/test_replace_ops_with_channels_last_variants.py
@@ -8,6 +8,7 @@ import operator
 import executorch.backends.transforms.channels_last_ops  # noqa: F401
 import pytest
 import torch
+from executorch.backends.transforms.remove_getitem_op import RemoveGetItemPass
 from executorch.backends.transforms.replace_ops_with_channels_last_variants import (
     _NCHW_TO_NHWC_PERM,
     _NHWC_TO_NCHW_PERM,
@@ -131,7 +132,6 @@ class UpsampleNearestModule(torch.nn.Module):
 
 
 class TestReplaceOpsWithChannelsLastVariants:
-
     def test_conv2d(self):
         ep = _export_to_edge(Conv2dModule(bias=True), (torch.randn(1, 4, 8, 8),))
         assert _count(ep.graph_module, exir_ops.edge.aten.convolution.default) == 1
@@ -251,7 +251,30 @@ class TestReplaceOpsWithChannelsLastVariants:
         assert output_permute.target == exir_ops.edge.channels_last.permute_copy.default
         assert list(output_permute.args[1]) == _NHWC_TO_NCHW_PERM
 
-    def test_max_pool2d__implicit_batch(self):
+    @pytest.mark.parametrize("input_shape", [(1, 4, 8, 8), (4, 8, 8)])
+    def test_single_output_max_pool2d(self, input_shape):
+        inputs = (torch.randn(*input_shape),)
+        ep = _export_to_edge(MaxPool2DModule(), inputs)
+        expected = ep.module()(*inputs)
+        removed = RemoveGetItemPass().call(ep.graph_module)
+
+        assert removed.modified
+        assert _count(removed.graph_module, exir_ops.edge.aten.max_pool2d.default) == 1
+
+        result = ReplaceOpsWithChannelsLastVariants(ep).call(removed.graph_module)
+        gm, modified = result.graph_module, result.modified
+
+        assert modified
+        assert _count(gm, exir_ops.edge.aten.max_pool2d.default) == 0
+        assert _count(gm, exir_ops.edge.channels_last.max_pool2d.default) == 1
+        permutes = _find_nodes(gm, exir_ops.edge.channels_last.permute_copy.default)
+        assert len(permutes) == 2
+        implicit_batch = len(input_shape) == 3
+        assert _count(gm, exir_ops.edge.aten.unsqueeze_copy.default) == implicit_batch
+        assert _count(gm, exir_ops.edge.aten.squeeze_copy.dims) == implicit_batch
+        torch.testing.assert_close(gm(*inputs)[0], expected)
+
+    def test_max_pool2d_with_indices__implicit_batch(self):
         input_shape = (4, 8, 8)  # Use implicit batch size of `1`.
         ep = _export_to_edge(MaxPool2DModule(), (torch.randn(*input_shape),))
         assert (


### PR DESCRIPTION
### Summary

Add channels_last::max_pool2d as the single-output counterpart to the existing max_pool2d_with_indices dialect operator. RemoveGetItemPass will canonicalize max_pool2d_with_indices followed by getitem(0) into aten::max_pool2d before Cortex-M layout lowering so quantization parameters attach to the values tensor rather than the tuple; the common replacement pass therefore needs a matching single-output target.

Teach ReplaceOpsWithChannelsLastVariants to select the new dialect operator and emit the existing channels-last boundary copies. DecomposeChannelsLastPass lowers both max-pool variants through the portable max_pool2d_with_indices operator, returning only values for the single-output form while sharing the common input and output conversion logic.

Exercise the real RemoveGetItemPass followed by replacement sequence for both rank-four and implicit-batch rank-three inputs. The tests verify dialect selection, boundary copies, squeeze and unsqueeze handling, default stride behavior, shapes, and numerical parity.

### Test Plan

Validated pytest -q backends/transforms/test/test_channels_last_ops.py backends/transforms/test/test_decompose_channels_last_pass.py backends/transforms/test/test_replace_ops_with_channels_last_variants.py: 61 passed.

Authored with Codex.