### PR TITLE
Add targeted gfx1100 Voxtral CI

### DIFF
--- a/.ci/scripts/test-rocm-voxtral.sh
+++ b/.ci/scripts/test-rocm-voxtral.sh
@@ -9,15 +9,22 @@ set -euo pipefail
 
 ROCM_VERSION="${ROCM_VERSION:-7.1}"
 ROCM_PATH="${ROCM_PATH:-/opt/rocm}"
+EXPECTED_ROCM_ARCH="${EXPECTED_ROCM_ARCH:-gfx950}"
+EXPECTED_WARP_SIZE="${EXPECTED_WARP_SIZE:-64}"
 PYTORCH_ROCM_INDEX="${PYTORCH_ROCM_INDEX:-https://download.pytorch.org/whl/test/rocm${ROCM_VERSION}}"
 TORCHAO_ROCM_WHEEL_BASE="${TORCHAO_ROCM_WHEEL_BASE:-https://download.pytorch.org/whl/nightly/rocm${ROCM_VERSION}}"
 VOXTRAL_CI_TMP_ROOT="${RUNNER_TEMP:-/tmp}"
-mkdir -p "${VOXTRAL_CI_TMP_ROOT}" 2>/dev/null || VOXTRAL_CI_TMP_ROOT=/tmp
+if ! mkdir -p "${VOXTRAL_CI_TMP_ROOT}" 2>/dev/null ||
+  [[ ! -w "${VOXTRAL_CI_TMP_ROOT}" ]]; then
+  VOXTRAL_CI_TMP_ROOT=/tmp
+fi
 VOXTRAL_CI_TMPDIR="$(mktemp -d "${VOXTRAL_CI_TMP_ROOT}/executorch-rocm-voxtral.XXXXXX")"
 trap 'rm -rf "${VOXTRAL_CI_TMPDIR}"' EXIT
 VOXTRAL_START_SECONDS="${SECONDS}"
 
 export ROCM_PATH
+export EXPECTED_ROCM_ARCH
+export EXPECTED_WARP_SIZE
 export HIP_VISIBLE_DEVICES=0
 export CUDA_VISIBLE_DEVICES=0
 export HF_HOME="${VOXTRAL_CI_TMP_ROOT}/hf-cache"
@@ -55,6 +62,8 @@ python -m pip install torchcodec==0.11.0 \
   --extra-index-url https://download.pytorch.org/whl/test/cpu
 
 python - <<'PY'
+import os
+
 import torch
 import torchao
 
@@ -65,8 +74,12 @@ assert "+rocm" in torchao.__version__, "TorchAO is not a ROCm build"
 
 device = torch.cuda.get_device_properties(0)
 arch = device.gcnArchName.split(":", 1)[0]
-assert arch == "gfx950", f"Expected gfx950, got {device.gcnArchName}"
-assert device.warp_size == 64, f"Expected wave64, got {device.warp_size}"
+expected_arch = os.environ["EXPECTED_ROCM_ARCH"]
+expected_warp_size = int(os.environ["EXPECTED_WARP_SIZE"])
+assert arch == expected_arch, f"Expected {expected_arch}, got {device.gcnArchName}"
+assert device.warp_size == expected_warp_size, (
+    f"Expected wave{expected_warp_size}, got {device.warp_size}"
+)
 print(
     torch.__version__,
     torchao.__version__,

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -1,6 +1,6 @@
 # Test ExecuTorch AOTI ROCm support.
-# Use gfx950 for functional coverage and reserve scarce gfx1100 RDNA runners
-# for a future focused performance job.
+# Use gfx950 for routine functional coverage and reserve scarce gfx1100 RDNA
+# runners for changes that directly affect the Voxtral ROCm path.
 
 name: Test ROCm AOTI
 
@@ -20,6 +20,7 @@ on:
       - .ci/scripts/test-rocm-voxtral.sh
       - CMakeLists.txt
       - CMakePresets.json
+      - Makefile
       - install_requirements.py
       - torch_pin.py
       - backends/aoti/**
@@ -102,18 +103,24 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run-voxtral: ${{ steps.decide.outputs.run-voxtral }}
+      run-gfx1100: ${{ steps.decide.outputs.run-gfx1100 }}
     steps:
       - name: Select Voxtral runs
         id: decide
         env:
           CHANGED_FILES: ${{ needs.changed-files.outputs.changed-files }}
+          EVENT_NAME: ${{ github.event_name }}
           FULL_RUN: ${{ needs.run-decision.outputs.is-full-run }}
         run: |
           set -efu
           RUN_VOXTRAL=false
+          RUN_GFX1100=false
 
-          if [[ "$FULL_RUN" == "true" ]]; then
+          if [[ "$CHANGED_FILES" == "*" || "$FULL_RUN" == "true" ]]; then
             RUN_VOXTRAL=true
+          fi
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            RUN_GFX1100=true
           fi
 
           for path in $CHANGED_FILES; do
@@ -124,19 +131,29 @@ jobs:
               examples/models/voxtral_realtime/* | \
               backends/cuda/aoti_packed_int4_tensor.py | \
               backends/cuda/triton/kernels/int4_matmul.py | \
+              backends/cuda/triton/replacement_pass.py | \
               .ci/scripts/test-rocm-voxtral.sh | \
+              .github/workflows/rocm.yml)
+                RUN_GFX1100=true
+                RUN_VOXTRAL=true
+                ;;
+              Makefile | \
+              CMakeLists.txt | \
+              CMakePresets.json | \
+              backends/aoti/* | \
+              backends/cuda/* | \
+              extension/cuda/* | \
               .github/workflows/_ci-run-decision.yml | \
               .github/workflows/_get-changed-files.yml | \
               install_requirements.py | \
-              torch_pin.py | \
-              .github/workflows/rocm.yml)
+              torch_pin.py)
                 RUN_VOXTRAL=true
-                break
                 ;;
             esac
           done
 
           echo "run-voxtral=$RUN_VOXTRAL" >> "$GITHUB_OUTPUT"
+          echo "run-gfx1100=$RUN_GFX1100" >> "$GITHUB_OUTPUT"
 
   unittest-rocm-gfx950:
     name: unittest-rocm-gfx950-rocm${{ matrix.rocm-version }}
@@ -199,4 +216,47 @@ jobs:
         eval "$(conda shell.bash hook)"
         conda create -n executorch-rocm-ci python=3.10 -y
         conda activate executorch-rocm-ci
-        ROCM_VERSION=${{ matrix.rocm-version }} bash .ci/scripts/test-rocm-voxtral.sh
+        EXPECTED_ROCM_ARCH=gfx950 EXPECTED_WARP_SIZE=64 \
+          ROCM_VERSION=${{ matrix.rocm-version }} \
+          bash .ci/scripts/test-rocm-voxtral.sh
+
+  # This scarce RDNA runner is limited to manual runs and direct changes to the
+  # Voxtral ROCm execution path; it does not participate in broad sampling.
+  test-voxtral-realtime-rocm-gfx1100:
+    name: test-voxtral-realtime-rocm-gfx1100-rocm${{ matrix.rocm-version }}
+    needs: [voxtral-run-decision]
+    if: |
+      needs.voxtral-run-decision.outputs.run-gfx1100 == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
+    concurrency:
+      group: rocm-gfx1100-${{ github.event.pull_request.number || github.ref_name }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        rocm-version: ["7.1"]
+    with:
+      timeout: 180
+      no-sudo: true
+      secrets-env: EXECUTORCH_HF_TOKEN
+      runner: linux.rocm.gpu.gfx1100
+      gpu-arch-type: rocm
+      gpu-arch-version: ${{ matrix.rocm-version }}
+      use-custom-docker-registry: false
+      docker-image: pytorch/manylinux2_28-builder:rocm${{ matrix.rocm-version }}
+      submodules: recursive
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      script: |
+        set -eux
+        eval "$(conda shell.bash hook)"
+        conda create -n executorch-rocm-ci python=3.10 -y
+        conda activate executorch-rocm-ci
+        EXPECTED_ROCM_ARCH=gfx1100 EXPECTED_WARP_SIZE=32 \
+          ROCM_VERSION=${{ matrix.rocm-version }} \
+          bash .ci/scripts/test-rocm-voxtral.sh

--- a/backends/cuda/rocm.md
+++ b/backends/cuda/rocm.md
@@ -6,8 +6,8 @@ GPUs as device type `cuda`, so names such as `CudaBackend` and
 
 `EXECUTORCH_BUILD_ROCM` is off by default, is never auto-enabled, and is
 mutually exclusive with `EXECUTORCH_BUILD_CUDA`. It requires
-`EXECUTORCH_BUILD_EXTENSION_TENSOR`. Execution has been validated only on
-MI300X (`gfx942`); CI is configured to exercise `gfx950`.
+`EXECUTORCH_BUILD_EXTENSION_TENSOR`. Execution has been validated manually on
+MI300X (`gfx942`); CI canaries exercise gfx950 and gfx1100.
 
 ## Requirements and limitations
 
@@ -19,10 +19,9 @@ MI300X (`gfx942`); CI is configured to exercise `gfx950`.
   as `executor_runner`.
 - Installed CMake consumers must be able to find the HIP package.
 - Voxtral Realtime has an explicit ROCm workflow. Other model runners do not
-  claim ROCm support. The gfx950 CI job covers the backend build, native
-  runtime, AOTI export and execution, and Triton W4 tests. Sampled CI is
-  configured to run the streaming packed-W4/BF16 Voxtral path; offline and
-  performance validation remain manual.
+  claim ROCm support. gfx950 provides routine coverage, while the scarce
+  gfx1100 runner is limited to direct Voxtral/ROCm changes and manual runs.
+  Both run streaming packed-W4/BF16; offline validation remains manual.
 
 ## Build
 

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -160,10 +160,11 @@ python export_voxtral_rt.py \
 
 #### ROCm export examples
 
-ROCm support is experimental and currently validated only on MI300X (`gfx942`).
-It is never enabled automatically. Use a ROCm PyTorch build with its matching
-Triton AMD backend; do not run `install_executorch.sh`, because its dependency
-setup can replace ROCm PyTorch with a CPU build.
+ROCm support is experimental. Manual validation currently covers MI300X
+(`gfx942`); CI canaries exercise `gfx950` and `gfx1100`. ROCm is never enabled
+automatically. Use a ROCm PyTorch build with its matching Triton AMD backend;
+do not run `install_executorch.sh`, because its dependency setup can replace
+ROCm PyTorch with a CPU build.
 
 The validated ROCm configurations use BF16 and optionally packed `4w` linear
 weights with an `8w` embedding. The exporter rejects other ROCm dtype and


### PR DESCRIPTION
Run the existing packed-W4/BF16 streaming canary on the scarce RDNA
runner only for direct Voxtral and ROCm execution-path changes or manual
dispatches. Share the CI script with gfx950 while validating the expected
architecture and wave size on each runner.