### PR TITLE
examples/arduino: write the platform layer against Arduino, not Zephyr

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -205,6 +205,10 @@ exclude_patterns = [
     # Top-level test and platform integration areas.
     'test/**',
     'zephyr/**',
+
+    # An ExecuTorch platform layer, same as runtime/platform/default above; the
+    # et_pal_* functions are called by the runtime, not from this file.
+    'examples/arduino/arduino_pal.cpp',
 ]
 command = [
     'python',

--- a/examples/arduino/ExecuTorch.h
+++ b/examples/arduino/ExecuTorch.h
@@ -22,6 +22,37 @@
 #define FLATBUFFERS_MAX_ALIGNMENT 1024
 #endif
 
+// ExecuTorch's C++ needs a compiler newer than some Arduino cores ship. The
+// Renesas cores are on arm-none-eabi-gcc 7.2.1 from 2017, which cannot resolve
+// EValue::to()'s overload set and fails with pages of template errors that say
+// nothing about the real cause. Fail with one line instead.
+//
+// Verified on GCC 12.2 (Zephyr SDK 0.16.8). 7.2.1 is known bad. The versions
+// in between are untested, so 9 is a conservative floor rather than a measured
+// one.
+//
+// library.properties still says architectures=zephyr, because every other
+// Arduino core currently ships arm-none-eabi-gcc 7. Advertising the library to
+// boards that cannot build it would trade a clear error for a wasted install.
+// This guard is for anyone who copies the library in by hand, and for whenever
+// a second core becomes usable.
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
+#error \
+    "ExecuTorch needs GCC 9 or newer. This board core ships an older \
+arm-none-eabi-gcc (Renesas cores are on 7.2.1 from 2017). Nothing in the \
+library can work around it; the core's toolchain has to be updated."
+#endif
+
+// Several Arduino cores define abs/min/max/round as macros in Arduino.h. They
+// expand inside c10's templates and inside <complex>, turning `inline T abs(T
+// a)` into a syntax error. The Zephyr core happens not to define abs, which is
+// the only reason this went unnoticed. Undefine them before the ExecuTorch
+// headers; std::abs, std::min and std::max are available to sketches instead.
+#undef abs
+#undef min
+#undef max
+#undef round
+
 #include <executorch/extension/data_loader/buffer_data_loader.h>
 #include <executorch/runtime/core/memory_allocator.h>
 #include <executorch/runtime/executor/method.h>

--- a/examples/arduino/arduino_pal.cpp
+++ b/examples/arduino/arduino_pal.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * ExecuTorch platform layer written against the Arduino API rather than any
+ * one board core. runtime/platform/default has a zephyr.cpp, but it calls
+ * k_uptime_ticks and k_malloc, which pins the library to the single Arduino
+ * core built on Zephyr. millis() and malloc() exist on all of them.
+ *
+ * The build script vendors this in place of the upstream backends and deletes
+ * them; shipping two would leave the choice to link order.
+ */
+
+#include <Arduino.h>
+#include <executorch/runtime/platform/compiler.h>
+#include <executorch/runtime/platform/platform.h>
+#include <cstdio>
+#include <cstdlib>
+
+/*
+ * Logging goes through a weak hook so the library does not have to know how a
+ * board exposes its console. On the Uno Q, Serial comes from
+ * Arduino_RouterBridge rather than the core, and a sketch may not want the
+ * runtime writing to it at all. Sketches that do implement this see the
+ * runtime's own diagnostics -- allocation shortfalls, operator mismatches --
+ * instead of a bare error code.
+ */
+extern "C" ET_WEAK void et_arduino_log(const char* message) {
+  (void)message;
+}
+
+void et_pal_init(void) {}
+
+ET_NORETURN void et_pal_abort(void) {
+  // No _Exit on a microcontroller: there is nothing to return to. Park with
+  // interrupts off so a watchdog resets the board rather than letting it run
+  // on in an undefined state.
+  noInterrupts();
+  while (true) {
+  }
+}
+
+et_timestamp_t et_pal_current_ticks(void) {
+  return static_cast<et_timestamp_t>(micros());
+}
+
+et_tick_ratio_t et_pal_ticks_to_ns_multiplier(void) {
+  // micros() ticks are microseconds, so nanoseconds are 1000/1 of them.
+  return {1000, 1};
+}
+
+void et_pal_emit_log_message(
+    ET_UNUSED et_timestamp_t timestamp,
+    et_pal_log_level_t level,
+    const char* filename,
+    ET_UNUSED const char* function,
+    size_t line,
+    const char* message,
+    ET_UNUSED size_t length) {
+  char buffer[256];
+  snprintf(
+      buffer,
+      sizeof(buffer),
+      "%c [ET:%s:%zu] %s",
+      static_cast<char>(level),
+      filename,
+      line,
+      message);
+  et_arduino_log(buffer);
+}
+
+void* et_pal_allocate(size_t size) {
+  return malloc(size);
+}
+
+void et_pal_free(void* ptr) {
+  free(ptr);
+}

--- a/examples/arduino/build_arduino_library.sh
+++ b/examples/arduino/build_arduino_library.sh
@@ -426,48 +426,15 @@ find "$OUT_DIR" -path "*test*" -name "*.cpp" -delete 2>/dev/null || true
 rm -f "$OUT_DIR/src/executorch/runtime/platform/default/android.cpp"
 rm -f "$OUT_DIR/src/executorch/runtime/platform/default/posix.cpp"
 rm -f "$OUT_DIR/src/executorch/runtime/platform/default/windows.cpp"
-# minimal.cpp and zephyr.cpp both define the et_pal_* backend, so shipping both
-# leaves the choice to link order. minimal's logger is an empty body and its
-# et_pal_allocate returns nullptr, which silently discards every ET_LOG.
+# Ship one platform layer, written against the Arduino API rather than any one
+# board core. Upstream's zephyr.cpp calls k_uptime_ticks and k_malloc, which
+# would pin the library to the single Arduino core built on Zephyr; minimal.cpp
+# has an empty logger and an allocator that returns nullptr. Both define the
+# same et_pal_* symbols, so keeping any of them alongside ours would leave the
+# choice to link order.
 rm -f "$OUT_DIR/src/executorch/runtime/platform/default/minimal.cpp"
-
-# zephyr.cpp logs through fprintf, and platform_stubs.c stubs fprintf out to
-# nothing, so runtime diagnostics never reach the user. Route them to a weak
-# hook a sketch can implement -- see the examples for a Serial implementation.
-ZEPHYR_PAL="$OUT_DIR/src/executorch/runtime/platform/default/zephyr.cpp"
-"$PYTHON" - "$ZEPHYR_PAL" << 'PATCH'
-import sys
-p = sys.argv[1]
-s = open(p).read()
-old = """  fprintf(
-      stderr,
-      "%c [executorch:%s:%zu %s()] %s\\n",
-      level,
-      filename,
-      line,
-      function,
-      message);"""
-new = """  char et_log_buf[256];
-  snprintf(
-      et_log_buf,
-      sizeof(et_log_buf),
-      "%c [ET:%s:%zu] %s",
-      (char)level,
-      filename,
-      line,
-      message);
-  et_arduino_log(et_log_buf);"""
-if old not in s:
-    sys.exit("ERROR: zephyr.cpp log call not found; the PAL changed upstream.")
-s = s.replace(old, new)
-s = s.replace(
-    "void et_pal_emit_log_message(",
-    'extern "C" __attribute__((weak)) void et_arduino_log(const char*) {}\n\n'
-    "void et_pal_emit_log_message(",
-    1,
-)
-open(p, "w").write(s)
-PATCH
+rm -f "$OUT_DIR/src/executorch/runtime/platform/default/zephyr.cpp"
+cp "$SCRIPT_DIR/arduino_pal.cpp" "$OUT_DIR/src/executorch/runtime/platform/default/"
 
 # Regenerate schema headers if flatc is available
 FLATC=""


### PR DESCRIPTION
## Summary

The library shipped `runtime/platform/default/zephyr.cpp`, which calls `k_uptime_ticks` and `k_malloc`. That pinned it to the one Arduino core built on Zephyr, for seven functions that all have Arduino equivalents. `arduino_pal.cpp` uses `micros()`, `malloc()` and `free()` instead, and routes logging through the weak `et_arduino_log` hook the examples already implement. Both upstream backends are dropped so link order cannot pick one.

It also corrects a timestamp bug: `zephyr.cpp` returned a tick ratio of `{1, 1}` with a comment admitting it did not know the units. `micros()` is microseconds, so `{1000, 1}` is right, and profiling numbers now mean something.

Two things had to be fixed before another core could work at all. The Renesas cores define `abs` as a macro in `Arduino.h`, which turns c10's `inline T abs(T a)` into a syntax error and takes `<complex>` with it — the Zephyr core happens not to, which is the only reason this was invisible. And those cores ship `arm-none-eabi-gcc 7.2.1` from 2017, which cannot resolve `EValue::to()`'s overload set. Nothing in the library fixes that, so it now fails with one line naming the toolchain rather than pages of template errors:

```
error: #error "ExecuTorch needs GCC 9 or newer. This board core ships an older
arm-none-eabi-gcc (Renesas cores are on 7.2.1 from 2017). Nothing in the
library can work around it; the core's toolchain has to be updated."
```

`architectures` stays `zephyr`. Every other Arduino core ships `arm-none-eabi-gcc 7` -- mbed_nano, renesas_uno and renesas_portenta all do -- so opening it up would advertise the library to boards that would every one of them stop at the `#error`, trading a clear message for a wasted install. Zephyr's SDK 0.16.8 is the only Arduino toolchain new enough today. It becomes `*` when that changes, and the guard is what makes that safe to do.

To be clear about what this does and does not do: **it adds no new board**. What it buys is the `abs` fix, the corrected tick ratio, one platform layer instead of two, and the blocker moving off our side and onto Arduino's toolchain.

GCC 12.2 is verified working and 7.2.1 verified failing. The floor of 9 is conservative rather than measured; 8 through 11 are untested.

## Test plan

Arduino Uno Q, core 0.90.0, `link_mode=static`:

```
HelloExecuTorch   473,368 flash (60%)    3,060 RAM (1%)
AddModel          508,556 flash (64%)   12,276 RAM (4%)
KeywordSpotting   564,352 flash (71%)   47,092 RAM (17%)
```

All three flashed and run. KeywordSpotting still detects every class, with scores identical to the `zephyr.cpp` build, so the swap is behaviourally inert:

```
yes 8.95  no -2.16  up -8.49  down -6.48  left -0.77  right -9.26
on -14.81  off -0.46  stop -5.40  go -7.10   ->  Detected: yes  CORRECT!
```

Compiler guard checked in both directions — Uno Q (GCC 12.2) compiles; Portenta C33 (GCC 7.2.1) stops at the `#error` above rather than emitting template failures.

`lintrunner` clean.

Authored with Claude Code (Opus 5).
