### PR TITLE
[ET-VK][runtime][ez] Add delegate node IDs to profiling metadata

### DIFF
--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -487,7 +487,7 @@ class GraphBuilder {
 
 #ifdef ET_EVENT_TRACER_ENABLED
       std::string operator_json =
-          make_operator_json(compute_graph_, op_name, args);
+          make_operator_json(compute_graph_, op_name, args, op_call->node_id());
       set_and_get_current_operator_json(operator_json);
       get_current_operator_count(true);
 #endif // ET_EVENT_TRACER_ENABLED

--- a/backends/vulkan/runtime/graph/Logging.cpp
+++ b/backends/vulkan/runtime/graph/Logging.cpp
@@ -83,9 +83,11 @@ std::string make_arg_json(ComputeGraph* const compute_graph, ValueRef arg) {
 std::string make_operator_json(
     ComputeGraph* const compute_graph,
     std::string& op_name,
-    std::vector<ValueRef>& args) {
+    std::vector<ValueRef>& args,
+    const uint32_t delegate_node_id) {
   std::stringstream ss;
-  ss << "\"name\": \"" << op_name << "\", \"args\": [";
+  ss << "\"name\": \"" << op_name
+     << "\", \"delegate_node_id\": " << delegate_node_id << ", \"args\": [";
   for (size_t i = 0; i < args.size(); ++i) {
     ss << make_arg_json(compute_graph, args[i]);
     if (i + 1 < args.size()) {

--- a/backends/vulkan/runtime/graph/Logging.h
+++ b/backends/vulkan/runtime/graph/Logging.h
@@ -61,6 +61,7 @@ std::string make_arg_json(ComputeGraph* const compute_graph, ValueRef arg);
 std::string make_operator_json(
     ComputeGraph* const compute_graph,
     std::string& op_name,
-    std::vector<ValueRef>& args);
+    std::vector<ValueRef>& args,
+    uint32_t delegate_node_id);
 
 } // namespace vkcompute


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #21994
* #21993

Include the serialized Vulkan OperatorCall node ID in event-tracing operator metadata. This provides a stable delegate identity that resolves directly through ETRecord mappings, enabling exact operator-instance profiling without relying on process-global dispatch order. Every dispatch emitted by a multi-dispatch operator inherits the same delegate node ID through the existing operator context.

Differential Revision: [D116509340](https://our.internmc.facebook.com/intern/diff/D116509340/)