### PR TITLE
Arm backend: Fix A16W8 convolution output rescaling

### DIFF
--- a/backends/arm/_passes/rewrite_conv_pass.py
+++ b/backends/arm/_passes/rewrite_conv_pass.py
@@ -334,56 +334,230 @@ class RewriteConvPass(ArmPass):
         )
         return rescale_node, rescale_fake_tensor
 
-    def insert_identity_int32_rescale(
-        self,
-        graph_module,
-        source_node,
-        conv_node,
-        conv_fake_tensor: torch.Tensor,
-    ):
-        with graph_module.graph.inserting_after(conv_node):
-            rescale_node = create_node(
-                graph=graph_module.graph,
-                op_target=exir_ops.backend.tosa.RESCALE.default,
-                args=(
-                    conv_node,
-                    torch.int32,
-                    [1.0],
-                    0,
-                    0,
-                ),
-                from_node=source_node,
+    @staticmethod
+    def _combine_rescale_scales(
+        lhs_scales: list[float], rhs_scales: list[float]
+    ) -> list[float]:
+        """Multiply scalar or equally sized per-channel rescale factors."""
+        if not lhs_scales or not rhs_scales:
+            raise ValueError("Cannot combine empty rescale factors.")
+        if (
+            len(lhs_scales) != 1
+            and len(rhs_scales) != 1
+            and len(lhs_scales) != len(rhs_scales)
+        ):
+            raise ValueError(
+                "Cannot combine rescales with incompatible scale counts: "
+                f"{len(lhs_scales)} and {len(rhs_scales)}."
             )
-        rescale_fake_tensor = exir_ops.backend.tosa.RESCALE.default(
-            conv_fake_tensor,
-            torch.int32,
-            [1.0],
-            0,
-            0,
-        )
-        return rescale_node, rescale_fake_tensor
+        scale_count = max(len(lhs_scales), len(rhs_scales))
+        return [
+            lhs_scales[index % len(lhs_scales)] * rhs_scales[index % len(rhs_scales)]
+            for index in range(scale_count)
+        ]
 
-    def _has_int32_rescale_user(self, node: torch.fx.Node) -> bool:
+    @staticmethod
+    def _is_direct_int32_rescale(node: torch.fx.Node) -> bool:
+        """Return whether a node directly rescales its input to INT32."""
+        return (
+            node.op == "call_function"
+            and node.target == exir_ops.backend.tosa.RESCALE.default
+            and len(node.args) > 1
+            and node.args[1] == torch.int32
+        )
+
+    def _get_direct_int32_rescale_users(
+        self, node: torch.fx.Node
+    ) -> list[torch.fx.Node]:
+        """Return consumers that directly request an INT32 value."""
+        return [user for user in node.users if self._is_direct_int32_rescale(user)]
+
+    def _get_permute_int32_rescale_users(
+        self, node: torch.fx.Node
+    ) -> dict[torch.fx.Node, list[torch.fx.Node]]:
+        """Return permutations and their direct INT32 rescale consumers."""
+        result: dict[torch.fx.Node, list[torch.fx.Node]] = {}
         for user in node.users:
-            if (
-                user.op == "call_function"
-                and user.target == exir_ops.backend.tosa.RESCALE.default
-                and len(user.args) > 1
-                and user.args[1] == torch.int32
-            ):
-                return True
             if (
                 user.op == "call_function"
                 and user.target == exir_ops.edge.aten.permute_copy.default
             ):
-                for inner_user in user.users:
-                    if (
-                        inner_user.op == "call_function"
-                        and inner_user.target == exir_ops.backend.tosa.RESCALE.default
-                        and inner_user.args[1] == torch.int32
-                    ):
-                        return True
-        return False
+                if int32_users := self._get_direct_int32_rescale_users(user):
+                    result[user] = int32_users
+        return result
+
+    @staticmethod
+    def _insert_layout_permute(
+        graph_module: torch.fx.GraphModule,
+        source_node: torch.fx.Node,
+        input_node: torch.fx.Node,
+        input_fake_tensor: FakeTensor,
+        dims: tuple[int, ...],
+    ) -> tuple[torch.fx.Node, FakeTensor]:
+        """Insert the mandatory TOSA-to-Edge output layout permutation."""
+        with graph_module.graph.inserting_after(input_node):
+            output = create_node(
+                graph=graph_module.graph,
+                op_target=exir_ops.edge.aten.permute_copy.default,
+                args=(input_node, list(dims)),
+                from_node=source_node,
+            )
+        output_fake_tensor = permute_fake_tensor_metadata(input_fake_tensor, dims)
+        output.meta["val"] = output_fake_tensor
+        return output, output_fake_tensor
+
+    def _insert_a16w8_output_branches(
+        self,
+        graph_module: torch.fx.GraphModule,
+        node: torch.fx.Node,
+        tosa_op: torch.fx.Node,
+        tosa_node_fake_tensor: torch.Tensor,
+        default_rescale: torch.fx.Node,
+        post_permute_dims: tuple[int, ...],
+    ) -> None:
+        """Route A16W8 convolution users through the required output types.
+
+        Keep INT32 consumers on a widened path from the INT48 accumulator, even
+        though the convolution's declared output is INT16. This preserves
+        numerical range by avoiding unnecessary INT16 rounding and clamping.
+
+        """
+        direct_int32_users = self._get_direct_int32_rescale_users(node)
+        permute_int32_users = self._get_permute_int32_rescale_users(node)
+        if not direct_int32_users and not permute_int32_users:
+            return
+
+        conv_scales = cast(list[float], default_rescale.args[2])
+        conv_output_zp = cast(int, default_rescale.args[4])
+
+        # The layout permutation cannot consume the INT48 accumulator. Fork
+        # before narrowing. A direct INT32 rescale can be combined with the
+        # convolution rescale:
+        #
+        #                         CONV (INT48)
+        #                               |
+        #                    +----------+---------+
+        #                    |                    |
+        #          RESCALE (INT16)     RESCALE (INT32, combined)
+        #                    |                    |
+        #                 PERMUTE              PERMUTE
+        #                    |                    |
+        #             INT16 consumer        INT32 consumer
+        #
+        # Direct consumers have no axis-changing operation between the
+        # convolution and rescale, so both scale factors can be combined.
+        for int32_user in direct_int32_users:
+            # Retarget the existing consumer rescale to the TOSA convolution;
+            # its previous consumers will be moved after the layout permute.
+            user_scales = cast(list[float], int32_user.args[2])
+            user_input_zp = int32_user.args[3]
+            user_output_zp = cast(int, int32_user.args[4])
+            if conv_output_zp != user_input_zp:
+                raise ValueError(
+                    "Cannot combine convolution and INT32 rescales with "
+                    f"different intermediate zero points: {conv_output_zp} "
+                    f"and {user_input_zp}."
+                )
+
+            # The intermediate zero points cancel, so the direct path can
+            # combine both scales without rounding through INT16.
+            combined_scales = self._combine_rescale_scales(conv_scales, user_scales)
+            # Capture the old consumers before adding the layout permute. A
+            # blanket replace afterward would also rewrite the new permute's
+            # input and create a cycle.
+            previous_users = list(int32_user.users)
+            int32_user.args = (
+                tosa_op,
+                torch.int32,
+                combined_scales,
+                0,
+                user_output_zp,
+            )
+            int32_fake_tensor = exir_ops.backend.tosa.RESCALE.default(
+                tosa_node_fake_tensor,
+                torch.int32,
+                combined_scales,
+                0,
+                user_output_zp,
+            )
+            int32_user.meta["val"] = int32_fake_tensor
+            int32_output, _ = self._insert_layout_permute(
+                graph_module,
+                node,
+                int32_user,
+                int32_fake_tensor,
+                post_permute_dims,
+            )
+            for user in previous_users:
+                user.replace_input_with(int32_user, int32_output)
+
+        # A source permutation may change the per-channel axis, so keep both
+        # rescales on a separate widened branch instead of combining them:
+        #
+        #              CONV (INT48)
+        #                   |
+        #           RESCALE (INT32)
+        #                   |
+        #           layout PERMUTE
+        #                   |
+        #           source PERMUTE
+        #                   |
+        #           RESCALE (INT32)
+        #                   |
+        #           INT32 consumer
+        #
+        # This also avoids an intermediate INT16 rounding step.
+        for permute, int32_users in permute_int32_users.items():
+            # Convert the accumulator to the declared convolution domain, but
+            # use INT32 storage to avoid clamping values to the INT16 range.
+            with graph_module.graph.inserting_after(tosa_op):
+                widened_rescale = create_node(
+                    graph=graph_module.graph,
+                    op_target=exir_ops.backend.tosa.RESCALE.default,
+                    args=(
+                        tosa_op,
+                        torch.int32,
+                        conv_scales,
+                        0,
+                        conv_output_zp,
+                    ),
+                    from_node=node,
+                )
+            widened_fake_tensor = exir_ops.backend.tosa.RESCALE.default(
+                tosa_node_fake_tensor,
+                torch.int32,
+                conv_scales,
+                0,
+                conv_output_zp,
+            )
+            widened_rescale.meta["val"] = widened_fake_tensor
+            widened_output, widened_output_fake_tensor = self._insert_layout_permute(
+                graph_module,
+                node,
+                widened_rescale,
+                widened_fake_tensor,
+                post_permute_dims,
+            )
+
+            # Clone the source permutation for the widened branch. The
+            # original may still have sibling consumers that require INT16.
+            source_permute_dims = cast(list[int], permute.args[1])
+            with graph_module.graph.inserting_after(widened_output):
+                widened_permute = create_node(
+                    graph=graph_module.graph,
+                    op_target=exir_ops.edge.aten.permute_copy.default,
+                    args=(widened_output, source_permute_dims),
+                    from_node=permute,
+                )
+            widened_permute.meta["val"] = permute_fake_tensor_metadata(
+                widened_output_fake_tensor,
+                tuple(source_permute_dims),
+            )
+            for int32_user in int32_users:
+                int32_user.replace_input_with(permute, widened_permute)
+
+            if not permute.users:
+                graph_module.graph.erase_node(permute)
 
     def _insert_output_conversion(
         self,
@@ -393,39 +567,38 @@ class RewriteConvPass(ArmPass):
         input_fake_tensor: torch.Tensor,
         tosa_node_fake_tensor: torch.Tensor,
     ) -> tuple[torch.fx.Node, FakeTensor]:
+        # Convolutions that match none of the special cases below require no
+        # output conversion and keep the original TOSA node.
         node_replacement: torch.fx.Node = tosa_op
         node_replacement_fake_tensor = tosa_node_fake_tensor
-        if (
+        is_a8w8_conv = (
             tosa_node_fake_tensor.dtype == torch.int32
             and input_fake_tensor.dtype == torch.int8
-        ):
+        )
+        is_a16w8_conv = (
+            tosa_node_fake_tensor.dtype == torch.int32
+            and input_fake_tensor.dtype == torch.int16
+        )
+        is_fp8_conv = (
+            tosa_node_fake_tensor.dtype == torch.float16
+            and input_fake_tensor.dtype in self._FP8_DTYPES
+        )
+        if is_a8w8_conv:
             node_replacement, node_replacement_fake_tensor = self.insert_output_rescale(
                 graph_module, node, tosa_op, tosa_node_fake_tensor
             )
-        elif (
-            tosa_node_fake_tensor.dtype == torch.int32
-            and input_fake_tensor.dtype == torch.int16
-        ):
-            # Explicit layout paths require a post-conv permute, which does
-            # not support INT48. Always rescale before post-permute.
-            if self._has_int32_rescale_user(node):
-                node_replacement, node_replacement_fake_tensor = (
-                    self.insert_identity_int32_rescale(
-                        graph_module, node, tosa_op, tosa_node_fake_tensor
-                    )
-                )
-            else:
-                node_replacement, node_replacement_fake_tensor = (
-                    self.insert_output_rescale(
-                        graph_module, node, tosa_op, tosa_node_fake_tensor
-                    )
-                )
-
+        elif is_a16w8_conv:
+            # Explicit layout paths require a post-conv permute, which cannot
+            # consume INT48. Return the declared INT16 rescale so the caller
+            # can create its standard layout permute first, then add parallel
+            # INT32 branches with their own layout permutations. If every
+            # consumer moves to INT32, the caller removes the unused INT16
+            # rescale and permutation.
+            node_replacement, node_replacement_fake_tensor = self.insert_output_rescale(
+                graph_module, node, tosa_op, tosa_node_fake_tensor
+            )
             tosa_op.meta[TosaSpecialDtype.meta_key()] = TosaSpecialDtype.INT48
-        elif (
-            tosa_node_fake_tensor.dtype == torch.float16
-            and input_fake_tensor.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
-        ):
+        elif is_fp8_conv:
             node_output_fake_tensor = get_first_fake_tensor(node)
             # TOSA FP8 conv widens the output. Cast back to the exported
             # graph dtype before the post-layout permute.
@@ -689,7 +862,32 @@ class RewriteConvPass(ArmPass):
                 node_replacement_fake_tensor, post_permute_dims
             )
 
-            node.replace_all_uses_with(node_replacement)
+            is_a16w8_conv = (
+                tosa_node_fake_tensor.dtype == torch.int32
+                and input_fake_tensor.dtype == torch.int16
+            )
+            if is_a16w8_conv:
+                # Keep values in INT32 whenever a consumer supports it, even
+                # though the declared output is INT16, by branching from the
+                # accumulator before narrowing.
+                self._insert_a16w8_output_branches(
+                    graph_module,
+                    node,
+                    tosa_op,
+                    tosa_node_fake_tensor,
+                    post_permute_input,
+                    post_permute_dims,
+                )
+                # Only users not moved to widened branches remain on the
+                # source node. Route those through the declared INT16 output,
+                # or remove that branch when every consumer was moved.
+                if node.users:
+                    node.replace_all_uses_with(node_replacement)
+                else:
+                    graph_module.graph.erase_node(node_replacement)
+                    graph_module.graph.erase_node(post_permute_input)
+            else:
+                node.replace_all_uses_with(node_replacement)
 
             graph_module.graph.erase_node(node)
 

--- a/backends/arm/test/passes/test_rewrite_conv_pass.py
+++ b/backends/arm/test/passes/test_rewrite_conv_pass.py
@@ -3,7 +3,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 import os
+from typing import Any, cast
 
 import pytest
 import torch
@@ -13,6 +15,7 @@ from executorch.backends.arm._passes import (
     ConvertToClampPass,
     FoldAndAnnotateQParamsPass,
     FuseQuantizedActivationPass,
+    InsertRescaleInt32Pass,
     QuantizeClampArgumentsPass,
 )
 from executorch.backends.arm._passes.rewrite_conv_pass import RewriteConvPass
@@ -25,7 +28,9 @@ from executorch.backends.arm.test.misc.test_dw_convs_with_shared_weights import 
     DWConvsModule,
 )
 from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
+from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
 from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
+from executorch.backends.arm.tosa.partitioner import TOSAPartitioner
 from executorch.backends.arm.tosa.specification import (
     TosaLoweringContext,
     TosaSpecification,
@@ -52,6 +57,66 @@ class TinyConvReluCat(nn.Module):
         relu_out = F.relu(self.conv1(x))
         merged = torch.cat((relu_out, y), dim=1)
         return self.conv2(merged)
+
+
+class A16W8MixedConsumerChain(nn.Module):
+    """Exercise a shared A16W8 convolution output with mixed consumers."""
+
+    def __init__(self, following: nn.Module) -> None:
+        super().__init__()
+        self.expand = nn.Conv2d(4, 8, 1)
+        self.depthwise = nn.Conv2d(8, 8, 3, padding=1, groups=8)
+        self.project = nn.Conv2d(8, 4, 1)
+        self.following = following
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Use a projection in both an addition and another operator."""
+        expanded = F.relu(self.expand(x))
+        filtered = F.relu(self.depthwise(expanded))
+        projected = self.project(filtered)
+        residual = projected + x
+        return self.following(projected) + residual
+
+
+class A16W8Int32Consumer(nn.Module):
+    """Exercise an A16W8 convolution consumed only by an INT32 add."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = nn.Conv2d(4, 4, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Feed the convolution output directly to a residual addition."""
+        return self.conv(x) + x
+
+
+class A16W8MixedConsumer(nn.Module):
+    """Exercise a shared A16W8 convolution output with mixed consumers."""
+
+    def __init__(self, producer: nn.Module, following: nn.Module) -> None:
+        super().__init__()
+        self.producer = producer
+        self.following = following
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Feed the convolution output to both INT16 and INT32 consumers."""
+        produced = self.producer(x)
+        return self.following(produced) + produced + x
+
+
+class A16W8PermutedInt32Consumer(nn.Module):
+    """Exercise an indirect INT32 consumer behind a permutation."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.producer = nn.Conv2d(4, 4, 1)
+        self.following = nn.Conv2d(4, 4, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Share the convolution between INT16 and permuted INT32 paths."""
+        produced = self.producer(x)
+        permuted = produced.permute(0, 1, 3, 2)
+        return self.following(produced) + permuted + x
 
 
 def _example_inputs() -> tuple[torch.Tensor, torch.Tensor]:
@@ -98,6 +163,16 @@ def _export_quantized_a16w8(model: nn.Module, inputs: tuple[torch.Tensor, ...]):
     return torch.export.export(quantized, inputs)
 
 
+def _lower_a16w8_to_tosa(model: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+    """Lower a VGF-quantized A16W8 model through the TOSA partitioner."""
+    compile_spec = TosaCompileSpec("TOSA-1.0+INT+int16")
+    to_edge_transform_and_lower(
+        _export_quantized_a16w8(model, inputs),
+        compile_config=EdgeCompileConfig(_check_ir_validity=False),
+        partitioner=[TOSAPartitioner(compile_spec)],
+    )
+
+
 def _run_pre_rewrite_passes(exported_program: torch.export.ExportedProgram):
     gm = exported_program.graph_module
     for pass_ in (
@@ -110,6 +185,75 @@ def _run_pre_rewrite_passes(exported_program: torch.export.ExportedProgram):
         assert result is not None
         gm = result.graph_module
     return gm
+
+
+def _get_expected_int32_scales(
+    gm: torch.fx.GraphModule, rewrite_pass: RewriteConvPass
+) -> list[list[float]]:
+    """Calculate expected scales for direct INT32 convolution consumers.
+
+    Args:
+        gm (torch.fx.GraphModule): Graph containing rescaled convolutions.
+        rewrite_pass (RewriteConvPass): Pass used to identify INT32 consumers.
+
+    Returns:
+        list[list[float]]: Expected per-consumer rescale values.
+
+    """
+    expected_int32_scales = []
+    for node in gm.graph.nodes:
+        if node.target != exir_ops.edge.aten.convolution.default:
+            continue
+        for int32_user in rewrite_pass._get_direct_int32_rescale_users(node):
+            input_qparams = node.meta["input_qparams"]
+            output_qparams = node.meta["output_qparams"][0]
+            activation_qparams = input_qparams[0]
+            weight_qparams = input_qparams[1]
+            weight_scales = (
+                weight_qparams.get_scale_per_channel()
+                if weight_qparams.per_channel
+                else [weight_qparams.get_scale_per_tensor()]
+            )
+            activation_scale = activation_qparams.get_scale_per_tensor()
+            output_scale = output_qparams.get_scale_per_tensor()
+            assert output_qparams.get_zp_per_tensor() == int32_user.args[3]
+            user_scales = cast(list[float], int32_user.args[2])
+            assert len(user_scales) in (1, len(weight_scales))
+            # Derive this independently from the rewrite helper:
+            #
+            #   accumulator -> declared output -> INT32 consumer
+            #   (input * weight / output) * consumer
+            expected_int32_scales.append(
+                [
+                    activation_scale * weight_scale / output_scale * user_scale
+                    for weight_scale, user_scale in zip(
+                        weight_scales,
+                        itertools.cycle(user_scales),
+                    )
+                ]
+            )
+    return expected_int32_scales
+
+
+def _rewrite_a16w8_convs(
+    model: nn.Module, inputs: tuple[torch.Tensor, ...]
+) -> tuple[torch.fx.GraphModule, list[list[float]]]:
+    """Run the passes needed to inspect rewritten A16W8 convolutions."""
+    exported_program = _export_quantized_a16w8(model, inputs)
+    edge_program = to_edge(
+        exported_program, compile_config=EdgeCompileConfig(_check_ir_validity=False)
+    ).exported_program()
+    gm = _run_pre_rewrite_passes(edge_program)
+    rewrite_pass = RewriteConvPass(edge_program)
+    with TosaLoweringContext(_compile_spec_int16().tosa_spec):
+        rescale_result = InsertRescaleInt32Pass()(gm)
+        assert rescale_result is not None
+        expected_int32_scales = _get_expected_int32_scales(
+            rescale_result.graph_module, rewrite_pass
+        )
+        rewrite_result = rewrite_pass(rescale_result.graph_module)
+        assert rewrite_result is not None
+    return rewrite_result.graph_module, expected_int32_scales
 
 
 def _get_call_function_node(gm: torch.fx.GraphModule, target):
@@ -214,6 +358,179 @@ def test_rewrite_conv_tosa_FP():
         module, module.get_inputs(), passes_with_exported_program=[RewriteConvPass]
     )
     pipeline.run()
+
+
+@pytest.mark.parametrize(
+    ("model", "inputs", "tosa_target"),
+    (
+        (
+            A16W8MixedConsumerChain(nn.Conv2d(4, 4, 1)),
+            (torch.randn(1, 4, 8, 8),),
+            exir_ops.backend.tosa.CONV2D.default,
+        ),
+        (
+            A16W8MixedConsumerChain(nn.Conv2d(4, 4, 3, padding=1, groups=4)),
+            (torch.randn(1, 4, 8, 8),),
+            exir_ops.backend.tosa.CONV2D.default,
+        ),
+        (
+            A16W8MixedConsumerChain(nn.AvgPool2d(3, stride=1, padding=1)),
+            (torch.randn(1, 4, 8, 8),),
+            exir_ops.backend.tosa.CONV2D.default,
+        ),
+        (
+            A16W8MixedConsumerChain(nn.MaxPool2d(3, stride=1, padding=1)),
+            (torch.randn(1, 4, 8, 8),),
+            exir_ops.backend.tosa.CONV2D.default,
+        ),
+        (
+            A16W8MixedConsumer(
+                nn.Conv3d(4, 4, 3, padding=1),
+                nn.Conv3d(4, 4, 1),
+            ),
+            (torch.randn(1, 4, 4, 8, 8),),
+            exir_ops.backend.tosa.CONV3D.default,
+        ),
+        (
+            A16W8MixedConsumer(
+                nn.ConvTranspose2d(4, 4, 3, padding=1),
+                nn.Conv2d(4, 4, 1),
+            ),
+            (torch.randn(1, 4, 8, 8),),
+            exir_ops.backend.tosa.TRANSPOSE_CONV2D.default,
+        ),
+    ),
+    ids=(
+        "conv",
+        "depthwise_conv",
+        "avg_pool",
+        "max_pool",
+        "conv3d",
+        "transpose_conv2d",
+    ),
+)
+def test_rewrite_conv_a16w8_mixed_consumers_restore_int16(
+    model: nn.Module,
+    inputs: tuple[torch.Tensor, ...],
+    tosa_target: Any,
+) -> None:
+    r"""Test that mixed consumers branch at the INT48 accumulator.
+
+                              +-> combined RESCALE (INT32) -> PERMUTE
+                              |                              -> residual ADD
+        A16W8 CONV ----------+
+        accumulator (INT48)  +-> RESCALE (INT16) -> PERMUTE
+                                                             -> following op
+
+    The INT32 branch must consume the convolution output directly. Routing it
+    through the INT16 rescale first would irreversibly lose accumulator range.
+    The parameterized following operation still receives INT16. This applies
+    to all convolution variants supported by the rewrite pass.
+
+    Args:
+        model (nn.Module): Model containing the convolution under test.
+        inputs (tuple[torch.Tensor, ...]): Inputs used to export the model.
+        tosa_target (Any): Expected rewritten TOSA convolution target.
+
+    """
+    _lower_a16w8_to_tosa(model, inputs)
+    gm, expected_int32_scales = _rewrite_a16w8_convs(model, inputs)
+
+    mixed_output_convs = [
+        node
+        for node in gm.graph.nodes
+        if node.target == tosa_target
+        and len(node.users) == 2
+        and {
+            user.args[1]
+            for user in node.users
+            if user.target == exir_ops.backend.tosa.RESCALE.default
+        }
+        == {torch.int16, torch.int32}
+    ]
+    assert len(mixed_output_convs) == 1
+    int32_rescale = next(
+        user for user in mixed_output_convs[0].users if user.args[1] == torch.int32
+    )
+    assert any(
+        int32_rescale.args[2] == pytest.approx(expected)
+        for expected in expected_int32_scales
+    )
+
+
+def test_rewrite_conv_a16w8_preserves_int32_for_int32_consumers() -> None:
+    r"""Test that an exclusively INT32 consumer keeps the widened path.
+
+        x (INT16) -> RESCALE (INT32) -------------------------+
+                                                              |
+        x (INT16) -> CONV (INT48)                              ADD
+                          -> combined RESCALE (INT32)           |
+                          -> PERMUTE ---------------------------+
+
+    No INT16 rescale is needed because every convolution consumer accepts
+    INT32. Combining both rescale factors converts directly from INT48 to the
+    addition's INT32 domain without changing the represented values.
+
+    """
+    inputs = (torch.randn(1, 4, 8, 8),)
+    gm, expected_int32_scales = _rewrite_a16w8_convs(A16W8Int32Consumer(), inputs)
+
+    direct_int32_rescales = [
+        node
+        for node in gm.graph.nodes
+        if node.op == "call_function"
+        and node.target == exir_ops.backend.tosa.RESCALE.default
+        and node.args[1] == torch.int32
+        and node.all_input_nodes[0].target
+        in {
+            exir_ops.backend.tosa.CONV2D.default,
+            exir_ops.backend.tosa.DEPTHWISE_CONV2D.default,
+        }
+    ]
+    assert len(direct_int32_rescales) == len(expected_int32_scales) == 1
+    assert direct_int32_rescales[0].args[2] == pytest.approx(expected_int32_scales[0])
+
+
+def test_rewrite_conv_a16w8_preserves_int32_after_permute() -> None:
+    r"""Test that an indirect INT32 consumer keeps a widened branch.
+
+        CONV (INT48) -+-> RESCALE (INT16) -> PERMUTE -> following CONV
+                      |
+                      +-> RESCALE (INT32) -> layout PERMUTE
+                          -> source PERMUTE -> RESCALE (INT32) -> ADD
+
+    The source permutation cannot operate on INT48. The first rescale widens
+    to the declared convolution domain in INT32, avoiding INT16 rounding while
+    leaving the following rescale on the correct side of the permutation.
+
+    """
+    inputs = (torch.randn(1, 4, 8, 8),)
+    model = A16W8PermutedInt32Consumer()
+    _lower_a16w8_to_tosa(model, inputs)
+    gm, _ = _rewrite_a16w8_convs(model, inputs)
+
+    widened_paths: list[torch.fx.Node] = []
+    for node in gm.graph.nodes:
+        if (
+            node.target != exir_ops.backend.tosa.RESCALE.default
+            or node.args[1] != torch.int32
+            or node.all_input_nodes[0].target != exir_ops.backend.tosa.CONV2D.default
+        ):
+            continue
+        for layout_permute in node.users:
+            if layout_permute.target != exir_ops.edge.aten.permute_copy.default:
+                continue
+            for source_permute in layout_permute.users:
+                if source_permute.target != exir_ops.edge.aten.permute_copy.default:
+                    continue
+                widened_paths.extend(
+                    consumer
+                    for consumer in source_permute.users
+                    if consumer.target == exir_ops.backend.tosa.RESCALE.default
+                    and consumer.args[1] == torch.int32
+                )
+
+    assert len(widened_paths) == 1
 
 
 @pytest.mark.skipif(not _VGF_ENABLED, reason="VGF not enabled")


### PR DESCRIPTION
Rescale A16W8 INT48 convolution accumulators to each consumer's required output type before the layout permutation. Keep the declared INT16 path for ordinary consumers and combine rescale factors for direct INT32 consumers to avoid intermediate narrowing and rounding.

Preserve widened INT32 branches when a source permutation separates the convolution from its rescale. Keep both rescales on these paths so per-channel axes remain unchanged without narrowing through INT16.

Add mixed-consumer coverage for Conv2D, depthwise convolution, pooling, Conv3D, transpose Conv2D, and permuted INT32 consumers.

### Test plan
Tests added to verify this works.

cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani