### PR TITLE
Catch a CUDA row built against the wrong minor version

### DIFF
--- a/install_utils.py
+++ b/install_utils.py
@@ -13,7 +13,7 @@ import shlex
 import shutil
 import subprocess
 import sys
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 # Supported CUDA versions - modify this to add/remove supported versions
 # Format: tuple of (major, minor) version numbers
@@ -209,14 +209,16 @@ def _cmake_args_from_env() -> List[str]:
 
 
 @functools.lru_cache(maxsize=1)
-def _detected_cuda_major() -> Optional[int]:
-    """The CUDA major version of the installed toolkit, or None if none is installed.
+def _detected_cuda_version() -> Optional[Tuple[int, int]]:
+    """The CUDA version of the installed toolkit, or None if none is installed.
 
     Kept separate from `_get_cuda_version` because the mismatch guard in the wheel build
-    needs the major regardless of whether the exact (major, minor) is listed in
+    needs whatever the toolkit reports regardless of whether that exact pair is listed in
     SUPPORTED_CUDA_VERSIONS. Reading through the validator caused the guard to see an
     empty detection for any unlisted minor (say 12.8), so a cu130 row built on a CUDA 12
-    toolkit produced a wheel with no error.
+    toolkit produced a wheel with no error. Both numbers are returned for the same
+    reason: a row names a train down to the minor, so comparing only majors let a cu132
+    row build against a 13.0 toolkit and declare a train it was not compiled for.
     """
     try:
         result = subprocess.run(
@@ -224,8 +226,14 @@ def _detected_cuda_major() -> Optional[int]:
         )
     except (subprocess.CalledProcessError, OSError):
         return None
-    match = re.search(r"release (\d+)\.\d+", result.stdout)
-    return int(match.group(1)) if match else None
+    match = re.search(r"release (\d+)\.(\d+)", result.stdout)
+    return (int(match.group(1)), int(match.group(2))) if match else None
+
+
+def _detected_cuda_major() -> Optional[int]:
+    """The CUDA major version of the installed toolkit, or None if none is installed."""
+    version = _detected_cuda_version()
+    return version[0] if version is not None else None
 
 
 def _extract_cmake_define(args: List[str], name: str) -> Optional[str]:

--- a/setup.py
+++ b/setup.py
@@ -333,15 +333,22 @@ def _cuda_train() -> str:
     # row spelled with an unsupported minor (say cu125) was classified CPU by the shell and
     # CUDA 12 here, and the wheel then declared CUDA runtime packages for a CPU build.
     digits = re.sub(r"[^0-9]", "", raw)
+    # The same rows as `trains` below, keeping both numbers rather than reducing to the
+    # major, so the guard can tell two rows of one major apart.
+    _CUDA_ROW_MINORS = {
+        f"{major}{minor}": (major, minor)
+        for major, minor in install_utils.SUPPORTED_CUDA_VERSIONS
+    }
     trains = {
         f"{major}{minor}": str(major)
         for major, minor in install_utils.SUPPORTED_CUDA_VERSIONS
     }
     requested = trains.get(digits, "")
 
-    # Read the toolkit major directly, without the (major, minor) validator, so the guard
+    # Read the toolkit version directly, without the (major, minor) validator, so the guard
     # below fires on any mismatch rather than only on the three listed pairs.
-    detected_major = install_utils._detected_cuda_major()
+    detected_version = install_utils._detected_cuda_version()
+    detected_major = detected_version[0] if detected_version is not None else None
     detected = (
         str(detected_major)
         if detected_major is not None and str(detected_major) in _CUDA_RUNTIME_PACKAGES
@@ -363,6 +370,26 @@ def _cuda_train() -> str:
                 "wheel would install and then fail to load. Install a matching toolkit "
                 "or build the row that matches this one."
             )
+        # The check above compares majors, which two rows of the same major share. A row
+        # names its train down to the minor, so cu130 and cu132 both reduce to 13 and a
+        # cu132 row built against a 13.0 toolkit passed. The device code and the version
+        # in the wheel's local label both come from the row, so that wheel claims a
+        # toolkit it was not compiled by. Compared here rather than folded above so the
+        # message can name both numbers.
+        if detected_version is not None and digits in _CUDA_ROW_MINORS:
+            requested_pair = _CUDA_ROW_MINORS[digits]
+            if detected_version != requested_pair:
+                requested_text = f"{requested_pair[0]}.{requested_pair[1]}"
+                detected_text = f"{detected_version[0]}.{detected_version[1]}"
+                raise RuntimeError(
+                    f"this build targets CUDA {requested_text} (from "
+                    f"{'CU_VERSION' if os.environ.get('CU_VERSION') else 'DESIRED_CUDA'}="
+                    f"{raw!r}) but the installed toolkit is CUDA {detected_text}. Those "
+                    "share a major version, so the runtime dependency this wheel declares "
+                    "is correct while the device code and the version recorded in its "
+                    "local label are not. Install a matching toolkit or build the row "
+                    "that matches this one."
+                )
         return requested
 
     if raw and not requested:


### PR DESCRIPTION
The wheel build refuses a row whose train disagrees with the installed toolkit, so a
wheel cannot declare one CUDA runtime and be compiled by another. The check compared
major versions only, and two of the published rows share a major: cu130 and cu132 both
reduce to 13. A cu132 row built on a 13.0 toolkit passed.

That combination is worth catching. The declared runtime dependency is per major, so it
stays correct, but the device code and the version recorded in the wheel's local label
both come from the row. The result installs, resolves its dependency, and claims a
toolkit it was not compiled by.

Read both numbers from the toolkit and compare the pair. The existing major-only
comparison stays, because it reports a different and blunter problem, and the new one
runs after it so its message can name both versions.

The detection helper keeps returning whatever the toolkit reports rather than reading
through the supported-version validator. That was already deliberate: going through the
validator made the guard blind to any unlisted minor, which is how a mismatched wheel
got built in the first place, and narrowing it now would reopen that hole.

Verified against every combination the published rows allow: a cu132 row on a 13.0
toolkit is now refused and names both versions; cu126 on 12.6, cu130 on 13.0 and cu132
on 13.2 are silent; a cu130 row on a 12.6 toolkit still fails on the major; and a build
with no toolkit installed is unaffected.