### PR TITLE
Arm backend: Fuse quantized activations by setting qmin to zp

### DIFF
--- a/backends/arm/_passes/fuse_quantized_activation_pass.py
+++ b/backends/arm/_passes/fuse_quantized_activation_pass.py
@@ -13,7 +13,7 @@ from executorch.backends.arm._passes.fold_qdq_with_annotated_qparams_pass import
     FoldAndAnnotateQParamsPass,
 )
 from executorch.backends.arm._passes.quant_args import QuantArgs
-from executorch.backends.arm.constants import Q_OPS
+from executorch.backends.arm.constants import QUANT_PER_TENSOR_OP
 from executorch.backends.transforms.remove_getitem_op import RemoveGetItemPass
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
@@ -29,23 +29,32 @@ class FuseQuantizedActivationPass(ArmPass):
 
     @staticmethod
     def _is_fuseable_quantized_activation(node: Node):
-        """Fuse activations that have a 0 lower bound and quantized with a qmin
-        zero-point.
-        """
+        """Fuse activations that have a 0 lower bound."""
         is_fuseable = node.target == exir_ops.edge.aten.relu.default
         if node.target == exir_ops.edge.aten.hardtanh.default:
             min_val = node.args[1]
             is_fuseable = min_val == 0
 
-        is_quantized = len(node.users) == 1 and next(iter(node.users)).target in Q_OPS
+        is_quantized = (
+            len(node.users) == 1
+            # qmin is an int argument; only copy scalar zero points into it.
+            and next(iter(node.users)).target == QUANT_PER_TENSOR_OP
+        )
         if is_fuseable and is_quantized:
             quant_node = next(iter(node.users))
             quant_args = QuantArgs.from_operator(quant_node.target, quant_node.args)
-            zp = quant_args.zp
-            qmin = quant_args.qmin
-            return zp == qmin
-        else:
-            return False
+            if quant_args.per_channel:
+                return False
+            if node.target == exir_ops.edge.aten.hardtanh.default:
+                max_val = node.args[2]
+                return quant_args.quantize_value(max_val).item() == quant_args.qmax
+            return True
+        return False
+
+    @staticmethod
+    def _set_quant_qmin_to_zp(quant_node: Node):
+        quant_args = QuantArgs.from_operator(quant_node.target, quant_node.args)
+        quant_node.update_arg(3, quant_args.zp)
 
     @staticmethod
     def _is_fuseable_input(node: Node):
@@ -71,6 +80,8 @@ class FuseQuantizedActivationPass(ArmPass):
             if not FuseQuantizedActivationPass._is_fuseable_input(input_node):
                 continue
 
+            quant_node = next(iter(node.users))
+            FuseQuantizedActivationPass._set_quant_qmin_to_zp(quant_node)
             node.replace_all_uses_with(input_node)
             graph_module.graph.erase_node(node)
             modified = True

--- a/backends/arm/test/passes/test_fuse_quantized_activation_pass.py
+++ b/backends/arm/test/passes/test_fuse_quantized_activation_pass.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
+from collections import Counter
 from typing import Tuple
 
 import torch
@@ -11,6 +13,7 @@ from executorch.backends.arm._passes.fuse_quantized_activation_pass import (
     FuseQuantizedActivationPass,
 )
 from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
+from executorch.exir.dialects._ops import ops as exir_ops
 
 input_t = Tuple[torch.Tensor]
 
@@ -30,6 +33,94 @@ class ConvRelu(torch.nn.Module):
         return self.relu(self.conv(x))
 
 
+def _activation_and_quant(
+    target,
+    activation_args,
+    scale: float = 0.1,
+    zp: int = 0,
+    qmin: int = -128,
+    qmax: int = 127,
+    dtype: torch.dtype = torch.int8,
+):
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    conv = graph.call_function(exir_ops.edge.aten.convolution.default, (x,))
+    activation = graph.call_function(target, (conv, *activation_args))
+    quant = graph.call_function(
+        exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+        (activation, scale, zp, qmin, qmax, dtype),
+    )
+    return activation, quant
+
+
+def _activation_and_tensor_qparam_quant(
+    target,
+    activation_args,
+    qmin: int = -128,
+    qmax: int = 127,
+    dtype: torch.dtype = torch.int8,
+):
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    scale = graph.placeholder("scale")
+    zp = graph.placeholder("zp")
+    conv = graph.call_function(exir_ops.edge.aten.convolution.default, (x,))
+    activation = graph.call_function(target, (conv, *activation_args))
+    quant = graph.call_function(
+        exir_ops.edge.quantized_decomposed.quantize_per_tensor.tensor,
+        (activation, scale, zp, qmin, qmax, dtype),
+    )
+    return activation, quant
+
+
+def _activation_quant_graph(
+    target,
+    activation_args,
+    scale: float = 0.1,
+    zp: int = 0,
+    qmin: int = -128,
+    qmax: int = 127,
+    dtype: torch.dtype = torch.int8,
+) -> torch.fx.GraphModule:
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty((2, 4))
+    weight = graph.placeholder("weight")
+    weight.meta["val"] = torch.empty((4, 4))
+    bias = graph.placeholder("bias")
+    bias.meta["val"] = torch.empty(4)
+    linear = graph.call_function(exir_ops.edge.aten.linear.default, (x, weight, bias))
+    linear.meta["val"] = torch.empty((2, 4))
+    activation = graph.call_function(target, (linear, *activation_args))
+    activation.meta["val"] = torch.empty((2, 4))
+    quant = graph.call_function(
+        exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+        (activation, scale, zp, qmin, qmax, dtype),
+    )
+    quant.meta["val"] = torch.empty((2, 4), dtype=dtype)
+    graph.output(quant)
+    return torch.fx.GraphModule(torch.nn.Module(), graph)
+
+
+def _assert_fusion_preserves_output(graph_module: torch.fx.GraphModule) -> None:
+    original = copy.deepcopy(graph_module)
+    result = FuseQuantizedActivationPass().call(graph_module)
+    assert result.modified
+
+    inputs = (
+        torch.tensor(
+            [[-5.0, -0.06, 0.0, 0.04], [1.2, 12.7, 13.0, 20.0]],
+        ),
+        torch.eye(4),
+        torch.zeros(4),
+    )
+    with torch.no_grad():
+        expected = original(*inputs)
+        actual = result.graph_module(*inputs)
+
+    torch.testing.assert_close(actual, expected)
+
+
 def test_fuse_relu_after_conv_quantized() -> None:
     """Existing behavior: ReLU after conv is fused in quantized graph."""
     module = ConvRelu()
@@ -46,3 +137,78 @@ def test_fuse_relu_after_conv_quantized() -> None:
         pass_list=[FuseQuantizedActivationPass],
     )
     pipeline.run()
+
+
+def test_relu_fusion_rewrites_qmin_to_zero_point() -> None:
+    activation, quant = _activation_and_quant(
+        exir_ops.edge.aten.relu.default,
+        (),
+    )
+
+    assert FuseQuantizedActivationPass._is_fuseable_quantized_activation(activation)
+    FuseQuantizedActivationPass._set_quant_qmin_to_zp(quant)
+
+    assert quant.args[3] == 0
+    assert quant.args[4] == 127
+
+
+def test_relu_fusion_preserves_quantized_values() -> None:
+    graph_module = _activation_quant_graph(
+        exir_ops.edge.aten.relu.default,
+        (),
+        zp=-3,
+    )
+
+    _assert_fusion_preserves_output(graph_module)
+    counts = Counter(
+        node.target for node in graph_module.graph.nodes if node.op == "call_function"
+    )
+    assert counts[exir_ops.edge.aten.relu.default] == 0
+
+
+def test_relu_with_tensor_qparams_is_not_fuseable() -> None:
+    activation, quant = _activation_and_tensor_qparam_quant(
+        exir_ops.edge.aten.relu.default,
+        (),
+    )
+
+    assert not FuseQuantizedActivationPass._is_fuseable_quantized_activation(activation)
+    assert quant.args[3] == -128
+    assert quant.args[4] == 127
+
+
+def test_hardtanh_with_non_saturating_max_is_not_fuseable() -> None:
+    activation, quant = _activation_and_quant(
+        exir_ops.edge.aten.hardtanh.default,
+        (0.0, 6.0),
+    )
+
+    assert not FuseQuantizedActivationPass._is_fuseable_quantized_activation(activation)
+    assert quant.args[3] == -128
+    assert quant.args[4] == 127
+
+
+def test_hardtanh_with_saturating_max_rewrites_qmin_to_zero_point() -> None:
+    activation, quant = _activation_and_quant(
+        exir_ops.edge.aten.hardtanh.default,
+        (0.0, 13.0),
+    )
+
+    assert FuseQuantizedActivationPass._is_fuseable_quantized_activation(activation)
+    FuseQuantizedActivationPass._set_quant_qmin_to_zp(quant)
+
+    assert quant.args[3] == 0
+    assert quant.args[4] == 127
+
+
+def test_saturating_hardtanh_fusion_preserves_quantized_values() -> None:
+    graph_module = _activation_quant_graph(
+        exir_ops.edge.aten.hardtanh.default,
+        (0.0, 13.0),
+    )
+
+    _assert_fusion_preserves_output(graph_module)
+    counts = Counter(
+        node.target for node in graph_module.graph.nodes if node.op == "call_function"
+    )
+    assert counts[exir_ops.edge.aten.hardtanh.default] == 0


### PR DESCRIPTION
### Summary

- Set qmin to the output zero point before removing ReLU. 
- Keep hardtanh fusion gated on max saturation to qmax. 
- Skip per-channel quantization because qmin is not in args. 
- Update tests for signed int8 qmin rewrite cases.



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani