### PR TITLE
Implement SharedPtrDataLoader load_into

### DIFF
--- a/extension/data_loader/shared_ptr_data_loader.h
+++ b/extension/data_loader/shared_ptr_data_loader.h
@@ -13,6 +13,7 @@
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
 #include <executorch/runtime/platform/log.h>
+#include <cstring>
 #include <memory>
 
 namespace executorch {
@@ -49,6 +50,24 @@ class SharedPtrDataLoader final : public executorch::runtime::DataLoader {
 
   ET_NODISCARD executorch::runtime::Result<size_t> size() const override {
     return size_;
+  }
+
+  ET_NODISCARD executorch::runtime::Error load_into(
+      size_t offset,
+      size_t size,
+      ET_UNUSED const SegmentInfo& segment_info,
+      void* buffer) const override {
+    ET_CHECK_OR_RETURN_ERROR(
+        buffer != nullptr,
+        InvalidArgument,
+        "Destination buffer cannot be null");
+
+    auto result = load(offset, size, segment_info);
+    if (!result.ok()) {
+      return result.error();
+    }
+    std::memcpy(buffer, result->data(), size);
+    return executorch::runtime::Error::Ok;
   }
 
  private:

--- a/extension/data_loader/test/shared_ptr_data_loader_test.cpp
+++ b/extension/data_loader/test/shared_ptr_data_loader_test.cpp
@@ -181,7 +181,10 @@ TEST_F(SharedPtrDataLoaderTest, LoadIntoCopiesRequestedData) {
           DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program),
           buffer),
       Error::Ok);
-  EXPECT_EQ(0, std::memcmp(buffer, data.get() + kDataSize - sizeof(buffer), 3));
+  EXPECT_EQ(
+      0,
+      std::memcmp(
+          buffer, data.get() + kDataSize - sizeof(buffer), sizeof(buffer)));
 
   EXPECT_EQ(
       edl.load_into(

--- a/extension/data_loader/test/shared_ptr_data_loader_test.cpp
+++ b/extension/data_loader/test/shared_ptr_data_loader_test.cpp
@@ -140,3 +140,55 @@ TEST_F(SharedPtrDataLoaderTest, OutOfBoundsLoadFails) {
     EXPECT_NE(fb.error(), Error::Ok);
   }
 }
+
+TEST_F(SharedPtrDataLoaderTest, LoadIntoNullDstFails) {
+  std::shared_ptr<uint8_t[]> data(new uint8_t[256]());
+  SharedPtrDataLoader edl(data, 256);
+
+  EXPECT_EQ(
+      edl.load_into(
+          /*offset=*/0,
+          /*size=*/1,
+          /*segment_info=*/
+          DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program),
+          nullptr),
+      Error::InvalidArgument);
+
+  EXPECT_EQ(
+      edl.load_into(
+          /*offset=*/0,
+          /*size=*/0,
+          /*segment_info=*/
+          DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program),
+          nullptr),
+      Error::InvalidArgument);
+}
+
+TEST_F(SharedPtrDataLoaderTest, LoadIntoCopiesRequestedData) {
+  constexpr size_t kDataSize = 256;
+  std::shared_ptr<uint8_t[]> data(new uint8_t[kDataSize]);
+  for (size_t i = 0; i < kDataSize; ++i) {
+    data[i] = static_cast<uint8_t>(i);
+  }
+  SharedPtrDataLoader edl(data, kDataSize);
+  uint8_t buffer[3] = {};
+
+  EXPECT_EQ(
+      edl.load_into(
+          /*offset=*/kDataSize - sizeof(buffer),
+          /*size=*/sizeof(buffer),
+          /*segment_info=*/
+          DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program),
+          buffer),
+      Error::Ok);
+  EXPECT_EQ(0, std::memcmp(buffer, data.get() + kDataSize - sizeof(buffer), 3));
+
+  EXPECT_EQ(
+      edl.load_into(
+          /*offset=*/0,
+          /*size=*/kDataSize + 1,
+          /*segment_info=*/
+          DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program),
+          buffer),
+      Error::InvalidArgument);
+}

--- a/extension/data_loader/test/shared_ptr_data_loader_test.cpp
+++ b/extension/data_loader/test/shared_ptr_data_loader_test.cpp
@@ -142,7 +142,8 @@ TEST_F(SharedPtrDataLoaderTest, OutOfBoundsLoadFails) {
 }
 
 TEST_F(SharedPtrDataLoaderTest, LoadIntoNullDstFails) {
-  std::shared_ptr<uint8_t[]> data(new uint8_t[256]());
+  std::shared_ptr<uint8_t[]> data(
+      new uint8_t[256](), std::default_delete<uint8_t[]>());
   SharedPtrDataLoader edl(data, 256);
 
   EXPECT_EQ(
@@ -166,7 +167,8 @@ TEST_F(SharedPtrDataLoaderTest, LoadIntoNullDstFails) {
 
 TEST_F(SharedPtrDataLoaderTest, LoadIntoCopiesRequestedData) {
   constexpr size_t kDataSize = 256;
-  std::shared_ptr<uint8_t[]> data(new uint8_t[kDataSize]);
+  std::shared_ptr<uint8_t[]> data(
+      new uint8_t[kDataSize], std::default_delete<uint8_t[]>());
   for (size_t i = 0; i < kDataSize; ++i) {
     data[i] = static_cast<uint8_t>(i);
   }


### PR DESCRIPTION
### Summary

- Implement SharedPtrDataLoader::load_into using the loader's existing bounds and overflow validation.
- Reject null destination buffers consistently with the other data loaders.
- Add tests for successful copies, null destinations, and out-of-bounds requests.

Fixes #11562

### Test plan

- Built and ran shared_ptr_data_loader_test.cpp against GoogleTest on WSL/Ubuntu 24.04 with GCC 13.3: 4 tests passed.
- git diff --check

### AI usage

This change was developed with assistance from OpenAI Codex. I reviewed the resulting diff and ran the tests listed above.

cc @larryliu0820 @JacobSzwejbka @lucylq