### PR TITLE
Arm backend: Add runtime ctest test suite.

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -266,7 +266,7 @@ jobs:
           - test_arm_backend: test_run_ethos_u85
           - test_arm_backend: test_smaller_stories_llama_tosa
           - test_arm_backend: test_model_smollm2_135M_ethos_u85
-          - test_arm_backend: test_memory_allocation
+          - test_arm_backend: test_runtime_ethos_u
           - test_arm_backend: test_ootb_tests_ethos_u
           - test_arm_backend: test_ootb_tests_tosa
           - test_arm_backend: test_deit_e2e_ethos_u

--- a/backends/arm/README.md
+++ b/backends/arm/README.md
@@ -271,7 +271,7 @@ Below is an overview of some of the testing options this script provides:
 | `test_arm_backend.sh test_deit_e2e_ethos_u`        | Runs DEiT end-to-end tests on Ethos-U.                       |
 | `test_arm_backend.sh test_smaller_stories_llama_tosa` | Runs Llama model tests for TOSA.                          |
 | `test_arm_backend.sh test_smaller_stories_llama_vkml` | Runs Llama model tests for VKML/VGF.                      |
-| `test_arm_backend.sh test_memory_allocation`       | Runs memory allocation tests for Ethos-U specific targets    |
+| `test_arm_backend.sh test_runtime_ethos_u`       | Runs runtime tests for Ethos-U specific targets    |
 
 For more information, please refer to the `backends/arm/test/test_arm_backend.sh` script.
 

--- a/backends/arm/runtime/tests/ethos-u/CMakeLists.txt
+++ b/backends/arm/runtime/tests/ethos-u/CMakeLists.txt
@@ -1,0 +1,65 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.19)
+project(arm_ethos_u_runtime_tests NONE)
+
+enable_testing()
+
+if(NOT EXECUTORCH_ROOT)
+  message(
+    FATAL_ERROR "EXECUTORCH_ROOT must be set to the ExecuTorch repository root."
+  )
+endif()
+get_filename_component(EXECUTORCH_ROOT "${EXECUTORCH_ROOT}" ABSOLUTE)
+
+set(_ethos_u_runtime_tests_dir "${CMAKE_CURRENT_SOURCE_DIR}")
+set(_ethos_u_runtime_test_output_dir "${CMAKE_CURRENT_BINARY_DIR}/test_run")
+
+message(
+  STATUS
+    "Ethos-U runtime tests configured. List tests with: ctest --test-dir ${CMAKE_CURRENT_BINARY_DIR} -N"
+)
+message(
+  STATUS
+    "Run all tests with output on failure: ctest --test-dir ${CMAKE_CURRENT_BINARY_DIR} --output-on-failure"
+)
+message(
+  STATUS
+    "Run one test: ctest --test-dir ${CMAKE_CURRENT_BINARY_DIR} -R '^memory_allocation_planned_fast$' --output-on-failure"
+)
+
+add_test(
+  NAME memory_allocation_baseline
+  COMMAND "${_ethos_u_runtime_tests_dir}/test_memory_allocation_baseline.sh"
+          "${EXECUTORCH_ROOT}" "${_ethos_u_runtime_test_output_dir}"
+)
+set_tests_properties(
+  memory_allocation_baseline
+  PROPERTIES LABELS "arm;ethos-u;runtime;memory_allocation;fvp" RESOURCE_LOCK
+             arm_ethos_u_runtime
+)
+
+add_test(
+  NAME runner_size_optimization
+  COMMAND "${_ethos_u_runtime_tests_dir}/test_runner_size_optimization.sh"
+          "${EXECUTORCH_ROOT}" "${_ethos_u_runtime_test_output_dir}"
+)
+set_tests_properties(
+  runner_size_optimization
+  PROPERTIES LABELS "arm;ethos-u;runtime;memory_allocation;runner"
+             RESOURCE_LOCK arm_ethos_u_runtime
+)
+
+add_test(
+  NAME memory_allocation_planned_fast
+  COMMAND "${_ethos_u_runtime_tests_dir}/test_memory_allocation_planned_fast.sh"
+          "${EXECUTORCH_ROOT}" "${_ethos_u_runtime_test_output_dir}"
+)
+set_tests_properties(
+  memory_allocation_planned_fast
+  PROPERTIES LABELS "arm;ethos-u;runtime;memory_allocation;fvp" RESOURCE_LOCK
+             arm_ethos_u_runtime
+)

--- a/backends/arm/runtime/tests/ethos-u/setup_env.sh
+++ b/backends/arm/runtime/tests/ethos-u/setup_env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+et_root_dir=$(realpath "${1:?Usage: $(basename "$0") <EXECUTORCH_ROOT> <TEST_OUTPUT_DIR>}")
+test_output_dir="${2:?Usage: $(basename "$0") <EXECUTORCH_ROOT> <TEST_OUTPUT_DIR>}"
+
+scratch_dir=${et_root_dir}/examples/arm/arm-scratch
+setup_path_script=${scratch_dir}/setup_path.sh
+_setup_msg="please refer to ${et_root_dir}/examples/arm/setup.sh to properly install necessary tools."
+
+[[ -f ${setup_path_script} ]] \
+    || { echo "Missing ${setup_path_script}. ${_setup_msg}"; exit 1; }
+source "${setup_path_script}"

--- a/backends/arm/runtime/tests/ethos-u/test_memory_allocation_baseline.sh
+++ b/backends/arm/runtime/tests/ethos-u/test_memory_allocation_baseline.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eo pipefail
+
+source "$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)/setup_env.sh"
+
+target="ethos-u85-128"
+test_dir="${test_output_dir}/memory_allocation_baseline"
+runner_build_dir="${test_dir}/${target}_Release_arm-none-eabi-gcc"
+log_file="${test_dir}/baseline.log"
+
+build_baseline_runner() {
+    echo "Build ethos-u baseline memory allocation runner"
+    mkdir -p "${test_dir}"
+    "${et_root_dir}/examples/arm/run.sh" \
+        --et_build_root="${test_dir}" \
+        --target="${target}" \
+        --model_name="${et_root_dir}/examples/arm/example_modules/add.py" \
+        --build_only
+}
+
+run_baseline_memory_allocation() {
+    echo "Test ethos-u baseline memory allocation"
+    "${et_root_dir}/examples/arm/run.sh" \
+        --et_build_root="${test_dir}" \
+        --build-dir="${runner_build_dir}" \
+        --target="${target}" \
+        --model_name="${et_root_dir}/examples/arm/example_modules/add.py" \
+        2>&1 | tee "${log_file}"
+
+    # method_allocator_input includes one 16-byte EValue input plus possible
+    # alignment padding before that allocation.
+    python3 "${et_root_dir}/backends/arm/test/test_memory_allocator_log.py" --log "${log_file}" \
+        --require "model_pte_program_size" "<= 3200 B" \
+        --require "method_allocator_planned" "<= 64 B" \
+        --require "method_allocator_loaded" "<= 1024 B" \
+        --require "method_allocator_input" "<= 24 B" \
+        --require "Total DRAM used" "<= 0.06 KiB"
+}
+
+build_baseline_runner
+run_baseline_memory_allocation

--- a/backends/arm/runtime/tests/ethos-u/test_memory_allocation_planned_fast.sh
+++ b/backends/arm/runtime/tests/ethos-u/test_memory_allocation_planned_fast.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eo pipefail
+
+source "$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)/setup_env.sh"
+
+target="ethos-u55-128"
+test_dir="${test_output_dir}/memory_allocation_planned_fast"
+pte_file="${test_dir}/memory_planning_mem_id_3.pte"
+runner_build_dir="${test_dir}/runner"
+log_file="${test_dir}/planned.log"
+
+echo "Build ethos-u planned slow and fast memory allocation runner"
+mkdir -p "${test_dir}"
+
+python3 "${et_root_dir}/backends/arm/test/assets/export_memory_planning_mem_id_3.py" \
+    --output="${pte_file}"
+
+"${et_root_dir}/backends/arm/scripts/build_executor_runner.sh" \
+    --pte="${pte_file}" \
+    --target="${target}" \
+    --output="${runner_build_dir}" \
+    --select_ops_list="aten::add.out,aten::mul.out" \
+    --extra_build_flags="-DFETCH_ETHOS_U_CONTENT=OFF -DET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=0x180000 -DET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE=0x1000"
+
+echo "Test ethos-u planned slow and fast memory allocation"
+"${et_root_dir}/backends/arm/scripts/run_fvp.sh" \
+    --elf="${runner_build_dir}/arm_executor_runner" \
+    --target="${target}" \
+    2>&1 | tee "${log_file}"
+
+python3 "${et_root_dir}/backends/arm/test/test_memory_allocator_log.py" --log "${log_file}" \
+    --require "method_allocator_planned" "== 8 B" \
+    --require "planned_fast_used" "== 8 B"

--- a/backends/arm/runtime/tests/ethos-u/test_runner_size_optimization.sh
+++ b/backends/arm/runtime/tests/ethos-u/test_runner_size_optimization.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+source "$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)/setup_env.sh"
+
+test_dir="${test_output_dir}/runner_size_optimization"
+default_build_dir="${test_dir}/default"
+optimized_build_dir="${test_dir}/optimized"
+
+get_required_text_section_bytes() {
+    local elf=$1
+    local size_tool="arm-none-eabi-size"
+    local value
+
+    command -v "${size_tool}" >/dev/null \
+        || { echo "Could not find ${size_tool} on PATH" >&2; exit 1; }
+
+    value=$("${size_tool}" -A --radix=10 "${elf}" |
+        awk '$1 == ".text" { print $2; found=1 } END { exit !found }')
+    if [[ -z "${value}" ]]; then
+        echo "Could not read .text size from ${elf}" >&2
+        exit 1
+    fi
+
+    echo "${value}"
+}
+
+min_text_saving_bytes=$((50 * 1024))
+
+echo "Compare runner text size with EXECUTORCH_OPTIMIZE_SIZE"
+"${et_root_dir}/backends/arm/scripts/build_executor_runner.sh" \
+    --pte=semihosting \
+    --output="${default_build_dir}"
+
+"${et_root_dir}/backends/arm/scripts/build_executor_runner.sh" \
+    --pte=semihosting \
+    --output="${optimized_build_dir}" \
+    --extra_build_flags="-DEXECUTORCH_OPTIMIZE_SIZE=ON"
+
+default_text=$(get_required_text_section_bytes "${default_build_dir}/arm_executor_runner")
+optimized_text=$(get_required_text_section_bytes "${optimized_build_dir}/arm_executor_runner")
+text_saving=$((default_text - optimized_text))
+
+echo "default .text=${default_text} bytes"
+echo "optimized .text=${optimized_text} bytes"
+if (( text_saving < min_text_saving_bytes )); then
+    echo "Expected EXECUTORCH_OPTIMIZE_SIZE to reduce .text by at least ${min_text_saving_bytes} bytes, got default=${default_text} optimized=${optimized_text} saving=${text_saving}" >&2
+    exit 1
+fi

--- a/backends/arm/test/setup_testing.sh
+++ b/backends/arm/test/setup_testing.sh
@@ -29,9 +29,9 @@ ops_list_quantized_decomposed=(
     quantized_decomposed::dequantize_per_tensor.out
 )
 
-${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-300" --extra_build_flags=${extraflags}
-${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-300-u65" --extra_build_flags=${extraflags}
-${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-320" --extra_build_flags=${extraflags}
+${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-300" --extra_build_flags="${extraflags}"
+${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-300-u65" --extra_build_flags="${extraflags}"
+${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-320" --extra_build_flags="${extraflags}"
 
 # List of portable ops used by testing, this is mainly used to test models in the flow
 # test setup to make sure models that are not fully delegated can still be tested and run OK
@@ -92,4 +92,11 @@ ops_list_u85=(
 
 ${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --select_ops_list="$(join_by_comma "${ops_list_u55[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-300" --extra_build_flags="${portable_extraflags}"
 ${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_u65[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-300-u65" --extra_build_flags="${portable_extraflags}"
-${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_u85[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-320" --extra_build_flags=${extraflags}
+${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_u85[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-320" --extra_build_flags="${extraflags}"
+
+ethos_u_runtime_ctest_dir="${et_root_dir}/arm_test/ethosu_runtime_tests"
+cmake \
+    -S "${et_root_dir}/backends/arm/runtime/tests/ethos-u" \
+    -B "${ethos_u_runtime_ctest_dir}" \
+    -DEXECUTORCH_ROOT="${et_root_dir}"
+cmake --build "${ethos_u_runtime_ctest_dir}"

--- a/backends/arm/test/test_arm_backend.sh
+++ b/backends/arm/test/test_arm_backend.sh
@@ -412,98 +412,19 @@ test_smaller_stories_llama_vkml() {
     _test_smaller_stories_llama vgf
 }
 
-_get_required_text_section_bytes() {
-    local elf=$1
-    local size_tool="arm-none-eabi-size"
-    local value
+test_runtime_ethos_u() {
+    echo "${TEST_SUITE_NAME}: Test ethos-u memory allocation"
 
-    command -v "${size_tool}" >/dev/null \
-        || { echo "Could not find ${size_tool} on PATH" >&2; exit 1; }
+    local ctest_build_dir="${et_root_dir}/arm_test/ethosu_runtime_tests"
+    cmake \
+        -S "${et_root_dir}/backends/arm/runtime/tests/ethos-u" \
+        -B "${ctest_build_dir}" \
+        -DEXECUTORCH_ROOT="${et_root_dir}"
 
-    value=$("${size_tool}" -A --radix=10 "${elf}" |
-        awk '$1 == ".text" { print $2; found=1 } END { exit !found }')
-    if [[ -z "${value}" ]]; then
-        echo "Could not read .text size from ${elf}" >&2
-        exit 1
-    fi
-
-    echo "${value}"
-}
-
-_test_runner_size_optimization() {
-    local output_root="arm_test/test_run"
-    local default_output="${output_root}/runner_size_default"
-    local optimized_output="${output_root}/runner_size_optimized"
-    local min_text_saving_bytes=$((50 * 1024))
-
-    echo "${TEST_SUITE_NAME}: Compare runner text size with EXECUTORCH_OPTIMIZE_SIZE"
-    backends/arm/scripts/build_executor_runner.sh \
-        --pte=semihosting \
-        --output="${default_output}"
-
-        backends/arm/scripts/build_executor_runner.sh \
-        --pte=semihosting \
-        --output="${optimized_output}" \
-        --extra_build_flags="-DEXECUTORCH_OPTIMIZE_SIZE=ON"
-
-    local default_text
-    local optimized_text
-    local text_saving
-    default_text=$(_get_required_text_section_bytes "${default_output}/arm_executor_runner")
-    optimized_text=$(_get_required_text_section_bytes "${optimized_output}/arm_executor_runner")
-    text_saving=$((default_text - optimized_text))
-
-    echo "${TEST_SUITE_NAME}: default .text=${default_text} bytes"
-    echo "${TEST_SUITE_NAME}: optimized .text=${optimized_text} bytes"
-    if (( text_saving < min_text_saving_bytes )); then
-        echo "Expected EXECUTORCH_OPTIMIZE_SIZE to reduce .text by at least ${min_text_saving_bytes} bytes, got default=${default_text} optimized=${optimized_text} saving=${text_saving}" >&2
-        exit 1
-    fi
-}
-
-test_memory_allocation() {
-    echo "${TEST_SUITE_NAME}: Test ethos-u memory allocation with run.sh"
-
-    mkdir -p arm_test/test_run
-    # Ethos-U85
-    echo "${TEST_SUITE_NAME}: Test target Ethos-U85"
-    examples/arm/run.sh --et_build_root=arm_test/test_run --target=ethos-u85-128 --model_name=examples/arm/example_modules/add.py &> arm_test/test_run/full.log
-    # method_allocator_input includes one 16-byte EValue input plus possible
-    # alignment padding before that allocation.
-    python3 backends/arm/test/test_memory_allocator_log.py --log arm_test/test_run/full.log \
-            --require "model_pte_program_size" "<= 3200 B" \
-            --require "method_allocator_planned" "<= 64 B" \
-            --require "method_allocator_loaded" "<= 1024 B" \
-            --require "method_allocator_input" "<= 24 B" \
-            --require "Total DRAM used" "<= 0.06 KiB"
-
-    _test_runner_size_optimization
-
-    echo "${TEST_SUITE_NAME}: Test planned slow and fast memory allocation"
-    local plan_dir="arm_test/test_run/memory_planning"
-    local pte_file="${plan_dir}/memory_planning_mem_id_3.pte"
-    local runner_dir="${plan_dir}/cmake-out"
-    local planned_log="${plan_dir}/planned.log"
-    mkdir -p "${plan_dir}"
-
-    python3 "${et_root_dir}/backends/arm/test/assets/export_memory_planning_mem_id_3.py" \
-        --output="${pte_file}"
-
-    backends/arm/scripts/build_executor_runner.sh \
-        --pte="${pte_file}" \
-        --target=ethos-u55-128 \
-        --output="${runner_dir}" \
-        --select_ops_list="aten::add.out,aten::mul.out" \
-        --extra_build_flags="-DFETCH_ETHOS_U_CONTENT=OFF -DET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=0x180000 -DET_ARM_BAREMETAL_PLANNED_FAST_MEMORY_SIZE=0x1000"
-
-    backends/arm/scripts/run_fvp.sh \
-        --elf="${runner_dir}/arm_executor_runner" \
-        --target=ethos-u55-128 \
-        &> "${planned_log}"
-
-    python3 backends/arm/test/test_memory_allocator_log.py --log "${planned_log}" \
-            --require "method_allocator_planned" "== 8 B" \
-            --require "planned_fast_used" "== 8 B"
+    ctest --test-dir "${ctest_build_dir}" \
+        --output-on-failure \
+        --no-tests=error \
+        -L memory_allocation
     echo "${TEST_SUITE_NAME}: PASS"
 }
 


### PR DESCRIPTION
Use this in test_memory_allocation. To allow this
suite to expand, name it more generally to
"test_runtime_ethos_u".

The tests are built in arm_test/ethosu_runtime_tests by setup_testing.sh

You can run all tests with

ctest --test-dir arm_test/ethosu_runtime_tests
-N for discovery
--output-on-failure
-I 0,2 for a range of tests
-R '^Test$' for a single test

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani