### PR TITLE
Arm backend: Delegate partial flip ops on U55

### DIFF
--- a/backends/arm/operator_support/ethos_u55_support.py
+++ b/backends/arm/operator_support/ethos_u55_support.py
@@ -197,7 +197,6 @@ class EthosU55NotSupported(OperatorSupportBase):
         exir_ops.edge.aten.lt.Scalar,
         exir_ops.edge.aten.ne.Tensor,
         exir_ops.edge.aten.ne.Scalar,
-        exir_ops.edge.aten.flip.default,  # REVERSE
         exir_ops.edge.aten.gather.default,  # GATHER
         exir_ops.edge.aten.grid_sampler_2d,  # GATHER
         exir_ops.edge.aten.index.Tensor,  # GATHER
@@ -334,6 +333,30 @@ class EthosU55ResizeCheck(OperatorSupportBase):
             node, "U55 nearest-neighbor resize requires a 2x, 4x, or 8x upscale."
         )
         return False
+
+
+class EthosU55ReverseCheck(OperatorSupportBase):
+    """Accept the REVERSE cases proven to run on Ethos-U55."""
+
+    def __init__(self, reporter: WhyNoPartitionReporter):
+        self.reporter = reporter
+
+    def is_node_supported(
+        self, submodules: typing.Mapping[str, torch.nn.Module], node: fx.Node
+    ) -> bool:
+        del submodules
+        if node.target == exir_ops.edge.aten.flip.default:
+            input_rank = len(get_first_fake_tensor(node.all_input_nodes[0]).shape)
+            dims = typing.cast(typing.Sequence[int], node.args[1])
+            if input_rank == 4 and len(dims) == 1 and dims[0] % input_rank in (1, 2):
+                return True
+            self.reporter.report_reject(
+                node,
+                "U55 flip support is limited to rank-4 channel or height reversal.",
+            )
+            return False
+
+        return True
 
 
 class EthosU55CastCheck(OperatorSupportBase):

--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -41,6 +41,7 @@ from executorch.backends.arm.operator_support.ethos_u55_support import (
     EthosU55DtypeSupport,
     EthosU55NotSupported,
     EthosU55ResizeCheck,
+    EthosU55ReverseCheck,
 )
 from executorch.backends.arm.operator_support.tosa_profile_supported_op_lists import (
     TOSA_PRO_FP_SupportList,
@@ -365,6 +366,7 @@ def _negative_checks(
     if tosa_spec.is_U55_subset:
         checks.append(EthosU55NotSupported(reporter))
         checks.append(EthosU55ResizeCheck(reporter))
+        checks.append(EthosU55ReverseCheck(reporter))
         checks.append(EthosU55DtypeSupport(reporter))
         checks.append(EthosU55CastCheck(reporter))
 

--- a/backends/arm/test/ops/test_flip.py
+++ b/backends/arm/test/ops/test_flip.py
@@ -12,13 +12,16 @@ from executorch.backends.arm.quantizer.arm_quantizer import (
     get_symmetric_a16w8_quantization_config,
 )
 from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
     EthosU85PipelineINT,
     OpNotSupportedPipeline,
     TosaPipelineFP,
     TosaPipelineINT,
     VgfPipeline,
 )
+from executorch.exir.dialects._ops import ops as exir_ops
 
 aten_op = "torch.ops.aten.flip.default"
 exir_op = "executorch_exir_dialects_edge__ops_aten_flip_default"
@@ -60,9 +63,9 @@ test_data_suite_fp8 = {
     ),
 }
 
-# U55 has no REVERSE, so flip must not be delegated there.
+# U55 supports selected REVERSE axes; width-axis flip remains unsupported.
 test_data_suite_u55_reject = {
-    "rank4_dim2": lambda: (torch.rand(2, 3, 4, 5), [2]),
+    "rank4_dim3": lambda: (torch.rand(1, 3, 4, 5), [3]),
 }
 
 # flip over no dims is the identity;
@@ -172,6 +175,30 @@ def test_flip_u55_INT_not_delegated(test_data):
     pipeline.run()
 
 
+@common.XfailIfNoCorstone300
+def test_flip_u55_INT_height():
+    data = torch.rand(1, 3, 4, 5)
+    pipeline = EthosU55PipelineINT[input_t1](
+        Flip([2]),
+        (data,),
+        aten_ops=[],
+        exir_ops=[],
+    )
+    pipeline.run()
+
+
+@common.XfailIfNoCorstone300
+def test_flip_u55_INT_channel():
+    data = torch.rand(1, 3, 4, 5)
+    pipeline = EthosU55PipelineINT[input_t1](
+        Flip([1]),
+        (data,),
+        aten_ops=[],
+        exir_ops=[],
+    )
+    pipeline.run()
+
+
 @common.parametrize("test_data", test_data_suite_empty)
 def test_flip_empty_dims_not_delegated(test_data):
     """Flip over no dims is the identity."""
@@ -224,3 +251,21 @@ def test_flip_vgf_quant(test_data):
         quantize=True,
     )
     pipeline.run()
+
+
+def test_flip_u55_INT_symbolic_height_not_delegated():
+    height = torch.export.Dim("height", min=3, max=8)
+    tester = ArmTester(
+        Flip([2]),
+        (torch.rand(1, 3, 4, 5),),
+        common.get_u55_compile_spec(),
+        dynamic_shapes={"x": {2: height}},
+    )
+    tester.quantize().export().to_edge().partition()
+
+    targets = {
+        node.target
+        for node in tester.stages[tester.cur].artifact.exported_program().graph.nodes
+    }
+    assert exir_ops.edge.aten.flip.default in targets
+    assert torch.ops.higher_order.executorch_call_delegate not in targets


### PR DESCRIPTION
Allow the U55 channel and height reverse cases verified through Vela and Corstone-300, while preserving explicit fallback for unsupported flip axes.

Authored with Codex.

Change-Id: Ic4d9014cf4812165330924899a5f919c7c6a189a


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani