### PR TITLE
Add concurrency to the wheel build workflows so ciflow tag re-pushes cancel

### DIFF
--- a/.github/workflows/build-wheels-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-aarch64-linux.yml
@@ -20,6 +20,10 @@ on:
       - ciflow/binaries/*
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   generate-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -20,6 +20,10 @@ on:
       - ciflow/binaries/*
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   generate-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -20,6 +20,10 @@ on:
       - ciflow/binaries/*
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   generate-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -23,6 +23,10 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   generate-matrix:
     uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main


### PR DESCRIPTION
The `build-wheels-*` workflows carry no `concurrency` block, so nothing cancels an in-flight run when a `ciflow/binaries/*` tag or a PR branch is re-pushed. Each re-push runs a full wheel matrix to completion alongside the stale one.

This is the same failure #21622 fixed, but those 29 workflows had a broken key while these have none, so they fell outside that PR's scope. The group matches pytorch/pytorch's binary workflows (generated from its `common.yml.j2` macro): gating the sha term on `ref_type == 'branch'` keeps a per-commit group for `nightly` pushes and stops distinct release tags from cross-cancelling, while a re-push of the same tag cancels the stale run.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
  cancel-in-progress: true
```

`build-wheels-cuda-linux.yml` and `build-wheels-cuda-aarch64-linux.yml` are not on main yet, arriving with the in-flight packaging stack, and will need the same block when they land.

Authored with assistance from Claude Code.