### PR TITLE
Make layout propagation fixed-point and broadcast-safe (#21956)

### DIFF
--- a/backends/arm/_passes/propagate_view_copy_permute_pass.py
+++ b/backends/arm/_passes/propagate_view_copy_permute_pass.py
@@ -13,7 +13,6 @@ from typing import Any, cast, Set, Type
 
 import torch
 from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
-from executorch.backends.arm.tosa.specification import get_context_spec
 from executorch.backends.transforms.canonicalize_view_copy_permute_pass import (
     CanonicalizeViewCopyPermutePass,
 )
@@ -152,6 +151,14 @@ class PropagateViewCopyPermutePass(ArmPass, ABC):
             if not self._can_cross_next_nodes(frontier, next_nodes):
                 break
 
+            # INT48 storage is not laid out like the int32 fake tensor used
+            # for metadata, so permuting it would address the packed data incorrectly.
+            if node.target == self._PERMUTE_TARGET and any(
+                self._node_or_inputs_are_int48(candidate)
+                for candidate in (frontier, *next_nodes)
+            ):
+                break
+
             if len(next_nodes) > 1:
                 if self._maybe_split_fork(
                     node, frontier, previous_frontier, next_nodes
@@ -202,6 +209,14 @@ class PropagateViewCopyPermutePass(ArmPass, ABC):
 
         """
         return None
+
+    @staticmethod
+    def _node_or_inputs_are_int48(node: torch.fx.Node) -> bool:
+        special_dtype_key = TosaSpecialDtype.meta_key()
+        return node.meta.get(special_dtype_key) == TosaSpecialDtype.INT48 or any(
+            input_node.meta.get(special_dtype_key) == TosaSpecialDtype.INT48
+            for input_node in node.all_input_nodes
+        )
 
     def fuse_vertical(self, graph_module: torch.fx.GraphModule) -> PassResult:
         """Fuse consecutive permute/view nodes."""
@@ -347,6 +362,27 @@ class PropagateViewCopyPermutePass(ArmPass, ABC):
                 )
         return True
 
+    @staticmethod
+    def _is_unsafe_table_operand_shape(shape: Any) -> bool:
+        """Whether a TABLE reading ``shape`` is miscompiled on Ethos-U85."""
+        return (
+            shape is not None
+            and len(shape) == 4
+            and all(isinstance(dim, int) for dim in shape)
+            and shape[0] > 1
+            and shape[1] == 1
+            and shape[2] == 1
+        )
+
+    def _shape_seen_by_next_node(self, moving_node: torch.fx.Node) -> Any:
+        """Shape the crossed node operates on once ``moving_node`` has moved.
+
+        Moving downwards leaves the crossed node reading ``moving_node``'s input.
+
+        """
+        val = cast(torch.fx.Node, moving_node.args[0]).meta.get("val")
+        return getattr(val, "shape", None)
+
     def _can_move_through_elementwise(
         self,
         moving_node: torch.fx.Node,
@@ -379,6 +415,17 @@ class PropagateViewCopyPermutePass(ArmPass, ABC):
             ):
                 return False
 
+            # Moving a view across a TABLE changes the shape the lookup table
+            # operates on. Ethos-U85 miscompiles a TABLE fed by a MAC op when
+            # that operand is [N, 1, 1, C] with N > 1 (MLBEDSW-11805), so keep
+            # the view on the other side of the table in that case.
+            if next_node.target == exir_ops.backend.tosa.TABLE.default and (
+                self._is_unsafe_table_operand_shape(
+                    self._shape_seen_by_next_node(moving_node)
+                )
+            ):
+                return False
+
         if moving_node.target != self._PERMUTE_TARGET:
             return True
 
@@ -405,12 +452,6 @@ class TosaPropagationOverrides(PropagateViewCopyPermutePass):
             return None
         return RemovePermutesAroundElementwiseTosaOps(self.exported_program)
 
-    def should_propagate(self) -> bool:
-        # Do not run for Ethos-U85 since this exposes a numerical issue.
-        # There is no target meta-data at this stage so use INT+cf as proxy.
-        # To be removed after MLBEDSW-11805.
-        return not self._is_u85_like_tosa_int_cf()
-
     def is_transparent(self, node: torch.fx.Node) -> bool:
         return (
             super().is_transparent(node)
@@ -429,21 +470,6 @@ class TosaPropagationOverrides(PropagateViewCopyPermutePass):
         if node.target == exir_ops.backend.tosa.TABLE.default:
             return True
         return super().is_elementwise(node)
-
-    def _is_u85_like_tosa_int_cf(self) -> bool:
-        if self.compile_spec is not None:
-            tosa_spec = self.compile_spec.tosa_spec
-        else:
-            try:
-                tosa_spec = get_context_spec()
-            except RuntimeError:
-                return False
-
-        return (
-            tosa_spec.support_integer()
-            and not tosa_spec.support_float()
-            and tosa_spec.support_extension("cf")
-        )
 
     def _is_per_tensor_rescale(self, node: torch.fx.Node) -> bool:
         if len(node.args) < 3:
@@ -494,6 +520,11 @@ class PropagateViewCopyPermuteUpPass(
             all(prev_node is frontier for prev_node in self._get_prev_nodes(next_node))
             for next_node in next_nodes
         )
+
+    def _shape_seen_by_next_node(self, moving_node: torch.fx.Node) -> Any:
+        """Moving up leaves the crossed node reading ``moving_node`` output."""
+        val = moving_node.meta.get("val")
+        return getattr(val, "shape", None)
 
     def _can_move_through_elementwise(
         self,

--- a/backends/arm/test/passes/test_propagate_permutes_views_pass.py
+++ b/backends/arm/test/passes/test_propagate_permutes_views_pass.py
@@ -373,7 +373,7 @@ def test_down_pass_moves_permute_after_transparent_chain() -> None:
     assert targets.index(RELU) < targets.index(NEG) < targets.index(PERMUTE)
 
 
-def test_down_pass_skips_propagation_for_u85_like_tosa_int_cf() -> None:
+def test_down_pass_propagates_for_u85_like_tosa_int_cf() -> None:
     graph = torch.fx.Graph()
     x = graph.placeholder("x")
     x.meta["val"] = torch.empty((1, 2, 3, 4))
@@ -388,7 +388,7 @@ def test_down_pass_skips_propagation_for_u85_like_tosa_int_cf() -> None:
     with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+INT+cf")):
         targets = _run_pass_on_graph(graph, PropagateViewCopyPermuteDownPass)
 
-    assert targets.index(PERMUTE) < targets.index(RELU) < targets.index(NEG)
+    assert targets.index(RELU) < targets.index(NEG) < targets.index(PERMUTE)
 
 
 def test_down_pass_still_canonicalizes_for_u85_like_tosa_int_cf() -> None:
@@ -941,6 +941,50 @@ def test_down_pass_moves_permutation_after_reduction() -> None:
     assert transform.meta["val"].shape == torch.Size((1, 3, 4, 1))
 
 
+@pytest.mark.parametrize("mean_first", [False, True])
+def test_down_pass_keeps_permute_before_reduction_with_layout_dependent_user(
+    mean_first: bool,
+) -> None:
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty((1, 512, 796))
+    direct = graph.placeholder("direct")
+    direct.meta["val"] = torch.empty((1, 796, 512))
+    permute = graph.call_function(PERMUTE, args=(x, [0, 2, 1]))
+    permute.meta["val"] = torch.empty((1, 796, 512))
+    relu = graph.call_function(RELU, args=(permute,))
+    relu.meta["val"] = torch.empty((1, 796, 512))
+    mean = graph.call_function(MEAN, args=(relu, [1], True))
+    mean.meta["val"] = torch.empty((1, 1, 512))
+    sub_args = (mean, direct) if mean_first else (direct, mean)
+    sub = graph.call_function(SUB, args=sub_args)
+    sub.meta["val"] = torch.empty((1, 796, 512))
+    graph.output(sub)
+
+    graph_module = _run_pass_on_graph_module(graph, PropagateViewCopyPermuteDownPass)
+    call_nodes = [
+        node for node in graph_module.graph.nodes if node.op == "call_function"
+    ]
+    mean = next(node for node in call_nodes if node.target == MEAN)
+    sub = next(node for node in call_nodes if node.target == SUB)
+    mean_input_shape = mean.all_input_nodes[0].meta["val"].shape
+    mean_output_shape = mean.meta["val"].shape
+    sub_input_shapes = [
+        input_node.meta["val"].shape for input_node in sub.all_input_nodes
+    ]
+    reduction_dims = [dim % len(mean_input_shape) for dim in mean.args[1]]
+
+    assert all(mean_output_shape[dim] == 1 for dim in reduction_dims)
+    assert all(
+        output_dim == 1 if dim in reduction_dims else output_dim == input_dim
+        for dim, (input_dim, output_dim) in enumerate(
+            zip(mean_input_shape, mean_output_shape)
+        )
+    )
+    assert torch.broadcast_shapes(*sub_input_shapes) == sub.meta["val"].shape
+    assert torch.Size((1, 512, 1)) not in sub_input_shapes
+
+
 def test_down_pass_splits_permute_over_elementwise_fanout() -> None:
     graph = torch.fx.Graph()
     x = graph.placeholder("x")
@@ -1256,6 +1300,74 @@ def test_propagate_fuses_permute_view_around_table() -> None:
     assert targets == [TABLE]
 
 
+def test_propagate_down_keeps_view_before_table_with_batched_singleton_spatial() -> (
+    None
+):
+    """Ethos-U85 miscompiles a TABLE reading [N, 1, 1, C] with N > 1.
+
+    Sinking the view would leave the table on the [990, 1, 1, 64] operand, so it
+    has to stay in front of the table.
+
+    """
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty((990, 1, 1, 64), dtype=torch.int8)
+    table = graph.placeholder("table")
+    table.meta["val"] = torch.empty((256,), dtype=torch.int8)
+    view = graph.call_function(VIEW, args=(x, [99, 10, 64]))
+    view.meta["val"] = torch.empty((99, 10, 64), dtype=torch.int8)
+    table_node = graph.call_function(TABLE, args=(view, table))
+    table_node.meta["val"] = torch.empty((99, 10, 64), dtype=torch.int8)
+    graph.output(table_node)
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+INT")):
+        targets = _run_pass_on_graph(graph, PropagateViewCopyPermuteDownPass)
+
+    assert targets.index(VIEW) < targets.index(TABLE)
+
+
+def test_propagate_up_keeps_view_after_table_with_batched_singleton_spatial() -> None:
+    """The upward pass must not hoist the view above the table either.
+
+    Hoisting it would leave the table reading the view's [990, 1, 1, 64] output.
+
+    """
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty((99, 10, 64), dtype=torch.int8)
+    table = graph.placeholder("table")
+    table.meta["val"] = torch.empty((256,), dtype=torch.int8)
+    table_node = graph.call_function(TABLE, args=(x, table))
+    table_node.meta["val"] = torch.empty((99, 10, 64), dtype=torch.int8)
+    view = graph.call_function(VIEW, args=(table_node, [990, 1, 1, 64]))
+    view.meta["val"] = torch.empty((990, 1, 1, 64), dtype=torch.int8)
+    graph.output(view)
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+INT")):
+        targets = _run_pass_on_graph(graph, PropagateViewCopyPermuteUpPass)
+
+    assert targets.index(TABLE) < targets.index(VIEW)
+
+
+def test_propagate_down_still_sinks_view_through_table_for_safe_shapes() -> None:
+    """The guard is limited to [N, 1, 1, C] with N > 1; other views sink."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty((1, 1, 1, 64), dtype=torch.int8)
+    table = graph.placeholder("table")
+    table.meta["val"] = torch.empty((256,), dtype=torch.int8)
+    view = graph.call_function(VIEW, args=(x, [1, 64]))
+    view.meta["val"] = torch.empty((1, 64), dtype=torch.int8)
+    table_node = graph.call_function(TABLE, args=(view, table))
+    table_node.meta["val"] = torch.empty((1, 64), dtype=torch.int8)
+    graph.output(table_node)
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+INT")):
+        targets = _run_pass_on_graph(graph, PropagateViewCopyPermuteDownPass)
+
+    assert targets.index(TABLE) < targets.index(VIEW)
+
+
 def test_propagate_stops_at_per_channel_rescale() -> None:
     graph = torch.fx.Graph()
     x = graph.placeholder("x")
@@ -1429,7 +1541,7 @@ def test_smaller_dtype_pass_restores_permute_after_narrowing_rescale_behind_unar
     assert targets.index(RESCALE) < targets.index(PERMUTE)
 
 
-def test_propagate_moves_before_int48_special_dtype() -> None:
+def test_tagged_int48_permute_does_not_propagate() -> None:
     graph = torch.fx.Graph()
     x = graph.placeholder("x")
     x.meta["val"] = torch.empty((1, 2, 3, 4), dtype=torch.int32)
@@ -1444,7 +1556,23 @@ def test_propagate_moves_before_int48_special_dtype() -> None:
 
     targets = _run_pass_on_graph(graph)
 
-    assert targets.index(PERMUTE) < targets.index(RELU)
+    assert targets.index(RELU) < targets.index(PERMUTE)
+
+
+def test_permute_does_not_cross_int48_rescale_input() -> None:
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty((2, 3, 5), dtype=torch.int32)
+    x.meta[TosaSpecialDtype.meta_key()] = TosaSpecialDtype.INT48
+    rescale = graph.call_function(RESCALE, args=(x, torch.int8, [0.25], 0, 0))
+    rescale.meta["val"] = torch.empty((2, 3, 5), dtype=torch.int8)
+    permute = graph.call_function(PERMUTE, args=(rescale, [1, 0, 2]))
+    permute.meta["val"] = torch.empty((3, 2, 5), dtype=torch.int8)
+    graph.output(permute)
+
+    targets = _run_pass_on_graph(graph)
+
+    assert targets.index(RESCALE) < targets.index(PERMUTE)
 
 
 def test_propagate_moves_output_view_before_sum_with_split_dim_remap() -> None:

--- a/backends/transforms/remove_permutes_around_elementwise_ops.py
+++ b/backends/transforms/remove_permutes_around_elementwise_ops.py
@@ -166,9 +166,9 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
         Flattening such a tensor -- e.g. the ``[1, C, 1, 1] -> [1, C]`` after a
         global pool -- is permutation-invariant: every layout of the input
         produces the identical output (the single non-unit run of elements is
-        contiguous regardless of which axis holds it). A permutation propagating
-        into it therefore simply dies, so the region can terminate here with no
-        compensating permute.
+        contiguous regardless of which axis holds it). The region may terminate
+        here without a compensating permute when downstream consumers do not use
+        the output shape for layout-dependent broadcasting.
         """
         if node.target not in self._VIEW_OPS:
             return False
@@ -179,6 +179,40 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
         # are treated as non-unit, i.e. conservatively not a sink).
         non_unit = [d for d in shape if not (isinstance(d, int) and d == 1)]
         return len(non_unit) <= 1
+
+    def _sink_users_are_layout_invariant(self, sink: torch.fx.Node) -> bool:
+        """Return whether dropping layout at ``sink`` is safe for its consumers."""
+        frontier = [(user, sink) for user in sink.users]
+        visited: set[torch.fx.Node] = set()
+        while frontier:
+            node, producer = frontier.pop()
+            if node in visited:
+                continue
+            visited.add(node)
+
+            if node.op == "output":
+                continue
+            if node.target == exir_ops.edge.aten.permute_copy.default:
+                # This explicit transform re-establishes the downstream layout,
+                # so consumers beyond it do not depend on the sink's layout.
+                continue
+            if self._is_permutation_sink_view(node):
+                continue
+
+            tensor_inputs = [
+                input_node
+                for input_node in node.all_input_nodes
+                if input_node.meta.get("val") is not None
+            ]
+            if any(
+                input_node is not producer and input_node.meta["val"].numel() != 1
+                for input_node in tensor_inputs
+            ):
+                return False
+            if not self.is_node_permutable(node):
+                return False
+            frontier.extend((user, node) for user in node.users)
+        return True
 
     def _inserted_unit_dim(self, node: torch.fx.Node) -> int | None:
         """Position of the size-1 dim ``node`` inserts, else None.
@@ -518,12 +552,10 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
             elif user.op == "output":
                 return False
             elif self._is_permutation_sink_view(user):
-                # The permutation dies at this reshape (see
-                # _is_permutation_sink_view), so terminate the region here with
-                # no compensating permute and no further downstream traversal.
-                # Checked before the rank-change handling below: a sink always
-                # terminates cleanly, whereas crossing it would leave the region
-                # hunting for an end permute that layout-invariance made moot.
+                # The tensor's element order is invariant at this reshape, but
+                # its output shape can still carry broadcast-axis meaning.
+                if not self._sink_users_are_layout_invariant(user):
+                    return False
                 continue
             elif not self.visit(
                 user, subgraph, processed_nodes, downstream_end, downstream_start

--- a/backends/transforms/test/test_permute_optimization_passes.py
+++ b/backends/transforms/test/test_permute_optimization_passes.py
@@ -1594,6 +1594,110 @@ class RemovePermutesAcrossViewTest(unittest.TestCase):
             "permutation_sink_view_splitting_the_non_unit_dim",
         )
 
+    def test_permutation_sink_view_preserves_broadcast_layout(self) -> None:
+        x_data = torch.randn(1, 4, 1, 1)
+        direct_data = torch.randn(1, 8, 4)
+        builder = GraphBuilder()
+        x = builder.placeholder("x", x_data)
+        direct = builder.placeholder("direct", direct_data)
+        permute = builder.call_operator(
+            op=exir_ops.edge.aten.permute_copy.default, args=(x, [0, 2, 3, 1])
+        )
+        mul = builder.call_operator(
+            op=exir_ops.edge.aten.mul.Tensor, args=(permute, permute)
+        )
+        view = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default, args=(mul, [1, 1, 4])
+        )
+        sub = builder.call_operator(
+            op=exir_ops.edge.aten.sub.Tensor, args=(direct, view)
+        )
+        builder.output([sub])
+        original = builder.get_graph_module()
+        gm_before = copy.deepcopy(original)
+
+        result = cast(PassResult, RemovePermutesAroundElementwiseOps()(original))
+        self.assertFalse(result.modified)
+        self.assertEqual(
+            count_node(result.graph_module, exir_ops.edge.aten.permute_copy.default), 1
+        )
+        validate_numerics(
+            gm_before,
+            result.graph_module,
+            [x_data, direct_data],
+            "permutation_sink_view_preserves_broadcast_layout",
+        )
+
+    def test_permutation_sink_view_preserves_cat_layout(self) -> None:
+        x_data = torch.randn(1, 4, 1, 1)
+        direct_data = torch.randn(1, 7, 4)
+        builder = GraphBuilder()
+        x = builder.placeholder("x", x_data)
+        direct = builder.placeholder("direct", direct_data)
+        permute = builder.call_operator(
+            op=exir_ops.edge.aten.permute_copy.default, args=(x, [0, 2, 3, 1])
+        )
+        mul = builder.call_operator(
+            op=exir_ops.edge.aten.mul.Tensor, args=(permute, permute)
+        )
+        view = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default, args=(mul, [1, 1, 4])
+        )
+        cat = builder.call_operator(
+            op=exir_ops.edge.aten.cat.default, args=([direct, view], 1)
+        )
+        builder.output([cat])
+        original = builder.get_graph_module()
+        gm_before = copy.deepcopy(original)
+
+        result = cast(PassResult, RemovePermutesAroundElementwiseOps()(original))
+        self.assertFalse(result.modified)
+        self.assertEqual(
+            count_node(result.graph_module, exir_ops.edge.aten.permute_copy.default), 1
+        )
+        validate_numerics(
+            gm_before,
+            result.graph_module,
+            [x_data, direct_data],
+            "permutation_sink_view_preserves_cat_layout",
+        )
+
+    def test_permutation_sink_view_preserves_keyword_broadcast_layout(self) -> None:
+        x_data = torch.randn(1, 4, 1, 1)
+        direct_data = torch.randn(1, 8, 4)
+        builder = GraphBuilder()
+        x = builder.placeholder("x", x_data)
+        direct = builder.placeholder("direct", direct_data)
+        permute = builder.call_operator(
+            op=exir_ops.edge.aten.permute_copy.default, args=(x, [0, 2, 3, 1])
+        )
+        mul = builder.call_operator(
+            op=exir_ops.edge.aten.mul.Tensor, args=(permute, permute)
+        )
+        view = builder.call_operator(
+            op=exir_ops.edge.aten.view_copy.default, args=(mul, [1, 1, 4])
+        )
+        sub = builder.call_operator(
+            op=exir_ops.edge.aten.sub.Tensor,
+            args=(view,),
+            kwargs={"other": direct},
+        )
+        builder.output([sub])
+        original = builder.get_graph_module()
+        gm_before = copy.deepcopy(original)
+
+        result = cast(PassResult, RemovePermutesAroundElementwiseOps()(original))
+        self.assertFalse(result.modified)
+        self.assertEqual(
+            count_node(result.graph_module, exir_ops.edge.aten.permute_copy.default), 1
+        )
+        validate_numerics(
+            gm_before,
+            result.graph_module,
+            [x_data, direct_data],
+            "permutation_sink_view_preserves_keyword_broadcast_layout",
+        )
+
     def test_upstream_squeeze_view_rank_mismatch_no_crash(self) -> None:
         """Regression test for IndexError when a squeeze view_copy is reached
         via upstream traversal with a permutation at the view's output rank.


### PR DESCRIPTION
Summary:

Run view/permute propagation to a fixed point for every supported TOSA specification instead of conditionally disabling iterative propagation for one specification family.

A layout transform may be element-order invariant at a reshape while the reshape output shape remains semantically significant to downstream broadcasting. Make permutation-sink termination conditional on downstream layout invariance, preserving the transform when another consumer depends on its logical axis placement.

This allows all targets to use the same propagation algorithm while retaining conservative correctness checks around elementwise inputs, reshape sinks, and keep-dimension reductions.

Reviewed By: rascani

Differential Revision: D116683130


