### PR TITLE
Qualcomm AI Engine Direct - Move QCOM_AXIS_ORDER pop into LayoutTransform pass

### DIFF
--- a/backends/qualcomm/_passes/layout_transform.py
+++ b/backends/qualcomm/_passes/layout_transform.py
@@ -351,6 +351,14 @@ class LayoutTransform(ExportPass):
                     self.traverse(node, graph_module)
             self.insert_permute, self.transformed_tag = True, QCOM_AXIS_ORDER
 
+            for node in graph.nodes:
+                if hasattr(node, "meta"):
+                    # Pop QCOM_AXIS_ORDER written by the to-edge LayoutTransform pass.
+                    # Without this, the main for-loop below would see is_transformed_node=True
+                    # for every sensitive node (deepcopy carries the tag from to-edge) and
+                    # skip them entirely, so no permute nodes would ever be inserted.
+                    node.meta.pop(QCOM_AXIS_ORDER, "")
+
         for node in sensitive_nodes:
             if not self.is_transformed_node(node):
                 self.mark_as_transformed(node)

--- a/backends/qualcomm/qnn_preprocess.py
+++ b/backends/qualcomm/qnn_preprocess.py
@@ -22,10 +22,7 @@ from executorch.backends.qualcomm.serialization.qc_schema import (
 from executorch.backends.qualcomm.serialization.qc_schema_serialize import (
     flatbuffer_to_option,
 )
-from executorch.backends.qualcomm.utils.constants import (
-    QCOM_AXIS_ORDER,
-    QCOM_TENSOR_NAME,
-)
+from executorch.backends.qualcomm.utils.constants import QCOM_TENSOR_NAME
 from executorch.backends.qualcomm.utils.qnn_manager_lifecycle import (
     get_current_qnn_manager,
 )
@@ -56,10 +53,6 @@ class QnnBackend(BackendDetails):
         use_mha2sha: bool,
         backend_type: QnnExecuTorchBackendType,
     ):
-        for node in edge_program.graph_module.graph.nodes:
-            if hasattr(node, "meta"):
-                # pop certain keys in meta for not affecting the passes in compilation
-                node.meta.pop(QCOM_AXIS_ORDER, "")
         # QNN Delegate Specific Passes
         graph_module = get_qnn_pass_manager_cls(
             backend_type

--- a/backends/qualcomm/tests/rework/passes/passes_helper.py
+++ b/backends/qualcomm/tests/rework/passes/passes_helper.py
@@ -287,13 +287,6 @@ class PassPipeline:
             quantizer=quantizer,
         )
         gm = edge_ep.graph_module
-        # Mirror qnn_preprocess.py: strip QCOM_AXIS_ORDER from all nodes
-        from executorch.backends.qualcomm.utils.constants import QCOM_AXIS_ORDER
-
-        for node in gm.graph.nodes:
-            if hasattr(node, "meta"):
-                node.meta.pop(QCOM_AXIS_ORDER, "")
-
         pm_cls = get_qnn_pass_manager_cls(backend_type)
         pass_classes = PassPipeline._slice_to_target(
             pm_cls.get_preprocess_passes(use_mha2sha=use_mha2sha),


### PR DESCRIPTION
### Context
This PR supersedes #21630.

The original PR was closed due to  CLA issues.
This new PR is created from a new branch to track CLA status and continue the review process.
      
Please refer to #21630 for previous review comments and discussion.
### Summary:
  - The pop of QCOM_AXIS_ORDER was previously done in
  QnnBackend._build_op_wrappers before calling
  transform_for_preprocess_pipeline. Moving it into
  LayoutTransform.call() when insert_permute=True keeps the cleanup
  logic co-located with the code that depends on it.

  - The pop is necessary because the delegated subgraph is created via
  deepcopy, which carries over the QCOM_AXIS_ORDER tags written by the
  to-edge LayoutTransform run. Without clearing them, is_transformed_node()
  returns True for every sensitive node in the
  main for-loop, causing all traversals to be skipped and no permute
  nodes to be inserted.



### Test plan
```bash
python -m backends.qualcomm.tests.test_qnn_delegate TestQNNQuantizedOperator  --device ${SERIAL_NUM}   --soc_model ${SOC_MODEL}   --build_folder build-android   --executorch_root .
```


cc @cccclai @winskuo-quic @shewu-quic @haowhsu-quic @DannyYuyang-quic @cbilgin @abhinaykukkadapu @psiddh