### PR TITLE
Recognise a buffer as mutated when the write is not its direct user

### DIFF
--- a/exir/backend/test/test_partitioner.py
+++ b/exir/backend/test/test_partitioner.py
@@ -620,6 +620,56 @@ class TestPartitioner(unittest.TestCase):
         ]
         self.assertEqual(len(copy_node), 1)
 
+    def test_buffer_mutated_indirectly_is_not_taken_for_constant(self):
+        """A buffer written a step after it is read still counts as mutated.
+
+        `tag_constant_data` used to decide by looking at a buffer's direct users for the
+        node that performs the mutation. A cache that is concatenated with its new values
+        and written back further down has something else as its user, so it was taken for
+        a constant and handed to the delegate as a buffer. A backend that compiles mutable
+        buffers into state then produced a model asking for state that the partitioner had
+        been told not to take over.
+        """
+
+        class IndirectlyMutated(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("cache", torch.zeros(1, 4))
+
+            def forward(self, x):
+                # The buffer's user is the cat, not the write.
+                joined = torch.cat([self.cache, x], dim=1)
+                self.cache.copy_(joined[:, -4:])
+                return joined.sum(1)
+
+        edge = exir.to_edge(
+            torch.export.export(IndirectlyMutated(), (torch.zeros(1, 2),), strict=True)
+        )
+        program = edge.exported_program()
+        signature = program.graph_signature
+        self.assertIn("cache", signature.buffers_to_mutate.values())
+
+        placeholder = next(
+            node
+            for node in program.graph.nodes
+            if node.op == "placeholder" and signature.inputs_to_buffers.get(node.name)
+        )
+        self.assertNotIn(
+            placeholder.name,
+            {user.name for user in placeholder.users} & set(signature.buffers_to_mutate),
+            "this test is only meaningful while the mutation is not a direct user",
+        )
+
+        for node in program.graph.nodes:
+            if node.op == "call_function":
+                node.meta["delegation_tag"] = "tag0"
+        tag_constant_data(program)
+
+        self.assertIsNone(
+            placeholder.meta.get("delegation_tag"),
+            "a mutated buffer must not be tagged as constant data",
+        )
+
     def test_buffer_mutation1(self):
         class TestModule(torch.nn.Module):
             def __init__(self):

--- a/exir/backend/utils.py
+++ b/exir/backend/utils.py
@@ -357,6 +357,16 @@ def tag_constant_data(edge_program: ExportedProgram) -> None:
     constants_map = sig.inputs_to_lifted_tensor_constants
     buffers_to_mutate = sig.buffers_to_mutate
 
+    # Which buffers the program says are mutated. Reading the targets rather than
+    # matching the mutating node's name against a buffer's direct users is what makes
+    # this hold for a buffer that is not mutated in one step: a cache that is first
+    # concatenated with the new values and written back further down the chain has
+    # something other than the mutation as its user, and used to be taken for a
+    # constant. It would then be handed to a delegate as a buffer, and a backend that
+    # compiles mutable buffers into state — Core ML does — produced a model asking for
+    # state that the runtime had been told, by take_over_mutable_buffer=False, not to
+    # provide.
+    mutated_targets = set(buffers_to_mutate.values())
     mutated_buffer = set()
     for node in edge_program.graph.nodes:
         if node.op == "placeholder" and (
@@ -364,6 +374,12 @@ def tag_constant_data(edge_program: ExportedProgram) -> None:
             or node.name in buffers_map
             or node.name in constants_map
         ):
+            if buffers_map.get(node.name) in mutated_targets:
+                logging.info(
+                    "The buffer node is a mutated buffer node, which is not constant."
+                )
+                mutated_buffer.add(node)
+                continue
             for node_user in node.users:
                 if node_user.name in buffers_to_mutate:
                     logging.info(

--- a/exir/backend/utils.py
+++ b/exir/backend/utils.py
@@ -342,31 +342,24 @@ def format_delegated_graph(graph_module: torch.fx.GraphModule) -> str:
     return graph_format_str
 
 
-def tag_constant_data(edge_program: ExportedProgram) -> None:
+def _mutated_buffer_placeholders(edge_program: ExportedProgram) -> Set[torch.fx.Node]:
     """
-    Util function for partitioners. This function tags the const/param/buffers nodes
-    whose users all belong within the same partition. This should be called after tagging all other nodes.
-    Any const/param/buffer which is used as input to a subgraph, will be tagged with the same tag as that
-    subgraph. Throw error when const/param/buffers is used across different partitions. That is the
-    underlying data will be owned by multiple delegates.
+    Placeholders whose data the program mutates, which must not be treated as
+    constant. A buffer is matched against the signature's mutation targets rather
+    than by looking through its users for the mutating node: a buffer that is not
+    written in one step — a cache first concatenated with new values and written
+    back further down the chain — has something other than the mutation as its
+    user, and would otherwise be taken for a constant and folded into a delegate
+    instead of remaining a mutable buffer input. Parameters and lifted constants
+    have no mutation target, so for them the direct-user check remains.
     """
-    # Cache signature lookups to avoid rebuilding dicts on every access.
     sig = edge_program.graph_signature
     params_map = sig.inputs_to_parameters
     buffers_map = sig.inputs_to_buffers
     constants_map = sig.inputs_to_lifted_tensor_constants
     buffers_to_mutate = sig.buffers_to_mutate
-
-    # Which buffers the program says are mutated. Reading the targets rather than
-    # matching the mutating node's name against a buffer's direct users is what makes
-    # this hold for a buffer that is not mutated in one step: a cache that is first
-    # concatenated with the new values and written back further down the chain has
-    # something other than the mutation as its user, and used to be taken for a
-    # constant. It would then be handed to a delegate as a buffer, and a backend that
-    # compiles mutable buffers into state — Core ML does — produced a model asking for
-    # state that the runtime had been told, by take_over_mutable_buffer=False, not to
-    # provide.
     mutated_targets = set(buffers_to_mutate.values())
+
     mutated_buffer = set()
     for node in edge_program.graph.nodes:
         if node.op == "placeholder" and (
@@ -386,6 +379,24 @@ def tag_constant_data(edge_program: ExportedProgram) -> None:
                         "The buffer node is a mutated buffer node, which is not constant."
                     )
                     mutated_buffer.add(node)
+    return mutated_buffer
+
+
+def tag_constant_data(edge_program: ExportedProgram) -> None:
+    """
+    Util function for partitioners. This function tags the const/param/buffers nodes
+    whose users all belong within the same partition. This should be called after tagging all other nodes.
+    Any const/param/buffer which is used as input to a subgraph, will be tagged with the same tag as that
+    subgraph. Throw error when const/param/buffers is used across different partitions. That is the
+    underlying data will be owned by multiple delegates.
+    """
+    # Cache signature lookups to avoid rebuilding dicts on every access.
+    sig = edge_program.graph_signature
+    params_map = sig.inputs_to_parameters
+    buffers_map = sig.inputs_to_buffers
+    constants_map = sig.inputs_to_lifted_tensor_constants
+
+    mutated_buffer = _mutated_buffer_placeholders(edge_program)
 
     for node in edge_program.graph.nodes:
         # go through const/param/buffer nodes, if all users of const/param/buffer nodes are partitioned then partition


### PR DESCRIPTION
Fixes #21855.

### What happens today

`tag_constant_data` decides whether a buffer is mutated by walking its users and looking
for the node that performs the write:

```python
for node_user in node.users:
    if node_user.name in buffers_to_mutate:
        mutated_buffer.add(node)
```

That holds only when the buffer is written in one step. A cache that is concatenated with
its new values and written back further down the chain has the `cat` as its user, not the
write, so it is taken for constant data and tagged into the delegate.

A backend that compiles mutable buffers into state then produces a model that asks the
runtime for state — after the partitioner was told, by `take_over_mutable_buffer=False`,
that this runtime has none. On Core ML that is a load which succeeds and an execute which
fails:

```
[backend_delegate.mm:435] [Core ML] Model execution failed
  The input feature for layers_7_conv_conv_state must be an MLState, but it was not.
[method.cpp:1530] CALL_DELEGATE execute failed at instruction 0: 0x32
```

Measured on LFM2.5-350M at partition time, ten of its twenty-two mutated buffers were
tagged and twelve were not. The twelve are the KV caches, written by `index_put` directly.
The ten are the short-convolution states, written a step later — and they are exactly the
buffers named in the error.

### The change

The signature already records which buffers are mutated, so match on the target rather
than on the mutating node's name. The direct-user walk stays for parameters and lifted
constants, which have no buffer target to match.

### Checking it

The new test in `test_partitioner.py` fails on `main` (`'tag0' is not None: a mutated
buffer must not be tagged as constant data`) and passes with the change.

End to end, `export_llm` with the Core ML backend now runs where it previously failed at
execute. LFM2.5-350M, c4w, macOS arm64:

| | |
|---|---|
| decode | 87 tok/s |
| `"The capital of France is"` | `" Paris"`, matching the unquantised model |

Argmax agrees with the original model on every position where the context determines the
token; the two that differ are the first, where the distribution after `<bos>` alone is
nearly flat.

I also checked that nothing else moves: the other buffer-mutation and constant-data tests
in that file pass, `take_over_mutable_buffer=True` behaves as before, and a mutable-buffer
model lowered to XNNPACK produces identical outputs with and without the change, cache
advancing correctly across calls.

One thing this does not fix, for completeness: a Qwen3.5-0.8B c4w build now runs but its
output is wrong, which looks like the 4-bit weights rather than the partitioning. I have
not shipped that one and will report it separately once I know which.

cc @JacobSzwejbka @angelayi @kimishpatel @YifanShenSZ @cymbalrush @metascroy @larryliu0820 @mergennachin @cccclai @helunwencser @jackzhxng @digantdesai