### PR TITLE
Run a model through the OpenVINO delegate in the wheel tests

### DIFF
--- a/.ci/scripts/wheel/test_base.py
+++ b/.ci/scripts/wheel/test_base.py
@@ -8,8 +8,10 @@
 import os
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from functools import cache
+from pathlib import Path
 from typing import List
 
 
@@ -39,6 +41,70 @@ from examples.models import Backend, Model
 class ModelTest:
     model: Model
     backend: Backend
+
+
+def test_a_model_runs_through_the_openvino_delegate() -> None:
+    """Export a model to the OpenVINO delegate and run it, comparing against eager.
+
+    The checks elsewhere prove the delegate library ships, owns its symbols and registers
+    itself. None of that proves it computes: a delegate can register and then produce wrong
+    numbers or refuse the graph, and a registration check reports success either way.
+
+    The OpenVINO runtime is not part of the wheel. It comes from the openvino extra, so a
+    default install cannot run this and says so rather than passing quietly. Where the runtime
+    is present the export and the comparison are the point of the check, and a failure there
+    is a real one.
+    """
+    import torch
+    from executorch.exir import to_edge_transform_and_lower
+    from executorch.exir.backend.compile_spec_schema import CompileSpec
+    from executorch.runtime import Runtime
+
+    # One guard around the whole chain rather than around openvino alone. Importing the
+    # partitioner reaches the quantizer, which requires nncf, so a check that only looked for
+    # openvino would still fail on the import it cannot satisfy. Measured on a default install
+    # with openvino present and nncf absent.
+    try:
+        from executorch.backends.openvino.partitioner import OpenvinoPartitioner
+    except ImportError as error:
+        print(
+            f"SKIP: the OpenVINO export stack is not installed, so the delegate cannot "
+            f"execute here ({error}). The wheel ships the adapter only; the runtime and the "
+            f"quantizer dependencies come from backends/openvino/requirements.txt. This row "
+            f"still verifies the shipped library, its owner and its registration."
+        )
+        return
+
+    class Add(torch.nn.Module):
+        def forward(self, x, y):
+            return x + y
+
+    example = (torch.ones(2, 2), torch.ones(2, 2) * 2)
+    eager = Add()(*example)
+
+    exported = torch.export.export(Add(), example)
+    lowered = to_edge_transform_and_lower(
+        exported,
+        partitioner=[OpenvinoPartitioner([CompileSpec("device", b"CPU")])],
+    )
+    program = lowered.to_executorch()
+
+    with tempfile.TemporaryDirectory() as work_dir:
+        pte = Path(work_dir) / "add_openvino.pte"
+        pte.write_bytes(program.buffer)
+
+        method = Runtime.get().load_program(pte).load_method("forward")
+        actual = method.execute(list(example))[0]
+
+    difference = (actual - eager).abs().max().item()
+    assert difference == 0.0, (
+        f"the OpenVINO delegate ran but its output does not match eager: maximum absolute "
+        f"difference {difference:.3e}. The delegate computed something other than the model."
+    )
+    print(
+        f"\u2713 a model runs through the OpenVINO delegate and matches eager "
+        f"\u2014 max abs diff {difference:.3e}"
+    )
 
 
 def test_cmsis_nn_install():

--- a/.ci/scripts/wheel/test_linux.py
+++ b/.ci/scripts/wheel/test_linux.py
@@ -46,6 +46,10 @@ if __name__ == "__main__":
 
         test_base.test_cmsis_nn_install()
 
+        # Registration above proves the delegate loaded, not that it computes. This runs a
+        # model through it where the OpenVINO runtime is available and says why when it is not.
+        test_base.test_a_model_runs_through_the_openvino_delegate()
+
         # The wheel ships the runtime, the kernels, the delegate, the thread
         # pool and the profiler as separate shared libraries now, so check that
         # each has exactly one owner and that all of them are loadable.


### PR DESCRIPTION
The wheel tests assert that the OpenVINO delegate library ships, that it is the only
owner of its symbols, and that it registers itself. None of that proves it computes.
A delegate can register and then refuse the graph or return wrong numbers, and a
registration check reports success either way.

Export a small model through the OpenVINO partitioner, run it, and compare against
eager. On a runner with the export stack installed this is the check that fails when
the delegate stops working; elsewhere it skips and prints the missing dependency
rather than passing quietly.

The guard wraps the whole import chain rather than the OpenVINO runtime alone.
Measured on a default install: with openvino present and nncf absent, importing the
partitioner still fails, because it reaches the quantizer which requires nncf. A guard
that looked only for openvino would have skipped for a reason it did not name, or
failed on an import it could not satisfy.

Verified with the export stack installed: the delegate loads its runtime and the
output matches eager exactly, maximum absolute difference 0.000e+00. Verified again
with nncf removed: the check skips and names nncf as the missing piece.