### PR TITLE
[executorch][native] Derive method names from the packaged graph

### DIFF
--- a/exir/native/README.md
+++ b/exir/native/README.md
@@ -79,6 +79,11 @@ deliberately, so the two pipelines read alike.
 | `methods` | Names of the methods in the program. |
 | `save(path)` | Write the program and its constants to `path` as a `.ptn`. |
 
+The constructor takes the graph blob and the constants, and nothing else. Method
+names and the package's mutable-buffer set are read back out of the blob on demand
+rather than passed alongside it, so a manager cannot describe a package it does not
+hold.
+
 The surface is intentionally small. TODO: add `buffer`, `exported_program`,
 `write_to_file`, and debug-map access only when concrete callers establish the
 required contracts; these additions can remain additive.

--- a/exir/native/native.py
+++ b/exir/native/native.py
@@ -30,6 +30,10 @@ class NativeProgramManager:
     deliberately, so the two pipelines read alike. The surface is intentionally
     small, we will expand this later.
 
+    The graph blob is the only source of truth: method names and package-wide
+    mutability are read back out of it on demand rather than carried alongside,
+    so a manager cannot describe a package it does not hold.
+
     Constants are held as tensor references returned by lowering. ``save`` may
     normalize device or layout before writing them.
     """
@@ -38,7 +42,6 @@ class NativeProgramManager:
         self,
         ptg: bytes,
         constants: dict[str, torch.Tensor],
-        methods: set[str],
     ) -> None:
         # TODO add args help
         raise NotImplementedError


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22009
* #22008
* #22007
* __->__ #22006

The landed `to_native` API skeleton declares `NativeProgramManager.__init__(ptg, constants, methods)`, but the graph blob the manager is constructed from already names every method. Taking both lets the two disagree, and the constructor has no way to notice.

Drop the argument from the declaration and state the contract the implementation has to honor: the blob is the only source of truth, so method names and package-wide mutability are read back out of it on demand rather than carried alongside it. `README.md` gets the same note.

Differential Revision: [D116838284](https://our.internmc.facebook.com/intern/diff/D116838284/)