### PR TITLE
Use S3 for CI Artifacts

### DIFF
--- a/.github/workflows/_test_backend.yml
+++ b/.github/workflows/_test_backend.yml
@@ -65,10 +65,14 @@ jobs:
       submodules: recursive
       timeout: ${{ inputs.timeout }}
       upload-artifact: test-report-${{ inputs.backend }}-${{ matrix.flow }}-${{ matrix.suite }}
+      upload-artifact-to-s3: true
       script: |
         set -eux
 
-        source .ci/scripts/test_backend.sh "${{ matrix.suite }}" "${{ matrix.flow }}" "${RUNNER_ARTIFACT_DIR}"
+        # Namespace per matrix cell: S3 uploads share one run-level prefix.
+        ARTIFACT_SUBDIR="${RUNNER_ARTIFACT_DIR}/test-report-${{ inputs.backend }}-${{ matrix.flow }}-${{ matrix.suite }}"
+        mkdir -p "${ARTIFACT_SUBDIR}"
+        source .ci/scripts/test_backend.sh "${{ matrix.suite }}" "${{ matrix.flow }}" "${ARTIFACT_SUBDIR}"
 
   package-golden-artifacts:
     if: ${{ inputs.run-linux }}
@@ -76,10 +80,11 @@ jobs:
     runs-on: linux.2xlarge
     steps:
       - name: Download model test artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: test-report-${{ inputs.backend }}-*-models
-          path: downloaded/
+        run: |
+          set -eux
+          aws s3 cp --recursive \
+            "s3://gha-artifacts/${{ github.repository }}/${{ github.run_id }}/artifacts/" downloaded/ \
+            --exclude "*" --include "test-report-${{ inputs.backend }}-*-models/*"
 
       - name: Package golden artifacts
         run: |
@@ -106,13 +111,6 @@ jobs:
           else
             echo "No golden artifacts found."
           fi
-
-      - name: Upload combined golden artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: golden-artifacts-${{ inputs.backend }}
-          path: golden_artifacts_*.zip
-          if-no-files-found: ignore
 
       - name: Upload golden artifacts to S3
         uses: seemethere/upload-artifact-s3@v5
@@ -143,10 +141,14 @@ jobs:
       submodules: recursive
       timeout: ${{ inputs.timeout }}
       upload-artifact: test-report-${{ inputs.backend }}-${{ matrix.flow }}-${{ matrix.suite }}
+      upload-artifact-to-s3: true
       script: |
         set -eux
 
         # This is needed to get the prebuilt PyTorch wheel from S3
         ${CONDA_RUN} --no-capture-output pip install awscli==1.37.21
 
-        source .ci/scripts/test_backend.sh "${{ matrix.suite }}" "${{ matrix.flow }}" "${RUNNER_ARTIFACT_DIR}"
+        # Namespace per matrix cell: S3 uploads share one run-level prefix.
+        ARTIFACT_SUBDIR="${RUNNER_ARTIFACT_DIR}/test-report-${{ inputs.backend }}-${{ matrix.flow }}-${{ matrix.suite }}"
+        mkdir -p "${ARTIFACT_SUBDIR}"
+        source .ci/scripts/test_backend.sh "${{ matrix.suite }}" "${{ matrix.flow }}" "${ARTIFACT_SUBDIR}"

--- a/.github/workflows/cuda-perf.yml
+++ b/.github/workflows/cuda-perf.yml
@@ -124,6 +124,9 @@ jobs:
   export-models:
     name: export-models
     needs: set-parameters
+    # Skip fork PRs: they get no OIDC token, so the OSDC runner cannot
+    # assume the role that uploads to S3 (and the HF secret is unavailable).
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
     permissions:
       id-token: write
@@ -141,6 +144,7 @@ jobs:
       use-custom-docker-registry: false
       submodules: recursive
       upload-artifact: model-${{ matrix.model_safe }}-${{ matrix.quant }}
+      upload-artifact-to-s3: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         set -eux
@@ -178,9 +182,13 @@ jobs:
 
         bash .ci/scripts/export_model_artifact.sh cuda "${{ matrix.model }}" "${{ matrix.quant }}" "$OUTPUT_DIR"
 
-        # Move artifacts to RUNNER_ARTIFACT_DIR for upload
-        mv "$OUTPUT_DIR"/* "${RUNNER_ARTIFACT_DIR}/"
-        ls -lah "${RUNNER_ARTIFACT_DIR}"
+        # Move artifacts to RUNNER_ARTIFACT_DIR for upload, namespaced per
+        # matrix cell: S3 uploads share one run-level prefix, so same-named
+        # files (model.pte) would otherwise collide.
+        ARTIFACT_SUBDIR="${RUNNER_ARTIFACT_DIR}/model-${{ matrix.model_safe }}-${{ matrix.quant }}"
+        mkdir -p "${ARTIFACT_SUBDIR}"
+        mv "$OUTPUT_DIR"/* "${ARTIFACT_SUBDIR}/"
+        ls -lah "${ARTIFACT_SUBDIR}"
         echo "::endgroup::"
 
   benchmark-cuda:
@@ -195,9 +203,11 @@ jobs:
     # cuda running even when some export-models matrix cells fail —
     # but only if the gate itself is open. Without the explicit gate
     # here, `always()` would fire benchmark-cuda even when set-
-    # parameters was gated out.
+    # parameters was gated out. Fork PRs are skipped like export-models:
+    # there is nothing in S3 for them to download.
     if: |
       always() &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request') &&
       (
         contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda-perf.yml') ||
         contains(needs.changed-files.outputs.changed-files, '.ci/scripts/cuda_benchmark.py') ||
@@ -220,7 +230,6 @@ jobs:
       gpu-arch-version: "13.0"
       use-custom-docker-registry: false
       submodules: recursive
-      download-artifact: model-${{ matrix.model_safe }}-${{ matrix.quant }}
       upload-artifact: results-${{ matrix.model_safe }}-${{ matrix.quant }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
@@ -245,39 +254,19 @@ jobs:
         pip list
         echo "::endgroup::"
 
-        echo "::group::Prepare model artifacts"
+        echo "::group::Download model artifacts from S3"
+        # Anonymous HTTPS from the public-read bucket, so the benchmark
+        # image needs no AWS CLI.
+        S3_URL="https://gha-artifacts.s3.amazonaws.com/${{ github.repository }}/${{ github.run_id }}/artifacts/model-${{ matrix.model_safe }}-${{ matrix.quant }}"
         mkdir -p model_artifacts
-        cp "${RUNNER_ARTIFACT_DIR}/model.pte" model_artifacts/model.pte
-        cp "${RUNNER_ARTIFACT_DIR}/aoti_cuda_blob.ptd" model_artifacts/aoti_cuda_blob.ptd
-
-        # Copy additional files if they exist
-        if [ -f "${RUNNER_ARTIFACT_DIR}/voxtral_preprocessor.pte" ]; then
-          cp "${RUNNER_ARTIFACT_DIR}/voxtral_preprocessor.pte" model_artifacts/
-        fi
-        if [ -f "${RUNNER_ARTIFACT_DIR}/whisper_preprocessor.pte" ]; then
-          cp "${RUNNER_ARTIFACT_DIR}/whisper_preprocessor.pte" model_artifacts/
-        fi
-        if [ -f "${RUNNER_ARTIFACT_DIR}/tekken.json" ]; then
-          cp "${RUNNER_ARTIFACT_DIR}/tekken.json" model_artifacts/
-        fi
-        if [ -f "${RUNNER_ARTIFACT_DIR}/poem.wav" ]; then
-          cp "${RUNNER_ARTIFACT_DIR}/poem.wav" model_artifacts/
-        fi
-        if [ -f "${RUNNER_ARTIFACT_DIR}/output.wav" ]; then
-          cp "${RUNNER_ARTIFACT_DIR}/output.wav" model_artifacts/
-        fi
-        if [ -f "${RUNNER_ARTIFACT_DIR}/tokenizer.model" ]; then
-          cp "${RUNNER_ARTIFACT_DIR}/tokenizer.model" model_artifacts/
-        fi
-        if [ -f "${RUNNER_ARTIFACT_DIR}/test_audio.wav" ]; then
-          cp "${RUNNER_ARTIFACT_DIR}/test_audio.wav" model_artifacts/
-        fi
-        # Copy tokenizer files
-        for file in tokenizer.json tokenizer_config.json special_tokens_map.json; do
-          if [ -f "${RUNNER_ARTIFACT_DIR}/$file" ]; then
-            cp "${RUNNER_ARTIFACT_DIR}/$file" model_artifacts/
-          fi
+        pushd model_artifacts
+        curl -fsSL --retry 3 -O "${S3_URL}/model.pte"
+        curl -fsSL --retry 3 -O "${S3_URL}/aoti_cuda_blob.ptd"
+        # Optional per-model files (preprocessors, tokenizers, test audio)
+        for file in voxtral_preprocessor.pte whisper_preprocessor.pte tekken.json poem.wav output.wav tokenizer.model test_audio.wav tokenizer.json tokenizer_config.json special_tokens_map.json; do
+          curl -fsSL --retry 3 -O "${S3_URL}/${file}" || true
         done
+        popd
 
         ls -lah model_artifacts/
         echo "::endgroup::"
@@ -377,11 +366,7 @@ jobs:
         }
         EOF
 
-        # Only copy benchmark results to RUNNER_ARTIFACT_DIR for upload (not the entire model)
-        # First, clean up the downloaded model artifacts from RUNNER_ARTIFACT_DIR
-        rm -rf "${RUNNER_ARTIFACT_DIR}"/*
-
-        # Then copy only the benchmark result JSON files
+        # Stage only the benchmark result JSON files for upload
         cp "$RESULTS_DIR"/*.json "${RUNNER_ARTIFACT_DIR}/"
         echo "Benchmark results prepared for upload:"
         ls -lah "${RUNNER_ARTIFACT_DIR}"
@@ -396,6 +381,7 @@ jobs:
     # closed (no benchmarks ran).
     if: |
       always() &&
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request') &&
       (
         contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda-perf.yml') ||
         contains(needs.changed-files.outputs.changed-files, '.ci/scripts/cuda_benchmark.py') ||

--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -95,6 +95,7 @@ jobs:
       docker-image: ci-image:executorch-ubuntu-22.04-cuda-windows
       submodules: recursive
       upload-artifact: ${{ matrix.model_repo }}-${{ matrix.model_name }}-cuda-windows-${{ matrix.quant }}
+      upload-artifact-to-s3: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         set -eux
@@ -142,7 +143,11 @@ jobs:
         if [ "${{ matrix.model_name }}" = "Voxtral-Mini-4B-Realtime-2602" ]; then
           VR_MODE="vr-offline"
         fi
-        source .ci/scripts/export_model_artifact.sh cuda-windows "${{ matrix.model_repo }}/${{ matrix.model_name }}" "${{ matrix.quant }}" "${RUNNER_ARTIFACT_DIR}" "${VR_MODE}"
+        # Namespace exports per matrix cell: S3 uploads share one run-level
+        # prefix, so same-named files (model.pte) would otherwise collide.
+        ARTIFACT_SUBDIR="${RUNNER_ARTIFACT_DIR}/${{ matrix.model_repo }}-${{ matrix.model_name }}-cuda-windows-${{ matrix.quant }}"
+        mkdir -p "${ARTIFACT_SUBDIR}"
+        source .ci/scripts/export_model_artifact.sh cuda-windows "${{ matrix.model_repo }}/${{ matrix.model_name }}" "${{ matrix.quant }}" "${ARTIFACT_SUBDIR}" "${VR_MODE}"
 
   test-model-cuda-windows-e2e:
     name: test-model-cuda-windows-e2e
@@ -194,7 +199,6 @@ jobs:
       runner: windows.g5.4xlarge.nvidia.gpu
       gpu-arch-type: cuda
       gpu-arch-version: "13.0"
-      download-artifact: ${{ matrix.model_repo }}-${{ matrix.model_name }}-cuda-windows-${{ matrix.quant }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         git config --global http.sslBackend openssl
@@ -213,8 +217,9 @@ jobs:
           .ci/scripts/setup-windows.ps1
           \$artifactDir = \$env:RUNNER_ARTIFACT_DIR
           if ([string]::IsNullOrWhiteSpace(\$artifactDir)) {
-            throw 'RUNNER_ARTIFACT_DIR is empty. Ensure download-artifact is configured for windows_job.yml.'
+            throw 'RUNNER_ARTIFACT_DIR is not set by windows_job.yml.'
           }
+          aws s3 cp --recursive 's3://gha-artifacts/${{ github.repository }}/${{ github.run_id }}/artifacts/${{ matrix.model_repo }}-${{ matrix.model_name }}-cuda-windows-${{ matrix.quant }}/' \$artifactDir
 
           .ci/scripts/test_model_e2e_windows.ps1 -Device cuda-windows -HfModel '${{ matrix.model_repo }}/${{ matrix.model_name }}' -QuantName '${{ matrix.quant }}' -ModelDir \$artifactDir -ExpectedCudaVersion '13.0'
         }"

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -513,6 +513,7 @@ jobs:
       use-custom-docker-registry: false
       submodules: recursive
       upload-artifact: ${{ matrix.model.repo }}-${{ matrix.model.name }}-cuda-${{ matrix.quant }}
+      upload-artifact-to-s3: true
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         set -eux
@@ -547,10 +548,12 @@ jobs:
           echo "::endgroup::"
         fi
 
+        # Namespace exports per matrix cell: S3 uploads share one run-level
+        # prefix, so same-named files (model.pte) would otherwise collide.
         RUN_EXPORT=1 source .ci/scripts/test_model_e2e.sh cuda \
           "${{ matrix.model.repo }}/${{ matrix.model.name }}" \
           "${{ matrix.quant }}" \
-          "${RUNNER_ARTIFACT_DIR}"
+          "${RUNNER_ARTIFACT_DIR}/${{ matrix.model.repo }}-${{ matrix.model.name }}-cuda-${{ matrix.quant }}"
 
   test-muse-glimmer-cuda-e2e:
     name: test-muse-glimmer-cuda-e2e-${{ matrix.variant }}-${{ matrix.mode }}
@@ -660,7 +663,6 @@ jobs:
     with:
       timeout: 120
       secrets-env: EXECUTORCH_HF_TOKEN
-      download-artifact: ${{ matrix.artifact }}
       runner: linux.g5.4xlarge.nvidia.gpu
       gpu-arch-type: cuda
       gpu-arch-version: "13.0"
@@ -704,6 +706,14 @@ jobs:
         OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
         pip install "optimum~=2.0.0" "transformers==5.0.0rc1"
         pip install --no-deps git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}
+        echo "::endgroup::"
+
+        echo "::group::Download model artifacts from S3"
+        pip install awscli==1.37.21
+        aws s3 cp --recursive \
+          "s3://gha-artifacts/${{ github.repository }}/${{ github.run_id }}/artifacts/${{ matrix.artifact }}/" \
+          "${RUNNER_ARTIFACT_DIR}/"
+        ls -lah "${RUNNER_ARTIFACT_DIR}"
         echo "::endgroup::"
 
         echo "::group::Test CUDA Model: ${{ matrix.model }} ${{ matrix.quantize }}"

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -252,6 +252,7 @@ jobs:
       timeout: 90
       secrets-env: EXECUTORCH_HF_TOKEN
       upload-artifact: ${{ matrix.model.repo }}-${{ matrix.model.name }}-metal-${{ matrix.quant }}
+      upload-artifact-to-s3: true
       script: |
         set -eux
 
@@ -284,7 +285,11 @@ jobs:
         if [ "${{ matrix.model.name }}" = "Voxtral-Mini-4B-Realtime-2602" ]; then
           VR_MODE="vr-offline"
         fi
-        ${CONDA_RUN} bash .ci/scripts/export_model_artifact.sh metal "${{ matrix.model.repo }}/${{ matrix.model.name }}" "${{ matrix.quant }}" "${RUNNER_ARTIFACT_DIR}" "${VR_MODE}"
+        # Namespace exports per matrix cell: S3 uploads share one run-level
+        # prefix, so same-named files (model.pte) would otherwise collide.
+        ARTIFACT_SUBDIR="${RUNNER_ARTIFACT_DIR}/${{ matrix.model.repo }}-${{ matrix.model.name }}-metal-${{ matrix.quant }}"
+        mkdir -p "${ARTIFACT_SUBDIR}"
+        ${CONDA_RUN} bash .ci/scripts/export_model_artifact.sh metal "${{ matrix.model.repo }}/${{ matrix.model.name }}" "${{ matrix.quant }}" "${ARTIFACT_SUBDIR}" "${VR_MODE}"
 
   test-model-metal-e2e:
     name: test-model-metal-e2e
@@ -335,9 +340,16 @@ jobs:
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90
-      download-artifact: ${{ matrix.model.repo }}-${{ matrix.model.name }}-metal-${{ matrix.quant }}
       script: |
         set -eux
+
+        echo "::group::Download model artifacts from S3"
+        ${CONDA_RUN} pip install awscli==1.37.21
+        ${CONDA_RUN} aws s3 cp --recursive \
+          "s3://gha-artifacts/${{ github.repository }}/${{ github.run_id }}/artifacts/${{ matrix.model.repo }}-${{ matrix.model.name }}-metal-${{ matrix.quant }}/" \
+          "${RUNNER_ARTIFACT_DIR}/"
+        ls -lah "${RUNNER_ARTIFACT_DIR}"
+        echo "::endgroup::"
 
         echo "::group::Print machine info"
         uname -a


### PR DESCRIPTION
### Summary

We saw a sudden increase in GitHub Action Storage cost a few months ago. This has now ballooned to the biggest expense item in our GitHub bill. So, to reduce this cost we should:

1) Use S3 for storage since it is cheaper. TBD on how much we'll save here
2) Reduce the storage retention period from 90 days to 14-30 days https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization

### Caveat

This now prevents certain jobs from running on forked PRs, specified in the workflows.

### Test plan

CI