### PR TITLE
Arm backend: Use shared Conv1d-to-Conv2d transform in Arm backend

### DIFF
--- a/backends/arm/_passes/BUCK
+++ b/backends/arm/_passes/BUCK
@@ -59,6 +59,7 @@ fbcode_target(
         "//executorch/backends/transforms:aten_to_dialect_pass",
         "//executorch/backends/arm/tosa:utils",
         "//executorch/backends/arm/tosa/dialect:lib",
+        "//executorch/backends/transforms:convert_conv1d_to_conv2d_pass",
         "//executorch/backends/transforms:fuse_view_copy",
         "//executorch/backends/transforms:remove_getitem_op",
         "//executorch/backends/transforms:replace_scalar_with_tensor",

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -578,7 +578,7 @@ class ArmPassManager(ExportedProgramPassManager):
                 DecomposeAdaptiveAvgPool2dPass(),
                 DecomposeDynamicAdaptiveAvgPool2dPass(),
                 DecomposeAvgPool2dPass(),
-                Conv1dUnsqueezePass(),
+                Conv1dUnsqueezePass(exported_program),
             ]
         )
 

--- a/backends/arm/_passes/conv1d_unsqueeze_pass.py
+++ b/backends/arm/_passes/conv1d_unsqueeze_pass.py
@@ -5,109 +5,24 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
 from typing import Set, Type
 
-from executorch.backends.arm._passes import ArmOpTargetedPass
-
+from executorch.backends.arm._passes.convert_squeezes_to_view import (
+    ConvertSqueezesToViewPass,
+)
 from executorch.backends.arm._passes.rewrite_conv_pass import RewriteConvPass
 from executorch.backends.arm._passes.size_adjust_input_pass import SizeAdjustInputPass
-
-from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.backends.transforms.convert_conv1d_to_conv2d_pass import (
+    ConvertConv1dToConv2dPass,
+)
 from executorch.exir.pass_base import ExportPass
-from torch.fx import GraphModule
 
 
-class Conv1dUnsqueezePass(ArmOpTargetedPass):
-    """This pass is used to change conv1d ops into conv2d since TOSA only
-    supports 2d and 3d convolution.
-
-    This is done by modifying the graph to do the
-    following:
-    1a) unsqueeze the convolution's input from 3d to 4d
-    1b) unsqueeze the convolution's weight from 3d to 4d
-    2) perform a conv2d (with a modified version of the original conv1d args)
-    3) squeeze the output back down to 3d.
-
-    """
+class Conv1dUnsqueezePass(ConvertConv1dToConv2dPass):
+    """Arm wrapper for the shared Conv1d-to-Conv2d transform."""
 
     _passes_required_after: Set[Type[ExportPass]] = {
+        ConvertSqueezesToViewPass,
         RewriteConvPass,
         SizeAdjustInputPass,
     }
-    target_ops = (exir_ops.edge.aten.convolution.default,)
-
-    def should_run_pass(self, graph_module: GraphModule) -> bool:
-        for node in graph_module.graph.nodes:
-            if node.op != "call_function" or node.target not in self.target_ops:
-                continue
-            if len(node.args) > 3 and len(node.args[3]) == 1:
-                return True
-        return any(
-            isinstance(child, GraphModule) and self.should_run_pass(child)
-            for child in graph_module.children()
-        )
-
-    def call_operator(self, op, args, kwargs, meta):
-        if op not in self.target_ops:
-            return super().call_operator(op, args, kwargs, meta)
-        stride = list(args[3])
-        if len(stride) != 1:
-            return super().call_operator(op, args, kwargs, meta)
-
-        x_meta = meta.copy()
-        x_meta.data["input_qparams"] = {}
-        x_meta.data["output_qparams"] = {}
-
-        x = args[0]
-        x_unsqueezed_shape = list(x.data.shape[:-1]) + [1] + [x.data.shape[-1]]
-        x = super().call_operator(
-            exir_ops.edge.aten.view_copy.default,
-            (x, x_unsqueezed_shape),
-            {},
-            x_meta,
-            updated=True,
-        )
-
-        w_meta = meta.copy()
-        w_meta.data["input_qparams"] = {}
-        w_meta.data["output_qparams"] = {}
-
-        w = args[1]
-        w_unsqueezed_shape = list(w.data.shape[:-1]) + [1] + [w.data.shape[-1]]
-        w = super().call_operator(
-            exir_ops.edge.aten.view_copy.default,
-            (w, w_unsqueezed_shape),
-            {},
-            w_meta,
-            updated=True,
-        )
-
-        new_args = (
-            x,
-            w,
-            args[2],
-            [1] + args[3],  # stride
-            [0] + args[4],  # padding
-            [1] + args[5],  # dilation
-            args[6],
-            [0] + args[7],
-            args[8],
-        )
-        x = super().call_operator(
-            exir_ops.edge.aten.convolution.default, new_args, kwargs, meta, updated=True
-        )
-
-        x_squeezed_meta = meta.copy()
-        x_squeezed_meta.data["input_qparams"] = {}
-        x_squeezed_meta.data["output_qparams"] = {}
-        x_squeezed_shape = list(x.data.shape[:-2]) + [x.data.shape[-1]]
-        x = super().call_operator(
-            exir_ops.edge.aten.view_copy.default,
-            (x, x_squeezed_shape),
-            {},
-            x_squeezed_meta,
-            updated=True,
-        )
-
-        return x

--- a/backends/arm/_passes/convert_squeezes_to_view.py
+++ b/backends/arm/_passes/convert_squeezes_to_view.py
@@ -24,6 +24,7 @@ class ConvertSqueezesToViewPass(ArmOpTargetedPass):
 
     _passes_required_after: Set[Type[ExportPass]] = {FuseViewCopyTransformPass}
     target_ops = (
+        exir_ops.edge.aten.squeeze_copy.dim,
         exir_ops.edge.aten.squeeze_copy.dims,
         exir_ops.edge.aten.unsqueeze_copy.default,
     )

--- a/backends/transforms/test/test_convert_conv1d_to_conv2d_pass.py
+++ b/backends/transforms/test/test_convert_conv1d_to_conv2d_pass.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -146,6 +147,25 @@ def test_convert_stride_and_dilation():
     ]
 
     assert conv.args[3:6] == ([1, 3], [0, 2], [1, 2])
+
+
+def test_convert_dynamic_activation_shapes():
+    model = Conv1d().eval()
+    example_input = torch.randn(2, 2, 8)
+    batch = torch.export.Dim("batch", min=1, max=4)
+    length = torch.export.Dim("length", min=4, max=32)
+    edge = to_edge(
+        torch.export.export(
+            model,
+            (example_input,),
+            dynamic_shapes={"x": {0: batch, 2: length}},
+        )
+    ).exported_program()
+
+    converted = _transform(edge, ConvertConv1dToConv2dPass(edge))
+    runtime_input = torch.randn(3, 2, 17)
+
+    torch.testing.assert_close(converted.module()(runtime_input), model(runtime_input))
 
 
 def test_convert_transposed_conv1d():


### PR DESCRIPTION
### Summary
Replace the Arm-specific conversion logic with a thin wrapper around the shared transform while preserving Arm pass-order constraints.

Handle the squeeze overload emitted by the shared transform and add dynamic activation-shape coverage.

### Test plan
Tests added in PR

cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani