### PR TITLE
Fix is_asymmetric parsing in get_quant_embedding_transform (#21997)

### DIFF
--- a/examples/models/llama/source_transformation/quantize.py
+++ b/examples/models/llama/source_transformation/quantize.py
@@ -791,13 +791,14 @@ def get_quant_embedding_transform(
             is_asymmetric = True
         else:
             bitwidth, group_size, is_asymmetric = quant_args
+            # bool("false") is True, so the third field has to be parsed as text.
+            is_asymmetric = is_asymmetric.strip().lower() not in ("false", "0", "no")
 
         if group_size in ["none", "None", "0"]:
             group_size = 0
 
         group_size = int(group_size)
         bitwidth = int(bitwidth)
-        is_asymmetric = bool(is_asymmetric)
         weight_dtype = getattr(torch, f"int{bitwidth}")
         granularity = PerAxis(0) if group_size == 0 else PerGroup(group_size)
         mapping_type = (


### PR DESCRIPTION
Summary:

The third field of a `torchao:<bits>,<group_size>,<is_asymmetric>` embedding-quantization spec has never worked. `get_quant_embedding_transform` unpacked it as a string and then ran it through `bool()`:

```python
bitwidth, group_size, is_asymmetric = quant_args
...
is_asymmetric = bool(is_asymmetric)     # bool("false") is True
```

Every non-empty string is truthy, so `"false"`, `"False"`, `"0"` and `"no"` all selected `MappingType.ASYMMETRIC`. The only way to get symmetric was `torchao:4,32,` with an empty third field, which happens to hit `bool("")`.

`examples/models/llama/README.md` documents the opposite:

> ... whereas `quantization.embedding_quantize="torchao:4,32,false"` means that the embedding is quantized to 4-bits with group_size=32 and is symmetric.

That paragraph is specifically about `model.use_shared_embedding=True`, so the one documented knob for tuning shared-embedding quantization was inert.

Parse the field as text where it is unpacked. The two-argument form is unchanged and still defaults to asymmetric, matching the README's stated default.

This matters for QAT checkpoints whose weights were trained symmetrically: requesting asymmetric quantization at export fits a different scheme than the one the model was trained under. On a Llama4 GDN2 range-learning checkpoint (weights `is_symmetric=True`), the `torchao:` embedding path scores ~4 dB below the default path; the mapping-type mismatch is one of two suspected contributors (the other being that the `torchao:` branch does a PTQ refit instead of `QATConfig(step="convert")`). Without this fix the two cannot be separated experimentally.

Behavior change: `torchao:<bits>,<gs>,` with an empty third field previously evaluated to symmetric via `bool("")`; it is now asymmetric. That was an accident of the old parse rather than an interface, and nothing in the tree relies on it. No in-tree caller passes a three-argument spec today.

Differential Revision: D116868435


