### PR TITLE
Migrate to Graph.materialize_symints; stop passing raw SymInts (#21919)

### DIFF
--- a/backends/arm/_passes/convert_full_like_to_full_pass.py
+++ b/backends/arm/_passes/convert_full_like_to_full_pass.py
@@ -42,7 +42,9 @@ class ConvertFullLikeToFullPass(ArmOpTargetedPass):
             return super().call_operator(op, args, kwargs, meta)
 
         tensor = args[0].data
-        full_args = (list(tensor.shape), args[1])
+        # Each entry is an int (static dim) or an aten.sym_size.int ProxyValue (dynamic dim).
+        size_args = self.call_size_operator_all(args[0], meta, edge_dialect=True)
+        full_args = (size_args, args[1])
         full_kwargs = {"dtype": tensor.dtype}
         return super().call_operator(
             exir_ops.edge.aten.full.default, full_args, full_kwargs, meta

--- a/backends/arm/_passes/decompose_linear_pass.py
+++ b/backends/arm/_passes/decompose_linear_pass.py
@@ -56,7 +56,23 @@ class DecomposeLinearPass(ArmOpTargetedPass):
             # weights have shape (Co, Ci)
             weights_reshaped_shape = [weights_shape[0], weights_shape[1], 1, 1]
 
+            # Materialize SymInts into FX nodes; one call shares
+            # the symbol subgraph across all three shape lists.
             with graph_module.graph.inserting_before(node):
+                n_in, n_w = (
+                    len(input_reshaped_shape),
+                    len(weights_reshaped_shape),
+                )
+                all_sizes = graph_module.graph.materialize_symints(
+                    [
+                        *input_reshaped_shape,
+                        *weights_reshaped_shape,
+                        *output_shape,
+                    ]
+                )
+                input_reshaped_shape = all_sizes[:n_in]
+                weights_reshaped_shape = all_sizes[n_in : n_in + n_w]
+                output_size = all_sizes[n_in + n_w :]
                 # Reshape input to 4D with shape (N, Ci, 1, 1)
                 input_reshaped = create_node(
                     graph=graph_module.graph,
@@ -103,7 +119,7 @@ class DecomposeLinearPass(ArmOpTargetedPass):
                 output = create_node(
                     graph=graph_module.graph,
                     op_target=exir_ops.edge.aten.view_copy.default,
-                    args=(conv, list(output_shape)),
+                    args=(conv, output_size),
                     kwargs={},
                     from_node=node,
                     inherit_qparams=False,

--- a/backends/arm/_passes/decompose_select.py
+++ b/backends/arm/_passes/decompose_select.py
@@ -56,10 +56,18 @@ class DecomposeSelectPass(ArmOpTargetedPass):
                 index = size_at_dim - abs(index)
 
             with graph_module.graph.inserting_before(node):
+                # ``Graph.create_node`` rejects raw SymInts in call_function
+                # args; ``materialize_symints`` lifts symbolic ``index`` /
+                # ``index + 1`` (from negative-index wrap-around against a
+                # dynamic shape) into graph nodes in a single call (shares
+                # producer-discovery + hash-cons). Static ints pass through.
+                start_arg, end_arg = graph_module.graph.materialize_symints(
+                    [index, index + 1]
+                )
                 slice_node = create_node(
                     graph_module.graph,
                     slice_op,
-                    (input_node, dim, index, index + 1),
+                    (input_node, dim, start_arg, end_arg),
                     from_node=node,
                     inherit_qparams=False,
                 )

--- a/backends/arm/_passes/insert_dynamic_padding.py
+++ b/backends/arm/_passes/insert_dynamic_padding.py
@@ -5,8 +5,6 @@
 
 from typing import Set, Type
 
-import torch
-
 from executorch.backends.arm._passes import ArmOpTargetedPass
 from executorch.backends.arm.tosa.dialect.shape import is_shape_op_node
 
@@ -41,7 +39,7 @@ class InsertDynamicPaddingPass(ArmOpTargetedPass):
         return (isinstance(padding, ProxyValue) and is_shape_op_node(padding.node)) or (
             (
                 isinstance(padding, (list, tuple))
-                and any(isinstance(p, torch.SymInt) for p in padding)
+                and any(isinstance(p, ProxyValue) for p in padding)
             )
         )
 

--- a/backends/arm/_passes/rewrite_conv_pass.py
+++ b/backends/arm/_passes/rewrite_conv_pass.py
@@ -817,6 +817,29 @@ class RewriteConvPass(ArmPass):
                     dilation,
                 )
 
+            # Compute fake tensor BEFORE materializing SymInts into FX nodes,
+            # since the underlying op expects ints/SymInts (not FX Nodes).
+            bias_fake_tensor = get_first_fake_tensor(bias) if bias else None
+            tosa_node_fake_tensor = target_op(
+                input_tensor_for_tosa_fake,
+                weight_fake_tensor,
+                bias_fake_tensor,
+                *conv_args[3:],
+            )
+
+            # ``Graph.create_node`` rejects raw SymInts in call_function args.
+            # If ``pad`` contains symbolic entries, materialize them into FX
+            # nodes so the TOSA conv node references the producing graph
+            # subgraph instead of holding raw SymInts.
+            if isinstance(pad, (list, tuple)) and any(
+                isinstance(p, torch.SymInt) for p in pad
+            ):
+                with graph_module.graph.inserting_before(node):
+                    materialized_pad = graph_module.graph.materialize_symints(pad)
+                new_conv_args = list(conv_args)
+                new_conv_args[4] = materialized_pad
+                conv_args = tuple(new_conv_args)
+
             with graph_module.graph.inserting_after(node):
                 tosa_op = create_node(
                     graph=graph_module.graph,
@@ -825,13 +848,6 @@ class RewriteConvPass(ArmPass):
                     from_node=node,
                     inherit_qparams=True,
                 )
-            bias_fake_tensor = get_first_fake_tensor(bias) if bias else None
-            tosa_node_fake_tensor = target_op(
-                input_tensor_for_tosa_fake,
-                weight_fake_tensor,
-                bias_fake_tensor,
-                *conv_args[3:],
-            )
             tosa_op.meta["val"] = tosa_node_fake_tensor
 
             node_replacement, node_replacement_fake_tensor = (

--- a/backends/arm/_passes/size_adjust_input_pass.py
+++ b/backends/arm/_passes/size_adjust_input_pass.py
@@ -83,13 +83,13 @@ def _get_slice_adjustment(
     if exact_values is not None:
         adjustments = {max(value - pad, 0) for value in exact_values}
         if len(adjustments) == 1:
-            adjustment = next(iter(adjustments))
-            return adjustment if adjustment > 0 else None
+            exact_adjustment = next(iter(adjustments))
+            return exact_adjustment if exact_adjustment > 0 else None
 
     if pad >= stride - 1:
         return None
 
-    adjustment: SymIntLike | None = None  # type: ignore[no-redef]
+    adjustment: SymIntLike | None = None
     for threshold in range(pad + 1, stride):
         term = (remainder + stride - threshold) // stride
         adjustment = term if adjustment is None else adjustment + term
@@ -272,10 +272,29 @@ class SizeAdjustInputPass(ArmPass):
 
             parent_node = node.args[0]
             with graph_module.graph.inserting_before(node):
+                # ``Graph.create_node`` rejects raw SymInts in
+                # call_function args. Aggregate every slice arg across
+                # all entries and lift via a single ``materialize_symints``
+                # call -- the helper walks the graph once for producer
+                # discovery, so a single call amortises that cost and lets
+                # symints with shared sub-expressions get hash-consed into
+                # one subgraph. Plain ints pass through unchanged.
+                flat = [a for args in slice_args for a in args]
+                materialized = iter(graph.materialize_symints(flat))
+                # Pop exactly len(args) values from the materialized iterator
+                # and pack them back into a tuple -- regroups the flat list
+                # of lifted values into the original (dim, start, end) shape.
+                lifted_slice_args = [
+                    tuple(next(materialized) for _ in args) for args in slice_args
+                ]
+
                 last_node = cast(torch.fx.Node, parent_node)
-                for args in slice_args:
+                for args in lifted_slice_args:
                     slice_node = create_node(
-                        graph, slice_op, (last_node,) + args, from_node=node
+                        graph,
+                        slice_op,
+                        (last_node,) + args,
+                        from_node=node,
                     )
                     last_node = slice_node
                 node.replace_input_with(cast(torch.fx.Node, parent_node), last_node)

--- a/backends/arm/test/passes/test_decompose_select_pass.py
+++ b/backends/arm/test/passes/test_decompose_select_pass.py
@@ -63,11 +63,18 @@ def test_decompose_select_negative_symbolic_index_uses_symbolic_sub() -> None:
 
     slice_node = slice_nodes[0]
     assert slice_node.args[1] == 1
-    assert slice_node.args[2] != -1
-    assert isinstance(slice_node.args[2], torch.SymInt)
-    assert isinstance(slice_node.args[3], torch.SymInt)
-    assert str(slice_node.args[2]).endswith(" - 1")
-    assert str(slice_node.args[3]) in str(slice_node.args[2])
+    # Start/end are now FX nodes (materialized from SymInts) rather than raw
+    # SymInts, since Graph.create_node rejects raw symbolic leaves in
+    # call_function args. The original SymInt is preserved in meta['val'].
+    start_arg, end_arg = slice_node.args[2], slice_node.args[3]
+    assert isinstance(start_arg, torch.fx.Node)
+    assert isinstance(end_arg, torch.fx.Node)
+    start_val = start_arg.meta["val"]
+    end_val = end_arg.meta["val"]
+    assert isinstance(start_val, torch.SymInt)
+    assert isinstance(end_val, torch.SymInt)
+    assert str(start_val).endswith(" - 1")
+    assert str(end_val) in str(start_val)
     assert squeeze_nodes[0].args == (slice_node, [1])
 
     result.graph_module.graph.lint()

--- a/backends/arm/test/passes/test_insert_dynamic_padding_pass.py
+++ b/backends/arm/test/passes/test_insert_dynamic_padding_pass.py
@@ -3,56 +3,20 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import executorch.backends.arm.tosa.dialect  # noqa: F401
 import torch
 from executorch.backends.arm._passes.insert_dynamic_padding import (
     InsertDynamicPaddingPass,
 )
-from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
+from executorch.backends.arm._passes.rewrite_conv_pass import RewriteConvPass
 from executorch.backends.arm.tosa.specification import (
     TosaLoweringContext,
     TosaSpecification,
 )
-from executorch.backends.test.graph_builder import GraphBuilder
+from executorch.exir import to_edge
 from executorch.exir.dialects._ops import ops as exir_ops
-from executorch.exir.pass_base import ExportPass
+from torch._export.utils import _get_shape_env_from_gm
+from torch.export import Dim, export
 from torch.fx import GraphModule
-from torch.fx.passes.infra.pass_base import PassResult
-
-
-SPEC = TosaSpecification.create_from_string("TOSA-1.1+FP+shape")
-
-
-def _build_conv_graph(
-    target_op,
-    input_shape: tuple[int, ...],
-    weight_shape: tuple[int, ...],
-    padding: list[int],
-    stride: list[int],
-    dilation: list[int],
-) -> GraphModule:
-    with TosaLoweringContext(SPEC):
-        builder = GraphBuilder()
-        input_tensor = builder.placeholder("input", torch.randn(input_shape))
-        weight = builder.placeholder("weight", torch.randn(weight_shape))
-        bias = builder.placeholder("bias", torch.randn(weight_shape[0]))
-        padding_shape = builder.call_operator(
-            exir_ops.backend.tosa.CONST_SHAPE.default, (padding,)
-        )
-        padding_shape.node.meta[TosaSpecialDtype.meta_key()] = TosaSpecialDtype.SHAPE
-        conv = builder.call_operator(
-            target_op,
-            (input_tensor, weight, bias, stride, padding_shape, dilation),
-        )
-        builder.output([conv])
-        return ExportPass().call(builder.get_graph_module()).graph_module
-
-
-def _run_insert_dynamic_padding(graph_module: GraphModule) -> GraphModule:
-    with TosaLoweringContext(SPEC):
-        result = InsertDynamicPaddingPass()(graph_module)
-    assert isinstance(result, PassResult)
-    return result.graph_module
 
 
 def _assert_inserted_padding(
@@ -63,7 +27,19 @@ def _assert_inserted_padding(
 ) -> None:
     nodes = graph_module.graph.nodes
     conv_node = next(n for n in nodes if n.target == target_op)
-    assert conv_node.args[4] == zero_spatial_padding
+    # ``Graph.materialize_symints`` may have lifted SymInt pad entries into
+    # FX nodes; accept either plain ints or Nodes with the SymInt in meta['val'].
+    assert (
+        all(
+            (
+                (p == exp)
+                if isinstance(p, int)
+                else (p.meta["val"] == exp) if isinstance(p, torch.fx.Node) else False
+            )
+            for p, exp in zip(conv_node.args[4], zero_spatial_padding, strict=True)
+        )
+        or conv_node.args[4] == zero_spatial_padding
+    )
 
     padding_node = next(
         n for n in nodes if n.target == exir_ops.backend.tosa.PAD.default
@@ -73,52 +49,172 @@ def _assert_inserted_padding(
 
     n_padding, spatial_padding, c_padding = padding_shape_node.args[0]
     assert n_padding.meta["val"] == [0, 0]
-    assert spatial_padding.target == exir_ops.backend.tosa.CONST_SHAPE.default
     assert c_padding.meta["val"] == [0, 0]
 
     pad_list = padding_shape_node.meta["val"]
-    spatial_padding_value = spatial_padding.meta["val"]
-    assert len(pad_list) == expected_full_padding_len
-    assert pad_list[:2] == [0, 0]
-    assert pad_list[2:-2] == spatial_padding_value
-    assert pad_list[-2:] == [0, 0]
+    pad_list_vals = [
+        p.meta["val"] if isinstance(p, torch.fx.Node) else p for p in pad_list
+    ]
+    assert len(pad_list_vals) == expected_full_padding_len
+    assert pad_list_vals[:2] == [0, 0]
+    assert pad_list_vals[-2:] == [0, 0]
+    # For static graphs spatial_padding is a CONST_SHAPE node; for dynamic
+    # graphs (RewriteConvPass materialized) it is an immutable_list of Nodes/ints.
+    if hasattr(spatial_padding, "target"):
+        assert spatial_padding.target == exir_ops.backend.tosa.CONST_SHAPE.default
+        spatial_padding_value = spatial_padding.meta["val"]
+        if isinstance(spatial_padding_value, (list, tuple)):
+            spatial_vals = [
+                p.meta["val"] if isinstance(p, torch.fx.Node) else p
+                for p in spatial_padding_value
+            ]
+            assert pad_list_vals[2:-2] == spatial_vals
+        else:
+            assert pad_list_vals[2:-2] == spatial_padding_value
+    else:
+        # Dynamic case: spatial_padding is the original pad list (possibly Nodes)
+        spatial_vals = [
+            p.meta["val"] if isinstance(p, torch.fx.Node) else p
+            for p in spatial_padding
+        ]
+        assert pad_list_vals[2:-2] == spatial_vals
+
+
+class ConvModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 16, kernel_size=2, stride=3, padding=2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+class Conv3dModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv3d(3, 16, kernel_size=2, stride=3, padding=2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+def _export_conv_model(conv_cls, example_inputs, dynamic_shapes):
+    model = conv_cls()
+    ep = export(model, example_inputs, dynamic_shapes=dynamic_shapes)
+    edge_model = to_edge(ep)
+    shape_env = _get_shape_env_from_gm(edge_model.exported_program().graph_module)
+    return edge_model, shape_env
 
 
 def test_insert_dynamic_padding():
-    graph_module = _build_conv_graph(
-        exir_ops.backend.tosa.CONV2D.default,
-        input_shape=(1, 8, 8, 3),
-        weight_shape=(16, 2, 2, 3),
-        padding=[2, 2, 2, 2],
-        stride=[3, 3],
-        dilation=[1, 1],
+    edge_model, shape_env = _export_conv_model(
+        ConvModule,
+        (torch.randn(1, 3, 8, 8),),
+        dynamic_shapes={
+            "x": {2: Dim("height", min=4, max=10), 3: Dim("width", min=4, max=10)}
+        },
     )
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ):
+        edge_model = edge_model.transform(
+            [RewriteConvPass(edge_model.exported_program())]
+        )
+        # Verify pad was materialized into FX nodes (Graph.materialize_symints).
+        nodes = edge_model.exported_program().graph.nodes
+        conv_node = next(
+            n for n in nodes if n.target == exir_ops.backend.tosa.CONV2D.default
+        )
+        initial_padding = conv_node.args[4]
+        assert any(isinstance(p, torch.fx.Node) for p in initial_padding)
+        initial_padding_vals = [
+            p.meta["val"] if isinstance(p, torch.fx.Node) else p
+            for p in initial_padding
+        ]
 
-    graph_module = _run_insert_dynamic_padding(graph_module)
+        edge_model = edge_model.transform([InsertDynamicPaddingPass()])
+        graph_module = edge_model.exported_program().graph_module
 
-    _assert_inserted_padding(
-        graph_module,
-        exir_ops.backend.tosa.CONV2D.default,
-        zero_spatial_padding=[0, 0, 0, 0],
-        expected_full_padding_len=8,
-    )
+        conv_node = next(
+            n
+            for n in graph_module.graph.nodes
+            if n.target == exir_ops.backend.tosa.CONV2D.default
+        )
+        assert conv_node.args[4] == [0, 0, 0, 0]
+        padding_node = next(
+            n
+            for n in graph_module.graph.nodes
+            if n.target == exir_ops.backend.tosa.PAD.default
+        )
+        assert padding_node is not None
+        pad_list = padding_node.args[1].meta["val"]
+        assert len(pad_list) == 8
+        assert pad_list[:2] == [0, 0]
+        assert pad_list[2:6] == initial_padding_vals
+        assert pad_list[6:] == [0, 0]
+
+        # Cross-check the shared _assert_inserted_padding helper against the same graph.
+        _assert_inserted_padding(
+            graph_module,
+            exir_ops.backend.tosa.CONV2D.default,
+            zero_spatial_padding=[0, 0, 0, 0],
+            expected_full_padding_len=8,
+        )
 
 
 def test_insert_dynamic_padding_conv3d():
-    graph_module = _build_conv_graph(
-        exir_ops.backend.tosa.CONV3D.default,
-        input_shape=(1, 8, 8, 8, 3),
-        weight_shape=(16, 2, 2, 2, 3),
-        padding=[2, 2, 2, 2, 2, 2],
-        stride=[3, 3, 3],
-        dilation=[1, 1, 1],
+    edge_model, shape_env = _export_conv_model(
+        Conv3dModule,
+        (torch.randn(1, 3, 8, 8, 8),),
+        dynamic_shapes={
+            "x": {
+                2: Dim("depth", min=4, max=10),
+                3: Dim("height", min=4, max=10),
+                4: Dim("width", min=4, max=10),
+            }
+        },
     )
+    with TosaLoweringContext(
+        TosaSpecification.create_from_string("TOSA-1.1+FP+shape"), shape_env
+    ):
+        edge_model = edge_model.transform(
+            [RewriteConvPass(edge_model.exported_program())]
+        )
+        nodes = edge_model.exported_program().graph.nodes
+        conv_node = next(
+            n for n in nodes if n.target == exir_ops.backend.tosa.CONV3D.default
+        )
+        initial_padding = conv_node.args[4]
+        assert any(isinstance(p, torch.fx.Node) for p in initial_padding)
+        initial_padding_vals = [
+            p.meta["val"] if isinstance(p, torch.fx.Node) else p
+            for p in initial_padding
+        ]
 
-    graph_module = _run_insert_dynamic_padding(graph_module)
+        edge_model = edge_model.transform([InsertDynamicPaddingPass()])
+        graph_module = edge_model.exported_program().graph_module
 
-    _assert_inserted_padding(
-        graph_module,
-        exir_ops.backend.tosa.CONV3D.default,
-        zero_spatial_padding=[0, 0, 0, 0, 0, 0],
-        expected_full_padding_len=10,
-    )
+        conv_node = next(
+            n
+            for n in graph_module.graph.nodes
+            if n.target == exir_ops.backend.tosa.CONV3D.default
+        )
+        assert conv_node.args[4] == [0, 0, 0, 0, 0, 0]
+        padding_node = next(
+            n
+            for n in graph_module.graph.nodes
+            if n.target == exir_ops.backend.tosa.PAD.default
+        )
+        assert padding_node is not None
+        pad_list = padding_node.args[1].meta["val"]
+        assert len(pad_list) == 10
+        assert pad_list[:2] == [0, 0]
+        assert pad_list[2:8] == initial_padding_vals
+        assert pad_list[8:] == [0, 0]
+
+        _assert_inserted_padding(
+            graph_module,
+            exir_ops.backend.tosa.CONV3D.default,
+            zero_spatial_padding=[0, 0, 0, 0, 0, 0],
+            expected_full_padding_len=10,
+        )

--- a/exir/BUCK
+++ b/exir/BUCK
@@ -255,6 +255,7 @@ fbcode_target(_kind = runtime.python_library,
         ":error",
         ":memory",
         "//caffe2:torch",
+        "//executorch/exir/dialects:lib",
         "//executorch/exir/dialects/edge:lib",
     ],
 )

--- a/exir/pass_base.py
+++ b/exir/pass_base.py
@@ -29,6 +29,7 @@ from typing import (
 import torch
 from executorch.exir import memory
 from executorch.exir.delegate import executorch_call_delegate, is_lowered_module
+from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
 from executorch.exir.error import ExportError, ExportErrorType
 from torch import fx
@@ -651,6 +652,58 @@ class _ExportPassBase(PassBase):
         meta: NodeMetadata,
     ) -> ProxyValue:
         return self._fx("call_function", op, args, kwargs, meta)
+
+    def call_size_operator(
+        self,
+        tensor_proxy: ProxyValue,
+        dim: int,
+        meta: NodeMetadata,
+        *,
+        edge_dialect: bool = False,
+    ) -> Union[ProxyValue, int]:
+        """Read ``tensor_proxy.size(dim)`` as a value usable in graph args.
+        Returns a plain ``int`` for static dims; emits and returns a
+        ``sym_size.int`` ``ProxyValue`` for SymInt dims (since
+        ``Graph.create_node`` rejects raw SymInts in call_function args).
+
+        When ``edge_dialect`` is True, emits ``exir_ops.edge.aten.sym_size.int``
+        so the node fits an edge-lowered graph; otherwise emits the raw
+        ``torch.ops.aten.sym_size.int``.
+        """
+        size = tensor_proxy.data.shape[dim]
+        if isinstance(size, torch.SymInt):
+            sym_size_op = (
+                exir_ops.edge.aten.sym_size.int
+                if edge_dialect
+                else torch.ops.aten.sym_size.int
+            )
+            new_proxy = self.call_operator(sym_size_op, (tensor_proxy, dim), {}, meta)
+            # Mirror source's "example_value" if present, so the new node
+            # matches the surrounding graph's meta-key convention. "val"
+            # is already set by call_operator → _fx → set_metadata.
+            if "example_value" in tensor_proxy.node.meta:
+                new_proxy.node.meta["example_value"] = new_proxy.node.meta["val"]
+            return new_proxy
+        return int(size)
+
+    def call_size_operator_all(
+        self,
+        tensor_proxy: ProxyValue,
+        meta: NodeMetadata,
+        *,
+        edge_dialect: bool = False,
+    ) -> list[Union[ProxyValue, int]]:
+        """Return all dims of ``tensor_proxy.shape`` as a list of values
+        usable in graph args. Each entry is an ``int`` (static dim) or a
+        ``sym_size.int`` ``ProxyValue`` (dynamic dim) — see
+        ``call_size_operator``.
+
+        ``edge_dialect`` selects the edge vs raw ATen ``sym_size.int`` op.
+        """
+        return [
+            self.call_size_operator(tensor_proxy, d, meta, edge_dialect=edge_dialect)
+            for d in range(len(tensor_proxy.data.shape))
+        ]
 
     def call_sym(
         self,

--- a/exir/tests/test_dynamic_shape_propagation.py
+++ b/exir/tests/test_dynamic_shape_propagation.py
@@ -115,7 +115,7 @@ class TestSymIntViewArgs(TestCase):
                 x = args[0]
                 x = super().call_operator(
                     exir_ops.edge.aten.view_copy.default,
-                    (x, list(x.data.shape) + [1]),
+                    (x, self.call_size_operator_all(x, meta) + [1]),
                     {},
                     meta,
                 )
@@ -123,7 +123,7 @@ class TestSymIntViewArgs(TestCase):
                 w = args[1]
                 w = super().call_operator(
                     exir_ops.edge.aten.view_copy.default,
-                    (w, list(w.data.shape) + [1]),
+                    (w, self.call_size_operator_all(w, meta) + [1]),
                     {},
                     meta,
                 )
@@ -144,7 +144,7 @@ class TestSymIntViewArgs(TestCase):
                 )
                 x = super().call_operator(
                     exir_ops.edge.aten.view_copy.default,
-                    (x, list(x.data.shape)[:-1]),
+                    (x, self.call_size_operator_all(x, meta)[:-1]),
                     {},
                     meta,
                 )


### PR DESCRIPTION
Summary:

Stacks on top of [fx] Add Graph.materialize_symints + helpers; warn on
raw SymInt args.

Updates the ARM backend passes (convert_full_like_to_full,
decompose_linear, decompose_select, insert_dynamic_padding,
rewrite_conv, size_adjust_input) and the ExportPass base to materialize
SymInt-typed FX-node arguments via Graph.materialize_symints /
create_size_node, so they no longer pass raw SymInts to
Graph.create_node and the new pytorch warning falls silent.

Test assertions in test_decompose_select_pass /
test_insert_dynamic_padding_pass / test_dynamic_shape_propagation are
updated to expect FX Nodes (with the SymInt stored in meta['val']).

This is the second of three diffs split from D107573548.

Reviewed By: digantdesai

Differential Revision: D109610966


