### PR TITLE
examples/arduino: release 0.2.0, and record both board cores

### DIFF
--- a/examples/arduino/README.md
+++ b/examples/arduino/README.md
@@ -505,9 +505,9 @@ against 786,432 bytes of flash and 262,144 bytes of RAM:
 
 | Build | Flash | RAM | On hardware |
 |-------|-------|-----|-------------|
-| HelloExecuTorch | 472,952 (60%) | 3,052 (1%) | `Model loaded OK!`, 1 method |
-| AddModel | 507,876 (64%) | 12,268 (4%) | `[1,2,3] + 1 = [2.00, 3.00, 4.00]` |
-| KeywordSpotting (CMSIS-NN) | 563,672 (71%) | 47,084 (17%) | detects `yes`, logit 8.95 |
+| HelloExecuTorch | 473,368 (60%) | 3,060 (1%) | `Model loaded OK!`, 1 method |
+| AddModel | 509,456 (64%) | 12,276 (4%) | `[1,2,3] + 1 = [2.00, 3.00, 4.00]` |
+| KeywordSpotting (CMSIS-NN) | 564,664 (71%) | 45,044 (17%) | detects `yes`, logit 8.95 |
 
 Core 0.55.2 reported a 131,072-byte RAM ceiling; 0.90.0 reports 262,144. Figures
 from before that change are not comparable.
@@ -521,14 +521,26 @@ comes out of what remains. KeywordSpotting's DS-CNN plans 16 KB of buffers but
 needs considerably more for the method's own structures, which leaves a usable
 band rather than a floor to clear.
 
-Measured on core **0.55.2**, where Zephyr took a 32 KB stack and a 32 KB heap out
-of 128 KB:
+The numbers move with the board core, so both are recorded. On **0.90.0**,
+which is what Library Manager installs today:
 
 | Arena | Result |
 |-------|--------|
 | 28 KB | `load_method` fails, `MemoryAllocationFailed` (0x21), 180 B short |
 | 40 KB | Works. What the sketch ships |
+| 48 KB | Works, with more margin. Globals reach 47 KB of the 256 KB the core reports |
+
+On **0.55.2**, where Zephyr took a 32 KB stack and a 32 KB heap out of 128 KB:
+
+| Arena | Result |
+|-------|--------|
+| 28 KB | Worked. This is what the example shipped with |
 | 64 KB | Globals reach 70,644, past Zephyr's reservation. It ran and printed the right answer, which is what makes it dangerous rather than safe |
+
+That 28 KB row is the whole point of recording both. It was the shipped value
+and it was correct, until the core changed underneath it. 64 KB has not been
+retried on 0.90.0, so whether the same reservation cliff exists there is
+unknown.
 
 The sketch ships 40 KB for that reason, and growing it is not automatically
 safer: `arduino-cli` reports RAM against the whole region and knows nothing about

--- a/examples/arduino/library.properties
+++ b/examples/arduino/library.properties
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 name=ExecuTorch
-version=0.1.1
+version=0.2.0
 author=Meta Platforms
 maintainer=ExecuTorch Team <executorch@meta.com>
 sentence=Run PyTorch models on Arduino microcontrollers with ExecuTorch.


### PR DESCRIPTION
ETModel.h is new public API that sketches will be written against, so this is a minor rather than a patch.

The memory notes now carry measurements for both board cores instead of one. 0.55.2 shipped a 28 KB arena and that was correct; 0.90.0 fails it by 180 bytes, which is how a working example became a broken one without anything in the repository changing. Keeping both rows is the point. The 40 KB row under 0.55.2 is gone because neither of us measured it, and 64 KB has not been retried on 0.90.0, which the text now says rather than implies.

Sizes are re-measured on 0.90.0 with the wrapper in place: keyword spotting now uses 45,044 bytes of RAM rather than 47,084.
