### PR TITLE
Arm backend: Fix stale VGF BatchNorm support documentation

### DIFF
--- a/docs/source/backends/arm-vgf/VGF_op_support.md
+++ b/docs/source/backends/arm-vgf/VGF_op_support.md
@@ -27,7 +27,7 @@ Total supported PyTorch APIs: **153**.
 | `torch.asinh` | FP, INT | `FP32`, `INT8` | 8x8 |
 | `torch.atan` | FP, INT | `FP32`, `INT8` | 8x8 |
 | `torch.atanh` | FP, INT | `FP32`, `INT8` | 8x8 |
-| `torch.batch_norm` | FP, INT | `FP32`, `INT8` | 8x8 |
+| `torch.batch_norm` | FP | `FP32` | - |
 | `torch.bitwise_and` / `&` | FP, INT | `FP32`, `INT8` | 8x8 |
 | `torch.bitwise_left_shift` / `<<` | FP, INT | `FP32`, `INT8` | 8x8 |
 | `torch.bitwise_not` / `~` | FP, INT | `FP32`, `INT8`, `BOOL` | 8x8 |


### PR DESCRIPTION
The generated page retained INT support for torch.batch_norm even though the current VGF tests provide only FP evidence for torch.ops.aten.batch_norm.default.

The history explains how the page became stale. Quantized non-folded BatchNorm support landed first in #21710 on August 11. The initial VGF operator documentation generator followed in #21776 on August 12. The BatchNorm test cleanup then landed in #21836 on August 14 and changed quantized VGF tests to use aten_op=[] or report only conv2d. Finally, #21871 landed on August 15, adding the generated page to the pre-push hook.

Both BatchNorm changes are ancestors of #21871, and the generator and relevant tests have not changed since #21871. The generated page committed by #21871 was therefore already inconsistent with its final source tree, most likely because it was produced on an earlier PR state and retained when the PR was updated over the BatchNorm cleanup. The newly added hook could not validate that server-created squash commit, so the stale row was first exposed by a later local push.

This correction does not remove quantized BatchNorm support represented by torch.ops.aten._native_batch_norm_legit_no_training.default. Its separate torch.nn.BatchNorm2d/functional.batch_norm row remains FP and INT based on the convolution-combination tests.

Authored with Codex.

Change-Id: I32d9a3ec01eec250d4badcfe49e1ded4f855fe0d


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani