### PR TITLE
Channels last: preserve metadata across op replacement

### DIFF
--- a/backends/transforms/replace_ops_with_channels_last_variants.py
+++ b/backends/transforms/replace_ops_with_channels_last_variants.py
@@ -133,6 +133,11 @@ class ReplaceOpsWithChannelsLastVariants(ExportPass):
 
     By default, all currently implemented channels_last dialect ops are replaced.
     Pass a custom op_map to restrict or extend the set of replacements.
+
+    Metadata from each replaced operator is preserved so provenance and backend
+    annotations survive the rewrite. ExportPass recomputes shape metadata after
+    retracing. Callers must reject or remap semantic metadata tied to dimensions
+    changed by ``input_indices`` or ``output_indices``, such as per-channel axes.
     """
 
     def __init__(
@@ -229,7 +234,7 @@ class ReplaceOpsWithChannelsLastVariants(ExportPass):
                     args=tuple(args),
                     kwargs=node.kwargs,
                 )
-                nhwc_node.meta = {}
+                nhwc_node.meta = dict(node.meta)
 
                 users = list(node.users)
                 if all(

--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -1,3 +1,4 @@
+load("@fbcode_macros//build_defs:python_pytest.bzl", "python_pytest")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def define_common_targets():
@@ -514,11 +515,13 @@ def define_common_targets():
         ],
     )
 
-    runtime.python_test(
+    python_pytest(
         name = "test_replace_ops_with_channels_last_variants",
         srcs = [
             "test/test_replace_ops_with_channels_last_variants.py",
         ],
+        compile = "with-source",
+        typing = False,
         deps = [
             "//caffe2:torch",
             ":channels_last_ops",

--- a/backends/transforms/test/test_replace_ops_with_channels_last_variants.py
+++ b/backends/transforms/test/test_replace_ops_with_channels_last_variants.py
@@ -132,6 +132,26 @@ class UpsampleNearestModule(torch.nn.Module):
 
 
 class TestReplaceOpsWithChannelsLastVariants:
+    def test_preserves_metadata_and_recomputes_shape(self):
+        ep = _export_to_edge(Conv2dModule(), (torch.randn(1, 4, 8, 8),))
+        conv = _find_nodes(ep.graph_module, exir_ops.edge.aten.convolution.default)[0]
+        metadata = {
+            "debug_handle": 1234,
+            "from_node": [("source", "convolution")],
+            "input_qparams": {0: "input"},
+            "output_qparams": {0: "output"},
+        }
+        conv.meta.update(metadata)
+
+        result = ReplaceOpsWithChannelsLastVariants(ep)(ep.graph_module)
+        replaced = _find_nodes(
+            result.graph_module, exir_ops.edge.channels_last.convolution.default
+        )[0]
+
+        for key, value in metadata.items():
+            assert replaced.meta[key] == value
+        assert tuple(replaced.meta["val"].shape) == (1, 8, 8, 4)
+
     def test_conv2d(self):
         ep = _export_to_edge(Conv2dModule(bias=True), (torch.randn(1, 4, 8, 8),))
         assert _count(ep.graph_module, exir_ops.edge.aten.convolution.default) == 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #21928
* #21927
* #21926
* #21925
* #21924
* __->__ #21923

Preserve the complete metadata dictionary when replacing an ATen operator with its channels-last dialect counterpart. ExportPass retracing recomputes layout-dependent shape fields such as val and tensor_meta, while source attribution and backend annotations such as debug_handle, from_node, input_qparams, output_qparams, and custom metadata survive the rewrite.

Document the remaining caller contract in terms of every input and output listed by ChannelsLastOpSpec. Semantic metadata tied to a permuted dimension, such as a per-channel quantization axis, must be rejected or remapped by the backend before replacement. This keeps provenance preservation as the default without implying that a metadata allowlist validates layout semantics.

Keep structural-layout helper definitions out of this change; the following optimizer Diff introduces them when they gain multiple consumers. Convert the existing Buck test target to pytest-aware discovery and add coverage for provenance survival together with recomputed NHWC output shape.

Differential Revision: [D116372280](https://our.internmc.facebook.com/intern/diff/D116372280/)