### PR TITLE
Cortex-M: share layout-aware CMSIS-NN kernels

### DIFF
--- a/backends/cortex_m/ops/cortex_m_ops_common.h
+++ b/backends/cortex_m/ops/cortex_m_ops_common.h
@@ -14,6 +14,7 @@
 
 #include <executorch/kernels/portable/cpu/util/elementwise_util.h>
 #include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 #include <executorch/runtime/platform/assert.h>
 
 #include <cinttypes>
@@ -35,6 +36,11 @@ using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
 // 16-byte alignment for MVE vector operations.
 constexpr size_t kCortexMMveAlignment = 16;
+
+enum class ActivationLayout {
+  NCHWLogical,
+  NHWCLogical,
+};
 
 // Basic tensor type / layout validation and dimension order checking
 inline void validate_cmsis_nn_tensor_requirements(
@@ -143,7 +149,24 @@ inline bool is_channels_last_tensor(const Tensor& tensor) {
   return tensor.dim_order() == channels_last_order;
 }
 
-inline bool is_channel_broadcast(const Tensor& tensor1, const Tensor& tensor2) {
+inline int64_t channel_dim(ActivationLayout layout) {
+  return layout == ActivationLayout::NHWCLogical ? 3 : 1;
+}
+
+inline bool has_activation_layout(
+    const Tensor& tensor,
+    ActivationLayout layout) {
+  if (layout == ActivationLayout::NCHWLogical) {
+    return is_channels_last_tensor(tensor);
+  }
+  return executorch::runtime::is_contiguous_dim_order(
+      tensor.dim_order().data(), tensor.dim_order().size());
+}
+
+inline bool is_channel_broadcast(
+    const Tensor& tensor1,
+    const Tensor& tensor2,
+    ActivationLayout layout) {
   if (tensor1.dim() != tensor2.dim()) {
     return false;
   }
@@ -152,12 +175,13 @@ inline bool is_channel_broadcast(const Tensor& tensor1, const Tensor& tensor2) {
     return false;
   }
 
-  if (tensor1.size(1) != tensor2.size(1)) {
+  const int64_t channel = channel_dim(layout);
+  if (tensor1.size(channel) != tensor2.size(channel)) {
     return false;
   }
 
-  const bool tensor1_channels_only = tensor1.numel() == tensor1.size(1);
-  const bool tensor2_channels_only = tensor2.numel() == tensor2.size(1);
+  const bool tensor1_channels_only = tensor1.numel() == tensor1.size(channel);
+  const bool tensor2_channels_only = tensor2.numel() == tensor2.size(channel);
 
   return tensor1_channels_only || tensor2_channels_only;
 }
@@ -203,7 +227,7 @@ inline bool prepare_cmsis_pool2d_config(
     int64_t activation_min,
     int64_t activation_max,
     CmsisPool2DConfig& config,
-    bool require_channels_last = true,
+    ActivationLayout layout,
     bool allow_ceil_mode = false) {
   if (input.dim() != 4 || output.dim() != 4) {
     ET_LOG(Error, "%s: tensors must be 4-D", op_name);
@@ -218,7 +242,9 @@ inline bool prepare_cmsis_pool2d_config(
     return false;
   }
 
-  if (input.size(0) != output.size(0) || input.size(1) != output.size(1)) {
+  const int64_t channel = channel_dim(layout);
+  if (input.size(0) != output.size(0) ||
+      input.size(channel) != output.size(channel)) {
     ET_LOG(
         Error,
         "%s: batch and channel dimensions must match between input and output",
@@ -227,13 +253,21 @@ inline bool prepare_cmsis_pool2d_config(
     return false;
   }
 
-  if (require_channels_last) {
-    if (!is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
-      ET_LOG(
-          Error, "%s: tensors must use channels_last dimension order", op_name);
+  if (layout == ActivationLayout::NHWCLogical) {
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            output.dim_order().data(), output.dim_order().size())) {
+      ET_LOG(Error, "%s: tensors must use contiguous dimension order", op_name);
       context.fail(Error::InvalidArgument);
       return false;
     }
+  } else if (
+      !is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
+    ET_LOG(
+        Error, "%s: tensors must use channels_last dimension order", op_name);
+    context.fail(Error::InvalidArgument);
+    return false;
   }
 
   auto check_tuple_len = [&](const Int64ArrayRef& arr,
@@ -312,19 +346,29 @@ inline bool prepare_cmsis_pool2d_config(
     return false;
   }
 
+  const int64_t height_dim = layout == ActivationLayout::NHWCLogical ? 1 : 2;
+  const int64_t width_dim = layout == ActivationLayout::NHWCLogical ? 2 : 3;
   int32_t batch, channels, input_h, input_w, output_h, output_w;
   if (!check_int32_within_range(
           context, op_name, input.size(0), "input batch", batch) ||
       !check_int32_within_range(
-          context, op_name, input.size(1), "input channels", channels) ||
+          context,
+          op_name,
+          input.size(channel_dim),
+          "input channels",
+          channels) ||
       !check_int32_within_range(
-          context, op_name, input.size(2), "input height", input_h) ||
+          context, op_name, input.size(height_dim), "input height", input_h) ||
       !check_int32_within_range(
-          context, op_name, input.size(3), "input width", input_w) ||
+          context, op_name, input.size(width_dim), "input width", input_w) ||
       !check_int32_within_range(
-          context, op_name, output.size(2), "output height", output_h) ||
+          context,
+          op_name,
+          output.size(height_dim),
+          "output height",
+          output_h) ||
       !check_int32_within_range(
-          context, op_name, output.size(3), "output width", output_w)) {
+          context, op_name, output.size(width_dim), "output width", output_w)) {
     return false;
   }
 

--- a/backends/cortex_m/ops/op_quantized_add.cpp
+++ b/backends/cortex_m/ops/op_quantized_add.cpp
@@ -11,11 +11,12 @@
 
 namespace cortex_m {
 namespace native {
+namespace {
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
-// cppcheck-suppress unusedFunction
-Tensor& quantized_add_out(
+Tensor& quantized_add_out_impl(
     KernelRuntimeContext& context,
+    const char* op_name,
     const Tensor& input1_int8,
     const int64_t input1_zero_point,
     const int64_t input1_multiplier,
@@ -29,9 +30,11 @@ Tensor& quantized_add_out(
     const int64_t output_shift,
     const int64_t activation_min,
     const int64_t activation_max,
-    Tensor& out) {
+    Tensor& out,
+    ActivationLayout layout) {
   // Validate tensor types and dim order
-  bool channel_broadcast = is_channel_broadcast(input1_int8, input2_int8);
+  bool channel_broadcast =
+      is_channel_broadcast(input1_int8, input2_int8, layout);
   validate_cmsis_nn_tensor_requirements(
       input1_int8,
       input2_int8,
@@ -39,6 +42,14 @@ Tensor& quantized_add_out(
       ScalarType::Char,
       /*require_channels_last=*/channel_broadcast,
       /*require_same_sizes=*/!channel_broadcast);
+  if (channel_broadcast) {
+    ET_CHECK_MSG(
+        has_activation_layout(input1_int8, layout) &&
+            has_activation_layout(input2_int8, layout) &&
+            has_activation_layout(out, layout),
+        "%s: broadcast tensors do not have the required activation layout",
+        op_name);
+  }
 
   // Validate quantization parameters
   validate_quantization_params(
@@ -54,7 +65,8 @@ Tensor& quantized_add_out(
 
   ET_LOG(
       Debug,
-      "quantized_add_out: input1_int8.sizes() = %zu",
+      "%s: input1_int8.sizes() = %zu",
+      op_name,
       input1_int8.sizes().size());
 
   int32_t zp1 = static_cast<int32_t>(input1_zero_point);
@@ -101,7 +113,7 @@ Tensor& quantized_add_out(
       std::swap<int>(input1_shift_val, input2_shift_val);
       std::swap<int8_t*>(input1_ptr, input2_ptr);
     }
-    adds_per_loop = input1_int8.size(1);
+    adds_per_loop = out.size(channel_dim(layout));
   } else {
     adds_per_loop = out.numel();
   }
@@ -130,7 +142,8 @@ Tensor& quantized_add_out(
     if (status != ARM_CMSIS_NN_SUCCESS) {
       ET_LOG(
           Error,
-          "quantized_add_out: arm_elementwise_add_s8 failed with status [%d]",
+          "%s: arm_elementwise_add_s8 failed with status [%d]",
+          op_name,
           status);
 
       context.fail(Error::Internal); // Fail the execution context
@@ -139,9 +152,49 @@ Tensor& quantized_add_out(
   }
   ET_LOG(
       Debug,
-      "quantized_add_out: Successfully completed with AoT-computed parameters!");
+      "%s: Successfully completed with AoT-computed parameters!",
+      op_name);
 
   return out;
+}
+
+} // namespace
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_add_out(
+    KernelRuntimeContext& context,
+    const Tensor& input1_int8,
+    const int64_t input1_zero_point,
+    const int64_t input1_multiplier,
+    const int64_t input1_shift,
+    const Tensor& input2_int8,
+    const int64_t input2_zero_point,
+    const int64_t input2_multiplier,
+    const int64_t input2_shift,
+    const int64_t output_zero_point,
+    const int64_t output_multiplier,
+    const int64_t output_shift,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    Tensor& out) {
+  return quantized_add_out_impl(
+      context,
+      "quantized_add_out",
+      input1_int8,
+      input1_zero_point,
+      input1_multiplier,
+      input1_shift,
+      input2_int8,
+      input2_zero_point,
+      input2_multiplier,
+      input2_shift,
+      output_zero_point,
+      output_multiplier,
+      output_shift,
+      activation_min,
+      activation_max,
+      out,
+      ActivationLayout::NCHWLogical);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/op_quantized_avg_pool2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_avg_pool2d.cpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  * Copyright 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -66,7 +68,7 @@ bool validate_avg_pool2d_output_size(
 } // namespace
 
 // cppcheck-suppress unusedFunction
-Tensor& quantized_avg_pool2d_out(
+static Tensor& quantized_avg_pool2d_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Int64ArrayRef kernel_size,
@@ -77,6 +79,7 @@ Tensor& quantized_avg_pool2d_out(
     const int64_t multiplier,
     const int64_t shift,
     const Tensor& scratch,
+    ActivationLayout layout,
     Tensor& out) {
   constexpr int32_t activation_min = std::numeric_limits<int8_t>::min();
   constexpr int32_t activation_max = std::numeric_limits<int8_t>::max();
@@ -97,7 +100,7 @@ Tensor& quantized_avg_pool2d_out(
           activation_min,
           activation_max,
           pool_config,
-          true,
+          layout,
           true)) {
     return out;
   }
@@ -151,6 +154,34 @@ Tensor& quantized_avg_pool2d_out(
   (void)shift;
 
   return out;
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_avg_pool2d_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef kernel_size,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const bool ceil_mode,
+    const int64_t zero_point,
+    const int64_t multiplier,
+    const int64_t shift,
+    const Tensor& scratch,
+    Tensor& out) {
+  return quantized_avg_pool2d_out_impl(
+      context,
+      input,
+      kernel_size,
+      stride,
+      padding,
+      ceil_mode,
+      zero_point,
+      multiplier,
+      shift,
+      scratch,
+      ActivationLayout::NCHWLogical,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/op_quantized_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_conv2d.cpp
@@ -1,9 +1,13 @@
 /*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  * Copyright 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 
 #include "cortex_m_ops_common.h"
 
@@ -25,7 +29,8 @@ bool validate_conv2d_arguments(
     const Int64ArrayRef& padding,
     const Int64ArrayRef& dilation,
     const Tensor& requantize_multipliers,
-    const Tensor& requantize_shifts) {
+    const Tensor& requantize_shifts,
+    ActivationLayout layout) {
   if (input.dim() != kConvDim || weight.dim() != kConvDim ||
       output.dim() != kConvDim) {
     ET_LOG(Error, "quantized_conv2d_out: tensors must be 4-D");
@@ -33,20 +38,22 @@ bool validate_conv2d_arguments(
     return false;
   }
 
-  // Check for channels_last dim_order (NHWC: 0, 2, 3, 1)
-  // Skip check if channels == 1, as dim_order is ambiguous in that case
-  if (input.size(1) > 1 && !is_channels_last_tensor(input)) {
+  if (layout == ActivationLayout::NHWCLogical) {
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            output.dim_order().data(), output.dim_order().size())) {
+      ET_LOG(
+          Error,
+          "quantized_conv2d_nhwc_out: input and output must have contiguous dim_order");
+      context.fail(Error::InvalidArgument);
+      return false;
+    }
+  } else if (
+      !is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
     ET_LOG(
         Error,
-        "quantized_conv2d_out: input must have channels_last dim_order (NHWC)");
-    context.fail(Error::InvalidArgument);
-    return false;
-  }
-
-  if (output.size(1) > 1 && !is_channels_last_tensor(output)) {
-    ET_LOG(
-        Error,
-        "quantized_conv2d_out: output must have channels_last dim_order (NHWC)");
+        "quantized_conv2d_out: input and output must have channels_last dim_order");
     context.fail(Error::InvalidArgument);
     return false;
   }
@@ -78,7 +85,8 @@ bool validate_conv2d_arguments(
     return false;
   }
 
-  const int64_t out_channels = output.size(1);
+  const int64_t out_channels =
+      output.size(layout == ActivationLayout::NHWCLogical ? 3 : 1);
   if (requantize_multipliers.size(0) != out_channels ||
       requantize_shifts.size(0) != out_channels) {
     ET_LOG(
@@ -94,7 +102,7 @@ bool validate_conv2d_arguments(
 } // namespace
 
 // cppcheck-suppress unusedFunction
-Tensor& quantized_conv2d_out(
+static Tensor& quantized_conv2d_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Tensor& weight,
@@ -109,6 +117,7 @@ Tensor& quantized_conv2d_out(
     const int64_t activation_min,
     const int64_t activation_max,
     const Tensor& scratch,
+    ActivationLayout layout,
     Tensor& out) {
   if (!validate_conv2d_arguments(
           context,
@@ -120,23 +129,30 @@ Tensor& quantized_conv2d_out(
           padding,
           dilation,
           requantize_multipliers,
-          requantize_shifts)) {
+          requantize_shifts,
+          layout)) {
     return out;
   }
 
   const int32_t batch = static_cast<int32_t>(input.size(0));
-  const int32_t input_channels = static_cast<int32_t>(input.size(1));
-  const int32_t input_height = static_cast<int32_t>(input.size(2));
-  const int32_t input_width = static_cast<int32_t>(input.size(3));
+  const int32_t input_channels = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t input_height = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t input_width = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   const int32_t kernel_output_channels = static_cast<int32_t>(weight.size(0));
   const int32_t kernel_height = static_cast<int32_t>(weight.size(1));
   const int32_t kernel_width = static_cast<int32_t>(weight.size(2));
   const int32_t kernel_input_channels = static_cast<int32_t>(weight.size(3));
 
-  const int32_t output_channels = static_cast<int32_t>(out.size(1));
-  const int32_t output_height = static_cast<int32_t>(out.size(2));
-  const int32_t output_width = static_cast<int32_t>(out.size(3));
+  const int32_t output_channels = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t output_height = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t output_width = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   const int32_t input_offset_val = static_cast<int32_t>(input_offset);
   const int32_t output_offset_val = static_cast<int32_t>(output_offset);
@@ -226,6 +242,42 @@ Tensor& quantized_conv2d_out(
   }
 
   return out;
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_conv2d_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef dilation,
+    const int64_t input_offset,
+    const int64_t output_offset,
+    const Tensor& requantize_multipliers,
+    const Tensor& requantize_shifts,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    const Tensor& scratch,
+    Tensor& out) {
+  return quantized_conv2d_out_impl(
+      context,
+      input,
+      weight,
+      bias,
+      stride,
+      padding,
+      dilation,
+      input_offset,
+      output_offset,
+      requantize_multipliers,
+      requantize_shifts,
+      activation_min,
+      activation_max,
+      scratch,
+      ActivationLayout::NCHWLogical,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/op_quantized_depthwise_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_depthwise_conv2d.cpp
@@ -1,9 +1,13 @@
 /*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  * Copyright 2025-2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 
 #include "cortex_m_ops_common.h"
 
@@ -26,7 +30,8 @@ bool validate_depthwise_conv2d_arguments(
     const Int64ArrayRef& dilation,
     const int64_t depth_multiplier,
     const Tensor& requantize_multipliers,
-    const Tensor& requantize_shifts) {
+    const Tensor& requantize_shifts,
+    ActivationLayout layout) {
   if (input.dim() != kConvDim || weight.dim() != kConvDim ||
       output.dim() != kConvDim) {
     ET_LOG(Error, "quantized_depthwise_conv2d_out: tensors must be 4-D");
@@ -55,7 +60,8 @@ bool validate_depthwise_conv2d_arguments(
   }
 
   const int64_t weight_output_channels = weight.size(3);
-  const int64_t output_channels = output.size(1);
+  const int64_t output_channels =
+      output.size(layout == ActivationLayout::NHWCLogical ? 3 : 1);
   if (weight_output_channels != output_channels) {
     ET_LOG(
         Error,
@@ -66,16 +72,22 @@ bool validate_depthwise_conv2d_arguments(
     return false;
   }
 
-  if (!is_channels_last_tensor(input)) {
+  if (layout == ActivationLayout::NHWCLogical) {
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            output.dim_order().data(), output.dim_order().size())) {
+      ET_LOG(
+          Error,
+          "quantized_depthwise_conv2d_nhwc_out: input and output must have contiguous dim_order");
+      context.fail(Error::InvalidArgument);
+      return false;
+    }
+  } else if (
+      !is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
     ET_LOG(
-        Error, "quantized_depthwise_conv2d_out: input must be channels_last");
-    context.fail(Error::InvalidArgument);
-    return false;
-  }
-
-  if (!is_channels_last_tensor(output)) {
-    ET_LOG(
-        Error, "quantized_depthwise_conv2d_out: output must be channels_last");
+        Error,
+        "quantized_depthwise_conv2d_out: input and output must be channels_last");
     context.fail(Error::InvalidArgument);
     return false;
   }
@@ -108,7 +120,8 @@ bool validate_depthwise_conv2d_arguments(
     return false;
   }
 
-  const int64_t input_channels = input.size(1);
+  const int64_t input_channels =
+      input.size(layout == ActivationLayout::NHWCLogical ? 3 : 1);
   // output_channels already extracted above for weight validation
   if (output_channels != input_channels * depth_multiplier) {
     ET_LOG(
@@ -136,7 +149,7 @@ bool validate_depthwise_conv2d_arguments(
 } // namespace
 
 // cppcheck-suppress unusedFunction
-Tensor& quantized_depthwise_conv2d_out(
+static Tensor& quantized_depthwise_conv2d_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Tensor& weight,
@@ -152,6 +165,7 @@ Tensor& quantized_depthwise_conv2d_out(
     const int64_t activation_min,
     const int64_t activation_max,
     const Tensor& scratch,
+    ActivationLayout layout,
     Tensor& out) {
   if (!validate_depthwise_conv2d_arguments(
           context,
@@ -164,23 +178,30 @@ Tensor& quantized_depthwise_conv2d_out(
           dilation,
           depth_multiplier,
           requantize_multipliers,
-          requantize_shifts)) {
+          requantize_shifts,
+          layout)) {
     return out;
   }
 
   const int32_t batch = static_cast<int32_t>(input.size(0));
-  const int32_t input_channels = static_cast<int32_t>(input.size(1));
-  const int32_t input_height = static_cast<int32_t>(input.size(2));
-  const int32_t input_width = static_cast<int32_t>(input.size(3));
+  const int32_t input_channels = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t input_height = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t input_width = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   // Weight is in IHWO layout after permutation in the pass: [1, H, W, C_OUT]
   // For depthwise conv, this matches CMSIS-NN's expected format
   const int32_t kernel_height = static_cast<int32_t>(weight.size(1));
   const int32_t kernel_width = static_cast<int32_t>(weight.size(2));
 
-  const int32_t output_channels = static_cast<int32_t>(out.size(1));
-  const int32_t output_height = static_cast<int32_t>(out.size(2));
-  const int32_t output_width = static_cast<int32_t>(out.size(3));
+  const int32_t output_channels = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t output_height = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t output_width = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   const int32_t depth_multiplier_val = static_cast<int32_t>(depth_multiplier);
 
@@ -270,6 +291,44 @@ Tensor& quantized_depthwise_conv2d_out(
   }
 
   return out;
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_depthwise_conv2d_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef dilation,
+    const int64_t depth_multiplier,
+    const int64_t input_offset,
+    const int64_t output_offset,
+    const Tensor& requantize_multipliers,
+    const Tensor& requantize_shifts,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    const Tensor& scratch,
+    Tensor& out) {
+  return quantized_depthwise_conv2d_out_impl(
+      context,
+      input,
+      weight,
+      bias,
+      stride,
+      padding,
+      dilation,
+      depth_multiplier,
+      input_offset,
+      output_offset,
+      requantize_multipliers,
+      requantize_shifts,
+      activation_min,
+      activation_max,
+      scratch,
+      ActivationLayout::NCHWLogical,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/op_quantized_max_pool2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_max_pool2d.cpp
@@ -1,4 +1,6 @@
 /*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  * Copyright 2026 Arm Limited and/or its affiliates.
  *
  * This source code is licensed under the BSD-style license found in the
@@ -11,7 +13,7 @@ namespace cortex_m {
 namespace native {
 
 // cppcheck-suppress unusedFunction
-Tensor& quantized_max_pool2d_out(
+static Tensor& quantized_max_pool2d_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Int64ArrayRef kernel_size,
@@ -23,6 +25,7 @@ Tensor& quantized_max_pool2d_out(
     const int64_t output_zero_point,
     const int64_t activation_min,
     const int64_t activation_max,
+    ActivationLayout layout,
     Tensor& out) {
   CmsisPool2DConfig pool_config;
   if (!prepare_cmsis_pool2d_config(
@@ -37,7 +40,8 @@ Tensor& quantized_max_pool2d_out(
           ceil_mode,
           activation_min,
           activation_max,
-          pool_config)) {
+          pool_config,
+          layout)) {
     return out;
   }
 
@@ -93,6 +97,36 @@ Tensor& quantized_max_pool2d_out(
   }
 
   return out;
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_max_pool2d_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef kernel_size,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef dilation,
+    const bool ceil_mode,
+    const int64_t input_zero_point,
+    const int64_t output_zero_point,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    Tensor& out) {
+  return quantized_max_pool2d_out_impl(
+      context,
+      input,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      ceil_mode,
+      input_zero_point,
+      output_zero_point,
+      activation_min,
+      activation_max,
+      ActivationLayout::NCHWLogical,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/op_quantized_mul.cpp
+++ b/backends/cortex_m/ops/op_quantized_mul.cpp
@@ -13,14 +13,11 @@ namespace {
 
 constexpr int32_t kInt8ActivationMin = std::numeric_limits<int8_t>::min();
 constexpr int32_t kInt8ActivationMax = std::numeric_limits<int8_t>::max();
-
-} // namespace
-
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
-// cppcheck-suppress unusedFunction
-Tensor& quantized_mul_out(
+Tensor& quantized_mul_out_impl(
     KernelRuntimeContext& context,
+    const char* op_name,
     const Tensor& input1_int8,
     const int64_t input1_zero_point,
     const Tensor& input2_int8,
@@ -28,10 +25,12 @@ Tensor& quantized_mul_out(
     const int64_t output_zero_point,
     const int64_t output_multiplier,
     const int64_t output_shift,
-    Tensor& out) {
+    Tensor& out,
+    ActivationLayout layout) {
   // Validate tensor types and quantization parameters
 
-  bool channel_broadcast = is_channel_broadcast(input1_int8, input2_int8);
+  bool channel_broadcast =
+      is_channel_broadcast(input1_int8, input2_int8, layout);
   validate_cmsis_nn_tensor_requirements(
       input1_int8,
       input2_int8,
@@ -39,6 +38,14 @@ Tensor& quantized_mul_out(
       ScalarType::Char,
       /*require_channels_last=*/channel_broadcast,
       /*require_same_sizes=*/!channel_broadcast);
+  if (channel_broadcast) {
+    ET_CHECK_MSG(
+        has_activation_layout(input1_int8, layout) &&
+            has_activation_layout(input2_int8, layout) &&
+            has_activation_layout(out, layout),
+        "%s: broadcast tensors do not have the required activation layout",
+        op_name);
+  }
 
   const int32_t kIdentityMultiplier(/*value=*/1);
   const int32_t kZeroShift(/*value=*/0);
@@ -70,7 +77,7 @@ Tensor& quantized_mul_out(
       std::swap<int8_t*>(input1_ptr, input2_ptr);
     }
 
-    muls_per_loop = input1_int8.size(1);
+    muls_per_loop = out.size(channel_dim(layout));
   } else {
     muls_per_loop = out.numel();
   }
@@ -108,13 +115,41 @@ Tensor& quantized_mul_out(
     if (status != ARM_CMSIS_NN_SUCCESS) {
       ET_LOG(
           Error,
-          "quantized_mul_out: arm_elementwise_mul_s8 failed with status [%d]",
+          "%s: arm_elementwise_mul_s8 failed with status [%d]",
+          op_name,
           status);
       context.fail(Error::Internal);
       return out;
     }
   }
   return out;
+}
+
+} // namespace
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_mul_out(
+    KernelRuntimeContext& context,
+    const Tensor& input1_int8,
+    const int64_t input1_zero_point,
+    const Tensor& input2_int8,
+    const int64_t input2_zero_point,
+    const int64_t output_zero_point,
+    const int64_t output_multiplier,
+    const int64_t output_shift,
+    Tensor& out) {
+  return quantized_mul_out_impl(
+      context,
+      "quantized_mul_out",
+      input1_int8,
+      input1_zero_point,
+      input2_int8,
+      input2_zero_point,
+      output_zero_point,
+      output_multiplier,
+      output_shift,
+      out,
+      ActivationLayout::NCHWLogical);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/op_quantized_transpose_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_transpose_conv2d.cpp
@@ -24,7 +24,8 @@ bool validate_transpose_conv2d_arguments(
     const std::optional<Tensor>& bias,
     const Tensor& output,
     const Tensor& requantize_multipliers,
-    const Tensor& requantize_shifts) {
+    const Tensor& requantize_shifts,
+    ActivationLayout layout) {
   if (input.dim() != kConvTransposeDim || weight.dim() != kConvTransposeDim ||
       output.dim() != kConvTransposeDim) {
     ET_LOG(Error, "quantized_transpose_conv2d_out: tensors must be 4-D");
@@ -32,16 +33,22 @@ bool validate_transpose_conv2d_arguments(
     return false;
   }
 
-  if (!is_channels_last_tensor(input)) {
+  if (layout == ActivationLayout::NHWCLogical) {
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            output.dim_order().data(), output.dim_order().size())) {
+      ET_LOG(
+          Error,
+          "quantized_transpose_conv2d_nhwc_out: input and output must have contiguous dim_order");
+      context.fail(Error::InvalidArgument);
+      return false;
+    }
+  } else if (
+      !is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
     ET_LOG(
-        Error, "quantized_transpose_conv2d_out: input must be channels_last");
-    context.fail(Error::InvalidArgument);
-    return false;
-  }
-
-  if (!is_channels_last_tensor(output)) {
-    ET_LOG(
-        Error, "quantized_transpose_conv2d_out: output must be channels_last");
+        Error,
+        "quantized_transpose_conv2d_out: input and output must be channels_last");
     context.fail(Error::InvalidArgument);
     return false;
   }
@@ -68,7 +75,8 @@ bool validate_transpose_conv2d_arguments(
     return false;
   }
 
-  const int64_t out_channels = output.size(1);
+  const int64_t out_channels =
+      output.size(layout == ActivationLayout::NHWCLogical ? 3 : 1);
   if (requantize_multipliers.size(0) != out_channels ||
       requantize_shifts.size(0) != out_channels) {
     ET_LOG(
@@ -84,7 +92,7 @@ bool validate_transpose_conv2d_arguments(
 } // namespace
 
 // cppcheck-suppress unusedFunction
-Tensor& quantized_transpose_conv2d_out(
+static Tensor& quantized_transpose_conv2d_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Tensor& weight,
@@ -101,6 +109,7 @@ Tensor& quantized_transpose_conv2d_out(
     const int64_t activation_max,
     const Tensor& scratch,
     const Tensor& output_scratch,
+    ActivationLayout layout,
     Tensor& out) {
   if (!validate_transpose_conv2d_arguments(
           context,
@@ -109,23 +118,30 @@ Tensor& quantized_transpose_conv2d_out(
           bias,
           out,
           requantize_multipliers,
-          requantize_shifts)) {
+          requantize_shifts,
+          layout)) {
     return out;
   }
 
   const int32_t batch = static_cast<int32_t>(input.size(0));
-  const int32_t input_channels = static_cast<int32_t>(input.size(1));
-  const int32_t input_height = static_cast<int32_t>(input.size(2));
-  const int32_t input_width = static_cast<int32_t>(input.size(3));
+  const int32_t input_channels = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t input_height = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t input_width = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   const int32_t kernel_output_channels = static_cast<int32_t>(weight.size(0));
   const int32_t kernel_height = static_cast<int32_t>(weight.size(1));
   const int32_t kernel_width = static_cast<int32_t>(weight.size(2));
   const int32_t kernel_input_channels = static_cast<int32_t>(weight.size(3));
 
-  const int32_t output_channels = static_cast<int32_t>(out.size(1));
-  const int32_t output_height = static_cast<int32_t>(out.size(2));
-  const int32_t output_width = static_cast<int32_t>(out.size(3));
+  const int32_t output_channels = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t output_height = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t output_width = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   if (kernel_output_channels != output_channels) {
     ET_LOG(
@@ -244,6 +260,46 @@ Tensor& quantized_transpose_conv2d_out(
   }
 
   return out;
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_transpose_conv2d_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef output_padding,
+    const Int64ArrayRef dilation,
+    const int64_t input_offset,
+    const int64_t output_offset,
+    const Tensor& requantize_multipliers,
+    const Tensor& requantize_shifts,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    const Tensor& scratch,
+    const Tensor& output_scratch,
+    Tensor& out) {
+  return quantized_transpose_conv2d_out_impl(
+      context,
+      input,
+      weight,
+      bias,
+      stride,
+      padding,
+      output_padding,
+      dilation,
+      input_offset,
+      output_offset,
+      requantize_multipliers,
+      requantize_shifts,
+      activation_min,
+      activation_max,
+      scratch,
+      output_scratch,
+      ActivationLayout::NCHWLogical,
+      out);
 }
 
 } // namespace native


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #21928
* #21927
* __->__ #21926
* #21925
* #21924
* #21923

Refactor the Cortex-M convolution, pooling, channel-broadcast add, and channel-broadcast multiply kernels behind shared internal implementations that accept an activation-layout mode. The shared code performs logical shape validation and dimension extraction for either legacy NCHW-logical tensors with channels-last dim order or contiguous NHWC-logical tensors, while continuing to pass the same physical NHWC buffers to CMSIS-NN.

All existing public operators continue to select the legacy layout, so their schemas, serialized programs, scratch behavior, and numerical behavior remain unchanged. Add and multiply select the channel dimension from the private layout mode instead of assuming logical dimension one. The layout selection remains a private C++ implementation detail rather than a serialized runtime operator parameter; fixed NHWC entrypoints are added separately in the following change.

Differential Revision: [D116372337](https://our.internmc.facebook.com/intern/diff/D116372337/)