### PR TITLE
wheel buckification (#21980)

### DIFF
--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -100,7 +100,7 @@ def define_arm_tests():
         }
         if not runtime.is_oss and _ENABLE_VGF:
             test_env.update({
-                "MODEL_CONVERTER_PATH": "$(location fbsource//third-party/pypi/ai-ml-sdk-model-converter/0.9.0:model-converter-bin)",
+                "MODEL_CONVERTER_PATH": "$(location fbsource//third-party/pypi/ai-ml-sdk-model-converter/0.10.0:model-converter-bin)",
                 "MODEL_CONVERTER_LIB_DIR": "$(location fbsource//third-party/nvidia-nsight-systems:linux-x86_64)/host-linux-x64",
                 "LAVAPIPE_LIB_PATH": "$(location fbsource//third-party/mesa:vulkan_lvp)",
                 "EMULATION_LAYER_TENSOR_SO": "$(location fbsource//third-party/arm-ml-emulation-layer/v0.9.0/src:libVkLayer_Tensor)",


### PR DESCRIPTION
Summary:

# Buckification Summary

Buckified `ai-ml-sdk-model-converter==0.10.0`. This diff is part of the stack to import `ai-ml-sdk-model-converter==0.10.0`.

Signals should be green prior to landing.
If anything looks wrong, please look into the BUCK file and fix.
If failed, please refer to the [Manual Buckification Wiki page](https://www.internalfb.com/wiki/Third-Party_%40_Meta/third-party/Using_mgt_to_Import_Third-Party_Code/Python_%28PyPI%29/Manual_Buckification_of_Packages/) to fix the BUCK file.

Differential Revision: D115907757


