### PR TITLE
[Vulkan] Let tensor wrap an external image with caller-supplied sizes

### DIFF
--- a/backends/vulkan/runtime/api/containers/Tensor.cpp
+++ b/backends/vulkan/runtime/api/containers/Tensor.cpp
@@ -851,7 +851,8 @@ vTensor::vTensor(
     const utils::StorageType storage_type,
     const utils::GPUMemoryLayout memory_layout,
     const bool allocate_memory,
-    const utils::AxisMapLayout axis_map_layout)
+    const utils::AxisMapLayout axis_map_layout,
+    const vkapi::VulkanImage* external_image)
     : dtype_(get_effective_scalar_type(context, dtype, memory_layout)),
       packed_dim_info_(calculate_packed_dim_info(memory_layout, storage_type)),
       // Calculate tensor metadata
@@ -879,15 +880,28 @@ vTensor::vTensor(
       uniforms_(),
       buffer_meta_(),
       // Construct Tensor storage
-      storage_(std::make_shared<vTensorStorage>(
-          context,
-          storage_type,
-          axis_map_,
-          packed_dim_info_,
-          padded_sizes_,
-          dtype_,
-          physical_numel_,
-          allocate_memory)) {
+      storage_(
+          external_image != nullptr
+              ? std::make_shared<vTensorStorage>(context, *external_image)
+              : std::make_shared<vTensorStorage>(
+                    context,
+                    storage_type,
+                    axis_map_,
+                    packed_dim_info_,
+                    padded_sizes_,
+                    dtype_,
+                    physical_numel_,
+                    allocate_memory)) {
+  // An external image was sized by its creator, so nothing guarantees it
+  // matches the metadata derived from `sizes`. The extents feed the
+  // shader-visible logical limits below, so they have to agree.
+  if (external_image != nullptr) {
+    VK_CHECK_COND(
+        storage_->image_extents_ ==
+            calculate_image_extents(
+                dtype_, packed_dim_info_, padded_sizes_, axis_map_),
+        "external image extents do not match the requested tensor sizes");
+  }
   // uniform_data_ only valid for low dim tensors
   if (sizes.size() <= 4) {
     uniform_data_ = std::make_shared<UniformData>(UniformData{

--- a/backends/vulkan/runtime/api/containers/Tensor.h
+++ b/backends/vulkan/runtime/api/containers/Tensor.h
@@ -210,7 +210,10 @@ class vTensor final {
       const utils::StorageType storage_type = utils::kTexture3D,
       const utils::GPUMemoryLayout memory_layout = utils::kChannelsPacked,
       const bool allocate_memory = true,
-      const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap);
+      const utils::AxisMapLayout axis_map_layout = utils::kDefaultAxisMap,
+      // When non-null, wrap this image instead of allocating. Stored as a
+      // VulkanImage copy, which aliases the handle without owning it.
+      const vkapi::VulkanImage* external_image = nullptr);
 
   vTensor(const vTensor& other) = delete;
 

--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -554,6 +554,25 @@ ValueRef ComputeGraph::add_tensor(
       axis_map_layout);
 }
 
+ValueRef ComputeGraph::add_tensor(
+    const std::vector<int64_t>& sizes,
+    const vkapi::ScalarType dtype,
+    const utils::GPUMemoryLayout memory_layout,
+    const vkapi::VulkanImage& image) {
+  ValueRef idx(static_cast<int>(values_.size()));
+  check_no_active_value_ptrs();
+  values_.emplace_back(api::vTensor(
+      context(),
+      sizes,
+      dtype,
+      utils::kTexture3D,
+      memory_layout,
+      /*allocate_memory=*/false,
+      utils::kDefaultAxisMap,
+      &image));
+  return idx;
+}
+
 ValueRef ComputeGraph::add_tensor(const vkapi::VulkanImage& image) {
   ValueRef idx(static_cast<int>(values_.size()));
   check_no_active_value_ptrs();

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -780,6 +780,17 @@ class ComputeGraph final {
   ValueRef add_tensor(const vkapi::VulkanImage& image);
 
   /*
+   * Wrap an externally owned image as a tensor with the given logical sizes.
+   * Unlike add_tensor(image), the shape is taken from the caller instead of
+   * being reconstructed from the image's extents.
+   */
+  ValueRef add_tensor(
+      const std::vector<int64_t>& sizes,
+      const vkapi::ScalarType dtype,
+      const utils::GPUMemoryLayout memory_layout,
+      const vkapi::VulkanImage& image);
+
+  /*
    * Add a `api::vTensor` value to the graph with the properties of `vref`.
    */
   ValueRef add_tensor_like(

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -1700,6 +1700,87 @@ TEST_F(VulkanComputeAPITest, test_tensor_creation_from_vulkan_image) {
   EXPECT_TRUE(tensor.numel() == exp_numel);
 }
 
+// Sizes an image can carry but its extents cannot express: rank 4, and a
+// sequence dim that is not the packed one.
+static const std::vector<int64_t> kExternalSizes = {1, 37, 8, 64};
+
+static vTensor make_image_owner() {
+  return vTensor(
+      context(),
+      kExternalSizes,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kWidthPacked);
+}
+
+TEST_F(
+    VulkanComputeAPITest,
+    test_tensor_over_external_image_keeps_logical_sizes) {
+  vTensor owner = make_image_owner();
+
+  vTensor view(
+      context(),
+      kExternalSizes,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kWidthPacked,
+      /*allocate_memory = */ false,
+      utils::kDefaultAxisMap,
+      &owner.image());
+
+  EXPECT_TRUE(view.sizes() == kExternalSizes);
+  EXPECT_TRUE(view.packed_dim() == 0);
+  EXPECT_TRUE(view.numel() == owner.numel());
+
+  // Reconstructing from the extents instead would collapse this to 3 sizes.
+  EXPECT_TRUE(vTensor(context(), owner.image()).sizes().size() == 3);
+}
+
+TEST_F(
+    VulkanComputeAPITest,
+    test_tensor_over_external_image_rejects_size_mismatch) {
+  vTensor owner = make_image_owner();
+
+  std::vector<int64_t> mismatched = kExternalSizes;
+  mismatched.back() *= 2;
+
+  EXPECT_THROW(
+      vTensor(
+          context(),
+          mismatched,
+          vkapi::kFloat,
+          utils::kTexture3D,
+          utils::kWidthPacked,
+          /*allocate_memory = */ false,
+          utils::kDefaultAxisMap,
+          &owner.image()),
+      vkapi::Error);
+}
+
+TEST_F(VulkanComputeAPITest, test_tensor_over_external_image_does_not_own_it) {
+  vTensor owner = make_image_owner();
+
+  {
+    vTensor view(
+        context(),
+        kExternalSizes,
+        vkapi::kFloat,
+        utils::kTexture3D,
+        utils::kWidthPacked,
+        /*allocate_memory = */ false,
+        utils::kDefaultAxisMap,
+        &owner.image());
+
+    EXPECT_TRUE(view.image().is_copy_of(owner.image()));
+  }
+
+  // The view is gone and its deferred cleanup has run; the image it aliased
+  // belongs to `owner` and is still live.
+  context()->flush();
+  EXPECT_TRUE(owner.image());
+  EXPECT_FALSE(owner.image().is_copy());
+}
+
 TEST(VulkanComputeGraphTest, test_values_scalars) {
   GraphConfig config;
   ComputeGraph graph(config);


### PR DESCRIPTION
## Summary

  `vTensor(context, image)` infers the tensor's shape from the image's extents, and a `VkImage` has three: width, height and depth, so that inference always yields a rank-3 shape. A logical shape such as `[B, S, H, D]` is unreachable, which blocks wrapping an externally owned image as a tensor whose axes the shaders can index.

  This lets the caller pass the image to the main vTensor constructor instead, so the sizes, dtype and layout come from the caller and only the storage comes from the image. A ComputeGraph::add_tensor overload reaches it. The image is held as a `VulkanImage` copy, which aliases the handle with `is_copy_` set, so the adopted view never destroys memory. An extent check rejects an image whose size disagrees with the requested sizes.

  The allocating path is untouched. The parameter defaults to `nullptr` and construction only diverges when it is set, so `logical_limits` still seeds from the physical extents as before.

  ## Files

  - `backends/vulkan/runtime/api/containers/Tensor.h` — `external_image` on the `vTensor` constructor.
  - `backends/vulkan/runtime/api/containers/Tensor.cpp` — storage selection between the adopting and allocating `vTensorStorage`, and the extent check.
  - `backends/vulkan/runtime/graph/ComputeGraph.h`, `.cpp` — an `add_tensor` overload taking sizes, dtype, memory layout and an image.
  - `backends/vulkan/test/vulkan_compute_api_test.cpp` — 3 new tests.

  ## Testing

  `vulkan_compute_api_test` New coverage: adopting at `[1, 37, 8, 64]` and keeping all four sizes, asserted against the inferring constructor collapsing the same image to rank 3; rejecting an image whose extents disagree with the requested sizes; and an adopted view reporting `is_copy_of` the source and leaving the source image live after the view is destroyed and deferred cleanup has run.

cc @SS-JIA @manuelcandales @digantdesai @cbilgin