### PR TITLE
Channels last: absorb boundary layout copies into the method contract

### DIFF
--- a/backends/transforms/absorb_boundary_layout_copies.py
+++ b/backends/transforms/absorb_boundary_layout_copies.py
@@ -1,0 +1,208 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from dataclasses import dataclass, field
+
+import torch
+
+from executorch.backends.transforms.channels_last_layout import is_layout_copy
+from executorch.exir import ExportedProgram
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+
+# Elementwise per-tensor quantization is layout-agnostic, so a layout copy on
+# the far side of one is still a boundary copy. Per-channel quantization is not:
+# its axis is dimension-dependent.
+_LAYOUT_AGNOSTIC_TARGETS = frozenset(
+    {
+        exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+        exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+    }
+)
+
+
+def _inverse(dims: tuple[int, ...]) -> list[int]:
+    inverse = [0] * len(dims)
+    for position, dim in enumerate(dims):
+        inverse[dim] = position
+    return inverse
+
+
+@dataclass(frozen=True)
+class BoundaryLayoutContract:
+    """Which method inputs and outputs changed layout, and to what.
+
+    An entry ``{0: (0, 2, 3, 1)}`` in ``inputs`` means argument 0 must now be
+    passed as ``argument.permute(0, 2, 3, 1)``. An entry in ``outputs`` means
+    the returned tensor needs the same permutation applied to recover what the
+    method used to return.
+    """
+
+    inputs: dict[int, tuple[int, ...]] = field(default_factory=dict)
+    outputs: dict[int, tuple[int, ...]] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return bool(self.inputs or self.outputs)
+
+
+class AbsorbBoundaryLayoutCopies(ExportPass):
+    """Move layout copies that sit on the method boundary into the signature.
+
+    A layout region formed by ``ToContiguousChannelsLastPass`` is bracketed by
+    ``channels_last.permute_copy``. Those in the interior cancel against each
+    other; the ones on the boundary have nothing to cancel against and survive.
+    Deleting them and declaring the corresponding method input or output to be
+    channels-last moves the transpose to the caller, which is free whenever the
+    caller already has the data in that layout.
+
+    Run this *after* region formation. Permuting the boundary first and hoping
+    the copies cancel is measurably worse: it inserts copies into graphs that
+    have no anchors at all, where nothing can cancel them.
+
+    A copy need not touch the boundary directly. Quantized graphs put a
+    per-tensor ``quantize``/``dequantize`` in between, which reorders nothing,
+    so the search walks through those and relabels them on the way.
+
+    Changing a method's layout is caller-visible, so the applied changes are
+    reported in ``contract`` rather than assumed.
+    """
+
+    def __init__(self, exported_program: ExportedProgram) -> None:
+        super().__init__()
+        self.exported_program = exported_program
+        self.contract = BoundaryLayoutContract()
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        if graph_module is not self.exported_program.graph_module:
+            raise RuntimeError(
+                "AbsorbBoundaryLayoutCopies rewrites the ExportedProgram's graph "
+                "and signature together; run it as its own transform rather than "
+                "after a pass that replaces the graph module."
+            )
+
+        inputs = self._absorb_inputs(graph_module)
+        outputs = self._absorb_outputs(graph_module)
+        self.contract = BoundaryLayoutContract(inputs=inputs, outputs=outputs)
+
+        modified = bool(self.contract)
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.recompile()
+        return PassResult(graph_module, modified)
+
+    def _forward_to_copies(self, node: torch.fx.Node):
+        """Follow every path out of ``node`` until it reaches a layout copy.
+
+        Returns the layout-agnostic nodes crossed, the copies terminating the
+        paths, and the permutation they agree on; ``None`` if any path ends
+        somewhere else or the copies disagree.
+        """
+        interior: list[torch.fx.Node] = []
+        copies: list[torch.fx.Node] = []
+        dims: tuple[int, ...] | None = None
+        frontier = [node]
+
+        while frontier:
+            users = list(frontier.pop().users)
+            if not users:
+                return None
+            for user in users:
+                if is_layout_copy(user):
+                    user_dims = tuple(user.args[1])
+                    if dims is not None and user_dims != dims:
+                        # A residual block feeds one value to several branches,
+                        # each with its own copy. They collapse to a single
+                        # contract entry only if they agree.
+                        return None
+                    dims = user_dims
+                    copies.append(user)
+                elif user.target in _LAYOUT_AGNOSTIC_TARGETS:
+                    if user in interior:
+                        continue
+                    interior.append(user)
+                    frontier.append(user)
+                else:
+                    return None
+
+        return None if dims is None else (interior, copies, dims)
+
+    def _backward_to_copy(self, result: torch.fx.Node):
+        """Walk back from a returned value to the layout copy that produced it."""
+        interior: list[torch.fx.Node] = []
+        current = result
+
+        while True:
+            if is_layout_copy(current):
+                if len(current.users) != 1:
+                    return None
+                source = current.args[0]
+                if not isinstance(source, torch.fx.Node):
+                    return None
+                return interior, current, source, tuple(current.args[1])
+            if (
+                current.target not in _LAYOUT_AGNOSTIC_TARGETS
+                or len(current.users) != 1
+            ):
+                return None
+            interior.append(current)
+            current = current.args[0]
+            if not isinstance(current, torch.fx.Node):
+                return None
+
+    def _absorb_inputs(self, graph_module) -> dict[int, tuple[int, ...]]:
+        user_inputs = list(self.exported_program.graph_signature.user_inputs)
+        absorbed: dict[int, tuple[int, ...]] = {}
+
+        for node in list(graph_module.graph.nodes):
+            if node.op != "placeholder" or node.name not in user_inputs:
+                continue
+            found = self._forward_to_copies(node)
+            if found is None:
+                continue
+            interior, copies, dims = found
+
+            for member in (node, *interior):
+                member.meta["val"] = member.meta["val"].permute(dims)
+            for copy in copies:
+                copy.replace_all_uses_with(copy.args[0])
+                graph_module.graph.erase_node(copy)
+            absorbed[user_inputs.index(node.name)] = dims
+
+        return absorbed
+
+    def _absorb_outputs(self, graph_module) -> dict[int, tuple[int, ...]]:
+        output_node = graph_module.graph.output_node()
+        results = list(output_node.args[0])
+        specs = self.exported_program.graph_signature.output_specs
+        absorbed: dict[int, tuple[int, ...]] = {}
+
+        for index, result in enumerate(results):
+            if not isinstance(result, torch.fx.Node):
+                continue
+            found = self._backward_to_copy(result)
+            if found is None:
+                continue
+            interior, copy, source, dims = found
+
+            for member in interior:
+                member.meta["val"] = member.meta["val"].permute(_inverse(dims))
+            if interior:
+                interior[-1].replace_input_with(copy, source)
+            else:
+                results[index] = source
+                # The manager re-derives the signature, but the direct
+                # exported_program= path does not.
+                if index < len(specs) and getattr(specs[index].arg, "name", None) == (
+                    result.name
+                ):
+                    specs[index].arg.name = source.name
+            absorbed[index] = dims
+
+        if absorbed:
+            output_node.args = (results,)
+        return absorbed

--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -562,6 +562,40 @@ def define_common_targets():
         ],
     )
 
+    runtime.python_library(
+        name = "absorb_boundary_layout_copies",
+        srcs = [
+            "absorb_boundary_layout_copies.py",
+        ],
+        visibility = [
+            "//executorch/backends/...",
+        ],
+        deps = [
+            "//caffe2:torch",
+            ":channels_last_layout",
+            "//executorch/exir:lib",
+            "//executorch/exir:pass_base",
+            "//executorch/exir/dialects:lib",
+        ],
+    )
+
+    runtime.python_test(
+        name = "test_absorb_boundary_layout_copies",
+        srcs = [
+            "test/test_absorb_boundary_layout_copies.py",
+            # The permute-count matrix the absorption totals are measured on.
+            "test/test_to_contiguous_channels_last_pass.py",
+        ],
+        deps = [
+            "//caffe2:torch",
+            ":absorb_boundary_layout_copies",
+            ":to_contiguous_channels_last_pass",
+            "//executorch/exir:lib",
+            "//executorch/exir/dialects:lib",
+            "fbsource//third-party/pypi/pytest:pytest",
+        ],
+    )
+
     runtime.python_test(
         name = "test_replace_ops_with_channels_last_variants",
         srcs = [

--- a/backends/transforms/test/test_absorb_boundary_layout_copies.py
+++ b/backends/transforms/test/test_absorb_boundary_layout_copies.py
@@ -1,0 +1,228 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from executorch.backends.transforms.absorb_boundary_layout_copies import (
+    AbsorbBoundaryLayoutCopies,
+)
+from executorch.backends.transforms.to_contiguous_channels_last_pass import (
+    ToContiguousChannelsLastPass,
+)
+from executorch.exir import EdgeCompileConfig, to_edge
+from executorch.exir.dialects._ops import ops as exir_ops
+
+_LAYOUT_COPY = exir_ops.edge.channels_last.permute_copy.default
+
+
+class Conv(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(4, 4, 3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+class ResidualConvPool(torch.nn.Module):
+    """One input feeding two branches, so the region brackets it twice."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(4, 4, 3, padding=1)
+        self.pool = torch.nn.MaxPool2d(3, stride=1, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x) + self.pool(x)
+
+
+def _count(graph_module, target) -> int:
+    return sum(
+        node.op == "call_function" and node.target == target
+        for node in graph_module.graph.nodes
+    )
+
+
+def _lower(module, inputs):
+    module.eval()
+    with torch.no_grad():
+        exported = torch.export.export(module, inputs)
+        edge = to_edge(
+            exported,
+            compile_config=EdgeCompileConfig(
+                _check_ir_validity=False, _skip_dim_order=True
+            ),
+        )
+        edge = edge.transform([ToContiguousChannelsLastPass(edge.exported_program())])
+    return edge
+
+
+def _absorb(edge):
+    layout_pass = AbsorbBoundaryLayoutCopies(edge.exported_program())
+    return edge.transform([layout_pass]), layout_pass.contract
+
+
+def _run(edge, contract, inputs):
+    args = list(inputs)
+    for index, dims in contract.inputs.items():
+        args[index] = args[index].permute(list(dims)).contiguous()
+    result = edge.exported_program().module()(*args)
+    results = list(result) if isinstance(result, (tuple, list)) else [result]
+    for index, dims in contract.outputs.items():
+        results[index] = results[index].permute(list(dims))
+    return results[0] if len(results) == 1 else results
+
+
+@pytest.mark.parametrize("module", [Conv(), ResidualConvPool()])
+def test_boundary_copies_are_absorbed_and_numerics_hold(module) -> None:
+    inputs = (torch.randn(1, 4, 8, 8),)
+    expected = module.eval()(*inputs)
+    edge = _lower(module, inputs)
+    assert _count(edge.exported_program().graph_module, _LAYOUT_COPY) > 0
+
+    edge, contract = _absorb(edge)
+
+    assert contract.inputs and contract.outputs
+    assert _count(edge.exported_program().graph_module, _LAYOUT_COPY) == 0
+    assert torch.allclose(_run(edge, contract, inputs), expected, atol=1e-6)
+
+
+def test_fan_out_collapses_to_one_contract_entry() -> None:
+    """Both branches of a residual share the input, so one entry covers them."""
+    module = ResidualConvPool()
+    inputs = (torch.randn(1, 4, 8, 8),)
+    edge = _lower(module, inputs)
+    copies_on_input = [
+        node
+        for node in edge.exported_program().graph_module.graph.nodes
+        if node.op == "placeholder"
+        and node.name in edge.exported_program().graph_signature.user_inputs
+        for _ in node.users
+    ]
+    assert len(copies_on_input) > 1
+
+    _, contract = _absorb(edge)
+
+    assert list(contract.inputs) == [0]
+
+
+def test_mixed_users_are_left_alone() -> None:
+    """An input consumed both by a layout region and directly is not a boundary."""
+
+    class MixedUse(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = torch.nn.Conv2d(4, 4, 3, padding=1)
+
+        def forward(self, x):
+            return self.conv(x) + x
+
+    inputs = (torch.randn(1, 4, 8, 8),)
+    module = MixedUse()
+    expected = module.eval()(*inputs)
+    edge = _lower(module, inputs)
+
+    edge, contract = _absorb(edge)
+
+    assert 0 not in contract.inputs
+    assert torch.allclose(_run(edge, contract, inputs), expected, atol=1e-6)
+
+
+def test_absorbing_is_idempotent() -> None:
+    inputs = (torch.randn(1, 4, 8, 8),)
+    edge = _lower(Conv(), inputs)
+    edge, first = _absorb(edge)
+    edge, second = _absorb(edge)
+
+    assert first
+    assert not second
+
+
+def test_signature_stays_valid() -> None:
+    inputs = (torch.randn(1, 4, 8, 8),)
+    edge = _lower(Conv(), inputs)
+    edge, contract = _absorb(edge)
+
+    assert contract
+    edge.exported_program()._validate()
+
+
+# The layout pass is measured against these 36 models in
+# test_to_contiguous_channels_last_pass.py, which pins its own per-case counts
+# but stops before absorption. These are the totals across that matrix.
+_MATRIX_BASELINE_PERMUTES = 138
+_MATRIX_LAYOUT_ONLY_PERMUTES = 156
+_MATRIX_ABSORBED_PERMUTES = 137
+
+# Absorption does not destroy 19 permutes, it moves them across the method
+# boundary: 17 become obligations on the caller. Pinning both numbers keeps the
+# in-graph count honest, since it could otherwise be driven to zero by handing
+# the caller unlimited work. The gap is the genuine saving, and it comes from
+# fan-out — one placeholder feeding several branches needs several copies but
+# only one contract entry.
+_MATRIX_CONTRACT_ENTRIES = 17
+
+# Cases still above baseline after absorbing. Every one of these is an internal
+# copy left by a region that a non-permutable op (batch_norm, linear) cut in
+# two, which is region-merging work rather than boundary work.
+_MATRIX_RESIDUAL_REGRESSIONS = {
+    "conv2d_rank3",
+    "model_1_conv_maxpool_residual_linear",
+    "model_8_conv_batchnorm_maxpool_residual",
+    "model_9_dilated_conv_batchnorm_avgpool_residual",
+    "views",
+}
+
+_PERMUTE_TARGETS = {
+    exir_ops.edge.aten.permute_copy.default,
+    exir_ops.edge.channels_last.permute_copy.default,
+}
+
+
+def _permutes(edge) -> int:
+    return sum(
+        node.op == "call_function" and node.target in _PERMUTE_TARGETS
+        for node in edge.exported_program().graph.nodes
+    )
+
+
+def test_absorption_pays_for_the_layout_pass_across_the_model_matrix() -> None:
+    from executorch.backends.transforms.test.test_to_contiguous_channels_last_pass import (
+        cases,
+    )
+
+    baseline = layout_only = absorbed = contract_entries = 0
+    regressions = set()
+    for name, case in cases.items():
+        case.module.eval()
+        with torch.no_grad():
+            exported = torch.export.export(case.module, case.inputs)
+            config = EdgeCompileConfig(_check_ir_validity=False, _skip_dim_order=True)
+            case_baseline = _permutes(to_edge(exported, compile_config=config))
+
+            edge = to_edge(exported, compile_config=config)
+            edge = edge.transform(
+                [ToContiguousChannelsLastPass(edge.exported_program())]
+            )
+            case_layout = _permutes(edge)
+
+            absorb = AbsorbBoundaryLayoutCopies(edge.exported_program())
+            edge = edge.transform([absorb])
+            case_absorbed = _permutes(edge)
+
+        baseline += case_baseline
+        layout_only += case_layout
+        absorbed += case_absorbed
+        contract_entries += len(absorb.contract.inputs) + len(absorb.contract.outputs)
+        if case_absorbed > case_baseline:
+            regressions.add(name)
+
+    assert baseline == _MATRIX_BASELINE_PERMUTES
+    assert layout_only == _MATRIX_LAYOUT_ONLY_PERMUTES
+    assert absorbed == _MATRIX_ABSORBED_PERMUTES
+    assert contract_entries == _MATRIX_CONTRACT_ENTRIES
+    assert regressions == _MATRIX_RESIDUAL_REGRESSIONS

--- a/backends/transforms/test/test_to_contiguous_channels_last_pass.py
+++ b/backends/transforms/test/test_to_contiguous_channels_last_pass.py
@@ -1001,7 +1001,6 @@ def test_one_sided_propagation_reaches_graph_boundary(
     assert torch.allclose(actual, expected, atol=1e-6)
 
     if isinstance(module, PadConv):
-        # The pad stays on the aten operator; only its argument is remapped.
         assert (
             _count(
                 transformed.exported_program().graph_module,


### PR DESCRIPTION
A layout region formed by ToContiguousChannelsLastPass is bracketed by
channels_last.permute_copy. Interior copies cancel against each other, but
the ones sitting on a method input or output have nothing to cancel against
and survive. On the 36-case matrix in
backends/transforms/test/test_to_contiguous_channels_last_pass.py they cost
+18 permutes against a no-layout-pass baseline of 138.

This pass deletes those copies and declares the corresponding input or output
channels-last instead, which moves the transpose to the caller — free whenever
the caller already holds the data in that layout. That takes the in-graph count
to 137, one below the baseline.

Read that number carefully, because most of it is a transfer rather than a
saving. Absorption removes 19 permutes from the graph and creates 17 obligations
on the caller; only the difference is genuinely eliminated, and it comes from
fan-out, where one placeholder feeding several branches needs several copies but
only one contract entry. For a caller that already holds NHWC the other 17 are
free, and for a delegate the boundary is internal so they disappear entirely,
but neither is true by construction. The test pins both totals, since an
in-graph count on its own could be driven to zero by handing the caller
unlimited work.

Two things about the design are worth stating because the obvious alternatives
are worse. First, ordering: permuting the boundary up front and hoping the
copies cancel during formation only reaches 151, and regresses more cases than
it fixes, because graphs with no layout anchors get copies inserted that nothing
can ever cancel. Absorbing after formation is what pays. Second, fan-out: a
residual block feeds one placeholder to several branches, each with its own
copy, and skipping those leaves most of the win on the table — handling them is
the difference between 141 and 137.

The copy need not be adjacent to the boundary. Quantized graphs interpose a
per-tensor quantize or dequantize, which reorders nothing, so the search walks
through those and relabels them on the way. Per-channel quantization is
excluded: its axis is dimension-dependent.

Because this changes what callers must pass and what they get back, the pass
reports the applied permutations rather than leaving them to be inferred. No
in-tree pipeline runs it yet.

Co-authored-by: Claude <noreply@anthropic.com>