### PR TITLE
Add packed W4 execution to ROCm AOTI

### DIFF
--- a/backends/cuda/aoti_packed_int4_tensor.py
+++ b/backends/cuda/aoti_packed_int4_tensor.py
@@ -1,0 +1,178 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Nibble-packed W4/BF16 weights for the AOTI Triton matmul path."""
+
+import torch
+import torch.nn as nn
+from executorch.backends.cuda.triton.kernels.int4_matmul import (
+    int4_matmul,
+    int4_matvec_bf16,
+)
+from torchao.utils import TorchAOBaseTensor
+
+
+class AotiPackedInt4Tensor(TorchAOBaseTensor):
+    """Symmetric groupwise INT4 weight consumed by AOTI Triton kernels.
+
+    Linears use ``triton::int4_matmul`` by default; the opt-in fixed-shape path
+    uses ``triton::int4_matvec_bf16``.
+    """
+
+    tensor_data_names = ["qdata", "scale"]
+    tensor_attribute_names = ["group_size", "orig_dtype", "use_matvec"]
+
+    def __new__(cls, qdata, scale, group_size, orig_dtype, use_matvec=False):
+        shape = (qdata.shape[0], qdata.shape[1] * 2)
+        self = torch.Tensor._make_wrapper_subclass(
+            cls,
+            shape,
+            dtype=orig_dtype,
+            device=qdata.device,
+            requires_grad=False,
+        )
+        self.qdata = qdata
+        self.scale = scale
+        self.group_size = group_size
+        self.orig_dtype = orig_dtype
+        self.use_matvec = use_matvec
+        return self
+
+    @classmethod
+    def from_intx_unpacked_to_int8_tensor(
+        cls, weight: torch.Tensor, use_matvec: bool = False
+    ) -> "AotiPackedInt4Tensor":
+        from torchao.quantization import IntxUnpackedToInt8Tensor
+
+        if not isinstance(weight, IntxUnpackedToInt8Tensor):
+            raise TypeError(
+                "AotiPackedInt4Tensor requires IntxUnpackedToInt8Tensor, got "
+                f"{type(weight).__name__}"
+            )
+        if weight.target_dtype != torch.int4:
+            raise ValueError("AotiPackedInt4Tensor requires target_dtype=torch.int4")
+        if weight.activation_quantization is not None:
+            raise ValueError("AotiPackedInt4Tensor only supports weight-only INT4")
+        if weight.dtype != torch.bfloat16:
+            raise ValueError("AotiPackedInt4Tensor requires BF16 activations")
+        if weight.qdata.ndim != 2 or weight.block_size[0] != 1:
+            raise ValueError("AotiPackedInt4Tensor requires 2D groupwise weights")
+        if torch.count_nonzero(weight.zero_point).item() != 0:
+            raise ValueError("AotiPackedInt4Tensor requires symmetric zero points")
+        group_size = int(weight.block_size[-1])
+        rows, columns = weight.qdata.shape
+        if columns % 2 != 0 or columns % group_size != 0:
+            raise ValueError(
+                "AotiPackedInt4Tensor requires the input dimension to be "
+                "divisible by two and the group size"
+            )
+        if weight.scale.shape != (rows, columns // group_size):
+            raise ValueError("AotiPackedInt4Tensor received incompatible scales")
+
+        qdata = (weight.qdata + 8).to(torch.uint8)
+        qdata = (qdata[..., ::2] | (qdata[..., 1::2] << 4)).to(torch.int8)
+        return cls(
+            qdata.contiguous(),
+            weight.scale.contiguous(),
+            group_size,
+            weight.dtype,
+            use_matvec,
+        )
+
+    def dequantize(self, output_dtype=None):
+        dtype = output_dtype or self.orig_dtype
+        packed = self.qdata.to(torch.uint8)
+        low = (packed & 0x0F).to(torch.float32) - 8.0
+        high = ((packed >> 4) & 0x0F).to(torch.float32) - 8.0
+        values = torch.stack([low, high], dim=-1).reshape(self.shape)
+        scale = self.scale.float().repeat_interleave(self.group_size, dim=-1)
+        return (values * scale).to(dtype)
+
+    def to(self, *args, **kwargs):
+        kwargs = self._get_to_kwargs(*args, **kwargs)
+        device = kwargs.pop("device")
+        dtype = kwargs.pop("dtype")
+        if dtype != torch.bfloat16:
+            raise ValueError("AotiPackedInt4Tensor requires BF16 activations")
+        return AotiPackedInt4Tensor(
+            self.qdata.to(device),
+            self.scale.to(device=device, dtype=dtype),
+            self.group_size,
+            dtype,
+            self.use_matvec,
+        )
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+
+implements = AotiPackedInt4Tensor.implements
+
+
+@implements([torch.ops.aten.linear.default])
+def _(func, types, args, kwargs):
+    input_tensor, weight = args[0], args[1]
+    bias = args[2] if len(args) > 2 else None
+    input_shape = input_tensor.shape
+    input_2d = input_tensor.reshape(-1, input_shape[-1])
+    rows = input_2d.shape[0]
+    if isinstance(rows, int) and rows == 1 and weight.use_matvec:
+        output = int4_matvec_bf16(
+            input_2d,
+            weight.qdata,
+            weight.scale,
+            weight.group_size,
+        )
+    else:
+        output = int4_matmul(
+            input_2d,
+            weight.qdata,
+            weight.scale,
+            weight.group_size,
+        )
+    output = output.reshape(*input_shape[:-1], weight.shape[0])
+    return output if bias is None else output + bias
+
+
+@implements([torch.ops.aten.detach.default, torch.ops.aten.alias.default])
+def _(func, types, args, kwargs):
+    return args[0]
+
+
+@implements([torch.ops.aten.t.default])
+def _(func, types, args, kwargs):
+    return args[0].dequantize().t()
+
+
+@implements([torch.ops.aten._to_copy.default])
+def _(func, types, args, kwargs):
+    return args[0].to(**kwargs)
+
+
+def pack_int4_weights_for_aoti(module: nn.Module, *, use_matvec: bool = False) -> int:
+    """Pack symmetric TorchAO INT4 linear weights in ``module`` in place."""
+    from torchao.quantization import IntxUnpackedToInt8Tensor
+
+    packed = 0
+    for child in module.modules():
+        if not isinstance(child, nn.Linear):
+            continue
+        weight = child.weight
+        if not isinstance(weight, IntxUnpackedToInt8Tensor):
+            continue
+        if weight.target_dtype != torch.int4:
+            continue
+        child.weight = nn.Parameter(
+            AotiPackedInt4Tensor.from_intx_unpacked_to_int8_tensor(
+                weight,
+                use_matvec=use_matvec,
+            ),
+            requires_grad=False,
+        )
+        packed += 1
+    return packed
+
+
+torch.serialization.add_safe_globals([AotiPackedInt4Tensor])

--- a/backends/cuda/tests/test_aoti_packed_int4_tensor.py
+++ b/backends/cuda/tests/test_aoti_packed_int4_tensor.py
@@ -1,0 +1,109 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.nn as nn
+from executorch.backends.cuda.aoti_packed_int4_tensor import (
+    AotiPackedInt4Tensor,
+    pack_int4_weights_for_aoti,
+)
+from executorch.extension.llm.export.quantize import quantize_model_
+
+
+def _make_quantized_linear(device="cpu"):
+    module = nn.Linear(64, 32, bias=False, dtype=torch.bfloat16, device=device)
+    quantize_model_(
+        module,
+        qlinear_config="4w",
+        qlinear_group_size=32,
+    )
+    return module
+
+
+class TestAotiPackedInt4Tensor(unittest.TestCase):
+    def test_pack_halves_weight_storage(self):
+        module = _make_quantized_linear()
+        unpacked = module.weight
+        expected = unpacked.dequantize()
+
+        self.assertEqual(pack_int4_weights_for_aoti(module), 1)
+        packed = module.weight
+
+        self.assertIsInstance(packed, AotiPackedInt4Tensor)
+        self.assertEqual(packed.qdata.shape, (32, 32))
+        torch.testing.assert_close(packed.dequantize(), expected)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU required")
+    def test_eager_linear_uses_packed_weight(self):
+        torch.manual_seed(42)
+        module = _make_quantized_linear("cuda")
+        inputs = torch.randn(7, 64, dtype=torch.bfloat16, device="cuda")
+        expected = module(inputs)
+
+        self.assertEqual(pack_int4_weights_for_aoti(module), 1)
+        actual = module(inputs)
+
+        torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.02)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU required")
+    def test_eager_single_row_uses_packed_weight(self):
+        torch.manual_seed(42)
+        module = _make_quantized_linear("cuda")
+        inputs = torch.randn(1, 64, dtype=torch.bfloat16, device="cuda")
+        expected = module(inputs)
+
+        self.assertEqual(pack_int4_weights_for_aoti(module, use_matvec=True), 1)
+        actual = module(inputs)
+
+        torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.02)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU required")
+    def test_export_contains_triton_int4_matmul(self):
+        module = _make_quantized_linear("cuda")
+        pack_int4_weights_for_aoti(module)
+        inputs = (torch.randn(4, 64, dtype=torch.bfloat16, device="cuda"),)
+
+        exported = torch.export.export(module, inputs, strict=True).run_decompositions(
+            {}
+        )
+
+        self.assertIn("triton.int4_matmul.default", exported.graph_module.code)
+        self.assertNotIn("triton.int4_matvec_bf16.default", exported.graph_module.code)
+        self.assertNotIn("dequantize_affine", exported.graph_module.code)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU required")
+    def test_single_row_export_defaults_to_triton_int4_matmul(self):
+        module = _make_quantized_linear("cuda")
+        pack_int4_weights_for_aoti(module)
+        inputs = (torch.randn(1, 64, dtype=torch.bfloat16, device="cuda"),)
+
+        exported = torch.export.export(module, inputs, strict=True).run_decompositions(
+            {}
+        )
+
+        self.assertIn("triton.int4_matmul.default", exported.graph_module.code)
+        self.assertNotIn("triton.int4_matvec_bf16.default", exported.graph_module.code)
+        self.assertNotIn("dequantize_affine", exported.graph_module.code)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "GPU required")
+    def test_single_row_export_can_select_triton_int4_matvec(self):
+        module = _make_quantized_linear("cuda")
+        pack_int4_weights_for_aoti(module, use_matvec=True)
+        inputs = (torch.randn(1, 64, dtype=torch.bfloat16, device="cuda"),)
+
+        exported = torch.export.export(module, inputs, strict=True).run_decompositions(
+            {}
+        )
+
+        self.assertIn("triton.int4_matvec_bf16.default", exported.graph_module.code)
+        self.assertNotIn("triton.int4_matmul.default", exported.graph_module.code)
+        self.assertNotIn("dequantize_affine", exported.graph_module.code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/cuda/tests/test_int4_matmul.py
+++ b/backends/cuda/tests/test_int4_matmul.py
@@ -23,6 +23,7 @@ from executorch.backends.cuda.triton.kernels.int4_matmul import (
     dequant_w4_to_bf16,
     int4_matmul,
     int4_matvec,
+    int4_matvec_bf16,
 )
 
 ATOL = 0.01
@@ -250,6 +251,24 @@ class TestInt4Matvec(unittest.TestCase):
         out_mm = int4_matmul(x, packed, scale, gs)
 
         _assert_snr(self, out_mv, out_mm, "matvec vs matmul")
+
+    def test_bf16_weight_rounding_matches_int4_matmul(self):
+        torch.manual_seed(42)
+        N, K, gs = 2048, 2048, 128
+        w = torch.randn(N, K, dtype=torch.bfloat16, device=DEVICE)
+        packed, scale, _ = _quantize_simple(w, gs)
+        x = torch.randn(1, K, dtype=torch.bfloat16, device=DEVICE)
+
+        out_mv = int4_matvec_bf16(x, packed, scale, gs)
+        out_mm = int4_matmul(x, packed, scale, gs)
+
+        _assert_snr(
+            self,
+            out_mv,
+            out_mm,
+            "BF16-rounded matvec vs matmul",
+            threshold_db=80.0,
+        )
 
 
 class TestDequantThenMatmul(unittest.TestCase):

--- a/backends/cuda/tests/test_output_stride_rearrange.py
+++ b/backends/cuda/tests/test_output_stride_rearrange.py
@@ -20,12 +20,82 @@ Usage:
 
 import glob
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+EXECUTORCH_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../.."))
+RUNNER_PATH = os.environ.get(
+    "EXECUTORCH_EXECUTOR_RUNNER",
+    os.path.join(EXECUTORCH_ROOT, "cmake-out", "executor_runner"),
+)
+
+
+def _save_tensor(tensor, path):
+    tensor = tensor.cpu().contiguous().clone()
+    with open(path, "wb") as f:
+        f.write(bytes(tensor.untyped_storage()))
+
+
+def _load_output(path, shape, strides, dtype):
+    data = np.fromfile(path, dtype=np.uint8)
+    flat = torch.frombuffer(bytearray(data), dtype=dtype)
+    return torch.as_strided(flat, shape, strides).clone()
+
+
+def _run_rocm_runner(module, inputs, output_strides, pte, ptd, tmpdir):
+    if not os.path.exists(RUNNER_PATH):
+        raise RuntimeError(
+            f"executor_runner not found at {RUNNER_PATH}; set "
+            "EXECUTORCH_EXECUTOR_RUNNER to the ROCm runner path"
+        )
+
+    input_files = []
+    for index, tensor in enumerate(inputs):
+        path = os.path.join(tmpdir, f"input-{index}.bin")
+        _save_tensor(tensor, path)
+        input_files.append(path)
+
+    output_base = os.path.join(tmpdir, "output")
+    command = [
+        RUNNER_PATH,
+        f"--model_path={pte}",
+        f"--inputs={','.join(input_files)}",
+        f"--output_file={output_base}",
+    ]
+    if ptd:
+        command.append(f"--data_path={ptd}")
+    env = os.environ.copy()
+    env["LD_LIBRARY_PATH"] = os.pathsep.join(
+        filter(None, [os.path.join(sys.prefix, "lib"), env.get("LD_LIBRARY_PATH")])
+    )
+    result = subprocess.run(command, capture_output=True, text=True, env=env)
+    if result.returncode != 0:
+        details = (
+            f"executor_runner failed:\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+        raise RuntimeError(details)
+
+    with torch.no_grad():
+        outputs = module(*inputs)
+    if isinstance(outputs, torch.Tensor):
+        outputs = (outputs,)
+    return [
+        _load_output(
+            f"{output_base}-{index}.bin",
+            output.shape,
+            output_strides[index],
+            output.dtype,
+        )
+        for index, output in enumerate(outputs)
+    ]
 
 
 def _run_et_aoti(module, inputs, triton_mode="OFF"):
@@ -39,7 +109,6 @@ def _run_et_aoti(module, inputs, triton_mode="OFF"):
     )
     from executorch.exir.backend.compile_spec_schema import CompileSpec
     from executorch.exir.passes import MemoryPlanningPass
-    from executorch.extension.pybindings.portable_lib import _load_for_executorch
 
     ep = torch.export.export(module, inputs, strict=True)
     compile_specs = [
@@ -70,6 +139,21 @@ def _run_et_aoti(module, inputs, triton_mode="OFF"):
             et.write_tensor_data_to_file(tmpdir)
             ptd_files = glob.glob(os.path.join(tmpdir, "*.ptd"))
             ptd = ptd_files[0] if ptd_files else None
+        if torch.version.hip is not None:
+            from executorch.exir.tensor import stride_from_dim_order
+
+            execution_plan = et.executorch_program.execution_plan[0]
+            output_strides = [
+                stride_from_dim_order(
+                    execution_plan.values[index].val.sizes,
+                    execution_plan.values[index].val.dim_order,
+                )
+                for index in execution_plan.outputs
+            ]
+            return _run_rocm_runner(module, inputs, output_strides, pte, ptd, tmpdir)
+
+        from executorch.extension.pybindings.portable_lib import _load_for_executorch
+
         mod = _load_for_executorch(pte, data_path=ptd)
         return mod.run_method("forward", [t.cpu() for t in inputs])
 

--- a/backends/cuda/tests/test_sort_shim.py
+++ b/backends/cuda/tests/test_sort_shim.py
@@ -155,6 +155,7 @@ class TestSortShim(unittest.TestCase):
             options = CudaBackend.get_aoti_compile_options([])
 
         self.assertEqual(len(options["aot_inductor.custom_ops_to_c_shims"]), 4)
+        self.assertNotIn("aot_inductor.precompile_headers", options)
 
     def test_rocm_advertises_no_unbuilt_shims(self):
         """ROCm does not advertise CUDA-only shims."""
@@ -164,6 +165,7 @@ class TestSortShim(unittest.TestCase):
 
         self.assertEqual(fallbacks, {})
         self.assertNotIn("aot_inductor.custom_ops_to_c_shims", options)
+        self.assertNotIn("aot_inductor.precompile_headers", options)
 
 
 if __name__ == "__main__":

--- a/backends/cuda/tests/test_topk.py
+++ b/backends/cuda/tests/test_topk.py
@@ -24,10 +24,8 @@ import unittest
 import numpy as np
 import torch
 import torch.nn as nn
-
 from executorch.backends.cuda.cuda_backend import CudaBackend
 from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
-
 from executorch.backends.cuda.triton.kernels.topk import topk as triton_topk
 from executorch.exir import (
     EdgeCompileConfig,
@@ -38,7 +36,10 @@ from executorch.exir.passes import MemoryPlanningPass
 from torch.export import export
 
 EXECUTORCH_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "../../.."))
-RUNNER_PATH = os.path.join(EXECUTORCH_ROOT, "cmake-out", "executor_runner")
+RUNNER_PATH = os.environ.get(
+    "EXECUTORCH_EXECUTOR_RUNNER",
+    os.path.join(EXECUTORCH_ROOT, "cmake-out", "executor_runner"),
+)
 
 # Test configurations: (seed, rows, cols, k, dim, largest, description)
 TEST_CONFIGS = [
@@ -135,7 +136,16 @@ def _run_cpp_runner(runner_path, pte_path, ptd_path, input_files, output_base):
         f"--inputs={','.join(input_files)}",
         f"--output_file={output_base}",
     ]
-    return subprocess.run(cmd, capture_output=True, text=True)
+    env = None
+    if torch.version.hip is not None:
+        env = os.environ.copy()
+        env["LD_LIBRARY_PATH"] = os.pathsep.join(
+            filter(
+                None,
+                [os.path.join(sys.prefix, "lib"), env.get("LD_LIBRARY_PATH")],
+            )
+        )
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
 
 
 class TestTopK(unittest.TestCase):
@@ -268,10 +278,14 @@ class TestTopK(unittest.TestCase):
                     result = _run_cpp_runner(
                         RUNNER_PATH, pte_path, ptd_path, input_files, output_base
                     )
+                    failure = (
+                        f"seed={seed} executor_runner failed:\n"
+                        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+                    )
                     self.assertEqual(
                         result.returncode,
                         0,
-                        f"seed={seed}: executor_runner failed:\n{result.stderr}",
+                        failure,
                     )
 
                     cpp_vals = _load_output(

--- a/backends/cuda/triton/kernels/__init__.py
+++ b/backends/cuda/triton/kernels/__init__.py
@@ -11,10 +11,10 @@ from executorch.backends.cuda.triton.kernels.fused_moe import (
     fused_moe_batched_gemm_int8,
     moe_align_block_size,
 )
-
 from executorch.backends.cuda.triton.kernels.int4_matmul import (
     dequant_w4_to_bf16,
     int4_matvec,
+    int4_matvec_bf16,
 )
 from executorch.backends.cuda.triton.kernels.sdpa import (
     sdpa,
@@ -30,6 +30,7 @@ __all__ = [
     "fused_moe_batched_gemm",
     "fused_moe_batched_gemm_int8",
     "int4_matvec",
+    "int4_matvec_bf16",
     "moe_align_block_size",
     "sdpa",
     "sdpa_decode_splitk",

--- a/backends/cuda/triton/kernels/int4_matmul.py
+++ b/backends/cuda/triton/kernels/int4_matmul.py
@@ -23,7 +23,6 @@ import triton
 import triton.language as tl
 from torch.library import triton_op, wrap_triton
 
-
 # -- Autotune configs ---------------------------------------------------------
 
 _INT4_MATMUL_CONFIGS = [
@@ -307,6 +306,7 @@ def _int4_matvec_kernel(
     stride_sn,
     stride_sk,
     group_size: tl.constexpr,
+    round_weight_to_bf16: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
 ):
@@ -344,29 +344,21 @@ def _int4_matvec_kernel(
             )
             w_dq = (w_uint4.to(tl.float32) - 8.0) * scale
 
+        if round_weight_to_bf16:
+            w_dq = w_dq.to(tl.bfloat16)
+
         acc += tl.sum(w_dq * x_val[None, :], axis=1)
 
     tl.store(Out + offs_n, acc.to(tl.bfloat16), mask=nm)
 
 
-@triton_op("triton::int4_matvec", mutates_args={})
-def int4_matvec(
+def _int4_matvec(
     x: torch.Tensor,
     w_packed: torch.Tensor,
     w_scale: torch.Tensor,
     group_size: int,
+    round_weight_to_bf16: bool,
 ) -> torch.Tensor:
-    """W4A16 matvec for M=1 decode: out[1,N] = x[1,K] @ dequant(w[N,K]).T
-
-    Args:
-        x:        [1, K] bf16 input (M=1)
-        w_packed: [N, K//2] int8 packed INT4 weights
-        w_scale:  [N, K//group_size] bf16 per-group scales
-        group_size: quantization group size
-
-    Returns:
-        [1, N] bf16
-    """
     K = x.shape[-1]
     N = w_packed.shape[0]
 
@@ -387,12 +379,49 @@ def int4_matvec(
         w_scale.stride(0),
         w_scale.stride(1),
         group_size,
+        round_weight_to_bf16,
     )
     return output
 
 
+@triton_op("triton::int4_matvec", mutates_args={})
+def int4_matvec(
+    x: torch.Tensor,
+    w_packed: torch.Tensor,
+    w_scale: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """W4A16 matvec for M=1 decode: out[1,N] = x[1,K] @ dequant(w[N,K]).T"""
+    return _int4_matvec(x, w_packed, w_scale, group_size, False)
+
+
 @int4_matvec.register_fake
 def _int4_matvec_fake(
+    x: torch.Tensor,
+    w_packed: torch.Tensor,
+    w_scale: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    N = w_packed.shape[0]
+    return torch.empty(1, N, dtype=torch.bfloat16, device=x.device)
+
+
+@triton_op("triton::int4_matvec_bf16", mutates_args={})
+def int4_matvec_bf16(
+    x: torch.Tensor,
+    w_packed: torch.Tensor,
+    w_scale: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """W4A16 matvec with BF16-rounded weights to reduce matmul divergence.
+
+    Activation precision and reduction order still differ from ``int4_matmul``.
+    """
+    return _int4_matvec(x, w_packed, w_scale, group_size, True)
+
+
+@int4_matvec_bf16.register_fake
+def _int4_matvec_bf16_fake(
     x: torch.Tensor,
     w_packed: torch.Tensor,
     w_scale: torch.Tensor,


### PR DESCRIPTION
Nibble-pack symmetric W4 weights and lower packed linears to Triton W4A16 matmul. Add an off-by-default BF16-rounded single-row matvec while preserving existing matvec behavior, and run ROCm execution tests through the native runner. Retain upstream AOTI header precompilation after cold-cache coverage.
