### PR TITLE
Arm backend: Support Ethos-U85 KV-cache export

### DIFF
--- a/examples/arm/executor_runner/arm_executor_runner.cpp
+++ b/examples/arm/executor_runner/arm_executor_runner.cpp
@@ -193,6 +193,7 @@ unsigned char __attribute__((
 
 using executorch::aten::ScalarType;
 using executorch::aten::Tensor;
+using executorch::aten::TensorImpl;
 using executorch::extension::BufferDataLoader;
 using executorch::runtime::Error;
 using executorch::runtime::EValue;
@@ -499,12 +500,19 @@ Error prepare_input_tensors(
             tensor_size);
         err = Error::InvalidArgument;
       } else if (input_evalues[i].isTensor()) {
-        // Copy the data from the input buffer to the tensor
-        Tensor& tensor = input_evalues[i].toTensor();
-        std::memcpy( // NOLINT(memcpy) - Buffer size is checked
-            tensor.mutable_data_ptr<int8_t>(),
+        // set_input copies shape metadata into its method-owned input tensor.
+        // For unplanned inputs it aliases only buffer, which remains valid
+        // through execute(); this temporary TensorImpl is not retained.
+        TensorImpl impl = TensorImpl(
+            tensor_meta->scalar_type(),
+            static_cast<ssize_t>(tensor_meta->sizes().size()),
+            const_cast<TensorImpl::SizesType*>(tensor_meta->sizes().data()),
             buffer,
-            buffer_size);
+            const_cast<TensorImpl::DimOrderType*>(
+                tensor_meta->dim_order().data()));
+        Tensor tensor(&impl);
+        err = method.set_input(tensor, i);
+        ET_CHECK_OK_OR_RETURN_ERROR(err);
       }
     }
 
@@ -609,8 +617,33 @@ struct RunnerContext {
 #if defined(SEMIHOSTING)
   Box<ArmMemoryAllocator> input_file_allocator;
   const char* output_basename = nullptr;
+  bool server_mode = false;
+  std::vector<const char*> input_filenames;
 #endif
 };
+
+#if defined(SEMIHOSTING)
+Error read_input_files(
+    RunnerContext& ctx,
+    const std::vector<const char*>& input_filenames,
+    std::vector<std::pair<char*, size_t>>& input_buffers) {
+  input_buffers.clear();
+  for (size_t i = 0; i < input_filenames.size(); ++i) {
+    auto [buffer, buffer_size] =
+        read_binary_file(input_filenames[i], ctx.input_file_allocator.value());
+    if (buffer == nullptr) {
+      ET_LOG(
+          Error,
+          "Reading input tensor %zu from file %s failed.",
+          i + 1,
+          input_filenames[i]);
+      return Error::AccessFailed;
+    }
+    input_buffers.push_back(std::make_pair(buffer, buffer_size));
+  }
+  return Error::Ok;
+}
+#endif
 
 void runner_init(
     RunnerContext& ctx,
@@ -1324,6 +1357,48 @@ bool run_model(RunnerContext& ctx, const void* model_data) {
   return model_ok;
 }
 
+#if defined(SEMIHOSTING)
+bool run_model_server(
+    RunnerContext& ctx,
+    const void* model_data,
+    std::vector<std::pair<char*, size_t>>& input_buffers) {
+  ET_LOG(Info, "Running in semihosting server mode.");
+  char line[16];
+  int server_inference_count = 0;
+  while (fgets(line, sizeof(line), stdin) != nullptr) {
+    ctx.input_file_allocator.reset(
+        input_file_allocation_pool_size, input_file_allocation_pool);
+    Error status = read_input_files(ctx, ctx.input_filenames, input_buffers);
+    ET_CHECK_MSG(
+        status == Error::Ok, "Could not reload inputs: 0x%" PRIx32, status);
+
+    status = ::prepare_input_tensors(
+        *ctx.method.value(), ctx.temp_allocator.value(), input_buffers);
+    ET_CHECK_MSG(
+        status == Error::Ok, "Failed to prepare inputs 0x%" PRIx32, status);
+
+    StartMeasurements();
+    status = ctx.method.value()->execute();
+    StopMeasurements(1);
+    ET_CHECK_MSG(
+        status == Error::Ok,
+        "Execution of method %s failed with status 0x%" PRIx32,
+        ctx.method_name,
+        status);
+
+    print_outputs(ctx);
+    ctx.temp_allocator.reset(temp_allocation_pool_size, temp_allocation_pool);
+    ET_LOG(Info, "SERVER_INFERENCE_DONE %d", server_inference_count++);
+    fflush(stdout);
+    fflush(stderr);
+  }
+
+  bool model_ok = verify_result(ctx, model_data);
+  ET_LOG(Info, "Model run: %d", model_ok);
+  return model_ok;
+}
+#endif
+
 } // namespace
 
 int main(int argc, const char* argv[]) {
@@ -1399,6 +1474,7 @@ int main(int argc, const char* argv[]) {
         _exit(1);
       }
       input_buffers.push_back(std::make_pair(buffer, buffer_size));
+      ctx.input_filenames.push_back(input_tensor_filename);
     } else if (std::strcmp(argv[i], "-m") == 0) {
       const char* pte_filename = argv[++i];
       ET_LOG(Info, "Reading pte model from file %s", pte_filename);
@@ -1414,6 +1490,19 @@ int main(int argc, const char* argv[]) {
     } else if (std::strcmp(argv[i], "-o") == 0) {
       // store the base filename to write output to.
       ctx.output_basename = argv[++i];
+    } else if (std::strcmp(argv[i], "--server_mode") == 0) {
+      if (++i >= argc) {
+        ET_LOG(Fatal, "--server_mode requires true or false");
+        return 1;
+      }
+      if (std::strcmp(argv[i], "true") == 0) {
+        ctx.server_mode = true;
+      } else if (std::strcmp(argv[i], "false") == 0) {
+        ctx.server_mode = false;
+      } else {
+        ET_LOG(Fatal, "Invalid --server_mode value: %s", argv[i]);
+        return 1;
+      }
     }
   }
 #endif
@@ -1442,7 +1531,15 @@ int main(int argc, const char* argv[]) {
 
   runner_init(ctx, model_data, model_size, input_buffers);
   bool model_ok = true;
+#if defined(SEMIHOSTING)
+  if (ctx.server_mode) {
+    model_ok = run_model_server(ctx, model_data, input_buffers);
+  } else {
+    model_ok = run_model(ctx, model_data);
+  }
+#else
   model_ok = run_model(ctx, model_data);
+#endif
   ET_LOG(Info, "Model run: %d", model_ok);
 
   log_mem_status(ctx);

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -35,7 +35,6 @@ from executorch.extension.llm.export.builder import DType, LLMEdgeManager
 from executorch.extension.llm.export.config.llm_config import LlmConfig
 from executorch.extension.llm.export.partitioner_lib import (
     get_coreml_partitioner,
-    get_ethosu_partitioner,
     get_mps_partitioner,
     get_openvino_partitioner,
     get_qnn_partitioner,
@@ -1263,12 +1262,41 @@ def _to_edge_and_lower_llama_arm(
 
     partitioners = []
     if llm_config.backend.ethosu.enabled:
+        from executorch.backends.arm.ethosu.compile_spec import EthosUCompileSpec
+        from executorch.backends.arm.ethosu.partitioner import EthosUPartitioner
+
+        compile_spec = EthosUCompileSpec(
+            llm_config.backend.ethosu.target,
+            system_config=(
+                None
+                if llm_config.backend.ethosu.system_config == "default"
+                else llm_config.backend.ethosu.system_config
+            ),
+            memory_mode=(
+                None
+                if llm_config.backend.ethosu.memory_mode == "default"
+                else llm_config.backend.ethosu.memory_mode
+            ),
+            extra_flags=llm_config.backend.ethosu.extra_flags,
+        )
+
+        additional_checks = []
+        if (
+            llm_config.model.use_kv_cache
+            and not llm_config.model.static_quantize_kv_cache
+        ):
+            from torch.fx.passes.operator_support import OperatorSupportBase
+
+            class EthosUKVCacheOperatorSupport(OperatorSupportBase):
+                def is_node_supported(self, submodules, node):
+                    return "aten.index.Tensor" not in str(node.target)
+
+            additional_checks.append(EthosUKVCacheOperatorSupport())
+
         partitioners.append(
-            get_ethosu_partitioner(
-                llm_config.backend.ethosu.target,
-                llm_config.backend.ethosu.system_config,
-                llm_config.backend.ethosu.memory_mode,
-                llm_config.backend.ethosu.extra_flags,
+            EthosUPartitioner(
+                compile_spec,
+                additional_checks=additional_checks or None,
             )
         )
         modelname = f"ethosu_{modelname}"

--- a/examples/models/llama/model.py
+++ b/examples/models/llama/model.py
@@ -308,19 +308,25 @@ class Llama2Model(EagerModelBase):
 
     # assumption is the custom op doesnt support dynamic shape right now. It might but its untested so lets first get static shape working
     def get_example_inputs_kvcache_sdpa(self):
+        backend = self.llm_config.backend
+        token_dtype = (
+            torch.int32
+            if (backend.ethosu.enabled or backend.tosa.enabled or backend.vgf.enabled)
+            else torch.long
+        )
         if self.enable_dynamic_shape:
             return (
-                torch.tensor([[2, 3, 4]], dtype=torch.long),
-                {"input_pos": torch.tensor([0], dtype=torch.long)},
+                torch.tensor([[2, 3, 4]], dtype=token_dtype),
+                {"input_pos": torch.tensor([0], dtype=token_dtype)},
             )
         else:
             return (
                 torch.tensor(
-                    [[1]], dtype=torch.long
+                    [[1]], dtype=token_dtype
                 ),  # tokens, with kv cache our input token length is always just 1 token.
                 {
                     "input_pos": torch.tensor(
-                        [0], dtype=torch.long
+                        [0], dtype=token_dtype
                     )  # start_pos, what token of output are we on.
                 },
             )

--- a/extension/llm/export/builder.py
+++ b/extension/llm/export/builder.py
@@ -311,9 +311,16 @@ class LLMEdgeManager:
                 while token_list[-1] != tokenizer.eos_id and pos < max_len:
                     logits_token_pos = -1
                     if self.use_kv_cache:
+                        input_dtype = self.example_inputs[0].dtype
+                        if self.example_kwarg_inputs is not None:
+                            input_pos_dtype = self.example_kwarg_inputs[
+                                "input_pos"
+                            ].dtype
+                        else:
+                            input_pos_dtype = self.example_inputs[1]["input_pos"].dtype
                         logits = module(
-                            torch.full((1, 1), token_list[pos]),
-                            {"input_pos": torch.tensor((pos,))},
+                            torch.full((1, 1), token_list[pos], dtype=input_dtype),
+                            {"input_pos": torch.tensor((pos,), dtype=input_pos_dtype)},
                         )
                     else:
                         prefix, logits_token_pos = self._prepare_calibration_prefix(


### PR DESCRIPTION
- Add the export/runtime plumbing needed for KV-cache SmolLM2-style models on Ethos-U. This includes int32 token/input_pos example inputs for Arm backends, initialized KV cache mutable buffers, calibration dtype preservation, and an Ethos-U partitioner guard for unsupported KV cache index ops.

- Extend the semihosting runner with input rebinding and server mode so step-wise KV-cache decoding can reuse one FVP process across token runs.

AI-assisted-by: Codex

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani