### PR TITLE
examples/arduino: Reduce boiler plate code for new Arduino Sketches with helper class

### DIFF
--- a/examples/arduino/ETModel.h
+++ b/examples/arduino/ETModel.h
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * A small wrapper over the ExecuTorch runtime for sketches that just want to
+ * run a model.
+ *
+ * Loading a method by hand means asking the program for its method name,
+ * asking that for its metadata, counting its planned buffers, allocating a
+ * span array, sizing and allocating each buffer, wrapping them in a
+ * HierarchicalAllocator and pairing that with a MemoryAllocator in a
+ * MemoryManager. That is around sixty lines before any inference happens, and
+ * none of it is a decision the sketch author makes.
+ *
+ *   alignas(16) static uint8_t pool[8 * 1024];
+ *   static ETModel model(model_pte, sizeof(model_pte), pool, sizeof(pool));
+ *
+ *   if (!model.begin()) { Serial.println(model.error()); }
+ *   model.setInput(0, values, 3);
+ *   if (!model.run()) { Serial.println(model.error()); }
+ *   const float* out = model.output(0);
+ *
+ * error() returns a readable reason rather than a code, because a bare hex
+ * status is what makes these failures expensive to diagnose. The full runtime
+ * API stays available through program() and method() for anything this does
+ * not cover.
+ */
+
+#pragma once
+
+#include <ExecuTorch.h>
+#include <cstdint>
+#include <cstdio>
+#include <optional>
+#include <utility>
+
+class ETModel {
+ public:
+  // The model buffer and the pool must outlive this object, which on Arduino
+  // means both are normally static or global.
+  ETModel(
+      const uint8_t* model_data,
+      size_t model_size,
+      uint8_t* pool,
+      size_t pool_size)
+      : loader_(model_data, model_size),
+        allocator_(static_cast<uint32_t>(pool_size), pool) {}
+
+  // Loads the program and its first method. Call once, from setup().
+  bool begin() {
+    auto program = executorch::runtime::Program::load(&loader_);
+    if (!program.ok()) {
+      return fail("Program::load", static_cast<int>(program.error()));
+    }
+    program_.emplace(std::move(program.get()));
+
+    auto name = program_->get_method_name(0);
+    if (!name.ok()) {
+      return fail("get_method_name", static_cast<int>(name.error()));
+    }
+    method_name_ = *name;
+
+    auto meta = program_->method_meta(method_name_);
+    if (!meta.ok()) {
+      return fail("method_meta", static_cast<int>(meta.error()));
+    }
+
+    // Planned buffers hold the intermediate tensors the memory planner sized
+    // at export time. They come out of the same pool as the method itself.
+    const size_t count = meta->num_memory_planned_buffers();
+    auto* spans = static_cast<Span*>(allocator_.allocate(count * sizeof(Span)));
+    if (spans == nullptr) {
+      return fail("allocating the planned-buffer table", pool_hint());
+    }
+    for (size_t i = 0; i < count; i++) {
+      auto size = meta->memory_planned_buffer_size(i);
+      if (!size.ok()) {
+        return fail(
+            "memory_planned_buffer_size", static_cast<int>(size.error()));
+      }
+      auto bytes = static_cast<size_t>(size.get());
+      auto* buffer = static_cast<uint8_t*>(allocator_.allocate(bytes));
+      if (buffer == nullptr) {
+        return fail("allocating a planned buffer", pool_hint());
+      }
+      spans[i] = Span(buffer, bytes);
+    }
+
+    planned_.emplace(executorch::runtime::Span<Span>(spans, count));
+    manager_.emplace(&allocator_, &*planned_);
+
+    auto method = program_->load_method(method_name_, &*manager_);
+    if (!method.ok()) {
+      // Much the most common failure, and the pool is nearly always why.
+      return fail("load_method", static_cast<int>(method.error()));
+    }
+    method_.emplace(std::move(method.get()));
+    return true;
+  }
+
+  // Points input `index` at `data` without copying it, so `data` must stay
+  // alive across run(). Passing a `const` array in flash works for every model
+  // here, but an operator that writes to its input would be writing to
+  // read-only memory; copy into a RAM buffer first if that is a risk. Not
+  // copying is the right default on a board with this little RAM -- the
+  // keyword spotting input alone is 2 KB.
+  //
+  // The shape and dtype come from the model, so only the element count is
+  // checked against it.
+  bool setInput(size_t index, const float* data, size_t count) {
+    if (!method_) {
+      return fail("setInput before begin()", 0);
+    }
+    if (index >= kMaxInputs) {
+      return fail("input index above the built-in limit", kMaxInputs);
+    }
+    auto meta = program_->method_meta(method_name_);
+    auto info = meta->input_tensor_meta(index);
+    if (!info.ok()) {
+      return fail("input_tensor_meta", static_cast<int>(info.error()));
+    }
+    size_t expected = 1;
+    for (size_t d = 0; d < info->sizes().size(); d++) {
+      sizes_[index][d] = info->sizes()[d];
+      dim_order_[index][d] = info->dim_order()[d];
+      expected *= static_cast<size_t>(info->sizes()[d]);
+    }
+    if (expected != count) {
+      return fail(
+          "input element count does not match the model",
+          static_cast<int>(expected));
+    }
+    impls_[index].emplace(
+        info->scalar_type(),
+        static_cast<ssize_t>(info->sizes().size()),
+        sizes_[index],
+        const_cast<float*>(data),
+        dim_order_[index]);
+    tensors_[index].emplace(&*impls_[index]);
+    auto status = method_->set_input(
+        executorch::runtime::EValue(*tensors_[index]), index);
+    if (status != executorch::runtime::Error::Ok) {
+      return fail("set_input", static_cast<int>(status));
+    }
+    return true;
+  }
+
+  bool run() {
+    if (!method_) {
+      return fail("run before begin()", 0);
+    }
+    auto status = method_->execute();
+    if (status != executorch::runtime::Error::Ok) {
+      return fail("execute", static_cast<int>(status));
+    }
+    return true;
+  }
+
+  // Valid until the next run().
+  const float* output(size_t index = 0) {
+    const auto* tensor = outputTensor(index);
+    return tensor ? tensor->const_data_ptr<float>() : nullptr;
+  }
+
+  size_t outputCount(size_t index = 0) {
+    const auto* tensor = outputTensor(index);
+    return tensor ? static_cast<size_t>(tensor->numel()) : 0;
+  }
+
+  // Index of the largest output element, which is what a classifier wants.
+  int argmax(size_t index = 0) {
+    const float* values = output(index);
+    size_t count = outputCount(index);
+    if (values == nullptr || count == 0) {
+      return -1;
+    }
+    int best = 0;
+    for (size_t i = 1; i < count; i++) {
+      if (values[i] > values[best]) {
+        best = static_cast<int>(i);
+      }
+    }
+    return best;
+  }
+
+  // Why the last call returned false. Never null.
+  const char* error() const {
+    return error_[0] ? error_ : "no error";
+  }
+
+  // For anything this wrapper does not cover.
+  executorch::runtime::Program* program() {
+    return program_ ? &*program_ : nullptr;
+  }
+  executorch::runtime::Method* method() {
+    return method_ ? &*method_ : nullptr;
+  }
+
+ private:
+  using Span = executorch::runtime::Span<uint8_t>;
+  static constexpr size_t kMaxInputs = 4;
+  static constexpr size_t kMaxDims = 8;
+
+  const executorch::aten::Tensor* outputTensor(size_t index) {
+    if (!method_) {
+      fail("output before begin()", 0);
+      return nullptr;
+    }
+    auto status = method_->get_outputs(&output_, 1 + index);
+    if (status != executorch::runtime::Error::Ok || !output_.isTensor()) {
+      fail("get_outputs", static_cast<int>(status));
+      return nullptr;
+    }
+    out_tensor_.emplace(output_.toTensor());
+    return &*out_tensor_;
+  }
+
+  // A pool shortfall is by far the most likely cause of a null allocation, and
+  // the runtime already logged the exact numbers through et_arduino_log.
+  int pool_hint() const {
+    return static_cast<int>(allocator_.size());
+  }
+
+  bool fail(const char* what, int detail) {
+    snprintf(error_, sizeof(error_), "%s failed (0x%x)", what, detail);
+    return false;
+  }
+
+  executorch::extension::BufferDataLoader loader_;
+  executorch::runtime::MemoryAllocator allocator_;
+  std::optional<executorch::runtime::Program> program_;
+  std::optional<executorch::runtime::HierarchicalAllocator> planned_;
+  std::optional<executorch::runtime::MemoryManager> manager_;
+  std::optional<executorch::runtime::Method> method_;
+  const char* method_name_ = nullptr;
+
+  std::optional<executorch::aten::TensorImpl> impls_[kMaxInputs];
+  std::optional<executorch::aten::Tensor> tensors_[kMaxInputs];
+  int32_t sizes_[kMaxInputs][kMaxDims] = {};
+  uint8_t dim_order_[kMaxInputs][kMaxDims] = {};
+
+  executorch::runtime::EValue output_;
+  std::optional<executorch::aten::Tensor> out_tensor_;
+  char error_[96] = {};
+};

--- a/examples/arduino/build_arduino_library.sh
+++ b/examples/arduino/build_arduino_library.sh
@@ -67,7 +67,7 @@ mkdir -p "$OUT_DIR/src" "$OUT_DIR/examples"
 # 1. Copy library metadata, wrapper header, and stubs
 # ─────────────────────────────────────────────────────────
 cp "$SCRIPT_DIR/library.properties" "$OUT_DIR/"
-cp "$SCRIPT_DIR/ExecuTorch.h" "$OUT_DIR/src/"
+cp "$SCRIPT_DIR/ExecuTorch.h" "$SCRIPT_DIR/ETModel.h" "$OUT_DIR/src/"
 cp "$SCRIPT_DIR/platform_stubs.c" "$OUT_DIR/src/"
 cp -r "$SCRIPT_DIR/examples/"* "$OUT_DIR/examples/"
 # Training checkpoints are how a model is regenerated, not something the

--- a/examples/arduino/examples/AddModel/AddModel.ino
+++ b/examples/arduino/examples/AddModel/AddModel.ino
@@ -6,51 +6,38 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// AddModel — Verified end-to-end ExecuTorch inference on Arduino
+// AddModel — end-to-end ExecuTorch inference on Arduino
 //
-// Runs a simple add model (x + 1.0) using portable ops.
-// Input: [1.0, 2.0, 3.0] → Output: [2.0, 3.0, 4.0]
+// Runs x + 1.0 with portable ops: [1, 2, 3] -> [2, 3, 4]. No backend-specific
+// operators, so this works on any board the library supports.
 //
-// This example uses the native ExecuTorch C++ API with no backend-specific
-// ops — it works on any Arduino board that supports the ExecuTorch library.
-//
-// To generate model.h:
-//   1. Export the model:  python -c "
+// To regenerate model.h:
+//   1. Export:  python -c "
 //        import torch; from executorch.exir import to_edge; from torch.export import export
 //        class Add(torch.nn.Module):
 //            def forward(self, x): return x + 1.0
 //        et = to_edge(export(Add().eval(), (torch.tensor([1.,2.,3.]),))).to_executorch()
 //        with open('add.pte','wb') as f: f.write(bytes(et.buffer))"
-//   2. Convert to header: python examples/arduino/pte_to_header.py \
-//        -p add.pte -o model.h
+//   2. Convert:  python examples/arduino/pte_to_header.py -p add.pte -o model.h
 
-#include <ExecuTorch.h>
+#include <ETModel.h>
 #if __has_include("model.h")
 #include "model.h"
 #else
 #error "model.h not found. Export a .pte and convert with pte_to_header.py (see comment above)."
 #endif
-#include <utility>
 
-using executorch::aten::ScalarType;
-using executorch::extension::BufferDataLoader;
-using executorch::runtime::Error;
-using executorch::runtime::EValue;
-using executorch::runtime::HierarchicalAllocator;
-using executorch::runtime::MemoryAllocator;
-using executorch::runtime::MemoryManager;
-using executorch::runtime::Program;
-using executorch::runtime::Result;
-using executorch::runtime::Span;
-
+// Holds the method and every tensor it works on. Too small and begin() fails
+// saying so.
 alignas(16) static uint8_t method_pool[8 * 1024];
 
-static BufferDataLoader* g_loader = nullptr;
-static Program* g_prog = nullptr;
+static ETModel model(model_pte, sizeof(model_pte), method_pool,
+                     sizeof(method_pool));
 
-// ExecuTorch logs go to a weak hook so the library does not depend on Serial.
-// Without this the runtime's own diagnostics -- allocation failures, operator
-// mismatches -- are discarded, and errors surface only as bare hex codes.
+static const float kInput[] = {1.0f, 2.0f, 3.0f};
+
+// ExecuTorch's own diagnostics arrive here. Without this they are discarded
+// and failures show up as bare status codes.
 extern "C" void et_arduino_log(const char* msg) {
   Serial.print("ET| ");
   Serial.println(msg);
@@ -61,103 +48,30 @@ void setup() {
   delay(2000);
   Serial.println("=== ExecuTorch Add Model ===");
 
-  executorch::runtime::runtime_init();
-
-  static BufferDataLoader loader(model_pte, sizeof(model_pte));
-  g_loader = &loader;
-  Result<Program> program = Program::load(g_loader);
-  if (!program.ok()) {
-    Serial.print("FAIL: load 0x");
-    Serial.println((int)program.error(), HEX);
+  if (!model.begin()) {
+    Serial.println(model.error());
     while (1) delay(1000);
   }
   Serial.print("Model: ");
   Serial.print(sizeof(model_pte));
   Serial.println(" bytes");
-
-  static Program prog = std::move(program.get());
-  g_prog = &prog;
   Serial.println("Ready!");
 }
 
 void loop() {
-  auto name_result = g_prog->get_method_name(0);
-  if (!name_result.ok()) {
-    Serial.println("FAIL: no methods");
-    delay(5000);
-    return;
-  }
-  const char* name = *name_result;
-  auto meta = g_prog->method_meta(name);
-  if (!meta.ok()) {
-    Serial.println("FAIL: method_meta");
+  if (!model.setInput(0, kInput, 3) || !model.run()) {
+    Serial.println(model.error());
     delay(5000);
     return;
   }
 
-  MemoryAllocator ma(sizeof(method_pool), method_pool);
-  size_t np = meta->num_memory_planned_buffers();
-  Span<uint8_t>* sp = static_cast<Span<uint8_t>*>(
-      ma.allocate(np * sizeof(Span<uint8_t>)));
-  if (!sp) { Serial.println("FAIL: OOM spans"); delay(5000); return; }
-  for (size_t i = 0; i < np; i++) {
-    auto sz_r = meta->memory_planned_buffer_size(i);
-    if (!sz_r.ok()) { Serial.println("FAIL: planned buf size"); delay(5000); return; }
-    size_t sz = static_cast<size_t>(sz_r.get());
-    uint8_t* buf = static_cast<uint8_t*>(ma.allocate(sz));
-    if (!buf) { Serial.println("FAIL: OOM planned buf"); delay(5000); return; }
-    sp[i] = {buf, sz};
+  const float* out = model.output();
+  Serial.print("[1,2,3] + 1 = [");
+  for (size_t i = 0; i < model.outputCount(); i++) {
+    if (i > 0) Serial.print(", ");
+    Serial.print(out[i]);
   }
-  HierarchicalAllocator pl({sp, np});
-  MemoryManager mm(&ma, &pl);
-
-  auto method = g_prog->load_method(name, &mm);
-  if (!method.ok()) {
-    Serial.print("FAIL: load_method 0x");
-    Serial.println((int)method.error(), HEX);
-    delay(5000);
-    return;
-  }
-
-  float input_data[] = {1.0f, 2.0f, 3.0f};
-  int32_t sizes[] = {3};
-  uint8_t dim_order[] = {0};
-  executorch::aten::TensorImpl impl(
-      ScalarType::Float, 1, sizes, input_data, dim_order);
-  executorch::aten::Tensor input(&impl);
-  Error err = method->set_input(EValue(input), 0);
-  if (err != Error::Ok) {
-    Serial.print("FAIL: set_input 0x");
-    Serial.println((int)err, HEX);
-    delay(5000);
-    return;
-  }
-
-  Error status = method->execute();
-  if (status != Error::Ok) {
-    Serial.print("FAIL: execute 0x");
-    Serial.println((int)status, HEX);
-    delay(5000);
-    return;
-  }
-
-  EValue output;
-  err = method->get_outputs(&output, 1);
-  if (err != Error::Ok) {
-    Serial.print("FAIL: get_outputs 0x");
-    Serial.println((int)err, HEX);
-    delay(5000);
-    return;
-  }
-  if (output.isTensor()) {
-    auto tensor = output.toTensor();
-    Serial.print("[1,2,3] + 1 = [");
-    for (int i = 0; i < tensor.numel(); i++) {
-      if (i > 0) Serial.print(", ");
-      Serial.print(tensor.const_data_ptr<float>()[i]);
-    }
-    Serial.println("]");
-  }
+  Serial.println("]");
 
   delay(3000);
 }

--- a/examples/arduino/examples/KeywordSpotting/KeywordSpotting.ino
+++ b/examples/arduino/examples/KeywordSpotting/KeywordSpotting.ino
@@ -6,29 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// KeywordSpotting — DS-CNN inference with ExecuTorch + CMSIS-NN
+// KeywordSpotting — int8 DS-CNN through CMSIS-NN on a Cortex-M
 //
-// Runs a quantized DS-CNN model (MLPerf Tiny KWS benchmark) on real
-// MFCC audio features and prints the detected keyword.
+// Classifies one second of speech into twelve classes: ten keywords plus
+// silence and unknown. The input is a precomputed MFCC of a real recording
+// from Google Speech Commands, so the sketch needs no microphone.
 //
-// To test a different keyword, change the #include below:
-//   #include "mfcc_yes.h"   → detects "yes"
+// To regenerate model.h, see the keyword spotting section of ../../README.md.
 
-//   #include "mfcc_no.h"    → detects "no"
-//   #include "mfcc_stop.h"  → detects "stop"
-//   etc.
-//
-// To test your own audio:
-//   python generate_test_input.py --input my_audio.wav --output mfcc_custom.h
-//   Then: #include "mfcc_custom.h"
-//
-// Pre-generated MFCC files from Google Speech Commands v2:
-//   mfcc_yes.h, mfcc_no.h, mfcc_up.h, mfcc_down.h, mfcc_left.h,
-//   mfcc_right.h, mfcc_on.h, mfcc_off.h, mfcc_stop.h, mfcc_go.h
-
-#include <ExecuTorch.h>
+#include <ETModel.h>
 #include <cstring>
-#include <utility>
 #if __has_include("model.h")
 #include "model.h"
 #else
@@ -38,33 +25,23 @@
 // *** Change this line to test different keywords ***
 #include "mfcc_yes.h"
 
-
-using executorch::aten::ScalarType;
-using executorch::extension::BufferDataLoader;
-using executorch::runtime::Error;
-using executorch::runtime::EValue;
-using executorch::runtime::HierarchicalAllocator;
-using executorch::runtime::MemoryAllocator;
-using executorch::runtime::MemoryManager;
-using executorch::runtime::Program;
-using executorch::runtime::Result;
-using executorch::runtime::Span;
-
-static const char* kLabels[] = {
-    "silence", "unknown", "yes", "no", "up", "down",
-    "left", "right", "on", "off", "stop", "go"};
+static const char* kLabels[] = {"silence", "unknown", "yes",  "no",
+                                "up",      "down",    "left", "right",
+                                "on",      "off",     "stop", "go"};
 
 // 28 KB fails load_method with MemoryAllocationFailed (0x21), and going the
 // other way is not free: Zephyr takes a 32 KB stack and a 32 KB heap out of the
-// board's 128 KB before the sketch sees any, so an arena large enough to push
-// globals past ~64 KB overruns that reservation. arduino-cli's RAM figure does
-// not account for it and will look comfortable either way. See "Memory" in
+// board's RAM before the sketch sees any, so an arena large enough to push
+// globals past that reservation overruns it. arduino-cli's RAM figure does not
+// account for it and will look comfortable either way. See "Memory" in
 // ../../README.md.
 alignas(16) static uint8_t method_pool[40 * 1024];
 
-// ExecuTorch logs go to a weak hook so the library does not depend on Serial.
-// Without this the runtime's own diagnostics -- allocation failures, operator
-// mismatches -- are discarded, and errors surface only as bare hex codes.
+static ETModel model(model_pte, sizeof(model_pte), method_pool,
+                     sizeof(method_pool));
+
+// ExecuTorch's own diagnostics arrive here. Without this they are discarded
+// and failures show up as bare status codes.
 extern "C" void et_arduino_log(const char* msg) {
   Serial.print("ET| ");
   Serial.println(msg);
@@ -78,122 +55,32 @@ void setup() {
   Serial.print("Testing: ");
   Serial.println(test_label);
 
-  executorch::runtime::runtime_init();
-
-  static BufferDataLoader loader(model_pte, sizeof(model_pte));
-  auto program = Program::load(&loader);
-  if (!program.ok()) {
-    Serial.print("FAIL: load 0x");
-    Serial.println((int)program.error(), HEX);
+  if (!model.begin()) {
+    Serial.println(model.error());
     while (1) delay(1000);
   }
 
-  static Program prog = std::move(program.get());
-  auto name_r = prog.get_method_name(0);
-  if (!name_r.ok()) { Serial.println("FAIL: name"); while (1) delay(1000); }
-  auto meta = prog.method_meta(*name_r);
-  if (!meta.ok()) { Serial.println("FAIL: meta"); while (1) delay(1000); }
-
-  MemoryAllocator ma(sizeof(method_pool), method_pool);
-  size_t np = meta->num_memory_planned_buffers();
-  Span<uint8_t>* sp = static_cast<Span<uint8_t>*>(
-      ma.allocate(np * sizeof(Span<uint8_t>)));
-  if (!sp) { Serial.println("FAIL: OOM"); while (1) delay(1000); }
-  for (size_t i = 0; i < np; i++) {
-    auto sz_r = meta->memory_planned_buffer_size(i);
-    if (!sz_r.ok()) { Serial.println("FAIL: planned buf size"); while (1) delay(1000); }
-    size_t sz = static_cast<size_t>(sz_r.get());
-    uint8_t* buf = static_cast<uint8_t*>(ma.allocate(sz));
-    if (!buf) { Serial.println("FAIL: OOM buf"); while (1) delay(1000); }
-    sp[i] = {buf, sz};
-  }
-
-  HierarchicalAllocator pl({sp, np});
-  MemoryManager mm(&ma, &pl);
-
-  auto method = prog.load_method(*name_r, &mm);
-  if (!method.ok()) {
-    Serial.print("FAIL: method 0x");
-    Serial.println((int)method.error(), HEX);
+  if (!model.setInput(0, test_input, 490) || !model.run()) {
+    Serial.println(model.error());
     while (1) delay(1000);
   }
 
-  // Set input from MFCC data
-  auto imeta = meta->input_tensor_meta(0);
-  if (!imeta.ok()) { Serial.println("FAIL: imeta"); while (1) delay(1000); }
-  // Copy sizes/dim_order to local mutable arrays — TensorImpl stores pointers.
-  const size_t ndim = imeta->sizes().size();
-  if (ndim != 4 || imeta->dim_order().size() != 4) {
-    Serial.println("FAIL: expected 4D input"); while (1) delay(1000);
-  }
-  if (imeta->scalar_type() != ScalarType::Float) {
-    Serial.println("FAIL: expected float input"); while (1) delay(1000);
-  }
-  int32_t input_sizes[4];
-  for (size_t d = 0; d < imeta->sizes().size(); d++) input_sizes[d] = imeta->sizes()[d];
-  uint8_t input_dim_order[4];
-  for (size_t d = 0; d < imeta->dim_order().size(); d++) input_dim_order[d] = imeta->dim_order()[d];
-  static float input_data[490];
-  int numel = 1;
-  for (size_t d = 0; d < ndim; d++) numel *= input_sizes[d];
-  if (numel != 490) {
-    Serial.println("FAIL: expected 490 input elements"); while (1) delay(1000);
-  }
-  memcpy(input_data, test_input, sizeof(input_data));
-  executorch::aten::TensorImpl iimpl(
-      ScalarType::Float, imeta->sizes().size(),
-      input_sizes, input_data, input_dim_order);
-  executorch::aten::Tensor it(&iimpl);
-  Error serr = method->set_input(EValue(it), 0);
-  if (serr != Error::Ok) {
-    Serial.print("FAIL: input 0x");
-    Serial.println((int)serr, HEX);
-    while (1) delay(1000);
+  const float* scores = model.output();
+  for (size_t i = 0; i < model.outputCount(); i++) {
+    Serial.print("  [");
+    Serial.print(kLabels[i]);
+    Serial.print("]=");
+    Serial.println(scores[i]);
   }
 
-  // Run inference
-  Error status = method->execute();
-  if (status != Error::Ok) {
-    Serial.print("FAIL: execute 0x");
-    Serial.println((int)status, HEX);
-    while (1) delay(1000);
-  }
-
-  // Read and display results
-  EValue output;
-  Error oerr = method->get_outputs(&output, 1);
-  if (oerr != Error::Ok) {
-    Serial.print("FAIL: output 0x");
-    Serial.println((int)oerr, HEX);
-    while (1) delay(1000);
-  }
-
-  if (output.isTensor()) {
-    auto tensor = output.toTensor();
-    int best = 0;
-    float best_val = -1e9f;
-    for (int i = 0; i < 12 && i < tensor.numel(); i++) {
-      float val;
-      if (tensor.scalar_type() == ScalarType::Float)
-        val = tensor.const_data_ptr<float>()[i];
-      else
-        val = static_cast<float>(tensor.const_data_ptr<int8_t>()[i]);
-      Serial.print("  [");
-      Serial.print(kLabels[i]);
-      Serial.print("]=");
-      Serial.println(val);
-      if (val > best_val) { best_val = val; best = i; }
-    }
-
-    Serial.print("\n>>> Detected: ");
-    Serial.println(kLabels[best]);
-
-    if (strcmp(test_label, kLabels[best]) == 0) {
-      Serial.println(">>> CORRECT!");
-    } else {
-      Serial.print(">>> Expected: ");
-      Serial.println(test_label);
-    }
+  const char* detected = kLabels[model.argmax()];
+  Serial.print("\n>>> Detected: ");
+  Serial.println(detected);
+  if (strcmp(test_label, detected) == 0) {
+    Serial.println(">>> CORRECT!");
+  } else {
+    Serial.print(">>> Expected: ");
+    Serial.println(test_label);
   }
 
   Serial.println("=== DONE ===");


### PR DESCRIPTION
## Summary

Running a model meant asking the program for its method name, asking that for its metadata, counting planned buffers, allocating a span array, sizing and allocating each buffer, building a HierarchicalAllocator, pairing it with a MemoryAllocator in a MemoryManager, and only then loading the method. None of that is a decision the sketch author makes, and all of it had to be copied into every new sketch.

ETModel does it once. A sketch picks a pool size and calls begin, setInput, run and output. AddModel drops from 163 lines to 77 and KeywordSpotting from 204 to 91, and what went is the part nobody could reason about.

Errors come back as a sentence. model.error() says "load_method failed (0x21)" rather than the sketch printing a bare hex code, which together with the et_arduino_log hook means a pool shortfall now reads as a number and an explanation instead of a status nobody can look up.

It also fixes a real bug: AddModel called load_method inside loop(), rebuilding the method, the allocator and every planned buffer on each iteration.

HelloExecuTorch deliberately stays on the raw API. Something has to show what the wrapper is doing, and program() and method() are there for anything it does not cover -- float inputs, at most four of them, at most eight dimensions. setInput points at the caller's buffer rather than copying it, which saves 2 KB per input on a board with 128 KB but means a model that wrote to its input would write to the caller's memory. That is documented where it is easy to hit.

## Test
Verified on an Arduino Uno Q, core 0.90.0, link_mode=static: AddModel prints [2.00, 3.00, 4.00], KeywordSpotting still detects every keyword with unchanged scores, and HelloExecuTorch loads and reports one method.


