### PR TITLE
Transforms: add a common Conv1d-to-Conv2d pass

### DIFF
--- a/backends/transforms/convert_conv1d_to_conv2d_pass.py
+++ b/backends/transforms/convert_conv1d_to_conv2d_pass.py
@@ -1,0 +1,126 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from executorch.backends.transforms.utils import (
+    get_param_tensor,
+    is_param_node,
+    set_param_tensor,
+)
+from executorch.exir import ExportedProgram
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+
+
+class ConvertConv1dToConv2dPass(ExportPass):
+    """Express Conv1d as Conv2d with a unit-height spatial dimension.
+
+    Only convolutions with lifted parameter, buffer, or constant weights are
+    converted. Dynamic weights and unfolded QDQ weights are left unchanged.
+    The pass emits squeeze and unsqueeze boundaries for each converted
+    convolution; downstream view cleanup can fold adjacent boundaries.
+    """
+
+    def __init__(self, exported_program: ExportedProgram) -> None:
+        super().__init__()
+        self.exported_program = exported_program
+
+    def _unsqueeze_weight(self, weight_node: torch.fx.Node) -> bool:
+        weight = get_param_tensor(self.exported_program, weight_node)
+        if weight is None:
+            return False
+        if weight.dim() == 4:
+            return True
+        if weight.dim() != 3:
+            return False
+
+        weight_2d = weight.unsqueeze(2).contiguous()
+        set_param_tensor(self.exported_program, weight_node, weight_2d)
+        weight_node.meta["val"] = weight_node.meta["val"].unsqueeze(2)
+        return True
+
+    def _conv1d_weight_node(self, node: torch.fx.Node) -> torch.fx.Node | None:
+        if (
+            node.op != "call_function"
+            or node.target != exir_ops.edge.aten.convolution.default
+            or len(node.args) != 9
+        ):
+            return None
+        weight_node = node.args[1]
+        if not isinstance(weight_node, torch.fx.Node) or not is_param_node(
+            self.exported_program, weight_node
+        ):
+            return None
+        weight = get_param_tensor(self.exported_program, weight_node)
+        weight_meta = weight_node.meta.get("val")
+        if (
+            not isinstance(weight, torch.Tensor)
+            or weight.dim() != 3
+            or not isinstance(weight_meta, torch.Tensor)
+            or weight_meta.dim() != 3
+        ):
+            return None
+        return weight_node
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        graph = graph_module.graph
+        modified = False
+        candidates = {
+            node: weight_node
+            for node in graph.nodes
+            if (weight_node := self._conv1d_weight_node(node)) is not None
+        }
+
+        for node, weight_node in candidates.items():
+            if any(
+                candidates.get(user) is not weight_node
+                or any(
+                    arg is weight_node
+                    for index, arg in enumerate(user.args)
+                    if index != 1
+                )
+                or any(arg is weight_node for arg in user.kwargs.values())
+                for user in weight_node.users
+            ):
+                continue
+
+            input_node = node.args[0]
+            if not isinstance(input_node, torch.fx.Node):
+                continue
+            if not self._unsqueeze_weight(weight_node):
+                continue
+            with graph.inserting_before(node):
+                input_2d = graph.call_function(
+                    exir_ops.edge.aten.unsqueeze_copy.default,
+                    args=(input_node, 2),
+                )
+
+            args = list(node.args)
+            args[0] = input_2d
+            args[3] = [1, *list(args[3])]  # stride
+            args[4] = [0, *list(args[4])]  # padding
+            args[5] = [1, *list(args[5])]  # dilation
+            args[7] = [0, *list(args[7])]  # output padding
+            node.args = tuple(args)
+
+            with graph.inserting_after(node):
+                output_1d = graph.call_function(
+                    exir_ops.edge.aten.squeeze_copy.dim,
+                    args=(node, 2),
+                )
+            for user in list(node.users):
+                if user is not output_1d:
+                    user.replace_input_with(node, output_1d)
+
+            modified = True
+
+        if not modified:
+            return PassResult(graph_module, False)
+
+        graph_module.recompile()
+        result = super().call(graph_module)
+        return PassResult(result.graph_module, True)

--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -205,6 +205,23 @@ def define_common_targets():
     )
 
     runtime.python_library(
+        name = "convert_conv1d_to_conv2d_pass",
+        srcs = [
+            "convert_conv1d_to_conv2d_pass.py",
+        ],
+        visibility = [
+            "//executorch/backends/...",
+        ],
+        deps = [
+            "//caffe2:torch",
+            ":utils",
+            "//executorch/exir:lib",
+            "//executorch/exir:pass_base",
+            "//executorch/exir/dialects:lib",
+        ],
+    )
+
+    runtime.python_library(
         name = "decompose_channels_last_pass",
         srcs = [
             "decompose_channels_last_pass.py",
@@ -506,6 +523,21 @@ def define_common_targets():
             ":channels_last_ops",
             ":replace_ops_with_channels_last_variants",
             "//executorch/exir:lib",
+            "fbsource//third-party/pypi/pytest:pytest",
+        ],
+    )
+
+    runtime.python_test(
+        name = "test_convert_conv1d_to_conv2d_pass",
+        srcs = [
+            "test/test_convert_conv1d_to_conv2d_pass.py",
+        ],
+        deps = [
+            "//caffe2:torch",
+            ":convert_conv1d_to_conv2d_pass",
+            ":utils",
+            "//executorch/exir:lib",
+            "//executorch/exir/dialects:lib",
             "fbsource//third-party/pypi/pytest:pytest",
         ],
     )

--- a/backends/transforms/test/test_convert_conv1d_to_conv2d_pass.py
+++ b/backends/transforms/test/test_convert_conv1d_to_conv2d_pass.py
@@ -1,0 +1,322 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from executorch.backends.transforms.convert_conv1d_to_conv2d_pass import (
+    ConvertConv1dToConv2dPass,
+)
+from executorch.backends.transforms.utils import set_param_tensor
+from executorch.exir import to_edge
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.program._program import _transform
+
+
+class Conv1d(torch.nn.Module):
+    def __init__(
+        self,
+        bias: bool = True,
+        groups: int = 1,
+        stride: int = 1,
+        padding: int = 1,
+        dilation: int = 1,
+    ):
+        super().__init__()
+        self.conv = torch.nn.Conv1d(
+            2,
+            4,
+            3,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias,
+            groups=groups,
+        )
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+class ConvTranspose1d(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.ConvTranspose1d(
+            2, 4, 3, stride=2, padding=1, output_padding=1
+        )
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+class DynamicWeightConv1d(torch.nn.Module):
+    def forward(self, x, weight):
+        return F.conv1d(x, weight, padding=1)
+
+
+class BufferConv1d(torch.nn.Module):
+    def __init__(self, persistent: bool):
+        super().__init__()
+        self.register_buffer("weight", torch.randn(4, 2, 3), persistent=persistent)
+
+    def forward(self, x):
+        return F.conv1d(x, self.weight, padding=1)
+
+
+class ConstantConv1d(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.randn(4, 2, 3)
+
+    def forward(self, x):
+        return F.conv1d(x, self.weight, padding=1)
+
+
+class SharedConv1d(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(4, 2, 3))
+
+    def forward(self, x):
+        return F.conv1d(x, self.weight, padding=1) + F.conv1d(x, self.weight, padding=1)
+
+
+class MixedUseWeight(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(4, 2, 3))
+
+    def forward(self, x):
+        return F.conv1d(x, self.weight, padding=1), self.weight
+
+
+class WeightUsedAsConvInput(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.shared = torch.nn.Parameter(torch.randn(4, 2, 3))
+        self.other_weight = torch.nn.Parameter(torch.randn(3, 2, 1))
+
+    def forward(self, x):
+        return F.conv1d(x, self.shared, padding=1), F.conv1d(
+            self.shared, self.other_weight
+        )
+
+
+def _edge(model: torch.nn.Module, inputs: tuple[torch.Tensor, ...]):
+    return to_edge(torch.export.export(model.eval(), inputs)).exported_program()
+
+
+def _convert_and_compare(model: torch.nn.Module, x: torch.Tensor):
+    reference = model(x)
+    edge = _edge(model, (x,))
+    converted = _transform(edge, ConvertConv1dToConv2dPass(edge))
+    torch.testing.assert_close(converted.module()(x), reference)
+    return converted
+
+
+@pytest.mark.parametrize("bias, groups", [(True, 1), (False, 1), (False, 2)])
+def test_convert_conv1d_to_conv2d(bias: bool, groups: int):
+    converted = _convert_and_compare(
+        Conv1d(bias=bias, groups=groups), torch.randn(1, 2, 8)
+    )
+    [conv] = [
+        node
+        for node in converted.graph.nodes
+        if node.target == exir_ops.edge.aten.convolution.default
+    ]
+
+    assert conv.args[1].meta["val"].shape == torch.Size([4, 2 // groups, 1, 3])
+    assert conv.args[3:6] == ([1, 1], [0, 1], [1, 1])
+    assert conv.args[0].target == exir_ops.edge.aten.unsqueeze_copy.default
+    assert next(iter(conv.users)).target == exir_ops.edge.aten.squeeze_copy.dim
+
+
+def test_convert_stride_and_dilation():
+    converted = _convert_and_compare(
+        Conv1d(stride=3, padding=2, dilation=2), torch.randn(1, 2, 16)
+    )
+    [conv] = [
+        node
+        for node in converted.graph.nodes
+        if node.target == exir_ops.edge.aten.convolution.default
+    ]
+
+    assert conv.args[3:6] == ([1, 3], [0, 2], [1, 2])
+
+
+def test_convert_transposed_conv1d():
+    converted = _convert_and_compare(ConvTranspose1d(), torch.randn(1, 2, 8))
+    [conv] = [
+        node
+        for node in converted.graph.nodes
+        if node.target == exir_ops.edge.aten.convolution.default
+    ]
+
+    assert conv.args[1].meta["val"].shape == torch.Size([2, 4, 1, 3])
+    assert conv.args[3:8] == ([1, 2], [0, 1], [1, 1], True, [0, 1])
+
+
+@pytest.mark.parametrize(
+    "model", [BufferConv1d(True), BufferConv1d(False), ConstantConv1d()]
+)
+def test_convert_lifted_weight_storage(model: torch.nn.Module):
+    _convert_and_compare(model, torch.randn(1, 2, 8))
+
+
+def test_convert_shared_conv1d_weight_once():
+    converted = _convert_and_compare(SharedConv1d(), torch.randn(1, 2, 8))
+    convs = [
+        node
+        for node in converted.graph.nodes
+        if node.target == exir_ops.edge.aten.convolution.default
+    ]
+
+    assert len(convs) == 2
+    assert convs[0].args[1] is convs[1].args[1]
+    assert convs[0].args[1].meta["val"].dim() == 4
+
+
+def test_skip_weight_with_non_conv1d_user():
+    model = MixedUseWeight().eval()
+    x = torch.randn(1, 2, 8)
+    reference = model(x)
+    edge = _edge(model, (x,))
+    result = ConvertConv1dToConv2dPass(edge).call(edge.graph_module)
+
+    assert not result.modified
+    actual = edge.module()(x)
+    torch.testing.assert_close(actual[0], reference[0])
+    torch.testing.assert_close(actual[1], reference[1])
+
+
+def test_skip_weight_used_as_another_conv1d_input():
+    model = WeightUsedAsConvInput().eval()
+    x = torch.randn(1, 2, 8)
+    reference = model(x)
+    edge = _edge(model, (x,))
+    converted = _transform(edge, ConvertConv1dToConv2dPass(edge))
+
+    actual = converted.module()(x)
+    torch.testing.assert_close(actual[0], reference[0])
+    torch.testing.assert_close(actual[1], reference[1])
+    weight_ranks = sorted(
+        node.args[1].meta["val"].dim()
+        for node in converted.graph.nodes
+        if node.target == exir_ops.edge.aten.convolution.default
+    )
+    assert weight_ranks == [3, 4]
+
+
+def test_skip_dynamic_weight():
+    model = DynamicWeightConv1d().eval()
+    inputs = (torch.randn(1, 2, 8), torch.randn(4, 2, 3))
+    reference = model(*inputs)
+    edge = _edge(model, inputs)
+
+    result = ConvertConv1dToConv2dPass(edge).call(edge.graph_module)
+
+    assert not result.modified
+    torch.testing.assert_close(edge.module()(*inputs), reference)
+
+
+def test_skip_unfolded_qdq_weight():
+    edge = _edge(Conv1d(), (torch.randn(1, 2, 8),))
+    [conv] = [
+        node
+        for node in edge.graph.nodes
+        if node.target == exir_ops.edge.aten.convolution.default
+    ]
+    weight = conv.args[1]
+    with edge.graph.inserting_before(conv):
+        dequantized_weight = edge.graph.call_function(
+            exir_ops.edge.quantized_decomposed.dequantize_per_channel.default,
+            args=(
+                weight,
+                torch.ones(4),
+                torch.zeros(4, dtype=torch.int64),
+                0,
+                -128,
+                127,
+                torch.int8,
+            ),
+        )
+    dequantized_weight.meta["val"] = weight.meta["val"]
+    args = list(conv.args)
+    args[1] = dequantized_weight
+    conv.args = tuple(args)
+
+    result = ConvertConv1dToConv2dPass(edge).call(edge.graph_module)
+
+    assert not result.modified
+
+
+def test_preserve_convolution_metadata():
+    edge = _edge(Conv1d(), (torch.randn(1, 2, 8),))
+    [conv] = [
+        node
+        for node in edge.graph.nodes
+        if node.target == exir_ops.edge.aten.convolution.default
+    ]
+    metadata = {
+        "input_qparams": {0: "input"},
+        "output_qparams": {0: "output"},
+        "custom": {"value": 1},
+        "delegation_tag": "test_tag",
+    }
+    conv.meta.update(metadata)
+
+    converted = _transform(edge, ConvertConv1dToConv2dPass(edge))
+    [converted_conv] = [
+        node
+        for node in converted.graph.nodes
+        if node.target == exir_ops.edge.aten.convolution.default
+    ]
+
+    for key, value in metadata.items():
+        assert converted_conv.meta[key] == value
+
+
+def test_set_param_tensor_get_attr_fallback():
+    edge = _edge(Conv1d(), (torch.randn(1, 2, 8),))
+    edge.graph_module.fallback_weight = torch.nn.Parameter(
+        torch.randn(4, 2, 3), requires_grad=True
+    )
+    graph = torch.fx.Graph()
+    weight_node = graph.get_attr("fallback_weight")
+    replacement = torch.randn(4, 2, 1, 3)
+
+    set_param_tensor(edge, weight_node, replacement)
+
+    actual = edge.graph_module.fallback_weight
+    assert isinstance(actual, torch.nn.Parameter)
+    assert actual.requires_grad
+    torch.testing.assert_close(actual, replacement)
+
+
+def test_rank4_weight_with_singleton_args_is_not_converted():
+    edge = _edge(torch.nn.Conv2d(2, 4, 3, padding=1), (torch.randn(1, 2, 8, 8),))
+    [conv] = [
+        node
+        for node in edge.graph.nodes
+        if node.target == exir_ops.edge.aten.convolution.default
+    ]
+    args = list(conv.args)
+    args[3:6] = ([1], [1], [1])
+    conv.args = tuple(args)
+
+    result = ConvertConv1dToConv2dPass(edge).call(edge.graph_module)
+
+    assert not result.modified
+    assert conv.args[3:6] == ([1], [1], [1])
+
+
+def test_conversion_is_idempotent():
+    converted = _convert_and_compare(Conv1d(), torch.randn(1, 2, 8))
+
+    result = ConvertConv1dToConv2dPass(converted).call(converted.graph_module)
+
+    assert not result.modified

--- a/backends/transforms/utils.py
+++ b/backends/transforms/utils.py
@@ -95,6 +95,39 @@ def get_param_tensor(
     raise RuntimeError(f"unsupported param type, {node.op}.")
 
 
+def set_param_tensor(
+    exp_prog: ExportedProgram, node: torch.fx.Node, data: torch.Tensor
+) -> None:
+    """Replace the tensor represented by a parameter-like graph node."""
+    if is_param(exp_prog, node):
+        target = exp_prog.graph_signature.inputs_to_parameters[node.name]
+        parameter = exp_prog.state_dict[target]
+        exp_prog.state_dict[target] = torch.nn.Parameter(
+            data, requires_grad=parameter.requires_grad
+        )
+    elif is_buffer(exp_prog, node):
+        target = exp_prog.graph_signature.inputs_to_buffers[node.name]
+        if target in exp_prog.graph_signature.non_persistent_buffers:
+            exp_prog.constants[target] = data
+        else:
+            exp_prog.state_dict[target] = data
+    elif is_lifted_tensor_constant(exp_prog, node):
+        target = exp_prog.graph_signature.inputs_to_lifted_tensor_constants[node.name]
+        exp_prog.constants[target] = data
+    elif is_get_attr_node(node):
+        module = node.graph.owning_module
+        try:
+            current = getattr(module, node.target)
+        except (AttributeError, TypeError):
+            module = exp_prog.graph_module
+            current = getattr(module, node.target)
+        if isinstance(current, torch.nn.Parameter):
+            data = torch.nn.Parameter(data, requires_grad=current.requires_grad)
+        setattr(module, node.target, data)
+    else:
+        raise RuntimeError(f"unsupported param type, {node.op}.")
+
+
 def _buffer_target(node_name: str) -> str:
     """Map a placeholder name to its state_dict target per the export
     convention: placeholder "b_foo" corresponds to buffer target "foo"."""


### PR DESCRIPTION
### Summary

Add a backend-independent transform that represents Conv1d and ConvTranspose1d as equivalent unit-height 2D convolutions. The pass unsqueezes rank-three activations and weights, expands stride, padding, dilation, and output-padding arguments at their Edge convolution positions, then squeezes the result back to the original rank.

Convert only convolutions whose weights are lifted parameters, buffers, constants, or get-attr tensors. Dynamic graph-input weights and unfolded QDQ weights are left unchanged rather than causing compilation to fail. Add set_param_tensor beside get_param_tensor so parameter, persistent-buffer, non-persistent-buffer, lifted-constant, and get-attr writeback share one symmetric implementation.

Shared weights are converted only when every use is exclusively the weight argument of a candidate Conv1d. ExportPass preserves arbitrary backend and quantization metadata through the retrace without a name-based allowlist. Each converted convolution retains explicit squeeze and unsqueeze boundaries so downstream view cleanup can fold adjacent boundaries.

### Test Plan

Validated pytest -q backends/transforms/test/test_convert_conv1d_to_conv2d_pass.py: 17 passed.

Validated pytest -q backends/transforms/test/test_create_delete_constant_placeholder.py backends/transforms/test/test_create_mutable_buffer.py: 15 passed.

Authored with Codex.
