### PR TITLE
Ship the Qualcomm delegate as a linkable component of the wheel

### DIFF
--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -2299,6 +2299,7 @@ def test_shipped_library_names_are_expected() -> None:
         "libextension_cuda",
         "libexecutorch_backend_xnnpack",
         "libexecutorch_backend_openvino",
+        "libexecutorch_backend_qnn",
         "libexecutorch_threadpool",
         "libexecutorch_etdump",
     )

--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -29,6 +29,7 @@ import importlib.metadata
 import importlib.util
 import json
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -143,6 +144,7 @@ else:
     _BUNDLED_THREADPOOL_SYMBOLS = ("pthreadpool_create", "cpuinfo_initialize")
 # The delegate's own entry points. A second definer means the delegate is compiled
 # into the Python extension as well, which would register it twice in one process.
+_QNN_BACKEND_SYMBOLS = ("QnnExecuTorchBackendRegister",)
 _OPENVINO_BACKEND_SYMBOLS = ("executorch::backends::openvino::OpenvinoBackend",)
 
 _BUNDLED_XNNPACK_SYMBOLS = ("xnn_create_runtime_v4",)
@@ -859,6 +861,11 @@ _REQUIRED_ON_A_CUDA_WHEEL = "cuda-wheel-only"
 
 # Marker for a row whose owner every Linux wheel carries and no macOS wheel does.
 _REQUIRED_ON_LINUX = "linux-only"
+# Narrower than the marker above on purpose. The Qualcomm SDK the delegate builds
+# against is published for Linux x86_64 only, so the aarch64 Linux wheels ship no such
+# library and demanding it there would fail a wheel that is correct. Reusing the
+# Linux-wide marker would do exactly that.
+_REQUIRED_ON_LINUX_X86 = "linux-x86-only"
 
 
 def _resolve_required(required):
@@ -867,6 +874,8 @@ def _resolve_required(required):
         return bool(_wheel_cuda_train())
     if required == _REQUIRED_ON_LINUX:
         return sys.platform == "linux"
+    if required == _REQUIRED_ON_LINUX_X86:
+        return sys.platform == "linux" and platform.machine() in ("x86_64", "amd64")
     return required
 
 
@@ -993,6 +1002,16 @@ _OWNED_COMPONENTS = (
         _OPENVINO_BACKEND_SYMBOLS,
         _library_file_name("libexecutorch_backend_openvino"),
         _REQUIRED_ON_LINUX,
+    ),
+    # Required on Linux x86_64 only, where the Qualcomm SDK the delegate builds against
+    # is published. A fixed False would pass a wheel that compiled the delegate back
+    # into the extension, since no library ships, the row skips, and one definer inside
+    # the extension is the monolithic layout a definer count cannot distinguish.
+    (
+        "Qualcomm delegate",
+        _QNN_BACKEND_SYMBOLS,
+        _library_file_name("libexecutorch_backend_qnn"),
+        _REQUIRED_ON_LINUX_X86,
     ),
 )
 

--- a/backends/qualcomm/CMakeLists.txt
+++ b/backends/qualcomm/CMakeLists.txt
@@ -262,9 +262,15 @@ target_link_libraries(
 if(EXECUTORCH_BUILD_SHARED)
   target_link_libraries(qnn_executorch_backend PRIVATE executorch_shared)
   executorch_target_link_shared_runtime(qnn_executorch_backend)
+  # Named like the other shipped delegates, so a consumer of the wheel finds it
+  # where it finds them and the package config needs no special case. Only the
+  # shared build renames: the device and direct-mode builds keep the original
+  # name, which their own tooling and the signing step expect.
+  set_target_properties(
+    qnn_executorch_backend PROPERTIES OUTPUT_NAME executorch_backend_qnn
+  )
   executorch_target_shared_runtime_path(
-    qnn_executorch_backend "backends/qualcomm"
-    "${CMAKE_INSTALL_LIBDIR}/executorch/backends/qualcomm"
+    qnn_executorch_backend "lib" "${CMAKE_INSTALL_LIBDIR}"
   )
 else()
   target_link_libraries(qnn_executorch_backend PRIVATE executorch_core)
@@ -336,12 +342,20 @@ add_subdirectory(
   ${QNN_EXECUTORCH_ROOT_DIR}/aot/wrappers
   ${CMAKE_CURRENT_BINARY_DIR}/qnn_executorch/wrappers
 )
+# The shared build installs beside the other delegates; every other build keeps
+# the original location, which the device tooling and the exporter's push list
+# expect.
+if(EXECUTORCH_BUILD_SHARED)
+  set(_qnn_install_dir ${CMAKE_INSTALL_LIBDIR})
+else()
+  set(_qnn_install_dir ${CMAKE_INSTALL_LIBDIR}/executorch/backends/qualcomm)
+endif()
 install(
   TARGETS qnn_executorch_backend
   EXPORT ExecuTorchTargets
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/executorch/backends/qualcomm
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/executorch/backends/qualcomm
-  RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/executorch/backends/qualcomm
+  LIBRARY DESTINATION ${_qnn_install_dir}
+  ARCHIVE DESTINATION ${_qnn_install_dir}
+  RUNTIME DESTINATION ${_qnn_install_dir}
 )
 
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES Hexagon)

--- a/setup.py
+++ b/setup.py
@@ -2367,12 +2367,19 @@ setup(
                 ),
                 # The stream helper this library needs ships in lib/ from here on,
                 # alongside the other components a C++ consumer links.
+                # The Qualcomm delegate, beside the others so a C++ consumer links it
+                # the same way. Only the adapter ships here: the Qualcomm runtime is
+                # resolved by name at run time and comes from the vendor SDK, which a
+                # user installs separately. The shared build renames the output to
+                # match its siblings, so this looks for that name.
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/backends/qualcomm/%BUILD_TYPE%/",
-                    src_name="qnn_executorch_backend",
-                    dst="executorch/backends/qualcomm/",
-                    is_dynamic_lib=True,
-                    dependent_cmake_flags=["EXECUTORCH_BUILD_QNN"],
+                    src_name="*executorch_backend_qnn" + _dynamic_lib_suffix(),
+                    dst="executorch/lib/",
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_QNN",
+                    ],
                 ),
                 BuiltExtension(
                     src_dir="backends/qualcomm/%BUILD_TYPE%/",

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -650,6 +650,12 @@ _executorch_define_component(backend_openvino executorch_backend_openvino)
 # while configuring.
 _executorch_define_component(backend_cuda executorch_backend_cuda)
 _executorch_define_component(extension_cuda executorch_extension_cuda)
+# The Qualcomm delegate, present only in a wheel whose build found the QNN SDK,
+# which today means Linux x86_64. Like the OpenVINO delegate it carries no
+# undefined vendor symbols, so it links without the SDK present and resolves the
+# SDK by name at run time. A consumer still needs the SDK installed to run a
+# model through it.
+_executorch_define_component(backend_qnn executorch_backend_qnn)
 
 # Find prebuilt _C.<EXT_SUFFIX>.so, the extension a custom-op project builds
 # against. Reported for that purpose only, not published as a target: see the


### PR DESCRIPTION
The wheel already carried the Qualcomm delegate, but a C++ application could not
link it. The package config published no target for it, so the only way to use it
from C++ was to build ExecuTorch from source.

Publish it as `executorch::backend_qnn`, the same shape as the XNNPACK, OpenVINO
and CUDA delegates. Two things had to change for that to need no special case.

The shared build now names the output `libexecutorch_backend_qnn.so` and installs it
into `lib/` beside the other delegates. Every other build keeps the original name and
location, because the device tooling, the signing step and the exporter's push list
all expect them there.

Without the rename the finder would have needed a per-component search directory, and
the component would have been the one delegate that did not look like the others. The
name was previously left alone on the belief that the exporter opens the library from
a copy shipped by the vendor SDK. That is not so: the signing script signs this
repository's own build output into the SDK tree, so the file under the SDK is ours.
Both the name and the location are therefore ours to choose, and the non-shared builds
that keep the old spelling are unaffected.

The ownership check gains the delegate, required on Linux x86_64 rather than on Linux
generally, since the SDK it builds against is published only for that architecture and
the aarch64 wheels ship no such library.

Verified against an installed wheel with the shipped config replaced and the library
staged as the rename produces it: a consumer asking for the component configures and
builds; a consumer asking only for the runtime and kernels is unaffected; and with the
library removed the component is not defined and the request fails while configuring
rather than at link time. The installed files were backed up first and restored after.