### PR TITLE
[executorch][native] Add the .ptn package format

### DIFF
--- a/exir/_serialize/BUCK
+++ b/exir/_serialize/BUCK
@@ -23,6 +23,21 @@ fbcode_target(_kind = runtime.cxx_python_extension,
 )
 
 # Use runtime.python_library instead of the one defined in python_library.bzl,
+# The .ptn format. Its own target so safetensors stays out of :lib, and therefore
+# out of everything that depends on exir.
+fbcode_target(_kind = runtime.python_library,
+    name = "ptn",
+    typing = True,
+    srcs = [
+        "_ptn.py",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        "fbsource//third-party/pypi/safetensors:safetensors",
+        "//caffe2:torch",
+    ],
+)
+
 # so we can have access to EXECUTORCH_CLIENTS list.
 fbcode_target(_kind = runtime.python_library,
     name = "lib",

--- a/exir/_serialize/_ptn.py
+++ b/exir/_serialize/_ptn.py
@@ -1,0 +1,321 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+The .ptn package format.
+
+A .ptn is an uncompressed zip holding a native Program flatbuffer and, when the
+program references constants, those tensors as safetensors. Member names are fixed,
+so renaming the package does not break it:
+
+    program.ptg           native Program flatbuffer (file identifier "NPTG")
+    program.safetensors   referenced constants, content-deduped (owners only)
+    aliases.json          duplicate data_key -> owner key, only when duplicates exist
+
+Byte-identical *immutable* tensors (same dtype, shape, and content) are stored
+once: the first key owns the safetensors entry and the rest alias to it. An owner
+is always a real safetensors key and never appears in the alias map, so resolution
+is ``owner = aliases.get(key, key)``.
+
+An alias means only "these keys had identical bytes at save time, so one copy was
+stored". It never asserts that two keys share runtime state, which is why mutable
+keys are excluded from dedup entirely -- see _dedup. Do not overload aliases to
+express mutable alias topology; that would need explicit storage groups in the
+format.
+
+Sits alongside the PTE and PTD serializers here because the format is independent
+of any backend: write_ptn treats the graph blob as opaque bytes. Its producer is
+``exir.native.to_native``, whose NativeProgramManager.save calls it.
+
+The safetensors payload is written a tensor at a time, straight into the zip entry,
+so the writer never materializes the whole model as Python bytes. Owner tensors are
+still retained until the write completes, and normalizing non-CPU or non-contiguous
+inputs can allocate tensor copies. The header is emitted here by hand because
+safetensors.torch.save_file goes through _flatten, which converts every tensor to
+bytes before writing anything. Reading goes through the real library, so the tests
+validate this writer against it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import zipfile
+from typing import IO
+
+import torch
+
+PTG_ENTRY = "program.ptg"
+SAFETENSORS_ENTRY = "program.safetensors"
+ALIASES_ENTRY = "aliases.json"
+_SAFETENSORS_METADATA_KEY = "__metadata__"
+
+# safetensors dtype codes; mirrors safetensors.torch._TYPES inverted.
+_DTYPE_CODES: dict[torch.dtype, str] = {
+    torch.float64: "F64",
+    torch.float32: "F32",
+    torch.float16: "F16",
+    torch.bfloat16: "BF16",
+    torch.int64: "I64",
+    torch.int32: "I32",
+    torch.int16: "I16",
+    torch.int8: "I8",
+    torch.uint8: "U8",
+    torch.bool: "BOOL",
+    torch.complex64: "C64",
+}
+for _name, _code in (("uint16", "U16"), ("uint32", "U32"), ("uint64", "U64")):
+    _dtype = getattr(torch, _name, None)
+    if _dtype is not None:
+        _DTYPE_CODES[_dtype] = _code
+
+
+def _raw(tensor: torch.Tensor) -> memoryview:
+    """A zero-copy byte view of a contiguous CPU tensor.
+
+    Reinterpreting as uint8 keeps dtypes numpy cannot express, such as bfloat16,
+    working; neither the view nor .numpy() copies.
+    """
+    return tensor.flatten().view(torch.uint8).numpy().data
+
+
+def _content_signature(tensor: torch.Tensor) -> tuple[str, tuple[int, ...], str]:
+    digest = hashlib.sha256()
+    digest.update(_raw(tensor))
+    return (str(tensor.dtype), tuple(tensor.shape), digest.hexdigest())
+
+
+def _check_mutable_storage_aliases(
+    constants: dict[str, torch.Tensor], mutable_keys: frozenset[str]
+) -> None:
+    """Reject alias topology that the current PTN data model cannot express.
+
+    Immutable views may be materialized independently because their storage
+    identity is not observable. If either of two distinct keys is mutable,
+    separating shared source storage would change program semantics. The current
+    format has no storage/view manifest, so fail rather than silently sever that
+    alias.
+    """
+    keys_by_storage: dict[tuple[str, int, int], list[str]] = {}
+    for key, tensor in constants.items():
+        # All empty tensors have an unobservable zero-byte range and commonly
+        # report data_ptr() == 0 even when their storages are unrelated.
+        if tensor.numel() == 0:
+            continue
+        device_index = tensor.device.index if tensor.device.index is not None else -1
+        storage = (
+            tensor.device.type,
+            device_index,
+            tensor.untyped_storage().data_ptr(),
+        )
+        keys_by_storage.setdefault(storage, []).append(key)
+
+    for keys in keys_by_storage.values():
+        if len(keys) > 1 and any(key in mutable_keys for key in keys):
+            names = sorted(keys)
+            raise ValueError(
+                "write_ptn: distinct data keys share source storage and at least "
+                f"one is mutable: {names}. The current PTN format cannot preserve "
+                "mutable alias topology; use one data key for one logical state "
+                "object."
+            )
+
+
+def _dedup(
+    constants: dict[str, torch.Tensor],
+    mutable_keys: frozenset[str],
+) -> tuple[dict[str, torch.Tensor], dict[str, str]]:
+    """Split constants into safetensors owners and a duplicate -> owner alias map.
+
+    Only immutable keys are deduplicated. Equal bytes are not evidence that two
+    mutable keys are the same runtime state: two independently mutable buffers can
+    be zero-initialized to identical bytes and still need separate storage, so
+    aliasing them would make a write to one visible through the other. A mutable
+    key is therefore always its own owner, and never becomes an owner some other
+    key aliases to.
+
+    Immutable tensors sharing storage need no special handling: each owner's bytes
+    are written independently. Distinct keys sharing storage when either is
+    mutable are rejected, because writing them independently would silently break
+    runtime aliasing and the current PTN format cannot encode their storage
+    topology.
+    """
+    unknown_mutable = sorted(mutable_keys.difference(constants))
+    if unknown_mutable:
+        raise ValueError(
+            "write_ptn: mutable_keys contains keys with no tensor data: "
+            f"{unknown_mutable}"
+        )
+
+    for key, tensor in constants.items():
+        if not isinstance(key, str):
+            raise TypeError(
+                f"write_ptn: tensor data key must be str, got {type(key).__name__}"
+            )
+        if key == _SAFETENSORS_METADATA_KEY:
+            raise ValueError(
+                f"write_ptn: {_SAFETENSORS_METADATA_KEY!r} is reserved by "
+                "safetensors and cannot be a tensor data key."
+            )
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(
+                f"write_ptn: value for {key!r} must be a Tensor, got "
+                f"{type(tensor).__name__}"
+            )
+        if tensor.dtype not in _DTYPE_CODES:
+            # Preflight before opening the destination. This does not make the
+            # complete save atomic, but predictable schema errors must not destroy
+            # an existing valid artifact.
+            raise KeyError(
+                f"write_ptn: safetensors cannot represent dtype {tensor.dtype} "
+                f"for data key {key!r}"
+            )
+
+    _check_mutable_storage_aliases(constants, mutable_keys)
+    owners: dict[str, torch.Tensor] = {}
+    aliases: dict[str, str] = {}
+    owner_by_content: dict[tuple[str, tuple[int, ...], str], str] = {}
+    for key in sorted(constants):
+        tensor = constants[key].detach().cpu().contiguous()
+        if key in mutable_keys:
+            owners[key] = tensor
+            continue
+        signature = _content_signature(tensor)
+        owner = owner_by_content.get(signature)
+        if owner is None:
+            owner_by_content[signature] = key
+            owners[key] = tensor
+        else:
+            aliases[key] = owner
+    return owners, aliases
+
+
+def _write_safetensors(stream: IO[bytes], owners: dict[str, torch.Tensor]) -> None:
+    """Emit the safetensors format: header length, JSON header, then tensor data.
+
+    Offsets in the header are relative to the start of the data section, and the
+    header is space-padded so that section begins 8-byte aligned.
+    """
+    header: dict[str, object] = {}
+    offset = 0
+    for key, tensor in owners.items():
+        size = tensor.numel() * tensor.element_size()
+        header[key] = {
+            "dtype": _DTYPE_CODES[tensor.dtype],
+            "shape": list(tensor.shape),
+            "data_offsets": [offset, offset + size],
+        }
+        offset += size
+
+    encoded = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    encoded += b" " * ((8 - len(encoded) % 8) % 8)
+
+    stream.write(len(encoded).to_bytes(8, "little"))
+    stream.write(encoded)
+    for tensor in owners.values():
+        stream.write(_raw(tensor))
+
+
+def write_ptn(
+    path: str,
+    ptg: bytes,
+    constants: dict[str, torch.Tensor],
+    mutable_keys: frozenset[str] = frozenset(),
+) -> None:
+    """Write a .ptn package, streaming the constants a tensor at a time.
+
+    Args:
+        path: Destination .ptn path. Member names inside are fixed, so the
+            filename carries no meaning and the package survives a rename.
+        ptg: Serialized native Program flatbuffer.
+        constants: Every data key the program references, mapped to its tensor.
+        mutable_keys: Keys whose runtime state is mutable. Excluded from content
+            dedup, since equal bytes do not make two mutable buffers the same
+            state. Passed in rather than derived here, so this stays independent of
+            the graph format. Every mutable key must occur in ``constants``.
+
+    Raises:
+        KeyError: If a constant has a dtype safetensors cannot represent.
+        TypeError: If a data key is not a string or a value is not a tensor.
+        ValueError: If mutable-key policy is inconsistent or a data key is reserved.
+    """
+    # TODO: save atomically. This opens the destination directly, so a failure
+    # part way through truncates an existing valid package. Write to a temporary
+    # file beside the destination and os.replace it once complete.
+    owners, aliases = _dedup(constants, mutable_keys)
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    # ZIP_STORED keeps entries byte-addressable; allowZip64 lifts the format's
+    # 4GiB per-entry and total-size limits.
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_STORED, allowZip64=True) as pkg:
+        pkg.writestr(PTG_ENTRY, ptg)
+        if owners:
+            with pkg.open(SAFETENSORS_ENTRY, "w") as stream:
+                _write_safetensors(stream, owners)
+            if aliases:
+                pkg.writestr(
+                    ALIASES_ENTRY, json.dumps(aliases, indent=2, sort_keys=True)
+                )
+
+
+def read_ptn(path: str) -> tuple[bytes, dict[str, torch.Tensor]]:
+    """Inverse of write_ptn, with aliases resolved back to their owner's tensor.
+
+    Returns every data key the program references, owners and aliases alike. Used
+    by the tests to verify the round-trip; the lowering path only ever writes.
+
+    Raises:
+        ValueError: If an alias names a key with no safetensors entry, or a key is
+            both an owner and an alias.
+    """
+    from safetensors.torch import load as safetensors_load
+
+    with zipfile.ZipFile(path) as pkg:
+        entries = set(pkg.namelist())
+        ptg = pkg.read(PTG_ENTRY)
+        owners: dict[str, torch.Tensor] = (
+            safetensors_load(pkg.read(SAFETENSORS_ENTRY))
+            if SAFETENSORS_ENTRY in entries
+            else {}
+        )
+        aliases: dict[str, str] = {}
+        if ALIASES_ENTRY in entries:
+            raw_aliases = json.loads(pkg.read(ALIASES_ENTRY))
+            if not isinstance(raw_aliases, dict):
+                raise ValueError("read_ptn: aliases.json must contain a JSON object.")
+            for key, owner in raw_aliases.items():
+                if not isinstance(key, str) or not isinstance(owner, str):
+                    raise ValueError(
+                        "read_ptn: every alias and owner name must be a string."
+                    )
+                if key == _SAFETENSORS_METADATA_KEY:
+                    raise ValueError(
+                        f"read_ptn: alias key {_SAFETENSORS_METADATA_KEY!r} is "
+                        "reserved by safetensors."
+                    )
+                aliases[key] = owner
+
+    constants = dict(owners)
+    for key, owner in aliases.items():
+        if owner not in owners:
+            raise ValueError(
+                f"read_ptn: alias {key!r} names owner {owner!r}, which has no "
+                f"safetensors entry."
+            )
+        if key in owners:
+            raise ValueError(
+                f"read_ptn: {key!r} is both a safetensors owner and an alias."
+            )
+        constants[key] = owners[owner]
+    return ptg, constants
+
+
+__all__ = ["ALIASES_ENTRY", "PTG_ENTRY", "SAFETENSORS_ENTRY", "read_ptn", "write_ptn"]

--- a/exir/_serialize/test/BUCK
+++ b/exir/_serialize/test/BUCK
@@ -69,3 +69,15 @@ fbcode_target(_kind = runtime.python_test,
         "//executorch/exir/tests:lib",
     ],
 )
+
+fbcode_target(_kind = runtime.python_test,
+    name = "test_ptn",
+    srcs = [
+        "test_ptn.py",
+    ],
+    deps = [
+        "fbsource//third-party/pypi/safetensors:safetensors",
+        "//caffe2:torch",
+        "//executorch/exir/_serialize:ptn",
+    ],
+)

--- a/exir/_serialize/test/test_ptn.py
+++ b/exir/_serialize/test/test_ptn.py
@@ -1,0 +1,299 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import os
+import tempfile
+import unittest
+import zipfile
+
+import torch
+
+from executorch.exir._serialize._ptn import (
+    ALIASES_ENTRY,
+    PTG_ENTRY,
+    read_ptn,
+    SAFETENSORS_ENTRY,
+    write_ptn,
+)
+from safetensors.torch import load as safetensors_load
+
+# write_ptn does not interpret the graph blob, so a stand-in keeps this a unit test.
+_PTG = b"\x00\x00\x00\x00NPTG stand-in graph blob"
+
+
+def _entries(path: str) -> set[str]:
+    with zipfile.ZipFile(path) as pkg:
+        return set(pkg.namelist())
+
+
+def _read_entry(path: str, entry: str) -> bytes:
+    with zipfile.ZipFile(path) as pkg:
+        return pkg.read(entry)
+
+
+def _rewrite(path: str, overrides: dict[str, bytes]) -> None:
+    """Rebuild a package in place, replacing or adding the named entries."""
+    with zipfile.ZipFile(path) as src:
+        entries = {name: src.read(name) for name in src.namelist()}
+    entries.update(overrides)
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_STORED) as pkg:
+        for name, data in entries.items():
+            pkg.writestr(name, data)
+
+
+class WritePtnTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.path = os.path.join(self._tmp.name, "m.ptn")
+
+    def test_no_constants_omits_safetensors(self):
+        write_ptn(self.path, _PTG, {})
+
+        self.assertEqual(_entries(self.path), {PTG_ENTRY})
+        self.assertEqual(read_ptn(self.path), (_PTG, {}))
+
+    def test_distinct_constants_omit_alias_map(self):
+        constants = {"a": torch.tensor([1.0, 2.0]), "b": torch.tensor([3.0, 4.0])}
+        write_ptn(self.path, _PTG, constants)
+
+        self.assertEqual(_entries(self.path), {PTG_ENTRY, SAFETENSORS_ENTRY})
+        ptg, out = read_ptn(self.path)
+        self.assertEqual(ptg, _PTG)
+        self.assertEqual(set(out), {"a", "b"})
+        for key, tensor in constants.items():
+            self.assertTrue(torch.equal(out[key], tensor))
+
+    def test_byte_identical_constants_dedup(self):
+        shared = torch.tensor([1.0, 2.0, 3.0])
+        write_ptn(
+            self.path,
+            _PTG,
+            {"a": shared, "b": shared.clone(), "c": torch.tensor([9.0])},
+        )
+
+        # Keys are packed in sorted order, so "a" owns the entry and "b" aliases.
+        self.assertEqual(json.loads(_read_entry(self.path, ALIASES_ENTRY)), {"b": "a"})
+        owners = safetensors_load(_read_entry(self.path, SAFETENSORS_ENTRY))
+        self.assertEqual(set(owners), {"a", "c"})
+
+        _, out = read_ptn(self.path)
+        self.assertEqual(set(out), {"a", "b", "c"})
+        self.assertTrue(torch.equal(out["b"], shared))
+
+    def test_mutable_key_does_not_dedup_with_identical_immutable_key(self):
+        zeros = torch.zeros(4)
+        write_ptn(
+            self.path,
+            _PTG,
+            {"immutable": zeros, "mutable": zeros.clone()},
+            mutable_keys=frozenset({"mutable"}),
+        )
+
+        self.assertNotIn(ALIASES_ENTRY, _entries(self.path))
+        owners = safetensors_load(_read_entry(self.path, SAFETENSORS_ENTRY))
+        self.assertEqual(set(owners), {"immutable", "mutable"})
+
+    def test_shared_mutable_storage_is_rejected(self):
+        base = torch.arange(8, dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "share source storage"):
+            write_ptn(
+                self.path,
+                _PTG,
+                {"a": base[:4], "b": base[2:6]},
+                mutable_keys=frozenset({"a", "b"}),
+            )
+
+    def test_unknown_mutable_key_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "no tensor data"):
+            write_ptn(
+                self.path,
+                _PTG,
+                {"weight": torch.ones(2)},
+                mutable_keys=frozenset({"missing"}),
+            )
+
+    def test_safetensors_metadata_key_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "reserved by safetensors"):
+            write_ptn(
+                self.path,
+                _PTG,
+                {"__metadata__": torch.ones(2)},
+            )
+
+    def test_data_key_must_be_a_string(self):
+        with self.assertRaisesRegex(TypeError, "data key must be str"):
+            write_ptn(self.path, _PTG, {1: torch.ones(2)})
+
+    def test_data_value_must_be_a_tensor(self):
+        with self.assertRaisesRegex(TypeError, "must be a Tensor"):
+            write_ptn(self.path, _PTG, {"weight": object()})
+
+    def test_unsupported_dtype_fails_before_replacing_existing_package(self):
+        write_ptn(self.path, _PTG, {"a": torch.ones(2)})
+        with open(self.path, "rb") as artifact:
+            before = artifact.read()
+
+        with self.assertRaisesRegex(KeyError, "complex128"):
+            write_ptn(self.path, _PTG, {"a": torch.ones(2, dtype=torch.complex128)})
+
+        with open(self.path, "rb") as artifact:
+            self.assertEqual(artifact.read(), before)
+
+    def test_tied_weight_sharing_storage_round_trips(self):
+        # The same tensor under two keys dedups to one owner.
+        base = torch.arange(6, dtype=torch.float32)
+        write_ptn(self.path, _PTG, {"w": base, "tied": base})
+
+        owners = safetensors_load(_read_entry(self.path, SAFETENSORS_ENTRY))
+        self.assertEqual(set(owners), {"tied"})
+        _, out = read_ptn(self.path)
+        self.assertEqual(set(out), {"w", "tied"})
+        self.assertTrue(torch.equal(out["w"], base))
+        self.assertTrue(torch.equal(out["tied"], base))
+
+    def test_reshaped_view_of_whole_storage(self):
+        # base and base.view(2, 3) both cover the same storage end to end, and
+        # their differing shapes stop content dedup collapsing them, so both are
+        # owners over one buffer. Writing each owner's bytes independently is what
+        # keeps that valid; safetensors.save_file would reject it.
+        base = torch.arange(6, dtype=torch.float32)
+        write_ptn(self.path, _PTG, {"flat": base, "matrix": base.view(2, 3)})
+
+        owners = safetensors_load(_read_entry(self.path, SAFETENSORS_ENTRY))
+        self.assertEqual(set(owners), {"flat", "matrix"})
+        _, out = read_ptn(self.path)
+        self.assertEqual(out["flat"].shape, base.shape)
+        self.assertEqual(tuple(out["matrix"].shape), (2, 3))
+        self.assertTrue(torch.equal(out["flat"], base))
+        self.assertTrue(torch.equal(out["matrix"], base.view(2, 3)))
+
+    def test_overlapping_views_of_one_storage(self):
+        # Different content, one storage: content dedup cannot collapse these.
+        base = torch.arange(8, dtype=torch.float32)
+        write_ptn(self.path, _PTG, {"lo": base[0:4], "hi": base[2:6]})
+
+        owners = safetensors_load(_read_entry(self.path, SAFETENSORS_ENTRY))
+        self.assertEqual(set(owners), {"lo", "hi"})
+        _, out = read_ptn(self.path)
+        self.assertTrue(torch.equal(out["lo"], base[0:4]))
+        self.assertTrue(torch.equal(out["hi"], base[2:6]))
+
+    def test_narrower_view_of_one_storage(self):
+        base = torch.arange(8, dtype=torch.float32)
+        write_ptn(self.path, _PTG, {"tail": base[4:]})
+
+        _, out = read_ptn(self.path)
+        self.assertTrue(torch.equal(out["tail"], base[4:]))
+
+    def test_same_content_different_dtype_not_deduped(self):
+        write_ptn(
+            self.path,
+            _PTG,
+            {
+                "f": torch.ones(4, dtype=torch.float32),
+                "i": torch.ones(4, dtype=torch.int32),
+            },
+        )
+
+        self.assertNotIn(ALIASES_ENTRY, _entries(self.path))
+        _, out = read_ptn(self.path)
+        self.assertEqual(out["f"].dtype, torch.float32)
+        self.assertEqual(out["i"].dtype, torch.int32)
+
+    def test_dtypes_round_trip(self):
+        # Also validates the hand-written header against the real reader for every
+        # dtype code, including ones numpy cannot express.
+        dtypes = [
+            torch.float64,
+            torch.float32,
+            torch.float16,
+            torch.bfloat16,
+            torch.int64,
+            torch.int32,
+            torch.int16,
+            torch.int8,
+            torch.uint8,
+            torch.bool,
+            torch.complex64,
+        ]
+        for name in ("uint16", "uint32", "uint64"):
+            dtype = getattr(torch, name, None)
+            if dtype is not None:
+                dtypes.append(dtype)
+
+        for dtype in dtypes:
+            with self.subTest(dtype=dtype):
+                tensor = torch.ones((2, 3), dtype=dtype)
+                path = os.path.join(
+                    self._tmp.name, f"{str(dtype).rsplit('.', 1)[-1]}.ptn"
+                )
+                write_ptn(path, _PTG, {"t": tensor})
+                _, out = read_ptn(path)
+                self.assertEqual(out["t"].dtype, dtype)
+                self.assertEqual(out["t"].shape, tensor.shape)
+                self.assertTrue(torch.equal(out["t"], tensor))
+
+    def test_multiple_tensors_read_back_at_correct_offsets(self):
+        # Guards the hand-written data_offsets: differing element sizes mean a
+        # mistake shifts later tensors rather than merely corrupting one.
+        constants = {
+            "a": torch.arange(3, dtype=torch.float32),
+            "b": torch.arange(5, dtype=torch.int64),
+            "c": torch.arange(7, dtype=torch.int8),
+        }
+        write_ptn(self.path, _PTG, constants)
+
+        _, out = read_ptn(self.path)
+        for key, tensor in constants.items():
+            self.assertTrue(torch.equal(out[key], tensor), f"{key} mismatched")
+
+    def test_member_names_are_fixed_so_renaming_is_safe(self):
+        write_ptn(self.path, _PTG, {"a": torch.zeros(2)})
+        self.assertEqual(_entries(self.path), {PTG_ENTRY, SAFETENSORS_ENTRY})
+
+        renamed = os.path.join(self._tmp.name, "renamed-artifact.ptn")
+        os.rename(self.path, renamed)
+        ptg, out = read_ptn(renamed)
+        self.assertEqual(ptg, _PTG)
+        self.assertTrue(torch.equal(out["a"], torch.zeros(2)))
+
+    def test_creates_missing_parent_directory(self):
+        path = os.path.join(self._tmp.name, "nested", "deeper", "m.ptn")
+        write_ptn(path, _PTG, {})
+
+        self.assertTrue(os.path.isfile(path))
+
+    def test_alias_naming_unknown_owner_raises(self):
+        write_ptn(self.path, _PTG, {"a": torch.zeros(2)})
+        _rewrite(self.path, {ALIASES_ENTRY: json.dumps({"b": "nope"}).encode()})
+
+        with self.assertRaisesRegex(ValueError, "has no safetensors entry"):
+            read_ptn(self.path)
+
+    def test_aliases_must_be_a_json_object(self):
+        write_ptn(self.path, _PTG, {"a": torch.zeros(2)})
+        _rewrite(self.path, {ALIASES_ENTRY: b"[]"})
+
+        with self.assertRaisesRegex(ValueError, "must contain a JSON object"):
+            read_ptn(self.path)
+
+    def test_alias_owner_must_be_a_string(self):
+        write_ptn(self.path, _PTG, {"a": torch.zeros(2)})
+        _rewrite(self.path, {ALIASES_ENTRY: json.dumps({"b": 1}).encode()})
+
+        with self.assertRaisesRegex(ValueError, "owner name must be a string"):
+            read_ptn(self.path)
+
+    def test_key_both_owner_and_alias_raises(self):
+        write_ptn(self.path, _PTG, {"a": torch.zeros(2), "b": torch.ones(2)})
+        _rewrite(self.path, {ALIASES_ENTRY: json.dumps({"a": "b"}).encode()})
+
+        with self.assertRaisesRegex(
+            ValueError, "both a safetensors owner and an alias"
+        ):
+            read_ptn(self.path)

--- a/exir/native/README.md
+++ b/exir/native/README.md
@@ -79,6 +79,11 @@ deliberately, so the two pipelines read alike.
 | `methods` | Names of the methods in the program. |
 | `save(path)` | Write the program and its constants to `path` as a `.ptn`. |
 
+The constructor takes the graph blob and the constants, and nothing else. Method
+names and the package's mutable-buffer set are read back out of the blob on demand
+rather than passed alongside it, so a manager cannot describe a package it does not
+hold.
+
 The surface is intentionally small. TODO: add `buffer`, `exported_program`,
 `write_to_file`, and debug-map access only when concrete callers establish the
 required contracts; these additions can remain additive.

--- a/exir/native/native.py
+++ b/exir/native/native.py
@@ -30,6 +30,10 @@ class NativeProgramManager:
     deliberately, so the two pipelines read alike. The surface is intentionally
     small, we will expand this later.
 
+    The graph blob is the only source of truth: method names and package-wide
+    mutability are read back out of it on demand rather than carried alongside,
+    so a manager cannot describe a package it does not hold.
+
     Constants are held as tensor references returned by lowering. ``save`` may
     normalize device or layout before writing them.
     """
@@ -38,7 +42,6 @@ class NativeProgramManager:
         self,
         ptg: bytes,
         constants: dict[str, torch.Tensor],
-        methods: set[str],
     ) -> None:
         # TODO add args help
         raise NotImplementedError


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22009
* #22008
* __->__ #22007
* #22006

Terminal native lowering needs one artifact that keeps the native graph and its tensor data together without depending on ExecuTorch emission. The format remains backend-independent so packaging policy is not coupled to graph serialization.

Differential Revision: [D116231152](https://our.internmc.facebook.com/intern/diff/D116231152/)