### PR TITLE
Add regression test for unlifted get_attr constants

### DIFF
--- a/backends/qualcomm/tests/BUCK
+++ b/backends/qualcomm/tests/BUCK
@@ -60,6 +60,21 @@ fbcode_target(_kind = runtime.python_library,
 )
 
 fbcode_target(_kind = runtime.python_test,
+    name = "test_builders_utils",
+    srcs = [
+        "test_builders_utils.py",
+    ],
+    env = {} if runtime.is_oss else {
+        "LD_LIBRARY_PATH": "$(location fbsource//third-party/qualcomm/qnn/qnn-{0}:qnn_offline_compile_libs)".format(get_qnn_library_version()),
+        "QNN_SDK_ROOT": "$(location fbsource//third-party/qualcomm/qnn/qnn-{0}:__dir__)".format(get_qnn_library_version()),
+    },
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/qualcomm/builders:builders",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_test,
     name = "test_passes",
     srcs = [
         "test_passes.py",

--- a/backends/qualcomm/tests/test_builders_utils.py
+++ b/backends/qualcomm/tests/test_builders_utils.py
@@ -1,0 +1,83 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+import unittest
+
+import torch
+from executorch.backends.qualcomm.builders.utils import get_parameter, is_parameter
+
+
+class TestBuildersUtils(unittest.TestCase):
+    """
+    Graph-level tests for the parameter lookup helpers in
+    ``backends/qualcomm/builders/utils.py``. No QNN SDK or device required.
+    """
+
+    def _exported_program_with_get_attr(self, const, val_dtype, graph=None):
+        """
+        Build an ExportedProgram holding ``const`` as an *unlifted* tensor
+        attribute, plus a ``get_attr`` node referring to it.
+
+        Passes that materialize new weights (e.g. while rewriting linear into
+        conv2d) attach the tensor with ``setattr`` and emit a plain ``get_attr``
+        instead of going through the lifted-constant machinery, so the node
+        appears in neither ``state_dict`` nor ``constants`` and the export graph
+        signature does not mention it.
+
+        When ``graph`` is passed the node is created in that graph instead of the
+        program's own graph, which leaves ``node.graph.owning_module`` unable to
+        resolve the target.
+        """
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        edge_program = torch.export.export(Model(), (torch.randn(2, 3),))
+        graph_module = edge_program.graph_module
+        attr_name = "_qnn_unlifted_const"
+        setattr(graph_module, attr_name, const)
+
+        target_graph = graph_module.graph if graph is None else graph
+        node = target_graph.create_node("get_attr", attr_name, name=attr_name)
+        node.meta["val"] = const.to(dtype=val_dtype, device="meta")
+        return edge_program, node
+
+    def test_is_parameter_accepts_unlifted_get_attr(self):
+        const = torch.arange(6, dtype=torch.int64).reshape(2, 3)
+        edge_program, node = self._exported_program_with_get_attr(
+            const, torch.int32
+        )
+
+        self.assertTrue(is_parameter(node, edge_program))
+
+    def test_get_parameter_reads_unlifted_get_attr(self):
+        const = torch.arange(6, dtype=torch.int64).reshape(2, 3)
+        edge_program, node = self._exported_program_with_get_attr(
+            const, torch.int32
+        )
+
+        param = get_parameter(node, edge_program)
+
+        self.assertIsInstance(param, torch.Tensor)
+        # get_parameter casts to the QNN-qualified dtype recorded on the node
+        self.assertEqual(param.dtype, torch.int32)
+        self.assertTrue(torch.equal(param, const.to(torch.int32)))
+
+    def test_get_parameter_falls_back_to_program_graph_module(self):
+        # A node parked in a detached graph has no owning module to read the
+        # attribute from; the lookup must fall back to the program's own module.
+        const = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+        edge_program, node = self._exported_program_with_get_attr(
+            const, torch.float32, graph=torch.fx.Graph()
+        )
+        self.assertIsNone(node.graph.owning_module)
+
+        self.assertTrue(is_parameter(node, edge_program))
+        self.assertTrue(torch.equal(get_parameter(node, edge_program), const))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
`is_parameter()` / `get_parameter()` in `backends/qualcomm/builders/utils.py` only
recognized lifted constants (`is_param` / `is_buffer` / `is_lifted_tensor_constant`).
An UNLIFTED `get_attr` node -- a tensor a pass attached with `setattr` and referenced
via a plain `get_attr`, present in neither `state_dict` nor `constants` nor the graph
signature -- fell through, so `get_parameter()` tripped its `assert param is not None`
and raised `Expect <name> to be parameter, buffer, or lifted tensor constant`.

https://github.com/pytorch/executorch/pull/22020 fixed that by adding a `node.op == "get_attr"` branch to both functions.
OSS CI never caught the original break because every failing path was internal-only
(the LPAI `LpaiPartitionFallbackSupport` pass and the internal
`examples/models/fb/llama4/...` exports); the OSS `[htp]` path lifts its constants, so
it never produces an unlifted `get_attr`.

This adds `backends/qualcomm/tests/test_builders_utils.py`, a backend-agnostic,
pure-fx-graph unit test that closes that coverage gap. It builds an `ExportedProgram`
whose graph carries an unlifted `get_attr` tensor constant and asserts `is_parameter()`
returns True, `get_parameter()` returns the tensor cast to `node.meta["val"].dtype`, and
that the lookup falls back to `edge_program.graph_module` when
`node.graph.owning_module` cannot resolve the target. No QNN SDK, no device, no LPAI
backend, no internal models -- it runs anywhere `torch.export` runs, including OSS CI.

Note on ordering: this diff contains only the new test, no `utils.py` change. It depends
on https://github.com/pytorch/executorch/pull/22020 and will fail until that lands.

Differential Revision: D116963247


