### PR TITLE
Fix channels-last any test under ATen

### DIFF
--- a/kernels/portable/cpu/util/test/reduce_test.cpp
+++ b/kernels/portable/cpu/util/test/reduce_test.cpp
@@ -15,6 +15,8 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+
 using namespace ::testing;
 using executorch::aten::ArrayRef;
 using executorch::aten::ScalarType;
@@ -443,8 +445,9 @@ TEST(ReduceUtilTest, ApplyOverDimListChannelsLast) {
   // here rather than written through, so an out-of-bounds index is reported
   // instead of corrupting memory.
   Tensor in = tf.zeros_channels_last({2, 2, 3, 3});
-  int64_t dim_array_023[3] = {0, 2, 3};
-  dim_list = optional<ArrayRef<int64_t>>(ArrayRef<int64_t>{dim_array_023, 3});
+  const std::array<int64_t, 3> dim_array_023{0, 2, 3};
+  dim_list = optional<ArrayRef<int64_t>>(
+      ArrayRef<int64_t>{dim_array_023.data(), dim_array_023.size()});
 
   const size_t numel = static_cast<size_t>(in.numel());
   std::vector<size_t> visits(numel, 0);

--- a/kernels/test/op_any_test.cpp
+++ b/kernels/test/op_any_test.cpp
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+
 using namespace ::testing;
 using executorch::aten::ArrayRef;
 using executorch::aten::ScalarType;
@@ -227,10 +229,13 @@ TEST_F(OpAnyOutTest, ChannelsLastMultiDimReduction) {
   Tensor in = tf.channels_last_like(tf.make({2, 2, 3, 3}, data));
 
   Tensor out = tf_bool.zeros_channels_last({1, 2, 1, 1});
-  int64_t dims[3] = {0, 2, 3};
-  op_any_dims_out(in, ArrayRef<int64_t>{dims, 3}, /*keepdim=*/true, out);
+  const std::array<int64_t, 3> dims{0, 2, 3};
+  op_any_dims_out(
+      in,
+      ArrayRef<int64_t>{dims.data(), dims.size()},
+      /*keepdim=*/true,
+      out);
 
-  Tensor expected =
-      tf_bool.channels_last_like(tf_bool.make({1, 2, 1, 1}, {false, true}));
+  Tensor expected = tf_bool.make_channels_last({1, 2, 1, 1}, {false, true});
   EXPECT_TENSOR_EQ(out, expected);
 }


### PR DESCRIPTION
## Summary

The channels-last `any` regression test aborts in the ATen variant because `TensorFactory<Bool>::channels_last_like` reads Bool storage as Byte. Build the expected tensor directly in channels-last order and replace the newly added C arrays with `std::array` to clear the associated lint failures.

## Test plan

- ATen and portable `op_any` tests
- `reduce_util` and `op_dequantize` tests
- Android ATen `ChannelsLastMultiDimReduction` test
- C++ lint