### PR TITLE
Add sliding windows to the off-graph KV-cache reference

### DIFF
--- a/extension/llm/cache/reference_cache.py
+++ b/extension/llm/cache/reference_cache.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import Dict, List, Mapping, Optional, Sequence, Set, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -54,6 +54,33 @@ class AttendSpec:
     mask: Optional[torch.Tensor] = None  # EXPLICIT only: bool, true = attend
 
 
+class LayerKind(Enum):
+    FLAT = "flat"  # retains all history
+    RING = "ring"  # sliding window over the newest `window` positions
+
+
+@dataclass(frozen=True)
+class LayerPolicy:
+    """Per-layer cache kind and its parameters. Mirrors the C++ LayerPolicy."""
+
+    kind: LayerKind = LayerKind.FLAT
+    window: int = 0  # RING only: window size in positions
+
+    def __post_init__(self):
+        if self.kind is LayerKind.RING and self.window <= 0:
+            raise ValueError("a ring layer needs a positive window")
+        if self.kind is LayerKind.FLAT and self.window != 0:
+            raise ValueError("a flat layer retains all history; window must be 0")
+
+    @classmethod
+    def flat(cls) -> "LayerPolicy":
+        return cls(kind=LayerKind.FLAT)
+
+    @classmethod
+    def ring(cls, window: int) -> "LayerPolicy":
+        return cls(kind=LayerKind.RING, window=window)
+
+
 @experimental(
     "update_and_attend KV cache is experimental and may change without notice."
 )
@@ -66,23 +93,17 @@ class CacheConfig:
     sizing: CacheSizing = CacheSizing.DYNAMIC
     dtype: torch.dtype = torch.float32
     batch_size: int = 1
-    # Sliding window in positions; 0 = keep all history. An int applies to
-    # every layer, a list is per layer.
-    window: Union[int, Sequence[int]] = 0
+    # Per-layer policy: one entry applies to every layer, else one per layer.
+    layers: Sequence[LayerPolicy] = (LayerPolicy.flat(),)
 
     def __post_init__(self):
         if self.capacity <= 0:
             raise ValueError("capacity must be positive")
-        windows = [self.window] if isinstance(self.window, int) else self.window
-        if len(windows) not in (1, self.n_layers):
-            raise ValueError("window must be an int, or one entry per layer")
-        if any(w < 0 for w in windows):
-            raise ValueError("window must not be negative")
+        if len(self.layers) not in (1, self.n_layers):
+            raise ValueError("layers must be one policy, or one per layer")
 
-    def window_for(self, layer_id: int) -> int:
-        if isinstance(self.window, int):
-            return self.window
-        return self.window[0] if len(self.window) == 1 else self.window[layer_id]
+    def policy_for(self, layer_id: int) -> LayerPolicy:
+        return self.layers[0] if len(self.layers) == 1 else self.layers[layer_id]
 
 
 @experimental(
@@ -179,7 +200,7 @@ class ContiguousReferenceCache:
         ``i + total - q_len - window``. Whichever bound the fused kinds cannot
         express is what makes the step EXPLICIT.
         """
-        window = self.config.window_for(layer_id)
+        window = self.config.policy_for(layer_id).window
         windowed = 0 < window < total
         if q_len == 1 and not windowed:
             return AttendSpec(kind=MaskKind.NONE)
@@ -436,7 +457,7 @@ class CellReferenceCache:
             self._v[layer_id][:, :, :read_len, :],
             AttendSpec(
                 kind=MaskKind.EXPLICIT,
-                mask=self._plan.mask_for(self.config.window_for(layer_id)),
+                mask=self._plan.mask_for(self.config.policy_for(layer_id).window),
             ),
         )
 

--- a/extension/llm/cache/reference_cache.py
+++ b/extension/llm/cache/reference_cache.py
@@ -61,7 +61,7 @@ class LayerKind(Enum):
 
 @dataclass(frozen=True)
 class LayerPolicy:
-    """Per-layer cache kind and its parameters. Mirrors the C++ LayerPolicy."""
+    """Per-layer cache kind and its parameters."""
 
     kind: LayerKind = LayerKind.FLAT
     window: int = 0  # RING only: window size in positions
@@ -206,9 +206,8 @@ class ContiguousReferenceCache:
             return AttendSpec(kind=MaskKind.NONE)
         if q_len == total and not windowed:
             return AttendSpec(kind=MaskKind.CAUSAL)
-        # A backend whose causal is lower-right aligned fuses the upper bound
-        # (MLX does); torch's is_causal is upper-left, and neither expresses the
-        # window, so the reference hands back the band itself.
+        # torch's is_causal is upper-left and expresses no window, so the band
+        # is handed back explicitly.
         offsets = torch.arange(total, device=device) - torch.arange(
             q_len, device=device
         ).unsqueeze(-1)

--- a/extension/llm/cache/reference_cache.py
+++ b/extension/llm/cache/reference_cache.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Mapping, Optional, Sequence, Set, Tuple
+from typing import List, Mapping, Optional, Sequence, Set, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -66,10 +66,23 @@ class CacheConfig:
     sizing: CacheSizing = CacheSizing.DYNAMIC
     dtype: torch.dtype = torch.float32
     batch_size: int = 1
+    # Sliding window in positions; 0 = keep all history. An int applies to
+    # every layer, a list is per layer.
+    window: Union[int, Sequence[int]] = 0
 
     def __post_init__(self):
         if self.capacity <= 0:
             raise ValueError("capacity must be positive")
+        windows = [self.window] if isinstance(self.window, int) else self.window
+        if len(windows) not in (1, self.n_layers):
+            raise ValueError("window must be an int, or one entry per layer")
+        if any(w < 0 for w in windows):
+            raise ValueError("window must not be negative")
+
+    def window_for(self, layer_id: int) -> int:
+        if isinstance(self.window, int):
+            return self.window
+        return self.window[0] if len(self.window) == 1 else self.window[layer_id]
 
 
 @experimental(
@@ -154,23 +167,34 @@ class ContiguousReferenceCache:
             v_hist = self._v[layer_id]
         self._used[layer_id] = new_used
 
-        return k_hist, v_hist, self._spec(q_len, new_used, k.device)
+        return k_hist, v_hist, self._spec(layer_id, q_len, new_used, k.device)
 
-    @staticmethod
-    def _spec(q_len: int, total: int, device: torch.device) -> AttendSpec:
-        """The mask semantic for q_len new cells at the tail of a total window."""
-        if q_len == 1:
+    def _spec(
+        self, layer_id: int, q_len: int, total: int, device: torch.device
+    ) -> AttendSpec:
+        """The mask semantic for q_len new cells at the tail of a total window.
+
+        The new cells are at the tail, so query i attends keys up to
+        ``i + total - q_len``, and a sliding window bounds it from below at
+        ``i + total - q_len - window``. Whichever bound the fused kinds cannot
+        express is what makes the step EXPLICIT.
+        """
+        window = self.config.window_for(layer_id)
+        windowed = 0 < window < total
+        if q_len == 1 and not windowed:
             return AttendSpec(kind=MaskKind.NONE)
-        if q_len == total:
+        if q_len == total and not windowed:
             return AttendSpec(kind=MaskKind.CAUSAL)
-        # Continuation (chunked / multi-turn): the new cells are at the tail, so
-        # query i attends keys up to i + total - q_len. A backend whose causal is
-        # lower-right aligned fuses that as CAUSAL; torch's is_causal
-        # is upper-left, so the reference hands back the band itself.
+        # A backend whose causal is lower-right aligned fuses the upper bound
+        # (MLX does); torch's is_causal is upper-left, and neither expresses the
+        # window, so the reference hands back the band itself.
         offsets = torch.arange(total, device=device) - torch.arange(
             q_len, device=device
         ).unsqueeze(-1)
-        return AttendSpec(kind=MaskKind.EXPLICIT, mask=offsets <= total - q_len)
+        band = offsets <= total - q_len
+        if windowed:
+            band &= offsets > total - q_len - window
+        return AttendSpec(kind=MaskKind.EXPLICIT, mask=band)
 
 
 # A cell's owners are a bitset in a torch int64, so bit 63 (the sign bit) is out.

--- a/extension/llm/cache/reference_cache.py
+++ b/extension/llm/cache/reference_cache.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -241,10 +241,24 @@ def flatten_step(
 
 @dataclass
 class _CellStepPlan:
-    """One step's allocation, shared by every layer of that forward."""
+    """One step's allocation, shared by every layer of that forward.
+
+    Layers can differ in window, so the mask is per *policy* rather than per
+    layer: membership and causality are common, and only the lower bound moves.
+    `masks` memoizes one per distinct window (0 = unwindowed) as layers ask, so
+    a mixed model costs two masks a step rather than one per layer.
+    """
 
     cells: torch.Tensor  # [n_tok] long -- the cell each query token was given
-    mask: torch.Tensor  # [n_tok, read_len] bool -- true = attend
+    base: torch.Tensor  # [n_tok, read_len] bool -- occupied, same seq, causal
+    cell_pos: torch.Tensor  # [read_len] -- the window's positions
+    tok_pos: torch.Tensor  # [n_tok, 1] -- this step's positions
+    masks: Dict[int, torch.Tensor]  # window -> mask; 0 is `base` itself
+
+    def mask_for(self, window: int) -> torch.Tensor:
+        if window not in self.masks:
+            self.masks[window] = self.base & (self.cell_pos > self.tok_pos - window)
+        return self.masks[window]
 
 
 @experimental(
@@ -257,14 +271,19 @@ class CellReferenceCache:
     sequences owning it, so a sequence need not be contiguous and two may share
     cells -- a fork sets a second bit instead of copying K/V. Visibility is then
     a property of the cell rather than of the layout: query i attends cell j iff
-    j is occupied, shares a sequence with i, and is no newer than i. No causal
-    alignment can express that, so the spec is always EXPLICIT.
+    j is occupied, shares a sequence with i, and is no newer than i -- and, on a
+    windowed layer, no older than its window. No causal alignment can express
+    that, so the spec is always EXPLICIT.
 
     The batch is flat: tokens from every sequence sit on one axis with B = 1,
     and sequence identity is supplied out-of-band. ``begin_step`` declares which
     sequence each of the next forward's tokens belongs to; the positions arrive
     with the forward itself, in the op's ``position`` tensor, so cells are
     allocated on the first layer of the step and memoized for the rest of it.
+
+    Layers may window differently: the mask is memoized per window rather than
+    per layer, over cells they all share. Nothing is evicted -- reclaiming under
+    mixed windows needs one cache per policy group.
 
     DYNAMIC sizing grows the pool to the occupied extent, so a short session
     reserves a short pool rather than the whole context. Growth must keep every
@@ -407,7 +426,7 @@ class CellReferenceCache:
             self._plan = self._allocate(position)
         self._served.add(layer_id)
 
-        read_len = self._plan.mask.shape[-1]
+        read_len = self._plan.base.shape[-1]
         self._ensure(layer_id, read_len)
         cells = self._plan.cells
         self._k[layer_id][:, :, cells, :] = k.to(self.config.dtype)
@@ -415,7 +434,10 @@ class CellReferenceCache:
         return (
             self._k[layer_id][:, :, :read_len, :],
             self._v[layer_id][:, :, :read_len, :],
-            AttendSpec(kind=MaskKind.EXPLICIT, mask=self._plan.mask),
+            AttendSpec(
+                kind=MaskKind.EXPLICIT,
+                mask=self._plan.mask_for(self.config.window_for(layer_id)),
+            ),
         )
 
     # -- internals ----------------------------------------------------------
@@ -443,9 +465,10 @@ class CellReferenceCache:
             self._claim(pos, 1 << seq_id)
             for pos, seq_id in zip(positions, self._step_seq_ids)
         ]
-        # Occupied, sharing a sequence, and no newer than the query. The step's
-        # own cells are already placed, so a query sees itself and any earlier
-        # token of its sequence in the same batch.
+        # Occupied, sharing a sequence, and no newer than the query -- plus, when
+        # windowed, no older than its window. The step's own cells are already
+        # placed, so a query sees itself and any earlier token of its sequence in
+        # the same batch.
         n = self._used_end
         cell_pos = torch.tensor(self._pos[:n], device=device)
         cell_owners = torch.tensor(self._owners[:n], device=device)
@@ -453,9 +476,13 @@ class CellReferenceCache:
         tok_bit = torch.tensor(
             [1 << seq_id for seq_id in self._step_seq_ids], device=device
         ).unsqueeze(-1)
-        mask = (cell_pos >= 0) & ((cell_owners & tok_bit) != 0) & (cell_pos <= tok_pos)
+        base = (cell_pos >= 0) & ((cell_owners & tok_bit) != 0) & (cell_pos <= tok_pos)
         return _CellStepPlan(
-            cells=torch.tensor(cells, dtype=torch.long, device=device), mask=mask
+            cells=torch.tensor(cells, dtype=torch.long, device=device),
+            base=base,
+            cell_pos=cell_pos,
+            tok_pos=tok_pos,
+            masks={0: base},
         )
 
     def _ensure(self, layer_id: int, rows: int) -> None:

--- a/extension/llm/cache/test_update_and_attend.py
+++ b/extension/llm/cache/test_update_and_attend.py
@@ -16,6 +16,8 @@ from executorch.extension.llm.cache.reference_cache import (
     CellReferenceCache,
     ContiguousReferenceCache,
     flatten_step,
+    LayerKind,
+    LayerPolicy,
     MaskKind,
     MAX_SEQS,
 )
@@ -286,7 +288,7 @@ class CellCacheTest(unittest.TestCase):
         REGISTRY.uninstall(self.cache_key)
 
     def _cache(
-        self, capacity=CAPACITY, sizing=CacheSizing.DYNAMIC, window=0, n_layers=None
+        self, capacity=CAPACITY, sizing=CacheSizing.DYNAMIC, layers=None, n_layers=None
     ):
         cache = CellReferenceCache(
             CacheConfig(
@@ -295,7 +297,7 @@ class CellCacheTest(unittest.TestCase):
                 head_dim=self.head_dim,
                 capacity=capacity,
                 sizing=sizing,
-                window=window,
+                layers=[LayerPolicy.flat()] if layers is None else layers,
             )
         )
         REGISTRY.install(self.cache_key, cache)
@@ -472,8 +474,20 @@ class CellCacheTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 call()
 
+    def test_layer_policy_rejects_a_mismatched_window(self):
+        # The kind carries the meaning, so a window on a flat layer -- or a ring
+        # layer without one -- is a config error rather than a silent no-op.
+        with self.assertRaises(ValueError):
+            LayerPolicy(kind=LayerKind.FLAT, window=4)
+        with self.assertRaises(ValueError):
+            LayerPolicy(kind=LayerKind.RING, window=0)
+        with self.assertRaises(ValueError):  # one policy, or one per layer
+            self._cache(
+                layers=[LayerPolicy.flat(), LayerPolicy.ring(2), LayerPolicy.ring(2)]
+            )
+
     def test_window_narrows_each_query_without_crossing_sequences(self):
-        cache = self._cache(window=2)
+        cache = self._cache(layers=[LayerPolicy.ring(2)])
         kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
         cache.begin_step([0] * 4)
         spec = cache.update_and_fetch(0, kv, kv, _positions(0, 4))[2]
@@ -495,7 +509,7 @@ class CellCacheTest(unittest.TestCase):
     def test_layers_can_window_independently(self):
         # One cell table, but layers may disagree about the window: the mask is
         # per policy, not per layer, so a mixed model costs one extra mask.
-        cache = self._cache(window=[0, 2])
+        cache = self._cache(layers=[LayerPolicy.flat(), LayerPolicy.ring(2)])
         kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
         cache.begin_step([0] * 4)
         pos = _positions(0, 4)
@@ -509,7 +523,10 @@ class CellCacheTest(unittest.TestCase):
     def test_layers_sharing_a_window_share_one_mask(self):
         # The mask is per policy: two windowed layers get the same object, and
         # the flat one a different mask, so a mixed model costs one extra.
-        cache = self._cache(window=[0, 2, 2], n_layers=3)
+        cache = self._cache(
+            layers=[LayerPolicy.flat(), LayerPolicy.ring(2), LayerPolicy.ring(2)],
+            n_layers=3,
+        )
         kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
         cache.begin_step([0] * 4)
         pos = _positions(0, 4)
@@ -522,7 +539,7 @@ class CellCacheTest(unittest.TestCase):
 
     def test_windowed_decode_attends_only_the_retained_cells(self):
         window = 2
-        cache = self._cache(window=window)
+        cache = self._cache(layers=[LayerPolicy.ring(window)])
         kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
         cache.begin_step([0] * 4)
         cache.update_and_fetch(0, kv, kv, _positions(0, 4))
@@ -654,14 +671,14 @@ class WindowedSpecTest(unittest.TestCase):
         torch.manual_seed(0)
         self.scale = self.DIM**-0.5
 
-    def _cache(self, window):
+    def _cache(self, policy):
         return ContiguousReferenceCache(
             CacheConfig(
                 n_layers=1,
                 n_kv_heads=self.HEADS,
                 head_dim=self.DIM,
                 capacity=32,
-                window=window,
+                layers=[policy],
             )
         )
 
@@ -674,7 +691,7 @@ class WindowedSpecTest(unittest.TestCase):
 
     def test_decode_attends_only_the_window(self):
         window = 3
-        cache = self._cache(window)
+        cache = self._cache(LayerPolicy.ring(window))
         self._update(cache, 5, 0)
         k, v, spec = self._update(cache, 1, 5)
 
@@ -691,7 +708,7 @@ class WindowedSpecTest(unittest.TestCase):
 
     def test_each_prefill_query_attends_its_own_window(self):
         window = 2
-        cache = self._cache(window)
+        cache = self._cache(LayerPolicy.ring(window))
         k, v, spec = self._update(cache, 4, 0)
         self.assertEqual(spec.kind, MaskKind.EXPLICIT)
 
@@ -718,7 +735,7 @@ class WindowedSpecTest(unittest.TestCase):
                 n_kv_heads=self.HEADS,
                 head_dim=self.DIM,
                 capacity=32,
-                window=[0, 2],
+                layers=[LayerPolicy.flat(), LayerPolicy.ring(2)],
             )
         )
         kv = torch.randn(1, self.HEADS, 4, self.DIM)
@@ -733,8 +750,8 @@ class WindowedSpecTest(unittest.TestCase):
 
     def test_window_wider_than_history_stays_fused(self):
         # Nothing to bound from below, so the window must not force a mask.
-        for window in (0, 64):
-            cache = self._cache(window)
+        for policy in (LayerPolicy.flat(), LayerPolicy.ring(64)):
+            cache = self._cache(policy)
             self.assertEqual(self._update(cache, 4, 0)[2].kind, MaskKind.CAUSAL)
             self.assertEqual(self._update(cache, 1, 4)[2].kind, MaskKind.NONE)
 

--- a/extension/llm/cache/test_update_and_attend.py
+++ b/extension/llm/cache/test_update_and_attend.py
@@ -481,6 +481,8 @@ class CellCacheTest(unittest.TestCase):
             LayerPolicy(kind=LayerKind.FLAT, window=4)
         with self.assertRaises(ValueError):
             LayerPolicy(kind=LayerKind.RING, window=0)
+        with self.assertRaises(ValueError):
+            LayerPolicy.ring(-1)
         with self.assertRaises(ValueError):  # one policy, or one per layer
             self._cache(
                 layers=[LayerPolicy.flat(), LayerPolicy.ring(2), LayerPolicy.ring(2)]
@@ -671,13 +673,14 @@ class WindowedSpecTest(unittest.TestCase):
         torch.manual_seed(0)
         self.scale = self.DIM**-0.5
 
-    def _cache(self, policy):
+    def _cache(self, policy, sizing=CacheSizing.DYNAMIC):
         return ContiguousReferenceCache(
             CacheConfig(
                 n_layers=1,
                 n_kv_heads=self.HEADS,
                 head_dim=self.DIM,
                 capacity=32,
+                sizing=sizing,
                 layers=[policy],
             )
         )
@@ -747,6 +750,47 @@ class WindowedSpecTest(unittest.TestCase):
         self.assertEqual(windowed.kind, MaskKind.EXPLICIT)
         offsets = torch.arange(4) - torch.arange(4).unsqueeze(-1)  # j - i
         torch.testing.assert_close(windowed.mask, (offsets <= 0) & (offsets > -2))
+
+    def test_windowed_continuation_bounds_the_band_at_both_ends(self):
+        # Continuation with a window: the upper bound (new cells at the tail)
+        # and the lower bound (the window) are both live in the same mask.
+        window = 2
+        cache = self._cache(LayerPolicy.ring(window))
+        self._update(cache, 4, 0)
+        _, _, spec = self._update(cache, 3, 4)
+
+        self.assertEqual(spec.kind, MaskKind.EXPLICIT)
+        q_len, total = 3, 7
+        offsets = torch.arange(total) - torch.arange(q_len).unsqueeze(-1)
+        torch.testing.assert_close(
+            spec.mask,
+            (offsets <= total - q_len) & (offsets > total - q_len - window),
+        )
+
+    def test_window_equal_to_history_stays_fused(self):
+        # windowed is 0 < window < total, so equality is the boundary: at
+        # exactly `window` cells nothing is bounded from below, and one cell
+        # later the band appears.
+        window = 4
+        cache = self._cache(LayerPolicy.ring(window))
+        self.assertEqual(self._update(cache, window, 0)[2].kind, MaskKind.CAUSAL)
+        self.assertEqual(self._update(cache, 1, window)[2].kind, MaskKind.EXPLICIT)
+
+    def test_static_sizing_windows_like_dynamic(self):
+        # STATIC writes into a preallocated buffer and slices it; the window is
+        # computed off the used length either way.
+        window = 2
+        torch.manual_seed(0)
+        static = self._cache(LayerPolicy.ring(window), sizing=CacheSizing.STATIC)
+        sk, sv, s_spec = self._update(static, 4, 0)
+        torch.manual_seed(0)
+        dynamic = self._cache(LayerPolicy.ring(window))
+        dk, dv, d_spec = self._update(dynamic, 4, 0)
+
+        torch.testing.assert_close(sk, dk)
+        torch.testing.assert_close(sv, dv)
+        self.assertEqual(s_spec.kind, d_spec.kind)
+        torch.testing.assert_close(s_spec.mask, d_spec.mask)
 
     def test_window_wider_than_history_stays_fused(self):
         # Nothing to bound from below, so the window must not force a mask.

--- a/extension/llm/cache/test_update_and_attend.py
+++ b/extension/llm/cache/test_update_and_attend.py
@@ -547,24 +547,120 @@ class ContiguousSpecTest(unittest.TestCase):
             CacheConfig(n_layers=1, n_kv_heads=2, head_dim=4, capacity=8)
         )
 
-    def _step(self, start, q_len):
+    def _update(self, start, q_len):
         kv = torch.randn(1, 2, q_len, 4)
         return self.cache.update_and_fetch(0, kv, kv, _positions(start, q_len))[2]
 
     def test_decode_is_unmasked(self):
-        self.assertEqual(self._step(0, 1).kind, MaskKind.NONE)
+        self.assertEqual(self._update(0, 1).kind, MaskKind.NONE)
 
     def test_fresh_prefill_is_causal(self):
-        self.assertEqual(self._step(0, 4).kind, MaskKind.CAUSAL)
+        self.assertEqual(self._update(0, 4).kind, MaskKind.CAUSAL)
 
     def test_continuation_is_an_explicit_lower_right_band(self):
-        self._step(0, 4)
-        spec = self._step(4, 3)  # 3 new cells at the tail of a 7-cell window
+        self._update(0, 4)
+        spec = self._update(4, 3)  # 3 new cells at the tail of a 7-cell window
         self.assertEqual(spec.kind, MaskKind.EXPLICIT)
         self.assertEqual(spec.mask.dtype, torch.bool)
         torch.testing.assert_close(
             spec.mask, torch.ones(3, 7, dtype=torch.bool).tril(7 - 3)
         )
+
+
+class WindowedSpecTest(unittest.TestCase):
+    # A sliding window bounds each query from below. The reference keeps the
+    # whole history and masks, so what is pinned here is the semantic a ring
+    # buffer has to reproduce, not the ring's addressing.
+
+    HEADS, DIM = 2, 4
+
+    def setUp(self):
+        torch.manual_seed(0)
+        self.scale = self.DIM**-0.5
+
+    def _cache(self, window):
+        return ContiguousReferenceCache(
+            CacheConfig(
+                n_layers=1,
+                n_kv_heads=self.HEADS,
+                head_dim=self.DIM,
+                capacity=32,
+                window=window,
+            )
+        )
+
+    def _update(self, cache, n, start):
+        kv = torch.randn(1, self.HEADS, n, self.DIM)
+        return cache.update_and_fetch(0, kv, kv, _positions(start, n))
+
+    def _attend(self, q, k, v, spec):
+        return attend(q, k, v, spec, self.scale, torch.float32)
+
+    def test_decode_attends_only_the_window(self):
+        window = 3
+        cache = self._cache(window)
+        self._update(cache, 5, 0)
+        k, v, spec = self._update(cache, 1, 5)
+
+        q = torch.randn(1, self.HEADS, 1, self.DIM)
+        torch.testing.assert_close(
+            self._attend(q, k, v, spec),
+            self._attend(  # the last `window` cells, unmasked
+                q,
+                k[:, :, -window:, :],
+                v[:, :, -window:, :],
+                AttendSpec(kind=MaskKind.NONE),
+            ),
+        )
+
+    def test_each_prefill_query_attends_its_own_window(self):
+        window = 2
+        cache = self._cache(window)
+        k, v, spec = self._update(cache, 4, 0)
+        self.assertEqual(spec.kind, MaskKind.EXPLICIT)
+
+        q = torch.randn(1, self.HEADS, 4, self.DIM)
+        out = self._attend(q, k, v, spec)
+        for i in range(4):  # query at position i sees (i - window, i]
+            lo = max(0, i - window + 1)
+            torch.testing.assert_close(
+                out[:, :, i : i + 1, :],
+                self._attend(
+                    q[:, :, i : i + 1, :],
+                    k[:, :, lo : i + 1, :],
+                    v[:, :, lo : i + 1, :],
+                    AttendSpec(kind=MaskKind.NONE),
+                ),
+            )
+
+    def test_layers_can_window_independently(self):
+        # gemma-style: only some layers are windowed, so one step yields two
+        # different semantics from the same cache.
+        cache = ContiguousReferenceCache(
+            CacheConfig(
+                n_layers=2,
+                n_kv_heads=self.HEADS,
+                head_dim=self.DIM,
+                capacity=32,
+                window=[0, 2],
+            )
+        )
+        kv = torch.randn(1, self.HEADS, 4, self.DIM)
+        pos = _positions(0, 4)
+        flat = cache.update_and_fetch(0, kv, kv, pos)[2]
+        windowed = cache.update_and_fetch(1, kv, kv, pos)[2]
+
+        self.assertEqual(flat.kind, MaskKind.CAUSAL)
+        self.assertEqual(windowed.kind, MaskKind.EXPLICIT)
+        offsets = torch.arange(4) - torch.arange(4).unsqueeze(-1)
+        torch.testing.assert_close(windowed.mask, (offsets <= 0) & (offsets > -2))
+
+    def test_window_wider_than_history_stays_fused(self):
+        # Nothing to bound from below, so the window must not force a mask.
+        for window in (0, 64):
+            cache = self._cache(window)
+            self.assertEqual(self._update(cache, 4, 0)[2].kind, MaskKind.CAUSAL)
+            self.assertEqual(self._update(cache, 1, 4)[2].kind, MaskKind.NONE)
 
 
 class AttendExplicitTest(unittest.TestCase):

--- a/extension/llm/cache/test_update_and_attend.py
+++ b/extension/llm/cache/test_update_and_attend.py
@@ -285,14 +285,17 @@ class CellCacheTest(unittest.TestCase):
     def tearDown(self):
         REGISTRY.uninstall(self.cache_key)
 
-    def _cache(self, capacity=CAPACITY, sizing=CacheSizing.DYNAMIC):
+    def _cache(
+        self, capacity=CAPACITY, sizing=CacheSizing.DYNAMIC, window=0, n_layers=None
+    ):
         cache = CellReferenceCache(
             CacheConfig(
-                n_layers=self.n_layers,
+                n_layers=self.n_layers if n_layers is None else n_layers,
                 n_kv_heads=self.n_kv_heads,
                 head_dim=self.head_dim,
                 capacity=capacity,
                 sizing=sizing,
+                window=window,
             )
         )
         REGISTRY.install(self.cache_key, cache)
@@ -468,6 +471,79 @@ class CellCacheTest(unittest.TestCase):
         ):
             with self.assertRaises(ValueError):
                 call()
+
+    def test_window_narrows_each_query_without_crossing_sequences(self):
+        cache = self._cache(window=2)
+        kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
+        cache.begin_step([0] * 4)
+        spec = cache.update_and_fetch(0, kv, kv, _positions(0, 4))[2]
+
+        # offsets[i][j] = j - i, so <= 0 is causal and > -2 keeps the newest
+        # two: a band whose row 2 drops key 0, which plain causal would keep.
+        offsets = torch.arange(4) - torch.arange(4).unsqueeze(-1)
+        torch.testing.assert_close(spec.mask, (offsets <= 0) & (offsets > -2))
+
+        # a second sequence is bounded the same way, and still sees none of
+        # the first's cells even though they are inside its window
+        cache.begin_step([1, 1])
+        kv = torch.randn(1, self.n_kv_heads, 2, self.head_dim)
+        spec = cache.update_and_fetch(0, kv, kv, _positions(0, 2))[2]
+        expected = torch.zeros(2, 6, dtype=torch.bool)
+        expected[0, 4] = expected[1, 4] = expected[1, 5] = True
+        torch.testing.assert_close(spec.mask, expected)
+
+    def test_layers_can_window_independently(self):
+        # One cell table, but layers may disagree about the window: the mask is
+        # per policy, not per layer, so a mixed model costs one extra mask.
+        cache = self._cache(window=[0, 2])
+        kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
+        cache.begin_step([0] * 4)
+        pos = _positions(0, 4)
+        flat = cache.update_and_fetch(0, kv, kv, pos)[2].mask
+        windowed = cache.update_and_fetch(1, kv, kv, pos)[2].mask
+
+        offsets = torch.arange(4) - torch.arange(4).unsqueeze(-1)
+        torch.testing.assert_close(flat, offsets <= 0)
+        torch.testing.assert_close(windowed, (offsets <= 0) & (offsets > -2))
+
+    def test_layers_sharing_a_window_share_one_mask(self):
+        # The mask is per policy: two windowed layers get the same object, and
+        # the flat one a different mask, so a mixed model costs one extra.
+        cache = self._cache(window=[0, 2, 2], n_layers=3)
+        kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
+        cache.begin_step([0] * 4)
+        pos = _positions(0, 4)
+        flat = cache.update_and_fetch(0, kv, kv, pos)[2].mask
+        first = cache.update_and_fetch(1, kv, kv, pos)[2].mask
+        second = cache.update_and_fetch(2, kv, kv, pos)[2].mask
+
+        self.assertIs(first, second)
+        self.assertIsNot(flat, first)
+
+    def test_windowed_decode_attends_only_the_retained_cells(self):
+        window = 2
+        cache = self._cache(window=window)
+        kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
+        cache.begin_step([0] * 4)
+        cache.update_and_fetch(0, kv, kv, _positions(0, 4))
+
+        cache.begin_step([0])
+        kv = torch.randn(1, self.n_kv_heads, 1, self.head_dim)
+        k, v, spec = cache.update_and_fetch(0, kv, kv, _positions(4, 1))
+
+        q = torch.randn(1, self.n_heads, 1, self.head_dim)
+        scale = self.head_dim**-0.5
+        torch.testing.assert_close(
+            attend(q, k, v, spec, scale, torch.float32),
+            attend(  # the last `window` cells of its sequence, unmasked
+                q,
+                k[:, :, -window:, :],
+                v[:, :, -window:, :],
+                AttendSpec(kind=MaskKind.NONE),
+                scale,
+                torch.float32,
+            ),
+        )
 
     def test_admission_fails_before_the_forward(self):
         cache = self._cache(capacity=4)
@@ -652,7 +728,7 @@ class WindowedSpecTest(unittest.TestCase):
 
         self.assertEqual(flat.kind, MaskKind.CAUSAL)
         self.assertEqual(windowed.kind, MaskKind.EXPLICIT)
-        offsets = torch.arange(4) - torch.arange(4).unsqueeze(-1)
+        offsets = torch.arange(4) - torch.arange(4).unsqueeze(-1)  # j - i
         torch.testing.assert_close(windowed.mask, (offsets <= 0) & (offsets > -2))
 
     def test_window_wider_than_history_stays_fused(self):


### PR DESCRIPTION
## Summary

  Adds a sliding window to the eager KV-cache reference. `CacheConfig.window` takes an int for every layer or one entry per layer, so a model that alternates policies (gemma-style) is expressible.

  Both reference caches honour it. `ContiguousReferenceCache` adds a lower bound to the band it already emits, and windowing alone is now enough to make a step EXPLICIT. `CellReferenceCache` memoizes the mask per *window* rather than per layer: occupancy, membership and causality are common to every layer of a step, and only the lower bound moves, so a mixed model pays two masks per step  instead of one per layer.

  The reference masks; it does not evict. Cells stay allocated under a window, because reclaiming them when layers disagree needs one cache per policy group.

  ## Files

  - `extension/llm/cache/reference_cache.py` — `CacheConfig.window` + `window_for`,  the windowed band in `ContiguousReferenceCache._spec`, and `_CellStepPlan`  split into a shared base plus a per-window memo.
  - `extension/llm/cache/test_update_and_attend.py` — 8 new tests.

  ## Testing

  `pytest extension/llm/cache/test_update_and_attend.py`

  New coverage: a window narrowing each query without crossing sequences, layers windowing independently, layers sharing a window sharing one mask, windowed decode attending only retained cells, and a window wider than the history staying fused.