### PR TITLE
Add QAT support and pass hooks to QuantizationRecipe.

### DIFF
--- a/export/recipe.py
+++ b/export/recipe.py
@@ -1,13 +1,16 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 # Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
 import copy
 import dataclasses
+import logging
 from abc import ABCMeta, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, EnumMeta
 from typing import Callable, Dict, Iterable, List, Optional, Union
 
@@ -138,6 +141,9 @@ class QuantizationRecipe:
                                  AOBaseConfig with optional filter functions.
         is_qat: If True, use the QAT flow (prepare_qat_pt2e -> train_fn -> convert_pt2e).
                 If False (default), use the PTQ flow (prepare_pt2e -> calibrate -> convert_pt2e).
+        dynamic_batch_size: If True, dimension 0 (batch) of the calibration/QAT
+                            training inputs may vary. Otherwise it is fixed to the
+                            example inputs' batch size.
         calibration_inputs_fn: Optional callable returning an iterable of input tuples used for
                                PTQ calibration. When None (default), the example inputs are used.
                                Ignored when is_qat=True.
@@ -159,6 +165,7 @@ class QuantizationRecipe:
     quantizers: Optional[List[Quantizer]] = None
     ao_quantization_configs: Optional[List[AOQuantizationConfig]] = None
     is_qat: bool = False
+    dynamic_batch_size: bool = False
     calibration_inputs_fn: Optional[Callable[[], Iterable[tuple]]] = None
     train_fn: Optional[Callable[["torch.fx.GraphModule"], None]] = None
     pre_prepare_passes: Optional[
@@ -216,6 +223,32 @@ class LoweringRecipe:
     ) = None
     # pyre-ignore[11]: Type not defined
     edge_compile_config: Optional[EdgeCompileConfig] = None
+
+
+@dataclass
+class _CombineAccumulator:
+    """Private accumulator used by ExportRecipe._collect_recipe_fields."""
+
+    partitioners: list = field(default_factory=list)
+    partitioners_by_method: dict = field(default_factory=dict)
+    quantizers: list = field(default_factory=list)
+    ao_quantization_configs: list = field(default_factory=list)
+    pre_edge_passes: list = field(default_factory=list)
+    edge_transform_passes: list = field(default_factory=list)
+    edge_manager_transform_passes: list = field(default_factory=list)
+    pre_prepare_passes: list = field(default_factory=list)
+    post_prepare_passes: list = field(default_factory=list)
+    pre_convert_passes: list = field(default_factory=list)
+    post_convert_passes: list = field(default_factory=list)
+    is_qat_values: list = field(default_factory=list)
+    dynamic_batch_size_values: list = field(default_factory=list)
+    train_fn_values: list = field(default_factory=list)
+    calibration_inputs_fn_values: list = field(default_factory=list)
+    strict_values: list = field(default_factory=list)
+    mode_values: list = field(default_factory=list)
+    pipeline_stages_values: list = field(default_factory=list)
+    source_transform_in_place_values: list = field(default_factory=list)
+    backend_config: object = None
 
 
 @experimental(
@@ -315,125 +348,45 @@ class ExportRecipe:
 
         return cls._combine_recipes(recipes, recipe_name)
 
-    @classmethod
-    def _combine_recipes(  # noqa: C901
-        cls, backend_recipes: List["ExportRecipe"], recipe_name: Optional[str] = None
-    ) -> "ExportRecipe":
-        """
-        Util to combine multiple backend recipes into a single multi-backend recipe.
-
-        Args:
-            backend_recipes: List of ExportRecipe objects to combine
-            recipe_name: Optional name for the combined recipe
-
-        Returns:
-            Combined ExportRecipe for multi-backend deployment
-        """
-        overriding = [
-            r.name or f"recipes[{i}]"
-            for i, r in enumerate(backend_recipes)
-            if r.pipeline_stages
-        ]
-        if overriding:
+    @staticmethod
+    def _assert_scalar_fields_agree(field_name: str, values: list) -> None:
+        """Raise ValueError when a scalar field has conflicting values across recipes."""
+        unique = set(values)
+        if len(unique) > 1:
             raise ValueError(
-                "Cannot combine recipes that override pipeline_stages, there is no "
-                f"correct way to merge the orderings: {overriding}"
+                f"Cannot combine recipes with conflicting '{field_name}' values: {unique}"
             )
 
-        # Scalar fields that must be identical across all recipes.
-        def _assert_agree(field_name: str, values: list) -> None:
-            unique = set(values)
-            if len(unique) > 1:
-                raise ValueError(
-                    f"Cannot combine recipes with conflicting '{field_name}' values: {unique}"
-                )
+    @classmethod
+    def _combine_quantization_recipe(
+        cls,
+        is_qat_values: list,
+        dynamic_batch_size_values: list,
+        train_fn_values: list,
+        calibration_inputs_fn_values: list,
+        all_quantizers: list,
+        all_ao_quantization_configs: list,
+        all_pre_prepare_passes: list,
+        all_post_prepare_passes: list,
+        all_pre_convert_passes: list,
+        all_post_convert_passes: list,
+    ) -> "Optional[QuantizationRecipe]":
+        """
+        Build the combined QuantizationRecipe from per-recipe collected lists.
 
-        # Collect all components.
-        all_partitioners: list = []
-        all_partitioners_by_method = {}
-        all_quantizers: list = []
-        all_ao_quantization_configs: list = []
-        all_pre_edge_passes: list = []
-        all_edge_transform_passes: list = []
-        all_edge_manager_transform_passes: list = []
-        all_pre_prepare_passes: list = []
-        all_post_prepare_passes: list = []
-        all_pre_convert_passes: list = []
-        all_post_convert_passes: list = []
-        combined_backend_config = None
+        Returns None when no recipe contributed any quantization fields, and logs
+        an INFO message so callers know quantization is absent from the combination.
+        """
+        # is_qat must agree: the two flows (QAT vs PTQ) are incompatible.
+        cls._assert_scalar_fields_agree("is_qat", is_qat_values)
 
-        is_qat_values: list = []
-        train_fn_values: list = []
-        calibration_inputs_fn_values: list = []
-        strict_values: list = []
-        mode_values: list = []
-        pipeline_stages_values: list = []
-        source_transform_in_place_values: list = []
-
-        for recipe in backend_recipes:
-            if recipe.aten_transform_passes:
-                all_pre_edge_passes.extend(recipe.aten_transform_passes)
-
-            if lr := recipe.lowering_recipe:
-                if lr.partitioners:
-                    if isinstance(lr.partitioners, dict):
-                        for method_name, method_partitioners in lr.partitioners.items():
-                            all_partitioners_by_method.setdefault(method_name, []).extend(
-                                method_partitioners
-                            )
-                    else:
-                        all_partitioners.extend(lr.partitioners)
-                if lr.edge_transform_passes:
-                    all_edge_transform_passes.extend(lr.edge_transform_passes)
-                if lr.edge_manager_transform_passes:
-                    all_edge_manager_transform_passes.extend(
-                        lr.edge_manager_transform_passes
-                    )
-
-            if qr := recipe.quantization_recipe:
-                if qr.quantizers:
-                    all_quantizers.extend(qr.quantizers)
-                if qr.ao_quantization_configs:
-                    all_ao_quantization_configs.extend(qr.ao_quantization_configs)
-                is_qat_values.append(qr.is_qat)
-                train_fn_values.append(qr.train_fn)
-                calibration_inputs_fn_values.append(qr.calibration_inputs_fn)
-                if qr.pre_prepare_passes:
-                    all_pre_prepare_passes.extend(qr.pre_prepare_passes)
-                if qr.post_prepare_passes:
-                    all_post_prepare_passes.extend(qr.post_prepare_passes)
-                if qr.pre_convert_passes:
-                    all_pre_convert_passes.extend(qr.pre_convert_passes)
-                if qr.post_convert_passes:
-                    all_post_convert_passes.extend(qr.post_convert_passes)
-
-            strict_values.append(recipe.strict)
-            mode_values.append(recipe.mode)
-            pipeline_stages_values.append(
-                tuple(recipe.pipeline_stages) if recipe.pipeline_stages else None
-            )
-            source_transform_in_place_values.append(recipe.source_transform_in_place)
-
-            # Use the first backend config as base
-            if combined_backend_config is None and recipe.executorch_backend_config:
-                combined_backend_config = copy.deepcopy(
-                    recipe.executorch_backend_config
-                )
-
-        # Validate fields that must agree across all recipes.
-        _assert_agree("strict", strict_values)
-        _assert_agree("mode", mode_values)
-        _assert_agree("pipeline_stages", pipeline_stages_values)
-        _assert_agree("source_transform_in_place", source_transform_in_place_values)
-
-        # is_qat must agree across all recipes that carry a QuantizationRecipe.
-        _assert_agree("is_qat", is_qat_values)
-        # train_fn must have at most one non-None value across all recipes.
+        # At most one recipe may supply a train_fn.
         non_none_train_fns = [f for f in train_fn_values if f is not None]
         if len(non_none_train_fns) > 1:
             raise ValueError(
                 "Cannot combine recipes: more than one recipe provides a train_fn."
             )
+
         # Multiple calibration_inputs_fn values are chained into a single factory.
         non_none_calib_fns = [f for f in calibration_inputs_fn_values if f is not None]
         if len(non_none_calib_fns) > 1:
@@ -443,13 +396,13 @@ class ExportRecipe:
                 for _fn in _fns:
                     yield from _fn()
 
-            combined_calib_fn = _combined_calib_fn
+            combined_calib_fn: "Optional[Callable[[], Iterable[tuple]]]" = (
+                _combined_calib_fn
+            )
         else:
             combined_calib_fn = non_none_calib_fns[0] if non_none_calib_fns else None
 
-        # Build combined QuantizationRecipe.
-        combined_quantization_recipe = None
-        if (
+        if not (
             all_quantizers
             or all_ao_quantization_configs
             or all_pre_prepare_passes
@@ -457,17 +410,40 @@ class ExportRecipe:
             or all_pre_convert_passes
             or all_post_convert_passes
         ):
-            combined_quantization_recipe = QuantizationRecipe(
-                quantizers=all_quantizers or None,
-                ao_quantization_configs=all_ao_quantization_configs or None,
-                is_qat=is_qat_values[0] if is_qat_values else False,
-                train_fn=non_none_train_fns[0] if non_none_train_fns else None,
-                calibration_inputs_fn=combined_calib_fn,
-                pre_prepare_passes=all_pre_prepare_passes or None,
-                post_prepare_passes=all_post_prepare_passes or None,
-                pre_convert_passes=all_pre_convert_passes or None,
-                post_convert_passes=all_post_convert_passes or None,
+            logging.info(
+                "Combined recipe has no quantizers, quantization configs, or "
+                "quantization passes; quantization_recipe will be None."
             )
+            return None
+
+        return QuantizationRecipe(
+            quantizers=all_quantizers or None,
+            ao_quantization_configs=all_ao_quantization_configs or None,
+            is_qat=is_qat_values[0] if is_qat_values else False,
+            dynamic_batch_size=any(dynamic_batch_size_values),
+            train_fn=non_none_train_fns[0] if non_none_train_fns else None,
+            calibration_inputs_fn=combined_calib_fn,
+            pre_prepare_passes=all_pre_prepare_passes or None,
+            post_prepare_passes=all_post_prepare_passes or None,
+            pre_convert_passes=all_pre_convert_passes or None,
+            post_convert_passes=all_post_convert_passes or None,
+        )
+
+    @classmethod
+    def _combine_lowering_recipe(
+        cls,
+        backend_recipes: "List[ExportRecipe]",
+        all_partitioners: list,
+        all_partitioners_by_method: dict,
+        all_edge_transform_passes: list,
+        all_edge_manager_transform_passes: list,
+    ) -> "Optional[LoweringRecipe]":
+        """
+        Build the combined LoweringRecipe from per-recipe collected lists.
+
+        Returns None when no recipe contributed any lowering fields, and logs
+        an INFO message so callers know lowering is absent from the combination.
+        """
 
         if all_partitioners and all_partitioners_by_method:
             raise ValueError(
@@ -476,7 +452,7 @@ class ExportRecipe:
             )
         combined_partitioners = all_partitioners_by_method or all_partitioners
 
-        # By value, not identity: every provider builds a fresh config object,
+        # Compare edge_compile_confgs by value, not identity: every provider builds a fresh config object,
         # so asking for the same thing twice is not a conflict.
         distinct: List[tuple[str, EdgeCompileConfig]] = []
         for i, recipe in enumerate(backend_recipes):
@@ -498,48 +474,164 @@ class ExportRecipe:
             )
         edge_compile_config = copy.deepcopy(distinct[0][1]) if distinct else None
 
-        combined_lowering_recipe = None
-        if (
+        if not (
             combined_partitioners
             or all_edge_transform_passes
             or all_edge_manager_transform_passes
             or edge_compile_config
         ):
-            edge_compile_config = None
-            for recipe in backend_recipes:
-                if (
-                    recipe.lowering_recipe
-                    and recipe.lowering_recipe.edge_compile_config
-                ):
-                    edge_compile_config = recipe.lowering_recipe.edge_compile_config
-                    break
-
-            combined_lowering_recipe = LoweringRecipe(
-                partitioners=combined_partitioners or None,
-                edge_transform_passes=all_edge_transform_passes or None,
-                edge_manager_transform_passes=all_edge_manager_transform_passes or None,
-                edge_compile_config=edge_compile_config or EdgeCompileConfig(),
+            logging.info(
+                "Combined recipe has no lowering fields; lowering_recipe will be None."
             )
+            return None
+
+        return LoweringRecipe(
+            partitioners=combined_partitioners or None,
+            edge_transform_passes=all_edge_transform_passes or None,
+            edge_manager_transform_passes=all_edge_manager_transform_passes or None,
+            edge_compile_config=edge_compile_config or EdgeCompileConfig(),
+        )
+
+    @staticmethod
+    def _collect_lowering_fields(
+        acc: "_CombineAccumulator", lr: "LoweringRecipe"
+    ) -> None:
+        """Accumulate fields from a single LoweringRecipe into acc."""
+        if lr.partitioners:
+            if isinstance(lr.partitioners, dict):
+                for method_name, method_partitioners in lr.partitioners.items():
+                    acc.partitioners_by_method.setdefault(method_name, []).extend(
+                        method_partitioners
+                    )
+            else:
+                acc.partitioners.extend(lr.partitioners)
+        if lr.edge_transform_passes:
+            acc.edge_transform_passes.extend(lr.edge_transform_passes)
+        if lr.edge_manager_transform_passes:
+            acc.edge_manager_transform_passes.extend(lr.edge_manager_transform_passes)
+
+    @staticmethod
+    def _collect_quantization_fields(
+        acc: "_CombineAccumulator", qr: "QuantizationRecipe"
+    ) -> None:
+        """Accumulate fields from a single QuantizationRecipe into acc."""
+        if qr.quantizers:
+            acc.quantizers.extend(qr.quantizers)
+        if qr.ao_quantization_configs:
+            acc.ao_quantization_configs.extend(qr.ao_quantization_configs)
+        acc.is_qat_values.append(qr.is_qat)
+        acc.dynamic_batch_size_values.append(qr.dynamic_batch_size)
+        acc.train_fn_values.append(qr.train_fn)
+        acc.calibration_inputs_fn_values.append(qr.calibration_inputs_fn)
+        if qr.pre_prepare_passes:
+            acc.pre_prepare_passes.extend(qr.pre_prepare_passes)
+        if qr.post_prepare_passes:
+            acc.post_prepare_passes.extend(qr.post_prepare_passes)
+        if qr.pre_convert_passes:
+            acc.pre_convert_passes.extend(qr.pre_convert_passes)
+        if qr.post_convert_passes:
+            acc.post_convert_passes.extend(qr.post_convert_passes)
+
+    @classmethod
+    def _collect_recipe_fields(
+        cls,
+        backend_recipes: "List[ExportRecipe]",
+    ) -> "_CombineAccumulator":
+        """
+        Iterate over all recipes and accumulate their fields into a single
+        _CombineAccumulator for later merging.
+        """
+        acc = _CombineAccumulator()
+
+        for recipe in backend_recipes:
+            if recipe.aten_transform_passes:
+                acc.pre_edge_passes.extend(recipe.aten_transform_passes)
+
+            if lr := recipe.lowering_recipe:
+                cls._collect_lowering_fields(acc, lr)
+
+            if qr := recipe.quantization_recipe:
+                cls._collect_quantization_fields(acc, qr)
+
+            acc.strict_values.append(recipe.strict)
+            acc.mode_values.append(recipe.mode)
+            acc.pipeline_stages_values.append(
+                tuple(recipe.pipeline_stages) if recipe.pipeline_stages else None
+            )
+            acc.source_transform_in_place_values.append(
+                recipe.source_transform_in_place
+            )
+
+            # Use the executorch_backend_config from the first recipe that supplies one.
+            if acc.backend_config is None and recipe.executorch_backend_config:
+                acc.backend_config = copy.deepcopy(recipe.executorch_backend_config)
+
+        return acc
+
+    @classmethod
+    def _combine_recipes(
+        cls, backend_recipes: "List[ExportRecipe]", recipe_name: "Optional[str]" = None
+    ) -> "ExportRecipe":
+        """
+        Util to combine multiple backend recipes into a single multi-backend recipe.
+
+        Args:
+            backend_recipes: List of ExportRecipe objects to combine
+            recipe_name: Optional name for the combined recipe
+
+        Returns:
+            Combined ExportRecipe for multi-backend deployment
+        """
+        acc = cls._collect_recipe_fields(backend_recipes)
+
+        # Validate scalar fields that must agree across all recipes.
+        cls._assert_scalar_fields_agree("strict", acc.strict_values)
+        cls._assert_scalar_fields_agree("mode", acc.mode_values)
+        cls._assert_scalar_fields_agree("pipeline_stages", acc.pipeline_stages_values)
+        cls._assert_scalar_fields_agree(
+            "source_transform_in_place", acc.source_transform_in_place_values
+        )
+
+        combined_quantization_recipe = cls._combine_quantization_recipe(
+            is_qat_values=acc.is_qat_values,
+            dynamic_batch_size_values=acc.dynamic_batch_size_values,
+            train_fn_values=acc.train_fn_values,
+            calibration_inputs_fn_values=acc.calibration_inputs_fn_values,
+            all_quantizers=acc.quantizers,
+            all_ao_quantization_configs=acc.ao_quantization_configs,
+            all_pre_prepare_passes=acc.pre_prepare_passes,
+            all_post_prepare_passes=acc.post_prepare_passes,
+            all_pre_convert_passes=acc.pre_convert_passes,
+            all_post_convert_passes=acc.post_convert_passes,
+        )
+
+        combined_lowering_recipe = cls._combine_lowering_recipe(
+            backend_recipes=backend_recipes,
+            all_partitioners=acc.partitioners,
+            all_partitioners_by_method=acc.partitioners_by_method,
+            all_edge_transform_passes=acc.edge_transform_passes,
+            all_edge_manager_transform_passes=acc.edge_manager_transform_passes,
+        )
 
         recipe_name = recipe_name or "_".join(
             [r.name for r in backend_recipes if r.name is not None]
         )
+        # All pipeline_stages values are equal (enforced above); use the first non-None one.
+        shared_pipeline_stages = next(
+            (r.pipeline_stages for r in backend_recipes if r.pipeline_stages), None
+        )
         return cls(
             name=recipe_name,
             quantization_recipe=combined_quantization_recipe,
-            aten_transform_passes=all_pre_edge_passes or None,
+            aten_transform_passes=acc.pre_edge_passes or None,
             lowering_recipe=combined_lowering_recipe,
-            executorch_backend_config=combined_backend_config,
-            strict=strict_values[0] if strict_values else True,
-            mode=mode_values[0] if mode_values else Mode.RELEASE,
-            pipeline_stages=(
-                list(pipeline_stages_values[0])
-                if pipeline_stages_values and pipeline_stages_values[0] is not None
-                else None
-            ),
+            executorch_backend_config=acc.backend_config,
+            pipeline_stages=shared_pipeline_stages,
+            strict=acc.strict_values[0] if acc.strict_values else True,
+            mode=acc.mode_values[0] if acc.mode_values else Mode.RELEASE,
             source_transform_in_place=(
-                source_transform_in_place_values[0]
-                if source_transform_in_place_values
+                acc.source_transform_in_place_values[0]
+                if acc.source_transform_in_place_values
                 else False
             ),
         )

--- a/export/recipe.py
+++ b/export/recipe.py
@@ -9,7 +9,7 @@ import dataclasses
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, Iterable, List, Optional, Union
 
 import torch
 from executorch.exir import EdgeProgramManager, ExportedProgram
@@ -129,16 +129,50 @@ class QuantizationRecipe:
     """
     Configuration recipe for quantization.
 
-    This class holds the configuration parameters for quantizing a model.
+    This class holds the configuration parameters for quantizing a model, supporting
+    both post-training quantization (PTQ) and quantization-aware training (QAT).
 
     Attributes:
-        quantizers: Optional list of quantizers for model quantization
+        quantizers: Optional list of quantizers for model quantization.
         ao_quantization_configs: Optional list of AOQuantizationConfig objects that pair
-                                 AOBaseConfig with optional filter functions
+                                 AOBaseConfig with optional filter functions.
+        is_qat: If True, use the QAT flow (prepare_qat_pt2e -> train_fn -> convert_pt2e).
+                If False (default), use the PTQ flow (prepare_pt2e -> calibrate -> convert_pt2e).
+        calibration_inputs_fn: Optional callable returning an iterable of input tuples used for
+                               PTQ calibration. When None (default), the example inputs are used.
+                               Ignored when is_qat=True.
+        train_fn: Callable that receives the prepared GraphModule and trains it.
+                  Required when is_qat=True; ignored otherwise.
+        pre_prepare_passes: Optional list of callables applied to the captured GraphModule
+                            before prepare_pt2e / prepare_qat_pt2e.
+                            Each callable receives a GraphModule and must return a GraphModule.
+        post_prepare_passes: Optional list of callables applied to the prepared GraphModule
+                             after prepare_pt2e / prepare_qat_pt2e and before calibration / training.
+                             Each callable receives a GraphModule and must return a GraphModule.
+        pre_convert_passes: Optional list of callables applied to the GraphModule after
+                            calibration (PTQ) or training (QAT) and before convert_pt2e.
+                            Each callable receives a GraphModule and must return a GraphModule.
+        post_convert_passes: Optional list of callables applied to the GraphModule after convert_pt2e.
+                             Each callable receives a GraphModule and must return a GraphModule.
     """
 
     quantizers: Optional[List[Quantizer]] = None
     ao_quantization_configs: Optional[List[AOQuantizationConfig]] = None
+    is_qat: bool = False
+    calibration_inputs_fn: Optional[Callable[[], Iterable[tuple]]] = None
+    train_fn: Optional[Callable[["torch.fx.GraphModule"], None]] = None
+    pre_prepare_passes: Optional[
+        List[Callable[["torch.fx.GraphModule"], "torch.fx.GraphModule"]]
+    ] = None
+    post_prepare_passes: Optional[
+        List[Callable[["torch.fx.GraphModule"], "torch.fx.GraphModule"]]
+    ] = None
+    pre_convert_passes: Optional[
+        List[Callable[["torch.fx.GraphModule"], "torch.fx.GraphModule"]]
+    ] = None
+    post_convert_passes: Optional[
+        List[Callable[["torch.fx.GraphModule"], "torch.fx.GraphModule"]]
+    ] = None
 
     def get_quantizers(self) -> Optional[List[Quantizer]]:
         """
@@ -306,48 +340,79 @@ class ExportRecipe:
                 f"correct way to merge the orderings: {overriding}"
             )
 
-        # Extract components from individual recipes
-        all_partitioners = []
+        # Scalar fields that must be identical across all recipes.
+        def _assert_agree(field_name: str, values: list) -> None:
+            unique = set(values)
+            if len(unique) > 1:
+                raise ValueError(
+                    f"Cannot combine recipes with conflicting '{field_name}' values: {unique}"
+                )
+
+        # Collect all components.
+        all_partitioners: list = []
         all_partitioners_by_method = {}
-        all_quantizers = []
-        all_ao_quantization_configs = []
-        all_pre_edge_passes = []
-        all_transform_passes = []
+        all_quantizers: list = []
+        all_ao_quantization_configs: list = []
+        all_pre_edge_passes: list = []
+        all_edge_transform_passes: list = []
+        all_edge_manager_transform_passes: list = []
+        all_pre_prepare_passes: list = []
+        all_post_prepare_passes: list = []
+        all_pre_convert_passes: list = []
+        all_post_convert_passes: list = []
         combined_backend_config = None
 
+        is_qat_values: list = []
+        train_fn_values: list = []
+        calibration_inputs_fn_values: list = []
+        strict_values: list = []
+        mode_values: list = []
+        pipeline_stages_values: list = []
+        source_transform_in_place_values: list = []
+
         for recipe in backend_recipes:
-            # Collect pre-edge transform passes
             if recipe.aten_transform_passes:
                 all_pre_edge_passes.extend(recipe.aten_transform_passes)
 
-            # Collect partitioners from lowering recipes
-            if recipe.lowering_recipe and recipe.lowering_recipe.partitioners:
-                partitioners = recipe.lowering_recipe.partitioners
-                if isinstance(partitioners, dict):
-                    for method_name, method_partitioners in partitioners.items():
-                        all_partitioners_by_method.setdefault(method_name, []).extend(
-                            method_partitioners
-                        )
-                else:
-                    all_partitioners.extend(partitioners)
-
-            # Collect transform passes from lowering recipes
-            if recipe.lowering_recipe and recipe.lowering_recipe.edge_transform_passes:
-                all_transform_passes.extend(
-                    recipe.lowering_recipe.edge_transform_passes
-                )
-
-            # Collect for quantize stage
-            if quantization_recipe := recipe.quantization_recipe:
-                # Collect PT2E quantizers
-                if quantization_recipe.quantizers:
-                    all_quantizers.extend(quantization_recipe.quantizers)
-
-                # Collect source transform configs
-                if quantization_recipe.ao_quantization_configs:
-                    all_ao_quantization_configs.extend(
-                        quantization_recipe.ao_quantization_configs
+            if lr := recipe.lowering_recipe:
+                if lr.partitioners:
+                    if isinstance(lr.partitioners, dict):
+                        for method_name, method_partitioners in lr.partitioners.items():
+                            all_partitioners_by_method.setdefault(method_name, []).extend(
+                                method_partitioners
+                            )
+                    else:
+                        all_partitioners.extend(lr.partitioners)
+                if lr.edge_transform_passes:
+                    all_edge_transform_passes.extend(lr.edge_transform_passes)
+                if lr.edge_manager_transform_passes:
+                    all_edge_manager_transform_passes.extend(
+                        lr.edge_manager_transform_passes
                     )
+
+            if qr := recipe.quantization_recipe:
+                if qr.quantizers:
+                    all_quantizers.extend(qr.quantizers)
+                if qr.ao_quantization_configs:
+                    all_ao_quantization_configs.extend(qr.ao_quantization_configs)
+                is_qat_values.append(qr.is_qat)
+                train_fn_values.append(qr.train_fn)
+                calibration_inputs_fn_values.append(qr.calibration_inputs_fn)
+                if qr.pre_prepare_passes:
+                    all_pre_prepare_passes.extend(qr.pre_prepare_passes)
+                if qr.post_prepare_passes:
+                    all_post_prepare_passes.extend(qr.post_prepare_passes)
+                if qr.pre_convert_passes:
+                    all_pre_convert_passes.extend(qr.pre_convert_passes)
+                if qr.post_convert_passes:
+                    all_post_convert_passes.extend(qr.post_convert_passes)
+
+            strict_values.append(recipe.strict)
+            mode_values.append(recipe.mode)
+            pipeline_stages_values.append(
+                tuple(recipe.pipeline_stages) if recipe.pipeline_stages else None
+            )
+            source_transform_in_place_values.append(recipe.source_transform_in_place)
 
             # Use the first backend config as base
             if combined_backend_config is None and recipe.executorch_backend_config:
@@ -355,14 +420,53 @@ class ExportRecipe:
                     recipe.executorch_backend_config
                 )
 
-        # Create combined quantization recipe
+        # Validate fields that must agree across all recipes.
+        _assert_agree("strict", strict_values)
+        _assert_agree("mode", mode_values)
+        _assert_agree("pipeline_stages", pipeline_stages_values)
+        _assert_agree("source_transform_in_place", source_transform_in_place_values)
+
+        # is_qat must agree across all recipes that carry a QuantizationRecipe.
+        _assert_agree("is_qat", is_qat_values)
+        # train_fn must have at most one non-None value across all recipes.
+        non_none_train_fns = [f for f in train_fn_values if f is not None]
+        if len(non_none_train_fns) > 1:
+            raise ValueError(
+                "Cannot combine recipes: more than one recipe provides a train_fn."
+            )
+        # Multiple calibration_inputs_fn values are chained into a single factory.
+        non_none_calib_fns = [f for f in calibration_inputs_fn_values if f is not None]
+        if len(non_none_calib_fns) > 1:
+            _fns = non_none_calib_fns
+
+            def _combined_calib_fn():
+                for _fn in _fns:
+                    yield from _fn()
+
+            combined_calib_fn = _combined_calib_fn
+        else:
+            combined_calib_fn = non_none_calib_fns[0] if non_none_calib_fns else None
+
+        # Build combined QuantizationRecipe.
         combined_quantization_recipe = None
-        if all_quantizers or all_ao_quantization_configs:
+        if (
+            all_quantizers
+            or all_ao_quantization_configs
+            or all_pre_prepare_passes
+            or all_post_prepare_passes
+            or all_pre_convert_passes
+            or all_post_convert_passes
+        ):
             combined_quantization_recipe = QuantizationRecipe(
-                quantizers=all_quantizers if all_quantizers else None,
-                ao_quantization_configs=(
-                    all_ao_quantization_configs if all_ao_quantization_configs else None
-                ),
+                quantizers=all_quantizers or None,
+                ao_quantization_configs=all_ao_quantization_configs or None,
+                is_qat=is_qat_values[0] if is_qat_values else False,
+                train_fn=non_none_train_fns[0] if non_none_train_fns else None,
+                calibration_inputs_fn=combined_calib_fn,
+                pre_prepare_passes=all_pre_prepare_passes or None,
+                post_prepare_passes=all_post_prepare_passes or None,
+                pre_convert_passes=all_pre_convert_passes or None,
+                post_convert_passes=all_post_convert_passes or None,
             )
 
         if all_partitioners and all_partitioners_by_method:
@@ -395,12 +499,25 @@ class ExportRecipe:
         edge_compile_config = copy.deepcopy(distinct[0][1]) if distinct else None
 
         combined_lowering_recipe = None
-        if combined_partitioners or all_transform_passes or edge_compile_config:
+        if (
+            combined_partitioners
+            or all_edge_transform_passes
+            or all_edge_manager_transform_passes
+            or edge_compile_config
+        ):
+            edge_compile_config = None
+            for recipe in backend_recipes:
+                if (
+                    recipe.lowering_recipe
+                    and recipe.lowering_recipe.edge_compile_config
+                ):
+                    edge_compile_config = recipe.lowering_recipe.edge_compile_config
+                    break
+
             combined_lowering_recipe = LoweringRecipe(
-                partitioners=combined_partitioners if combined_partitioners else None,
-                edge_transform_passes=(
-                    all_transform_passes if all_transform_passes else None
-                ),
+                partitioners=combined_partitioners or None,
+                edge_transform_passes=all_edge_transform_passes or None,
+                edge_manager_transform_passes=all_edge_manager_transform_passes or None,
                 edge_compile_config=edge_compile_config or EdgeCompileConfig(),
             )
 
@@ -410,7 +527,19 @@ class ExportRecipe:
         return cls(
             name=recipe_name,
             quantization_recipe=combined_quantization_recipe,
-            aten_transform_passes=all_pre_edge_passes,
+            aten_transform_passes=all_pre_edge_passes or None,
             lowering_recipe=combined_lowering_recipe,
             executorch_backend_config=combined_backend_config,
+            strict=strict_values[0] if strict_values else True,
+            mode=mode_values[0] if mode_values else Mode.RELEASE,
+            pipeline_stages=(
+                list(pipeline_stages_values[0])
+                if pipeline_stages_values and pipeline_stages_values[0] is not None
+                else None
+            ),
+            source_transform_in_place=(
+                source_transform_in_place_values[0]
+                if source_transform_in_place_values
+                else False
+            ),
         )

--- a/export/stages.py
+++ b/export/stages.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 # Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -23,6 +24,11 @@ from torch import nn
 from torch._export.pass_base import PassType
 from torch.fx.passes.infra.pass_manager import PassManager as GraphModulePassManager
 from torchao.quantization import quantize_
+from torchao.quantization.pt2e import (
+    allow_exported_model_train_eval,
+    move_exported_model_to_eval,
+    move_exported_model_to_train,
+)
 from torchao.quantization.pt2e.quantize_pt2e import (
     convert_pt2e,
     prepare_pt2e,
@@ -475,13 +481,18 @@ class QuantizeStage(Stage):
         passes: Optional[List[Callable]],
     ) -> "torch.fx.GraphModule":
         for pass_fn in passes or []:
-            model = pass_fn(model)
+            try:
+                model = pass_fn(model)
+            except Exception as exc:
+                raise RuntimeError(
+                    f"QuantizeStage: Pass '{pass_fn!r}' raised an error: {exc}"
+                ) from exc
         return model
 
     def run(self, artifact: PipelineArtifact) -> None:
         if not self._quantization_recipe or not self._quantization_recipe.quantizers:
             logging.info(
-                "Quantization recipe is invalid to run QunatizeStage, returning original model"
+                "Quantization recipe is invalid to run QuantizeStage, returning original model"
             )
             self._artifact = artifact
             return
@@ -501,7 +512,22 @@ class QuantizeStage(Stage):
                 )
 
             inputs = example_inputs[method_name][0]
-            captured_graph = torch.export.export(model, inputs, strict=True).module()
+
+            # When dynamic_batch_size is requested, mark dimension 0 of every
+            # tensor input as dynamic so that a QAT training loop can feed
+            # mini-batches of arbitrary size through the prepared graph.
+            export_dynamic_shapes = None
+            if recipe.dynamic_batch_size:
+                from torch.export import Dim
+
+                batch = Dim("batch", min=1)
+                export_dynamic_shapes = tuple(
+                    {0: batch} if isinstance(t, torch.Tensor) else None for t in inputs
+                )
+
+            captured_graph = torch.export.export(
+                model, inputs, dynamic_shapes=export_dynamic_shapes, strict=True
+            ).module()
 
             # Pass 1: pre-prepare passes.
             captured_graph = self._apply_passes(
@@ -520,7 +546,10 @@ class QuantizeStage(Stage):
                     prepared_model, recipe.post_prepare_passes
                 )
 
+                allow_exported_model_train_eval(prepared_model)
+                move_exported_model_to_train(prepared_model)
                 recipe.train_fn(prepared_model)
+                move_exported_model_to_eval(prepared_model)
             else:
                 prepared_model = prepare_pt2e(captured_graph, quantizer)
 

--- a/export/stages.py
+++ b/export/stages.py
@@ -23,7 +23,11 @@ from torch import nn
 from torch._export.pass_base import PassType
 from torch.fx.passes.infra.pass_manager import PassManager as GraphModulePassManager
 from torchao.quantization import quantize_
-from torchao.quantization.pt2e.quantize_pt2e import convert_pt2e, prepare_pt2e
+from torchao.quantization.pt2e.quantize_pt2e import (
+    convert_pt2e,
+    prepare_pt2e,
+    prepare_qat_pt2e,
+)
 from torchao.quantization.pt2e.quantizer import (
     ComposableQuantizer,
     Quantizer as TorchAOPT2EQuantizer,
@@ -465,6 +469,15 @@ class QuantizeStage(Stage):
         else:
             raise ValueError("No quantizers detected")
 
+    @staticmethod
+    def _apply_passes(
+        model: "torch.fx.GraphModule",
+        passes: Optional[List[Callable]],
+    ) -> "torch.fx.GraphModule":
+        for pass_fn in passes or []:
+            model = pass_fn(model)
+        return model
+
     def run(self, artifact: PipelineArtifact) -> None:
         if not self._quantization_recipe or not self._quantization_recipe.quantizers:
             logging.info(
@@ -475,6 +488,7 @@ class QuantizeStage(Stage):
 
         assert isinstance(artifact.data, dict)
 
+        recipe = self._quantization_recipe
         models = artifact.data
         example_inputs = artifact.get_context("example_inputs")
 
@@ -489,15 +503,53 @@ class QuantizeStage(Stage):
             inputs = example_inputs[method_name][0]
             captured_graph = torch.export.export(model, inputs, strict=True).module()
 
-            quantizer = self._get_quantizer_for_prepare_pt2e(
-                self._quantization_recipe.quantizers  # pyre-ignore
+            # Pass 1: pre-prepare passes.
+            captured_graph = self._apply_passes(
+                captured_graph, recipe.pre_prepare_passes
             )
-            prepared_model = prepare_pt2e(captured_graph, quantizer)
 
-            for calibration_input in example_inputs[method_name]:
-                prepared_model(*calibration_input)
+            quantizer = self._get_quantizer_for_prepare_pt2e(recipe.quantizers)
+
+            if recipe.is_qat:
+                if recipe.train_fn is None:
+                    raise ValueError("train_fn must be provided when is_qat=True")
+                prepared_model = prepare_qat_pt2e(captured_graph, quantizer)
+
+                # Pass 2: post-prepare passes.
+                prepared_model = self._apply_passes(
+                    prepared_model, recipe.post_prepare_passes
+                )
+
+                recipe.train_fn(prepared_model)
+            else:
+                prepared_model = prepare_pt2e(captured_graph, quantizer)
+
+                # Pass 2: post-prepare passes.
+                prepared_model = self._apply_passes(
+                    prepared_model, recipe.post_prepare_passes
+                )
+
+                # Use custom calibration inputs when provided; fall back to example inputs.
+                if recipe.calibration_inputs_fn is not None:
+                    calibration_inputs = recipe.calibration_inputs_fn()
+                else:
+                    calibration_inputs = example_inputs[method_name]
+
+                for calibration_input in calibration_inputs:
+                    prepared_model(*calibration_input)
+
+            # Pass 3: pre-convert passes.
+            prepared_model = self._apply_passes(
+                prepared_model, recipe.pre_convert_passes
+            )
 
             quantized_model = convert_pt2e(prepared_model)
+
+            # Pass 4: post-convert passes.
+            quantized_model = self._apply_passes(
+                quantized_model, recipe.post_convert_passes
+            )
+
             quantized_models[method_name] = quantized_model
 
         self._artifact = artifact.copy_with_new_data(quantized_models)

--- a/export/stages.py
+++ b/export/stages.py
@@ -525,6 +525,11 @@ class QuantizeStage(Stage):
                     {0: batch} if isinstance(t, torch.Tensor) else None for t in inputs
                 )
 
+            # QAT requires the model to be in training mode at capture time so
+            # that batch_norm and dropout decompose with training-mode semantics.
+            if recipe.is_qat:
+                model.train()
+
             captured_graph = torch.export.export(
                 model, inputs, dynamic_shapes=export_dynamic_shapes, strict=True
             ).module()

--- a/export/tests/test_export_recipe.py
+++ b/export/tests/test_export_recipe.py
@@ -7,12 +7,18 @@
 # pyre-strict
 
 import unittest
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 from unittest.mock import Mock
 
 import torch
 
-from executorch.export.recipe import ExportRecipe, RecipeType
+from executorch.export.recipe import (
+    ExportRecipe,
+    LoweringRecipe,
+    Mode,
+    QuantizationRecipe,
+    RecipeType,
+)
 from executorch.export.recipe_provider import BackendRecipeProvider
 from executorch.export.recipe_registry import recipe_registry
 
@@ -334,3 +340,436 @@ class TestExportRecipeCombine(unittest.TestCase):
         self.assertEqual(
             combined.lowering_recipe.edge_transform_passes, [first, second]
         )
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by combine-recipe tests
+# ---------------------------------------------------------------------------
+
+
+def _make_pass(name: str, call_log: List[str]):
+    """Return a graph-module pass that appends *name* to *call_log*."""
+
+    def pass_fn(m):
+        call_log.append(name)
+        return m
+
+    return pass_fn
+
+
+class TestCombineRecipesEmpty(unittest.TestCase):
+    def test_empty_recipes_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            ExportRecipe.combine([])
+
+
+class TestCombineRecipesSingleRecipe(unittest.TestCase):
+    def test_single_recipe_returned_unchanged(self) -> None:
+        recipe = ExportRecipe(name="solo")
+        result = ExportRecipe.combine([recipe])
+        self.assertIs(result, recipe)
+
+
+class TestCombineRecipesScalarFields(unittest.TestCase):
+    """Fields that must be identical across all combined recipes."""
+
+    def test_conflicting_strict_raises(self) -> None:
+        r1 = ExportRecipe(name="a", strict=True)
+        r2 = ExportRecipe(name="b", strict=False)
+        with self.assertRaises(ValueError) as cm:
+            ExportRecipe.combine([r1, r2])
+        self.assertIn("strict", str(cm.exception))
+
+    def test_conflicting_mode_raises(self) -> None:
+        r1 = ExportRecipe(name="a", mode=Mode.DEBUG)
+        r2 = ExportRecipe(name="b", mode=Mode.RELEASE)
+        with self.assertRaises(ValueError) as cm:
+            ExportRecipe.combine([r1, r2])
+        self.assertIn("mode", str(cm.exception))
+
+    def test_conflicting_source_transform_in_place_raises(self) -> None:
+        r1 = ExportRecipe(name="a", source_transform_in_place=True)
+        r2 = ExportRecipe(name="b", source_transform_in_place=False)
+        with self.assertRaises(ValueError) as cm:
+            ExportRecipe.combine([r1, r2])
+        self.assertIn("source_transform_in_place", str(cm.exception))
+
+    def test_agreeing_scalar_fields_are_preserved(self) -> None:
+        r1 = ExportRecipe(
+            name="a", strict=False, mode=Mode.DEBUG, source_transform_in_place=True
+        )
+        r2 = ExportRecipe(
+            name="b", strict=False, mode=Mode.DEBUG, source_transform_in_place=True
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertFalse(result.strict)
+        self.assertEqual(result.mode, Mode.DEBUG)
+        self.assertTrue(result.source_transform_in_place)
+
+    def test_name_is_joined_from_input_recipe_names(self) -> None:
+        r1 = ExportRecipe(name="backend_a")
+        r2 = ExportRecipe(name="backend_b")
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(result.name, "backend_a_backend_b")
+
+    def test_custom_recipe_name_is_used(self) -> None:
+        r1 = ExportRecipe(name="a")
+        r2 = ExportRecipe(name="b")
+        result = ExportRecipe.combine([r1, r2], recipe_name="custom_name")
+        self.assertEqual(result.name, "custom_name")
+
+
+class TestCombineRecipesAtenTransformPasses(unittest.TestCase):
+    def test_aten_transform_passes_merged(self) -> None:
+        pass1 = Mock()
+        pass2 = Mock()
+        r1 = ExportRecipe(name="a", aten_transform_passes=[pass1])
+        r2 = ExportRecipe(name="b", aten_transform_passes=[pass2])
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(result.aten_transform_passes, [pass1, pass2])
+
+    def test_aten_transform_passes_none_when_both_empty(self) -> None:
+        r1 = ExportRecipe(name="a")
+        r2 = ExportRecipe(name="b")
+        result = ExportRecipe.combine([r1, r2])
+        self.assertIsNone(result.aten_transform_passes)
+
+    def test_aten_transform_passes_one_side_none(self) -> None:
+        pass1 = Mock()
+        r1 = ExportRecipe(name="a", aten_transform_passes=[pass1])
+        r2 = ExportRecipe(name="b")
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(result.aten_transform_passes, [pass1])
+
+
+class TestCombineRecipesLowering(unittest.TestCase):
+    def test_partitioners_merged(self) -> None:
+        p1 = Mock()
+        p2 = Mock()
+        r1 = ExportRecipe(name="a", lowering_recipe=LoweringRecipe(partitioners=[p1]))
+        r2 = ExportRecipe(name="b", lowering_recipe=LoweringRecipe(partitioners=[p2]))
+        result = ExportRecipe.combine([r1, r2])
+        self.assertIsNotNone(result.lowering_recipe)
+        self.assertEqual(result.lowering_recipe.partitioners, [p1, p2])
+
+    def test_edge_transform_passes_merged(self) -> None:
+        pass1 = Mock()
+        pass2 = Mock()
+        r1 = ExportRecipe(
+            name="a", lowering_recipe=LoweringRecipe(edge_transform_passes=[pass1])
+        )
+        r2 = ExportRecipe(
+            name="b", lowering_recipe=LoweringRecipe(edge_transform_passes=[pass2])
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(result.lowering_recipe.edge_transform_passes, [pass1, pass2])
+
+    def test_edge_manager_transform_passes_merged(self) -> None:
+        pass1 = Mock()
+        pass2 = Mock()
+        r1 = ExportRecipe(
+            name="a",
+            lowering_recipe=LoweringRecipe(edge_manager_transform_passes=[pass1]),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            lowering_recipe=LoweringRecipe(edge_manager_transform_passes=[pass2]),
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(
+            result.lowering_recipe.edge_manager_transform_passes, [pass1, pass2]
+        )
+
+    def test_lowering_recipe_none_when_nothing_contributed(self) -> None:
+        r1 = ExportRecipe(name="a")
+        r2 = ExportRecipe(name="b")
+        result = ExportRecipe.combine([r1, r2])
+        self.assertIsNone(result.lowering_recipe)
+
+    def test_edge_compile_config_taken_from_first_recipe_with_one(self) -> None:
+        from executorch.exir.capture import EdgeCompileConfig
+
+        config = EdgeCompileConfig()
+        r1 = ExportRecipe(name="a")
+        r2 = ExportRecipe(
+            name="b",
+            lowering_recipe=LoweringRecipe(
+                partitioners=[Mock()], edge_compile_config=config
+            ),
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertIs(result.lowering_recipe.edge_compile_config, config)
+
+
+class TestCombineRecipesQuantization(unittest.TestCase):
+    def test_quantizers_merged(self) -> None:
+        q1 = Mock()
+        q2 = Mock()
+        r1 = ExportRecipe(
+            name="a", quantization_recipe=QuantizationRecipe(quantizers=[q1])
+        )
+        r2 = ExportRecipe(
+            name="b", quantization_recipe=QuantizationRecipe(quantizers=[q2])
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertIsNotNone(result.quantization_recipe)
+        self.assertEqual(result.quantization_recipe.quantizers, [q1, q2])
+
+    def test_ao_quantization_configs_merged(self) -> None:
+        from executorch.export.recipe import AOQuantizationConfig
+        from torchao.core.config import AOBaseConfig
+
+        cfg1 = AOQuantizationConfig(ao_base_config=Mock(spec=AOBaseConfig))
+        cfg2 = AOQuantizationConfig(ao_base_config=Mock(spec=AOBaseConfig))
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(ao_quantization_configs=[cfg1]),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(ao_quantization_configs=[cfg2]),
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(
+            result.quantization_recipe.ao_quantization_configs, [cfg1, cfg2]
+        )
+
+    def test_quantization_recipe_none_when_nothing_contributed(self) -> None:
+        r1 = ExportRecipe(name="a")
+        r2 = ExportRecipe(name="b")
+        result = ExportRecipe.combine([r1, r2])
+        self.assertIsNone(result.quantization_recipe)
+
+    def test_conflicting_is_qat_raises(self) -> None:
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(quantizers=[Mock()], is_qat=True),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(quantizers=[Mock()], is_qat=False),
+        )
+        with self.assertRaises(ValueError) as cm:
+            ExportRecipe.combine([r1, r2])
+        self.assertIn("is_qat", str(cm.exception))
+
+    def test_agreeing_is_qat_preserved(self) -> None:
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(quantizers=[Mock()], is_qat=True),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(quantizers=[Mock()], is_qat=True),
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertTrue(result.quantization_recipe.is_qat)
+
+    def test_two_train_fns_raises(self) -> None:
+        fn1 = Mock()
+        fn2 = Mock()
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], is_qat=True, train_fn=fn1
+            ),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], is_qat=True, train_fn=fn2
+            ),
+        )
+        with self.assertRaises(ValueError) as cm:
+            ExportRecipe.combine([r1, r2])
+        self.assertIn("train_fn", str(cm.exception))
+
+    def test_single_train_fn_preserved(self) -> None:
+        fn = Mock()
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], is_qat=True, train_fn=fn
+            ),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(quantizers=[Mock()], is_qat=True),
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertIs(result.quantization_recipe.train_fn, fn)
+
+    def test_single_calibration_inputs_fn_preserved(self) -> None:
+        fn = Mock(return_value=[(1,), (2,)])
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], calibration_inputs_fn=fn
+            ),
+        )
+        r2 = ExportRecipe(
+            name="b", quantization_recipe=QuantizationRecipe(quantizers=[Mock()])
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertIs(result.quantization_recipe.calibration_inputs_fn, fn)
+
+    def test_two_calibration_inputs_fns_chained(self) -> None:
+        fn1 = Mock(return_value=[(1,), (2,)])
+        fn2 = Mock(return_value=[(3,), (4,)])
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], calibration_inputs_fn=fn1
+            ),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], calibration_inputs_fn=fn2
+            ),
+        )
+        result = ExportRecipe.combine([r1, r2])
+        combined_fn = result.quantization_recipe.calibration_inputs_fn
+        self.assertIsNotNone(combined_fn)
+        # Each factory must be called exactly once when the combined factory is consumed.
+        all_inputs = list(combined_fn())
+        fn1.assert_called_once_with()
+        fn2.assert_called_once_with()
+        self.assertEqual(all_inputs, [(1,), (2,), (3,), (4,)])
+
+    def test_three_calibration_inputs_fns_chained_in_order(self) -> None:
+        fn1 = Mock(return_value=[(1,)])
+        fn2 = Mock(return_value=[(2,)])
+        fn3 = Mock(return_value=[(3,)])
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], calibration_inputs_fn=fn1
+            ),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], calibration_inputs_fn=fn2
+            ),
+        )
+        r3 = ExportRecipe(
+            name="c",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], calibration_inputs_fn=fn3
+            ),
+        )
+        result = ExportRecipe.combine([r1, r2, r3])
+        combined_fn = result.quantization_recipe.calibration_inputs_fn
+        self.assertEqual(list(combined_fn()), [(1,), (2,), (3,)])
+
+    def test_no_calibration_inputs_fn_stays_none(self) -> None:
+        r1 = ExportRecipe(
+            name="a", quantization_recipe=QuantizationRecipe(quantizers=[Mock()])
+        )
+        r2 = ExportRecipe(
+            name="b", quantization_recipe=QuantizationRecipe(quantizers=[Mock()])
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertIsNone(result.quantization_recipe.calibration_inputs_fn)
+
+    def test_pre_prepare_passes_merged(self) -> None:
+        log: List[str] = []
+        p1 = _make_pass("pre_a", log)
+        p2 = _make_pass("pre_b", log)
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], pre_prepare_passes=[p1]
+            ),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], pre_prepare_passes=[p2]
+            ),
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(result.quantization_recipe.pre_prepare_passes, [p1, p2])
+
+    def test_post_prepare_passes_merged(self) -> None:
+        p1 = Mock()
+        p2 = Mock()
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], post_prepare_passes=[p1]
+            ),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], post_prepare_passes=[p2]
+            ),
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(result.quantization_recipe.post_prepare_passes, [p1, p2])
+
+    def test_pre_convert_passes_merged(self) -> None:
+        p1 = Mock()
+        p2 = Mock()
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], pre_convert_passes=[p1]
+            ),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], pre_convert_passes=[p2]
+            ),
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(result.quantization_recipe.pre_convert_passes, [p1, p2])
+
+    def test_post_convert_passes_merged(self) -> None:
+        p1 = Mock()
+        p2 = Mock()
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], post_convert_passes=[p1]
+            ),
+        )
+        r2 = ExportRecipe(
+            name="b",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], post_convert_passes=[p2]
+            ),
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(result.quantization_recipe.post_convert_passes, [p1, p2])
+
+    def test_all_pass_lists_none_when_nothing_contributed(self) -> None:
+        r1 = ExportRecipe(
+            name="a", quantization_recipe=QuantizationRecipe(quantizers=[Mock()])
+        )
+        r2 = ExportRecipe(
+            name="b", quantization_recipe=QuantizationRecipe(quantizers=[Mock()])
+        )
+        result = ExportRecipe.combine([r1, r2])
+        qr = result.quantization_recipe
+        self.assertIsNone(qr.pre_prepare_passes)
+        self.assertIsNone(qr.post_prepare_passes)
+        self.assertIsNone(qr.pre_convert_passes)
+        self.assertIsNone(qr.post_convert_passes)
+
+    def test_pass_lists_preserved_when_only_one_recipe_contributes(self) -> None:
+        p = Mock()
+        r1 = ExportRecipe(
+            name="a",
+            quantization_recipe=QuantizationRecipe(
+                quantizers=[Mock()], pre_prepare_passes=[p]
+            ),
+        )
+        r2 = ExportRecipe(
+            name="b", quantization_recipe=QuantizationRecipe(quantizers=[Mock()])
+        )
+        result = ExportRecipe.combine([r1, r2])
+        self.assertEqual(result.quantization_recipe.pre_prepare_passes, [p])

--- a/export/tests/test_export_recipe.py
+++ b/export/tests/test_export_recipe.py
@@ -299,8 +299,8 @@ class TestExportRecipeCombine(unittest.TestCase):
     def test_combine_rejects_pipeline_stages(self) -> None:
         from executorch.export.types import StageType
 
-        # Unnamed recipes fall back to their position; named ones are named.
-        with self.assertRaisesRegex(ValueError, r"pipeline_stages.*recipes\[0\]"):
+        # Recipes with different pipeline_stages (including None vs. a list) must be rejected.
+        with self.assertRaisesRegex(ValueError, r"pipeline_stages"):
             ExportRecipe.combine(
                 [
                     ExportRecipe(
@@ -309,7 +309,7 @@ class TestExportRecipeCombine(unittest.TestCase):
                     ExportRecipe(name="b"),
                 ]
             )
-        with self.assertRaisesRegex(ValueError, r"pipeline_stages.*'stagey'"):
+        with self.assertRaisesRegex(ValueError, r"pipeline_stages"):
             ExportRecipe.combine(
                 [
                     ExportRecipe(
@@ -498,7 +498,11 @@ class TestCombineRecipesLowering(unittest.TestCase):
             ),
         )
         result = ExportRecipe.combine([r1, r2])
-        self.assertIs(result.lowering_recipe.edge_compile_config, config)
+        # combine() deepcopies the config so the combined recipe cannot mutate
+        # the provider's shared object; assert value-equality, not identity.
+        self.assertIsNotNone(result.lowering_recipe)
+        self.assertEqual(result.lowering_recipe.edge_compile_config, config)
+        self.assertIsNot(result.lowering_recipe.edge_compile_config, config)
 
 
 class TestCombineRecipesQuantization(unittest.TestCase):

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2026 NXP
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -409,6 +410,7 @@ class TestQuantizeStage(unittest.TestCase):
         result_artifact = stage.get_artifacts()
         self.assertEqual(result_artifact, artifact)
 
+    @patch("executorch.export.stages.move_exported_model_to_eval")
     @patch("executorch.export.stages.convert_pt2e")
     @patch("executorch.export.stages.prepare_pt2e")
     @patch("executorch.export.stages.ComposableQuantizer")
@@ -419,12 +421,14 @@ class TestQuantizeStage(unittest.TestCase):
         mock_composable_quantizer: Mock,
         mock_prepare_pt2e: Mock,
         mock_convert_pt2e: Mock,
+        mock_move_to_eval: Mock,
     ) -> None:
         """Test execution with quantizers"""
         mock_quantizer = self.create_dummy_quantizer()
         mock_recipe = Mock(spec=QuantizationRecipe)
         mock_recipe.quantizers = [mock_quantizer]
         mock_recipe.is_qat = False
+        mock_recipe.dynamic_batch_size = False
         mock_recipe.calibration_inputs_fn = None
         mock_recipe.pre_prepare_passes = None
         mock_recipe.post_prepare_passes = None
@@ -449,9 +453,9 @@ class TestQuantizeStage(unittest.TestCase):
         artifact = PipelineArtifact(data=self.models_dict, context=self.context)
         stage.run(artifact)
 
-        # Verify torch.export.export was called
+        # Verify torch.export.export was called with dynamic_shapes=None (no dynamic batch)
         mock_torch_export.assert_called_once_with(
-            self.model, self.example_inputs[0], strict=True
+            self.model, self.example_inputs[0], dynamic_shapes=None, strict=True
         )
 
         # Verify ComposableQuantizer was created with the quantizers
@@ -477,6 +481,9 @@ class TestQuantizeStage(unittest.TestCase):
         self.assertEqual(artifact.data["forward"], self.model)
         self.assertIsNot(result_artifact.data["forward"], self.model)
 
+    @patch("executorch.export.stages.allow_exported_model_train_eval")
+    @patch("executorch.export.stages.move_exported_model_to_eval")
+    @patch("executorch.export.stages.move_exported_model_to_train")
     @patch("executorch.export.stages.convert_pt2e")
     @patch("executorch.export.stages.prepare_qat_pt2e")
     @patch("executorch.export.stages.ComposableQuantizer")
@@ -487,13 +494,27 @@ class TestQuantizeStage(unittest.TestCase):
         mock_composable_quantizer: Mock,
         mock_prepare_qat_pt2e: Mock,
         mock_convert_pt2e: Mock,
+        mock_move_to_train: Mock,
+        mock_move_to_eval: Mock,
+        mock_allow_train_eval: Mock,
     ) -> None:
-        """QAT flow: prepare_qat_pt2e is called and train_fn is invoked with the prepared model."""
+        """QAT flow: prepare_qat_pt2e is called and train_fn is invoked with the prepared model.
+        allow_exported_model_train_eval must be called after preparation.
+        move_exported_model_to_train must be called before train_fn, and
+        move_exported_model_to_eval must be called after train_fn."""
         mock_quantizer = self.create_dummy_quantizer()
-        train_fn = Mock()
+        call_order = []
+        mock_allow_train_eval.side_effect = lambda m: call_order.append(
+            "allow_train_eval"
+        )
+        mock_move_to_train.side_effect = lambda m: call_order.append("to_train")
+        mock_move_to_eval.side_effect = lambda m: call_order.append("to_eval")
+
+        train_fn = Mock(side_effect=lambda m: call_order.append("train_fn"))
         mock_recipe = Mock(spec=QuantizationRecipe)
         mock_recipe.quantizers = [mock_quantizer]
         mock_recipe.is_qat = True
+        mock_recipe.dynamic_batch_size = False
         mock_recipe.train_fn = train_fn
         mock_recipe.pre_prepare_passes = None
         mock_recipe.post_prepare_passes = None
@@ -520,6 +541,13 @@ class TestQuantizeStage(unittest.TestCase):
         mock_prepare_qat_pt2e.assert_called_once_with(
             mock_captured_graph, mock_composed_quantizer
         )
+        # allow_exported_model_train_eval before move_to_train, then train_fn, then to_eval
+        self.assertEqual(
+            call_order, ["allow_train_eval", "to_train", "train_fn", "to_eval"]
+        )
+        mock_allow_train_eval.assert_called_once_with(mock_prepared_model)
+        mock_move_to_train.assert_called_once_with(mock_prepared_model)
+        mock_move_to_eval.assert_called_once_with(mock_prepared_model)
         # train_fn must be called with the prepared model
         train_fn.assert_called_once_with(mock_prepared_model)
         # convert_pt2e must still be called after training
@@ -535,6 +563,7 @@ class TestQuantizeStage(unittest.TestCase):
         mock_recipe = Mock(spec=QuantizationRecipe)
         mock_recipe.quantizers = [mock_quantizer]
         mock_recipe.is_qat = True
+        mock_recipe.dynamic_batch_size = False
         mock_recipe.train_fn = None
         mock_recipe.pre_prepare_passes = None
         mock_recipe.post_prepare_passes = None
@@ -552,6 +581,7 @@ class TestQuantizeStage(unittest.TestCase):
             stage.run(artifact)
         self.assertIn("train_fn must be provided when is_qat=True", str(cm.exception))
 
+    @patch("executorch.export.stages.move_exported_model_to_eval")
     @patch("executorch.export.stages.convert_pt2e")
     @patch("executorch.export.stages.prepare_pt2e")
     @patch("executorch.export.stages.prepare_qat_pt2e")
@@ -564,12 +594,14 @@ class TestQuantizeStage(unittest.TestCase):
         mock_prepare_qat_pt2e: Mock,
         mock_prepare_pt2e: Mock,
         mock_convert_pt2e: Mock,
+        mock_move_to_eval: Mock,
     ) -> None:
         """PTQ flow must not call prepare_qat_pt2e (regression guard)."""
         mock_quantizer = self.create_dummy_quantizer()
         mock_recipe = Mock(spec=QuantizationRecipe)
         mock_recipe.quantizers = [mock_quantizer]
         mock_recipe.is_qat = False
+        mock_recipe.dynamic_batch_size = False
         mock_recipe.calibration_inputs_fn = None
         mock_recipe.pre_prepare_passes = None
         mock_recipe.post_prepare_passes = None
@@ -590,6 +622,7 @@ class TestQuantizeStage(unittest.TestCase):
         mock_prepare_pt2e.assert_called_once()
         mock_prepare_qat_pt2e.assert_not_called()
 
+    @patch("executorch.export.stages.move_exported_model_to_eval")
     @patch("executorch.export.stages.convert_pt2e")
     @patch("executorch.export.stages.prepare_pt2e")
     @patch("executorch.export.stages.ComposableQuantizer")
@@ -600,6 +633,7 @@ class TestQuantizeStage(unittest.TestCase):
         mock_composable_quantizer: Mock,
         mock_prepare_pt2e: Mock,
         mock_convert_pt2e: Mock,
+        mock_move_to_eval: Mock,
     ) -> None:
         """All four pass hooks are called at the correct points in the PTQ flow."""
         call_order = []
@@ -615,6 +649,7 @@ class TestQuantizeStage(unittest.TestCase):
         mock_recipe = Mock(spec=QuantizationRecipe)
         mock_recipe.quantizers = [mock_quantizer]
         mock_recipe.is_qat = False
+        mock_recipe.dynamic_batch_size = False
         mock_recipe.calibration_inputs_fn = None
         mock_recipe.pre_prepare_passes = [make_pass("pre_prepare")]
         mock_recipe.post_prepare_passes = [make_pass("post_prepare")]
@@ -638,6 +673,9 @@ class TestQuantizeStage(unittest.TestCase):
             ["pre_prepare", "post_prepare", "pre_convert", "post_convert"],
         )
 
+    @patch("executorch.export.stages.allow_exported_model_train_eval")
+    @patch("executorch.export.stages.move_exported_model_to_eval")
+    @patch("executorch.export.stages.move_exported_model_to_train")
     @patch("executorch.export.stages.convert_pt2e")
     @patch("executorch.export.stages.prepare_qat_pt2e")
     @patch("executorch.export.stages.ComposableQuantizer")
@@ -648,6 +686,9 @@ class TestQuantizeStage(unittest.TestCase):
         mock_composable_quantizer: Mock,
         mock_prepare_qat_pt2e: Mock,
         mock_convert_pt2e: Mock,
+        mock_move_to_train: Mock,
+        mock_move_to_eval: Mock,
+        mock_allow_train_eval: Mock,
     ) -> None:
         """All four pass hooks are called at the correct points in the QAT flow."""
         call_order = []
@@ -663,6 +704,7 @@ class TestQuantizeStage(unittest.TestCase):
         mock_recipe = Mock(spec=QuantizationRecipe)
         mock_recipe.quantizers = [mock_quantizer]
         mock_recipe.is_qat = True
+        mock_recipe.dynamic_batch_size = False
         mock_recipe.train_fn = Mock()
         mock_recipe.pre_prepare_passes = [make_pass("pre_prepare")]
         mock_recipe.post_prepare_passes = [make_pass("post_prepare")]
@@ -685,6 +727,7 @@ class TestQuantizeStage(unittest.TestCase):
             ["pre_prepare", "post_prepare", "pre_convert", "post_convert"],
         )
 
+    @patch("executorch.export.stages.move_exported_model_to_eval")
     @patch("executorch.export.stages.convert_pt2e")
     @patch("executorch.export.stages.prepare_pt2e")
     @patch("executorch.export.stages.ComposableQuantizer")
@@ -695,6 +738,7 @@ class TestQuantizeStage(unittest.TestCase):
         mock_composable_quantizer: Mock,
         mock_prepare_pt2e: Mock,
         mock_convert_pt2e: Mock,
+        mock_move_to_eval: Mock,
     ) -> None:
         """When calibration_inputs_fn is set, it is called and its output is used for calibration."""
         custom_input = (torch.randn(2, 10),)
@@ -704,6 +748,7 @@ class TestQuantizeStage(unittest.TestCase):
         mock_recipe = Mock(spec=QuantizationRecipe)
         mock_recipe.quantizers = [mock_quantizer]
         mock_recipe.is_qat = False
+        mock_recipe.dynamic_batch_size = False
         mock_recipe.calibration_inputs_fn = calibration_inputs_fn
         mock_recipe.pre_prepare_passes = None
         mock_recipe.post_prepare_passes = None
@@ -727,6 +772,7 @@ class TestQuantizeStage(unittest.TestCase):
         # prepared model must be called with the custom calibration input
         mock_prepared_model.assert_called_once_with(*custom_input)
 
+    @patch("executorch.export.stages.move_exported_model_to_eval")
     @patch("executorch.export.stages.convert_pt2e")
     @patch("executorch.export.stages.prepare_pt2e")
     @patch("executorch.export.stages.ComposableQuantizer")
@@ -737,12 +783,14 @@ class TestQuantizeStage(unittest.TestCase):
         mock_composable_quantizer: Mock,
         mock_prepare_pt2e: Mock,
         mock_convert_pt2e: Mock,
+        mock_move_to_eval: Mock,
     ) -> None:
         """When calibration_inputs_fn is None, example inputs are used for calibration."""
         mock_quantizer = self.create_dummy_quantizer()
         mock_recipe = Mock(spec=QuantizationRecipe)
         mock_recipe.quantizers = [mock_quantizer]
         mock_recipe.is_qat = False
+        mock_recipe.dynamic_batch_size = False
         mock_recipe.calibration_inputs_fn = None
         mock_recipe.pre_prepare_passes = None
         mock_recipe.post_prepare_passes = None
@@ -947,6 +995,175 @@ class TestToBackendStage(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             stage.run(artifact)
         self.assertIn("Edge program manager is not set", str(cm.exception))
+
+
+class TestQuantizeStageExportDynamicShapes(unittest.TestCase):
+    """Tests for the dynamic_batch_size export behavior in QuantizeStage."""
+
+    def setUp(self) -> None:
+        self.model = torch.nn.Linear(10, 5)
+        self.models_dict = {"forward": self.model}
+        self.example_inputs = [(torch.randn(1, 10),)]
+        self.context = {"example_inputs": {"forward": self.example_inputs}}
+
+    @staticmethod
+    def _make_recipe(is_qat: bool, dynamic_batch_size: bool) -> Mock:
+        mock_recipe = Mock(spec=QuantizationRecipe)
+        mock_recipe.quantizers = [Mock(spec=TorchAOPT2EQuantizer)]
+        mock_recipe.is_qat = is_qat
+        mock_recipe.dynamic_batch_size = dynamic_batch_size
+        mock_recipe.calibration_inputs_fn = None
+        mock_recipe.train_fn = Mock() if is_qat else None
+        mock_recipe.pre_prepare_passes = None
+        mock_recipe.post_prepare_passes = None
+        mock_recipe.pre_convert_passes = None
+        mock_recipe.post_convert_passes = None
+        return mock_recipe
+
+    @patch("executorch.export.stages.move_exported_model_to_eval")
+    @patch("executorch.export.stages.convert_pt2e")
+    @patch("executorch.export.stages.prepare_pt2e")
+    @patch("executorch.export.stages.ComposableQuantizer")
+    @patch("torch.export.export")
+    def test_dynamic_batch_size_false_exports_without_dynamic_shapes(
+        self,
+        mock_torch_export: Mock,
+        mock_composable_quantizer: Mock,
+        mock_prepare_pt2e: Mock,
+        mock_convert_pt2e: Mock,
+        mock_move_to_eval: Mock,
+    ) -> None:
+        """When dynamic_batch_size=False, torch.export.export is called with dynamic_shapes=None."""
+        mock_ep = Mock(spec=ExportedProgram)
+        mock_ep.module.return_value = Mock()
+        mock_torch_export.return_value = mock_ep
+        mock_composable_quantizer.return_value = Mock()
+        mock_prepare_pt2e.return_value = Mock()
+        mock_convert_pt2e.return_value = Mock()
+
+        recipe = self._make_recipe(is_qat=False, dynamic_batch_size=False)
+        stage = QuantizeStage(recipe)
+        stage.run(PipelineArtifact(data=self.models_dict, context=self.context))
+
+        mock_torch_export.assert_called_once_with(
+            self.model,
+            self.example_inputs[0],
+            dynamic_shapes=None,
+            strict=True,
+        )
+
+    @patch("executorch.export.stages.allow_exported_model_train_eval")
+    @patch("executorch.export.stages.move_exported_model_to_eval")
+    @patch("executorch.export.stages.move_exported_model_to_train")
+    @patch("executorch.export.stages.convert_pt2e")
+    @patch("executorch.export.stages.prepare_qat_pt2e")
+    @patch("executorch.export.stages.ComposableQuantizer")
+    @patch("torch.export.export")
+    def test_dynamic_batch_size_true_exports_with_dynamic_batch_dim(
+        self,
+        mock_torch_export: Mock,
+        mock_composable_quantizer: Mock,
+        mock_prepare_qat_pt2e: Mock,
+        mock_convert_pt2e: Mock,
+        mock_move_to_train: Mock,
+        mock_move_to_eval: Mock,
+        mock_allow_train_eval: Mock,
+    ) -> None:
+        """When dynamic_batch_size=True, torch.export.export is called with a
+        dynamic_shapes tuple where dimension 0 of every tensor is dynamic."""
+        mock_ep = Mock(spec=ExportedProgram)
+        mock_ep.module.return_value = Mock()
+        mock_torch_export.return_value = mock_ep
+        mock_composable_quantizer.return_value = Mock()
+        mock_prepare_qat_pt2e.return_value = Mock()
+        mock_convert_pt2e.return_value = Mock()
+
+        recipe = self._make_recipe(is_qat=True, dynamic_batch_size=True)
+        stage = QuantizeStage(recipe)
+        stage.run(PipelineArtifact(data=self.models_dict, context=self.context))
+
+        call_kwargs = mock_torch_export.call_args
+        dynamic_shapes_arg = call_kwargs.kwargs.get(
+            "dynamic_shapes", call_kwargs.args[2] if len(call_kwargs.args) > 2 else None
+        )
+        # dynamic_shapes must be a non-None tuple with one entry per input tensor.
+        self.assertIsNotNone(dynamic_shapes_arg)
+        self.assertIsInstance(dynamic_shapes_arg, tuple)
+        self.assertEqual(len(dynamic_shapes_arg), len(self.example_inputs[0]))
+        # The entry for the single tensor input must map dim 0 to a Dim.
+        first_entry = dynamic_shapes_arg[0]
+        self.assertIsInstance(first_entry, dict)
+        self.assertIn(0, first_entry)
+
+    @patch("executorch.export.stages.move_exported_model_to_eval")
+    @patch("executorch.export.stages.convert_pt2e")
+    @patch("executorch.export.stages.prepare_pt2e")
+    @patch("executorch.export.stages.ComposableQuantizer")
+    @patch("torch.export.export")
+    def test_dynamic_batch_size_true_ptq_exports_with_dynamic_shapes(
+        self,
+        mock_torch_export: Mock,
+        mock_composable_quantizer: Mock,
+        mock_prepare_pt2e: Mock,
+        mock_convert_pt2e: Mock,
+        mock_move_to_eval: Mock,
+    ) -> None:
+        """When dynamic_batch_size=True and is_qat=False, export is called with dynamic shapes."""
+        mock_ep = Mock(spec=ExportedProgram)
+        mock_ep.module.return_value = Mock()
+        mock_torch_export.return_value = mock_ep
+        mock_composable_quantizer.return_value = Mock()
+        mock_prepare_pt2e.return_value = Mock()
+        mock_convert_pt2e.return_value = Mock()
+
+        recipe = self._make_recipe(is_qat=False, dynamic_batch_size=True)
+        stage = QuantizeStage(recipe)
+        stage.run(PipelineArtifact(data=self.models_dict, context=self.context))
+
+        call_kwargs = mock_torch_export.call_args
+        dynamic_shapes_arg = call_kwargs.kwargs.get(
+            "dynamic_shapes", call_kwargs.args[2] if len(call_kwargs.args) > 2 else None
+        )
+        self.assertIsNotNone(dynamic_shapes_arg)
+        self.assertIsInstance(dynamic_shapes_arg, tuple)
+        self.assertEqual(len(dynamic_shapes_arg), len(self.example_inputs[0]))
+        first_entry = dynamic_shapes_arg[0]
+        self.assertIsInstance(first_entry, dict)
+        self.assertIn(0, first_entry)
+
+    def test_dynamic_batch_size_true_ptq_calibration_with_variable_batch_sizes(
+        self,
+    ) -> None:
+        """PTQ calibration runs without error when batch sizes vary across calibration inputs."""
+        from executorch.export.recipe import QuantizationRecipe
+
+        class PassthroughQuantizer(TorchAOPT2EQuantizer):
+            def annotate(self, model):
+                return model
+
+            def validate(self, model):
+                pass
+
+        def calibration_inputs_fn():
+            for batch_size in (2, 4, 8):
+                yield (torch.randn(batch_size, 10),)
+
+        recipe = QuantizationRecipe(
+            quantizers=[PassthroughQuantizer()],
+            is_qat=False,
+            dynamic_batch_size=True,
+            calibration_inputs_fn=calibration_inputs_fn,
+        )
+        stage = QuantizeStage(recipe)
+        # Use batch size 2 for the example input so torch.export does not
+        # specialize dim 0 as the constant 1.
+        context = {"example_inputs": {"forward": [(torch.randn(2, 10),)]}}
+        artifact = PipelineArtifact(
+            data={"forward": torch.nn.Linear(10, 5)},
+            context=context,
+        )
+        stage.run(artifact)
+        self.assertIn("forward", stage.get_artifacts().data)
 
 
 class TestEmptyPassDictIsNotApplied(unittest.TestCase):

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -424,6 +424,12 @@ class TestQuantizeStage(unittest.TestCase):
         mock_quantizer = self.create_dummy_quantizer()
         mock_recipe = Mock(spec=QuantizationRecipe)
         mock_recipe.quantizers = [mock_quantizer]
+        mock_recipe.is_qat = False
+        mock_recipe.calibration_inputs_fn = None
+        mock_recipe.pre_prepare_passes = None
+        mock_recipe.post_prepare_passes = None
+        mock_recipe.pre_convert_passes = None
+        mock_recipe.post_convert_passes = None
         stage = QuantizeStage(mock_recipe)
 
         # Mock the torch.export.export chain
@@ -471,11 +477,304 @@ class TestQuantizeStage(unittest.TestCase):
         self.assertEqual(artifact.data["forward"], self.model)
         self.assertIsNot(result_artifact.data["forward"], self.model)
 
+    @patch("executorch.export.stages.convert_pt2e")
+    @patch("executorch.export.stages.prepare_qat_pt2e")
+    @patch("executorch.export.stages.ComposableQuantizer")
+    @patch("torch.export.export")
+    def test_run_qat_calls_prepare_qat_pt2e(
+        self,
+        mock_torch_export: Mock,
+        mock_composable_quantizer: Mock,
+        mock_prepare_qat_pt2e: Mock,
+        mock_convert_pt2e: Mock,
+    ) -> None:
+        """QAT flow: prepare_qat_pt2e is called and train_fn is invoked with the prepared model."""
+        mock_quantizer = self.create_dummy_quantizer()
+        train_fn = Mock()
+        mock_recipe = Mock(spec=QuantizationRecipe)
+        mock_recipe.quantizers = [mock_quantizer]
+        mock_recipe.is_qat = True
+        mock_recipe.train_fn = train_fn
+        mock_recipe.pre_prepare_passes = None
+        mock_recipe.post_prepare_passes = None
+        mock_recipe.pre_convert_passes = None
+        mock_recipe.post_convert_passes = None
+
+        mock_exported_program = Mock(spec=ExportedProgram)
+        mock_captured_graph = Mock()
+        mock_exported_program.module.return_value = mock_captured_graph
+        mock_torch_export.return_value = mock_exported_program
+
+        mock_composed_quantizer = Mock()
+        mock_composable_quantizer.return_value = mock_composed_quantizer
+        mock_prepared_model = Mock()
+        mock_prepare_qat_pt2e.return_value = mock_prepared_model
+        mock_quantized_model = Mock()
+        mock_convert_pt2e.return_value = mock_quantized_model
+
+        stage = QuantizeStage(mock_recipe)
+        artifact = PipelineArtifact(data=self.models_dict, context=self.context)
+        stage.run(artifact)
+
+        # prepare_qat_pt2e must be called, not prepare_pt2e
+        mock_prepare_qat_pt2e.assert_called_once_with(
+            mock_captured_graph, mock_composed_quantizer
+        )
+        # train_fn must be called with the prepared model
+        train_fn.assert_called_once_with(mock_prepared_model)
+        # convert_pt2e must still be called after training
+        mock_convert_pt2e.assert_called_once_with(mock_prepared_model)
+
+        result_artifact = stage.get_artifacts()
+        self.assertEqual(result_artifact.data["forward"], mock_quantized_model)
+
+    @patch("torch.export.export")
+    def test_run_qat_missing_train_fn_raises(self, mock_torch_export: Mock) -> None:
+        """QAT flow with train_fn=None must raise ValueError."""
+        mock_quantizer = self.create_dummy_quantizer()
+        mock_recipe = Mock(spec=QuantizationRecipe)
+        mock_recipe.quantizers = [mock_quantizer]
+        mock_recipe.is_qat = True
+        mock_recipe.train_fn = None
+        mock_recipe.pre_prepare_passes = None
+        mock_recipe.post_prepare_passes = None
+        mock_recipe.pre_convert_passes = None
+        mock_recipe.post_convert_passes = None
+
+        mock_exported_program = Mock(spec=ExportedProgram)
+        mock_exported_program.module.return_value = Mock()
+        mock_torch_export.return_value = mock_exported_program
+
+        stage = QuantizeStage(mock_recipe)
+        artifact = PipelineArtifact(data=self.models_dict, context=self.context)
+
+        with self.assertRaises(ValueError) as cm:
+            stage.run(artifact)
+        self.assertIn("train_fn must be provided when is_qat=True", str(cm.exception))
+
+    @patch("executorch.export.stages.convert_pt2e")
+    @patch("executorch.export.stages.prepare_pt2e")
+    @patch("executorch.export.stages.prepare_qat_pt2e")
+    @patch("executorch.export.stages.ComposableQuantizer")
+    @patch("torch.export.export")
+    def test_run_ptq_does_not_call_prepare_qat_pt2e(
+        self,
+        mock_torch_export: Mock,
+        mock_composable_quantizer: Mock,
+        mock_prepare_qat_pt2e: Mock,
+        mock_prepare_pt2e: Mock,
+        mock_convert_pt2e: Mock,
+    ) -> None:
+        """PTQ flow must not call prepare_qat_pt2e (regression guard)."""
+        mock_quantizer = self.create_dummy_quantizer()
+        mock_recipe = Mock(spec=QuantizationRecipe)
+        mock_recipe.quantizers = [mock_quantizer]
+        mock_recipe.is_qat = False
+        mock_recipe.calibration_inputs_fn = None
+        mock_recipe.pre_prepare_passes = None
+        mock_recipe.post_prepare_passes = None
+        mock_recipe.pre_convert_passes = None
+        mock_recipe.post_convert_passes = None
+
+        mock_exported_program = Mock(spec=ExportedProgram)
+        mock_exported_program.module.return_value = Mock()
+        mock_torch_export.return_value = mock_exported_program
+        mock_composable_quantizer.return_value = Mock()
+        mock_prepare_pt2e.return_value = Mock()
+        mock_convert_pt2e.return_value = Mock()
+
+        stage = QuantizeStage(mock_recipe)
+        artifact = PipelineArtifact(data=self.models_dict, context=self.context)
+        stage.run(artifact)
+
+        mock_prepare_pt2e.assert_called_once()
+        mock_prepare_qat_pt2e.assert_not_called()
+
+    @patch("executorch.export.stages.convert_pt2e")
+    @patch("executorch.export.stages.prepare_pt2e")
+    @patch("executorch.export.stages.ComposableQuantizer")
+    @patch("torch.export.export")
+    def test_run_ptq_four_passes_called_in_order(
+        self,
+        mock_torch_export: Mock,
+        mock_composable_quantizer: Mock,
+        mock_prepare_pt2e: Mock,
+        mock_convert_pt2e: Mock,
+    ) -> None:
+        """All four pass hooks are called at the correct points in the PTQ flow."""
+        call_order = []
+
+        def make_pass(name):
+            def pass_fn(m):
+                call_order.append(name)
+                return m
+
+            return pass_fn
+
+        mock_quantizer = self.create_dummy_quantizer()
+        mock_recipe = Mock(spec=QuantizationRecipe)
+        mock_recipe.quantizers = [mock_quantizer]
+        mock_recipe.is_qat = False
+        mock_recipe.calibration_inputs_fn = None
+        mock_recipe.pre_prepare_passes = [make_pass("pre_prepare")]
+        mock_recipe.post_prepare_passes = [make_pass("post_prepare")]
+        mock_recipe.pre_convert_passes = [make_pass("pre_convert")]
+        mock_recipe.post_convert_passes = [make_pass("post_convert")]
+
+        mock_exported_program = Mock(spec=ExportedProgram)
+        mock_graph = Mock()
+        mock_exported_program.module.return_value = mock_graph
+        mock_torch_export.return_value = mock_exported_program
+        mock_composable_quantizer.return_value = Mock()
+        mock_prepare_pt2e.return_value = Mock()
+        mock_convert_pt2e.return_value = Mock()
+
+        stage = QuantizeStage(mock_recipe)
+        artifact = PipelineArtifact(data=self.models_dict, context=self.context)
+        stage.run(artifact)
+
+        self.assertEqual(
+            call_order,
+            ["pre_prepare", "post_prepare", "pre_convert", "post_convert"],
+        )
+
+    @patch("executorch.export.stages.convert_pt2e")
+    @patch("executorch.export.stages.prepare_qat_pt2e")
+    @patch("executorch.export.stages.ComposableQuantizer")
+    @patch("torch.export.export")
+    def test_run_qat_four_passes_called_in_order(
+        self,
+        mock_torch_export: Mock,
+        mock_composable_quantizer: Mock,
+        mock_prepare_qat_pt2e: Mock,
+        mock_convert_pt2e: Mock,
+    ) -> None:
+        """All four pass hooks are called at the correct points in the QAT flow."""
+        call_order = []
+
+        def make_pass(name):
+            def pass_fn(m):
+                call_order.append(name)
+                return m
+
+            return pass_fn
+
+        mock_quantizer = self.create_dummy_quantizer()
+        mock_recipe = Mock(spec=QuantizationRecipe)
+        mock_recipe.quantizers = [mock_quantizer]
+        mock_recipe.is_qat = True
+        mock_recipe.train_fn = Mock()
+        mock_recipe.pre_prepare_passes = [make_pass("pre_prepare")]
+        mock_recipe.post_prepare_passes = [make_pass("post_prepare")]
+        mock_recipe.pre_convert_passes = [make_pass("pre_convert")]
+        mock_recipe.post_convert_passes = [make_pass("post_convert")]
+
+        mock_exported_program = Mock(spec=ExportedProgram)
+        mock_exported_program.module.return_value = Mock()
+        mock_torch_export.return_value = mock_exported_program
+        mock_composable_quantizer.return_value = Mock()
+        mock_prepare_qat_pt2e.return_value = Mock()
+        mock_convert_pt2e.return_value = Mock()
+
+        stage = QuantizeStage(mock_recipe)
+        artifact = PipelineArtifact(data=self.models_dict, context=self.context)
+        stage.run(artifact)
+
+        self.assertEqual(
+            call_order,
+            ["pre_prepare", "post_prepare", "pre_convert", "post_convert"],
+        )
+
+    @patch("executorch.export.stages.convert_pt2e")
+    @patch("executorch.export.stages.prepare_pt2e")
+    @patch("executorch.export.stages.ComposableQuantizer")
+    @patch("torch.export.export")
+    def test_run_ptq_uses_calibration_inputs_fn_when_provided(
+        self,
+        mock_torch_export: Mock,
+        mock_composable_quantizer: Mock,
+        mock_prepare_pt2e: Mock,
+        mock_convert_pt2e: Mock,
+    ) -> None:
+        """When calibration_inputs_fn is set, it is called and its output is used for calibration."""
+        custom_input = (torch.randn(2, 10),)
+        calibration_inputs_fn = Mock(return_value=[custom_input])
+
+        mock_quantizer = self.create_dummy_quantizer()
+        mock_recipe = Mock(spec=QuantizationRecipe)
+        mock_recipe.quantizers = [mock_quantizer]
+        mock_recipe.is_qat = False
+        mock_recipe.calibration_inputs_fn = calibration_inputs_fn
+        mock_recipe.pre_prepare_passes = None
+        mock_recipe.post_prepare_passes = None
+        mock_recipe.pre_convert_passes = None
+        mock_recipe.post_convert_passes = None
+
+        mock_exported_program = Mock(spec=ExportedProgram)
+        mock_exported_program.module.return_value = Mock()
+        mock_torch_export.return_value = mock_exported_program
+        mock_composable_quantizer.return_value = Mock()
+        mock_prepared_model = Mock()
+        mock_prepare_pt2e.return_value = mock_prepared_model
+        mock_convert_pt2e.return_value = Mock()
+
+        stage = QuantizeStage(mock_recipe)
+        artifact = PipelineArtifact(data=self.models_dict, context=self.context)
+        stage.run(artifact)
+
+        # calibration_inputs_fn must be called with no arguments
+        calibration_inputs_fn.assert_called_once_with()
+        # prepared model must be called with the custom calibration input
+        mock_prepared_model.assert_called_once_with(*custom_input)
+
+    @patch("executorch.export.stages.convert_pt2e")
+    @patch("executorch.export.stages.prepare_pt2e")
+    @patch("executorch.export.stages.ComposableQuantizer")
+    @patch("torch.export.export")
+    def test_run_ptq_falls_back_to_example_inputs_when_no_calibration_fn(
+        self,
+        mock_torch_export: Mock,
+        mock_composable_quantizer: Mock,
+        mock_prepare_pt2e: Mock,
+        mock_convert_pt2e: Mock,
+    ) -> None:
+        """When calibration_inputs_fn is None, example inputs are used for calibration."""
+        mock_quantizer = self.create_dummy_quantizer()
+        mock_recipe = Mock(spec=QuantizationRecipe)
+        mock_recipe.quantizers = [mock_quantizer]
+        mock_recipe.is_qat = False
+        mock_recipe.calibration_inputs_fn = None
+        mock_recipe.pre_prepare_passes = None
+        mock_recipe.post_prepare_passes = None
+        mock_recipe.pre_convert_passes = None
+        mock_recipe.post_convert_passes = None
+
+        mock_exported_program = Mock(spec=ExportedProgram)
+        mock_exported_program.module.return_value = Mock()
+        mock_torch_export.return_value = mock_exported_program
+        mock_composable_quantizer.return_value = Mock()
+        mock_prepared_model = Mock()
+        mock_prepare_pt2e.return_value = mock_prepared_model
+        mock_convert_pt2e.return_value = Mock()
+
+        stage = QuantizeStage(mock_recipe)
+        artifact = PipelineArtifact(data=self.models_dict, context=self.context)
+        stage.run(artifact)
+
+        # The prepared model must be called with the example inputs (one tuple)
+        mock_prepared_model.assert_called_once_with(*self.example_inputs[0])
+
     def test_run_empty_example_inputs(self) -> None:
         """Test error when example inputs list is empty."""
         mock_quantizer = Mock()
         mock_recipe = Mock(spec=QuantizationRecipe)
         mock_recipe.quantizers = [mock_quantizer]
+        mock_recipe.is_qat = False
+        mock_recipe.calibration_inputs_fn = None
+        mock_recipe.pre_prepare_passes = None
+        mock_recipe.post_prepare_passes = None
+        mock_recipe.pre_convert_passes = None
+        mock_recipe.post_convert_passes = None
         stage = QuantizeStage(mock_recipe)
         context = {"example_inputs": {"forward": []}}
         artifact = PipelineArtifact(data=self.models_dict, context=context)

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -581,6 +581,59 @@ class TestQuantizeStage(unittest.TestCase):
             stage.run(artifact)
         self.assertIn("train_fn must be provided when is_qat=True", str(cm.exception))
 
+    @patch("executorch.export.stages.allow_exported_model_train_eval")
+    @patch("executorch.export.stages.move_exported_model_to_eval")
+    @patch("executorch.export.stages.move_exported_model_to_train")
+    @patch("executorch.export.stages.convert_pt2e")
+    @patch("executorch.export.stages.prepare_qat_pt2e")
+    @patch("executorch.export.stages.ComposableQuantizer")
+    @patch("torch.export.export")
+    def test_run_qat_model_put_in_train_mode_before_export(
+        self,
+        mock_torch_export: Mock,
+        mock_composable_quantizer: Mock,
+        mock_prepare_qat_pt2e: Mock,
+        mock_convert_pt2e: Mock,
+        mock_move_to_train: Mock,
+        mock_move_to_eval: Mock,
+        mock_allow_train_eval: Mock,
+    ) -> None:
+        """QAT: model.train() must be called before torch.export.export so that
+        batch_norm and dropout decompose with training-mode semantics."""
+        mock_quantizer = self.create_dummy_quantizer()
+        mock_recipe = Mock(spec=QuantizationRecipe)
+        mock_recipe.quantizers = [mock_quantizer]
+        mock_recipe.is_qat = True
+        mock_recipe.dynamic_batch_size = False
+        mock_recipe.train_fn = Mock()
+        mock_recipe.pre_prepare_passes = None
+        mock_recipe.post_prepare_passes = None
+        mock_recipe.pre_convert_passes = None
+        mock_recipe.post_convert_passes = None
+
+        # Start model in eval mode; the stage must switch it to train.
+        self.model.eval()
+        self.assertFalse(self.model.training)
+
+        training_at_export_time = []
+
+        mock_exported_program = Mock(spec=ExportedProgram)
+        mock_exported_program.module.return_value = Mock()
+
+        def capture_training_flag(model, *args, **kwargs):
+            training_at_export_time.append(model.training)
+            return mock_exported_program
+
+        mock_torch_export.side_effect = capture_training_flag
+        mock_prepare_qat_pt2e.return_value = Mock()
+        mock_convert_pt2e.return_value = Mock()
+
+        stage = QuantizeStage(mock_recipe)
+        stage.run(PipelineArtifact(data=self.models_dict, context=self.context))
+
+        # The model must have been in training mode when export was called.
+        self.assertEqual(training_at_export_time, [True])
+
     @patch("executorch.export.stages.move_exported_model_to_eval")
     @patch("executorch.export.stages.convert_pt2e")
     @patch("executorch.export.stages.prepare_pt2e")


### PR DESCRIPTION
### Summary
Extend `QuantizationRecipe` with QAT support and four ordered pass hooks, then wire them into `QuantizeStage`.

`QuantizationRecipe` gains `is_qat`, `train_fn`, `calibration_inputs_fn`, and four pass-list fields (`pre_prepare_passes`, `post_prepare_passes`, `pre_convert_passes`, `post_convert_passes`). When `is_qat=True`, `QuantizeStage` calls `prepare_qat_pt2e` instead of `prepare_pt2e`, invokes `train_fn` on the prepared model, and skips calibration. When `is_qat=False` (default), PTQ proceeds as before, but callers may now supply a `calibration_inputs_fn` to supply their own calibration data. If omitted, the existing example-inputs fallback is used. The four pass hooks are applied at the appropriate points in both flows and compose cleanly with `_combine_recipes`.

`_combine_recipes` is overhauled to handle all previously dropped fields: the four pass lists are concatenated, `is_qat` must agree across all combined recipes, at most one `train_fn` is allowed, and multiple `calibration_inputs_fn` values are chained into a single factory. The `strict`, `mode`, `pipeline_stages`, and `source_transform_in_place` scalar fields are now also validated for agreement and propagated to the combined recipe. `edge_manager_transform_passes` from `LoweringRecipe` is similarly merged.

### Test Plan
```
pytest -q export/tests/test_export_recipe.py export/tests/test_export_stages.py
```
