### PR TITLE
Reject non-default dim order in unfold_copy and select_scatter

### DIFF
--- a/kernels/portable/cpu/op_select_scatter.cpp
+++ b/kernels/portable/cpu/op_select_scatter.cpp
@@ -37,6 +37,8 @@ Tensor& select_scatter_out(
   ET_KERNEL_CHECK(
       ctx, tensors_have_same_dim_order(in, src, out), InvalidArgument, out);
 
+  ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(in), InvalidArgument, out);
+
   // Account for negative indices
   if (dim < 0) {
     dim += in.dim();

--- a/kernels/portable/cpu/op_unfold_copy.cpp
+++ b/kernels/portable/cpu/op_unfold_copy.cpp
@@ -39,6 +39,10 @@ Tensor& unfold_copy_out(
       InvalidArgument,
       out);
 
+  ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(self), InvalidArgument, out);
+
+  ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(out), InvalidArgument, out);
+
   // Copy data
   const size_t leading_dims = getLeadingDims(self, dim);
   const size_t trailing_dims = getTrailingDims(self, dim);

--- a/kernels/test/CMakeLists.txt
+++ b/kernels/test/CMakeLists.txt
@@ -306,6 +306,7 @@ set(all_test_sources
     "op_tril_test.cpp"
     "op_trunc_test.cpp"
     "op_unbind_copy_test.cpp"
+    "op_unfold_copy_test.cpp"
     "op_unsqueeze_copy_test.cpp"
     "op_upsample_bilinear2d_test.cpp"
     "op_upsample_bilinear2d_aa_test.cpp"

--- a/kernels/test/op_select_scatter_test.cpp
+++ b/kernels/test/op_select_scatter_test.cpp
@@ -665,3 +665,24 @@ TEST_F(OpSelectScatterOutTest, DynamicShapeUnbound) {
   test_dynamic_shape(
       {1, 1, 1}, torch::executor::TensorShapeDynamism::DYNAMIC_UNBOUND);
 }
+
+TEST_F(OpSelectScatterOutTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  // src is one rank below in, so at rank 4 the same dim order check above
+  // rejects first. Only rank 5 reaches the default dim order check, because
+  // is_channels_last_dim_order accepts both 4 and 5 dims.
+  Tensor in = tf.make_with_dimorder(
+      {2, 2, 2, 2, 2}, std::vector<float>(32, 1), {0, 2, 3, 4, 1});
+  Tensor src = tf.make_with_dimorder(
+      {2, 2, 2, 2}, std::vector<float>(16, 2), {0, 2, 3, 1});
+  Tensor out = tf.make_with_dimorder(
+      {2, 2, 2, 2, 2}, std::vector<float>(32), {0, 2, 3, 4, 1});
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_, op_select_scatter_out(in, src, /*dim=*/0, /*index=*/0, out));
+}

--- a/kernels/test/op_select_scatter_test.cpp
+++ b/kernels/test/op_select_scatter_test.cpp
@@ -669,13 +669,14 @@ TEST_F(OpSelectScatterOutTest, DynamicShapeUnbound) {
 TEST_F(OpSelectScatterOutTest, NonDefaultDimOrderDies) {
   TensorFactory<ScalarType::Float> tf;
 
-  // src is one rank below in, so at rank 4 the same dim order check above
+  // src is one rank below x, so at rank 4 the same dim order check above
   // rejects first. Only rank 5 reaches the default dim order check, because
   // is_channels_last_dim_order accepts both 4 and 5 dims.
-  Tensor in = tf.make_with_dimorder(
+  Tensor x = tf.make_with_dimorder(
       {2, 2, 2, 2, 2}, std::vector<float>(32, 1), {0, 2, 3, 4, 1});
   Tensor src = tf.make_with_dimorder(
       {2, 2, 2, 2}, std::vector<float>(16, 2), {0, 2, 3, 1});
+
   Tensor out = tf.make_with_dimorder(
       {2, 2, 2, 2, 2}, std::vector<float>(32), {0, 2, 3, 4, 1});
 
@@ -684,5 +685,5 @@ TEST_F(OpSelectScatterOutTest, NonDefaultDimOrderDies) {
       "ATen kernel can handle non-default dim order");
 
   ET_EXPECT_KERNEL_FAILURE(
-      context_, op_select_scatter_out(in, src, /*dim=*/0, /*index=*/0, out));
+      context_, op_select_scatter_out(x, src, /*dim=*/0, /*index=*/0, out));
 }

--- a/kernels/test/op_unfold_copy_test.cpp
+++ b/kernels/test/op_unfold_copy_test.cpp
@@ -13,6 +13,8 @@
 #include <executorch/runtime/core/exec_aten/util/tensor_util.h>
 
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
+#include <executorch/kernels/test/supported_features_skip.h>
 
 #include <gtest/gtest.h>
 
@@ -126,4 +128,34 @@ TEST_F(OpUnfoldTest, InvalidDimAndSizeTooLargeDies) {
   ET_EXPECT_KERNEL_FAILURE(
       context_,
       op_unfold_copy_out(input, /*dim=*/1, /*size=*/10, /*step=*/1, output));
+}
+
+TEST_F(OpUnfoldTest, NonDefaultDimOrderSelfDies) {
+  TensorFactory<ScalarType::Float> tf;
+  const auto input =
+      tf.channels_last_like(tf.make({1, 2, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8}));
+  auto output = tf.zeros({1, 2, 2, 2, 1});
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_unfold_copy_out(input, /*dim=*/3, /*size=*/1, /*step=*/1, output));
+}
+
+TEST_F(OpUnfoldTest, NonDefaultDimOrderOutDies) {
+  TensorFactory<ScalarType::Float> tf;
+  const auto input = tf.make({1, 2, 2, 2}, {1, 2, 3, 4, 5, 6, 7, 8});
+  auto output = tf.make_with_dimorder(
+      {1, 2, 2, 2, 1}, std::vector<float>(8), {0, 2, 3, 4, 1});
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      op_unfold_copy_out(input, /*dim=*/3, /*size=*/1, /*step=*/1, output));
 }


### PR DESCRIPTION
### Summary

Follow-up to #21865. Two more portable kernels index with `getLeadingDims` and `getTrailingDims`, which describe a contiguous run only in the default dim order.

`unfold_copy` carries no dim order check at all. Checked against the same logical data in two memory formats:

| kernel | contiguous input | channels-last input |
|---|---|---|
| `aten.unfold_copy` | matches | wrong, max abs diff 14.0 |

It reads `self` as a contiguous run and writes `out` as a flat run, so neither side survives a non-default layout. `unfold` appears in shipped example models including the Qualcomm llama vision encoder and the gemma4 speech transform, where a channels-last input is ordinary.

`select_scatter` has the same arithmetic and the same defect, but it is not reachable from export today. It carries `tensors_have_same_dim_order(in, src, out)`, which is not sufficient on its own, because `is_channels_last_dim_order` accepts 4 and 5 dims, so a rank-5 input and its rank-4 `src` can both be channels-last and pass together. At rank 4 the `src` is rank 3 and the check does reject. Reaching the rank-5 case needs a channels-last dim order that `exir/dim_order_utils.py` refuses to generate, since it raises for any rank other than 4. So the kernel is protected by a gap in the export layer rather than by its own checks, and the guard closes that before 5D channels-last support makes it reachable.

Both get the guard `op_addmm`, `op_bmm` and the kernels in #21865 use:

```cpp
ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(in), InvalidArgument, out);
```

`unfold_copy` needs it on `out` as well, since `out` is one rank above `self` and is written as a flat run. Checking the pair with `tensors_have_same_dim_order` would not work there, for the same rank reason as above.

### Test plan

A `NonDefaultDimOrderDies` per kernel, plus a second `unfold_copy` case covering the `out` guard. Reverting the two kernel sources while keeping the tests fails all three.

The `select_scatter` test has to be rank 5. A rank-4 case is rejected by the pre-existing same dim order check on current main, so it would pass without reaching the new guard. It builds its tensors with `make_with_dimorder`, because `channels_last_like` asserts `sizes.size() == 4` and cannot express the failing case.

All three tests skip under `is_aten`, since the ATen kernels handle a non-default dim order and do not throw.

This also registers `op_unfold_copy_test.cpp` in `kernels/test/CMakeLists.txt`, without which neither the existing tests in that file nor the new ones run in a CMake build.


cc @larryliu0820 @manuelcandales @JakeStevens