### PR TITLE
Preserve runtime allocations during constant propagation (#21897)

### DIFF
--- a/exir/passes/constant_prop_pass.py
+++ b/exir/passes/constant_prop_pass.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 from typing import cast, Mapping, Optional
 
 import torch
+from executorch.exir import memory
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
 from executorch.exir.operator.util import _QUANT_PRIMITIVES
@@ -141,7 +142,11 @@ def get_propagated_const_tensor_dict(
         all_skip_targets = _DEFAULT_SKIP_TARGETS
 
     for node in exported_program.graph.nodes:
-        if node.op != "call_function" or node.target in all_skip_targets:
+        if (
+            node.op != "call_function"
+            or node.target is memory.alloc
+            or node.target in all_skip_targets
+        ):
             continue
 
         if not is_const(

--- a/exir/tests/test_passes.py
+++ b/exir/tests/test_passes.py
@@ -1621,6 +1621,42 @@ class TestPasses(unittest.TestCase):
         edge.exported_program()._validate()
         edge.to_executorch()
 
+    def test_constant_prop_preserves_memory_alloc(self) -> None:
+        class Add(torch.nn.Module):
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x + 1
+
+        for custom_skip_targets in (None, set()):
+            with self.subTest(custom_skip_targets=custom_skip_targets):
+                edge = to_edge(
+                    export(Add(), (torch.ones(1),), strict=True),
+                    compile_config=EdgeCompileConfig(_skip_dim_order=False),
+                )
+                exported_program = edge.exported_program()
+                [add] = exported_program.graph.find_nodes(
+                    op="call_function", target=exir_ops.edge.aten.add.Tensor
+                )
+                with exported_program.graph.inserting_before(add):
+                    alloc = exported_program.graph.call_function(
+                        memory.alloc, args=(((1,), torch.float32),)
+                    )
+                alloc.meta["val"] = torch.empty(1, dtype=torch.float32, device="meta")
+                add.args = (add.args[0], alloc)
+                exported_program.graph_module.recompile()
+
+                new_ep = constant_prop_pass(
+                    exported_program, custom_skip_targets=custom_skip_targets
+                )
+
+                self.assertEqual(
+                    new_ep.graph.find_nodes(op="call_function", target=memory.alloc),
+                    [alloc],
+                )
+                self.assertNotIn(alloc.name, new_ep.constants)
+                FileCheck().check("executorch_exir_memory_alloc").check_not(
+                    "_prop_tensor_constant"
+                ).run(new_ep.graph_module.code)
+
     def test_constant_prop_pass_for_add(self) -> None:
         class Add(torch.nn.Module):
             def forward(self, x: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Summary:

Treat executorch.exir.memory.alloc as intrinsically non-constant so constant propagation never executes and lifts runtime-planned workspaces into serialized model data. This applies even when callers replace the default skip targets.

Add mirrored framework coverage for default and custom skip sets, plus a Cortex-M fused depthwise-convolution regression that verifies scratch remains a uint8 runtime allocation rather than a lifted constant.

Reviewed By: angelayi

Differential Revision: D116349009


