### PR TITLE
Rename channelwise_gated_delta_rule to gated_delta_rule (#21920)

### DIFF
--- a/examples/models/llama/attention.py
+++ b/examples/models/llama/attention.py
@@ -74,13 +74,13 @@ def register_attention(name: str):
 def _get_gated_delta_rule_op() -> Optional[Any]:
     """Return the fused gated delta rule op, or None if it is unavailable.
 
-    ``channelwise_gated_delta_rule`` accepts a per-head scalar decay as a 3D
+    ``gated_delta_rule`` accepts a per-head scalar decay as a 3D
     ``[B, H, T]`` tensor, which is the layout GatedDeltaNet produces. Resolve it
     lazily (importing the custom ops library on first use) and memoize so
     environments without the custom op fall back to the Python recurrence.
     """
     try:
-        return torch.ops.llama.channelwise_gated_delta_rule.default
+        return torch.ops.llama.gated_delta_rule.default
     except (AttributeError, RuntimeError):
         pass
 
@@ -91,7 +91,7 @@ def _get_gated_delta_rule_op() -> Optional[Any]:
         return None
 
     try:
-        return torch.ops.llama.channelwise_gated_delta_rule.default
+        return torch.ops.llama.gated_delta_rule.default
     except (AttributeError, RuntimeError):
         return None
 

--- a/examples/models/llama/tests/test_qwen3_5_attention.py
+++ b/examples/models/llama/tests/test_qwen3_5_attention.py
@@ -131,7 +131,7 @@ class Qwen35AttentionTest(unittest.TestCase):
         # the decode (T == 1) and prefill (T > 1) routes.
         from executorch.extension.llm.custom_ops import custom_ops  # noqa: F401
 
-        op = torch.ops.llama.channelwise_gated_delta_rule.default
+        op = torch.ops.llama.gated_delta_rule.default
 
         for seq_len in (1, 5, 40):
             with self.subTest(seq_len=seq_len):

--- a/extension/llm/custom_ops/BUCK
+++ b/extension/llm/custom_ops/BUCK
@@ -114,20 +114,20 @@ fbcode_target(_kind = runtime.python_test,
 )
 
 fbcode_target(_kind = runtime.python_library,
-    name = "bench_channelwise_gated_delta_rule_lib",
-    srcs = ["bench_channelwise_gated_delta_rule.py"],
+    name = "bench_gated_delta_rule_lib",
+    srcs = ["bench_gated_delta_rule.py"],
     base_module = "executorch.extension.llm.custom_ops",
     deps = ["//caffe2:torch"],
 )
 
 fbcode_target(_kind = runtime.python_binary,
-    name = "bench_channelwise_gated_delta_rule",
-    main_module = "executorch.extension.llm.custom_ops.bench_channelwise_gated_delta_rule",
+    name = "bench_gated_delta_rule",
+    main_module = "executorch.extension.llm.custom_ops.bench_gated_delta_rule",
     preload_deps = [
         ":custom_ops_aot_lib_mkl_noomp",
         ":custom_ops_aot_py",
     ],
-    deps = [":bench_channelwise_gated_delta_rule_lib"],
+    deps = [":bench_gated_delta_rule_lib"],
 )
 
 fbcode_target(_kind = runtime.python_test,

--- a/extension/llm/custom_ops/bench_gated_delta_rule.py
+++ b/extension/llm/custom_ops/bench_gated_delta_rule.py
@@ -6,7 +6,7 @@
 
 # pyre-unsafe
 
-"""Microbenchmark for the ``channelwise_gated_delta_rule`` custom op.
+"""Microbenchmark for the ``gated_delta_rule`` custom op.
 
 Times the fused recurrent kernel in isolation (no model) at representative
 GatedDeltaNet sizes, for both the decode (T=1) and prefill (T>1) regimes. Use it
@@ -14,7 +14,7 @@ to compare kernel variants (e.g. naive vs. fused) — rebuild the custom op, run
 this, and diff the numbers.
 
 Run (in an env where the custom op is built):
-    python -m executorch.extension.llm.custom_ops.bench_channelwise_gated_delta_rule
+    python -m executorch.extension.llm.custom_ops.bench_gated_delta_rule
 """
 
 import itertools
@@ -24,7 +24,7 @@ import torch
 
 from executorch.extension.llm.custom_ops import custom_ops  # noqa: F401
 
-_OP = torch.ops.llama.channelwise_gated_delta_rule.default
+_OP = torch.ops.llama.gated_delta_rule.default
 
 
 def _make_inputs(b: int, h: int, t: int, k: int, v: int, scalar_decay: bool = False):
@@ -74,7 +74,7 @@ def main() -> None:
     ]
 
     print(
-        f"channelwise_gated_delta_rule microbenchmark "
+        f"gated_delta_rule microbenchmark "
         f"(K=V={k}, fp32, 1 thread, state={32 * k * v * 4 // 1024}KB)"
     )
     print(

--- a/extension/llm/custom_ops/custom_ops.py
+++ b/extension/llm/custom_ops/custom_ops.py
@@ -379,7 +379,7 @@ def update_cache_with_indices_meta(
     return torch.empty((1,), dtype=value.dtype, device="meta")
 
 
-def _validate_channelwise_gated_delta_rule_params(
+def _validate_gated_delta_rule_params(
     query,
     key,
     value,
@@ -436,8 +436,8 @@ def _validate_channelwise_gated_delta_rule_params(
     )
 
 
-@impl(custom_ops_lib, "channelwise_gated_delta_rule", "Meta")
-def channelwise_gated_delta_rule_meta(
+@impl(custom_ops_lib, "gated_delta_rule", "Meta")
+def gated_delta_rule_meta(
     query,
     key,
     value,
@@ -445,7 +445,7 @@ def channelwise_gated_delta_rule_meta(
     beta,
     initial_state,
 ):
-    _validate_channelwise_gated_delta_rule_params(
+    _validate_gated_delta_rule_params(
         query,
         key,
         value,
@@ -455,6 +455,20 @@ def channelwise_gated_delta_rule_meta(
     )
     output_shape = (*query.shape[:3], value.size(3))
     return query.new_empty(output_shape), torch.empty_like(initial_state)
+
+
+# Deprecated alias of gated_delta_rule, kept so graphs built against the
+# pre-scalar-decay name keep tracing. Remove once those have been re-exported.
+@impl(custom_ops_lib, "channelwise_gated_delta_rule", "Meta")
+def channelwise_gated_delta_rule_meta(
+    query,
+    key,
+    value,
+    decay,
+    beta,
+    initial_state,
+):
+    return gated_delta_rule_meta(query, key, value, decay, beta, initial_state)
 
 
 def _validate_quantized_sdpa_params(

--- a/extension/llm/custom_ops/op_sdpa.cpp
+++ b/extension/llm/custom_ops/op_sdpa.cpp
@@ -193,7 +193,7 @@ bool validate_cache_params(
   return true;
 }
 
-bool validate_channelwise_gated_delta_rule_args(
+bool validate_gated_delta_rule_args(
     const Tensor& query,
     const Tensor& key,
     const Tensor& value,
@@ -1531,7 +1531,7 @@ void run_gated_delta_rule_chunked(
   }
 }
 
-std::tuple<Tensor&, Tensor&> channelwise_gated_delta_rule_out(
+std::tuple<Tensor&, Tensor&> gated_delta_rule_out(
     RuntimeContext& ctx,
     const Tensor& query,
     const Tensor& key,
@@ -1546,7 +1546,7 @@ std::tuple<Tensor&, Tensor&> channelwise_gated_delta_rule_out(
   // caller's out/final_state_out tensors untouched.
   ET_KERNEL_CHECK(
       ctx,
-      validate_channelwise_gated_delta_rule_args(
+      validate_gated_delta_rule_args(
           query, key, value, decay, beta, initial_state),
       InvalidArgument,
       ret);
@@ -1555,7 +1555,7 @@ std::tuple<Tensor&, Tensor&> channelwise_gated_delta_rule_out(
       !tensor_memory_ranges_overlap(initial_state, final_state_out),
       InvalidArgument,
       ret,
-      "channelwise_gated_delta_rule final_state_out must not alias initial_state.");
+      "gated_delta_rule final_state_out must not alias initial_state.");
   ET_KERNEL_CHECK(
       ctx, out.scalar_type() == ScalarType::Float, InvalidArgument, ret);
   ET_KERNEL_CHECK(
@@ -1587,13 +1587,13 @@ std::tuple<Tensor&, Tensor&> channelwise_gated_delta_rule_out(
               output_sizes, 4)) == Error::Ok,
       InvalidArgument,
       ret,
-      "Failed to resize channelwise_gated_delta_rule output tensor.");
+      "Failed to resize gated_delta_rule output tensor.");
   ET_KERNEL_CHECK_MSG(
       ctx,
       resize_tensor(final_state_out, initial_state.sizes()) == Error::Ok,
       InvalidArgument,
       ret,
-      "Failed to resize channelwise_gated_delta_rule final_state tensor.");
+      "Failed to resize gated_delta_rule final_state tensor.");
 
   // Route on sequence length: T == 1 is autoregressive decode (token-by-token
   // recurrence), T != 1 is prefill (chunkwise WY kernel). Prefill falls back to
@@ -1651,13 +1651,13 @@ EXECUTORCH_LIBRARY(
 
 namespace {
 
-void channelwise_gated_delta_rule_out_boxed(
+void gated_delta_rule_out_boxed(
     executorch::runtime::KernelRuntimeContext& ctx,
     executorch::runtime::Span<executorch::runtime::EValue*> stack) {
   executorch::runtime::internal::EventTracerProfileOpScope
       event_tracer_op_scope(
           ctx.internal_event_tracer(),
-          "native_call_llama::channelwise_gated_delta_rule.out");
+          "native_call_llama::gated_delta_rule.out");
   // Multi-output out variants get a trailing TensorList aggregating the two
   // outputs appended by the emitter, so the boxed stack has 9 entries: 6 inputs
   // + out + final_state_out + [out, final_state_out]. The aggregate (stack[8])
@@ -1680,13 +1680,22 @@ void channelwise_gated_delta_rule_out_boxed(
   auto& out = stack[6]->toTensor();
   auto& final_state_out = stack[7]->toTensor();
 
-  (void)torch::executor::native::channelwise_gated_delta_rule_out(
+  (void)torch::executor::native::gated_delta_rule_out(
       ctx, query, key, value, decay, beta, initial_state, out, final_state_out);
 }
 
+const auto gated_delta_rule_out_registration =
+    executorch::runtime::register_kernel(executorch::runtime::Kernel(
+        "llama::gated_delta_rule.out",
+        gated_delta_rule_out_boxed));
+
+// Deprecated alias: the op was named channelwise_gated_delta_rule before it
+// learned the scalar decay layout. Kept so .pte files emitted against the old
+// name still resolve a kernel; remove once those have been re-exported. Traces
+// report the new name for both, since the boxed function is shared.
 const auto channelwise_gated_delta_rule_out_registration =
     executorch::runtime::register_kernel(executorch::runtime::Kernel(
         "llama::channelwise_gated_delta_rule.out",
-        channelwise_gated_delta_rule_out_boxed));
+        gated_delta_rule_out_boxed));
 
 } // namespace

--- a/extension/llm/custom_ops/op_sdpa.h
+++ b/extension/llm/custom_ops/op_sdpa.h
@@ -78,7 +78,7 @@ Tensor& custom_quantized_sdpa_out(
     const bool is_seq_at_dim_1,
     Tensor& output);
 
-std::tuple<Tensor&, Tensor&> channelwise_gated_delta_rule_out(
+std::tuple<Tensor&, Tensor&> gated_delta_rule_out(
     RuntimeContext& ctx,
     const Tensor& query,
     const Tensor& key,

--- a/extension/llm/custom_ops/op_sdpa_aot.cpp
+++ b/extension/llm/custom_ops/op_sdpa_aot.cpp
@@ -377,7 +377,7 @@ at::Tensor update_cache_with_indices_aten(
   return output;
 }
 
-std::tuple<Tensor&, Tensor&> channelwise_gated_delta_rule_out_no_context(
+std::tuple<Tensor&, Tensor&> gated_delta_rule_out_no_context(
     const Tensor& query,
     const Tensor& key,
     const Tensor& value,
@@ -387,7 +387,7 @@ std::tuple<Tensor&, Tensor&> channelwise_gated_delta_rule_out_no_context(
     Tensor& out,
     Tensor& final_state_out);
 
-std::tuple<at::Tensor, at::Tensor> channelwise_gated_delta_rule_aten(
+std::tuple<at::Tensor, at::Tensor> gated_delta_rule_aten(
     const at::Tensor& query,
     const at::Tensor& key,
     const at::Tensor& value,
@@ -395,7 +395,7 @@ std::tuple<at::Tensor, at::Tensor> channelwise_gated_delta_rule_aten(
     const at::Tensor& beta,
     const at::Tensor& initial_state);
 
-std::tuple<at::Tensor&, at::Tensor&> channelwise_gated_delta_rule_out_aten(
+std::tuple<at::Tensor&, at::Tensor&> gated_delta_rule_out_aten(
     const at::Tensor& query,
     const at::Tensor& key,
     const at::Tensor& value,
@@ -405,7 +405,7 @@ std::tuple<at::Tensor&, at::Tensor&> channelwise_gated_delta_rule_out_aten(
     at::Tensor& out,
     at::Tensor& final_state_out);
 
-std::tuple<Tensor&, Tensor&> channelwise_gated_delta_rule_out_no_context(
+std::tuple<Tensor&, Tensor&> gated_delta_rule_out_no_context(
     const Tensor& query,
     const Tensor& key,
     const Tensor& value,
@@ -415,7 +415,7 @@ std::tuple<Tensor&, Tensor&> channelwise_gated_delta_rule_out_no_context(
     Tensor& out,
     Tensor& final_state_out) {
   executorch::aten::RuntimeContext context{};
-  auto result = torch::executor::native::channelwise_gated_delta_rule_out(
+  auto result = torch::executor::native::gated_delta_rule_out(
       context,
       query,
       key,
@@ -427,11 +427,11 @@ std::tuple<Tensor&, Tensor&> channelwise_gated_delta_rule_out_no_context(
       final_state_out);
   TORCH_CHECK(
       context.failure_state() == executorch::runtime::Error::Ok,
-      "channelwise_gated_delta_rule failed");
+      "gated_delta_rule failed");
   return result;
 }
 
-std::tuple<at::Tensor, at::Tensor> channelwise_gated_delta_rule_aten(
+std::tuple<at::Tensor, at::Tensor> gated_delta_rule_aten(
     const at::Tensor& query,
     const at::Tensor& key,
     const at::Tensor& value,
@@ -442,12 +442,12 @@ std::tuple<at::Tensor, at::Tensor> channelwise_gated_delta_rule_aten(
       {query.size(0), query.size(1), query.size(2), value.size(3)},
       query.options());
   auto final_state = at::empty_like(initial_state);
-  channelwise_gated_delta_rule_out_aten(
+  gated_delta_rule_out_aten(
       query, key, value, decay, beta, initial_state, output, final_state);
   return {output, final_state};
 }
 
-std::tuple<at::Tensor&, at::Tensor&> channelwise_gated_delta_rule_out_aten(
+std::tuple<at::Tensor&, at::Tensor&> gated_delta_rule_out_aten(
     const at::Tensor& query,
     const at::Tensor& key,
     const at::Tensor& value,
@@ -458,8 +458,8 @@ std::tuple<at::Tensor&, at::Tensor&> channelwise_gated_delta_rule_out_aten(
     at::Tensor& final_state_out) {
   TORCH_CHECK(
       !initial_state.is_alias_of(final_state_out),
-      "channelwise_gated_delta_rule final_state_out must not alias initial_state.");
-  return WRAP_TO_ATEN(channelwise_gated_delta_rule_out_no_context, 6)(
+      "gated_delta_rule final_state_out must not alias initial_state.");
+  return WRAP_TO_ATEN(gated_delta_rule_out_no_context, 6)(
       query, key, value, decay, beta, initial_state, out, final_state_out);
 }
 
@@ -509,6 +509,15 @@ TORCH_LIBRARY_FRAGMENT(llama, m) {
       "Tensor? k_zero_points=None, Tensor? k_scales=None, Tensor? v_zero_points=None, "
       "Tensor? v_scales=None, bool is_seq_at_dim_2=False, *, Tensor(a!) out) -> Tensor(a!)");
   m.def(
+      "gated_delta_rule(Tensor query, Tensor key, Tensor value, Tensor decay, "
+      "Tensor beta, Tensor initial_state) -> (Tensor, Tensor)");
+  m.def(
+      "gated_delta_rule.out(Tensor query, Tensor key, Tensor value, Tensor decay, "
+      "Tensor beta, Tensor initial_state, *, Tensor(a!) out, Tensor(b!) final_state_out) "
+      "-> (Tensor(a!), Tensor(b!))");
+  // Deprecated alias of gated_delta_rule, kept so graphs and .pte files built
+  // against the pre-scalar-decay name keep working. Remove once re-exported.
+  m.def(
       "channelwise_gated_delta_rule(Tensor query, Tensor key, Tensor value, Tensor decay, "
       "Tensor beta, Tensor initial_state) -> (Tensor, Tensor)");
   m.def(
@@ -548,10 +557,14 @@ TORCH_LIBRARY_IMPL(llama, CompositeExplicitAutograd, m) {
       "custom_quantized_sdpa.out",
       WRAP_TO_ATEN(
           torch::executor::native::custom_quantized_sdpa_out_no_context, 15));
+  m.impl("gated_delta_rule", torch::executor::native::gated_delta_rule_aten);
+  m.impl(
+      "gated_delta_rule.out",
+      torch::executor::native::gated_delta_rule_out_aten);
   m.impl(
       "channelwise_gated_delta_rule",
-      torch::executor::native::channelwise_gated_delta_rule_aten);
+      torch::executor::native::gated_delta_rule_aten);
   m.impl(
       "channelwise_gated_delta_rule.out",
-      torch::executor::native::channelwise_gated_delta_rule_out_aten);
+      torch::executor::native::gated_delta_rule_out_aten);
 }

--- a/extension/llm/custom_ops/op_sdpa_test.cpp
+++ b/extension/llm/custom_ops/op_sdpa_test.cpp
@@ -34,7 +34,7 @@ executorch::aten::Tensor op_scaled_dot_product_attention(
 }
 
 std::tuple<executorch::aten::Tensor&, executorch::aten::Tensor&>
-op_channelwise_gated_delta_rule(
+op_gated_delta_rule(
     executorch::runtime::KernelRuntimeContext& context,
     const executorch::aten::Tensor& query,
     const executorch::aten::Tensor& key,
@@ -44,7 +44,7 @@ op_channelwise_gated_delta_rule(
     const executorch::aten::Tensor& initial_state,
     executorch::aten::Tensor& out,
     executorch::aten::Tensor& final_state_out) {
-  return torch::executor::native::channelwise_gated_delta_rule_out(
+  return torch::executor::native::gated_delta_rule_out(
       context,
       query,
       key,
@@ -143,7 +143,7 @@ void test_scalar_decay_matches_broadcast_channelwise(
       tfFloat.zeros({batch_size, num_kv_heads, k_head_dim, v_head_dim});
 
   executorch::runtime::KernelRuntimeContext scalar_context{};
-  op_channelwise_gated_delta_rule(
+  op_gated_delta_rule(
       scalar_context,
       query,
       key,
@@ -156,7 +156,7 @@ void test_scalar_decay_matches_broadcast_channelwise(
   ASSERT_EQ(scalar_context.failure_state(), torch::executor::Error::Ok);
 
   executorch::runtime::KernelRuntimeContext channelwise_context{};
-  op_channelwise_gated_delta_rule(
+  op_gated_delta_rule(
       channelwise_context,
       query,
       key,
@@ -174,27 +174,27 @@ void test_scalar_decay_matches_broadcast_channelwise(
 
 } // namespace
 
-TEST(ChannelwiseGatedDeltaRuleTest, ScalarDecayDecodeMatchesBroadcast) {
+TEST(GatedDeltaRuleTest, ScalarDecayDecodeMatchesBroadcast) {
   test_scalar_decay_matches_broadcast_channelwise(
       /*sequence_length=*/1, /*query_heads_per_kv=*/1);
 }
 
-TEST(ChannelwiseGatedDeltaRuleTest, ScalarDecayPrefillMatchesBroadcast) {
+TEST(GatedDeltaRuleTest, ScalarDecayPrefillMatchesBroadcast) {
   test_scalar_decay_matches_broadcast_channelwise(
       /*sequence_length=*/40, /*query_heads_per_kv=*/1);
 }
 
-TEST(ChannelwiseGatedDeltaRuleTest, ScalarDecayGroupedMatchesBroadcast) {
+TEST(GatedDeltaRuleTest, ScalarDecayGroupedMatchesBroadcast) {
   test_scalar_decay_matches_broadcast_channelwise(
       /*sequence_length=*/40, /*query_heads_per_kv=*/3);
 }
 
-TEST(ChannelwiseGatedDeltaRuleTest, ScalarDecayGroupedDecodeMatchesBroadcast) {
+TEST(GatedDeltaRuleTest, ScalarDecayGroupedDecodeMatchesBroadcast) {
   test_scalar_decay_matches_broadcast_channelwise(
       /*sequence_length=*/1, /*query_heads_per_kv=*/3);
 }
 
-TEST(ChannelwiseGatedDeltaRuleTest, RejectsMismatchedScalarDecay) {
+TEST(GatedDeltaRuleTest, RejectsMismatchedScalarDecay) {
   TensorFactory<executorch::aten::ScalarType::Float> tfFloat;
 
   executorch::aten::Tensor query = tfFloat.ones({1, 1, 3, 2});
@@ -207,7 +207,7 @@ TEST(ChannelwiseGatedDeltaRuleTest, RejectsMismatchedScalarDecay) {
   executorch::aten::Tensor final_state_out = tfFloat.zeros({1, 1, 2, 2});
 
   executorch::runtime::KernelRuntimeContext context{};
-  op_channelwise_gated_delta_rule(
+  op_gated_delta_rule(
       context,
       query,
       key,
@@ -221,7 +221,7 @@ TEST(ChannelwiseGatedDeltaRuleTest, RejectsMismatchedScalarDecay) {
   EXPECT_NE(context.failure_state(), torch::executor::Error::Ok);
 }
 
-TEST(ChannelwiseGatedDeltaRuleTest, RejectsPartiallyOverlappingFinalStateOut) {
+TEST(GatedDeltaRuleTest, RejectsPartiallyOverlappingFinalStateOut) {
   TensorFactory<executorch::aten::ScalarType::Float> tfFloat;
 
   executorch::aten::Tensor query = tfFloat.ones({1, 1, 1, 2});
@@ -236,7 +236,7 @@ TEST(ChannelwiseGatedDeltaRuleTest, RejectsPartiallyOverlappingFinalStateOut) {
       initial_state.mutable_data_ptr<float>() + 1);
 
   executorch::runtime::KernelRuntimeContext context{};
-  op_channelwise_gated_delta_rule(
+  op_gated_delta_rule(
       context,
       query,
       key,

--- a/extension/llm/custom_ops/test_gated_delta.py
+++ b/extension/llm/custom_ops/test_gated_delta.py
@@ -15,7 +15,7 @@ import torch
 from executorch.extension.llm.custom_ops import custom_ops  # noqa
 
 
-class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
+class GatedDeltaRuleTest(unittest.TestCase):
     def _make_inputs(
         self,
         batch_size: int = 2,
@@ -41,7 +41,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
         initial_state = torch.randn(batch_size, num_state_heads, k_head_dim, v_head_dim)
         return query, key, value, decay, beta, initial_state
 
-    def _reference_channelwise_gated_delta_rule(
+    def _reference_gated_delta_rule(
         self,
         query: torch.Tensor,
         key: torch.Tensor,
@@ -77,7 +77,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
 
         return output, state
 
-    def test_channelwise_gated_delta_rule_grouped_matches_reference(self):
+    def test_gated_delta_rule_grouped_matches_reference(self):
         torch.manual_seed(0)
 
         for seq_len in (1, 35):
@@ -88,12 +88,10 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
                     num_state_heads=2,
                     seq_len=seq_len,
                 )
-                expected_output, expected_state = (
-                    self._reference_channelwise_gated_delta_rule(*inputs)
+                expected_output, expected_state = self._reference_gated_delta_rule(
+                    *inputs
                 )
-                actual_output, actual_state = (
-                    torch.ops.llama.channelwise_gated_delta_rule(*inputs)
-                )
+                actual_output, actual_state = torch.ops.llama.gated_delta_rule(*inputs)
 
                 self.assertTrue(
                     torch.allclose(actual_output, expected_output, atol=1e-3, rtol=1e-3)
@@ -122,12 +120,10 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
                 )
                 self.assertEqual(inputs[3].dim(), 3)
 
-                expected_output, expected_state = (
-                    self._reference_channelwise_gated_delta_rule(*inputs)
+                expected_output, expected_state = self._reference_gated_delta_rule(
+                    *inputs
                 )
-                actual_output, actual_state = (
-                    torch.ops.llama.channelwise_gated_delta_rule(*inputs)
-                )
+                actual_output, actual_state = torch.ops.llama.gated_delta_rule(*inputs)
 
                 self.assertTrue(
                     torch.allclose(actual_output, expected_output, atol=1e-3, rtol=1e-3)
@@ -141,16 +137,41 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
         short_decay = torch.rand(query.size(0), key.size(1), 3)
 
         with self.assertRaises(RuntimeError):
-            torch.ops.llama.channelwise_gated_delta_rule(
+            torch.ops.llama.gated_delta_rule(
                 query, key, value, short_decay, beta, initial_state
             )
 
-    def test_channelwise_gated_delta_rule_rejects_uneven_groups(self):
+    def test_deprecated_channelwise_alias_matches_new_name(self):
+        # channelwise_gated_delta_rule is the pre-scalar-decay name, kept as an
+        # alias so graphs and .pte files built against it still resolve.
+        torch.manual_seed(0)
+
+        inputs = self._make_inputs(seq_len=35)
+        expected_output, expected_state = torch.ops.llama.gated_delta_rule(*inputs)
+        alias_output, alias_state = torch.ops.llama.channelwise_gated_delta_rule(
+            *inputs
+        )
+
+        self.assertTrue(torch.equal(alias_output, expected_output))
+        self.assertTrue(torch.equal(alias_state, expected_state))
+
+    def test_deprecated_channelwise_alias_exports(self):
+        class Module(torch.nn.Module):
+            def forward(self, query, key, value, decay, beta, initial_state):
+                return torch.ops.llama.channelwise_gated_delta_rule(
+                    query, key, value, decay, beta, initial_state
+                )
+
+        ep = torch.export.export(Module(), self._make_inputs())
+        targets = [str(n.target) for n in ep.graph.nodes if n.op == "call_function"]
+        self.assertIn("llama.channelwise_gated_delta_rule.default", targets)
+
+    def test_gated_delta_rule_rejects_uneven_groups(self):
         inputs = self._make_inputs(num_heads=3, num_state_heads=2)
         with self.assertRaises(RuntimeError):
-            torch.ops.llama.channelwise_gated_delta_rule(*inputs)
+            torch.ops.llama.gated_delta_rule(*inputs)
 
-    def test_channelwise_gated_delta_rule_matches_reference(self):
+    def test_gated_delta_rule_matches_reference(self):
         torch.manual_seed(0)
 
         test_cases = (
@@ -169,28 +190,24 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
                     initial_state,
                 ) = self._make_inputs(*case)
 
-                expected_output, expected_state = (
-                    self._reference_channelwise_gated_delta_rule(
-                        query,
-                        key,
-                        value,
-                        decay,
-                        beta,
-                        initial_state,
-                    )
+                expected_output, expected_state = self._reference_gated_delta_rule(
+                    query,
+                    key,
+                    value,
+                    decay,
+                    beta,
+                    initial_state,
                 )
 
                 # Functional op: initial_state must not be mutated.
                 initial_state_before = initial_state.clone()
-                actual_output, actual_state = (
-                    torch.ops.llama.channelwise_gated_delta_rule(
-                        query,
-                        key,
-                        value,
-                        decay,
-                        beta,
-                        initial_state,
-                    )
+                actual_output, actual_state = torch.ops.llama.gated_delta_rule(
+                    query,
+                    key,
+                    value,
+                    decay,
+                    beta,
+                    initial_state,
                 )
 
                 self.assertTrue(
@@ -199,11 +216,11 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
                 self.assertTrue(torch.allclose(actual_state, expected_state, atol=1e-5))
                 self.assertTrue(torch.equal(initial_state, initial_state_before))
 
-    def test_channelwise_gated_delta_rule_out_matches_reference(self):
+    def test_gated_delta_rule_out_matches_reference(self):
         torch.manual_seed(0)
 
         query, key, value, decay, beta, initial_state = self._make_inputs()
-        expected_output, expected_state = self._reference_channelwise_gated_delta_rule(
+        expected_output, expected_state = self._reference_gated_delta_rule(
             query,
             key,
             value,
@@ -214,17 +231,15 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
 
         actual_output = torch.empty_like(value)
         actual_final_state = torch.empty_like(initial_state)
-        returned_output, returned_state = (
-            torch.ops.llama.channelwise_gated_delta_rule.out(
-                query,
-                key,
-                value,
-                decay,
-                beta,
-                initial_state,
-                out=actual_output,
-                final_state_out=actual_final_state,
-            )
+        returned_output, returned_state = torch.ops.llama.gated_delta_rule.out(
+            query,
+            key,
+            value,
+            decay,
+            beta,
+            initial_state,
+            out=actual_output,
+            final_state_out=actual_final_state,
         )
 
         self.assertEqual(returned_output.data_ptr(), actual_output.data_ptr())
@@ -232,7 +247,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
         self.assertTrue(torch.allclose(actual_output, expected_output, atol=1e-5))
         self.assertTrue(torch.allclose(actual_final_state, expected_state, atol=1e-5))
 
-    def test_channelwise_gated_delta_rule_out_invalid_args_raise(
+    def test_gated_delta_rule_out_invalid_args_raise(
         self,
     ):
         torch.manual_seed(0)
@@ -243,7 +258,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
         actual_final_state = torch.empty(1)
 
         with self.assertRaises(RuntimeError):
-            torch.ops.llama.channelwise_gated_delta_rule.out(
+            torch.ops.llama.gated_delta_rule.out(
                 query,
                 invalid_key,
                 value,
@@ -257,7 +272,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
         self.assertEqual(tuple(actual_output.shape), (1,))
         self.assertEqual(tuple(actual_final_state.shape), (1,))
 
-    def test_channelwise_gated_delta_rule_out_rejects_initial_state_alias(
+    def test_gated_delta_rule_out_rejects_initial_state_alias(
         self,
     ):
         torch.manual_seed(0)
@@ -269,7 +284,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
             RuntimeError,
             "final_state_out must not alias initial_state",
         ):
-            torch.ops.llama.channelwise_gated_delta_rule.out(
+            torch.ops.llama.gated_delta_rule.out(
                 query,
                 key,
                 value,
@@ -280,7 +295,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
                 final_state_out=initial_state,
             )
 
-    def test_channelwise_gated_delta_rule_out_rejects_initial_state_overlap(
+    def test_gated_delta_rule_out_rejects_initial_state_overlap(
         self,
     ):
         torch.manual_seed(0)
@@ -302,7 +317,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
             RuntimeError,
             "final_state_out must not alias initial_state",
         ):
-            torch.ops.llama.channelwise_gated_delta_rule.out(
+            torch.ops.llama.gated_delta_rule.out(
                 query,
                 key,
                 value,
@@ -313,7 +328,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
                 final_state_out=final_state_out,
             )
 
-    def test_channelwise_gated_delta_rule_chunked_matches_full_sequence(self):
+    def test_gated_delta_rule_chunked_matches_full_sequence(self):
         torch.manual_seed(0)
 
         # seq_len > CHUNK_SIZE (32 in the C++ kernel): the single full call runs
@@ -330,7 +345,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
             seq_len=seq_len
         )
 
-        full_output, full_state = torch.ops.llama.channelwise_gated_delta_rule(
+        full_output, full_state = torch.ops.llama.gated_delta_rule(
             query,
             key,
             value,
@@ -342,7 +357,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
         chunk_state = initial_state
         chunk_outputs = []
         for start, end in ((0, 64), (64, 192), (192, 200)):
-            chunk_output, chunk_state = torch.ops.llama.channelwise_gated_delta_rule(
+            chunk_output, chunk_state = torch.ops.llama.gated_delta_rule(
                 query[:, :, start:end, :],
                 key[:, :, start:end, :],
                 value[:, :, start:end, :],
@@ -358,7 +373,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
         )
         self.assertTrue(torch.allclose(chunk_state, full_state, atol=1e-3, rtol=1e-3))
 
-    def test_channelwise_gated_delta_rule_multichunk_matches_reference(self):
+    def test_gated_delta_rule_multichunk_matches_reference(self):
         torch.manual_seed(0)
 
         # Drive the prefill route past a single CHUNK_SIZE (32) so the kernel's
@@ -369,13 +384,11 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
         for seq_len in (130, 256):
             with self.subTest(seq_len=seq_len):
                 inputs = self._make_inputs(seq_len=seq_len)
-                expected_output, expected_state = (
-                    self._reference_channelwise_gated_delta_rule(*inputs)
+                expected_output, expected_state = self._reference_gated_delta_rule(
+                    *inputs
                 )
 
-                actual_output, actual_state = (
-                    torch.ops.llama.channelwise_gated_delta_rule(*inputs)
-                )
+                actual_output, actual_state = torch.ops.llama.gated_delta_rule(*inputs)
 
                 self.assertTrue(
                     torch.allclose(actual_output, expected_output, atol=1e-3, rtol=1e-3)
@@ -384,14 +397,14 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
                     torch.allclose(actual_state, expected_state, atol=1e-3, rtol=1e-3)
                 )
 
-    def test_channelwise_gated_delta_rule_prefill_tiny_decay_is_finite(self):
+    def test_gated_delta_rule_prefill_tiny_decay_is_finite(self):
         # Regression test for the chunked-prefill overflow NaN in op_sdpa.cpp.
         # The prefill kernel forms eg_inv = exp(-cumsum(log decay)) per
         # CHUNK_SIZE (32) tokens; for tiny positive decay the within-chunk
         # cumulative -log(decay) exceeds the float expf overflow limit (~88.7),
         # so eg_inv overflows to +inf and eg * eg_inv becomes 0 * inf = NaN,
         # poisoning the whole head's output. The
-        # channelwise_gated_delta_rule_chunked_is_safe guard must route such
+        # gated_delta_rule_chunked_is_safe guard must route such
         # inputs to the exact recurrence, which stays finite (and correct) for
         # tiny decay; without it the isfinite assertions below fail.
         torch.manual_seed(0)
@@ -404,10 +417,10 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
         # bound and exp(-gc) would overflow to +inf -> NaN.
         decay = torch.full_like(decay, 1e-12)
 
-        expected_output, expected_state = self._reference_channelwise_gated_delta_rule(
+        expected_output, expected_state = self._reference_gated_delta_rule(
             query, key, value, decay, beta, initial_state
         )
-        actual_output, actual_state = torch.ops.llama.channelwise_gated_delta_rule(
+        actual_output, actual_state = torch.ops.llama.gated_delta_rule(
             query, key, value, decay, beta, initial_state
         )
 
@@ -426,10 +439,10 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
             torch.allclose(actual_state, expected_state, atol=1e-3, rtol=1e-3)
         )
 
-    def test_channelwise_gated_delta_rule_exports(self):
+    def test_gated_delta_rule_exports(self):
         class Module(torch.nn.Module):
             def forward(self, query, key, value, decay, beta, initial_state):
-                return torch.ops.llama.channelwise_gated_delta_rule(
+                return torch.ops.llama.gated_delta_rule(
                     query, key, value, decay, beta, initial_state
                 )
 
@@ -443,7 +456,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
                 targets = [
                     str(n.target) for n in ep.graph.nodes if n.op == "call_function"
                 ]
-                self.assertIn("llama.channelwise_gated_delta_rule.default", targets)
+                self.assertIn("llama.gated_delta_rule.default", targets)
 
                 # Dynamic sequence length: one graph shared across
                 # prefill/decode. T is dim 2 for both decay layouts.
@@ -461,7 +474,7 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
                 )
                 self.assertTrue(
                     any(
-                        "channelwise_gated_delta_rule" in str(n.target)
+                        "gated_delta_rule" in str(n.target)
                         for n in ep_dyn.graph.nodes
                         if n.op == "call_function"
                     )
@@ -470,12 +483,12 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
     @unittest.skipUnless(
         sys.platform == "linux",
         "Custom-kernel .pte execution via the Python Runtime is Linux-only: the "
-        "channelwise_gated_delta_rule kernel is not registered in the ExecuTorch "
+        "gated_delta_rule kernel is not registered in the ExecuTorch "
         "pybindings runtime on Windows (custom-op static registration does not "
         "cross the DLL boundary). Eager + export paths are covered on all "
         "platforms by the other tests.",
     )
-    def test_channelwise_gated_delta_rule_pte_execution(self):
+    def test_gated_delta_rule_pte_execution(self):
         # Exports, lowers, and *executes* the op through the ExecuTorch runtime.
         # This is the only test that hits the boxed kernel and its stack
         # arg-count contract: the emitter appends a trailing TensorList to a
@@ -488,11 +501,11 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
         from executorch.exir import EdgeCompileConfig, to_edge
         from executorch.runtime import Runtime
 
-        op_event_name = "native_call_llama::channelwise_gated_delta_rule.out"
+        op_event_name = "native_call_llama::gated_delta_rule.out"
 
         class Module(torch.nn.Module):
             def forward(self, query, key, value, decay, beta, initial_state):
-                return torch.ops.llama.channelwise_gated_delta_rule(
+                return torch.ops.llama.gated_delta_rule(
                     query, key, value, decay, beta, initial_state
                 )
 
@@ -502,8 +515,8 @@ class ChannelwiseGatedDeltaRuleTest(unittest.TestCase):
             with self.subTest(seq_len=seq_len, scalar_decay=scalar_decay):
                 torch.manual_seed(seq_len)
                 inputs = self._make_inputs(seq_len=seq_len, scalar_decay=scalar_decay)
-                expected_output, expected_state = (
-                    self._reference_channelwise_gated_delta_rule(*inputs)
+                expected_output, expected_state = self._reference_gated_delta_rule(
+                    *inputs
                 )
 
                 ep = torch.export.export(Module(), inputs)


### PR DESCRIPTION
Summary:

The op handles both a per-channel and a per-head scalar decay gate now, so `channelwise` in the name is misleading — the internal kernels are already called `gated_delta_rule_recurrence` / `gated_delta_rule_chunked`, and `GatedDeltaNet` in `attention.py` reaches the op with a scalar gate. Rename the operator, its C++ entry points, the meta kernel, the benchmark and the tests to `gated_delta_rule`. The new name also pairs with the fused `gated_delta_net`: rule is the core recurrence, net is the whole block.

Comments and messages that describe the channelwise *layout* are left alone; only the identifier changes.

`channelwise_gated_delta_rule` stays registered as a deprecated alias — a second `register_kernel` entry sharing the boxed function, plus the AOT schema/impl and the Meta kernel — so graphs and `.pte` files emitted against the old name keep resolving. ETDump reports the new name for both, since the boxed function is shared. Drop the alias once anything exported against the old name has been re-exported.

No behavior change.

Reviewed By: YIWENX14

Differential Revision: D114737925
