### PR TITLE
Add bf16 enable flag to LLM Config and thread through export (#21981)

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -459,6 +459,11 @@ def build_args_parser() -> argparse.ArgumentParser:
         help="Delegate more operators beyond DQLinear to the xnnpack backend. Requires -X or --xnnpack to be set.",
     )
     parser.add_argument(
+        "--xnnpack-enable-bf16",
+        action="store_true",
+        help="Delegate BF16 operators to XNNPACK. Requires runtime hardware support.",
+    )
+    parser.add_argument(
         "--use-torchao-kernels",
         action="store_true",
         help="Delegate tied-embedding and quantized linear ops to torchao kernels",
@@ -1523,11 +1528,17 @@ def _get_xnnpack_partitioners(llm_config: LlmConfig) -> Optional[List[Partitione
     # both xnnpack and xnnpack_extended_ops are enabled.
     if llm_config.backend.xnnpack.enabled:
         partitioners.append(
-            get_xnnpack_partitioner(dynamic_quant_only_partitioner=True)
+            get_xnnpack_partitioner(
+                dynamic_quant_only_partitioner=True,
+                enable_bf16=llm_config.backend.xnnpack.enable_bf16,
+            )
         )
         if llm_config.backend.xnnpack.extended_ops:
             partitioners.append(
-                get_xnnpack_partitioner(dynamic_quant_only_partitioner=False)
+                get_xnnpack_partitioner(
+                    dynamic_quant_only_partitioner=False,
+                    enable_bf16=llm_config.backend.xnnpack.enable_bf16,
+                )
             )
 
     return partitioners if partitioners else None
@@ -1713,6 +1724,7 @@ def _export_llama(llm_config: LlmConfig) -> LLMEdgeManager:  # noqa: C901
             generate_etrecord=llm_config.debug.generate_etrecord,
             verbose=llm_config.debug.verbose,
             gen_tag_fn=gen_tag_fn,
+            enable_bf16=llm_config.backend.xnnpack.enable_bf16,
         )
     elif llm_config.backend.openvino.enabled:
         builder = _to_edge_and_lower_llama_openvino(

--- a/examples/models/llama/tests/test_export_llama_lib.py
+++ b/examples/models/llama/tests/test_export_llama_lib.py
@@ -70,6 +70,24 @@ class ExportLlamaLibTest(unittest.TestCase):
         for op, _op_info in delegation_info.delegation_by_operator.items():
             self.assertTrue(op not in UNWANTED_OPS)
 
+    def test_bf16_xnnpack_delegates_linears_when_enabled(self):
+        parser = build_args_parser()
+        args = parser.parse_args([])
+        args.use_kv_cache = True
+        args.xnnpack = True
+        args.xnnpack_extended_ops = True
+        args.xnnpack_enable_bf16 = True
+        args.dtype_override = "bf16"
+
+        llm_config = LlmConfig.from_args(args)
+        builder = _export_llama(llm_config)
+        graph_module = builder.edge_manager.exported_program().graph_module
+        delegation_info = get_delegation_info(graph_module)
+
+        linear = delegation_info.delegation_by_operator["aten_linear_default"]
+        self.assertGreater(linear.delegated, 0)
+        self.assertEqual(linear.non_delegated, 0)
+
     @unittest.skipUnless(HAS_ARM_BACKEND, "ARM backend not available")
     def test_get_quantizer_and_quant_params_returns_tosa_quantizer(self):
         llm_config = LlmConfig()

--- a/extension/llm/export/config/llm_config.py
+++ b/extension/llm/export/config/llm_config.py
@@ -528,10 +528,13 @@ class XNNPackConfig:
     Attributes:
         enabled: :)
         extended_ops: Whether to match more types of ops to delegates to XNNPack.
+        enable_bf16: Whether to delegate BF16 ops to XNNPack. The target runtime
+            must have hardware support for XNNPACK's BF16 kernels.
     """
 
     enabled: bool = False
     extended_ops: bool = False
+    enable_bf16: bool = False
 
 
 class CoreMLQuantize(str, Enum):
@@ -812,6 +815,8 @@ class LlmConfig:
             llm_config.backend.xnnpack.enabled = args.xnnpack
         if hasattr(args, "xnnpack_extended_ops"):
             llm_config.backend.xnnpack.extended_ops = args.xnnpack_extended_ops
+        if hasattr(args, "xnnpack_enable_bf16"):
+            llm_config.backend.xnnpack.enable_bf16 = args.xnnpack_enable_bf16
 
         # CoreML
         if hasattr(args, "coreml"):

--- a/extension/llm/export/test/test_export_llm.py
+++ b/extension/llm/export/test/test_export_llm.py
@@ -72,6 +72,8 @@ quantization:
   pt2e_quantize: xnnpack_dynamic
   use_spin_quant: cuda
 backend:
+  xnnpack:
+    enable_bf16: true
   coreml:
     quantize: c4w
     compute_units: cpu_and_gpu
@@ -98,6 +100,7 @@ backend:
                 called_config.quantization.pt2e_quantize.value, "xnnpack_dynamic"
             )
             self.assertEqual(called_config.quantization.use_spin_quant.value, "cuda")
+            self.assertTrue(called_config.backend.xnnpack.enable_bf16)
             self.assertEqual(called_config.backend.coreml.quantize.value, "c4w")
             self.assertEqual(
                 called_config.backend.coreml.compute_units.value, "cpu_and_gpu"


### PR DESCRIPTION
Summary:

Previous attempt used dtype only, which can cause issues if using an older version of XNNPACK.

This way, consumer has to explicitly opt-in.

Differential Revision: D116814175


