### PR TITLE
Add the off-graph KV-cache cell layout to the neutral C++ layer

### DIFF
--- a/extension/llm/cache/CMakeLists.txt
+++ b/extension/llm/cache/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT EXECUTORCH_ROOT)
   set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
 endif()
 
-add_library(extension_llm_cache cache_registry.cpp)
+add_library(extension_llm_cache cache_registry.cpp cell_cache.cpp)
 target_link_libraries(extension_llm_cache executorch_core)
 target_include_directories(
   extension_llm_cache PUBLIC ${_common_include_directories}

--- a/extension/llm/cache/cache.h
+++ b/extension/llm/cache/cache.h
@@ -106,32 +106,34 @@ class LayoutPolicy {
   virtual int retained_from(int length) const = 0;
 };
 
-// How a step's queries may attend the window the cache hands back.
-enum class MaskKind : int {
-  None = 0, // one query over a window it may attend entirely
-  Causal = 1, // queries at the tail of the window, each seeing up to itself
-  Explicit = 2 // anything else: mask_bits says which cells are visible
-};
-
 // Application face of any multi-sequence cache: the sequence verbs. They run
 // between forwards, never during one.
 class BatchControl : public CacheControl {
  public:
   // Which sequence each of the next forward's tokens belongs to, one entry per
-  // token. Also the admission gate: false = rejected and nothing changed, and a
-  // step that passes has room for its tokens. Whether its positions are
-  // well-formed is checked when the step is placed.
-  virtual bool begin_step(const std::vector<int32_t>& seq_ids) = 0;
-  // Give dst a claim on src's slots below `upto`, all of them when unset. A
-  // shared slot keeps one position, so only a prefix can be shared. False =
-  // an unknown sequence, or a dst that already holds slots: a sequence owns at
-  // most one slot per position.
-  virtual bool seq_cp(int32_t src, int32_t dst, std::optional<int> upto) = 0;
-  // Drop seq's claim on positions [p0, p1). A slot frees only once no sequence
-  // owns it. False = an unknown sequence; a range owning nothing is a no-op.
-  virtual bool seq_rm(int32_t seq, int p0, std::optional<int> p1) = 0;
-  virtual int seq_len(int32_t seq) const = 0; // slots the sequence owns
-  virtual int next_pos(int32_t seq) const = 0; // one past its newest position
+  // token; every id must be one seq_new handed out. Also the admission gate:
+  // false = rejected and nothing changed, and a step that passes has room for
+  // its tokens. Whether its positions are well-formed is checked when the step
+  // is placed.
+  virtual bool declare_step(const std::vector<int32_t>& seq_ids) = 0;
+  // An id no live sequence is using, held until that sequence's last slot is
+  // freed. nullopt = every id is in use. Ids may also be chosen by the caller;
+  // this only guarantees the one it returns is not already taken.
+  virtual std::optional<int32_t> seq_new() = 0;
+  // A new sequence claiming src's slots below `upto`, all of them when unset.
+  // A shared slot keeps one position, so only a prefix can be shared, and the
+  // fork is a snapshot: slots src gains afterwards are its own. Nothing is
+  // copied. nullopt = an unknown or empty src, or no free sequence id.
+  virtual std::optional<int32_t> seq_clone(
+      int32_t src,
+      std::optional<int> upto) = 0;
+  // Drop the sequence's claim on positions [p0, p1). A slot frees only once
+  // no sequence owns it. False = an unknown sequence; a range owning nothing
+  // is a no-op.
+  virtual bool seq_rm(int32_t seq_id, int p0, std::optional<int> p1) = 0;
+  virtual int seq_len(int32_t seq_id) const = 0; // slots the sequence owns
+  // one past its newest position
+  virtual int next_pos(int32_t seq_id) const = 0;
 };
 
 // Per-layer cache kind and its parameters.

--- a/extension/llm/cache/cache.h
+++ b/extension/llm/cache/cache.h
@@ -9,16 +9,10 @@
 #pragma once
 
 // Neutral, tensor-free, ET-independent KV-cache core shared across backends. A
-// cache exposes two faces recovered from the owning CacheBase* (static upcasts
-// -- no dynamic_cast/RTTI, no diamond): a runner-facing control face and a
-// backend-facing planner face. Which pair depends on the kind. A single-
-// sequence cache (SequenceCache) drives all layers from one logical length and
-// dispatches per-layer layout to a LayoutPolicy (flat = full history, ring =
-// sliding window), so a mixed model (e.g. gemma4's alternating full/sliding-
-// window layers) stays coherent. A cell cache holds many sequences over one
-// pool of per-token cells and plans a whole forward at once. Errors are plain
-// C++ (bool / std::optional); cache_et.h adapts them to Error/Result for ET
-// consumers.
+// cache exposes a runner-facing control face and a backend-facing planner face,
+// recovered from the owning CacheBase*. Which pair it implements depends on the
+// layout: one sequence over per-layer runs, or many sequences over a pool of
+// per-token cells.
 
 #include <cstdint>
 #include <optional>
@@ -32,12 +26,10 @@ namespace cache {
 class SequenceControl;
 class SequencePlanner;
 class BatchControl;
-class CellPlanner;
+class CellStepper;
 
-// Registry ownership / erasure anchor. The registry owns a cache as a
-// CacheBase*; the runner recovers a control face and the backend a planner
-// face through these accessors. A cache returns `this` from the pair it
-// implements and leaves the other pair null -- static upcasts, no RTTI.
+// Registry ownership anchor. A cache returns `this` from the faces it
+// implements and leaves the rest null.
 class CacheBase {
  public:
   virtual ~CacheBase() = default;
@@ -50,13 +42,12 @@ class CacheBase {
   virtual BatchControl* as_batch_control() {
     return nullptr;
   }
-  virtual CellPlanner* as_cell_planner() {
+  virtual CellStepper* as_cell_stepper() {
     return nullptr;
   }
 };
 
-// What every cache exposes to the application: lifecycle + admission,
-// tensor-free.
+// Lifecycle and admission, tensor-free.
 class CacheControl {
  public:
   virtual ~CacheControl() = default;
@@ -68,8 +59,8 @@ class CacheControl {
 // Application face of a single-sequence cache: one length to rewind.
 class SequenceControl : public CacheControl {
  public:
-  // Truncate to new_len (agent backtracking); false = cannot grow, or the
-  // target is older than an evicting layer still retains.
+  // Truncate to new_len; false = cannot grow, or the target is older than an
+  // evicting layer still retains.
   virtual bool rewind(int new_len) = 0;
 };
 
@@ -79,11 +70,9 @@ struct Run {
   int len;
 };
 
-// Integer-only handoff from the planner to the backend byte layer. Runs are in
-// logical order (oldest -> newest); a flat layer uses one run, a ring layer up
-// to two (a write/read that wraps the buffer splits in two). read_base_pos is
-// the logical position of read[0].start (0 for flat; the window start for
-// ring), so the backend can align RoPE / the attention mask.
+// Integer-only handoff to the backend byte layer. Runs are in logical order
+// (oldest -> newest); a flat layer uses one, a ring layer two when it wraps.
+// read_base_pos is the logical position of read[0].start.
 struct SeqStepPlan {
   Run write[2];
   int n_write;
@@ -92,59 +81,55 @@ struct SeqStepPlan {
   int read_base_pos;
 };
 
-// Backend face. plan() is pure -- it computes a layer's layout for a step
-// without changing state; commit() advances the shared logical length once the
-// step is accepted. `layer` selects the layer's policy. nullopt = the step
-// would exceed capacity or `layer` is out of range.
+// Backend face. plan() is const: it computes a layer's layout without changing
+// state, and commit() advances the shared logical length. nullopt = the step
+// exceeds capacity, or `layer` is out of range.
 class SequencePlanner {
  public:
   virtual ~SequencePlanner() = default;
   virtual std::optional<SeqStepPlan> plan(int layer, int position, int T)
       const = 0;
-  // Advance the logical length past this step. Idempotent (commits the max), so
-  // calling it once per step -- not per layer -- suffices.
+  // Advance the logical length past this step. Idempotent, so once per step
+  // suffices.
   virtual void commit(const SeqStepPlan& plan) = 0;
 };
 
-// Per-layer layout behavior (flat = full history; ring = sliding window). Pure:
-// plan() has no side effects, so the controller (SequenceCache) owns length.
+// Per-layer layout: flat keeps all history, ring slides a window. Stateless.
 class LayoutPolicy {
  public:
   virtual ~LayoutPolicy() = default;
   // Write/read runs for T cells at logical `position`. Precondition: T fits the
-  // policy's window (the runner chunks prefill so a step fits).
+  // policy's window.
   virtual SeqStepPlan plan(int position, int T) const = 0;
-  // Oldest logical position still retained given the current length (0 for
-  // flat; length - window for ring). Used to bound rewind.
+  // Oldest logical position still retained at this length: 0 for flat,
+  // length - window for ring.
   virtual int retained_from(int length) const = 0;
 };
 
-// How a step's queries may attend the window the cache hands back: the cache
-// owns the semantic, the backend the mechanism. Mirrors the eager reference.
+// How a step's queries may attend the window the cache hands back.
 enum class MaskKind : int {
   None = 0, // one query over a window it may attend entirely
   Causal = 1, // queries at the tail of the window, each seeing up to itself
   Explicit = 2 // anything else: mask_bits says which cells are visible
 };
 
-// Application face of any multi-sequence cache, whatever its layout: the
-// sequence verbs, integer-only. A sequence exists while some slot lists it as
-// an owner -- begin_step or seq_cp brings it into being, its last freed slot
-// ends it.
+// Application face of any multi-sequence cache: the sequence verbs. They run
+// between forwards, never during one.
 class BatchControl : public CacheControl {
  public:
   // Which sequence each of the next forward's tokens belongs to, one entry per
-  // token, and the admission gate: false = rejected, nothing changed. Deciding
-  // it here means a step that passes cannot later fail to place.
-  virtual bool begin_step(const int32_t* seq_ids, int n_tok) = 0;
-  // Give dst a claim on src's slots below `upto` (all of them when unset) -- a
-  // fork, zero-copy where sequences share a pool. A shared slot keeps one
-  // position, so only a prefix can be shared.
-  virtual void seq_cp(int32_t src, int32_t dst, std::optional<int> upto) = 0;
-  // Drop seq's claim on positions [p0, p1); a slot frees only once no sequence
-  // owns it, so removing a shared range reclaims nothing until the last owner
-  // lets go.
-  virtual void seq_rm(int32_t seq, int p0, std::optional<int> p1) = 0;
+  // token. Also the admission gate: false = rejected and nothing changed, and a
+  // step that passes has room for its tokens. Whether its positions are
+  // well-formed is checked when the step is placed.
+  virtual bool begin_step(const std::vector<int32_t>& seq_ids) = 0;
+  // Give dst a claim on src's slots below `upto`, all of them when unset. A
+  // shared slot keeps one position, so only a prefix can be shared. False =
+  // an unknown sequence, or a dst that already holds slots: a sequence owns at
+  // most one slot per position.
+  virtual bool seq_cp(int32_t src, int32_t dst, std::optional<int> upto) = 0;
+  // Drop seq's claim on positions [p0, p1). A slot frees only once no sequence
+  // owns it. False = an unknown sequence; a range owning nothing is a no-op.
+  virtual bool seq_rm(int32_t seq, int p0, std::optional<int> p1) = 0;
   virtual int seq_len(int32_t seq) const = 0; // slots the sequence owns
   virtual int next_pos(int32_t seq) const = 0; // one past its newest position
 };
@@ -166,29 +151,23 @@ struct LayerConfig {
   int head_dim;
 };
 
-// Model facts + runtime policy the byte layer sizes its pools from. capacity is
-// the logical cap; kv_dtype is the ET ScalarType the byte layer stores K/V in;
-// initial_capacity tunes the byte layer's lazy-doubling pool; max_write is the
-// max tokens written per step (a ring layer sizes its slots to window +
-// max_write - 1 so a multi-token step fits); unset means each ring layer uses
-// its own window. `layers` is per-layer: size 1 == uniform across all layers,
-// else == n_layers.
+// Model facts and the policy the byte layer sizes its pools from. `layers` is
+// per-layer: size 1 applies to every layer, else one entry each.
 struct CacheConfig {
-  int capacity;
+  int capacity; // logical cap in cells
   int n_layers;
   std::vector<LayerConfig> layers;
-  int kv_dtype;
-  int initial_capacity = 512;
+  int kv_dtype; // ET ScalarType the byte layer stores K/V in
+  int initial_capacity = 512; // starting pool size; grows lazily to capacity
+  // Max tokens per step; a ring layer sizes slots to window + max_write - 1.
+  // Unset = each ring layer uses its own window.
   std::optional<int> max_write;
 };
 
-// Whether `cfg` satisfies the contract above. Callers must check this before
-// constructing a cache: the `layers` broadcast rule is indexed directly, so a
-// list that is neither size 1 nor n_layers reads past the end. Reported as a
-// bool rather than thrown, so each backend picks its own failure mode.
+// Whether `cfg` satisfies the contract above.
 inline bool valid(const CacheConfig& cfg) {
-  // initial_capacity may be 0 (allocate nothing up front) but not negative, and
-  // may exceed capacity -- the byte layer clamps it.
+  // initial_capacity may be 0 but not negative, and may exceed capacity -- the
+  // byte layer clamps it.
   return cfg.capacity > 0 && cfg.n_layers > 0 && cfg.initial_capacity >= 0 &&
       (cfg.layers.size() == 1 ||
        cfg.layers.size() == static_cast<size_t>(cfg.n_layers));

--- a/extension/llm/cache/cache.h
+++ b/extension/llm/cache/cache.h
@@ -9,16 +9,18 @@
 #pragma once
 
 // Neutral, tensor-free, ET-independent KV-cache core shared across backends. A
-// cache exposes two faces recovered from the owning CacheBase* via
-// as_control()/as_planner() (static upcasts -- no dynamic_cast/RTTI, no
-// diamond): a runner-facing control face (SequenceControl) and a backend-facing
-// planner face (SequencePlanner). One controller (SequenceCache) drives all
-// layers and dispatches per-layer layout to a LayoutPolicy (flat = full
-// history, ring = sliding window), so a mixed model (e.g. gemma4's alternating
-// full/sliding-window layers) shares one logical length. Errors are plain C++
-// (bool / std::optional); cache_et.h adapts them to Error/Result for ET
+// cache exposes two faces recovered from the owning CacheBase* (static upcasts
+// -- no dynamic_cast/RTTI, no diamond): a runner-facing control face and a
+// backend-facing planner face. Which pair depends on the kind. A single-
+// sequence cache (SequenceCache) drives all layers from one logical length and
+// dispatches per-layer layout to a LayoutPolicy (flat = full history, ring =
+// sliding window), so a mixed model (e.g. gemma4's alternating full/sliding-
+// window layers) stays coherent. A cell cache holds many sequences over one
+// pool of per-token cells and plans a whole forward at once. Errors are plain
+// C++ (bool / std::optional); cache_et.h adapts them to Error/Result for ET
 // consumers.
 
+#include <cstdint>
 #include <optional>
 #include <vector>
 
@@ -29,27 +31,46 @@ namespace cache {
 
 class SequenceControl;
 class SequencePlanner;
+class BatchControl;
+class CellPlanner;
 
 // Registry ownership / erasure anchor. The registry owns a cache as a
-// CacheBase*; the runner recovers the control face and the backend recovers the
-// planner face through these accessors (each concrete cache returns `this`).
+// CacheBase*; the runner recovers a control face and the backend a planner
+// face through these accessors. A cache returns `this` from the pair it
+// implements and leaves the other pair null -- static upcasts, no RTTI.
 class CacheBase {
  public:
   virtual ~CacheBase() = default;
-  virtual SequenceControl* as_control() = 0;
-  virtual SequencePlanner* as_planner() = 0;
+  virtual SequenceControl* as_control() {
+    return nullptr;
+  }
+  virtual SequencePlanner* as_planner() {
+    return nullptr;
+  }
+  virtual BatchControl* as_batch_control() {
+    return nullptr;
+  }
+  virtual CellPlanner* as_cell_planner() {
+    return nullptr;
+  }
 };
 
-// Application (runner) face: lifecycle + admission, tensor-free.
-class SequenceControl {
+// What every cache exposes to the application: lifecycle + admission,
+// tensor-free.
+class CacheControl {
  public:
-  virtual ~SequenceControl() = default;
+  virtual ~CacheControl() = default;
   virtual bool can_extend(int n = 1) const = 0; // admission / hard-stop
   virtual int capacity() const = 0; // logical cap
+  virtual void clear() = 0; // reset for reuse
+};
+
+// Application face of a single-sequence cache: one length to rewind.
+class SequenceControl : public CacheControl {
+ public:
   // Truncate to new_len (agent backtracking); false = cannot grow, or the
   // target is older than an evicting layer still retains.
   virtual bool rewind(int new_len) = 0;
-  virtual void clear() = 0; // reset for reuse
 };
 
 // A contiguous span of physical rows in a layer's pool.
@@ -96,6 +117,36 @@ class LayoutPolicy {
   // Oldest logical position still retained given the current length (0 for
   // flat; length - window for ring). Used to bound rewind.
   virtual int retained_from(int length) const = 0;
+};
+
+// How a step's queries may attend the window the cache hands back: the cache
+// owns the semantic, the backend the mechanism. Mirrors the eager reference.
+enum class MaskKind : int {
+  None = 0, // one query over a window it may attend entirely
+  Causal = 1, // queries at the tail of the window, each seeing up to itself
+  Explicit = 2 // anything else: mask_bits says which cells are visible
+};
+
+// Application face of any multi-sequence cache, whatever its layout: the
+// sequence verbs, integer-only. A sequence exists while some slot lists it as
+// an owner -- begin_step or seq_cp brings it into being, its last freed slot
+// ends it.
+class BatchControl : public CacheControl {
+ public:
+  // Which sequence each of the next forward's tokens belongs to, one entry per
+  // token, and the admission gate: false = rejected, nothing changed. Deciding
+  // it here means a step that passes cannot later fail to place.
+  virtual bool begin_step(const int32_t* seq_ids, int n_tok) = 0;
+  // Give dst a claim on src's slots below `upto` (all of them when unset) -- a
+  // fork, zero-copy where sequences share a pool. A shared slot keeps one
+  // position, so only a prefix can be shared.
+  virtual void seq_cp(int32_t src, int32_t dst, std::optional<int> upto) = 0;
+  // Drop seq's claim on positions [p0, p1); a slot frees only once no sequence
+  // owns it, so removing a shared range reclaims nothing until the last owner
+  // lets go.
+  virtual void seq_rm(int32_t seq, int p0, std::optional<int> p1) = 0;
+  virtual int seq_len(int32_t seq) const = 0; // slots the sequence owns
+  virtual int next_pos(int32_t seq) const = 0; // one past its newest position
 };
 
 // Per-layer cache kind and its parameters.

--- a/extension/llm/cache/cache_registry.cpp
+++ b/extension/llm/cache/cache_registry.cpp
@@ -69,6 +69,14 @@ Result<std::shared_ptr<CacheBase>> CacheBuilderRegistry::build(
         kind.c_str());
     builder = it->second;
   }
+  // Checked here rather than in each cache: `layers` is indexed directly, so a
+  // list that is neither size 1 nor n_layers reads past the end.
+  ET_CHECK_OR_RETURN_ERROR(
+      valid(cfg),
+      InvalidArgument,
+      "cache: invalid CacheConfig for %s:%s",
+      backend_id.c_str(),
+      kind.c_str());
   return builder(cfg);
 }
 

--- a/extension/llm/cache/cache_registry.h
+++ b/extension/llm/cache/cache_registry.h
@@ -12,9 +12,8 @@
 // is opaque to the host, so the runner (which knows the cache kind) creates the
 // cache and binds it to the delegate through a process-global registry; the two
 // sides rendezvous on a cache_key passed as a runtime backend-load option.
-// Caches are owned as CacheBase* and the faces are recovered via
-// as_control()/as_planner() (no RTTI). This layer is delegate-specific and may
-// use ExecuTorch Error/Result directly; the cache core (cache.h) stays ET-free.
+// Caches are owned as CacheBase* and the faces are recovered through its as_*
+// accessors (no RTTI), each null for a face the cache does not implement.
 
 #include <functional>
 #include <map>

--- a/extension/llm/cache/cell_cache.cpp
+++ b/extension/llm/cache/cell_cache.cpp
@@ -50,7 +50,11 @@ void CellCache::clear() {
   used_end_ = 0;
   used_count_ = 0;
   reserved_ = 0;
-  invalidate_step();
+  declared_ = false;
+  step_seq_ids_.clear();
+  step_pos_.clear();
+  std::fill(served_.begin(), served_.end(), false);
+  invalidate_steps();
 }
 
 // -- BatchControl ------------------------------------------------------------
@@ -210,14 +214,6 @@ int CellCache::lowest_free(int from) const {
 void CellCache::invalidate_steps() {
   placed_ = false;
   steps_.clear();
-}
-
-void CellCache::invalidate_step() {
-  invalidate_steps();
-  declared_ = false;
-  std::fill(served_.begin(), served_.end(), false);
-  step_seq_ids_.clear();
-  step_pos_.clear();
 }
 
 void CellCache::rescan(int32_t seq_id) {

--- a/extension/llm/cache/cell_cache.cpp
+++ b/extension/llm/cache/cell_cache.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/llm/cache/cell_cache.h>
+
+#include <algorithm>
+#include <cassert>
+
+namespace executorch {
+namespace extension {
+namespace llm {
+namespace cache {
+
+CellCache::CellCache(const CacheConfig& cfg)
+    : capacity_(cfg.capacity),
+      pos_(cfg.capacity, -1),
+      owners_(cfg.capacity, 0),
+      served_(cfg.n_layers, false) {
+  assert(valid(cfg));
+  // One window per layer, from the same per-layer config the sequence cache
+  // reads. Layers agreeing on a window share a step.
+  windows_.reserve(cfg.n_layers);
+  for (int l = 0; l < cfg.n_layers; ++l) {
+    const LayerConfig& lc =
+        cfg.layers.size() == 1 ? cfg.layers.front() : cfg.layers[l];
+    windows_.push_back(
+        lc.policy.kind == LayerPolicy::Kind::Ring ? lc.policy.window : 0);
+  }
+}
+
+// -- CacheControl ------------------------------------------------------------
+
+bool CellCache::can_extend(int n) const {
+  return capacity_ - used_count_ >= n;
+}
+
+int CellCache::capacity() const {
+  return capacity_;
+}
+
+void CellCache::clear() {
+  std::fill(pos_.begin(), pos_.end(), -1);
+  std::fill(owners_.begin(), owners_.end(), 0);
+  info_.fill(SeqInfo{});
+  used_end_ = 0;
+  used_count_ = 0;
+  invalidate_step();
+}
+
+// -- BatchControl ------------------------------------------------------------
+
+bool CellCache::begin_step(const std::vector<int32_t>& seq_ids) {
+  if (seq_ids.empty() || !can_extend(static_cast<int>(seq_ids.size()))) {
+    return false;
+  }
+  for (int32_t seq : seq_ids) {
+    if (!valid_seq(seq)) {
+      return false;
+    }
+  }
+  step_seq_ids_ = seq_ids;
+  declared_ = true;
+  invalidate_steps();
+  std::fill(served_.begin(), served_.end(), false);
+  return true;
+}
+
+bool CellCache::seq_cp(int32_t src, int32_t dst, std::optional<int> upto) {
+  // A fork targets a fresh sequence: `upto` bounds a prefix, so copying onto
+  // a sequence that already holds slots would give it two for one position.
+  if (!valid_seq(src) || !valid_seq(dst) || src == dst ||
+      info_[dst].count != 0) {
+    return false;
+  }
+  const uint64_t src_bit = bit(src), dst_bit = bit(dst);
+  for (int i = 0; i < used_end_; ++i) {
+    if ((owners_[i] & src_bit) && (!upto || pos_[i] < *upto)) {
+      owners_[i] |= dst_bit;
+    }
+  }
+  rescan(dst);
+  invalidate_steps();
+  return true;
+}
+
+bool CellCache::seq_rm(int32_t seq, int p0, std::optional<int> p1) {
+  if (!valid_seq(seq)) {
+    return false;
+  }
+  const uint64_t b = bit(seq);
+  for (int i = 0; i < used_end_; ++i) {
+    if ((owners_[i] & b) && pos_[i] >= p0 && (!p1 || pos_[i] < *p1)) {
+      owners_[i] &= ~b;
+      if (owners_[i] == 0) {
+        pos_[i] = -1;
+        --used_count_;
+      }
+    }
+  }
+  while (used_end_ > 0 && pos_[used_end_ - 1] < 0) {
+    --used_end_;
+  }
+  rescan(seq);
+  invalidate_steps();
+  return true;
+}
+
+int CellCache::seq_len(int32_t seq) const {
+  return valid_seq(seq) ? info_[seq].count : 0;
+}
+
+int CellCache::next_pos(int32_t seq) const {
+  return valid_seq(seq) ? info_[seq].max_pos + 1 : 0;
+}
+
+int CellCache::free_cells() const {
+  return capacity_ - used_count_;
+}
+
+int CellCache::used_end() const {
+  return used_end_;
+}
+
+// -- CellStepper -------------------------------------------------------------
+
+const CellStep*
+CellCache::place_step(int layer, const int32_t* positions, int n_tok) {
+  if (layer < 0 || layer >= static_cast<int>(windows_.size()) ||
+      served_[layer]) {
+    return nullptr; // out of range, or a forward that skipped begin_step
+  }
+  if (!placed_) {
+    if (!declared_ || n_tok != static_cast<int>(step_seq_ids_.size())) {
+      return nullptr; // no declaration, or a token count disagreeing with it
+    }
+    if (!extends(positions, n_tok)) {
+      return nullptr; // nothing mutated yet, so the step can be re-placed
+    }
+    step_pos_.assign(positions, positions + n_tok);
+    if (!place()) {
+      return nullptr;
+    }
+    declared_ = false; // one declaration, one placement
+    placed_ = true;
+  }
+  served_[layer] = true;
+  return &step_for(windows_[layer]);
+}
+
+// -- internals ---------------------------------------------------------------
+
+uint64_t CellCache::bit(int32_t seq) {
+  return uint64_t{1} << seq;
+}
+
+bool CellCache::valid_seq(int32_t seq) {
+  return seq >= 0 && seq < kMaxSeqs;
+}
+
+bool CellCache::extends(const int32_t* positions, int n_tok) const {
+  std::array<int32_t, kMaxSeqs> newest{};
+  for (int s = 0; s < kMaxSeqs; ++s) {
+    newest[s] = info_[s].max_pos;
+  }
+  for (int i = 0; i < n_tok; ++i) {
+    const int32_t seq = step_seq_ids_[i];
+    if (positions[i] <= newest[seq]) {
+      return false;
+    }
+    newest[seq] = positions[i];
+  }
+  return true;
+}
+
+int CellCache::lowest_free(int from) const {
+  for (int i = from; i < capacity_; ++i) {
+    if (pos_[i] < 0) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+void CellCache::invalidate_steps() {
+  placed_ = false;
+  steps_.clear();
+}
+
+void CellCache::invalidate_step() {
+  invalidate_steps();
+  declared_ = false;
+  std::fill(served_.begin(), served_.end(), false);
+  step_seq_ids_.clear();
+  step_pos_.clear();
+}
+
+void CellCache::rescan(int32_t seq) {
+  const uint64_t b = bit(seq);
+  SeqInfo info;
+  info.min_cell = capacity_;
+  for (int i = 0; i < used_end_; ++i) {
+    if (!(owners_[i] & b)) {
+      continue;
+    }
+    info.min_cell = std::min(info.min_cell, i);
+    info.max_cell = i;
+    info.max_pos = std::max(info.max_pos, pos_[i]);
+    ++info.count;
+  }
+  if (info.count == 0) {
+    info = SeqInfo{};
+  }
+  info_[seq] = info;
+}
+
+void CellCache::claim(int cell, int32_t pos, int32_t seq) {
+  pos_[cell] = pos;
+  owners_[cell] = bit(seq);
+  used_end_ = std::max(used_end_, cell + 1);
+  ++used_count_;
+  SeqInfo& info = info_[seq];
+  info.min_cell = info.count == 0 ? cell : std::min(info.min_cell, cell);
+  info.max_cell = std::max(info.max_cell, cell);
+  info.max_pos = std::max(info.max_pos, pos);
+  ++info.count;
+}
+
+bool CellCache::place() {
+  const int n_tok = static_cast<int>(step_pos_.size());
+  cells_.resize(n_tok);
+  // A free cell leaves every cell below it occupied, so the next scan resumes
+  // past it.
+  int from = 0;
+  for (int i = 0; i < n_tok; ++i) {
+    const int cell = lowest_free(from);
+    if (cell < 0) {
+      return false;
+    }
+    cells_[i] = cell;
+    from = cell + 1;
+  }
+  for (int i = 0; i < n_tok; ++i) {
+    claim(cells_[i], step_pos_[i], step_seq_ids_[i]);
+  }
+  return true;
+}
+
+const CellStep& CellCache::step_for(int window) {
+  auto it = steps_.find(window);
+  if (it != steps_.end()) {
+    return it->second;
+  }
+  CellStep step;
+  step.n_tok = static_cast<int>(cells_.size());
+  step.read_len = used_end_;
+  if (fused(window)) {
+    step.kind = step.n_tok == 1 ? MaskKind::None : MaskKind::Causal;
+    step.write_start = cells_.front();
+  } else {
+    step.kind = MaskKind::Explicit;
+    step.write_start = -1;
+    step.cells = cells_;
+    step.mask_bits = build_mask(window);
+  }
+  return steps_.emplace(window, std::move(step)).first->second;
+}
+
+bool CellCache::fused(int window) const {
+  // The window is measured in positions, so the oldest cell in the read
+  // window must fall inside the newest query's window.
+  if (window > 0) {
+    int32_t oldest = INT32_MAX, newest = INT32_MIN;
+    for (int j = 0; j < used_end_; ++j) {
+      if (pos_[j] >= 0) {
+        oldest = std::min(oldest, pos_[j]);
+        newest = std::max(newest, pos_[j]);
+      }
+    }
+    if (oldest <= newest && newest - oldest >= window) {
+      return false;
+    }
+  }
+  // More than one sequence: each would need a different subset.
+  const int32_t seq = step_seq_ids_.front();
+  for (int32_t s : step_seq_ids_) {
+    if (s != seq) {
+      return false;
+    }
+  }
+  // Holes or another sequence's cells: the window is then not this
+  // sequence's causal prefix.
+  const SeqInfo& info = info_[seq];
+  if (info.count != used_end_) {
+    return false;
+  }
+  // The step's cells are the run at the tail.
+  const int n_tok = static_cast<int>(cells_.size());
+  for (int i = 0; i < n_tok; ++i) {
+    if (cells_[i] != used_end_ - n_tok + i) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::vector<uint8_t> CellCache::build_mask(int window) const {
+  const int n_tok = static_cast<int>(cells_.size());
+  std::vector<uint8_t> bits(
+      static_cast<size_t>(n_tok) * static_cast<size_t>(used_end_), 0);
+  for (int i = 0; i < n_tok; ++i) {
+    const uint64_t tok_bit = bit(step_seq_ids_[i]);
+    const int32_t tok_pos = step_pos_[i];
+    // A flat layer reaches back to the start; a windowed one to its window.
+    const int32_t oldest = window > 0 ? tok_pos - window + 1 : 0;
+    uint8_t* row = bits.data() + static_cast<size_t>(i) * used_end_;
+    for (int j = 0; j < used_end_; ++j) {
+      row[j] =
+          (pos_[j] >= 0 && // occupied: a freed cell holds nothing
+           (owners_[j] & tok_bit) && // one of this query's sequences
+           pos_[j] <= tok_pos && // not the future; <= so a query sees itself
+           pos_[j] >= oldest); // within the window
+    }
+  }
+  return bits;
+}
+
+} // namespace cache
+} // namespace llm
+} // namespace extension
+} // namespace executorch

--- a/extension/llm/cache/cell_cache.cpp
+++ b/extension/llm/cache/cell_cache.cpp
@@ -219,18 +219,11 @@ void CellCache::invalidate_steps() {
 void CellCache::rescan(int32_t seq_id) {
   const uint64_t b = bit(seq_id);
   SeqInfo info;
-  info.min_cell = capacity_;
   for (int i = 0; i < used_end_; ++i) {
-    if (!(owners_[i] & b)) {
-      continue;
+    if (owners_[i] & b) {
+      info.max_pos = std::max(info.max_pos, pos_[i]);
+      ++info.count;
     }
-    info.min_cell = std::min(info.min_cell, i);
-    info.max_cell = i;
-    info.max_pos = std::max(info.max_pos, pos_[i]);
-    ++info.count;
-  }
-  if (info.count == 0) {
-    info = SeqInfo{};
   }
   info_[seq_id] = info;
 }
@@ -241,8 +234,6 @@ void CellCache::claim(int cell, int32_t pos, int32_t seq_id) {
   used_end_ = std::max(used_end_, cell + 1);
   ++used_count_;
   SeqInfo& info = info_[seq_id];
-  info.min_cell = info.count == 0 ? cell : std::min(info.min_cell, cell);
-  info.max_cell = std::max(info.max_cell, cell);
   info.max_pos = std::max(info.max_pos, pos);
   ++info.count;
 }
@@ -291,11 +282,11 @@ std::vector<uint8_t> CellCache::build_mask(int window) const {
     const int32_t oldest = window > 0 ? tok_pos - window + 1 : 0;
     uint8_t* row = bits.data() + static_cast<size_t>(i) * used_end_;
     for (int j = 0; j < used_end_; ++j) {
-      row[j] =
-          (pos_[j] >= 0 && // occupied: a freed cell holds nothing
-           (owners_[j] & tok_bit) && // one of this query's sequences
-           pos_[j] <= tok_pos && // not the future; <= so a query sees itself
-           pos_[j] >= oldest); // within the window
+      row[j] = static_cast<uint8_t>(
+          pos_[j] >= 0 && // occupied: a freed cell holds nothing
+          (owners_[j] & tok_bit) && // one of this query's sequences
+          pos_[j] <= tok_pos && // not the future; <= so a query sees itself
+          pos_[j] >= oldest); // within the window
     }
   }
   return bits;

--- a/extension/llm/cache/cell_cache.cpp
+++ b/extension/llm/cache/cell_cache.cpp
@@ -49,17 +49,18 @@ void CellCache::clear() {
   info_.fill(SeqInfo{});
   used_end_ = 0;
   used_count_ = 0;
+  reserved_ = 0;
   invalidate_step();
 }
 
 // -- BatchControl ------------------------------------------------------------
 
-bool CellCache::begin_step(const std::vector<int32_t>& seq_ids) {
+bool CellCache::declare_step(const std::vector<int32_t>& seq_ids) {
   if (seq_ids.empty() || !can_extend(static_cast<int>(seq_ids.size()))) {
     return false;
   }
-  for (int32_t seq : seq_ids) {
-    if (!valid_seq(seq)) {
+  for (int32_t seq_id : seq_ids) {
+    if (!valid_seq(seq_id) || !live(seq_id)) {
       return false;
     }
   }
@@ -70,29 +71,46 @@ bool CellCache::begin_step(const std::vector<int32_t>& seq_ids) {
   return true;
 }
 
-bool CellCache::seq_cp(int32_t src, int32_t dst, std::optional<int> upto) {
-  // A fork targets a fresh sequence: `upto` bounds a prefix, so copying onto
-  // a sequence that already holds slots would give it two for one position.
-  if (!valid_seq(src) || !valid_seq(dst) || src == dst ||
-      info_[dst].count != 0) {
-    return false;
+bool CellCache::live(int32_t seq_id) const {
+  return (reserved_ & bit(seq_id)) != 0;
+}
+
+std::optional<int32_t> CellCache::seq_new() {
+  for (int32_t seq_id = 0; seq_id < kMaxSeqs; ++seq_id) {
+    if (!live(seq_id)) {
+      reserved_ |= bit(seq_id);
+      return seq_id;
+    }
   }
-  const uint64_t src_bit = bit(src), dst_bit = bit(dst);
+  return std::nullopt;
+}
+
+std::optional<int32_t> CellCache::seq_clone(
+    int32_t src,
+    std::optional<int> upto) {
+  if (!valid_seq(src) || info_[src].count == 0) {
+    return std::nullopt;
+  }
+  const std::optional<int32_t> dst = seq_new();
+  if (!dst) {
+    return std::nullopt;
+  }
+  const uint64_t src_bit = bit(src), dst_bit = bit(*dst);
   for (int i = 0; i < used_end_; ++i) {
     if ((owners_[i] & src_bit) && (!upto || pos_[i] < *upto)) {
       owners_[i] |= dst_bit;
     }
   }
-  rescan(dst);
+  rescan(*dst);
   invalidate_steps();
-  return true;
+  return dst;
 }
 
-bool CellCache::seq_rm(int32_t seq, int p0, std::optional<int> p1) {
-  if (!valid_seq(seq)) {
+bool CellCache::seq_rm(int32_t seq_id, int p0, std::optional<int> p1) {
+  if (!valid_seq(seq_id)) {
     return false;
   }
-  const uint64_t b = bit(seq);
+  const uint64_t b = bit(seq_id);
   for (int i = 0; i < used_end_; ++i) {
     if ((owners_[i] & b) && pos_[i] >= p0 && (!p1 || pos_[i] < *p1)) {
       owners_[i] &= ~b;
@@ -105,17 +123,20 @@ bool CellCache::seq_rm(int32_t seq, int p0, std::optional<int> p1) {
   while (used_end_ > 0 && pos_[used_end_ - 1] < 0) {
     --used_end_;
   }
-  rescan(seq);
+  rescan(seq_id);
+  if (info_[seq_id].count == 0) {
+    reserved_ &= ~bit(seq_id); // the last slot went, so the id is free again
+  }
   invalidate_steps();
   return true;
 }
 
-int CellCache::seq_len(int32_t seq) const {
-  return valid_seq(seq) ? info_[seq].count : 0;
+int CellCache::seq_len(int32_t seq_id) const {
+  return valid_seq(seq_id) ? info_[seq_id].count : 0;
 }
 
-int CellCache::next_pos(int32_t seq) const {
-  return valid_seq(seq) ? info_[seq].max_pos + 1 : 0;
+int CellCache::next_pos(int32_t seq_id) const {
+  return valid_seq(seq_id) ? info_[seq_id].max_pos + 1 : 0;
 }
 
 int CellCache::free_cells() const {
@@ -129,19 +150,19 @@ int CellCache::used_end() const {
 // -- CellStepper -------------------------------------------------------------
 
 const CellStep*
-CellCache::place_step(int layer, const int32_t* positions, int n_tok) {
+CellCache::place_step(int layer, const int32_t* positions, int length) {
   if (layer < 0 || layer >= static_cast<int>(windows_.size()) ||
       served_[layer]) {
-    return nullptr; // out of range, or a forward that skipped begin_step
+    return nullptr; // out of range, or a forward that skipped declare_step
   }
   if (!placed_) {
-    if (!declared_ || n_tok != static_cast<int>(step_seq_ids_.size())) {
+    if (!declared_ || length != static_cast<int>(step_seq_ids_.size())) {
       return nullptr; // no declaration, or a token count disagreeing with it
     }
-    if (!extends(positions, n_tok)) {
+    if (!extends(positions, length)) {
       return nullptr; // nothing mutated yet, so the step can be re-placed
     }
-    step_pos_.assign(positions, positions + n_tok);
+    step_pos_.assign(positions, positions + length);
     if (!place()) {
       return nullptr;
     }
@@ -154,25 +175,25 @@ CellCache::place_step(int layer, const int32_t* positions, int n_tok) {
 
 // -- internals ---------------------------------------------------------------
 
-uint64_t CellCache::bit(int32_t seq) {
-  return uint64_t{1} << seq;
+uint64_t CellCache::bit(int32_t seq_id) {
+  return uint64_t{1} << seq_id;
 }
 
-bool CellCache::valid_seq(int32_t seq) {
-  return seq >= 0 && seq < kMaxSeqs;
+bool CellCache::valid_seq(int32_t seq_id) {
+  return seq_id >= 0 && seq_id < kMaxSeqs;
 }
 
-bool CellCache::extends(const int32_t* positions, int n_tok) const {
+bool CellCache::extends(const int32_t* positions, int length) const {
   std::array<int32_t, kMaxSeqs> newest{};
   for (int s = 0; s < kMaxSeqs; ++s) {
     newest[s] = info_[s].max_pos;
   }
-  for (int i = 0; i < n_tok; ++i) {
-    const int32_t seq = step_seq_ids_[i];
-    if (positions[i] <= newest[seq]) {
+  for (int i = 0; i < length; ++i) {
+    const int32_t seq_id = step_seq_ids_[i];
+    if (positions[i] <= newest[seq_id]) {
       return false;
     }
-    newest[seq] = positions[i];
+    newest[seq_id] = positions[i];
   }
   return true;
 }
@@ -199,8 +220,8 @@ void CellCache::invalidate_step() {
   step_pos_.clear();
 }
 
-void CellCache::rescan(int32_t seq) {
-  const uint64_t b = bit(seq);
+void CellCache::rescan(int32_t seq_id) {
+  const uint64_t b = bit(seq_id);
   SeqInfo info;
   info.min_cell = capacity_;
   for (int i = 0; i < used_end_; ++i) {
@@ -215,15 +236,15 @@ void CellCache::rescan(int32_t seq) {
   if (info.count == 0) {
     info = SeqInfo{};
   }
-  info_[seq] = info;
+  info_[seq_id] = info;
 }
 
-void CellCache::claim(int cell, int32_t pos, int32_t seq) {
+void CellCache::claim(int cell, int32_t pos, int32_t seq_id) {
   pos_[cell] = pos;
-  owners_[cell] = bit(seq);
+  owners_[cell] = bit(seq_id);
   used_end_ = std::max(used_end_, cell + 1);
   ++used_count_;
-  SeqInfo& info = info_[seq];
+  SeqInfo& info = info_[seq_id];
   info.min_cell = info.count == 0 ? cell : std::min(info.min_cell, cell);
   info.max_cell = std::max(info.max_cell, cell);
   info.max_pos = std::max(info.max_pos, pos);
@@ -231,12 +252,12 @@ void CellCache::claim(int cell, int32_t pos, int32_t seq) {
 }
 
 bool CellCache::place() {
-  const int n_tok = static_cast<int>(step_pos_.size());
-  cells_.resize(n_tok);
+  const int length = static_cast<int>(step_pos_.size());
+  cells_.resize(length);
   // A free cell leaves every cell below it occupied, so the next scan resumes
   // past it.
   int from = 0;
-  for (int i = 0; i < n_tok; ++i) {
+  for (int i = 0; i < length; ++i) {
     const int cell = lowest_free(from);
     if (cell < 0) {
       return false;
@@ -244,7 +265,7 @@ bool CellCache::place() {
     cells_[i] = cell;
     from = cell + 1;
   }
-  for (int i = 0; i < n_tok; ++i) {
+  for (int i = 0; i < length; ++i) {
     claim(cells_[i], step_pos_[i], step_seq_ids_[i]);
   }
   return true;
@@ -256,63 +277,18 @@ const CellStep& CellCache::step_for(int window) {
     return it->second;
   }
   CellStep step;
-  step.n_tok = static_cast<int>(cells_.size());
+  step.length = static_cast<int>(cells_.size());
   step.read_len = used_end_;
-  if (fused(window)) {
-    step.kind = step.n_tok == 1 ? MaskKind::None : MaskKind::Causal;
-    step.write_start = cells_.front();
-  } else {
-    step.kind = MaskKind::Explicit;
-    step.write_start = -1;
-    step.cells = cells_;
-    step.mask_bits = build_mask(window);
-  }
+  step.cells = cells_;
+  step.mask_bits = build_mask(window);
   return steps_.emplace(window, std::move(step)).first->second;
 }
 
-bool CellCache::fused(int window) const {
-  // The window is measured in positions, so the oldest cell in the read
-  // window must fall inside the newest query's window.
-  if (window > 0) {
-    int32_t oldest = INT32_MAX, newest = INT32_MIN;
-    for (int j = 0; j < used_end_; ++j) {
-      if (pos_[j] >= 0) {
-        oldest = std::min(oldest, pos_[j]);
-        newest = std::max(newest, pos_[j]);
-      }
-    }
-    if (oldest <= newest && newest - oldest >= window) {
-      return false;
-    }
-  }
-  // More than one sequence: each would need a different subset.
-  const int32_t seq = step_seq_ids_.front();
-  for (int32_t s : step_seq_ids_) {
-    if (s != seq) {
-      return false;
-    }
-  }
-  // Holes or another sequence's cells: the window is then not this
-  // sequence's causal prefix.
-  const SeqInfo& info = info_[seq];
-  if (info.count != used_end_) {
-    return false;
-  }
-  // The step's cells are the run at the tail.
-  const int n_tok = static_cast<int>(cells_.size());
-  for (int i = 0; i < n_tok; ++i) {
-    if (cells_[i] != used_end_ - n_tok + i) {
-      return false;
-    }
-  }
-  return true;
-}
-
 std::vector<uint8_t> CellCache::build_mask(int window) const {
-  const int n_tok = static_cast<int>(cells_.size());
+  const int length = static_cast<int>(cells_.size());
   std::vector<uint8_t> bits(
-      static_cast<size_t>(n_tok) * static_cast<size_t>(used_end_), 0);
-  for (int i = 0; i < n_tok; ++i) {
+      static_cast<size_t>(length) * static_cast<size_t>(used_end_), 0);
+  for (int i = 0; i < length; ++i) {
     const uint64_t tok_bit = bit(step_seq_ids_[i]);
     const int32_t tok_pos = step_pos_[i];
     // A flat layer reaches back to the start; a windowed one to its window.

--- a/extension/llm/cache/cell_cache.h
+++ b/extension/llm/cache/cell_cache.h
@@ -95,8 +95,6 @@ class CellCache : public CacheBase, public BatchControl, public CellStepper {
  private:
   struct SeqInfo {
     int count = 0;
-    int min_cell = 0;
-    int max_cell = -1;
     int max_pos = -1;
   };
 

--- a/extension/llm/cache/cell_cache.h
+++ b/extension/llm/cache/cell_cache.h
@@ -11,7 +11,7 @@
 // The cell layout: many sequences over one pool of per-token cells. A cell
 // holds one token's position and the sequences owning it, so a sequence needs
 // no contiguous range and a fork sets a second owner bit. The step's tokens sit
-// on one flat axis, sequence identity supplied out-of-band by begin_step.
+// on one flat axis, sequence identity supplied out-of-band by declare_step.
 // Tensor-free; the byte layer holds the pools and applies what it is given.
 
 #include <array>
@@ -28,18 +28,12 @@ namespace llm {
 namespace cache {
 
 // Integer-only handoff to the byte layer, covering the whole forward: a cell
-// means the same token in every layer's pool. A fused kind means the step's
-// cells are a contiguous run at the tail of a window its sequence owns
-// outright, so the write is one run and no mask is needed. Explicit gives each
-// token's cell and the bits it may attend.
+// means the same token in every layer's pool.
 struct CellStep {
-  MaskKind kind;
-  int n_tok;
+  int length;
   int read_len; // the window is cells [0, read_len)
-  int write_start; // fused only: first cell of the run
-  std::vector<int32_t> cells; // Explicit only: cell per query token
-  std::vector<uint8_t>
-      mask_bits; // Explicit only: [n_tok, read_len], 1 = attend
+  std::vector<int32_t> cells; // cell per query token
+  std::vector<uint8_t> mask_bits; // [length, read_len], 1 = attend
 };
 
 // Backend face of the cell layout. The step's first layer places its tokens and
@@ -52,7 +46,7 @@ class CellStepper {
  public:
   virtual ~CellStepper() = default;
   virtual const CellStep*
-  place_step(int layer, const int32_t* positions, int n_tok) = 0;
+  place_step(int layer, const int32_t* positions, int length) = 0;
 };
 
 class CellCache : public CacheBase, public BatchControl, public CellStepper {
@@ -82,18 +76,20 @@ class CellCache : public CacheBase, public BatchControl, public CellStepper {
 
   // -- BatchControl ------------------------------------------------------
 
-  bool begin_step(const std::vector<int32_t>& seq_ids) override;
-  bool seq_cp(int32_t src, int32_t dst, std::optional<int> upto) override;
-  bool seq_rm(int32_t seq, int p0, std::optional<int> p1) override;
-  int seq_len(int32_t seq) const override;
-  int next_pos(int32_t seq) const override;
+  bool declare_step(const std::vector<int32_t>& seq_ids) override;
+  std::optional<int32_t> seq_new() override;
+  std::optional<int32_t> seq_clone(int32_t src, std::optional<int> upto)
+      override;
+  bool seq_rm(int32_t seq_id, int p0, std::optional<int> p1) override;
+  int seq_len(int32_t seq_id) const override;
+  int next_pos(int32_t seq_id) const override;
 
   int free_cells() const;
   int used_end() const;
 
   // -- CellStepper -------------------------------------------------------
 
-  const CellStep* place_step(int layer, const int32_t* positions, int n_tok)
+  const CellStep* place_step(int layer, const int32_t* positions, int length)
       override;
 
  private:
@@ -104,13 +100,17 @@ class CellCache : public CacheBase, public BatchControl, public CellStepper {
     int max_pos = -1;
   };
 
-  static uint64_t bit(int32_t seq);
-  static bool valid_seq(int32_t seq);
+  static uint64_t bit(int32_t seq_id);
+  // Live from the moment seq_new hands the id out until its last slot goes.
+  // The bit alone answers this because a sequence can only take slots under an
+  // id declare_step accepted, and only a live id is accepted.
+  bool live(int32_t seq_id) const;
+  static bool valid_seq(int32_t seq_id);
 
   // Every position must be newer than what that sequence already holds, or it
   // would own two cells for one token. Two cells with the same pos and owner
   // are indistinguishable, so a branch is its own sequence.
-  bool extends(const int32_t* positions, int n_tok) const;
+  bool extends(const int32_t* positions, int length) const;
 
   // Placement policy: the lowest free cell, so freed cells refill before the
   // extent grows. The choice moves only the read window's width and how often a
@@ -121,9 +121,9 @@ class CellCache : public CacheBase, public BatchControl, public CellStepper {
   void invalidate_step();
 
   // Recompute a sequence's summary after the verbs move cells under it.
-  void rescan(int32_t seq);
+  void rescan(int32_t seq_id);
 
-  void claim(int cell, int32_t pos, int32_t seq);
+  void claim(int cell, int32_t pos, int32_t seq_id);
 
   // Claim a cell per token, shared by every layer of the forward. False = the
   // pool cannot supply them; no cell is claimed until every one is found, so a
@@ -133,11 +133,6 @@ class CellCache : public CacheBase, public BatchControl, public CellStepper {
   // One window's step, built the first time a layer with this window asks and
   // kept for the rest of the step.
   const CellStep& step_for(int window);
-
-  // Fused needs one sequence owning the whole read window, with this step's
-  // cells the run at its tail. A sliding window bounds queries from below,
-  // which no fused kind expresses.
-  bool fused(int window) const;
 
   // Query i attends cell j iff j is occupied, shares a sequence with i, is no
   // newer than i, and on a windowed layer no older than its window. The step's
@@ -150,8 +145,9 @@ class CellCache : public CacheBase, public BatchControl, public CellStepper {
   int used_count_ = 0; // occupied cells, so admission stays O(1)
   int used_end_ = 0; // every occupied cell is in [0, used_end)
   std::array<SeqInfo, kMaxSeqs> info_{};
+  uint64_t reserved_ = 0; // ids handed out by seq_new
 
-  std::vector<int32_t> step_seq_ids_; // set by begin_step
+  std::vector<int32_t> step_seq_ids_; // set by declare_step
   std::vector<int32_t> step_pos_; // set when the step is placed
   std::vector<int32_t> cells_; // the step's placement, shared by every layer
   std::vector<bool> served_; // layers this step has already answered

--- a/extension/llm/cache/cell_cache.h
+++ b/extension/llm/cache/cell_cache.h
@@ -10,14 +10,11 @@
 
 // The cell layout: many sequences over one pool of per-token cells. A cell
 // holds one token's position and the sequences owning it, so a sequence needs
-// no contiguous range and a fork sets a second owner bit rather than copying
-// K/V. The step's tokens sit on one flat axis, sequence identity supplied
-// out-of-band by begin_step, so one sequence or many is the same graph.
-// Tensor-free; the byte layer holds the pools and applies the plan.
+// no contiguous range and a fork sets a second owner bit. The step's tokens sit
+// on one flat axis, sequence identity supplied out-of-band by begin_step.
+// Tensor-free; the byte layer holds the pools and applies what it is given.
 
-#include <algorithm>
 #include <array>
-#include <cassert>
 #include <cstdint>
 #include <map>
 #include <optional>
@@ -31,11 +28,11 @@ namespace llm {
 namespace cache {
 
 // Integer-only handoff to the byte layer, covering the whole forward: a cell
-// means the same token in every layer's pool, so placement happens once per
-// step. A fused kind (None / Causal) means the step's cells are a contiguous
-// run at the tail of a window its sequence owns outright -- one run write, no
-// mask. Explicit gives each token's cell and the bits it may attend.
-struct CellStepPlan {
+// means the same token in every layer's pool. A fused kind means the step's
+// cells are a contiguous run at the tail of a window its sequence owns
+// outright, so the write is one run and no mask is needed. Explicit gives each
+// token's cell and the bits it may attend.
+struct CellStep {
   MaskKind kind;
   int n_tok;
   int read_len; // the window is cells [0, read_len)
@@ -46,38 +43,26 @@ struct CellStepPlan {
 };
 
 // Backend face of the cell layout. The step's first layer places its tokens and
-// every later layer reuses that placement, so there is no commit -- placing the
-// cells is what commits them. `layer` selects the layer's window, which decides
-// its kind and mask, so the plan is per policy and memoized for the step.
-// nullptr = no declaration, a token count disagreeing with it, a layer out of
-// range, or a layer served twice.
-class CellPlanner {
+// every later layer reuses that placement. `layer` selects the window, which
+// decides the kind and mask, so a step is per policy and memoized for the
+// forward. The returned step is owned by the cache and valid until the next
+// verb. nullptr = no declaration, a token count disagreeing with it, a position
+// a sequence already holds, a layer out of range, or a layer served twice.
+class CellStepper {
  public:
-  virtual ~CellPlanner() = default;
-  virtual const CellStepPlan*
-  plan(int layer, const int32_t* positions, int n_tok) = 0;
+  virtual ~CellStepper() = default;
+  virtual const CellStep*
+  place_step(int layer, const int32_t* positions, int n_tok) = 0;
 };
 
-class CellCache : public CacheBase, public BatchControl, public CellPlanner {
+class CellCache : public CacheBase, public BatchControl, public CellStepper {
  public:
   // One bit per sequence in the owner bitset.
   static constexpr int kMaxSeqs = 64;
 
-  explicit CellCache(const CacheConfig& cfg)
-      : capacity_(cfg.capacity),
-        pos_(cfg.capacity, -1),
-        owners_(cfg.capacity, 0),
-        served_(cfg.n_layers, false) {
-    // One window per layer, from the same per-layer config the sequence cache
-    // reads. Layers agreeing on a window share a plan.
-    windows_.reserve(cfg.n_layers);
-    for (int l = 0; l < cfg.n_layers; ++l) {
-      const LayerConfig& lc =
-          cfg.layers.size() == 1 ? cfg.layers.front() : cfg.layers[l];
-      windows_.push_back(
-          lc.policy.kind == LayerPolicy::Kind::Ring ? lc.policy.window : 0);
-    }
-  }
+  // Precondition: valid(cfg). CacheBuilderRegistry::build enforces it for
+  // registry-created caches; direct construction must check first.
+  explicit CellCache(const CacheConfig& cfg);
 
   CacheBase* base() {
     return this;
@@ -85,117 +70,31 @@ class CellCache : public CacheBase, public BatchControl, public CellPlanner {
   BatchControl* as_batch_control() override {
     return this;
   }
-  CellPlanner* as_cell_planner() override {
+  CellStepper* as_cell_stepper() override {
     return this;
   }
 
   // -- CacheControl ------------------------------------------------------
 
-  bool can_extend(int n = 1) const override {
-    return capacity_ - used_count_ >= n;
-  }
-  int capacity() const override {
-    return capacity_;
-  }
-  void clear() override {
-    std::fill(pos_.begin(), pos_.end(), -1);
-    std::fill(owners_.begin(), owners_.end(), 0);
-    info_.fill(SeqInfo{});
-    used_end_ = 0;
-    used_count_ = 0;
-    invalidate_step();
-  }
+  bool can_extend(int n = 1) const override;
+  int capacity() const override;
+  void clear() override;
 
   // -- BatchControl ------------------------------------------------------
 
-  bool begin_step(const int32_t* seq_ids, int n_tok) override {
-    if (n_tok <= 0 || !can_extend(n_tok)) {
-      return false;
-    }
-    for (int i = 0; i < n_tok; ++i) {
-      if (seq_ids[i] < 0 || seq_ids[i] >= kMaxSeqs) {
-        return false;
-      }
-    }
-    step_seq_ids_.assign(seq_ids, seq_ids + n_tok);
-    declared_ = true;
-    invalidate_plan();
-    std::fill(served_.begin(), served_.end(), false);
-    return true;
-  }
+  bool begin_step(const std::vector<int32_t>& seq_ids) override;
+  bool seq_cp(int32_t src, int32_t dst, std::optional<int> upto) override;
+  bool seq_rm(int32_t seq, int p0, std::optional<int> p1) override;
+  int seq_len(int32_t seq) const override;
+  int next_pos(int32_t seq) const override;
 
-  void seq_cp(int32_t src, int32_t dst, std::optional<int> upto) override {
-    if (!valid_seq(src) || !valid_seq(dst) || src == dst) {
-      return;
-    }
-    const uint64_t src_bit = bit(src), dst_bit = bit(dst);
-    for (int i = 0; i < used_end_; ++i) {
-      if ((owners_[i] & src_bit) && (!upto || pos_[i] < *upto)) {
-        owners_[i] |= dst_bit;
-      }
-    }
-    rescan(dst);
-    invalidate_plan();
-  }
+  int free_cells() const;
+  int used_end() const;
 
-  void seq_rm(int32_t seq, int p0, std::optional<int> p1) override {
-    if (!valid_seq(seq)) {
-      return;
-    }
-    const uint64_t b = bit(seq);
-    for (int i = 0; i < used_end_; ++i) {
-      if ((owners_[i] & b) && pos_[i] >= p0 && (!p1 || pos_[i] < *p1)) {
-        owners_[i] &= ~b;
-        if (owners_[i] == 0) {
-          pos_[i] = -1;
-          --used_count_;
-        }
-      }
-    }
-    while (used_end_ > 0 && pos_[used_end_ - 1] < 0) {
-      --used_end_;
-    }
-    rescan(seq);
-    invalidate_plan();
-  }
+  // -- CellStepper -------------------------------------------------------
 
-  int seq_len(int32_t seq) const override {
-    return valid_seq(seq) ? info_[seq].count : 0;
-  }
-  int next_pos(int32_t seq) const override {
-    return valid_seq(seq) ? info_[seq].max_pos + 1 : 0;
-  }
-
-  int free_cells() const {
-    return capacity_ - used_count_;
-  }
-  int used_end() const {
-    return used_end_;
-  }
-
-  // -- CellPlanner -------------------------------------------------------
-
-  const CellStepPlan* plan(int layer, const int32_t* positions, int n_tok)
-      override {
-    if (layer < 0 || layer >= static_cast<int>(windows_.size()) ||
-        served_[layer]) {
-      return nullptr; // out of range, or a forward that skipped begin_step
-    }
-    if (!placed_) {
-      if (!declared_ || n_tok != static_cast<int>(step_seq_ids_.size())) {
-        return nullptr; // no declaration, or a token count disagreeing with it
-      }
-      declared_ = false; // one declaration, one attempt at placing it
-      if (!extends(positions, n_tok)) {
-        return nullptr;
-      }
-      step_pos_.assign(positions, positions + n_tok);
-      place();
-      placed_ = true;
-    }
-    served_[layer] = true;
-    return &plan_for(windows_[layer]);
-  }
+  const CellStep* place_step(int layer, const int32_t* positions, int n_tok)
+      override;
 
  private:
   struct SeqInfo {
@@ -205,182 +104,45 @@ class CellCache : public CacheBase, public BatchControl, public CellPlanner {
     int max_pos = -1;
   };
 
-  static uint64_t bit(int32_t seq) {
-    return uint64_t{1} << seq;
-  }
-  static bool valid_seq(int32_t seq) {
-    return seq >= 0 && seq < kMaxSeqs;
-  }
+  static uint64_t bit(int32_t seq);
+  static bool valid_seq(int32_t seq);
 
-  // A step only extends its sequences: every position must be newer than what
-  // that sequence already holds, or it would own two cells for one token.
-  // Siblings at one position are a tree, which two cells with the same pos and
-  // owner cannot tell apart; here a branch is its own sequence.
-  bool extends(const int32_t* positions, int n_tok) const {
-    std::array<int32_t, kMaxSeqs> newest{};
-    for (int s = 0; s < kMaxSeqs; ++s) {
-      newest[s] = info_[s].max_pos;
-    }
-    for (int i = 0; i < n_tok; ++i) {
-      const int32_t seq = step_seq_ids_[i];
-      if (positions[i] <= newest[seq]) {
-        return false;
-      }
-      newest[seq] = positions[i];
-    }
-    return true;
-  }
+  // Every position must be newer than what that sequence already holds, or it
+  // would own two cells for one token. Two cells with the same pos and owner
+  // are indistinguishable, so a branch is its own sequence.
+  bool extends(const int32_t* positions, int n_tok) const;
 
   // Placement policy: the lowest free cell, so freed cells refill before the
-  // extent grows. The choice changes no result -- the mask keys off pos/owners,
-  // never the index -- only the read window's width and how often a step fuses.
-  // Precondition: begin_step admitted the step, so a free cell exists.
-  int lowest_free() const {
-    for (int i = 0; i < capacity_; ++i) {
-      if (pos_[i] < 0) {
-        return i;
-      }
-    }
-    return -1;
-  }
+  // extent grows. The choice moves only the read window's width and how often a
+  // step fuses; the mask keys off pos/owners, never the index.
+  int lowest_free(int from) const;
 
-  void invalidate_plan() {
-    placed_ = false;
-    plans_.clear();
-  }
-  void invalidate_step() {
-    invalidate_plan();
-    declared_ = false;
-    std::fill(served_.begin(), served_.end(), false);
-    step_seq_ids_.clear();
-    step_pos_.clear();
-  }
+  void invalidate_steps();
+  void invalidate_step();
 
   // Recompute a sequence's summary after the verbs move cells under it.
-  void rescan(int32_t seq) {
-    const uint64_t b = bit(seq);
-    SeqInfo info;
-    info.min_cell = capacity_;
-    for (int i = 0; i < used_end_; ++i) {
-      if (!(owners_[i] & b)) {
-        continue;
-      }
-      info.min_cell = std::min(info.min_cell, i);
-      info.max_cell = i;
-      info.max_pos = std::max(info.max_pos, pos_[i]);
-      ++info.count;
-    }
-    if (info.count == 0) {
-      info = SeqInfo{};
-    }
-    info_[seq] = info;
-  }
+  void rescan(int32_t seq);
 
-  int claim(int32_t pos, int32_t seq) {
-    const int cell = lowest_free();
-    // Only a slip in used_count_ can get here: begin_step admitted the step,
-    // and the step claims exactly the cells it declared.
-    assert(cell >= 0);
-    pos_[cell] = pos;
-    owners_[cell] = bit(seq);
-    used_end_ = std::max(used_end_, cell + 1);
-    ++used_count_;
-    SeqInfo& info = info_[seq];
-    info.min_cell = info.count == 0 ? cell : std::min(info.min_cell, cell);
-    info.max_cell = std::max(info.max_cell, cell);
-    info.max_pos = std::max(info.max_pos, pos);
-    ++info.count;
-    return cell;
-  }
+  void claim(int cell, int32_t pos, int32_t seq);
 
-  // The step's cells, shared by every layer: a cell means the same token in
-  // each layer's pool, so they are claimed once per forward.
-  void place() {
-    const int n_tok = static_cast<int>(step_pos_.size());
-    cells_.resize(n_tok);
-    for (int i = 0; i < n_tok; ++i) {
-      cells_[i] = claim(step_pos_[i], step_seq_ids_[i]);
-    }
-  }
+  // Claim a cell per token, shared by every layer of the forward. False = the
+  // pool cannot supply them; no cell is claimed until every one is found, so a
+  // refusal leaves the table unchanged.
+  bool place();
 
-  // The plan for one window, built from that placement the first time a layer
-  // with this window asks and kept for the rest of the step.
-  const CellStepPlan& plan_for(int window) {
-    auto it = plans_.find(window);
-    if (it != plans_.end()) {
-      return it->second;
-    }
-    CellStepPlan plan;
-    plan.n_tok = static_cast<int>(cells_.size());
-    plan.read_len = used_end_;
-    if (fused(window)) {
-      plan.kind = plan.n_tok == 1 ? MaskKind::None : MaskKind::Causal;
-      plan.write_start = cells_.front();
-    } else {
-      plan.kind = MaskKind::Explicit;
-      plan.write_start = -1;
-      plan.cells = cells_;
-      plan.mask_bits = build_mask(window);
-    }
-    return plans_.emplace(window, std::move(plan)).first->second;
-  }
+  // One window's step, built the first time a layer with this window asks and
+  // kept for the rest of the step.
+  const CellStep& step_for(int window);
 
   // Fused needs one sequence owning the whole read window, with this step's
-  // cells the run at its tail: the window is then exactly what these queries
-  // may attend. A sliding window also bounds them from below, which no fused
-  // kind expresses.
-  bool fused(int window) const {
-    // The window has outgrown the span, so old cells need excluding.
-    if (window > 0 && window < used_end_) {
-      return false;
-    }
-    // More than one sequence: each would need a different subset.
-    const int32_t seq = step_seq_ids_.front();
-    for (int32_t s : step_seq_ids_) {
-      if (s != seq) {
-        return false;
-      }
-    }
-    // Holes or another sequence's cells: the window is then not this
-    // sequence's causal prefix.
-    const SeqInfo& info = info_[seq];
-    if (info.count != used_end_) {
-      return false;
-    }
-    // The step's cells are the run at the tail, which is what lower-right
-    // alignment means.
-    const int n_tok = static_cast<int>(cells_.size());
-    for (int i = 0; i < n_tok; ++i) {
-      if (cells_[i] != used_end_ - n_tok + i) {
-        return false;
-      }
-    }
-    return true;
-  }
+  // cells the run at its tail. A sliding window bounds queries from below,
+  // which no fused kind expresses.
+  bool fused(int window) const;
 
   // Query i attends cell j iff j is occupied, shares a sequence with i, is no
   // newer than i, and on a windowed layer no older than its window. The step's
   // cells are already placed, so a query sees itself and its earlier tokens.
-  std::vector<uint8_t> build_mask(int window) const {
-    const int n_tok = static_cast<int>(cells_.size());
-    std::vector<uint8_t> bits(
-        static_cast<size_t>(n_tok) * static_cast<size_t>(used_end_), 0);
-    for (int i = 0; i < n_tok; ++i) {
-      const uint64_t tok_bit = bit(step_seq_ids_[i]);
-      const int32_t tok_pos = step_pos_[i];
-      // A flat layer reaches back to the start; a windowed one to its window.
-      const int32_t oldest = window > 0 ? tok_pos - window + 1 : 0;
-      uint8_t* row = bits.data() + static_cast<size_t>(i) * used_end_;
-      for (int j = 0; j < used_end_; ++j) {
-        row[j] =
-            (pos_[j] >= 0 && // occupied: a freed cell holds nothing
-             (owners_[j] & tok_bit) && // one of this query's sequences
-             pos_[j] <= tok_pos && // not the future; <= so a query sees itself
-             pos_[j] >= oldest); // within the window
-      }
-    }
-    return bits;
-  }
+  std::vector<uint8_t> build_mask(int window) const;
 
   int capacity_;
   std::vector<int32_t> pos_; // per cell; -1 = free
@@ -390,11 +152,13 @@ class CellCache : public CacheBase, public BatchControl, public CellPlanner {
   std::array<SeqInfo, kMaxSeqs> info_{};
 
   std::vector<int32_t> step_seq_ids_; // set by begin_step
-  std::vector<int32_t> step_pos_; // set by the step's first plan()
+  std::vector<int32_t> step_pos_; // set when the step is placed
   std::vector<int32_t> cells_; // the step's placement, shared by every layer
   std::vector<bool> served_; // layers this step has already answered
   std::vector<int> windows_; // per layer; 0 = keeps all history
-  std::map<int, CellStepPlan> plans_; // window -> plan, memoized per step
+  // window -> step, memoized per forward. Node-based is required: a step
+  // handed to one layer must survive another layer's insert.
+  std::map<int, CellStep> steps_;
   bool declared_ = false;
   bool placed_ = false;
 };

--- a/extension/llm/cache/cell_cache.h
+++ b/extension/llm/cache/cell_cache.h
@@ -1,0 +1,405 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// The cell layout: many sequences over one pool of per-token cells. A cell
+// holds one token's position and the sequences owning it, so a sequence needs
+// no contiguous range and a fork sets a second owner bit rather than copying
+// K/V. The step's tokens sit on one flat axis, sequence identity supplied
+// out-of-band by begin_step, so one sequence or many is the same graph.
+// Tensor-free; the byte layer holds the pools and applies the plan.
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <vector>
+
+#include <executorch/extension/llm/cache/cache.h>
+
+namespace executorch {
+namespace extension {
+namespace llm {
+namespace cache {
+
+// Integer-only handoff to the byte layer, covering the whole forward: a cell
+// means the same token in every layer's pool, so placement happens once per
+// step. A fused kind (None / Causal) means the step's cells are a contiguous
+// run at the tail of a window its sequence owns outright -- one run write, no
+// mask. Explicit gives each token's cell and the bits it may attend.
+struct CellStepPlan {
+  MaskKind kind;
+  int n_tok;
+  int read_len; // the window is cells [0, read_len)
+  int write_start; // fused only: first cell of the run
+  std::vector<int32_t> cells; // Explicit only: cell per query token
+  std::vector<uint8_t>
+      mask_bits; // Explicit only: [n_tok, read_len], 1 = attend
+};
+
+// Backend face of the cell layout. The step's first layer places its tokens and
+// every later layer reuses that placement, so there is no commit -- placing the
+// cells is what commits them. `layer` selects the layer's window, which decides
+// its kind and mask, so the plan is per policy and memoized for the step.
+// nullptr = no declaration, a token count disagreeing with it, a layer out of
+// range, or a layer served twice.
+class CellPlanner {
+ public:
+  virtual ~CellPlanner() = default;
+  virtual const CellStepPlan*
+  plan(int layer, const int32_t* positions, int n_tok) = 0;
+};
+
+class CellCache : public CacheBase, public BatchControl, public CellPlanner {
+ public:
+  // One bit per sequence in the owner bitset.
+  static constexpr int kMaxSeqs = 64;
+
+  explicit CellCache(const CacheConfig& cfg)
+      : capacity_(cfg.capacity),
+        pos_(cfg.capacity, -1),
+        owners_(cfg.capacity, 0),
+        served_(cfg.n_layers, false) {
+    // One window per layer, from the same per-layer config the sequence cache
+    // reads. Layers agreeing on a window share a plan.
+    windows_.reserve(cfg.n_layers);
+    for (int l = 0; l < cfg.n_layers; ++l) {
+      const LayerConfig& lc =
+          cfg.layers.size() == 1 ? cfg.layers.front() : cfg.layers[l];
+      windows_.push_back(
+          lc.policy.kind == LayerPolicy::Kind::Ring ? lc.policy.window : 0);
+    }
+  }
+
+  CacheBase* base() {
+    return this;
+  }
+  BatchControl* as_batch_control() override {
+    return this;
+  }
+  CellPlanner* as_cell_planner() override {
+    return this;
+  }
+
+  // -- CacheControl ------------------------------------------------------
+
+  bool can_extend(int n = 1) const override {
+    return capacity_ - used_count_ >= n;
+  }
+  int capacity() const override {
+    return capacity_;
+  }
+  void clear() override {
+    std::fill(pos_.begin(), pos_.end(), -1);
+    std::fill(owners_.begin(), owners_.end(), 0);
+    info_.fill(SeqInfo{});
+    used_end_ = 0;
+    used_count_ = 0;
+    invalidate_step();
+  }
+
+  // -- BatchControl ------------------------------------------------------
+
+  bool begin_step(const int32_t* seq_ids, int n_tok) override {
+    if (n_tok <= 0 || !can_extend(n_tok)) {
+      return false;
+    }
+    for (int i = 0; i < n_tok; ++i) {
+      if (seq_ids[i] < 0 || seq_ids[i] >= kMaxSeqs) {
+        return false;
+      }
+    }
+    step_seq_ids_.assign(seq_ids, seq_ids + n_tok);
+    declared_ = true;
+    invalidate_plan();
+    std::fill(served_.begin(), served_.end(), false);
+    return true;
+  }
+
+  void seq_cp(int32_t src, int32_t dst, std::optional<int> upto) override {
+    if (!valid_seq(src) || !valid_seq(dst) || src == dst) {
+      return;
+    }
+    const uint64_t src_bit = bit(src), dst_bit = bit(dst);
+    for (int i = 0; i < used_end_; ++i) {
+      if ((owners_[i] & src_bit) && (!upto || pos_[i] < *upto)) {
+        owners_[i] |= dst_bit;
+      }
+    }
+    rescan(dst);
+    invalidate_plan();
+  }
+
+  void seq_rm(int32_t seq, int p0, std::optional<int> p1) override {
+    if (!valid_seq(seq)) {
+      return;
+    }
+    const uint64_t b = bit(seq);
+    for (int i = 0; i < used_end_; ++i) {
+      if ((owners_[i] & b) && pos_[i] >= p0 && (!p1 || pos_[i] < *p1)) {
+        owners_[i] &= ~b;
+        if (owners_[i] == 0) {
+          pos_[i] = -1;
+          --used_count_;
+        }
+      }
+    }
+    while (used_end_ > 0 && pos_[used_end_ - 1] < 0) {
+      --used_end_;
+    }
+    rescan(seq);
+    invalidate_plan();
+  }
+
+  int seq_len(int32_t seq) const override {
+    return valid_seq(seq) ? info_[seq].count : 0;
+  }
+  int next_pos(int32_t seq) const override {
+    return valid_seq(seq) ? info_[seq].max_pos + 1 : 0;
+  }
+
+  int free_cells() const {
+    return capacity_ - used_count_;
+  }
+  int used_end() const {
+    return used_end_;
+  }
+
+  // -- CellPlanner -------------------------------------------------------
+
+  const CellStepPlan* plan(int layer, const int32_t* positions, int n_tok)
+      override {
+    if (layer < 0 || layer >= static_cast<int>(windows_.size()) ||
+        served_[layer]) {
+      return nullptr; // out of range, or a forward that skipped begin_step
+    }
+    if (!placed_) {
+      if (!declared_ || n_tok != static_cast<int>(step_seq_ids_.size())) {
+        return nullptr; // no declaration, or a token count disagreeing with it
+      }
+      declared_ = false; // one declaration, one attempt at placing it
+      if (!extends(positions, n_tok)) {
+        return nullptr;
+      }
+      step_pos_.assign(positions, positions + n_tok);
+      place();
+      placed_ = true;
+    }
+    served_[layer] = true;
+    return &plan_for(windows_[layer]);
+  }
+
+ private:
+  struct SeqInfo {
+    int count = 0;
+    int min_cell = 0;
+    int max_cell = -1;
+    int max_pos = -1;
+  };
+
+  static uint64_t bit(int32_t seq) {
+    return uint64_t{1} << seq;
+  }
+  static bool valid_seq(int32_t seq) {
+    return seq >= 0 && seq < kMaxSeqs;
+  }
+
+  // A step only extends its sequences: every position must be newer than what
+  // that sequence already holds, or it would own two cells for one token.
+  // Siblings at one position are a tree, which two cells with the same pos and
+  // owner cannot tell apart; here a branch is its own sequence.
+  bool extends(const int32_t* positions, int n_tok) const {
+    std::array<int32_t, kMaxSeqs> newest{};
+    for (int s = 0; s < kMaxSeqs; ++s) {
+      newest[s] = info_[s].max_pos;
+    }
+    for (int i = 0; i < n_tok; ++i) {
+      const int32_t seq = step_seq_ids_[i];
+      if (positions[i] <= newest[seq]) {
+        return false;
+      }
+      newest[seq] = positions[i];
+    }
+    return true;
+  }
+
+  // Placement policy: the lowest free cell, so freed cells refill before the
+  // extent grows. The choice changes no result -- the mask keys off pos/owners,
+  // never the index -- only the read window's width and how often a step fuses.
+  // Precondition: begin_step admitted the step, so a free cell exists.
+  int lowest_free() const {
+    for (int i = 0; i < capacity_; ++i) {
+      if (pos_[i] < 0) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  void invalidate_plan() {
+    placed_ = false;
+    plans_.clear();
+  }
+  void invalidate_step() {
+    invalidate_plan();
+    declared_ = false;
+    std::fill(served_.begin(), served_.end(), false);
+    step_seq_ids_.clear();
+    step_pos_.clear();
+  }
+
+  // Recompute a sequence's summary after the verbs move cells under it.
+  void rescan(int32_t seq) {
+    const uint64_t b = bit(seq);
+    SeqInfo info;
+    info.min_cell = capacity_;
+    for (int i = 0; i < used_end_; ++i) {
+      if (!(owners_[i] & b)) {
+        continue;
+      }
+      info.min_cell = std::min(info.min_cell, i);
+      info.max_cell = i;
+      info.max_pos = std::max(info.max_pos, pos_[i]);
+      ++info.count;
+    }
+    if (info.count == 0) {
+      info = SeqInfo{};
+    }
+    info_[seq] = info;
+  }
+
+  int claim(int32_t pos, int32_t seq) {
+    const int cell = lowest_free();
+    // Only a slip in used_count_ can get here: begin_step admitted the step,
+    // and the step claims exactly the cells it declared.
+    assert(cell >= 0);
+    pos_[cell] = pos;
+    owners_[cell] = bit(seq);
+    used_end_ = std::max(used_end_, cell + 1);
+    ++used_count_;
+    SeqInfo& info = info_[seq];
+    info.min_cell = info.count == 0 ? cell : std::min(info.min_cell, cell);
+    info.max_cell = std::max(info.max_cell, cell);
+    info.max_pos = std::max(info.max_pos, pos);
+    ++info.count;
+    return cell;
+  }
+
+  // The step's cells, shared by every layer: a cell means the same token in
+  // each layer's pool, so they are claimed once per forward.
+  void place() {
+    const int n_tok = static_cast<int>(step_pos_.size());
+    cells_.resize(n_tok);
+    for (int i = 0; i < n_tok; ++i) {
+      cells_[i] = claim(step_pos_[i], step_seq_ids_[i]);
+    }
+  }
+
+  // The plan for one window, built from that placement the first time a layer
+  // with this window asks and kept for the rest of the step.
+  const CellStepPlan& plan_for(int window) {
+    auto it = plans_.find(window);
+    if (it != plans_.end()) {
+      return it->second;
+    }
+    CellStepPlan plan;
+    plan.n_tok = static_cast<int>(cells_.size());
+    plan.read_len = used_end_;
+    if (fused(window)) {
+      plan.kind = plan.n_tok == 1 ? MaskKind::None : MaskKind::Causal;
+      plan.write_start = cells_.front();
+    } else {
+      plan.kind = MaskKind::Explicit;
+      plan.write_start = -1;
+      plan.cells = cells_;
+      plan.mask_bits = build_mask(window);
+    }
+    return plans_.emplace(window, std::move(plan)).first->second;
+  }
+
+  // Fused needs one sequence owning the whole read window, with this step's
+  // cells the run at its tail: the window is then exactly what these queries
+  // may attend. A sliding window also bounds them from below, which no fused
+  // kind expresses.
+  bool fused(int window) const {
+    // The window has outgrown the span, so old cells need excluding.
+    if (window > 0 && window < used_end_) {
+      return false;
+    }
+    // More than one sequence: each would need a different subset.
+    const int32_t seq = step_seq_ids_.front();
+    for (int32_t s : step_seq_ids_) {
+      if (s != seq) {
+        return false;
+      }
+    }
+    // Holes or another sequence's cells: the window is then not this
+    // sequence's causal prefix.
+    const SeqInfo& info = info_[seq];
+    if (info.count != used_end_) {
+      return false;
+    }
+    // The step's cells are the run at the tail, which is what lower-right
+    // alignment means.
+    const int n_tok = static_cast<int>(cells_.size());
+    for (int i = 0; i < n_tok; ++i) {
+      if (cells_[i] != used_end_ - n_tok + i) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Query i attends cell j iff j is occupied, shares a sequence with i, is no
+  // newer than i, and on a windowed layer no older than its window. The step's
+  // cells are already placed, so a query sees itself and its earlier tokens.
+  std::vector<uint8_t> build_mask(int window) const {
+    const int n_tok = static_cast<int>(cells_.size());
+    std::vector<uint8_t> bits(
+        static_cast<size_t>(n_tok) * static_cast<size_t>(used_end_), 0);
+    for (int i = 0; i < n_tok; ++i) {
+      const uint64_t tok_bit = bit(step_seq_ids_[i]);
+      const int32_t tok_pos = step_pos_[i];
+      // A flat layer reaches back to the start; a windowed one to its window.
+      const int32_t oldest = window > 0 ? tok_pos - window + 1 : 0;
+      uint8_t* row = bits.data() + static_cast<size_t>(i) * used_end_;
+      for (int j = 0; j < used_end_; ++j) {
+        row[j] =
+            (pos_[j] >= 0 && // occupied: a freed cell holds nothing
+             (owners_[j] & tok_bit) && // one of this query's sequences
+             pos_[j] <= tok_pos && // not the future; <= so a query sees itself
+             pos_[j] >= oldest); // within the window
+      }
+    }
+    return bits;
+  }
+
+  int capacity_;
+  std::vector<int32_t> pos_; // per cell; -1 = free
+  std::vector<uint64_t> owners_; // per cell; owning-sequence bitset
+  int used_count_ = 0; // occupied cells, so admission stays O(1)
+  int used_end_ = 0; // every occupied cell is in [0, used_end)
+  std::array<SeqInfo, kMaxSeqs> info_{};
+
+  std::vector<int32_t> step_seq_ids_; // set by begin_step
+  std::vector<int32_t> step_pos_; // set by the step's first plan()
+  std::vector<int32_t> cells_; // the step's placement, shared by every layer
+  std::vector<bool> served_; // layers this step has already answered
+  std::vector<int> windows_; // per layer; 0 = keeps all history
+  std::map<int, CellStepPlan> plans_; // window -> plan, memoized per step
+  bool declared_ = false;
+  bool placed_ = false;
+};
+
+} // namespace cache
+} // namespace llm
+} // namespace extension
+} // namespace executorch

--- a/extension/llm/cache/cell_cache.h
+++ b/extension/llm/cache/cell_cache.h
@@ -117,8 +117,9 @@ class CellCache : public CacheBase, public BatchControl, public CellStepper {
   // step fuses; the mask keys off pos/owners, never the index.
   int lowest_free(int from) const;
 
+  // Drop the step's placement and the per-window steps built from it, after
+  // the table moves underneath them.
   void invalidate_steps();
-  void invalidate_step();
 
   // Recompute a sequence's summary after the verbs move cells under it.
   void rescan(int32_t seq_id);

--- a/extension/llm/cache/sequence_cache.h
+++ b/extension/llm/cache/sequence_cache.h
@@ -14,6 +14,7 @@
 // flat/ring model (gemma4) stays coherent. Tensor-free / ET-independent.
 
 #include <algorithm>
+#include <cassert>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -97,6 +98,7 @@ class SequenceCache : public CacheBase,
  public:
   explicit SequenceCache(const CacheConfig& cfg)
       : capacity_(cfg.capacity), max_write_(cfg.max_write) {
+    assert(valid(cfg));
     layer_to_policy_.reserve(cfg.n_layers);
     for (int l = 0; l < cfg.n_layers; ++l) {
       // layers size 1 = one config broadcast to every layer, else per-layer.

--- a/extension/llm/cache/test/cache_test.cpp
+++ b/extension/llm/cache/test/cache_test.cpp
@@ -27,8 +27,8 @@ using executorch::extension::llm::cache::CacheConfig;
 using executorch::extension::llm::cache::CacheRegistry;
 using executorch::extension::llm::cache::CacheSession;
 using executorch::extension::llm::cache::CellCache;
-using executorch::extension::llm::cache::CellPlanner;
-using executorch::extension::llm::cache::CellStepPlan;
+using executorch::extension::llm::cache::CellStep;
+using executorch::extension::llm::cache::CellStepper;
 using executorch::extension::llm::cache::LayerConfig;
 using executorch::extension::llm::cache::LayerPolicy;
 using executorch::extension::llm::cache::make_unique_key;
@@ -212,6 +212,19 @@ TEST_F(CacheTest, BuilderBuildsRegisteredKindElseError) {
   EXPECT_EQ(cache.get()->as_control()->capacity(), 32);
 
   EXPECT_EQ(reg.build("TestBackend", "missing", cfg).error(), Error::NotFound);
+
+  // A layers list that is neither size 1 nor n_layers would be indexed past
+  // the end, so build refuses it before the cache is constructed.
+  EXPECT_EQ(
+      reg.build("TestBackend", "seq", CacheConfig{32, 3, {}}).error(),
+      Error::InvalidArgument);
+  EXPECT_EQ(
+      reg.build(
+             "TestBackend",
+             "seq",
+             CacheConfig{32, 3, {flat_layer(), flat_layer()}})
+          .error(),
+      Error::InvalidArgument);
 }
 
 TEST_F(CacheTest, SessionInstallsOnCtorErasesOnDtor) {
@@ -245,36 +258,59 @@ TEST_F(CacheTest, EtAdapterMapsResultsAndCodes) {
 // ---- Cell layout -----------------------------------------------------------
 
 namespace {
+// One sequence's tokens in a step: `n_tokens` of them from `start_pos` onward.
+struct SeqTokens {
+  int32_t seq_id;
+  int n_tokens;
+  int32_t start_pos;
+};
+
 // A cell cache and the two faces a caller holds: the runner drives the verbs,
-// the backend asks for the step's plan.
+// the backend places each step.
 struct Cells {
   explicit Cells(
       int capacity,
       std::vector<LayerConfig> layers = {flat_layer(), flat_layer()})
       : cache(CacheConfig{capacity, static_cast<int>(layers.size()), layers}),
         ctl(cache.as_batch_control()),
-        planner(cache.as_cell_planner()) {}
+        stepper(cache.as_cell_stepper()) {}
 
-  const CellStepPlan* step(
+  // One layer of an already-declared step.
+  const CellStep* place(int layer, std::vector<int32_t> positions) {
+    return stepper->place_step(
+        layer, positions.data(), static_cast<int>(positions.size()));
+  }
+
+  // A whole single-layer step: declare it, then place it.
+  const CellStep* step(
       std::vector<int32_t> seq_ids,
       std::vector<int32_t> positions) {
-    if (!ctl->begin_step(seq_ids.data(), static_cast<int>(seq_ids.size()))) {
-      return nullptr;
+    return ctl->begin_step(seq_ids) ? place(/*layer=*/0, positions) : nullptr;
+  }
+
+  // The same step, from each sequence's tokens rather than the per-token
+  // arrays.
+  const CellStep* step_of(std::initializer_list<SeqTokens> sequences) {
+    std::vector<int32_t> seq_ids, positions;
+    for (const SeqTokens& t : sequences) {
+      for (int i = 0; i < t.n_tokens; ++i) {
+        seq_ids.push_back(t.seq_id);
+        positions.push_back(t.start_pos + i);
+      }
     }
-    return planner->plan(
-        0, positions.data(), static_cast<int>(positions.size()));
+    return step(seq_ids, positions);
   }
 
   CellCache cache;
   BatchControl* ctl;
-  CellPlanner* planner;
+  CellStepper* stepper;
 };
 
 // The mask row for query `i`, as a string of '.' and '1' -- readable.
-std::string row(const CellStepPlan& plan, int i) {
-  std::string out(plan.read_len, '.');
-  for (int j = 0; j < plan.read_len; ++j) {
-    out[j] = plan.mask_bits[i * plan.read_len + j] ? '1' : '.';
+std::string row(const CellStep& step, int i) {
+  std::string out(step.read_len, '.');
+  for (int j = 0; j < step.read_len; ++j) {
+    out[j] = step.mask_bits[i * step.read_len + j] ? '1' : '.';
   }
   return out;
 }
@@ -282,15 +318,14 @@ std::string row(const CellStepPlan& plan, int i) {
 
 TEST_F(CacheTest, CellSingleSequenceIsFused) {
   Cells c(16);
-  const auto* prefill =
-      c.step({0, 0, 0, 0}, {0, 1, 2, 3}); // seq 0 places 4 tokens at 0..3
+  const auto* prefill = c.step_of({{0, 4, 0}}); // seq 0 places 4 tokens at 0..3
   ASSERT_NE(prefill, nullptr);
   EXPECT_EQ(prefill->kind, MaskKind::Causal); // one run at the tail it owns
   EXPECT_EQ(prefill->write_start, 0);
   EXPECT_EQ(prefill->read_len, 4);
   EXPECT_TRUE(prefill->mask_bits.empty()); // fused kinds carry no mask
 
-  const auto* decode = c.step({0}, {4}); // seq 0 places one more at 4
+  const auto* decode = c.step_of({{0, 1, 4}}); // one more at 4
   ASSERT_NE(decode, nullptr);
   EXPECT_EQ(decode->kind, MaskKind::None); // one query over its own window
   EXPECT_EQ(decode->write_start, 4);
@@ -298,40 +333,43 @@ TEST_F(CacheTest, CellSingleSequenceIsFused) {
 
 TEST_F(CacheTest, CellSecondSequenceForcesAnExplicitMask) {
   Cells c(16);
-  c.step({0, 0, 0, 0}, {0, 1, 2, 3}); // seq 0 places 4 tokens at 0..3
+  c.step_of({{0, 4, 0}}); // seq 0 places 4 tokens at 0..3
 
-  const auto* plan =
-      c.step({1, 1}, {0, 1}); // seq 1 places 2 at positions seq 0 also holds
-  ASSERT_NE(plan, nullptr);
-  EXPECT_EQ(plan->kind, MaskKind::Explicit);
-  EXPECT_EQ(plan->read_len, 6);
-  EXPECT_EQ(plan->cells, (std::vector<int32_t>{4, 5}));
+  const auto* step =
+      c.step_of({{1, 2, 0}}); // seq 1 places 2 at positions seq 0 also holds
+  ASSERT_NE(step, nullptr);
+  EXPECT_EQ(step->kind, MaskKind::Explicit);
+  EXPECT_EQ(step->read_len, 6);
+  EXPECT_EQ(step->cells, (std::vector<int32_t>{4, 5}));
   // sequence 1 sees none of sequence 0's cells, though they share positions
-  EXPECT_EQ(row(*plan, 0), "....1.");
-  EXPECT_EQ(row(*plan, 1), "....11");
+  EXPECT_EQ(row(*step, 0), "....1.");
+  EXPECT_EQ(row(*step, 1), "....11");
 }
 
-TEST_F(CacheTest, CellPlanIsSharedByEveryLayerOfTheStep) {
+TEST_F(CacheTest, CellPlacementIsSharedByEveryLayerOfTheStep) {
   Cells c(16);
-  const int32_t seqs[2] = {0, 1};
-  const int32_t pos[2] = {0, 0};
-  ASSERT_TRUE(c.ctl->begin_step(seqs, 2));
+  const std::vector<int32_t> seqs{0, 1};
 
-  const auto* first = c.planner->plan(0, pos, 2); // layer 0 places the cells
+  ASSERT_TRUE(c.ctl->begin_step(seqs));
+
+  const auto* first = c.place(0, {0, 0}); // layer 0 places the cells
   ASSERT_NE(first, nullptr);
-  EXPECT_EQ(c.planner->plan(1, pos, 2), first); // later layers reuse them
-  EXPECT_EQ(c.planner->plan(0, pos, 2), nullptr); // asking twice is a new step
+  EXPECT_EQ(c.place(1, {0, 0}), first); // later layers reuse them
+  EXPECT_EQ(c.place(0, {0, 0}), nullptr); // asking twice is a new step
   EXPECT_EQ(c.cache.free_cells(), 14); // placed once, not once per layer
 }
 
 TEST_F(CacheTest, CellForkSharesCellsAndEvictionRefcounts) {
   Cells c(16);
-  c.step({0, 0, 0, 0}, {0, 1, 2, 3}); // seq 0 places 4 tokens at 0..3
+  c.step_of({{0, 4, 0}}); // seq 0 places 4 tokens at 0..3
 
   ASSERT_EQ(c.cache.free_cells(), 12); // the four it placed, out of sixteen
 
-  c.ctl->seq_cp(0, 1, std::nullopt);
+  ASSERT_TRUE(c.ctl->seq_cp(0, 1, std::nullopt));
   EXPECT_EQ(c.cache.free_cells(), 12); // no cell, no byte copied
+  // seq 1 now holds positions 0-3, so a second fork onto it is refused: it
+  // would own two cells for each of them.
+  EXPECT_FALSE(c.ctl->seq_cp(0, 1, std::nullopt));
   EXPECT_EQ(c.ctl->seq_len(1), 4);
   EXPECT_EQ(c.ctl->next_pos(1), 4);
 
@@ -347,7 +385,7 @@ TEST_F(CacheTest, CellForkSharesCellsAndEvictionRefcounts) {
 
 TEST_F(CacheTest, CellRangedRemovalFreesOnlyThatWindow) {
   Cells c(16);
-  c.step({0, 0, 0, 0, 0}, {0, 1, 2, 3, 4}); // seq 0 places 5 tokens at 0..4
+  c.step_of({{0, 5, 0}}); // seq 0 places 5 tokens at 0..4
 
   c.ctl->seq_rm(0, 0, 2); // sliding window: drop the oldest two
   EXPECT_EQ(c.ctl->seq_len(0), 3);
@@ -361,20 +399,20 @@ TEST_F(CacheTest, CellRangedRemovalFreesOnlyThatWindow) {
 
 TEST_F(CacheTest, CellRefillingHolesGivesUpTheFusedPath) {
   Cells c(16);
-  c.step({0, 0, 0, 0}, {0, 1, 2, 3}); // seq 0 places 4 tokens at 0..3
+  c.step_of({{0, 4, 0}}); // seq 0 places 4 tokens at 0..3
   c.ctl->seq_rm(0, 0, 2); // free the oldest cells, leaving holes at 0 and 1
 
   // The new tokens take those holes, so the sequence owns the whole window
   // again -- but its cells no longer ascend with its positions.
-  const auto* plan = c.step({0, 0}, {4, 5}); // seq 0 places two more at 4..5
-  ASSERT_NE(plan, nullptr);
-  EXPECT_EQ(plan->cells, (std::vector<int32_t>{0, 1}));
-  EXPECT_EQ(plan->kind, MaskKind::Explicit);
+  const auto* step = c.step_of({{0, 2, 4}}); // seq 0 places two more at 4..5
+  ASSERT_NE(step, nullptr);
+  EXPECT_EQ(step->cells, (std::vector<int32_t>{0, 1}));
+  EXPECT_EQ(step->kind, MaskKind::Explicit);
 }
 
 TEST_F(CacheTest, CellRejectsAPositionASequenceStillHolds) {
   Cells c(16);
-  c.step({0, 0, 0, 0}, {0, 1, 2, 3}); // seq 0 places 4 tokens at 0..3
+  c.step_of({{0, 4, 0}}); // seq 0 places 4 tokens at 0..3
   c.ctl->seq_rm(0, 3, std::nullopt); // free the newest cell
 
   // A step only extends its sequences. Writing 0 again would leave seq 0 with
@@ -382,19 +420,52 @@ TEST_F(CacheTest, CellRejectsAPositionASequenceStillHolds) {
   EXPECT_EQ(c.step({0}, {0}), nullptr);
   EXPECT_EQ(c.step({0, 0}, {5, 4}), nullptr); // nor may its own tokens descend
   EXPECT_NE(c.step({0}, {3}), nullptr); // the position it just freed is fine
+
+  // A refusal places nothing, so the declaration stands and the same step can
+  // be placed again with corrected positions.
+  ASSERT_TRUE(c.ctl->begin_step({0}));
+  EXPECT_EQ(c.place(0, {0}), nullptr);
+  EXPECT_NE(c.place(0, {4}), nullptr);
 }
 
-TEST_F(CacheTest, CellLayersSharingAWindowShareAPlan) {
+TEST_F(CacheTest, CellFusesOnlyWhileTheWindowCoversTheSpan) {
+  // A fused kind says the whole read window is attendable, so it is only safe
+  // while the window spans every position the step holds.
+  {
+    Cells c(16, {ring_layer(4)});
+    // span 3 < window 4: nothing to exclude.
+    EXPECT_EQ(c.step_of({{0, 4, 0}})->kind, MaskKind::Causal);
+  }
+  {
+    Cells c(16, {ring_layer(3)});
+    // span 3 == window 3: position 0 is one too old for the query at 3.
+    EXPECT_EQ(c.step_of({{0, 4, 0}})->kind, MaskKind::Explicit);
+  }
+  {
+    Cells c(16, {ring_layer(2)});
+    // Two cells, five positions apart: the span is what counts.
+    c.step({0}, {0});
+    EXPECT_EQ(c.step({0}, {5})->kind, MaskKind::Explicit);
+  }
+  {
+    Cells c(16, {ring_layer(8)});
+    // Sparse but inside the window, so the fused path still holds.
+    c.step({0}, {0});
+    EXPECT_EQ(c.step({0}, {5})->kind, MaskKind::None);
+  }
+}
+
+TEST_F(CacheTest, CellLayersSharingAWindowShareAStep) {
   // gemma-style: one flat layer beside two windowed ones. The placement is
   // shared, the plan is per policy -- so the flat layer still fuses while the
   // windowed pair gets one banded plan between them.
   Cells c(16, {flat_layer(), ring_layer(2), ring_layer(2)});
-  const int32_t seqs[4] = {0, 0, 0, 0};
-  const int32_t pos[4] = {0, 1, 2, 3};
-  ASSERT_TRUE(c.ctl->begin_step(seqs, 4));
+  const std::vector<int32_t> seqs{0, 0, 0, 0};
 
-  const auto* flat = c.planner->plan(0, pos, 4);
-  const auto* windowed = c.planner->plan(1, pos, 4);
+  ASSERT_TRUE(c.ctl->begin_step(seqs));
+
+  const auto* flat = c.place(0, {0, 1, 2, 3});
+  const auto* windowed = c.place(1, {0, 1, 2, 3});
   ASSERT_NE(flat, nullptr);
   ASSERT_NE(windowed, nullptr);
   EXPECT_EQ(flat->kind, MaskKind::Causal);
@@ -402,27 +473,25 @@ TEST_F(CacheTest, CellLayersSharingAWindowShareAPlan) {
   EXPECT_EQ(windowed->kind, MaskKind::Explicit);
   EXPECT_EQ(row(*windowed, 2), ".11."); // query 2 drops position 0
 
-  EXPECT_EQ(c.planner->plan(2, pos, 4), windowed); // same window, same plan
+  EXPECT_EQ(c.place(2, {0, 1, 2, 3}), windowed); // same window, same step
   EXPECT_EQ(c.cache.free_cells(), 12); // placed once for all three layers
 }
 
 TEST_F(CacheTest, CellStepProtocolIsEnforced) {
   Cells c(4);
-  const int32_t seqs[2] = {0, 0};
-  const int32_t pos[2] = {0, 1};
+  const std::vector<int32_t> seqs{0, 0};
+  EXPECT_FALSE(c.ctl->begin_step({})); // no tokens
+  EXPECT_FALSE(c.ctl->begin_step({0, 0, 0, 0, 0})); // 5 tokens, 4 cells
+  EXPECT_FALSE(
+      c.ctl->begin_step({CellCache::kMaxSeqs})); // seq id past the last bit
+  // The verbs report a bad sequence rather than doing nothing quietly.
+  EXPECT_FALSE(c.ctl->seq_cp(0, CellCache::kMaxSeqs, std::nullopt));
+  EXPECT_FALSE(c.ctl->seq_rm(-1, 0, std::nullopt));
 
-  EXPECT_FALSE(c.ctl->begin_step(seqs, 0)); // no tokens
-  const int32_t many[5] = {0, 0, 0, 0, 0};
-  EXPECT_FALSE(c.ctl->begin_step(many, 5)); // 5 tokens, 4 cells
-  const int32_t bad[1] = {CellCache::kMaxSeqs};
-  EXPECT_FALSE(c.ctl->begin_step(bad, 1)); // seq id past the last owner bit
+  EXPECT_EQ(c.place(0, {0, 1}), nullptr); // no declaration
+  ASSERT_TRUE(c.ctl->begin_step(seqs));
+  EXPECT_EQ(c.place(0, {0}), nullptr); // token count disagrees
+  ASSERT_NE(c.place(0, {0, 1}), nullptr); // 2 tokens, as declared
 
-  EXPECT_EQ(c.planner->plan(0, pos, 2), nullptr); // no declaration
-  ASSERT_TRUE(c.ctl->begin_step(seqs, 2));
-  EXPECT_EQ(c.planner->plan(0, pos, 1), nullptr); // token count disagrees
-  ASSERT_NE(c.planner->plan(0, pos, 2), nullptr); // 2 tokens, as declared
-
-  const int32_t next[2] = {2, 3};
-  EXPECT_EQ(
-      c.planner->plan(0, next, 2), nullptr); // a second step, no begin_step
+  EXPECT_EQ(c.place(0, {2, 3}), nullptr); // a second step, no begin_step
 }

--- a/extension/llm/cache/test/cache_test.cpp
+++ b/extension/llm/cache/test/cache_test.cpp
@@ -13,6 +13,7 @@
 #include <executorch/extension/llm/cache/sequence_cache.h>
 
 #include <memory>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -32,7 +33,6 @@ using executorch::extension::llm::cache::CellStepper;
 using executorch::extension::llm::cache::LayerConfig;
 using executorch::extension::llm::cache::LayerPolicy;
 using executorch::extension::llm::cache::make_unique_key;
-using executorch::extension::llm::cache::MaskKind;
 using executorch::extension::llm::cache::SequenceCache;
 using executorch::runtime::Error;
 namespace et = executorch::extension::llm::cache::et;
@@ -258,12 +258,31 @@ TEST_F(CacheTest, EtAdapterMapsResultsAndCodes) {
 // ---- Cell layout -----------------------------------------------------------
 
 namespace {
-// One sequence's tokens in a step: `n_tokens` of them from `start_pos` onward.
+// One sequence's tokens in a step: `length` of them from `start_pos` onward.
 struct SeqTokens {
   int32_t seq_id;
-  int n_tokens;
   int32_t start_pos;
+  int length;
 };
+
+// The per-token arrays a step is made of.
+struct StepArgs {
+  std::vector<int32_t> seq_ids;
+  std::vector<int32_t> positions;
+};
+
+// Lay a step's sequences on one token axis, building the two arrays together
+// so they cannot fall out of alignment.
+StepArgs flatten_step(std::initializer_list<SeqTokens> sequences) {
+  StepArgs args;
+  for (const SeqTokens& t : sequences) {
+    for (int i = 0; i < t.length; ++i) {
+      args.seq_ids.push_back(t.seq_id);
+      args.positions.push_back(t.start_pos + i);
+    }
+  }
+  return args;
+}
 
 // A cell cache and the two faces a caller holds: the runner drives the verbs,
 // the backend places each step.
@@ -274,6 +293,14 @@ struct Cells {
       : cache(CacheConfig{capacity, static_cast<int>(layers.size()), layers}),
         ctl(cache.as_batch_control()),
         stepper(cache.as_cell_stepper()) {}
+
+  // Ids come from the cache, so a test names sequences by allocating them.
+  // Unlike the face's, this one unwraps and fails the test if none is free.
+  int32_t seq_new() {
+    const auto id = ctl->seq_new();
+    EXPECT_TRUE(id) << "no free sequence id";
+    return id ? *id : -1;
+  }
 
   // One layer of an already-declared step.
   const CellStep* place(int layer, std::vector<int32_t> positions) {
@@ -286,21 +313,12 @@ struct Cells {
   const CellStep* step(
       std::vector<int32_t> seq_ids,
       std::vector<int32_t> positions) {
-    EXPECT_TRUE(ctl->begin_step(seq_ids)) << "the step was not admitted";
+    EXPECT_TRUE(ctl->declare_step(seq_ids)) << "the step was not admitted";
     return place(/*layer=*/0, positions);
   }
 
-  // The same step, from each sequence's tokens rather than the per-token
-  // arrays.
-  const CellStep* step_of(std::initializer_list<SeqTokens> sequences) {
-    std::vector<int32_t> seq_ids, positions;
-    for (const SeqTokens& t : sequences) {
-      for (int i = 0; i < t.n_tokens; ++i) {
-        seq_ids.push_back(t.seq_id);
-        positions.push_back(t.start_pos + i);
-      }
-    }
-    return step(seq_ids, positions);
+  const CellStep* step(StepArgs args) {
+    return step(std::move(args.seq_ids), std::move(args.positions));
   }
 
   CellCache cache;
@@ -308,13 +326,11 @@ struct Cells {
   CellStepper* stepper;
 };
 
-// The mask row for query `i`, as a string of '.' and '1'. Explicit steps only:
-// a fused step carries no bits.
+// The mask row for query `i`, as a string of '.' and '1'.
 std::string row(const CellStep& step, int i) {
-  EXPECT_EQ(step.kind, MaskKind::Explicit);
   EXPECT_EQ(
       step.mask_bits.size(),
-      static_cast<size_t>(step.n_tok) * static_cast<size_t>(step.read_len));
+      static_cast<size_t>(step.length) * static_cast<size_t>(step.read_len));
   if (step.mask_bits.empty()) {
     return {};
   }
@@ -326,29 +342,33 @@ std::string row(const CellStep& step, int i) {
 }
 } // namespace
 
-TEST_F(CacheTest, CellSingleSequenceIsFused) {
+TEST_F(CacheTest, CellSingleSequenceAttendsItsOwnPrefix) {
   Cells c(16);
-  const auto* prefill = c.step_of({{0, 4, 0}}); // seq 0 places 4 tokens at 0..3
+  const int32_t s0 = c.seq_new();
+  // seq 0 places 4 tokens at 0..3
+  const auto* prefill = c.step(flatten_step({{s0, 0, 4}}));
   ASSERT_NE(prefill, nullptr);
-  EXPECT_EQ(prefill->kind, MaskKind::Causal); // one run at the tail it owns
-  EXPECT_EQ(prefill->write_start, 0);
   EXPECT_EQ(prefill->read_len, 4);
-  EXPECT_TRUE(prefill->mask_bits.empty()); // fused kinds carry no mask
+  EXPECT_EQ(prefill->cells, (std::vector<int32_t>{0, 1, 2, 3}));
+  EXPECT_EQ(row(*prefill, 0), "1...");
+  EXPECT_EQ(row(*prefill, 3), "1111");
 
-  const auto* decode = c.step_of({{0, 1, 4}}); // one more at 4
+  const auto* decode = c.step(flatten_step({{s0, 4, 1}})); // one more at 4
   ASSERT_NE(decode, nullptr);
-  EXPECT_EQ(decode->kind, MaskKind::None); // one query over its own window
-  EXPECT_EQ(decode->write_start, 4);
+  EXPECT_EQ(decode->cells, (std::vector<int32_t>{4}));
+  EXPECT_EQ(row(*decode, 0), "11111"); // the whole history it owns
 }
 
 TEST_F(CacheTest, CellSecondSequenceForcesAnExplicitMask) {
   Cells c(16);
-  c.step_of({{0, 4, 0}}); // seq 0 places 4 tokens at 0..3
+  const int32_t s0 = c.seq_new();
+  const int32_t s1 = c.seq_new();
+  c.step(flatten_step({{s0, 0, 4}})); // seq 0 places 4 tokens at 0..3
 
   const auto* step =
-      c.step_of({{1, 2, 0}}); // seq 1 places 2 at positions seq 0 also holds
+      // seq 1 places 2 at positions seq 0 also holds
+      c.step(flatten_step({{s1, 0, 2}}));
   ASSERT_NE(step, nullptr);
-  EXPECT_EQ(step->kind, MaskKind::Explicit);
   EXPECT_EQ(step->read_len, 6);
   EXPECT_EQ(step->cells, (std::vector<int32_t>{4, 5}));
   // sequence 1 sees none of sequence 0's cells, though they share positions
@@ -356,67 +376,145 @@ TEST_F(CacheTest, CellSecondSequenceForcesAnExplicitMask) {
   EXPECT_EQ(row(*step, 1), "....11");
 }
 
+TEST_F(CacheTest, CellBatchedPrefillKeepsSequencesApart) {
+  Cells c(16);
+  const int32_t s0 = c.seq_new();
+  const int32_t s1 = c.seq_new();
+
+  // One step, two prefills of different lengths on a single token axis.
+  const auto* step = c.step(flatten_step({{s0, 0, 3}, {s1, 0, 2}}));
+  ASSERT_NE(step, nullptr);
+  EXPECT_EQ(step->cells, (std::vector<int32_t>{0, 1, 2, 3, 4}));
+  EXPECT_EQ(step->read_len, 5);
+
+  EXPECT_EQ(row(*step, 0), "1...."); // seq 0 causally over its own three
+  EXPECT_EQ(row(*step, 1), "11...");
+  EXPECT_EQ(row(*step, 2), "111..");
+  EXPECT_EQ(row(*step, 3), "...1."); // seq 1 sees none of seq 0's, though
+  EXPECT_EQ(row(*step, 4), "...11"); // they hold the same positions
+}
+
+TEST_F(CacheTest, CellDecodeAndPrefillShareOneStep) {
+  Cells c(16);
+  const int32_t s0 = c.seq_new();
+  c.step(flatten_step({{s0, 0, 2}})); // an existing conversation at 0..1
+
+  // Continuous batching: s0 decodes while s1 arrives and prefills.
+  const int32_t s1 = c.seq_new();
+  const auto* step = c.step(flatten_step({{s0, 2, 1}, {s1, 0, 2}}));
+  ASSERT_NE(step, nullptr);
+  EXPECT_EQ(step->cells, (std::vector<int32_t>{2, 3, 4}));
+
+  EXPECT_EQ(row(*step, 0), "111.."); // s0's decode sees its own history
+  EXPECT_EQ(row(*step, 1), "...1."); // s1 starts from nothing
+  EXPECT_EQ(row(*step, 2), "...11");
+  EXPECT_EQ(c.ctl->next_pos(s0), 3);
+  EXPECT_EQ(c.ctl->next_pos(s1), 2);
+}
+
+TEST_F(CacheTest, CellExtendsIsCheckedPerSequence) {
+  Cells c(16);
+  const int32_t s0 = c.seq_new();
+  const int32_t s1 = c.seq_new();
+  c.step(flatten_step({{s0, 0, 1}, {s1, 0, 1}})); // both at position 0
+
+  // One sequence advancing does not license another to repeat: the check is
+  // against what each sequence itself already holds.
+  EXPECT_EQ(c.step({s0, s1}, {1, 0}), nullptr);
+  EXPECT_NE(c.step(flatten_step({{s0, 1, 1}, {s1, 1, 1}})), nullptr);
+}
+
 TEST_F(CacheTest, CellPlacementIsSharedByEveryLayerOfTheStep) {
   Cells c(16);
-  const std::vector<int32_t> seqs{0, 1};
+  const int32_t s0 = c.seq_new();
+  const int32_t s1 = c.seq_new();
+  const auto args = flatten_step({{s0, 0, 1}, {s1, 0, 1}});
+  ASSERT_TRUE(c.ctl->declare_step(args.seq_ids));
 
-  ASSERT_TRUE(c.ctl->begin_step(seqs));
-
-  const auto* first = c.place(0, {0, 0}); // layer 0 places the cells
+  const auto* first = c.place(0, args.positions); // layer 0 places the cells
   ASSERT_NE(first, nullptr);
-  EXPECT_EQ(c.place(1, {0, 0}), first); // later layers reuse them
-  EXPECT_EQ(c.place(0, {0, 0}), nullptr); // asking twice is a new step
+  EXPECT_EQ(c.place(1, args.positions), first); // later layers reuse them
+  EXPECT_EQ(c.place(0, args.positions), nullptr); // asking twice is a new step
   EXPECT_EQ(c.cache.free_cells(), 14); // placed once, not once per layer
 }
 
 TEST_F(CacheTest, CellForkSharesCellsAndEvictionRefcounts) {
   Cells c(16);
-  c.step_of({{0, 4, 0}}); // seq 0 places 4 tokens at 0..3
+  const int32_t s0 = c.seq_new();
+  c.step(flatten_step({{s0, 0, 4}})); // seq 0 places 4 tokens at 0..3
 
   ASSERT_EQ(c.cache.free_cells(), 12); // the four it placed, out of sixteen
 
-  ASSERT_TRUE(c.ctl->seq_cp(0, 1, std::nullopt));
+  const auto s1 = c.ctl->seq_clone(s0, std::nullopt);
+  ASSERT_TRUE(s1);
   EXPECT_EQ(c.cache.free_cells(), 12); // no cell, no byte copied
-  // seq 1 now holds positions 0-3, so a second fork onto it is refused: it
-  // would own two cells for each of them.
-  EXPECT_FALSE(c.ctl->seq_cp(0, 1, std::nullopt));
-  EXPECT_EQ(c.ctl->seq_len(1), 4);
-  EXPECT_EQ(c.ctl->next_pos(1), 4);
+  EXPECT_EQ(c.ctl->seq_len(*s1), 4);
+  EXPECT_EQ(c.ctl->next_pos(*s1), 4);
 
-  c.ctl->seq_rm(0, 0, std::nullopt);
-  EXPECT_EQ(c.ctl->seq_len(0), 0);
-  EXPECT_EQ(c.ctl->seq_len(1), 4); // the fork still owns them
+  c.ctl->seq_rm(s0, 0, std::nullopt);
+  EXPECT_EQ(c.ctl->seq_len(s0), 0);
+  EXPECT_EQ(c.ctl->seq_len(*s1), 4); // the fork still owns them
   EXPECT_EQ(c.cache.free_cells(), 12); // so nothing is reclaimed yet
 
-  c.ctl->seq_rm(1, 0, std::nullopt);
+  c.ctl->seq_rm(*s1, 0, std::nullopt);
   EXPECT_EQ(c.cache.free_cells(), 16);
   EXPECT_EQ(c.cache.used_end(), 0); // the extent comes back too
 }
 
+TEST_F(CacheTest, CellSeqNewHandsOutIdsUntilTheyAreReleased) {
+  Cells c(16);
+  const auto a = c.ctl->seq_new();
+  const auto b = c.ctl->seq_new();
+  ASSERT_TRUE(a && b);
+  EXPECT_NE(*a, *b);
+
+  // Reserved before it holds anything, so the next call cannot hand it out.
+  EXPECT_EQ(c.ctl->seq_len(*a), 0);
+  EXPECT_NE(*c.ctl->seq_new(), *a);
+
+  // Removing everything a sequence holds returns its id, whether or not it
+  // ever held a slot.
+  ASSERT_TRUE(c.ctl->seq_rm(*a, 0, std::nullopt));
+  EXPECT_EQ(*c.ctl->seq_new(), *a);
+
+  // An id nobody was handed does not start a sequence.
+  EXPECT_FALSE(c.ctl->declare_step({40}));
+
+  while (c.ctl->seq_new()) {
+  }
+  EXPECT_FALSE(c.ctl->seq_new()); // every id is now in use
+
+  c.ctl->clear();
+  EXPECT_EQ(*c.ctl->seq_new(), 0);
+}
+
 TEST_F(CacheTest, CellForkCanShareAPrefixOnly) {
   Cells c(16);
-  c.step_of({{0, 4, 0}}); // positions 0..3
+  const int32_t s0 = c.seq_new();
+  c.step(flatten_step({{s0, 0, 4}})); // positions 0..3
 
-  ASSERT_TRUE(c.ctl->seq_cp(0, 1, /*upto=*/2)); // share positions 0..1 only
-  EXPECT_EQ(c.ctl->seq_len(1), 2);
-  EXPECT_EQ(c.ctl->next_pos(1), 2); // the fork resumes where the prefix ends
-  EXPECT_EQ(c.ctl->seq_len(0), 4); // the source keeps all of its own
+  const auto s1 = c.ctl->seq_clone(s0, /*upto=*/2); // positions 0..1 only
+  ASSERT_TRUE(s1);
+  EXPECT_EQ(c.ctl->seq_len(*s1), 2);
+  EXPECT_EQ(c.ctl->next_pos(*s1), 2); // the fork resumes where the prefix ends
+  EXPECT_EQ(c.ctl->seq_len(s0), 4); // the source keeps all of its own
   EXPECT_EQ(c.cache.free_cells(), 12); // still no cell copied
 
   // Removing the source's shared range frees nothing: the fork still owns it.
-  ASSERT_TRUE(c.ctl->seq_rm(0, 0, 2));
+  ASSERT_TRUE(c.ctl->seq_rm(s0, 0, 2));
   EXPECT_EQ(c.cache.free_cells(), 12);
-  EXPECT_EQ(c.ctl->seq_len(1), 2);
+  EXPECT_EQ(c.ctl->seq_len(*s1), 2);
 }
 
 TEST_F(CacheTest, CellWindowAndSequenceBothNarrowTheMask) {
   // The two mask bounds together: a query sees only its own sequence, and only
   // inside its window.
   Cells c(16, {ring_layer(2), ring_layer(2)});
-  c.step_of({{0, 3, 0}}); // seq 0 at 0..2
-  const auto* step = c.step_of({{1, 1, 0}, {0, 1, 3}});
+  const int32_t s0 = c.seq_new();
+  const int32_t s1 = c.seq_new();
+  c.step(flatten_step({{s0, 0, 3}})); // seq 0 at 0..2
+  const auto* step = c.step(flatten_step({{s1, 0, 1}, {s0, 3, 1}}));
   ASSERT_NE(step, nullptr);
-  ASSERT_EQ(step->kind, MaskKind::Explicit);
   EXPECT_EQ(step->read_len, 5);
 
   // Seq 1 holds only its own new cell, and its window reaches no further.
@@ -428,127 +526,135 @@ TEST_F(CacheTest, CellWindowAndSequenceBothNarrowTheMask) {
 
 TEST_F(CacheTest, CellVerbBetweenLayersInvalidatesTheStep) {
   Cells c(16);
-  c.step_of({{0, 2, 0}});
+  const int32_t s0 = c.seq_new();
+  c.step(flatten_step({{s0, 0, 2}}));
 
-  ASSERT_TRUE(c.ctl->begin_step({0}));
+  ASSERT_TRUE(c.ctl->declare_step({s0}));
   ASSERT_NE(c.place(0, {2}), nullptr);
   // A verb rebuilds the table under the step: the placement no longer stands
   // and the remaining layers are refused.
-  ASSERT_TRUE(c.ctl->seq_rm(0, 0, 1));
+  ASSERT_TRUE(c.ctl->seq_rm(s0, 0, 1));
   EXPECT_EQ(c.place(1, {2}), nullptr);
 }
 
 TEST_F(CacheTest, CellRangedRemovalFreesOnlyThatWindow) {
   Cells c(16);
-  c.step_of({{0, 5, 0}}); // seq 0 places 5 tokens at 0..4
+  const int32_t s0 = c.seq_new();
+  c.step(flatten_step({{s0, 0, 5}})); // seq 0 places 5 tokens at 0..4
 
-  c.ctl->seq_rm(0, 0, 2); // sliding window: drop the oldest two
-  EXPECT_EQ(c.ctl->seq_len(0), 3);
+  c.ctl->seq_rm(s0, 0, 2); // sliding window: drop the oldest two
+  EXPECT_EQ(c.ctl->seq_len(s0), 3);
   EXPECT_EQ(c.cache.free_cells(), 13);
-  EXPECT_EQ(c.ctl->next_pos(0), 5); // a count is not a position
+  EXPECT_EQ(c.ctl->next_pos(s0), 5); // a count is not a position
 
-  c.ctl->seq_rm(0, 4, std::nullopt); // backtrack: drop position 4 onwards
-  EXPECT_EQ(c.ctl->seq_len(0), 2);
-  EXPECT_EQ(c.ctl->next_pos(0), 4);
+  c.ctl->seq_rm(s0, 4, std::nullopt); // backtrack: drop position 4 onwards
+  EXPECT_EQ(c.ctl->seq_len(s0), 2);
+  EXPECT_EQ(c.ctl->next_pos(s0), 4);
 }
 
-TEST_F(CacheTest, CellRefillingHolesGivesUpTheFusedPath) {
+TEST_F(CacheTest, CellRefillingHolesKeepsTheMaskOnPositions) {
   Cells c(16);
-  c.step_of({{0, 4, 0}}); // seq 0 places 4 tokens at 0..3
-  c.ctl->seq_rm(0, 0, 2); // free the oldest cells, leaving holes at 0 and 1
+  const int32_t s0 = c.seq_new();
+  c.step(flatten_step({{s0, 0, 4}})); // seq 0 places 4 tokens at 0..3
+  c.ctl->seq_rm(s0, 0, 2); // free the oldest cells, leaving holes at 0 and 1
 
-  // The new tokens take those holes, so the sequence owns the whole window
-  // again -- but its cells no longer ascend with its positions.
-  const auto* step = c.step_of({{0, 2, 4}}); // seq 0 places two more at 4..5
+  // The new tokens take those holes, so the sequence's cells no longer ascend
+  // with its positions -- the mask keys off pos/owners, never the index.
+  // seq 0 places two more at 4..5
+  const auto* step = c.step(flatten_step({{s0, 4, 2}}));
   ASSERT_NE(step, nullptr);
   EXPECT_EQ(step->cells, (std::vector<int32_t>{0, 1}));
-  EXPECT_EQ(step->kind, MaskKind::Explicit);
+  // cells 0,1 hold positions 4,5; cells 2,3 hold 2,3
+  EXPECT_EQ(row(*step, 0), "1.11"); // query at 4 sees 2, 3 and itself
+  EXPECT_EQ(row(*step, 1), "1111"); // query at 5 sees all of them
 }
 
 TEST_F(CacheTest, CellRejectsAPositionASequenceStillHolds) {
   Cells c(16);
-  c.step_of({{0, 4, 0}}); // seq 0 places 4 tokens at 0..3
-  c.ctl->seq_rm(0, 3, std::nullopt); // free the newest cell
+  const int32_t s0 = c.seq_new();
+  c.step(flatten_step({{s0, 0, 4}})); // seq 0 places 4 tokens at 0..3
+  c.ctl->seq_rm(s0, 3, std::nullopt); // free the newest cell
 
   // A step only extends its sequences. Writing 0 again would leave seq 0 with
   // two cells for one token and a window that is no longer a causal prefix.
-  EXPECT_EQ(c.step({0}, {0}), nullptr);
-  EXPECT_EQ(c.step({0, 0}, {5, 4}), nullptr); // nor may its own tokens descend
-  EXPECT_NE(c.step({0}, {3}), nullptr); // the position it just freed is fine
+  EXPECT_EQ(c.step({s0}, {0}), nullptr);
+  // nor may its own tokens descend
+  EXPECT_EQ(c.step({s0, s0}, {5, 4}), nullptr);
+  EXPECT_NE(c.step({s0}, {3}), nullptr); // the position it just freed is fine
 
   // A refusal places nothing, so the declaration stands and the same step can
   // be placed again with corrected positions.
-  ASSERT_TRUE(c.ctl->begin_step({0}));
+  ASSERT_TRUE(c.ctl->declare_step({s0}));
   EXPECT_EQ(c.place(0, {0}), nullptr);
   EXPECT_NE(c.place(0, {4}), nullptr);
 }
 
-TEST_F(CacheTest, CellFusesOnlyWhileTheWindowCoversTheSpan) {
-  // A fused kind says the whole read window is attendable, so it is only safe
-  // while the window spans every position the step holds.
+TEST_F(CacheTest, CellWindowBoundsEachQueryByPosition) {
   {
     Cells c(16, {ring_layer(4)});
-    // span 3 < window 4: nothing to exclude.
-    EXPECT_EQ(c.step_of({{0, 4, 0}})->kind, MaskKind::Causal);
+    // span 3 < window 4: the last query still sees position 0.
+    EXPECT_EQ(row(*c.step(flatten_step({{c.seq_new(), 0, 4}})), 3), "1111");
   }
   {
     Cells c(16, {ring_layer(3)});
     // span 3 == window 3: position 0 is one too old for the query at 3.
-    EXPECT_EQ(c.step_of({{0, 4, 0}})->kind, MaskKind::Explicit);
+    EXPECT_EQ(row(*c.step(flatten_step({{c.seq_new(), 0, 4}})), 3), ".111");
   }
   {
     Cells c(16, {ring_layer(2)});
     // Two cells, five positions apart: the span is what counts.
-    c.step({0}, {0});
-    EXPECT_EQ(c.step({0}, {5})->kind, MaskKind::Explicit);
+    const int32_t s = c.seq_new();
+    c.step({s}, {0});
+    EXPECT_EQ(row(*c.step({s}, {5}), 0), ".1");
   }
   {
     Cells c(16, {ring_layer(8)});
-    // Sparse but inside the window, so the fused path still holds.
-    c.step({0}, {0});
-    EXPECT_EQ(c.step({0}, {5})->kind, MaskKind::None);
+    // Sparse but inside the window, so both cells stay visible.
+    const int32_t s = c.seq_new();
+    c.step({s}, {0});
+    EXPECT_EQ(row(*c.step({s}, {5}), 0), "11");
   }
 }
 
 TEST_F(CacheTest, CellLayersSharingAWindowShareAStep) {
   // gemma-style: one flat layer beside two windowed ones. The placement is
-  // shared, the plan is per policy -- so the flat layer still fuses while the
-  // windowed pair gets one banded plan between them.
+  // shared, the step is per policy -- so the flat layer keeps the whole prefix
+  // while the windowed pair gets one banded step between them.
   Cells c(16, {flat_layer(), ring_layer(2), ring_layer(2)});
-  const std::vector<int32_t> seqs{0, 0, 0, 0};
+  const int32_t s0 = c.seq_new();
+  const auto args = flatten_step({{s0, 0, 4}});
+  ASSERT_TRUE(c.ctl->declare_step(args.seq_ids));
 
-  ASSERT_TRUE(c.ctl->begin_step(seqs));
-
-  const auto* flat = c.place(0, {0, 1, 2, 3});
-  const auto* windowed = c.place(1, {0, 1, 2, 3});
+  const auto* flat = c.place(0, args.positions);
+  const auto* windowed = c.place(1, args.positions);
   ASSERT_NE(flat, nullptr);
   ASSERT_NE(windowed, nullptr);
-  EXPECT_EQ(flat->kind, MaskKind::Causal);
-  EXPECT_TRUE(flat->mask_bits.empty());
-  EXPECT_EQ(windowed->kind, MaskKind::Explicit);
-  EXPECT_EQ(row(*windowed, 2), ".11."); // query 2 drops position 0
+  EXPECT_EQ(row(*flat, 2), "111."); // the flat layer keeps position 0
+  EXPECT_EQ(row(*windowed, 2), ".11."); // the windowed one drops it
 
-  EXPECT_EQ(c.place(2, {0, 1, 2, 3}), windowed); // same window, same step
+  EXPECT_EQ(c.place(2, args.positions), windowed); // same window, same step
   EXPECT_EQ(c.cache.free_cells(), 12); // placed once for all three layers
 }
 
 TEST_F(CacheTest, CellStepProtocolIsEnforced) {
   Cells c(4);
-  const std::vector<int32_t> seqs{0, 0};
-  EXPECT_FALSE(c.ctl->begin_step({})); // no tokens
-  EXPECT_FALSE(c.ctl->begin_step({0, 0, 0, 0, 0})); // 5 tokens, 4 cells
+  const int32_t s0 = c.seq_new();
+  const std::vector<int32_t> seqs{s0, s0};
+  EXPECT_FALSE(c.ctl->declare_step({})); // no tokens
+  EXPECT_FALSE(c.ctl->declare_step({s0, s0, s0, s0, s0})); // 5 tokens, 4 cells
   EXPECT_FALSE(
-      c.ctl->begin_step({CellCache::kMaxSeqs})); // seq id past the last bit
+      c.ctl->declare_step({CellCache::kMaxSeqs})); // seq id past the last bit
   // The verbs report a bad sequence rather than doing nothing quietly.
-  EXPECT_FALSE(c.ctl->seq_cp(0, CellCache::kMaxSeqs, std::nullopt));
+  EXPECT_FALSE(c.ctl->seq_clone(CellCache::kMaxSeqs, std::nullopt));
+  EXPECT_FALSE(c.ctl->seq_clone(s0 + 30, std::nullopt)); // src holds nothing
   EXPECT_FALSE(c.ctl->seq_rm(-1, 0, std::nullopt));
 
   EXPECT_EQ(c.place(0, {0, 1}), nullptr); // no declaration
-  ASSERT_TRUE(c.ctl->begin_step(seqs));
+  ASSERT_TRUE(c.ctl->declare_step(seqs));
   EXPECT_EQ(c.place(0, {0}), nullptr); // token count disagrees
   ASSERT_NE(c.place(0, {0, 1}), nullptr); // 2 tokens, as declared
 
-  EXPECT_EQ(c.place(0, {2, 3}), nullptr); // a second step, no begin_step
+  EXPECT_EQ(c.place(0, {2, 3}), nullptr); // a second step, no declare_step
 
   EXPECT_EQ(c.place(-1, {0, 1}), nullptr); // layers outside the model
   EXPECT_EQ(c.place(2, {0, 1}), nullptr);
@@ -556,18 +662,19 @@ TEST_F(CacheTest, CellStepProtocolIsEnforced) {
 
 TEST_F(CacheTest, CellClearReturnsEveryCell) {
   Cells c(4);
+  const int32_t s0 = c.seq_new();
   EXPECT_EQ(c.cache.capacity(), 4);
   EXPECT_TRUE(c.ctl->can_extend(4));
 
-  c.step_of({{0, 3, 0}});
+  c.step(flatten_step({{s0, 0, 3}}));
   EXPECT_FALSE(c.ctl->can_extend(2)); // one cell left
-  EXPECT_EQ(c.ctl->seq_len(0), 3);
+  EXPECT_EQ(c.ctl->seq_len(s0), 3);
 
   c.ctl->clear();
   EXPECT_TRUE(c.ctl->can_extend(4));
   EXPECT_EQ(c.cache.free_cells(), 4);
   EXPECT_EQ(c.cache.used_end(), 0);
-  EXPECT_EQ(c.ctl->seq_len(0), 0);
-  EXPECT_EQ(c.ctl->next_pos(0), 0); // the sequence is gone
+  EXPECT_EQ(c.ctl->seq_len(s0), 0);
+  EXPECT_EQ(c.ctl->next_pos(s0), 0); // the sequence is gone
   EXPECT_EQ(c.place(0, {0}), nullptr); // and the step went with it
 }

--- a/extension/llm/cache/test/cache_test.cpp
+++ b/extension/llm/cache/test/cache_test.cpp
@@ -9,22 +9,30 @@
 #include <executorch/extension/llm/cache/cache.h>
 #include <executorch/extension/llm/cache/cache_et.h>
 #include <executorch/extension/llm/cache/cache_registry.h>
+#include <executorch/extension/llm/cache/cell_cache.h>
 #include <executorch/extension/llm/cache/sequence_cache.h>
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/platform/runtime.h>
 #include <gtest/gtest.h>
 
+using executorch::extension::llm::cache::BatchControl;
 using executorch::extension::llm::cache::CacheBase;
 using executorch::extension::llm::cache::CacheBuilderRegistry;
 using executorch::extension::llm::cache::CacheConfig;
 using executorch::extension::llm::cache::CacheRegistry;
 using executorch::extension::llm::cache::CacheSession;
+using executorch::extension::llm::cache::CellCache;
+using executorch::extension::llm::cache::CellPlanner;
+using executorch::extension::llm::cache::CellStepPlan;
 using executorch::extension::llm::cache::LayerConfig;
 using executorch::extension::llm::cache::LayerPolicy;
 using executorch::extension::llm::cache::make_unique_key;
+using executorch::extension::llm::cache::MaskKind;
 using executorch::extension::llm::cache::SequenceCache;
 using executorch::runtime::Error;
 namespace et = executorch::extension::llm::cache::et;
@@ -232,4 +240,189 @@ TEST_F(CacheTest, EtAdapterMapsResultsAndCodes) {
 
   EXPECT_EQ(et::rewind(cache, 9), Error::InvalidArgument); // cannot grow
   EXPECT_EQ(et::rewind(cache, 1), Error::Ok);
+}
+
+// ---- Cell layout -----------------------------------------------------------
+
+namespace {
+// A cell cache and the two faces a caller holds: the runner drives the verbs,
+// the backend asks for the step's plan.
+struct Cells {
+  explicit Cells(
+      int capacity,
+      std::vector<LayerConfig> layers = {flat_layer(), flat_layer()})
+      : cache(CacheConfig{capacity, static_cast<int>(layers.size()), layers}),
+        ctl(cache.as_batch_control()),
+        planner(cache.as_cell_planner()) {}
+
+  const CellStepPlan* step(
+      std::vector<int32_t> seq_ids,
+      std::vector<int32_t> positions) {
+    if (!ctl->begin_step(seq_ids.data(), static_cast<int>(seq_ids.size()))) {
+      return nullptr;
+    }
+    return planner->plan(
+        0, positions.data(), static_cast<int>(positions.size()));
+  }
+
+  CellCache cache;
+  BatchControl* ctl;
+  CellPlanner* planner;
+};
+
+// The mask row for query `i`, as a string of '.' and '1' -- readable.
+std::string row(const CellStepPlan& plan, int i) {
+  std::string out(plan.read_len, '.');
+  for (int j = 0; j < plan.read_len; ++j) {
+    out[j] = plan.mask_bits[i * plan.read_len + j] ? '1' : '.';
+  }
+  return out;
+}
+} // namespace
+
+TEST_F(CacheTest, CellSingleSequenceIsFused) {
+  Cells c(16);
+  const auto* prefill =
+      c.step({0, 0, 0, 0}, {0, 1, 2, 3}); // seq 0 places 4 tokens at 0..3
+  ASSERT_NE(prefill, nullptr);
+  EXPECT_EQ(prefill->kind, MaskKind::Causal); // one run at the tail it owns
+  EXPECT_EQ(prefill->write_start, 0);
+  EXPECT_EQ(prefill->read_len, 4);
+  EXPECT_TRUE(prefill->mask_bits.empty()); // fused kinds carry no mask
+
+  const auto* decode = c.step({0}, {4}); // seq 0 places one more at 4
+  ASSERT_NE(decode, nullptr);
+  EXPECT_EQ(decode->kind, MaskKind::None); // one query over its own window
+  EXPECT_EQ(decode->write_start, 4);
+}
+
+TEST_F(CacheTest, CellSecondSequenceForcesAnExplicitMask) {
+  Cells c(16);
+  c.step({0, 0, 0, 0}, {0, 1, 2, 3}); // seq 0 places 4 tokens at 0..3
+
+  const auto* plan =
+      c.step({1, 1}, {0, 1}); // seq 1 places 2 at positions seq 0 also holds
+  ASSERT_NE(plan, nullptr);
+  EXPECT_EQ(plan->kind, MaskKind::Explicit);
+  EXPECT_EQ(plan->read_len, 6);
+  EXPECT_EQ(plan->cells, (std::vector<int32_t>{4, 5}));
+  // sequence 1 sees none of sequence 0's cells, though they share positions
+  EXPECT_EQ(row(*plan, 0), "....1.");
+  EXPECT_EQ(row(*plan, 1), "....11");
+}
+
+TEST_F(CacheTest, CellPlanIsSharedByEveryLayerOfTheStep) {
+  Cells c(16);
+  const int32_t seqs[2] = {0, 1};
+  const int32_t pos[2] = {0, 0};
+  ASSERT_TRUE(c.ctl->begin_step(seqs, 2));
+
+  const auto* first = c.planner->plan(0, pos, 2); // layer 0 places the cells
+  ASSERT_NE(first, nullptr);
+  EXPECT_EQ(c.planner->plan(1, pos, 2), first); // later layers reuse them
+  EXPECT_EQ(c.planner->plan(0, pos, 2), nullptr); // asking twice is a new step
+  EXPECT_EQ(c.cache.free_cells(), 14); // placed once, not once per layer
+}
+
+TEST_F(CacheTest, CellForkSharesCellsAndEvictionRefcounts) {
+  Cells c(16);
+  c.step({0, 0, 0, 0}, {0, 1, 2, 3}); // seq 0 places 4 tokens at 0..3
+
+  ASSERT_EQ(c.cache.free_cells(), 12); // the four it placed, out of sixteen
+
+  c.ctl->seq_cp(0, 1, std::nullopt);
+  EXPECT_EQ(c.cache.free_cells(), 12); // no cell, no byte copied
+  EXPECT_EQ(c.ctl->seq_len(1), 4);
+  EXPECT_EQ(c.ctl->next_pos(1), 4);
+
+  c.ctl->seq_rm(0, 0, std::nullopt);
+  EXPECT_EQ(c.ctl->seq_len(0), 0);
+  EXPECT_EQ(c.ctl->seq_len(1), 4); // the fork still owns them
+  EXPECT_EQ(c.cache.free_cells(), 12); // so nothing is reclaimed yet
+
+  c.ctl->seq_rm(1, 0, std::nullopt);
+  EXPECT_EQ(c.cache.free_cells(), 16);
+  EXPECT_EQ(c.cache.used_end(), 0); // the extent comes back too
+}
+
+TEST_F(CacheTest, CellRangedRemovalFreesOnlyThatWindow) {
+  Cells c(16);
+  c.step({0, 0, 0, 0, 0}, {0, 1, 2, 3, 4}); // seq 0 places 5 tokens at 0..4
+
+  c.ctl->seq_rm(0, 0, 2); // sliding window: drop the oldest two
+  EXPECT_EQ(c.ctl->seq_len(0), 3);
+  EXPECT_EQ(c.cache.free_cells(), 13);
+  EXPECT_EQ(c.ctl->next_pos(0), 5); // a count is not a position
+
+  c.ctl->seq_rm(0, 4, std::nullopt); // backtrack: drop position 4 onwards
+  EXPECT_EQ(c.ctl->seq_len(0), 2);
+  EXPECT_EQ(c.ctl->next_pos(0), 4);
+}
+
+TEST_F(CacheTest, CellRefillingHolesGivesUpTheFusedPath) {
+  Cells c(16);
+  c.step({0, 0, 0, 0}, {0, 1, 2, 3}); // seq 0 places 4 tokens at 0..3
+  c.ctl->seq_rm(0, 0, 2); // free the oldest cells, leaving holes at 0 and 1
+
+  // The new tokens take those holes, so the sequence owns the whole window
+  // again -- but its cells no longer ascend with its positions.
+  const auto* plan = c.step({0, 0}, {4, 5}); // seq 0 places two more at 4..5
+  ASSERT_NE(plan, nullptr);
+  EXPECT_EQ(plan->cells, (std::vector<int32_t>{0, 1}));
+  EXPECT_EQ(plan->kind, MaskKind::Explicit);
+}
+
+TEST_F(CacheTest, CellRejectsAPositionASequenceStillHolds) {
+  Cells c(16);
+  c.step({0, 0, 0, 0}, {0, 1, 2, 3}); // seq 0 places 4 tokens at 0..3
+  c.ctl->seq_rm(0, 3, std::nullopt); // free the newest cell
+
+  // A step only extends its sequences. Writing 0 again would leave seq 0 with
+  // two cells for one token and a window that is no longer a causal prefix.
+  EXPECT_EQ(c.step({0}, {0}), nullptr);
+  EXPECT_EQ(c.step({0, 0}, {5, 4}), nullptr); // nor may its own tokens descend
+  EXPECT_NE(c.step({0}, {3}), nullptr); // the position it just freed is fine
+}
+
+TEST_F(CacheTest, CellLayersSharingAWindowShareAPlan) {
+  // gemma-style: one flat layer beside two windowed ones. The placement is
+  // shared, the plan is per policy -- so the flat layer still fuses while the
+  // windowed pair gets one banded plan between them.
+  Cells c(16, {flat_layer(), ring_layer(2), ring_layer(2)});
+  const int32_t seqs[4] = {0, 0, 0, 0};
+  const int32_t pos[4] = {0, 1, 2, 3};
+  ASSERT_TRUE(c.ctl->begin_step(seqs, 4));
+
+  const auto* flat = c.planner->plan(0, pos, 4);
+  const auto* windowed = c.planner->plan(1, pos, 4);
+  ASSERT_NE(flat, nullptr);
+  ASSERT_NE(windowed, nullptr);
+  EXPECT_EQ(flat->kind, MaskKind::Causal);
+  EXPECT_TRUE(flat->mask_bits.empty());
+  EXPECT_EQ(windowed->kind, MaskKind::Explicit);
+  EXPECT_EQ(row(*windowed, 2), ".11."); // query 2 drops position 0
+
+  EXPECT_EQ(c.planner->plan(2, pos, 4), windowed); // same window, same plan
+  EXPECT_EQ(c.cache.free_cells(), 12); // placed once for all three layers
+}
+
+TEST_F(CacheTest, CellStepProtocolIsEnforced) {
+  Cells c(4);
+  const int32_t seqs[2] = {0, 0};
+  const int32_t pos[2] = {0, 1};
+
+  EXPECT_FALSE(c.ctl->begin_step(seqs, 0)); // no tokens
+  const int32_t many[5] = {0, 0, 0, 0, 0};
+  EXPECT_FALSE(c.ctl->begin_step(many, 5)); // 5 tokens, 4 cells
+  const int32_t bad[1] = {CellCache::kMaxSeqs};
+  EXPECT_FALSE(c.ctl->begin_step(bad, 1)); // seq id past the last owner bit
+
+  EXPECT_EQ(c.planner->plan(0, pos, 2), nullptr); // no declaration
+  ASSERT_TRUE(c.ctl->begin_step(seqs, 2));
+  EXPECT_EQ(c.planner->plan(0, pos, 1), nullptr); // token count disagrees
+  ASSERT_NE(c.planner->plan(0, pos, 2), nullptr); // 2 tokens, as declared
+
+  const int32_t next[2] = {2, 3};
+  EXPECT_EQ(
+      c.planner->plan(0, next, 2), nullptr); // a second step, no begin_step
 }

--- a/extension/llm/cache/test/cache_test.cpp
+++ b/extension/llm/cache/test/cache_test.cpp
@@ -281,11 +281,13 @@ struct Cells {
         layer, positions.data(), static_cast<int>(positions.size()));
   }
 
-  // A whole single-layer step: declare it, then place it.
+  // A whole single-layer step: declare it, then place it. A nullptr from here
+  // is the placement's refusal -- admission failing is a test failure.
   const CellStep* step(
       std::vector<int32_t> seq_ids,
       std::vector<int32_t> positions) {
-    return ctl->begin_step(seq_ids) ? place(/*layer=*/0, positions) : nullptr;
+    EXPECT_TRUE(ctl->begin_step(seq_ids)) << "the step was not admitted";
+    return place(/*layer=*/0, positions);
   }
 
   // The same step, from each sequence's tokens rather than the per-token
@@ -306,8 +308,16 @@ struct Cells {
   CellStepper* stepper;
 };
 
-// The mask row for query `i`, as a string of '.' and '1' -- readable.
+// The mask row for query `i`, as a string of '.' and '1'. Explicit steps only:
+// a fused step carries no bits.
 std::string row(const CellStep& step, int i) {
+  EXPECT_EQ(step.kind, MaskKind::Explicit);
+  EXPECT_EQ(
+      step.mask_bits.size(),
+      static_cast<size_t>(step.n_tok) * static_cast<size_t>(step.read_len));
+  if (step.mask_bits.empty()) {
+    return {};
+  }
   std::string out(step.read_len, '.');
   for (int j = 0; j < step.read_len; ++j) {
     out[j] = step.mask_bits[i * step.read_len + j] ? '1' : '.';
@@ -381,6 +391,51 @@ TEST_F(CacheTest, CellForkSharesCellsAndEvictionRefcounts) {
   c.ctl->seq_rm(1, 0, std::nullopt);
   EXPECT_EQ(c.cache.free_cells(), 16);
   EXPECT_EQ(c.cache.used_end(), 0); // the extent comes back too
+}
+
+TEST_F(CacheTest, CellForkCanShareAPrefixOnly) {
+  Cells c(16);
+  c.step_of({{0, 4, 0}}); // positions 0..3
+
+  ASSERT_TRUE(c.ctl->seq_cp(0, 1, /*upto=*/2)); // share positions 0..1 only
+  EXPECT_EQ(c.ctl->seq_len(1), 2);
+  EXPECT_EQ(c.ctl->next_pos(1), 2); // the fork resumes where the prefix ends
+  EXPECT_EQ(c.ctl->seq_len(0), 4); // the source keeps all of its own
+  EXPECT_EQ(c.cache.free_cells(), 12); // still no cell copied
+
+  // Removing the source's shared range frees nothing: the fork still owns it.
+  ASSERT_TRUE(c.ctl->seq_rm(0, 0, 2));
+  EXPECT_EQ(c.cache.free_cells(), 12);
+  EXPECT_EQ(c.ctl->seq_len(1), 2);
+}
+
+TEST_F(CacheTest, CellWindowAndSequenceBothNarrowTheMask) {
+  // The two mask bounds together: a query sees only its own sequence, and only
+  // inside its window.
+  Cells c(16, {ring_layer(2), ring_layer(2)});
+  c.step_of({{0, 3, 0}}); // seq 0 at 0..2
+  const auto* step = c.step_of({{1, 1, 0}, {0, 1, 3}});
+  ASSERT_NE(step, nullptr);
+  ASSERT_EQ(step->kind, MaskKind::Explicit);
+  EXPECT_EQ(step->read_len, 5);
+
+  // Seq 1 holds only its own new cell, and its window reaches no further.
+  EXPECT_EQ(row(*step, 0), "...1.");
+  // Seq 0 at position 3 sees positions 2 and 3 -- cells 2 and 4 -- but not its
+  // own cells 0 and 1, which the window excludes.
+  EXPECT_EQ(row(*step, 1), "..1.1");
+}
+
+TEST_F(CacheTest, CellVerbBetweenLayersInvalidatesTheStep) {
+  Cells c(16);
+  c.step_of({{0, 2, 0}});
+
+  ASSERT_TRUE(c.ctl->begin_step({0}));
+  ASSERT_NE(c.place(0, {2}), nullptr);
+  // A verb rebuilds the table under the step: the placement no longer stands
+  // and the remaining layers are refused.
+  ASSERT_TRUE(c.ctl->seq_rm(0, 0, 1));
+  EXPECT_EQ(c.place(1, {2}), nullptr);
 }
 
 TEST_F(CacheTest, CellRangedRemovalFreesOnlyThatWindow) {
@@ -494,4 +549,25 @@ TEST_F(CacheTest, CellStepProtocolIsEnforced) {
   ASSERT_NE(c.place(0, {0, 1}), nullptr); // 2 tokens, as declared
 
   EXPECT_EQ(c.place(0, {2, 3}), nullptr); // a second step, no begin_step
+
+  EXPECT_EQ(c.place(-1, {0, 1}), nullptr); // layers outside the model
+  EXPECT_EQ(c.place(2, {0, 1}), nullptr);
+}
+
+TEST_F(CacheTest, CellClearReturnsEveryCell) {
+  Cells c(4);
+  EXPECT_EQ(c.cache.capacity(), 4);
+  EXPECT_TRUE(c.ctl->can_extend(4));
+
+  c.step_of({{0, 3, 0}});
+  EXPECT_FALSE(c.ctl->can_extend(2)); // one cell left
+  EXPECT_EQ(c.ctl->seq_len(0), 3);
+
+  c.ctl->clear();
+  EXPECT_TRUE(c.ctl->can_extend(4));
+  EXPECT_EQ(c.cache.free_cells(), 4);
+  EXPECT_EQ(c.cache.used_end(), 0);
+  EXPECT_EQ(c.ctl->seq_len(0), 0);
+  EXPECT_EQ(c.ctl->next_pos(0), 0); // the sequence is gone
+  EXPECT_EQ(c.place(0, {0}), nullptr); // and the step went with it
 }


### PR DESCRIPTION
## Summary

Adds the cell layout to the neutral C++ cache. Cells are addressed absolutely: each holds a position and a bitset of the sequences that own it, so a sequence need not be contiguous, a fork sets a second bit instead of copying K/V, and a cell frees when its bitset empties.

  `plan()` places a step's tokens once and every later layer of that forward reuses the placement. It classifies: a single sequence appending a contiguous run at the tail of a window it owns outright gets a fused kind and a run write; anything else
  — multi-sequence, forks, holes from removals — gets each token's cell plus a dense mask. Layers may window differently, so the mask is memoized per policy.

  A step is declared before the forward through `begin_step`, which is also the admission gate: it reports whether the tokens fit before any compute is spent. A step may only extend its sequences, and one that would rewrite a position a  sequence still holds is refused rather than stored twice.

  Nothing constructs a `CellCache` yet — this is the neutral layer only. The existing `SequenceCache` is untouched behaviourally.

  ## Files

  - `extension/llm/cache/cache.h` — `CacheControl` factored out of `SequenceControl` to hold `can_extend`/`capacity`/`clear`; new `BatchControl` (the sequence verbs) and `CellPlanner` faces; `MaskKind`; the four `as_*` accessors now default to `nullptr` so a cache exposes only the faces it has.
  - `extension/llm/cache/cell_cache.h` — new. `CellStepPlan`, `CellPlanner`, `CellCache`: placement, the seq verbs, classification, and the per-policy mask.
  - `extension/llm/cache/test/cache_test.cpp` — 9 cell tests.

  ## Testing

  `cmake --build cmake-out --target extension_llm_cache_test && ctest --test-dir cmake-out -R extension_llm_cache --output-on-failure`

  Covers the fused path, a second sequence forcing an explicit mask, one plan shared
  across layers, a fork sharing cells and the refcounted free, ranged removal, holes
  giving up the fused path, a rejected rewrite, layers sharing a window sharing a
  plan, and the step protocol.