### PR TITLE
Fall back for asymmetric Conv2d weights (#21900)

### DIFF
--- a/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
+++ b/backends/cadence/hifi/operators/op_quantized_conv2d_nhwc_out.cpp
@@ -167,7 +167,9 @@ void xa_opt_quantized_conv2d_nhwc(
   bool conv1d = input.dim() == 3;
   constexpr int kNnlibMaxDim = 4;
 
-  if (input.scalar_type() == ScalarType::Char) {
+  // NNLib's int8 entry points require symmetric weights. Let the generic
+  // implementation handle non-zero weight zero points.
+  if (input.scalar_type() == ScalarType::Char && weight_zero_point == 0) {
     WORD8* __restrict__ p_out =
         (WORD8* __restrict__)out.mutable_data_ptr<int8_t>();
     WORD8* __restrict__ p_inp =
@@ -213,11 +215,7 @@ void xa_opt_quantized_conv2d_nhwc(
     WORD32 dilation_width = dilation[1];
     WORD32 dilation_height = dilation[0];
 
-    // WORD32* kernel_bias_ptr =
-    //   (WORD32*)weight_zero_point.const_data_ptr<int32_t>();
-
     WORD32 input_zero_bias = -in_zero_point;
-    WORD32 kernel_zero_bias = -weight_zero_point;
 
     WORD32 out_multiplier32[out_channels];
     WORD32 out_shift32[out_channels];


### PR DESCRIPTION
Summary:

The HiFi NNLib int8 Conv2d entry points require symmetric weights, but the wrapper selected them when `weight_zero_point` was non-zero. Restrict the optimized path to symmetric weights so asymmetric cases use the generic implementation. Mirror the fix in `fbcode` and `xplat`.

Reviewed By: aliafzal

Differential Revision: D116334309


