### PR TITLE
Skip ATen-mode out-of-range integer clamp/hardtanh death tests

### DIFF
--- a/kernels/test/op_clamp_test.cpp
+++ b/kernels/test/op_clamp_test.cpp
@@ -368,6 +368,10 @@ TEST_F(OpClampOutTest, ByteTensorNegativeClampDies) {
 }
 
 TEST_F(OpClampOutTest, ByteTensorTooLargeClampDies) {
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel treats an out-of-range integer clamp bound as a no-op or an "
+      "error depending on direction");
   // Cannot be represented by a uint8_t.
   expect_bad_clamp_value_dies<ScalarType::Byte>(256);
 }

--- a/kernels/test/op_hardtanh_test.cpp
+++ b/kernels/test/op_hardtanh_test.cpp
@@ -9,9 +9,12 @@
 #include <executorch/kernels/test/FunctionHeaderWrapper.h> // Declares the operator
 #include <executorch/kernels/test/ScalarOverflowTestMacros.h>
 #include <executorch/kernels/test/TestUtil.h>
+#include <executorch/kernels/test/supported_features.h>
+#include <executorch/kernels/test/supported_features_skip.h>
 #include <executorch/runtime/core/exec_aten/exec_aten.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_util.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 
 #include <gtest/gtest.h>
 
@@ -55,6 +58,16 @@ class OpHardTanhTest : public OperatorTest {
 
   template <ScalarType DTYPE>
   void expect_bad_scalar_value_dies(const Scalar& bad_value) {
+    if constexpr (executorch::runtime::isIntegralType(
+                      DTYPE, /*includeBool=*/false)) {
+      // ATen treats an out-of-range integer hardtanh bound as a no-op or an
+      // error depending on direction, so the death test no longer holds.
+      ET_SKIP_IF(
+          torch::executor::testing::SupportedFeatures::get()->is_aten,
+          "ATen kernel treats out-of-range integer hardtanh bounds by "
+          "direction (no-op or error)");
+    }
+
     TensorFactory<DTYPE> tf;
     Tensor in = tf.ones({2, 2});
     Tensor out = tf.zeros({2, 2});


### PR DESCRIPTION
pytorch/pytorch#193169 changes how ATen's scalar `clamp` handles an out-of-range
integer bound. Instead of converting the bound straight to the input dtype
(which raised for signed dtypes and silently wrapped for unsigned ones), ATen
now reconciles the bound by direction: a `min` below the dtype's range (or a
`max` above it) is a no-op and is dropped, while the opposite direction is
rejected. `hardtanh` shares this behavior.

The portable kernels keep their own strict bounds check and are unaffected, but
the ATen-mode death tests (built with -DUSE_ATEN_LIB) assume every out-of-range
integer bound raises, which no longer holds. Skip those integer cases in ATen
mode, matching the existing skips for negative uint8 and out-of-range int32
bounds:

- op_clamp_test: ByteTensorTooLargeClampDies
- op_hardtanh_test: ByteTensorTooLargeScalarDies, CharTensorTooSmallScalarDies,
  ShortTensorTooLargeScalarDies (gated in the fixture helper, not the shared
  ScalarOverflowTestMacros.h, which eight suites depend on)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

### Summary
[PLEASE REMOVE] See [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests) for ExecuTorch PR guidelines.

[PLEASE REMOVE] If this PR closes an issue, please add a `Fixes #<issue-id>` line.

[PLEASE REMOVE] If this PR introduces a fix or feature that should be the upcoming release notes, please add a "Release notes: <area>" label. For a list of available release notes labels, check out [CONTRIBUTING.md's Pull Requests](https://github.com/pytorch/executorch/blob/main/CONTRIBUTING.md#pull-requests).

### Test plan
[PLEASE REMOVE] How did you test this PR? Please write down any manual commands you used and note down tests that you have written if applicable.


cc @larryliu0820 @manuelcandales @JakeStevens