### PR TITLE
Guard access to dump_artifacts pytest option

### DIFF
--- a/backends/arm/test/conftest.py
+++ b/backends/arm/test/conftest.py
@@ -25,7 +25,7 @@ def pytest_configure(config):
 
     if getattr(config.option, "llama_inputs", False) and config.option.llama_inputs:
         pytest._test_options["llama_inputs"] = config.option.llama_inputs  # type: ignore[attr-defined]
-    if config.option.dump_artifacts:
+    if getattr(config.option, "dump_artifacts", False) and config.option.dump_artifacts:
         pytest._test_options["dump_artifacts"] = config.option.dump_artifacts  # type: ignore[attr-defined]
 
     logging.basicConfig(stream=sys.stdout)


### PR DESCRIPTION
### Summary
Guard access to the `dump_artifacts` pytest option so ARM test configuration does not fail when the option is not registered.

### Test plan
- `git diff --check`
- `python3 -m py_compile backends/arm/test/conftest.py`

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani