### PR TITLE
Arm backend: Add KV cache SmolLM2 VGF demo flow

### DIFF
--- a/examples/arm/smollm2_example_vgf/README.md
+++ b/examples/arm/smollm2_example_vgf/README.md
@@ -1,6 +1,8 @@
 # SmolLM2 → VGF Quickstart
 
-> **Heads-up:** The current VGF PTQ flow is still experimental. Use FP32 as the baseline, expect `linear8a8w` to be accuracy-sensitive, and treat `linear16a8w` as the preferred quantized path to try first.
+> **Heads-up:** Use FP32 as the accuracy baseline and `linear16a8w` with an
+> FP32 KV cache as the recommended quantized path. Treat static INT8 KV-cache
+> storage and `linear8a8w` as experimental.
 
 This is a host-only VGF workflow built around `executor_runner`. Run the
 commands from the root of an ExecuTorch source checkout.
@@ -34,7 +36,7 @@ If you want the broader Arm backend setup flow, see
 ## 1. Tokenizer (one-time)
 ```bash
 mkdir -p data/tokenizers/smollm2
-huggingface-cli download HuggingFaceTB/SmolLM2-135M-Instruct tokenizer.json \
+huggingface-cli download HuggingFaceTB/SmolLM2-135M tokenizer.json \
   --local-dir data/tokenizers/smollm2
 ```
 The download lives at `data/tokenizers/smollm2/tokenizer.json`. Use this path in the export and sampling commands below.
@@ -48,60 +50,32 @@ export CXX=/usr/bin/g++-12
 export CUDAHOSTCXX=$CXX
 ```
 
-## 2. Recommended: FP32 export
-Produces a stable `.pte` for experimentation and sampling.
+## 2. Baseline: full-FP32 model and KV cache
+Produces a stable `.pte` for experimentation and sampling. KV cache is the
+preferred runtime flow because each decode step reuses cached attention state
+instead of recomputing the full prompt window.
+
 ```bash
 python -m extension.llm.export.export_llm \
   base.model_class=smollm2 \
   base.params=examples/models/smollm2/135M_config.json \
   base.tokenizer_path=data/tokenizers/smollm2/tokenizer.json \
-  export.output_dir=outputs/$(date +%F)/$(date +%H-%M-%S)_fp32 \
-  export.output_name=smollm2_vgf_fp32_full_logits.pte \
-  export.max_seq_length=64 \
-  export.max_context_length=64 \
-  backend.vgf.enabled=True \
-  backend.vgf.compile_spec=TOSA-1.0+FP \
-  model.use_kv_cache=False \
-  model.enable_dynamic_shape=False \
-  debug.verbose=True \
-  debug.generate_full_logits=True
-```
-
-
-## 3. Experimental: 8-bit PTQ (Linear-only)
-This quantizes only `torch.nn.Linear` modules using the Arm VGF PT2E quantizer.
-
-Supported calibration inputs:
-- `quantization.calibration_data=@...` for a text corpus
-- `quantization.calibration_tasks=[wikitext]` for LM-Eval tasks
-
-For this static non-KV-cache flow, keep `debug.generate_full_logits=True` for
-calibrated exports. Calibration uses padded fixed-shape prefixes, and full
-logits let the calibration/eval helpers select the last real-token logits row
-instead of accidentally using the padded tail.
-
-Example (LM-Eval wikitext calibration):
-```bash
-python -m extension.llm.export.export_llm \
-  base.model_class=smollm2 \
-  base.params=examples/models/smollm2/135M_config.json \
-  base.tokenizer_path=data/tokenizers/smollm2/tokenizer.json \
-  export.output_dir=outputs/$(date +%F)/$(date +%H-%M-%S)_linear8a8w \
-  export.output_name=smollm2_vgf_linear8a8w_wikitext_full_logits.pte \
-  export.max_seq_length=64 \
-  export.max_context_length=64 \
-  quantization.pt2e_quantize=vgf_8a8w \
-  quantization.calibration_tasks=\[wikitext\] \
-  quantization.calibration_limit=64 \
-  quantization.calibration_seq_length=64 \
+  export.output_dir=outputs/$(date +%F)/$(date +%H-%M-%S)_kv_fp32 \
+  export.output_name=smollm2_vgf_kv_fp32.pte \
+  export.max_seq_length=128 \
+  export.max_context_length=128 \
   backend.vgf.enabled=True \
   backend.vgf.compile_spec=TOSA-1.0+FP+INT \
-  backend.vgf.quantize_scope=linear \
-  model.use_kv_cache=False \
+  model.use_kv_cache=True \
   model.enable_dynamic_shape=False \
-  debug.verbose=True \
-  debug.generate_full_logits=True
+  debug.verbose=True
 ```
+
+## 3. Recommended quantized path: `linear16a8w` with FP32 KV storage
+This quantizes `torch.nn.Linear` modules with the Arm VGF PT2E quantizer and
+keeps the persistent KV cache in FP32. This is the recommended starting point
+because static INT8 cache storage has not yet demonstrated a performance
+benefit on VGF hardware.
 
 Example (16-bit activations, 8-bit weights, Linear-only):
 
@@ -110,27 +84,85 @@ python -m extension.llm.export.export_llm \
   base.model_class=smollm2 \
   base.params=examples/models/smollm2/135M_config.json \
   base.tokenizer_path=data/tokenizers/smollm2/tokenizer.json \
-  export.output_dir=outputs/$(date +%F)/$(date +%H-%M-%S)_linear16a8w \
-  export.output_name=smollm2_vgf_linear16a8w_wikitext_full_logits.pte \
-  export.max_seq_length=64 \
-  export.max_context_length=64 \
+  export.output_dir=outputs/$(date +%F)/$(date +%H-%M-%S)_kv_linear16a8w \
+  export.output_name=smollm2_vgf_kv_linear16a8w.pte \
+  export.max_seq_length=128 \
+  export.max_context_length=128 \
   quantization.pt2e_quantize=vgf_16a8w \
   quantization.calibration_tasks=\[wikitext\] \
   quantization.calibration_limit=64 \
-  quantization.calibration_seq_length=64 \
+  quantization.calibration_seq_length=128 \
   backend.vgf.enabled=True \
   backend.vgf.compile_spec=TOSA-1.0+FP+INT+int16 \
   backend.vgf.quantize_scope=linear \
-  model.use_kv_cache=False \
+  model.use_kv_cache=True \
   model.enable_dynamic_shape=False \
-  debug.verbose=True \
-  debug.generate_full_logits=True
+  debug.verbose=True
+```
+
+### 3.1 Experimental: `linear16a8w` with static INT8 KV storage
+
+This path stores the persistent KV cache as calibrated INT8 data. It is
+different from `model.quantize_kv_cache=True`, which performs dynamic per-token
+KV quantization and currently leaves cache QDQ/update maintenance outside the
+VGF delegate.
+
+When `quantization.calibration_tasks` is set, export first runs the task
+through a float KV cache and derives separate symmetric per-head-dimension K/V
+scales for every layer. The same task is then reused for normal PT2E Linear
+calibration. Without a calibration task, static KV storage uses
+`model.static_quantize_kv_cache_scale` as a fixed fallback;
+`calibration_data` alone only calibrates the PT2E operators.
+
+Use the recommended command above with these changes:
+
+```bash
+export.output_dir=outputs/$(date +%F)/$(date +%H-%M-%S)_static_kvq_linear16a8w \
+export.output_name=smollm2_vgf_static_kvq_linear16a8w.pte \
+model.static_quantize_kv_cache=True
+```
+
+The static KV-cache path uses symmetric per-head-dimension scales with
+zero-point `0` and dequantizes the cache back to float for the existing
+attention path. Treat its accuracy and performance as experimental until they
+have been validated for the target hardware and context length.
+
+Alternative `linear8a8w` mode:
+
+```bash
+python -m extension.llm.export.export_llm \
+  base.model_class=smollm2 \
+  base.params=examples/models/smollm2/135M_config.json \
+  base.tokenizer_path=data/tokenizers/smollm2/tokenizer.json \
+  export.output_dir=outputs/$(date +%F)/$(date +%H-%M-%S)_kv_linear8a8w \
+  export.output_name=smollm2_vgf_kv_linear8a8w.pte \
+  export.max_seq_length=128 \
+  export.max_context_length=128 \
+  quantization.pt2e_quantize=vgf_8a8w \
+  quantization.calibration_tasks=\[wikitext\] \
+  quantization.calibration_limit=64 \
+  quantization.calibration_seq_length=128 \
+  backend.vgf.enabled=True \
+  backend.vgf.compile_spec=TOSA-1.0+FP+INT \
+  backend.vgf.quantize_scope=linear \
+  model.use_kv_cache=True \
+  model.enable_dynamic_shape=False \
+  debug.verbose=True
 ```
 
 `quantization.pt2e_quantize` selects the numeric mode.
 `backend.vgf.quantize_scope=linear` keeps quantization limited to
 `torch.nn.Linear` modules. The compile spec still includes FP because the rest
 of the graph remains floating point.
+
+### 3.2 Alternative: static non-KV full-logits exports
+Use the static non-KV path when you specifically need full-window logits, for
+example faster perplexity evaluation or debugging padded fixed-shape behavior.
+For calibrated non-KV exports, keep `debug.generate_full_logits=True`; this lets
+the helpers select the last real-token logits row instead of the padded tail.
+Set `model.use_kv_cache=False`, keep `export.max_seq_length` and
+`quantization.calibration_seq_length` aligned, and add
+`debug.generate_full_logits=True` to the export commands above.
 
 ## 4. Sampling with `executor_runner`
 
@@ -149,8 +181,9 @@ CPU kernel coverage.
 
 ### 4.1 Greedy and `T=0.8` sampling
 `examples/arm/smollm2_example_vgf/generate_sampled.py` wraps
-`cmake-out-vkml/executor_runner`, keeps a sliding fixed-length token window,
-and can print the top-5 logits each step.
+`cmake-out-vkml/executor_runner` and supports both KV-cache and static non-KV
+exports. The recommended KV-cache path uses `--use-kv-cache`; the static
+non-KV path uses a fixed token window plus `--full-logits`.
 
 Greedy generation (`--temperature 0`) always chooses the highest-logit next
 token, which is useful for deterministic comparisons. Stochastic generation
@@ -160,46 +193,47 @@ with a fixed `--seed`.
 
 Notes:
 - `--max-seq-length` must match the export `export.max_seq_length` (otherwise you will hit input size mismatch).
-- The exported SmolLM2 VGF input is `int32[1, max_seq_length]`; the helper writes
-  token windows as `int32` binary inputs for `executor_runner`.
-- Use `--persistent-runner` for faster multi-token generation (loads the model once).
+- KV-cache exports take `token,input_pos` inputs and should pass `--use-kv-cache`.
+- Static non-KV exports take an `int32[1, max_seq_length]` token window and should pass `--full-logits`.
+- The KV-cache path keeps `executor_runner` alive in server mode automatically.
 - The documented examples use `--temperature 0` (greedy) and `--temperature 0.8`.
 - For deterministic comparisons against saved `temp0` outputs, use `--seed 0`, `--repetition-penalty 1.1`, and `--no-topk-print`. At `--temperature 0`, token selection is greedy, so `--top-p` does not affect the chosen token.
 
 Greedy example (`T=0`):
 ```bash
 python examples/arm/smollm2_example_vgf/generate_sampled.py \
-  --persistent-runner \
   --runner cmake-out-vkml/executor_runner \
-  --pte smollm2_vgf_fp32_full_logits.pte \
+  --pte smollm2_vgf_kv_linear16a8w.pte \
   --tokenizer data/tokenizers/smollm2/tokenizer.json \
   --prompt "Once upon a time in a small village," \
-  --max-seq-length 64 \
+  --max-seq-length 128 \
+  --max-context-length 128 \
   --max-new-tokens 10 \
   --seed 0 \
   --temperature 0 \
   --repetition-penalty 1.1 \
-  --full-logits
+  --use-kv-cache
 ```
 
 Stochastic example (`T=0.8`):
 ```bash
 python examples/arm/smollm2_example_vgf/generate_sampled.py \
-  --persistent-runner \
   --runner cmake-out-vkml/executor_runner \
-  --pte smollm2_vgf_fp32_full_logits.pte \
+  --pte smollm2_vgf_kv_linear16a8w.pte \
   --tokenizer data/tokenizers/smollm2/tokenizer.json \
   --prompt "Once upon a time in a small village," \
-  --max-seq-length 64 \
+  --max-seq-length 128 \
+  --max-context-length 128 \
   --max-new-tokens 10 \
   --seed 0 \
   --temperature 0.8 \
   --top-p 0.9 \
   --repetition-penalty 1.1 \
-  --full-logits
+  --use-kv-cache
 ```
-> Swap `--pte` to the quantized build to compare behaviour. `linear8a8w` still
-> tends to drift more than `linear16a8w`.
+> Swap `--pte` to `smollm2_vgf_static_kvq_linear16a8w.pte` to compare
+> experimental static INT8 KV storage, or to `smollm2_vgf_kv_fp32.pte` for the
+> full-FP32 baseline.
 
 
 
@@ -209,40 +243,49 @@ To generate for *all* prompts in `default_prompts.txt` and save to a file:
 
 ```bash
 python examples/arm/smollm2_example_vgf/generate_sampled.py \
-  --persistent-runner \
   --runner cmake-out-vkml/executor_runner \
-  --pte smollm2_vgf_fp32_full_logits.pte \
+  --pte smollm2_vgf_kv_linear16a8w.pte \
   --tokenizer data/tokenizers/smollm2/tokenizer.json \
   --prompt-file examples/arm/smollm2_example_vgf/default_prompts.txt \
   --prompt-all \
-  --max-seq-length 64 \
+  --max-seq-length 128 \
+  --max-context-length 128 \
   --max-new-tokens 64 \
   --temperature 0.8 \
   --top-p 0.9 \
   --repetition-penalty 1.1 \
-  --full-logits \
+  --use-kv-cache \
   --save-generations outputs/$(date +%F)/$(date +%H-%M-%S)_smollm2_gen.txt
 ```
 
 ## 5. Wikitext prompts and perplexity
 
+For a smoke test before a dedicated comparison, run the `default_prompts.txt`
+command above with `smollm2_vgf_kv_linear16a8w.pte` and inspect the
+generations. To evaluate the experimental static INT8 cache artifact alone,
+pass `smollm2_vgf_static_kvq_linear16a8w.pte` to any one of the PTE options
+below.
+
 Build a reusable 1000-prompt file from `wikitext-2-raw-v1` and evaluate
-perplexity on the first 100 prompts for FP32, `linear8a8w`, and `linear16a8w`:
+perplexity on the first 100 prompts for KV-cache FP32, `linear8a8w`, and
+`linear16a8w`:
 
 ```bash
 OUT_DIR=outputs/$(date +%F)/$(date +%H-%M-%S)_smollm2_vgf_eval
 
 python examples/arm/smollm2_example_vgf/eval_wikitext_perplexity.py \
   --runner cmake-out-vkml/executor_runner \
-  --pte-fp32 "${OUT_DIR}/smollm2_vgf_fp32_full_logits.pte" \
-  --pte-linear8a8w "${OUT_DIR}/smollm2_vgf_linear8a8w_wikitext_full_logits.pte" \
-  --pte-linear16a8w "${OUT_DIR}/smollm2_vgf_linear16a8w_wikitext_full_logits.pte" \
+  --pte-fp32 "${OUT_DIR}/smollm2_vgf_kv_fp32.pte" \
+  --pte-linear8a8w "${OUT_DIR}/smollm2_vgf_kv_linear8a8w.pte" \
+  --pte-linear16a8w "${OUT_DIR}/smollm2_vgf_kv_linear16a8w.pte" \
   --tokenizer data/tokenizers/smollm2/tokenizer.json \
   --prompts-file "${OUT_DIR}/wikitext_prompts_1000.txt" \
   --num-prompts 1000 \
   --ppl-prompts 100 \
-  --max-seq-length 64 \
-  --max-prompt-tokens 64 \
+  --max-seq-length 128 \
+  --max-prompt-tokens 128 \
+  --max-tokens-per-prompt 64 \
+  --use-kv-cache \
   --refresh-prompts
 ```
 
@@ -250,15 +293,23 @@ Notes:
 - This script downloads `wikitext-2-raw-v1` via Hugging Face `datasets`.
 - The prompts file is reusable; omit `--refresh-prompts` on later runs.
 - Perplexity is computed on the first 100 prompts from that file.
-- Each prompt is capped to 64 tokens and scored from one full-logits
-  `executor_runner` invocation per prompt, rather than one invocation per token.
+- KV-cache prompts are scored step-by-step with `token` and `input_pos`
+  inputs, so this path is slower but matches the recommended decode contract.
+- `--max-tokens-per-prompt` controls how many tokens are scored from each
+  prompt. Use `64` for comparison with the static-window baseline, or a larger
+  value to stress a longer KV context.
+- For static non-KV PTEs, omit `--use-kv-cache` and pass full-logits PTEs; each
+  prompt is then scored from one full-logits invocation rather than one
+  invocation per token.
 
 ## 6. Notes
-- This flow keeps KV cache disabled and uses a fixed token window. KV-cache
-  support is the expected next step for faster generation, but it is outside
-  this static VGF quickstart.
-- Without KV cache, the model recomputes the entire token window for each
-  generated token.
+- The quickstart exports use KV cache. Static non-KV full-logits exports are
+  still useful for faster perplexity experiments and fixed-window debugging.
+- The recommended quantized export keeps KV storage in FP32. Static INT8 KV
+  storage remains available for experimental memory and performance studies.
+- With KV cache, generation replays one token plus `input_pos` per runner
+  invocation; without KV cache, the model recomputes the full token window for
+  each generated token.
 - `linear8a8w` still shows noticeably more quality loss than `linear16a8w`.
 - When you change `max_seq_length`, regenerate any cached prompt inputs to match the new window size.
 - On hosts with multiple Vulkan devices, use `vulkaninfo --summary` to check
@@ -267,7 +318,9 @@ Notes:
 ### Implementation details
 - The VKML runner is `examples/portable/executor_runner/executor_runner.cpp`,
   built here as `cmake-out-vkml/executor_runner`.
-- `generate_sampled.py` tokenizes prompts, prepares the fixed token window,
-  invokes `executor_runner`, reads logits, and decodes sampled tokens.
-- The sampling and perplexity commands pass `--full-logits` to match the
-  exported full-logits PTEs.
+- `generate_sampled.py` tokenizes prompts, prepares either the fixed non-KV
+  token window or KV-cache `token,input_pos` inputs, invokes `executor_runner`,
+  reads logits, and decodes sampled tokens.
+- The non-KV sampling and perplexity commands pass `--full-logits` to match the
+  exported full-logits PTEs. KV-cache PTEs return next-token logits directly
+  and should use `--use-kv-cache` instead.

--- a/examples/arm/smollm2_example_vgf/eval_wikitext_perplexity.py
+++ b/examples/arm/smollm2_example_vgf/eval_wikitext_perplexity.py
@@ -17,6 +17,7 @@ import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from generate_sampled import (  # type: ignore[import-not-found]
+    KvRunnerSession,
     prepare_input,
     RunnerSession,
 )
@@ -122,6 +123,13 @@ def reshape_full_logits(*, logits: np.ndarray, window: int) -> np.ndarray:
     return logits.reshape(window, vocab_size)
 
 
+def token_nll(logits: np.ndarray, target_id: int) -> float:
+    max_logit = float(np.max(logits))
+    shifted = logits - max_logit
+    log_denom = max_logit + math.log(float(np.exp(shifted).sum()))
+    return log_denom - float(logits[target_id])
+
+
 def eval_prompt_nll(
     *,
     runner: RunnerSession,
@@ -168,6 +176,30 @@ def eval_prompt_nll(
     return total_nll, valid_len
 
 
+def eval_prompt_nll_kv(
+    *,
+    runner: KvRunnerSession,
+    tokenizer,
+    prompt: str,
+    max_tokens_per_prompt: int,
+) -> Tuple[float, int]:
+    token_ids = tokenizer.encode(prompt, bos=True, eos=False)
+    if max_tokens_per_prompt > 0:
+        token_ids = token_ids[:max_tokens_per_prompt]
+
+    if len(token_ids) < 2:
+        return 0.0, 0
+
+    total_nll = 0.0
+    for pos, token_id in enumerate(token_ids[:-1]):
+        logits = runner.run(token_id, pos)
+        target_id = token_ids[pos + 1]
+        if target_id >= logits.shape[0]:
+            raise RuntimeError(f"Target id {target_id} outside vocab {logits.shape[0]}")
+        total_nll += token_nll(logits, target_id)
+    return total_nll, len(token_ids) - 1
+
+
 def eval_model_ppl(
     *,
     runner: Path,
@@ -177,28 +209,55 @@ def eval_model_ppl(
     window: int,
     pad_id: int,
     max_tokens_per_prompt: int,
+    use_kv_cache: bool,
 ) -> float:
     total_nll = 0.0
     total_tokens = 0
 
-    with RunnerSession(
-        runner=str(runner),
-        pte=str(pte),
-        extra_args=[],
-        persistent=True,
-    ) as session:
-        for idx, prompt in enumerate(prompts, start=1):
-            print(f"[eval] {pte.name} prompt {idx}/{len(prompts)}")
-            prompt_nll, prompt_tokens = eval_prompt_nll(
-                runner=session,
-                tokenizer=tokenizer,
-                prompt=prompt,
-                window=window,
-                pad_id=pad_id,
-                max_tokens_per_prompt=max_tokens_per_prompt,
-            )
-            total_nll += prompt_nll
-            total_tokens += prompt_tokens
+    if use_kv_cache:
+        with KvRunnerSession(
+            runner=str(runner),
+            pte=str(pte),
+            extra_args=[],
+            persistent=True,
+        ) as session:
+            for idx, prompt in enumerate(prompts, start=1):
+                print(f"[eval-kv] {pte.name} prompt {idx}/{len(prompts)}")
+                prompt_nll, prompt_tokens = eval_prompt_nll_kv(
+                    runner=session,
+                    tokenizer=tokenizer,
+                    prompt=prompt,
+                    max_tokens_per_prompt=max_tokens_per_prompt,
+                )
+                total_nll += prompt_nll
+                total_tokens += prompt_tokens
+                if total_tokens > 0:
+                    cumulative_ppl = f"{math.exp(total_nll / total_tokens):.4f}"
+                else:
+                    cumulative_ppl = "n/a"
+                print(
+                    f"[eval-kv] {pte.name} prompt {idx}: "
+                    f"tokens={prompt_tokens} cumulative_ppl={cumulative_ppl}"
+                )
+    else:
+        with RunnerSession(
+            runner=str(runner),
+            pte=str(pte),
+            extra_args=[],
+            persistent=True,
+        ) as session:
+            for idx, prompt in enumerate(prompts, start=1):
+                print(f"[eval] {pte.name} prompt {idx}/{len(prompts)}")
+                prompt_nll, prompt_tokens = eval_prompt_nll(
+                    runner=session,
+                    tokenizer=tokenizer,
+                    prompt=prompt,
+                    window=window,
+                    pad_id=pad_id,
+                    max_tokens_per_prompt=max_tokens_per_prompt,
+                )
+                total_nll += prompt_nll
+                total_tokens += prompt_tokens
 
     if total_tokens == 0:
         raise RuntimeError("No prompt tokens were scored.")
@@ -266,6 +325,11 @@ def main() -> None:
         help="Fixed token sequence length expected by the exported model.",
     )
     parser.add_argument(
+        "--use-kv-cache",
+        action="store_true",
+        help="Evaluate KV-cache exports that take token and input_pos inputs.",
+    )
+    parser.add_argument(
         "--refresh-prompts",
         action="store_true",
         help="Rebuild prompts even if --prompts-file already exists.",
@@ -306,6 +370,7 @@ def main() -> None:
             window=args.window,
             pad_id=pad_id,
             max_tokens_per_prompt=args.max_tokens_per_prompt,
+            use_kv_cache=args.use_kv_cache,
         )
 
     print("\n=== Perplexity summary ===")

--- a/examples/arm/smollm2_example_vgf/generate_sampled.py
+++ b/examples/arm/smollm2_example_vgf/generate_sampled.py
@@ -34,15 +34,18 @@ class RunnerSession:
         extra_args: List[str],
         *,
         persistent: bool,
+        input_names: Optional[List[str]] = None,
     ) -> None:
         self._runner = runner
         self._pte = pte
         self._extra_args = extra_args
         self._persistent = persistent
+        self._input_names = input_names or ["tokens.bin"]
 
         self._tmpdir: Optional[tempfile.TemporaryDirectory[str]] = None
         self._tmpdir_path: Optional[Path] = None
         self._input_path: Optional[Path] = None
+        self._input_paths: List[Path] = []
         self._output_prefix: Optional[Path] = None
 
         self._proc: Optional[subprocess.Popen[str]] = None
@@ -55,18 +58,19 @@ class RunnerSession:
     def _init_paths(self) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self._tmpdir_path = Path(self._tmpdir.name)
-        self._input_path = self._tmpdir_path / "tokens.bin"
+        self._input_paths = [self._tmpdir_path / name for name in self._input_names]
+        self._input_path = self._input_paths[0]
         self._output_prefix = self._tmpdir_path / "logits"
 
     def _base_cmd(self) -> List[str]:
-        assert self._input_path is not None
+        assert self._input_paths
         assert self._output_prefix is not None
         return [
             self._runner,
             "--model_path",
             self._pte,
             "--inputs",
-            str(self._input_path),
+            ",".join(str(path) for path in self._input_paths),
             "--output_file",
             str(self._output_prefix),
         ] + self._extra_args
@@ -130,8 +134,17 @@ class RunnerSession:
     def run(self, tokens: np.ndarray) -> np.ndarray:
         """Run executor_runner once and return output logits as float32."""
 
-        assert self._input_path is not None
-        tokens.tofile(self._input_path)
+        return self.run_inputs([tokens])
+
+    def run_inputs(self, inputs: List[np.ndarray]) -> np.ndarray:
+        """Run executor_runner once with one or more input tensor files."""
+
+        if len(inputs) != len(self._input_paths):
+            raise ValueError(
+                f"Expected {len(self._input_paths)} inputs, got {len(inputs)}."
+            )
+        for input_array, input_path in zip(inputs, self._input_paths):
+            input_array.tofile(input_path)
         output_path = self._output_path()
         output_path.unlink(missing_ok=True)
 
@@ -179,6 +192,44 @@ class RunnerSession:
         if not output_path.exists() or output_path.stat().st_size == 0:
             raise RuntimeError("executor_runner did not write logits output")
         return self._read_logits()
+
+
+class KvRunnerSession:
+    """Step-wise runner for KV-cache exports."""
+
+    def __init__(
+        self,
+        runner: str,
+        pte: str,
+        extra_args: List[str],
+        *,
+        persistent: bool,
+    ) -> None:
+        self._runner = RunnerSession(
+            runner=runner,
+            pte=pte,
+            extra_args=extra_args,
+            persistent=persistent,
+            input_names=["token.bin", "input_pos.bin"],
+        )
+
+    def close(self) -> None:
+        self._runner.close()
+
+    def __enter__(self) -> "KvRunnerSession":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+        self.close()
+
+    def run(self, token_id: int, input_pos: int) -> np.ndarray:
+        logits = self._runner.run_inputs(
+            [
+                np.array([[token_id]], dtype=np.int64),
+                np.array([input_pos], dtype=np.int64),
+            ]
+        )
+        return logits.reshape(1, -1)[0]
 
 
 def prepare_input(
@@ -594,6 +645,98 @@ def run_one_prompt(
         )
 
 
+def run_one_prompt_kv(
+    *,
+    runner: KvRunnerSession,
+    tokenizer,
+    prompt: str,
+    prompt_no: int,
+    vocab_size: Optional[int],
+    eos_id: int,
+    max_context_length: int,
+    max_new_tokens: int,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    repetition_penalty: float,
+    save_generations_path: Optional[Path],
+    topk_print: bool,
+) -> None:
+    ids = tokenizer.encode(prompt, bos=True, eos=False)
+    if not ids:
+        raise RuntimeError("Tokenizer returned no prompt tokens")
+    if len(ids) >= max_context_length:
+        ids = ids[: max_context_length - 1]
+    max_new_tokens = min(max_new_tokens, max_context_length - len(ids))
+
+    print(
+        f"\n==================== Prompt {prompt_no} ====================\n{prompt}",
+        end="",
+        flush=True,
+    )
+
+    logits_0: Optional[np.ndarray] = None
+    input_pos = 0
+    for token_id in ids:
+        logits_0 = runner.run(token_id, input_pos)
+        input_pos += 1
+
+    generated = 0
+    while generated < max_new_tokens and input_pos <= max_context_length:
+        if logits_0 is None:
+            raise RuntimeError("KV decode did not produce logits")
+
+        if topk_print:
+            print_topk_candidates(
+                logits=logits_0,
+                tokenizer=tokenizer,
+                step=generated,
+                k=5,
+            )
+
+        logits_for_sampling = apply_repetition_penalty(
+            logits_0.copy(),
+            generated_ids=ids,
+            penalty=repetition_penalty,
+        )
+        next_id = sample_token_topk_topp(
+            logits_for_sampling,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+        )
+        if vocab_size is not None and next_id >= vocab_size:
+            raise RuntimeError(
+                f"Sampled token id {next_id} out of vocab_size {vocab_size}."
+            )
+
+        ids.append(next_id)
+        generated += 1
+        token_text = tokenizer.decode_token(next_id)
+        print("Chosen token:", token_text)
+        print(token_text, end="", flush=True)
+
+        if next_id == eos_id or generated >= max_new_tokens:
+            break
+        if input_pos >= max_context_length:
+            break
+
+        logits_0 = runner.run(next_id, input_pos)
+        input_pos += 1
+
+    print("\n=== Generation complete ===")
+    decoded = tokenizer.decode(ids)
+    print(decoded)
+
+    if save_generations_path is not None:
+        append_generation(
+            path=save_generations_path,
+            prompt=prompt,
+            prompt_no=prompt_no,
+            decoded=decoded,
+        )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Temperature sampling via executor_runner"
@@ -660,6 +803,17 @@ def main() -> None:
         help="Assume the export produces full logits and select the last valid token row.",
     )
     parser.add_argument(
+        "--use-kv-cache",
+        action="store_true",
+        help="Run a KV-cache export that takes token and input_pos inputs.",
+    )
+    parser.add_argument(
+        "--max-context-length",
+        type=int,
+        default=None,
+        help="KV-cache context length. Defaults to --max-seq-length/--window.",
+    )
+    parser.add_argument(
         "--input-dtype",
         choices=("int32", "int64"),
         default="int32",
@@ -724,6 +878,33 @@ def main() -> None:
         prompt_index=args.prompt_index,
         prompt_limit=args.prompt_limit,
     )
+
+    if args.use_kv_cache:
+        max_context_length = args.max_context_length or args.window
+        with KvRunnerSession(
+            args.runner,
+            args.pte,
+            args.runner_args,
+            persistent=True,
+        ) as runner:
+            for i, prompt in enumerate(prompts):
+                run_one_prompt_kv(
+                    runner=runner,
+                    tokenizer=tokenizer,
+                    prompt=prompt,
+                    prompt_no=i,
+                    vocab_size=vocab_size,
+                    eos_id=eos_id,
+                    max_context_length=max_context_length,
+                    max_new_tokens=args.max_new_tokens,
+                    temperature=args.temperature,
+                    top_k=args.topk,
+                    top_p=args.top_p,
+                    repetition_penalty=args.repetition_penalty,
+                    save_generations_path=args.save_generations,
+                    topk_print=not args.no_topk_print,
+                )
+        return
 
     with RunnerSession(
         args.runner,


### PR DESCRIPTION
Unify the SmolLM2 VGF generation and perplexity helpers so the same entry points support static non-KV full-logits and KV-cache exports.

Recommend linear16a8w with an FP32 KV cache for the default quantized workflow. Document calibrated static INT8 KV storage as experimental while retaining FP32 and static non-KV alternatives.

AI-assisted-by: Codex

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani