### PR TITLE
Arm backend: add SmolLM2 Ethos-U KV-cache demo support

### DIFF
--- a/examples/arm/smollm2_example_ethos_u/README.md
+++ b/examples/arm/smollm2_example_ethos_u/README.md
@@ -14,11 +14,11 @@
 
 This document focuses on one validated flow:
 
-1. Export one generation-ready full-logits `w8a16` PTE with a fixed sequence window of 32.
+1. Export one generation-ready KV-cache `w8a16` PTE with a 64-token context.
 2. Build one runner that embeds that PTE and uses semihosting for host-side
    input/output tensor exchange.
 3. Run a short prompt-generation smoke test on Corstone-320 FVP.
-4. Optionally evaluate Wikitext perplexity with the same full-logits artifact.
+4. Optionally evaluate Wikitext perplexity with the same KV-cache artifact.
 
 In this example, semihosting is mainly a convenient FVP integration path for
 passing meaningful input tensors into the runner and reading output tensors back
@@ -29,15 +29,14 @@ copying the model file at runtime. On real silicon, the same preprocessing would
 more likely populate the model input buffer directly from software rather than
 via semihosting.
 
-The example uses a fixed sequence length of 32 because that is the current
-validated tradeoff for this branch on Corstone-320 FVP. Larger windows were more
-expensive in runtime and stalled in our experiments, while smaller windows were
-easier to validate earlier but produced weaker prompts and less representative
-perplexity results. This branch also does not use KV-cache decoding, so every
-generated token recomputes attention across the whole window and larger sequence
-lengths become even more costly. If KV-cache support is added later, it should
-reduce the incremental decode cost, but it is not the direct reason seq32 was
-chosen here.
+The primary path below uses KV-cache decoding with a 64-token context. Each
+runtime step executes one token plus its `input_pos`, while the exported context
+length controls the KV-cache capacity. The older static non-KV seq32 full-logits
+flow remains the safest fallback when debugging full-window execution. Larger
+non-KV windows are experimental: they are more expensive at runtime and require
+retuning the runner allocator pools. For example, a seq48 embedded-PTE smoke run
+needed a scratch pool just under 5 MiB instead of the 4 MiB pool used by the
+seq32 non-KV commands.
 
 ## 0. Prerequisites
 
@@ -100,10 +99,11 @@ These are the settings used by the main flow in this README:
 
 - `quantization.pt2e_quantize=ethosu_16a8w`
 - `quantization.quantize_scope=linear`
-- `export.max_seq_length=32`
-- `export.max_context_length=32`
-- `quantization.calibration_seq_length=32`
-- `quantization.calibration_limit=62`
+- `model.use_kv_cache=True`
+- `export.max_seq_length=64`
+- `export.max_context_length=64`
+- `quantization.calibration_seq_length=64`
+- `quantization.calibration_limit=1`
 - `backend.ethosu.target=ethos-u85-256`
 - `backend.ethosu.system_config=Ethos_U85_SYS_DRAM_High`
 - `backend.ethosu.memory_mode=Dedicated_Sram_512KB`
@@ -112,26 +112,27 @@ Why these settings matter:
 
 - `linear` scope means only the linear layers are quantized onto Ethos-U. This
   is the current validated path for meaningful output in this example.
-- `max_seq_length=32` and `calibration_seq_length=32` are kept equal so the
-  quantizer observes the same token-window shape that the runtime will execute.
-  Keeping them aligned avoids calibrating a shape that the deployed runner never
-  uses.
-- `calibration_limit=62` is the current fuller-calibration setting for this
-  README. With the newer full-logits calibration path, larger limits are now
-  practical enough to use by default. For quicker iteration, `calibration_limit=2`
-  is the fast validation setting discussed later in this document.
+- `model.use_kv_cache=True` exports the token and `input_pos` inputs used for
+  step-wise decoding.
+- `max_seq_length=64` and `max_context_length=64` set the documented 64-token
+  generation context. In KV-cache mode, `generate_sampled.py` can derive the
+  context length from `--window 64`; pass `--max-context-length 64` explicitly
+  when you want the command line to make that relationship obvious.
+- `calibration_limit=1` keeps this experimental KV-cache flow practical for
+  local iteration. Increase it when you want more calibration coverage.
 
 ## 3. Export the generation artifact
 
-This command produces the full-logits PTE used for the generation smoke test and optional perplexity evaluation. Static non-KV calibration uses padded prefixes, so calibrated exports must produce full logits to let calibration select the last real token position instead of a padded position.
+This command produces the KV-cache PTE used for the generation smoke test and optional perplexity evaluation.
 
 ```bash
 bash examples/arm/smollm2_example_ethos_u/export_smollm2_ethosu.sh \
   --mode=w8a16 \
-  --max_seq_length=32 \
-  --max_context_length=32 \
-  --calibration_limit=62 \
-  --calibration_seq_length=32 \
+  --use-kv-cache \
+  --max_seq_length=64 \
+  --max_context_length=64 \
+  --calibration_limit=1 \
+  --calibration_seq_length=64 \
   --quantize_scope=linear
 ```
 
@@ -140,20 +141,21 @@ What this command does:
 - `--mode=w8a16` selects the 16-bit activation, 8-bit weight Ethos-U quantizer.
 - By default the helper writes the exported `.pte` into the repository root, so
   the runner build commands below can reference the artifact by filename.
-- `--max_seq_length=32` fixes the deployed token window to 32 tokens.
-- `--max_context_length=32` keeps prompt context management consistent with that
-  same fixed window.
-- `--calibration_limit=62` uses the fuller calibration setting now recommended
-  for this example.
-- `--calibration_seq_length=32` calibrates on the same token length that the
-  runtime will execute.
+- `--use-kv-cache` exports token and `input_pos` inputs and disables full-logits
+  output naming.
+- `--max_seq_length=64` and `--max_context_length=64` set the documented
+  64-token KV-cache context.
+- `--calibration_limit=1` is the quick validation setting used for this
+  experimental KV-cache path.
+- `--calibration_seq_length=64` calibrates with the same context length used at
+  runtime.
 - `--quantize_scope=linear` keeps the validated hybrid setup where linear layers
   run on Ethos-U and the rest of the graph remains FP32.
 
 The output artifact is named:
 
 ```text
-smollm2_ethosu_seq32_w8a16_wikitext_full_logits.pte
+smollm2_ethosu_kv_seq64_w8a16_wikitext.pte
 ```
 
 ## 4. Build the semihosting runner
@@ -162,10 +164,10 @@ Build one runner that embeds the generation artifact:
 
 ```bash
 bash examples/arm/smollm2_example_ethos_u/build_executor_runner_semihosting.sh \
-  --pte=smollm2_ethosu_seq32_w8a16_wikitext_full_logits.pte \
-  --output=smollm2_ethosu_seq32_w8a16_wikitext_full_logits/cmake-out \
+  --pte=smollm2_ethosu_kv_seq64_w8a16_wikitext.pte \
+  --output=smollm2_ethosu_kv_seq64_w8a16_wikitext/cmake-out \
   --method_pool_size=0x01000000 \
-  --scratch_pool_size=0x00400000 \
+  --scratch_pool_size=0x00800000 \
   --input_file_pool_size=0x00100000
 ```
 
@@ -177,8 +179,8 @@ What this command does:
 - Uses the validated `Ethos_U85_SYS_DRAM_High` and `Dedicated_Sram_512KB`
   defaults from the build helper, so you do not need to pass them explicitly in
   the common case.
-- Sets three allocator pool sizes that keep the embedded-PTE full-logits runner inside a
-  practical Corstone-320 DDR budget.
+- Sets three allocator pool sizes that keep the embedded-PTE KV-cache runner
+  inside a practical Corstone-320 DDR budget.
 
 How to read the pool sizes:
 
@@ -189,8 +191,8 @@ How to read the pool sizes:
   as `i0.bin`.
 
 These values are not universal tuning rules. They are simply the validated pool
-sizes for this example's seq32 embedded-PTE runner. Start with them unless you
-are actively changing the export shape or runtime integration.
+sizes for this example's seq64 KV-cache embedded-PTE runner. Start with them
+unless you are actively changing the export shape or runtime integration.
 
 ## 5. Run a generation smoke test
 
@@ -201,13 +203,14 @@ output logits, and decode the generated token IDs into text:
 ```bash
 python examples/arm/smollm2_example_ethos_u/generate_sampled.py \
   --fvp examples/arm/arm-scratch/FVP-corstone320/models/Linux64_GCC-9.3/FVP_Corstone_SSE-320 \
-  --runner smollm2_ethosu_seq32_w8a16_wikitext_full_logits/cmake-out/arm_executor_runner \
+  --runner smollm2_ethosu_kv_seq64_w8a16_wikitext/cmake-out/arm_executor_runner \
   --embedded-pte \
   --tokenizer data/tokenizers/smollm2/tokenizer.json \
   --prompt "Once upon a time in a small village," \
-  --window 32 \
+  --window 64 \
+  --max-context-length 64 \
+  --use-kv-cache \
   --max-new-tokens 2 \
-  --full-logits \
   --temperature 0 \
   --top-p 0.9 \
   --repetition-penalty 1.1
@@ -217,13 +220,13 @@ How to interpret the main options:
 
 - `--embedded-pte` tells the script not to copy a separate `program.pte`,
   because the runner already contains the model.
-- `--window 32` must match the exported `max_seq_length`. If these differ, the
-  runner will reject the input tensor shape.
+- `--window 64` provides the main context length used by the script.
+- `--max-context-length 64` makes the KV-cache capacity explicit; omitting it
+  would use `--window`.
+- `--use-kv-cache` runs the two-input token/position path and keeps one FVP
+  process alive in semihosting server mode for step-wise decoding.
 - `--max-new-tokens 2` keeps the smoke test short. The goal here is to show the
   end-to-end path works, not to benchmark long decoding.
-- `--full-logits` tells `generate_sampled.py` to select the last valid prompt
-  row from the `[window, vocab]` output. This matches the calibrated static
-  non-KV export path and avoids sampling from padded positions.
 - `--temperature 0` switches to greedy decoding, which is the most stable way
   to compare short smoke runs.
 - `--top-p 0.9` is kept for consistency with the broader sampling interface,
@@ -233,60 +236,167 @@ How to interpret the main options:
 
 ## 6. Optional: evaluate Wikitext perplexity
 
-The calibrated generation artifact already returns full logits for every token position in the 32-token window, so the same PTE and runner can be used for perplexity scoring.
+The KV-cache generation artifact can also be used for step-wise perplexity scoring over the same 64-token context.
 
 ### 6.1 Build the matching runner
 
 ```bash
 bash examples/arm/smollm2_example_ethos_u/build_executor_runner_semihosting.sh \
-  --pte=smollm2_ethosu_seq32_w8a16_wikitext_full_logits.pte \
-  --output=smollm2_ethosu_seq32_w8a16_wikitext_full_logits/cmake-out \
+  --pte=smollm2_ethosu_kv_seq64_w8a16_wikitext.pte \
+  --output=smollm2_ethosu_kv_seq64_w8a16_wikitext/cmake-out \
   --method_pool_size=0x01000000 \
-  --scratch_pool_size=0x00400000 \
+  --scratch_pool_size=0x00800000 \
   --input_file_pool_size=0x00100000
 ```
 
-The full-logits artifact uses `--method_pool_size=0x01000000` (`16 MiB`).
+The KV-cache artifact uses `--method_pool_size=0x01000000` (`16 MiB`).
 
 ### 6.2 Run perplexity
 
 ```bash
 python examples/arm/smollm2_example_ethos_u/eval_wikitext_perplexity.py \
   --fvp examples/arm/arm-scratch/FVP-corstone320/models/Linux64_GCC-9.3/FVP_Corstone_SSE-320 \
-  --runner-w8a8 smollm2_ethosu_seq32_w8a16_wikitext_full_logits/cmake-out/arm_executor_runner \
-  --runner-w8a16 smollm2_ethosu_seq32_w8a16_wikitext_full_logits/cmake-out/arm_executor_runner \
-  --prompts-file outputs/$(date +%F)/wikitext_prompts_seq32.txt \
+  --runner-w8a8 smollm2_ethosu_kv_seq64_w8a16_wikitext/cmake-out/arm_executor_runner \
+  --runner-w8a16 smollm2_ethosu_kv_seq64_w8a16_wikitext/cmake-out/arm_executor_runner \
+  --prompts-file outputs/$(date +%F)/wikitext_prompts_kv_seq64.txt \
   --num-prompts 100 \
-  --ppl-prompts 100 \
-  --min-prompt-tokens 32 \
-  --max-prompt-tokens 32 \
-  --max-tokens-per-prompt 32 \
-  --window 32 \
-  --timeout 36000 \
+  --ppl-prompts 50 \
+  --min-prompt-tokens 64 \
+  --max-prompt-tokens 64 \
+  --max-tokens-per-prompt 64 \
+  --window 64 \
+  --max-context-length 64 \
+  --use-kv-cache \
+  --timeout 2400 \
   --refresh-prompts
 ```
 
-Why the prompt settings are all 32 here:
+Why the prompt settings are all 64 here:
 
-- `--window 32` must match the export shape.
-- `--min-prompt-tokens 32` and `--max-prompt-tokens 32` force every prompt to
-  fill exactly one scoring window, which makes the comparison easier to reason
-  about.
-- `--max-tokens-per-prompt 32` keeps scoring aligned with that same fixed
-  window.
+- `--window 64` and `--max-context-length 64` match the exported KV-cache
+  context.
+- `--min-prompt-tokens 64` and `--max-prompt-tokens 64` force every prompt to
+  fill one scoring context, which makes the comparison easier to reason about.
+- `--max-tokens-per-prompt 64` keeps scoring aligned with that same context.
 - `--num-prompts 100` builds a reusable prompt file with enough samples for a
   stable comparison.
-- `--ppl-prompts 100` then scores all prompts from that file. Lower this value
-  when you want a quicker but noisier local check.
+- `--ppl-prompts 50` keeps the FVP check manageable. Raise it when you want a
+  fuller but slower run.
 
 The evaluator script compares two runners, which is why it asks for both
 `--runner-w8a8` and `--runner-w8a16`. In this simplified `w8a16`-only flow, it
 is acceptable to pass the same runner to both options when you only want one
-number from the validated artifact.
+number from the validated artifact. A 50-prompt seq64 KV-cache run in this
+branch completed with perplexity around 45.
 
-## 7. Additional notes
+## 7. Experimental static quantized KV cache
 
-### Why padding is needed for full-logits evaluation
+Ethos-U does not support the dynamic per-token quantization used by
+`model.quantize_kv_cache=True`. The static path instead calibrates fixed
+per-channel K/V scales from Wikitext before export, stores the cache as int8,
+and uses standard tensor cache updates. It does not link the Llama custom cache
+operator, and runner inputs remain int32.
+
+Export the seq64 `w8a16` static-KVQ artifact with one Wikitext calibration
+sample:
+
+```bash
+bash examples/arm/smollm2_example_ethos_u/export_smollm2_ethosu.sh \
+  --mode=w8a16 \
+  --use-kv-cache \
+  --static-quantize-kv-cache \
+  --so_library=/path/to/cmake-out/kernels/quantized/libquantized_ops_aot_lib.so \
+  --max_seq_length=64 \
+  --max_context_length=64 \
+  --calibration_limit=1 \
+  --calibration_seq_length=64 \
+  --quantize_scope=linear
+```
+
+`--so_library` is needed only during export to register portable QDQ out
+variants. Build it with `EXECUTORCH_BUILD_KERNELS_QUANTIZED_AOT=ON` if your
+ExecuTorch installation does not already provide it. The embedded runner uses
+the standard `quantized_ops_lib`; it does not link Llama custom cache operators.
+
+This produces:
+
+```text
+smollm2_ethosu_static_kvq_seq64_w8a16_wikitext.pte
+```
+
+Build it with the standard semihosting runner; no custom cache-op source or
+linkage is required:
+
+```bash
+bash examples/arm/smollm2_example_ethos_u/build_executor_runner_semihosting.sh \
+  --pte=smollm2_ethosu_static_kvq_seq64_w8a16_wikitext.pte \
+  --output=smollm2_ethosu_static_kvq_seq64_w8a16_wikitext/cmake-out \
+  --method_pool_size=0x01000000 \
+  --scratch_pool_size=0x00800000 \
+  --input_file_pool_size=0x00100000
+```
+
+Run the ten-token greedy smoke test:
+
+```bash
+python examples/arm/smollm2_example_ethos_u/generate_sampled.py \
+  --fvp examples/arm/arm-scratch/FVP-corstone320/models/Linux64_GCC-9.3/FVP_Corstone_SSE-320 \
+  --runner smollm2_ethosu_static_kvq_seq64_w8a16_wikitext/cmake-out/arm_executor_runner \
+  --embedded-pte \
+  --tokenizer data/tokenizers/smollm2/tokenizer.json \
+  --prompt "Once upon a time in a small village," \
+  --window 64 \
+  --max-context-length 64 \
+  --use-kv-cache \
+  --max-new-tokens 10 \
+  --temperature 0 \
+  --top-p 0.9 \
+  --repetition-penalty 1.1
+```
+
+Run all nine default prompts greedily and save the generated text:
+
+```bash
+python examples/arm/smollm2_example_ethos_u/generate_sampled.py \
+  --fvp examples/arm/arm-scratch/FVP-corstone320/models/Linux64_GCC-9.3/FVP_Corstone_SSE-320 \
+  --runner smollm2_ethosu_static_kvq_seq64_w8a16_wikitext/cmake-out/arm_executor_runner \
+  --embedded-pte \
+  --tokenizer data/tokenizers/smollm2/tokenizer.json \
+  --prompt-file examples/arm/smollm2_example_ethos_u/default_prompts.txt \
+  --prompt-all \
+  --save-generations outputs/$(date +%F)/ethosu_static_kvq_seq64_generations.txt \
+  --window 64 \
+  --max-context-length 64 \
+  --use-kv-cache \
+  --max-new-tokens 64 \
+  --temperature 0 \
+  --top-p 0.9 \
+  --repetition-penalty 1.1 \
+  --timeout 2400
+```
+
+For a 50-prompt comparison, pass the plain-KV runner as `w8a8` and the
+static-KVQ runner as `w8a16`; those labels are only result keys in this helper:
+
+```bash
+python examples/arm/smollm2_example_ethos_u/eval_wikitext_perplexity.py \
+  --runner-w8a8 smollm2_ethosu_kv_seq64_w8a16_wikitext/cmake-out/arm_executor_runner \
+  --runner-w8a16 smollm2_ethosu_static_kvq_seq64_w8a16_wikitext/cmake-out/arm_executor_runner \
+  --prompts-file outputs/$(date +%F)/wikitext_prompts_kv_seq64.txt \
+  --num-prompts 100 \
+  --ppl-prompts 50 \
+  --min-prompt-tokens 64 \
+  --max-prompt-tokens 64 \
+  --max-tokens-per-prompt 64 \
+  --window 64 \
+  --max-context-length 64 \
+  --use-kv-cache \
+  --timeout 24000
+```
+
+## 8. Additional notes
+
+### Non-KV fallback: why padding is needed for full-logits evaluation
 
 The full-logits export returns one logits row per position in the fixed window.
 Short prompts therefore need padding so the runtime still receives a tensor with
@@ -302,7 +412,7 @@ just the linear layers. That path exists for experimentation, but it is not the
 validated path in this README because the linear-only setup is the one that
 currently produces the clearest end-to-end result on Ethos-U FVP.
 
-### Can calibration be faster?
+### Non-KV fallback: can calibration be faster?
 
 Yes. The quickest way to iterate is to lower `--calibration_limit`. The tradeoff
 is that you are collecting activation statistics from fewer samples, which can
@@ -319,13 +429,6 @@ bearable as the fuller-calibration setting, while `--calibration_limit=2`
 remains the fast validation option. On the 100-prompt perplexity check, `2`
 scored best, but `62` was still competitive and is the more conservative
 default when export turnaround is less important than fuller calibration.
-
-### Historical seq8 artifacts
-
-Earlier experiments in this directory used smaller seq8 exports and separate
-included-PTE runners. They are useful as implementation history, but they are
-not the main path for this README because they add options without improving the
-clarity of the validated seq32 `w8a16` workflow.
 
 ### Clean-checkout checklist
 

--- a/examples/arm/smollm2_example_ethos_u/build_executor_runner_semihosting.sh
+++ b/examples/arm/smollm2_example_ethos_u/build_executor_runner_semihosting.sh
@@ -19,8 +19,8 @@ pte_file=""
 target="ethos-u85-256"
 system_config="Ethos_U85_SYS_DRAM_High"
 memory_mode="Dedicated_Sram_512KB"
-method_pool_size="0x00800000"
-scratch_pool_size="0x00400000"
+method_pool_size="0x01000000"
+scratch_pool_size="0x00800000"
 input_file_pool_size="0x00100000"
 
 usage() {

--- a/examples/arm/smollm2_example_ethos_u/eval_wikitext_perplexity.py
+++ b/examples/arm/smollm2_example_ethos_u/eval_wikitext_perplexity.py
@@ -13,6 +13,7 @@ from typing import Iterable, List, Optional, Tuple
 import numpy as np
 from generate_sampled import (  # type: ignore[import-not-found]
     FvpRunnerSession,
+    KvFvpRunnerSession,
     prepare_input,
 )
 from pytorch_tokenizers import (  # type: ignore[import-not-found, import-untyped]
@@ -186,6 +187,31 @@ def eval_prompt_nll(
     return total_nll, valid_len
 
 
+def eval_prompt_nll_kv(
+    *,
+    runner: KvFvpRunnerSession,
+    tokenizer,
+    prompt: str,
+    max_context_length: int,
+    max_tokens_per_prompt: int,
+) -> Tuple[float, int]:
+    token_ids = tokenizer.encode(prompt, bos=True, eos=False)
+    if max_tokens_per_prompt > 0:
+        token_ids = token_ids[:max_tokens_per_prompt]
+    token_ids = token_ids[:max_context_length]
+    if len(token_ids) < 2:
+        return 0.0, 0
+
+    total_nll = 0.0
+    for pos, token_id in enumerate(token_ids[:-1]):
+        logits = runner.run(token_id, pos)
+        target_id = token_ids[pos + 1]
+        if target_id >= logits.shape[0]:
+            raise RuntimeError(f"Target id {target_id} outside vocab {logits.shape[0]}")
+        total_nll += token_nll(logits, target_id)
+    return total_nll, len(token_ids) - 1
+
+
 def eval_model_ppl(
     *,
     name: str,
@@ -198,23 +224,39 @@ def eval_model_ppl(
     pad_id: int,
     max_tokens_per_prompt: int,
     timeout: int,
+    use_kv_cache: bool,
+    max_context_length: int,
 ) -> float:
     """Run FVP for each prompt and return perplexity for one runner."""
     total_nll = 0.0
     total_tokens = 0
-    with FvpRunnerSession(fvp, runner, pte, timeout) as session:
-        for idx, prompt in enumerate(prompts, start=1):
-            print(f"[eval] {name} prompt {idx}/{len(prompts)}")
-            prompt_nll, prompt_tokens = eval_prompt_nll(
-                runner=session,
-                tokenizer=tokenizer,
-                prompt=prompt,
-                window=window,
-                pad_id=pad_id,
-                max_tokens_per_prompt=max_tokens_per_prompt,
-            )
-            total_nll += prompt_nll
-            total_tokens += prompt_tokens
+    if use_kv_cache:
+        with KvFvpRunnerSession(fvp, runner, pte, timeout) as session:
+            for idx, prompt in enumerate(prompts, start=1):
+                print(f"[eval-kv] {name} prompt {idx}/{len(prompts)}")
+                prompt_nll, prompt_tokens = eval_prompt_nll_kv(
+                    runner=session,
+                    tokenizer=tokenizer,
+                    prompt=prompt,
+                    max_context_length=max_context_length,
+                    max_tokens_per_prompt=max_tokens_per_prompt,
+                )
+                total_nll += prompt_nll
+                total_tokens += prompt_tokens
+    else:
+        with FvpRunnerSession(fvp, runner, pte, timeout) as session:
+            for idx, prompt in enumerate(prompts, start=1):
+                print(f"[eval] {name} prompt {idx}/{len(prompts)}")
+                prompt_nll, prompt_tokens = eval_prompt_nll(
+                    runner=session,
+                    tokenizer=tokenizer,
+                    prompt=prompt,
+                    window=window,
+                    pad_id=pad_id,
+                    max_tokens_per_prompt=max_tokens_per_prompt,
+                )
+                total_nll += prompt_nll
+                total_tokens += prompt_tokens
     if total_tokens == 0:
         raise RuntimeError(f"No prompt tokens were scored for {name}.")
     return math.exp(total_nll / total_tokens)
@@ -298,7 +340,18 @@ def main() -> None:
         "--window",
         type=int,
         default=8,
-        help="Fixed runner window. Must match the exported model shape.",
+        help="Fixed runner window. Must match the exported non-KV model shape.",
+    )
+    parser.add_argument(
+        "--use-kv-cache",
+        action="store_true",
+        help="Evaluate KV-cache exports that take token and input_pos inputs.",
+    )
+    parser.add_argument(
+        "--max-context-length",
+        type=int,
+        default=None,
+        help="KV-cache context length. Defaults to --window.",
     )
     parser.add_argument(
         "--timeout",
@@ -330,6 +383,7 @@ def main() -> None:
     prompts = read_prompts(args.prompts_file, args.ppl_prompts)
     print(f"[info] Using first {len(prompts)} prompts from {args.prompts_file}")
 
+    max_context_length = args.max_context_length or args.window
     results = {
         "w8a8": eval_model_ppl(
             name="w8a8",
@@ -342,6 +396,8 @@ def main() -> None:
             pad_id=pad_id,
             max_tokens_per_prompt=args.max_tokens_per_prompt,
             timeout=args.timeout,
+            use_kv_cache=args.use_kv_cache,
+            max_context_length=max_context_length,
         ),
         "w8a16": eval_model_ppl(
             name="w8a16",
@@ -354,6 +410,8 @@ def main() -> None:
             pad_id=pad_id,
             max_tokens_per_prompt=args.max_tokens_per_prompt,
             timeout=args.timeout,
+            use_kv_cache=args.use_kv_cache,
+            max_context_length=max_context_length,
         ),
     }
 

--- a/examples/arm/smollm2_example_ethos_u/export_smollm2_ethosu.sh
+++ b/examples/arm/smollm2_example_ethos_u/export_smollm2_ethosu.sh
@@ -9,14 +9,17 @@ mode="all"
 quantize_scope="linear"
 output_dir="${repo_root}"
 tokenizer_path="${repo_root}/data/tokenizers/smollm2/tokenizer.json"
-max_seq_length=32
-max_context_length=32
-calibration_limit=4
-calibration_seq_length=32
+max_seq_length=64
+max_context_length=64
+calibration_limit=1
+calibration_seq_length=64
 target="ethos-u85-256"
 system_config="Ethos_U85_SYS_DRAM_High"
 memory_mode="Dedicated_Sram_512KB"
-full_logits=1
+full_logits=0
+use_kv_cache=1
+static_quantize_kv_cache=0
+so_library=""
 ethosu_extra_flags=""
 
 usage() {
@@ -29,6 +32,8 @@ Options:
   --output_dir=DIR               Output directory. Default: ${output_dir}
                                  The repo-root default matches the quickstart.
   --tokenizer=PATH               Tokenizer JSON path. Default: ${tokenizer_path}
+  --so_library=PATH              Quantized AOT ops library used to register export
+                                 out variants for static KVQ.
   --max_seq_length=N             Export window size. Default: ${max_seq_length}
   --max_context_length=N         Export context size. Default: ${max_context_length}
   --calibration_limit=N          Wikitext sample count. Default: ${calibration_limit}
@@ -38,9 +43,15 @@ Options:
   --memory_mode=NAME             Vela memory mode. Default: ${memory_mode}
   --ethosu_extra_flags=LIST      JSON-style Hydra list of extra Vela flags, e.g.
                                  '["--arena-cache-size=1048576"]'
-  --full_logits                  Export full logits and append _full_logits to filenames.
-                                 This is the default for calibrated static
-                                 non-KV exports.
+  --full_logits                  Export static non-KV full logits and append
+                                 _full_logits to filenames.
+  --use_kv_cache|--use-kv-cache  Export KV-cache model inputs. Full logits are disabled.
+                                 This is the default for the quickstart.
+  --static_quantize_kv_cache|--static-quantize-kv-cache
+                                 Store KV cache as calibrated static int8. Requires
+                                 --mode=w8a16 and --quantize_scope=linear.
+  --no_kv_cache|--no-kv-cache    Export the static non-KV fallback path.
+                                 Full logits are enabled by default for this path.
 EOF
 }
 
@@ -51,6 +62,7 @@ for arg in "$@"; do
     --quantize_scope=*) quantize_scope="${arg#*=}" ;;
     --output_dir=*) output_dir="${arg#*=}" ;;
     --tokenizer=*) tokenizer_path="${arg#*=}" ;;
+    --so_library=*) so_library="${arg#*=}" ;;
     --max_seq_length=*) max_seq_length="${arg#*=}" ;;
     --max_context_length=*) max_context_length="${arg#*=}" ;;
     --calibration_limit=*) calibration_limit="${arg#*=}" ;;
@@ -59,7 +71,10 @@ for arg in "$@"; do
     --system_config=*) system_config="${arg#*=}" ;;
     --memory_mode=*) memory_mode="${arg#*=}" ;;
     --ethosu_extra_flags=*) ethosu_extra_flags="${arg#*=}" ;;
-    --full_logits) full_logits=1 ;;
+    --full_logits) full_logits=1; use_kv_cache=0 ;;
+    --use_kv_cache|--use-kv-cache) use_kv_cache=1; full_logits=0 ;;
+    --static_quantize_kv_cache|--static-quantize-kv-cache) static_quantize_kv_cache=1 ;;
+    --no_kv_cache|--no-kv-cache) use_kv_cache=0; full_logits=1 ;;
     *)
       echo "Unknown option: ${arg}" >&2
       usage
@@ -67,6 +82,21 @@ for arg in "$@"; do
       ;;
   esac
 done
+
+if [[ "${static_quantize_kv_cache}" -eq 1 ]]; then
+  if [[ "${use_kv_cache}" -ne 1 ]]; then
+    echo "Static quantized KV cache requires --use-kv-cache." >&2
+    exit 1
+  fi
+  if [[ "${mode}" != "w8a16" ]]; then
+    echo "Static quantized KV cache requires --mode=w8a16." >&2
+    exit 1
+  fi
+  if [[ "${quantize_scope}" != "linear" ]]; then
+    echo "Static quantized KV cache requires --quantize_scope=linear." >&2
+    exit 1
+  fi
+fi
 
 mkdir -p "${output_dir}"
 
@@ -95,11 +125,17 @@ run_export() {
     backend.ethosu.target="${target}"
     backend.ethosu.system_config="${system_config}"
     backend.ethosu.memory_mode="${memory_mode}"
-    model.use_kv_cache=False
+    model.use_kv_cache=$( [[ "${use_kv_cache}" -eq 1 ]] && echo True || echo False )
     model.enable_dynamic_shape=False
     debug.verbose=True
     debug.generate_full_logits=$( [[ "${full_logits}" -eq 1 ]] && echo True || echo False )
   )
+  if [[ "${static_quantize_kv_cache}" -eq 1 ]]; then
+    cmd+=("model.static_quantize_kv_cache=True")
+  fi
+  if [[ -n "${so_library}" ]]; then
+    cmd+=("export.so_library=${so_library}")
+  fi
   if [[ -n "${ethosu_extra_flags}" ]]; then
     cmd+=("backend.ethosu.extra_flags=${ethosu_extra_flags}")
   fi
@@ -109,6 +145,13 @@ run_export() {
 
 output_name_for() {
   local stem="$1"
+  if [[ "${static_quantize_kv_cache}" -eq 1 ]]; then
+    stem="smollm2_ethosu_static_kvq_seq${max_seq_length}_${stem}"
+  elif [[ "${use_kv_cache}" -eq 1 ]]; then
+    stem="smollm2_ethosu_kv_seq${max_seq_length}_${stem}"
+  else
+    stem="smollm2_ethosu_seq${max_seq_length}_${stem}"
+  fi
   if [[ "${full_logits}" -eq 1 ]]; then
     printf '%s_full_logits.pte' "${stem}"
   else
@@ -120,14 +163,14 @@ cd "${repo_root}"
 
 case "${mode}" in
   all)
-    run_export ethosu_8a8w "$(output_name_for smollm2_ethosu_seq${max_seq_length}_w8a8_wikitext)"
-    run_export ethosu_16a8w "$(output_name_for smollm2_ethosu_seq${max_seq_length}_w8a16_wikitext)"
+    run_export ethosu_8a8w "$(output_name_for w8a8_wikitext)"
+    run_export ethosu_16a8w "$(output_name_for w8a16_wikitext)"
     ;;
   w8a8)
-    run_export ethosu_8a8w "$(output_name_for smollm2_ethosu_seq${max_seq_length}_w8a8_wikitext)"
+    run_export ethosu_8a8w "$(output_name_for w8a8_wikitext)"
     ;;
   w8a16)
-    run_export ethosu_16a8w "$(output_name_for smollm2_ethosu_seq${max_seq_length}_w8a16_wikitext)"
+    run_export ethosu_16a8w "$(output_name_for w8a16_wikitext)"
     ;;
   *)
     echo "Unsupported mode: ${mode}" >&2

--- a/examples/arm/smollm2_example_ethos_u/generate_sampled.py
+++ b/examples/arm/smollm2_example_ethos_u/generate_sampled.py
@@ -6,11 +6,15 @@
 import argparse
 import re
 import secrets
+import select
 import shutil
 import subprocess  # nosec B404
 import tempfile
+import time
+
+from collections import deque
 from pathlib import Path
-from typing import List, Optional
+from typing import Deque, List, Optional, Sequence
 
 import numpy as np
 from pytorch_tokenizers import (  # type: ignore[import-not-found, import-untyped]
@@ -214,22 +218,27 @@ class FvpRunnerSession:
         runner: str,
         pte: Optional[str],
         timeout: int,
+        input_names: Optional[Sequence[str]] = None,
+        server_mode: bool = False,
     ) -> None:
         self._fvp = fvp
         self._runner = runner
         self._pte = pte
         self._timeout = timeout
+        self._server_mode = server_mode
+        self._proc: Optional[subprocess.Popen[str]] = None
+        self._recent_stdout: Deque[str] = deque(maxlen=400)
         self._tmpdir: Optional[tempfile.TemporaryDirectory[str]] = None
         self._tmpdir_path: Optional[Path] = None
-        self._input_path: Optional[Path] = None
+        self._input_paths: List[Path] = []
         self._output_prefix: Optional[Path] = None
         self._program_path: Optional[Path] = None
-        self._init_paths()
+        self._init_paths(input_names or ["i0.bin"])
 
-    def _init_paths(self) -> None:
+    def _init_paths(self, input_names: Sequence[str]) -> None:
         self._tmpdir = tempfile.TemporaryDirectory()
         self._tmpdir_path = Path(self._tmpdir.name)
-        self._input_path = self._tmpdir_path / "i0.bin"
+        self._input_paths = [self._tmpdir_path / name for name in input_names]
         self._output_prefix = self._tmpdir_path / "out"
         if self._pte is not None:
             self._program_path = self._tmpdir_path / "program.pte"
@@ -272,6 +281,13 @@ class FvpRunnerSession:
         ]
 
     def close(self) -> None:
+        if self._proc is not None:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+            self._proc = None
         if self._tmpdir is not None:
             self._tmpdir.cleanup()
             self._tmpdir = None
@@ -282,22 +298,102 @@ class FvpRunnerSession:
     def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
         self.close()
 
-    def _run_once(self, tokens: np.ndarray) -> np.ndarray:
+    def _command_parts(self) -> List[str]:
+        cmd_parts = ["executor_runner"]
+        if self._program_path is not None:
+            cmd_parts += ["-m", "program.pte"]
+        cmd_parts += ["-o", "out"]
+        for input_path in self._input_paths:
+            cmd_parts += ["-i", input_path.name]
+        if self._server_mode:
+            cmd_parts += ["--server_mode", "true"]
+        return cmd_parts
+
+    def _check_proc(self) -> None:
+        if self._proc is None:
+            return
+        rc = self._proc.poll()
+        if rc is None:
+            return
+        tail = "".join(self._recent_stdout)
+        extra = ""
+        if self._proc.stdout is not None:
+            try:
+                extra = self._proc.stdout.read() or ""
+            except Exception:
+                extra = ""
+        raise RuntimeError(
+            f"FVP runner exited unexpectedly (rc={rc}).\n\n[FVP stdout tail]\n{tail}{extra}"
+        )
+
+    def _start_server(self) -> None:
+        self._proc = subprocess.Popen(  # nosec B603
+            self._build_command(" ".join(self._command_parts())),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+
+    def _run_server_once(self, output_path: Path) -> np.ndarray:
+        if self._proc is None:
+            self._start_server()
+        self._check_proc()
+        assert self._proc is not None
+        assert self._proc.stdin is not None
+        assert self._proc.stdout is not None
+
+        self._proc.stdin.write("go\n")
+        self._proc.stdin.flush()
+
+        deadline = time.monotonic() + self._timeout
+        while time.monotonic() < deadline:
+            self._check_proc()
+            readable, _, _ = select.select([self._proc.stdout], [], [], 1.0)
+            if not readable:
+                continue
+            line = self._proc.stdout.readline()
+            if line == "":
+                self._check_proc()
+                rc = self._proc.poll()
+                raise RuntimeError(
+                    f"FVP runner stdout closed unexpectedly (rc={rc})."
+                    f"\n\n[FVP stdout tail]\n{''.join(self._recent_stdout)}"
+                )
+            self._recent_stdout.append(line)
+            if "SERVER_INFERENCE_DONE" in line:
+                if output_path.exists() and output_path.stat().st_size > 0:
+                    return np.fromfile(output_path, dtype=np.float32)
+                raise RuntimeError(
+                    "FVP server completed inference but did not write output."
+                    f"\n\n[FVP stdout tail]\n{''.join(self._recent_stdout)}"
+                )
+
+        raise TimeoutError(
+            "Timed out waiting for FVP server inference."
+            f"\n\n[FVP stdout tail]\n{''.join(self._recent_stdout)}"
+        )
+
+    def _run_once(self, inputs: Sequence[np.ndarray]) -> np.ndarray:
         assert self._tmpdir_path is not None
-        assert self._input_path is not None
         assert self._output_prefix is not None
-        tokens.tofile(self._input_path)
+        if len(inputs) != len(self._input_paths):
+            raise ValueError(
+                f"Expected {len(self._input_paths)} inputs, got {len(inputs)}."
+            )
+        for input_array, input_path in zip(inputs, self._input_paths):
+            input_array.tofile(input_path)
 
         output_path = self._output_prefix.with_name(self._output_prefix.name + "-0.bin")
         if output_path.exists():
             output_path.unlink()
 
-        cmd_line = "executor_runner"
-        if self._program_path is not None:
-            cmd_line += " -m program.pte"
-        cmd_line += " -o out -i i0.bin"
+        if self._server_mode:
+            return self._run_server_once(output_path)
+
         proc = subprocess.run(
-            self._build_command(cmd_line),
+            self._build_command(" ".join(self._command_parts())),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )  # nosec B603
@@ -313,8 +409,8 @@ class FvpRunnerSession:
         hint = ""
         if "input size (" in out and "tensor size (" in out and "mismatch" in out:
             hint = (
-                "\nLikely cause: `--window` does not match the exported model input shape. "
-                "For example, a seq8 export must be run with `--window 8`."
+                "\nLikely cause: runner inputs do not match the exported model input shapes. "
+                "For non-KV exports, check `--window`; for KV exports, check `--max-context-length`."
             )
         if matches:
             hint += "\nDetected FVP/runtime fault markers:\n" + "\n".join(matches)
@@ -322,8 +418,49 @@ class FvpRunnerSession:
             f"FVP execution failed (rc={proc.returncode}).{hint}\n\n[FVP stdout]\n{out}"
         )
 
+    def run_inputs(self, inputs: Sequence[np.ndarray]) -> np.ndarray:
+        return self._run_once(inputs)
+
     def run(self, tokens: np.ndarray) -> np.ndarray:
-        return self._run_once(tokens)
+        return self._run_once([tokens])
+
+
+class KvFvpRunnerSession:
+    """Step-wise FVP runner for KV-cache exports."""
+
+    def __init__(
+        self,
+        fvp: str,
+        runner: str,
+        pte: Optional[str],
+        timeout: int,
+    ) -> None:
+        self._runner = FvpRunnerSession(
+            fvp,
+            runner,
+            pte,
+            timeout,
+            input_names=["i0.bin", "i1.bin"],
+            server_mode=True,
+        )
+
+    def close(self) -> None:
+        self._runner.close()
+
+    def __enter__(self) -> "KvFvpRunnerSession":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+        self.close()
+
+    def run(self, token_id: int, input_pos: int) -> np.ndarray:
+        logits = self._runner.run_inputs(
+            [
+                np.array([[token_id]], dtype=np.int32),
+                np.array([input_pos], dtype=np.int32),
+            ]
+        )
+        return logits.reshape(1, -1)[0]
 
 
 def run_one_prompt(
@@ -405,6 +542,79 @@ def run_one_prompt(
         )
 
 
+def run_one_prompt_kv(
+    *,
+    runner: KvFvpRunnerSession,
+    tokenizer,
+    prompt: str,
+    prompt_no: int,
+    eos_id: int,
+    max_context_length: int,
+    max_new_tokens: int,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    repetition_penalty: float,
+    save_generations_path: Optional[Path],
+    topk_print: bool,
+) -> None:
+    ids = tokenizer.encode(prompt, bos=True, eos=False)
+    if len(ids) >= max_context_length:
+        ids = ids[: max_context_length - 1]
+    max_new_tokens = min(max_new_tokens, max_context_length - len(ids))
+    if max_new_tokens <= 0:
+        raise ValueError("Prompt leaves no room for generated tokens in the KV cache")
+
+    print(
+        f"\n==================== Prompt {prompt_no} ====================\n{prompt}",
+        end="",
+        flush=True,
+    )
+
+    logits = None
+    for pos, token_id in enumerate(ids):
+        logits = runner.run(token_id, pos)
+        if topk_print:
+            token_text = tokenizer.decode_token(int(token_id))
+            print(
+                f"\n[KV prefill pos={pos} token={token_id} text={token_text!r}]",
+                flush=True,
+            )
+            print_topk_candidates(logits, tokenizer, pos, k=5)
+
+    assert logits is not None
+    for step in range(max_new_tokens):
+        if topk_print:
+            print_topk_candidates(logits, tokenizer, step, k=5)
+        logits_for_sample = apply_repetition_penalty(
+            logits.copy(),
+            generated_ids=ids,
+            penalty=repetition_penalty,
+        )
+        next_id = sample_token_topk_topp(
+            logits_for_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+        )
+        ids.append(next_id)
+        print(tokenizer.decode_token(next_id), end="", flush=True)
+        if next_id == eos_id or step == max_new_tokens - 1:
+            break
+        logits = runner.run(next_id, len(ids) - 1)
+
+    print("\n=== Generation complete ===")
+    decoded = tokenizer.decode(ids)
+    print(decoded)
+    if save_generations_path is not None:
+        append_generation(
+            path=save_generations_path,
+            prompt=prompt,
+            prompt_no=prompt_no,
+            decoded=decoded,
+        )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Prompted generation on Ethos-U FVP via semihosting executor_runner"
@@ -457,7 +667,18 @@ def main() -> None:
         "--window",
         type=int,
         default=16,
-        help="Fixed input window. Must match the exported model shape.",
+        help="Fixed input window. Must match the exported non-KV model shape.",
+    )
+    parser.add_argument(
+        "--use-kv-cache",
+        action="store_true",
+        help="Run a KV-cache export that takes token and input_pos inputs.",
+    )
+    parser.add_argument(
+        "--max-context-length",
+        type=int,
+        default=None,
+        help="KV-cache context length. Defaults to --window.",
     )
     parser.add_argument(
         "--save-generations",
@@ -537,26 +758,48 @@ def main() -> None:
     if not args.embedded_pte and pte_path is None:
         raise ValueError("--pte is required unless --embedded-pte is set")
 
-    with FvpRunnerSession(args.fvp, args.runner, pte_path, args.timeout) as runner:
-        for i, prompt in enumerate(prompts):
-            run_one_prompt(
-                runner=runner,
-                tokenizer=tokenizer,
-                prompt=prompt,
-                prompt_no=i,
-                vocab_size=vocab_size,
-                pad_id=pad_id,
-                eos_id=eos_id,
-                window=args.window,
-                max_new_tokens=args.max_new_tokens,
-                temperature=args.temperature,
-                top_k=args.topk,
-                top_p=args.top_p,
-                repetition_penalty=args.repetition_penalty,
-                use_full_logits=args.full_logits,
-                save_generations_path=args.save_generations,
-                topk_print=not args.no_topk_print,
-            )
+    max_context_length = args.max_context_length or args.window
+    if args.use_kv_cache:
+        with KvFvpRunnerSession(
+            args.fvp, args.runner, pte_path, args.timeout
+        ) as runner:
+            for i, prompt in enumerate(prompts):
+                run_one_prompt_kv(
+                    runner=runner,
+                    tokenizer=tokenizer,
+                    prompt=prompt,
+                    prompt_no=i,
+                    eos_id=eos_id,
+                    max_context_length=max_context_length,
+                    max_new_tokens=args.max_new_tokens,
+                    temperature=args.temperature,
+                    top_k=args.topk,
+                    top_p=args.top_p,
+                    repetition_penalty=args.repetition_penalty,
+                    save_generations_path=args.save_generations,
+                    topk_print=not args.no_topk_print,
+                )
+    else:
+        with FvpRunnerSession(args.fvp, args.runner, pte_path, args.timeout) as runner:
+            for i, prompt in enumerate(prompts):
+                run_one_prompt(
+                    runner=runner,
+                    tokenizer=tokenizer,
+                    prompt=prompt,
+                    prompt_no=i,
+                    vocab_size=vocab_size,
+                    pad_id=pad_id,
+                    eos_id=eos_id,
+                    window=args.window,
+                    max_new_tokens=args.max_new_tokens,
+                    temperature=args.temperature,
+                    top_k=args.topk,
+                    top_p=args.top_p,
+                    repetition_penalty=args.repetition_penalty,
+                    use_full_logits=args.full_logits,
+                    save_generations_path=args.save_generations,
+                    topk_print=not args.no_topk_print,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extend the SmolLM2 Ethos-U helper scripts for KV-cache exports, generation, and perplexity evaluation. Keep the non-KV seq32 full-logits path as the documented baseline.

Add static quantized KV-cache export using fixed per-channel scales calibrated with Wikitext. Document the export, runner, generation, and perplexity flows for comparing plain and static-quantized caches.



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani