### PR TITLE
Channels last: add the common layout pipeline

### DIFF
--- a/backends/transforms/remove_permutes_around_elementwise_ops.py
+++ b/backends/transforms/remove_permutes_around_elementwise_ops.py
@@ -7,6 +7,7 @@
 
 # pyre-unsafe
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import cast
 
@@ -74,10 +75,12 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
         *,
         exported_program: ExportedProgram | None = None,
         allow_layout_boundary_propagation: bool = False,
+        can_propagate: Callable[[torch.fx.Node], bool] | None = None,
     ) -> None:
         super().__init__()
         self.exported_program = exported_program
         self.allow_layout_boundary_propagation = allow_layout_boundary_propagation
+        self.can_propagate = can_propagate
         self._permutable_ops = {
             exir_ops.edge.aten.add.Tensor,
             exir_ops.edge.aten.mul.Tensor,
@@ -718,6 +721,8 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
         return False
 
     def is_node_permutable(self, node: torch.fx.Node) -> bool:
+        if self.can_propagate is not None and not self.can_propagate(node):
+            return False
         if node.target in self._PAD_OPS and not self._is_constant_pad(node):
             return False
         if node.target in self._permutable_ops:

--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -537,6 +537,31 @@ def define_common_targets():
         ],
     )
 
+    runtime.python_library(
+        name = "to_contiguous_channels_last_pass",
+        srcs = [
+            "to_contiguous_channels_last_pass.py",
+        ],
+        visibility = [
+            "//executorch/backends/...",
+        ],
+        deps = [
+            "//caffe2:torch",
+            ":channels_last_layout",
+            ":fuse_cascaded_transpose_or_permute_ops",
+            ":fuse_cascaded_view_ops",
+            ":fuse_transpose_or_permute_op_pairs_pass",
+            ":postpone_permute_below_squeeze_view",
+            ":remove_permutes_around_elementwise_ops",
+            ":replace_nop_transpose_or_permute_with_view",
+            ":replace_ops_with_channels_last_variants",
+            ":replace_squeeze_unsqueeze_with_view",
+            "//executorch/exir:lib",
+            "//executorch/exir:pass_base",
+            "//executorch/exir/dialects:lib",
+        ],
+    )
+
     python_pytest(
         name = "test_replace_ops_with_channels_last_variants",
         srcs = [
@@ -563,6 +588,22 @@ def define_common_targets():
             "//caffe2:torch",
             ":convert_conv1d_to_conv2d_pass",
             ":utils",
+            "//executorch/exir:lib",
+            "//executorch/exir/dialects:lib",
+            "fbsource//third-party/pypi/pytest:pytest",
+        ],
+    )
+
+    python_pytest(
+        name = "test_to_contiguous_channels_last_pipeline",
+        srcs = [
+            "test/test_to_contiguous_channels_last_pipeline.py",
+        ],
+        compile = "with-source",
+        typing = False,
+        deps = [
+            "//caffe2:torch",
+            ":to_contiguous_channels_last_pass",
             "//executorch/exir:lib",
             "//executorch/exir/dialects:lib",
             "fbsource//third-party/pypi/pytest:pytest",

--- a/backends/transforms/test/test_to_contiguous_channels_last_pipeline.py
+++ b/backends/transforms/test/test_to_contiguous_channels_last_pipeline.py
@@ -1,0 +1,309 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from executorch.backends.transforms.to_contiguous_channels_last_pass import (
+    ToContiguousChannelsLastPass,
+)
+from executorch.exir import EdgeCompileConfig, to_edge
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+class ConvChain(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(4, 4, 3, padding=1)
+        self.conv2 = torch.nn.Conv2d(4, 4, 3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv2(torch.relu(self.conv1(x)))
+
+
+class ConvOnly(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(4, 4, 3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+class ConvThenLinear(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(4, 4, 3, padding=1)
+        self.linear = torch.nn.Linear(4 * 8 * 8, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(self.conv(x).flatten(1))
+
+
+class UserPermute(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.permute(0, 2, 3, 1)
+
+
+class ConvChannelBias(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(4, 4, 3, padding=1)
+        self.register_buffer("channel_bias", torch.randn(1, 4, 1, 1))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x) + self.channel_bias
+
+
+class PadConv(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(4, 4, 3)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(torch.nn.functional.pad(x, (1, 1, 1, 1)))
+
+
+class ConvSoftmax(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(4, 4, 3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.softmax(self.conv(x), dim=-1)
+
+
+class ConvRuntimeBiasConv(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(4, 4, 3, padding=1)
+        self.conv2 = torch.nn.Conv2d(4, 4, 3, padding=1)
+
+    def forward(self, x: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:
+        return self.conv2(self.conv1(x) + bias)
+
+
+class ConvSpatialBufferConv(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(4, 4, 3, padding=1)
+        self.conv2 = torch.nn.Conv2d(4, 4, 3, padding=1)
+        self.register_buffer("bias", torch.randn(4, 8, 8))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv2(self.conv1(x) + self.bias)
+
+
+def _edge(module: torch.nn.Module, inputs: tuple[torch.Tensor, ...]):
+    exported = torch.export.export(module.eval(), inputs)
+    return to_edge(
+        exported,
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False,
+            _skip_dim_order=True,
+        ),
+    )
+
+
+def _count(graph_module: torch.fx.GraphModule, target: object) -> int:
+    return sum(
+        node.op == "call_function" and node.target == target
+        for node in graph_module.graph.nodes
+    )
+
+
+def test_conv_chain_folds_to_boundary_copies() -> None:
+    torch.manual_seed(0)
+    module = ConvChain().eval()
+    inputs = (torch.randn(1, 4, 8, 8),)
+    expected = module(*inputs)
+    edge = _edge(module, inputs)
+    layout_pass = ToContiguousChannelsLastPass(edge.exported_program())
+
+    transformed = edge.transform([layout_pass])
+    graph_module = transformed.exported_program().graph_module
+
+    assert _count(graph_module, exir_ops.edge.channels_last.convolution.default) == 2
+    assert _count(graph_module, exir_ops.edge.channels_last.permute_copy.default) == 2
+    assert layout_pass.report.inserted_copy_count == 4
+    assert layout_pass.report.eliminated_copy_count == 2
+    assert layout_pass.report.boundary_copy_count == 2
+    assert layout_pass.report.internal_copy_count == 0
+    assert layout_pass.report.unknown_copy_count == 0
+    assert layout_pass.report.boundary_copy_bytes == 2048
+    assert layout_pass.report.internal_copy_bytes == 0
+    assert layout_pass.report.unknown_copy_bytes == 0
+    assert layout_pass.report.copies_with_unknown_size == 0
+    actual = transformed.exported_program().module()(*inputs)
+    assert torch.allclose(actual, expected, atol=1e-6)
+
+
+def test_strict_rejects_internal_layout_copy() -> None:
+    inputs = (torch.randn(1, 4, 8, 8),)
+    edge = _edge(ConvThenLinear().eval(), inputs)
+
+    with pytest.raises(RuntimeError, match="left .* internal"):
+        ToContiguousChannelsLastPass(edge.exported_program(), strict=True).call(
+            edge.exported_program().graph_module
+        )
+
+
+def test_strict_rejects_unknown_boundary_copy_size() -> None:
+    inputs = (torch.randn(1, 4, 8, 8),)
+    exported = torch.export.export(
+        ConvOnly().eval(),
+        inputs,
+        dynamic_shapes={"x": {2: torch.export.Dim("height", min=4, max=16)}},
+    )
+    edge = to_edge(
+        exported,
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False,
+            _skip_dim_order=True,
+        ),
+    )
+    layout_pass = ToContiguousChannelsLastPass(edge.exported_program(), strict=True)
+
+    with pytest.raises(RuntimeError, match="unknown sizes"):
+        layout_pass.call(edge.exported_program().graph_module)
+
+    assert layout_pass.report.boundary_copy_count == 2
+    assert layout_pass.report.boundary_copy_bytes == 0
+    assert layout_pass.report.copies_with_unknown_size == 2
+
+
+def test_backend_can_block_layout_propagation_at_a_node() -> None:
+    torch.manual_seed(0)
+    module = ConvChain().eval()
+    inputs = (torch.randn(1, 4, 8, 8),)
+    expected = module(*inputs)
+    edge = _edge(module, inputs)
+    layout_pass = ToContiguousChannelsLastPass(
+        edge.exported_program(),
+        can_propagate=lambda node: node.target != exir_ops.edge.aten.relu.default,
+    )
+
+    transformed = edge.transform([layout_pass])
+
+    assert layout_pass.report.boundary_copy_count == 2
+    assert layout_pass.report.internal_copy_count == 2
+    actual = transformed.exported_program().module()(*inputs)
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("module", [ConvChannelBias(), PadConv()])
+def test_one_sided_propagation_reaches_graph_boundary(
+    module: torch.nn.Module,
+) -> None:
+    torch.manual_seed(0)
+    module.eval()
+    inputs = (torch.randn(1, 4, 8, 8),)
+    expected = module(*inputs)
+    edge = _edge(module, inputs)
+    layout_pass = ToContiguousChannelsLastPass(edge.exported_program())
+
+    transformed = edge.transform([layout_pass])
+
+    assert layout_pass.report.boundary_copy_count == 2
+    assert layout_pass.report.internal_copy_count == 0
+    assert layout_pass.report.unknown_copy_count == 0
+    actual = transformed.exported_program().module()(*inputs)
+    assert torch.allclose(actual, expected, atol=1e-6)
+
+    if isinstance(module, PadConv):
+        assert (
+            _count(
+                transformed.exported_program().graph_module,
+                exir_ops.edge.channels_last.constant_pad_nd.default,
+            )
+            == 1
+        )
+
+
+def test_softmax_blocks_layout_propagation() -> None:
+    module = ConvSoftmax().eval()
+    inputs = (torch.randn(1, 4, 8, 8),)
+    expected = module(*inputs)
+    edge = _edge(module, inputs)
+    layout_pass = ToContiguousChannelsLastPass(edge.exported_program())
+
+    transformed = edge.transform([layout_pass])
+
+    assert layout_pass.report.boundary_copy_count == 1
+    assert layout_pass.report.internal_copy_count == 1
+    softmax = next(
+        node
+        for node in transformed.exported_program().graph.nodes
+        if node.target
+        in (exir_ops.edge.aten._softmax.default, exir_ops.edge.aten.softmax.int)
+    )
+    assert softmax.args[1] in (-1, 3)
+    actual = transformed.exported_program().module()(*inputs)
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "module, inputs",
+    [
+        (
+            ConvRuntimeBiasConv(),
+            (torch.randn(1, 4, 8, 8), torch.randn(4, 1, 1)),
+        ),
+        (ConvSpatialBufferConv(), (torch.randn(1, 4, 8, 8),)),
+    ],
+)
+def test_boundary_propagation_rejects_unsafe_broadcast_rewrites(
+    module: torch.nn.Module, inputs: tuple[torch.Tensor, ...]
+) -> None:
+    module.eval()
+    expected = module(*inputs)
+    edge = _edge(module, inputs)
+    layout_pass = ToContiguousChannelsLastPass(edge.exported_program())
+
+    transformed = edge.transform([layout_pass])
+
+    assert layout_pass.report.boundary_copy_count == 2
+    assert layout_pass.report.internal_copy_count == 2
+    actual = transformed.exported_program().module()(*inputs)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_layout_copy_report_is_idempotent() -> None:
+    inputs = (torch.randn(1, 4, 8, 8),)
+    edge = _edge(ConvChain().eval(), inputs)
+    first_pass = ToContiguousChannelsLastPass(edge.exported_program())
+    transformed = edge.transform([first_pass])
+    second_pass = ToContiguousChannelsLastPass(transformed.exported_program())
+
+    transformed.transform([second_pass])
+
+    assert second_pass.report.inserted_copy_count == 0
+    assert second_pass.report.eliminated_copy_count == 0
+
+
+def test_user_permute_is_not_reported_as_layout_copy() -> None:
+    inputs = (torch.randn(1, 4, 8, 8),)
+    edge = _edge(UserPermute(), inputs)
+    layout_pass = ToContiguousChannelsLastPass(edge.exported_program(), op_map={})
+
+    transformed = edge.transform([layout_pass])
+    permutes = [
+        node
+        for node in transformed.exported_program().graph.nodes
+        if node.target == exir_ops.edge.aten.permute_copy.default
+    ]
+
+    assert len(permutes) == 1
+    assert (
+        _count(
+            transformed.exported_program().graph_module,
+            exir_ops.edge.channels_last.permute_copy.default,
+        )
+        == 0
+    )
+    assert layout_pass.report.inserted_copy_count == 0
+    assert layout_pass.report.boundary_copy_count == 0
+    assert layout_pass.report.internal_copy_count == 0

--- a/backends/transforms/to_contiguous_channels_last_pass.py
+++ b/backends/transforms/to_contiguous_channels_last_pass.py
@@ -1,0 +1,279 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from executorch.backends.transforms.channels_last_layout import is_layout_copy
+from executorch.backends.transforms.fuse_cascaded_transpose_or_permute_ops import (
+    FuseCascadedTransposeOrPermuteOps,
+)
+from executorch.backends.transforms.fuse_cascaded_view_ops import FuseCascadedViewOps
+from executorch.backends.transforms.fuse_transpose_or_permute_op_pairs_pass import (
+    FuseTransposeOrPermuteOpPairsPass,
+)
+from executorch.backends.transforms.postpone_permute_below_squeeze_view import (
+    PostponePermuteOpBelowSqueezeOrUnsqueezeLikeView,
+)
+from executorch.backends.transforms.remove_permutes_around_elementwise_ops import (
+    RemovePermutesAroundElementwiseOps,
+)
+from executorch.backends.transforms.replace_nop_transpose_or_permute_with_view import (
+    ReplaceNopTransposeOrPermuteWithViewPass,
+)
+from executorch.backends.transforms.replace_ops_with_channels_last_variants import (
+    ChannelsLastOpSpec,
+    ReplaceOpsWithChannelsLastVariants,
+)
+from executorch.backends.transforms.replace_squeeze_unsqueeze_with_view import (
+    ReplaceSqueezeAndUnsqueezeWithViewPass,
+)
+from executorch.exir import ExportedProgram
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+from torch.fx.node import Target
+
+_BOUNDARY_TRANSPARENT_TARGETS = {
+    exir_ops.edge.aten.squeeze_copy.default,
+    exir_ops.edge.aten.squeeze_copy.dim,
+    exir_ops.edge.aten.squeeze_copy.dims,
+    exir_ops.edge.aten.unsqueeze_copy.default,
+    exir_ops.edge.aten.view.default,
+    exir_ops.edge.aten.view_copy.default,
+}
+try:
+    _BOUNDARY_TRANSPARENT_TARGETS.update(
+        {
+            exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+            exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+        }
+    )
+except AttributeError:
+    pass
+
+
+@dataclass(frozen=True)
+class ChannelsLastLayoutReport:
+    inserted_copy_count: int = 0
+    eliminated_copy_count: int = 0
+    boundary_copy_count: int = 0
+    internal_copy_count: int = 0
+    unknown_copy_count: int = 0
+    boundary_copy_bytes: int = 0
+    internal_copy_bytes: int = 0
+    unknown_copy_bytes: int = 0
+    copies_with_unknown_size: int = 0
+    internal_copy_nodes: tuple[str, ...] = ()
+    unknown_copy_nodes: tuple[str, ...] = ()
+
+
+class ToContiguousChannelsLastPass(ExportPass):
+    """Build and optimize explicit contiguous-NHWC regions.
+
+    The pass replaces selected NCHW operators with channels-last dialect
+    anchors surrounded by ``channels_last.permute_copy`` nodes. It then runs
+    the common data-movement optimizers to a fixed point and reports only the
+    surviving layout copies. Strict mode rejects structurally unsafe copies;
+    it does not estimate peak arena usage after memory planning.
+    """
+
+    _MAX_OPTIMIZATION_ITERATIONS = 8
+
+    def __init__(
+        self,
+        exported_program: ExportedProgram,
+        op_map: dict[Target, ChannelsLastOpSpec] | None = None,
+        extra_permutable_ops: set[Target] | None = None,
+        can_propagate: Callable[[torch.fx.Node], bool] | None = None,
+        strict: bool = False,
+    ) -> None:
+        super().__init__()
+        self.exported_program = exported_program
+        self.op_map = op_map
+        self.extra_permutable_ops: set[Target] = set()
+        if extra_permutable_ops:
+            self.extra_permutable_ops |= extra_permutable_ops
+        self.can_propagate = can_propagate
+        self.strict = strict
+        self.report = ChannelsLastLayoutReport()
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        existing_copy_count = len(self._layout_copy_nodes(graph_module))
+        replacement = ReplaceOpsWithChannelsLastVariants(
+            self.exported_program,
+            op_map=self.op_map,
+        ).call(graph_module)
+        graph_module = replacement.graph_module
+        modified = replacement.modified
+        preoptimization_copy_count = len(self._layout_copy_nodes(graph_module))
+        inserted_copy_count = max(0, preoptimization_copy_count - existing_copy_count)
+
+        for iteration in range(self._MAX_OPTIMIZATION_ITERATIONS):
+            iteration_modified = False
+            for transform in self._optimization_passes():
+                result = transform.call(graph_module)
+                graph_module = result.graph_module
+                iteration_modified |= result.modified
+
+            modified |= iteration_modified
+            if not iteration_modified:
+                break
+            if iteration == self._MAX_OPTIMIZATION_ITERATIONS - 1:
+                raise RuntimeError(
+                    "Channels-last layout optimization did not converge after "
+                    f"{self._MAX_OPTIMIZATION_ITERATIONS} iterations."
+                )
+
+        self.report = self._build_report(
+            graph_module, inserted_copy_count, preoptimization_copy_count
+        )
+        if self.strict and (
+            self.report.internal_copy_count
+            or self.report.unknown_copy_count
+            or self.report.copies_with_unknown_size
+        ):
+            raise RuntimeError(
+                "Channels-last layout optimization left "
+                f"{self.report.internal_copy_count} internal and "
+                f"{self.report.unknown_copy_count} unknown copies, with "
+                f"{self.report.copies_with_unknown_size} unknown sizes. "
+                f"Internal nodes: {self.report.internal_copy_nodes}; "
+                f"unknown nodes: {self.report.unknown_copy_nodes}."
+            )
+
+        return PassResult(graph_module, modified)
+
+    def _optimization_passes(self) -> tuple[ExportPass, ...]:
+        return (
+            ReplaceSqueezeAndUnsqueezeWithViewPass(),
+            ReplaceNopTransposeOrPermuteWithViewPass(),
+            PostponePermuteOpBelowSqueezeOrUnsqueezeLikeView(),
+            FuseCascadedViewOps(),
+            FuseCascadedTransposeOrPermuteOps(),
+            RemovePermutesAroundElementwiseOps(
+                self.extra_permutable_ops,
+                exported_program=self.exported_program,
+                allow_layout_boundary_propagation=True,
+                can_propagate=self.can_propagate,
+            ),
+            FuseTransposeOrPermuteOpPairsPass(),
+            FuseCascadedViewOps(),
+            FuseCascadedTransposeOrPermuteOps(),
+        )
+
+    @staticmethod
+    def _layout_copy_nodes(
+        graph_module: torch.fx.GraphModule,
+    ) -> list[torch.fx.Node]:
+        return [node for node in graph_module.graph.nodes if is_layout_copy(node)]
+
+    def _build_report(
+        self,
+        graph_module: torch.fx.GraphModule,
+        inserted_copy_count: int,
+        preoptimization_copy_count: int,
+    ) -> ChannelsLastLayoutReport:
+        boundary_nodes: list[torch.fx.Node] = []
+        internal_nodes: list[torch.fx.Node] = []
+        unknown_nodes: list[torch.fx.Node] = []
+
+        for node in self._layout_copy_nodes(graph_module):
+            dims = self._normalized_dims(node)
+            if dims is None:
+                unknown_nodes.append(node)
+            elif self._reaches_user_input(node) or self._reaches_graph_output(node):
+                boundary_nodes.append(node)
+            else:
+                internal_nodes.append(node)
+
+        boundary_bytes, boundary_unknown = self._copy_bytes(boundary_nodes)
+        internal_bytes, internal_unknown = self._copy_bytes(internal_nodes)
+        unknown_bytes, unknown_unknown = self._copy_bytes(unknown_nodes)
+        surviving_count = len(boundary_nodes) + len(internal_nodes) + len(unknown_nodes)
+        return ChannelsLastLayoutReport(
+            inserted_copy_count=inserted_copy_count,
+            eliminated_copy_count=max(0, preoptimization_copy_count - surviving_count),
+            boundary_copy_count=len(boundary_nodes),
+            internal_copy_count=len(internal_nodes),
+            unknown_copy_count=len(unknown_nodes),
+            boundary_copy_bytes=boundary_bytes,
+            internal_copy_bytes=internal_bytes,
+            unknown_copy_bytes=unknown_bytes,
+            copies_with_unknown_size=(
+                boundary_unknown + internal_unknown + unknown_unknown
+            ),
+            internal_copy_nodes=tuple(node.name for node in internal_nodes),
+            unknown_copy_nodes=tuple(node.name for node in unknown_nodes),
+        )
+
+    def _reaches_user_input(self, node: torch.fx.Node) -> bool:
+        current = node.args[0] if node.args else None
+        visited: set[torch.fx.Node] = set()
+        while isinstance(current, torch.fx.Node) and current not in visited:
+            visited.add(current)
+            if current.op == "placeholder":
+                return current.name in self.exported_program.graph_signature.user_inputs
+            if (
+                current.op != "call_function"
+                or current.target not in _BOUNDARY_TRANSPARENT_TARGETS
+                or len(current.all_input_nodes) != 1
+            ):
+                return False
+            current = current.all_input_nodes[0]
+        return False
+
+    def _reaches_graph_output(self, node: torch.fx.Node) -> bool:
+        pending = list(node.users)
+        visited: set[torch.fx.Node] = set()
+        reached_output = False
+        while pending:
+            current = pending.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            if current.op == "output":
+                reached_output = True
+                continue
+            if (
+                current.op != "call_function"
+                or current.target not in _BOUNDARY_TRANSPARENT_TARGETS
+                or not current.users
+            ):
+                return False
+            pending.extend(current.users)
+        return reached_output
+
+    @staticmethod
+    def _normalized_dims(node: torch.fx.Node) -> list[int] | None:
+        if len(node.args) < 2 or not isinstance(node.args[1], (list, tuple)):
+            return None
+        dims = list(node.args[1])
+        if not all(isinstance(dim, int) for dim in dims):
+            return None
+        rank = len(dims)
+        normalized = [dim + rank if dim < 0 else dim for dim in dims]
+        if sorted(normalized) != list(range(rank)):
+            return None
+        return normalized
+
+    @staticmethod
+    def _copy_bytes(nodes: list[torch.fx.Node]) -> tuple[int, int]:
+        known_bytes = 0
+        unknown_count = 0
+        for node in nodes:
+            val: Any = node.meta.get("val")
+            if not isinstance(val, torch.Tensor) or not all(
+                isinstance(dim, int) for dim in val.shape
+            ):
+                unknown_count += 1
+                continue
+            known_bytes += val.numel() * val.element_size()
+        return known_bytes, unknown_count


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #21928
* #21927
* #21926
* __->__ #21925
* #21924
* #21923

Add ToContiguousChannelsLastPass as the common fixed-point pipeline for replacing selected operators with channels-last variants and composing the existing data-movement transforms. Backends can restrict the operator map, opt additional dimension-safe operators into propagation, and provide a node-level can_propagate capability barrier without forking the common implementation. Operator replacement already preserves complete metadata and recomputes shape fields during retracing, so this pipeline does not expose a separate metadata allowlist.

Report inserted, eliminated, boundary, internal, and unknown structural copies, including known byte counts. Strict mode rejects graphs that retain internal or unclassified copies and also rejects surviving copies whose sizes cannot be proven. These diagnostics bound structural-copy volume, not executor peak arena; backend integrations should retain planned-memory regression tests.

Keep dimension-sensitive behavior explicit. Softmax remains a barrier by default, user-authored ATen permutes are not counted as layout copies, and repeated pipeline execution is idempotent. Integration coverage exercises convolution chains, one-sided propagation, padding, softmax, unsafe runtime and constant broadcasts, backend capability barriers, strict mode, known and unknown byte reporting, and idempotence.

Differential Revision: [D116374085](https://our.internmc.facebook.com/intern/diff/D116374085/)