### PR TITLE
Disable -v in install_executorch.py by default

### DIFF
--- a/install_executorch.py
+++ b/install_executorch.py
@@ -191,6 +191,12 @@ def _parse_args() -> argparse.Namespace:
         help="Only installs necessary dependencies for core executorch and skips "
         " packages necessary for running example scripts.",
     )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Pass -v to pip when installing the ExecuTorch package.",
+    )
     allowed_optional_dependencies = ["ethos_u", "vgf", "openvino"]
     parser.add_argument(
         "--optional-dependency",
@@ -241,9 +247,10 @@ def main(args):
         + [
             package_spec,
             "--no-build-isolation",
-            "-v",
         ]
     )
+    if args.verbose:
+        cmd.append("-v")
     subprocess.run(cmd, check=True)
 
     # Step 3: Extra (optional) packages that is only useful for running examples.


### PR DESCRIPTION
It produces extremley long logs (~18k lines) without a clear benefit in most cases.

It can be re-enabled in select jobs by passing --verbose.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani