### PR TITLE
Arm backend: fix stale `serializer` import in Conv3d visitor

### DIFF
--- a/backends/arm/operators/op_tosa_conv3d.py
+++ b/backends/arm/operators/op_tosa_conv3d.py
@@ -15,7 +15,7 @@ class Conv3dVisitor(Conv2dVisitor):
     target = "tosa.CONV3D.default"
 
     def _get_tosa_op(self):
-        import serializer.tosa_serializer as ts  # type: ignore
+        import tosa_serializer as ts
 
         return ts.Op.CONV3D
 


### PR DESCRIPTION
Summary:
`Conv3dVisitor._get_tosa_op` imported the TOSA serializer as `serializer.tosa_serializer`, a module path that no longer exists. The `fbsource//third-party/tosa_tools:serializer` target resolves to `v2026.05.0/src/serialization:serializer`, which exports the package as top-level `tosa_serializer` (`base_module = ""`). That is what every other visitor in `backends/arm/operators` already imports. Lowering any CONV3D node therefore raised `ModuleNotFoundError: No module named 'serializer'`. The legacy `serializer` package only existed under `third-party/tosa_tools/v1.00`.

The bad import is lazy, so it fires only when a CONV3D node is actually serialized, and `ops/test_conv3d.py` is absent from the explicit allowlist in `backends/arm/test/targets.bzl`. Nothing internally reached it until D116518866 added a Conv3d parametrization to `passes/test_rewrite_conv_pass.py`, which is covered by the `passes/test_*.py` glob in that same file. D116518866 is land-blocked on the resulting failure; this change unblocks it.

Authored with Claude Code.

Differential Revision: D116673787




cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell