### PR TITLE
Cortex-M: add a contiguous-layout pad operator

### DIFF
--- a/backends/cortex_m/ops/op_pad.cpp
+++ b/backends/cortex_m/ops/op_pad.cpp
@@ -13,7 +13,11 @@ namespace native {
 
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
+namespace {
+
 constexpr size_t kMaxSupportedDims = 4;
+
+} // namespace
 
 // cppcheck-suppress unusedFunction
 Tensor& pad_out(
@@ -27,7 +31,7 @@ Tensor& pad_out(
       out.scalar_type() != ScalarType::Char) {
     ET_LOG(
         Error,
-        "cortex_m::pad: only int8 tensors are supported (input=%d, out=%d)",
+        "pad_out: only int8 tensors are supported (input=%d, out=%d)",
         static_cast<int>(input.scalar_type()),
         static_cast<int>(out.scalar_type()));
     context.fail(Error::InvalidArgument);
@@ -38,29 +42,23 @@ Tensor& pad_out(
   if (rank == 0 || rank > kMaxSupportedDims) {
     ET_LOG(
         Error,
-        "cortex_m::pad: expected tensor rank in [1, %zu], got %zu",
+        "pad_out: expected tensor rank in [1, %zu], got %zu",
         kMaxSupportedDims,
         rank);
     context.fail(Error::InvalidArgument);
     return out;
   }
-  if (pre_pad.size() != kMaxSupportedDims ||
-      post_pad.size() != kMaxSupportedDims) {
-    ET_LOG(Error, "cortex_m::pad: pre_pad and post_pad must have length 4");
-    context.fail(Error::InvalidArgument);
-    return out;
-  }
 
-  // Read the sizes in physical memory order. The dim order says which logical
-  // axis sits where, so this covers an NCHW-logical channels-last tensor and an
-  // NHWC-logical contiguous one without asking which contract is in force.
+  // Permute logical sizes to physical memory order.
   // Padding is already in physical order from the AOT pass.
+  constexpr size_t kNhwcDimOrder[] = {0, 2, 3, 1};
   const size_t offset = kMaxSupportedDims - rank;
-  const auto dim_order = input.dim_order();
+  const bool nhwc = is_channels_last_tensor(input);
 
   int32_t dims[kMaxSupportedDims] = {1, 1, 1, 1};
   for (size_t i = 0; i < rank; ++i) {
-    dims[offset + i] = static_cast<int32_t>(input.size(dim_order[i]));
+    const size_t src = nhwc ? kNhwcDimOrder[offset + i] : i;
+    dims[offset + i] = static_cast<int32_t>(input.size(src));
   }
 
   cmsis_nn_dims input_dims = {dims[0], dims[1], dims[2], dims[3]};
@@ -89,7 +87,7 @@ Tensor& pad_out(
   if (status != ARM_CMSIS_NN_SUCCESS) {
     ET_LOG(
         Error,
-        "cortex_m::pad: arm_pad_s8 failed with status [%d]",
+        "pad_out: arm_pad_s8 failed with status [%d]",
         static_cast<int>(status));
     context.fail(Error::Internal);
     return out;

--- a/backends/cortex_m/ops/op_pad.cpp
+++ b/backends/cortex_m/ops/op_pad.cpp
@@ -17,21 +17,19 @@ namespace {
 
 constexpr size_t kMaxSupportedDims = 4;
 
-} // namespace
-
-// cppcheck-suppress unusedFunction
-Tensor& pad_out(
+Tensor& pad_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Int64ArrayRef pre_pad,
     const Int64ArrayRef post_pad,
     int64_t pad_value,
+    bool require_contiguous,
     Tensor& out) {
   if (input.scalar_type() != ScalarType::Char ||
       out.scalar_type() != ScalarType::Char) {
     ET_LOG(
         Error,
-        "pad_out: only int8 tensors are supported (input=%d, out=%d)",
+        "cortex_m::pad: only int8 tensors are supported (input=%d, out=%d)",
         static_cast<int>(input.scalar_type()),
         static_cast<int>(out.scalar_type()));
     context.fail(Error::InvalidArgument);
@@ -42,22 +40,48 @@ Tensor& pad_out(
   if (rank == 0 || rank > kMaxSupportedDims) {
     ET_LOG(
         Error,
-        "pad_out: expected tensor rank in [1, %zu], got %zu",
+        "cortex_m::pad: expected tensor rank in [1, %zu], got %zu",
         kMaxSupportedDims,
         rank);
     context.fail(Error::InvalidArgument);
     return out;
+  }
+  if (pre_pad.size() != kMaxSupportedDims ||
+      post_pad.size() != kMaxSupportedDims) {
+    ET_LOG(Error, "cortex_m::pad: pre_pad and post_pad must have length 4");
+    context.fail(Error::InvalidArgument);
+    return out;
+  }
+
+  if (require_contiguous) {
+    // This entry point infers nothing: it requires the dim order to say the
+    // tensor is contiguous, and then indexes the padding by logical axis.
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            out.dim_order().data(), out.dim_order().size())) {
+      ET_LOG(
+          Error,
+          "cortex_m::pad_contiguous: input and output must use contiguous dim order");
+      context.fail(Error::InvalidArgument);
+      return out;
+    }
   }
 
   // Permute logical sizes to physical memory order.
   // Padding is already in physical order from the AOT pass.
   constexpr size_t kNhwcDimOrder[] = {0, 2, 3, 1};
   const size_t offset = kMaxSupportedDims - rank;
-  const bool nhwc = is_channels_last_tensor(input);
+  // Only the legacy entry point infers the layout. Its predicate is tolerant on
+  // purpose: the tolerance short-circuits before the dim order is consulted,
+  // which is what keeps it agreeing with the AOT pass for shapes whose
+  // serialized dim order cannot name the channel axis.
+  const bool legacy_channels_last =
+      !require_contiguous && is_channels_last_tensor(input);
 
   int32_t dims[kMaxSupportedDims] = {1, 1, 1, 1};
   for (size_t i = 0; i < rank; ++i) {
-    const size_t src = nhwc ? kNhwcDimOrder[offset + i] : i;
+    const size_t src = legacy_channels_last ? kNhwcDimOrder[offset + i] : i;
     dims[offset + i] = static_cast<int32_t>(input.size(src));
   }
 
@@ -87,13 +111,51 @@ Tensor& pad_out(
   if (status != ARM_CMSIS_NN_SUCCESS) {
     ET_LOG(
         Error,
-        "pad_out: arm_pad_s8 failed with status [%d]",
+        "cortex_m::pad: arm_pad_s8 failed with status [%d]",
         static_cast<int>(status));
     context.fail(Error::Internal);
     return out;
   }
 
   return out;
+}
+
+} // namespace
+
+// cppcheck-suppress unusedFunction
+Tensor& pad_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef pre_pad,
+    const Int64ArrayRef post_pad,
+    int64_t pad_value,
+    Tensor& out) {
+  return pad_out_impl(
+      context,
+      input,
+      pre_pad,
+      post_pad,
+      pad_value,
+      /*require_contiguous=*/false,
+      out);
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& pad_contiguous_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef pre_pad,
+    const Int64ArrayRef post_pad,
+    int64_t pad_value,
+    Tensor& out) {
+  return pad_out_impl(
+      context,
+      input,
+      pre_pad,
+      post_pad,
+      pad_value,
+      /*require_contiguous=*/true,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/operators.py
+++ b/backends/cortex_m/ops/operators.py
@@ -13,9 +13,8 @@ import torch
 import torch.nn.functional as F
 from executorch.backends.cortex_m.passes.passes_utils import (
     dequantize_per_tensor_cmsis,
-    is_channel_broadcast,
-    has_channels_last_dim_order,
     is_channels_last,
+    is_channel_broadcast,
     quantize_per_tensor_cmsis,
     requantize_cmsis,
     SHIFT_INT8,
@@ -200,9 +199,6 @@ def quantized_add_impl(
     return result
 
 
-# ===================================================================
-# QUANTIZED MUL OPERATION DEFINITION
-# ===================================================================
 lib.define(
     "quantized_mul("
     "Tensor self, int self_zero_point, "
@@ -265,9 +261,6 @@ def quantized_mul_impl(
     return result
 
 
-# ===================================================================
-# QUANTIZED DIV OPERATION DEFINITION
-# ===================================================================
 lib.define(
     "quantized_div("
     "Tensor self, int self_zero_point, "
@@ -672,7 +665,7 @@ lib.define(
 )
 def _pad_to_logical_order(physical_pad: list[int], input: torch.Tensor) -> list[int]:
     """Inverse of _to_physical_order: map physical-order padding back to logical."""
-    if not has_channels_last_dim_order(input):
+    if not is_channels_last(input):
         return list(physical_pad)
     return [physical_pad[_NHWC_INV_ORDER[i]] for i in range(4)]
 
@@ -697,7 +690,7 @@ def pad_meta(
     for i in range(rank):
         output_shape[i] += logical_pre[offset + i] + logical_post[offset + i]
     result = torch.empty(output_shape, dtype=input.dtype, device=input.device)
-    if has_channels_last_dim_order(input):
+    if is_channels_last(input):
         result = result.to(memory_format=torch.channels_last)
     return result
 

--- a/backends/cortex_m/ops/operators.py
+++ b/backends/cortex_m/ops/operators.py
@@ -663,6 +663,18 @@ lib.define(
     "pad.out(Tensor input, int[] pre_pad, int[] post_pad, int pad_value, "
     "*, Tensor(a!) out) -> Tensor(a!)"
 )
+lib.define(
+    "pad_contiguous(Tensor input, int[] pre_pad, int[] post_pad, int pad_value) -> Tensor"
+)
+lib.define(
+    "pad_contiguous.out(Tensor input, int[] pre_pad, int[] post_pad, int pad_value, "
+    "*, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+_NHWC_INV_ORDER = [0, 3, 1, 2]
+
+
 def _pad_to_logical_order(physical_pad: list[int], input: torch.Tensor) -> list[int]:
     """Inverse of _to_physical_order: map physical-order padding back to logical."""
     if not is_channels_last(input):
@@ -716,6 +728,58 @@ def pad_impl(
         padding.extend([logical_pre[offset + i], logical_post[offset + i]])
     return F.pad(input, padding, mode="constant", value=pad_value)
 
+
+@register_fake("cortex_m::pad_contiguous")  # type: ignore[misc]
+def pad_contiguous_meta(
+    input: torch.Tensor,
+    pre_pad: list[int],
+    post_pad: list[int],
+    pad_value: int,
+) -> torch.Tensor:
+    del pad_value
+    rank = input.dim()
+    if rank == 0 or rank > 4:
+        raise RuntimeError(
+            f"cortex_m.pad_contiguous expects a rank in [1, 4], got {rank}"
+        )
+    if len(pre_pad) != 4 or len(post_pad) != 4:
+        raise RuntimeError(
+            "cortex_m.pad_contiguous expects four padding values per side"
+        )
+    offset = 4 - rank
+    output_shape = [
+        input.shape[dim] + pre_pad[offset + dim] + post_pad[offset + dim]
+        for dim in range(rank)
+    ]
+    return torch.empty(output_shape, dtype=input.dtype, device=input.device)
+
+
+@impl(lib, "pad_contiguous", "CompositeExplicitAutograd")  # type: ignore[misc]
+def pad_contiguous_impl(
+    input: torch.Tensor,
+    pre_pad: list[int],
+    post_pad: list[int],
+    pad_value: int,
+) -> torch.Tensor:
+    rank = input.dim()
+    if rank == 0 or rank > 4:
+        raise RuntimeError(
+            f"cortex_m.pad_contiguous expects a rank in [1, 4], got {rank}"
+        )
+    if len(pre_pad) != 4 or len(post_pad) != 4:
+        raise RuntimeError(
+            "cortex_m.pad_contiguous expects four padding values per side"
+        )
+    offset = 4 - rank
+    padding = []
+    for dim in reversed(range(rank)):
+        padding.extend([pre_pad[offset + dim], post_pad[offset + dim]])
+    return F.pad(input, padding, mode="constant", value=pad_value)
+
+
+# ===================================================================
+# QUANTIZED CONV2D OPERATION DEFINITION
+# ===================================================================
 
 lib.define(
     "quantized_conv2d("

--- a/backends/cortex_m/ops/operators.yaml
+++ b/backends/cortex_m/ops/operators.yaml
@@ -77,6 +77,12 @@
     - arg_meta: null
       kernel_name: cortex_m::pad_out
 
+- func: cortex_m::pad_contiguous.out(Tensor input, int[] pre_pad, int[] post_pad, int pad_value, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: cortex_m::pad_contiguous_out
+
 - func: cortex_m::quantized_conv2d.out(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, Tensor scratch, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:

--- a/backends/cortex_m/passes/passes_utils.py
+++ b/backends/cortex_m/passes/passes_utils.py
@@ -325,23 +325,13 @@ def is_channels_last(tensor: torch.Tensor) -> bool:
     return dim_order[0:2] == [0, 2]
 
 
-def has_channels_last_dim_order(tensor: torch.Tensor) -> bool:
-    """Exact channels-last test, read from the dim order.
-
-    Unlike ``is_channels_last`` this does not treat unit-sized dimensions as
-    ambiguously channels-last, so a contiguous tensor with a singleton channel
-    or spatial extent is correctly reported as contiguous.
-    """
-    return tensor.ndim == 4 and tuple(tensor.dim_order()) == (0, 2, 3, 1)
-
-
 _NHWC_DIM_ORDER = [0, 2, 3, 1]
 
 
 def to_physical_order(logical_pad: list[int], tensor: torch.Tensor) -> list[int]:
     """Permute a 4-element NCHW-ordered list to NHWC physical memory order
     when ``tensor`` is in channels_last format, otherwise return unchanged."""
-    if not has_channels_last_dim_order(tensor):
+    if not is_channels_last(tensor):
         return logical_pad
     return [logical_pad[_NHWC_DIM_ORDER[i]] for i in range(4)]
 

--- a/backends/cortex_m/test/build_test_runner.sh
+++ b/backends/cortex_m/test/build_test_runner.sh
@@ -65,6 +65,7 @@ ops_list=(
     cortex_m::softmax.out
     cortex_m::transpose.out
     cortex_m::pad.out
+    cortex_m::pad_contiguous.out
     cortex_m::quantized_conv2d.out
     cortex_m::quantized_conv2d_nhwc.out
     cortex_m::quantized_depthwise_conv2d.out

--- a/backends/cortex_m/test/ops/test_explicit_nhwc_runtime.py
+++ b/backends/cortex_m/test/ops/test_explicit_nhwc_runtime.py
@@ -217,16 +217,6 @@ class MaxPool2dNhwc(torch.nn.Module):
         )
 
 
-class PadNhwc(torch.nn.Module):
-    def forward(self, x):
-        return torch.ops.cortex_m.pad.default(
-            x,
-            [0, 1, 2, 0],
-            [0, 2, 1, 0],
-            -7,
-        )
-
-
 def test_conv2d_nhwc_runs_on_fvp(cortex_m_target):
     _run_on_fvp(
         Conv2dNhwc(),
@@ -286,11 +276,3 @@ def test_max_pool2d_nhwc_runs_on_fvp(cortex_m_target):
         cortex_m_target,
     )
 
-
-def test_pad_runs_on_fvp_with_singleton_nhwc_height(cortex_m_target):
-    _run_on_fvp(
-        PadNhwc(),
-        _int8_values((1, 1, 7, 3)),
-        exir_ops.edge.cortex_m.pad.default,
-        cortex_m_target,
-    )

--- a/backends/cortex_m/test/ops/test_explicit_nhwc_runtime.py
+++ b/backends/cortex_m/test/ops/test_explicit_nhwc_runtime.py
@@ -217,6 +217,16 @@ class MaxPool2dNhwc(torch.nn.Module):
         )
 
 
+class PadNhwc(torch.nn.Module):
+    def forward(self, x):
+        return torch.ops.cortex_m.pad_contiguous.default(
+            x,
+            [0, 1, 2, 0],
+            [0, 2, 1, 0],
+            -7,
+        )
+
+
 def test_conv2d_nhwc_runs_on_fvp(cortex_m_target):
     _run_on_fvp(
         Conv2dNhwc(),
@@ -276,3 +286,11 @@ def test_max_pool2d_nhwc_runs_on_fvp(cortex_m_target):
         cortex_m_target,
     )
 
+
+def test_pad_contiguous_runs_on_fvp_with_singleton_height(cortex_m_target):
+    _run_on_fvp(
+        PadNhwc(),
+        _int8_values((1, 1, 7, 3)),
+        exir_ops.edge.cortex_m.pad_contiguous.default,
+        cortex_m_target,
+    )

--- a/backends/cortex_m/test/ops/test_pad.py
+++ b/backends/cortex_m/test/ops/test_pad.py
@@ -77,6 +77,19 @@ test_cases = {
         CortexMPad((1, 2, 3, 4)),
         (ramp_tensor(-1.0, 1.0, (1, 3, 4, 5)).to(memory_format=torch.channels_last),),
     ),
+    # A channels-last tensor with one channel serializes its dim order as
+    # (0, 2, 1, 3), which names no channel axis. Deriving the physical sizes
+    # from it instead of from the shape sizes the pad write wrongly.
+    "pad_rank4_single_channel_channels_last": McuTestCase(
+        CortexMPad((1, 1, 2, 2)),
+        (ramp_tensor(-0.5, 0.5, (1, 1, 3, 4)).to(memory_format=torch.channels_last),),
+    ),
+    # With one channel and unit width the dim order collapses all the way to
+    # (0, 1, 2, 3), making the tensor indistinguishable from a contiguous one.
+    "pad_rank4_single_channel_unit_width_channels_last": McuTestCase(
+        CortexMPad((0, 0, 2, 2)),
+        (ramp_tensor(-0.5, 0.5, (1, 1, 8, 1)).to(memory_format=torch.channels_last),),
+    ),
 }
 
 

--- a/backends/transforms/absorb_boundary_layout_copies.py
+++ b/backends/transforms/absorb_boundary_layout_copies.py
@@ -1,0 +1,208 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from dataclasses import dataclass, field
+
+import torch
+
+from executorch.backends.transforms.channels_last_layout import is_layout_copy
+from executorch.exir import ExportedProgram
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+
+# Elementwise per-tensor quantization is layout-agnostic, so a layout copy on
+# the far side of one is still a boundary copy. Per-channel quantization is not:
+# its axis is dimension-dependent.
+_LAYOUT_AGNOSTIC_TARGETS = frozenset(
+    {
+        exir_ops.edge.quantized_decomposed.quantize_per_tensor.default,
+        exir_ops.edge.quantized_decomposed.dequantize_per_tensor.default,
+    }
+)
+
+
+def _inverse(dims: tuple[int, ...]) -> list[int]:
+    inverse = [0] * len(dims)
+    for position, dim in enumerate(dims):
+        inverse[dim] = position
+    return inverse
+
+
+@dataclass(frozen=True)
+class BoundaryLayoutContract:
+    """Which method inputs and outputs changed layout, and to what.
+
+    An entry ``{0: (0, 2, 3, 1)}`` in ``inputs`` means argument 0 must now be
+    passed as ``argument.permute(0, 2, 3, 1)``. An entry in ``outputs`` means
+    the returned tensor needs the same permutation applied to recover what the
+    method used to return.
+    """
+
+    inputs: dict[int, tuple[int, ...]] = field(default_factory=dict)
+    outputs: dict[int, tuple[int, ...]] = field(default_factory=dict)
+
+    def __bool__(self) -> bool:
+        return bool(self.inputs or self.outputs)
+
+
+class AbsorbBoundaryLayoutCopies(ExportPass):
+    """Move layout copies that sit on the method boundary into the signature.
+
+    A layout region formed by ``ToContiguousChannelsLastPass`` is bracketed by
+    ``channels_last.permute_copy``. Those in the interior cancel against each
+    other; the ones on the boundary have nothing to cancel against and survive.
+    Deleting them and declaring the corresponding method input or output to be
+    channels-last moves the transpose to the caller, which is free whenever the
+    caller already has the data in that layout.
+
+    Run this *after* region formation. Permuting the boundary first and hoping
+    the copies cancel is measurably worse: it inserts copies into graphs that
+    have no anchors at all, where nothing can cancel them.
+
+    A copy need not touch the boundary directly. Quantized graphs put a
+    per-tensor ``quantize``/``dequantize`` in between, which reorders nothing,
+    so the search walks through those and relabels them on the way.
+
+    Changing a method's layout is caller-visible, so the applied changes are
+    reported in ``contract`` rather than assumed.
+    """
+
+    def __init__(self, exported_program: ExportedProgram) -> None:
+        super().__init__()
+        self.exported_program = exported_program
+        self.contract = BoundaryLayoutContract()
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        if graph_module is not self.exported_program.graph_module:
+            raise RuntimeError(
+                "AbsorbBoundaryLayoutCopies rewrites the ExportedProgram's graph "
+                "and signature together; run it as its own transform rather than "
+                "after a pass that replaces the graph module."
+            )
+
+        inputs = self._absorb_inputs(graph_module)
+        outputs = self._absorb_outputs(graph_module)
+        self.contract = BoundaryLayoutContract(inputs=inputs, outputs=outputs)
+
+        modified = bool(self.contract)
+        if modified:
+            graph_module.graph.eliminate_dead_code()
+            graph_module.recompile()
+        return PassResult(graph_module, modified)
+
+    def _forward_to_copies(self, node: torch.fx.Node):
+        """Follow every path out of ``node`` until it reaches a layout copy.
+
+        Returns the layout-agnostic nodes crossed, the copies terminating the
+        paths, and the permutation they agree on; ``None`` if any path ends
+        somewhere else or the copies disagree.
+        """
+        interior: list[torch.fx.Node] = []
+        copies: list[torch.fx.Node] = []
+        dims: tuple[int, ...] | None = None
+        frontier = [node]
+
+        while frontier:
+            users = list(frontier.pop().users)
+            if not users:
+                return None
+            for user in users:
+                if is_layout_copy(user):
+                    user_dims = tuple(user.args[1])
+                    if dims is not None and user_dims != dims:
+                        # A residual block feeds one value to several branches,
+                        # each with its own copy. They collapse to a single
+                        # contract entry only if they agree.
+                        return None
+                    dims = user_dims
+                    copies.append(user)
+                elif user.target in _LAYOUT_AGNOSTIC_TARGETS:
+                    if user in interior:
+                        continue
+                    interior.append(user)
+                    frontier.append(user)
+                else:
+                    return None
+
+        return None if dims is None else (interior, copies, dims)
+
+    def _backward_to_copy(self, result: torch.fx.Node):
+        """Walk back from a returned value to the layout copy that produced it."""
+        interior: list[torch.fx.Node] = []
+        current = result
+
+        while True:
+            if is_layout_copy(current):
+                if len(current.users) != 1:
+                    return None
+                source = current.args[0]
+                if not isinstance(source, torch.fx.Node):
+                    return None
+                return interior, current, source, tuple(current.args[1])
+            if (
+                current.target not in _LAYOUT_AGNOSTIC_TARGETS
+                or len(current.users) != 1
+            ):
+                return None
+            interior.append(current)
+            current = current.args[0]
+            if not isinstance(current, torch.fx.Node):
+                return None
+
+    def _absorb_inputs(self, graph_module) -> dict[int, tuple[int, ...]]:
+        user_inputs = list(self.exported_program.graph_signature.user_inputs)
+        absorbed: dict[int, tuple[int, ...]] = {}
+
+        for node in list(graph_module.graph.nodes):
+            if node.op != "placeholder" or node.name not in user_inputs:
+                continue
+            found = self._forward_to_copies(node)
+            if found is None:
+                continue
+            interior, copies, dims = found
+
+            for member in (node, *interior):
+                member.meta["val"] = member.meta["val"].permute(dims)
+            for copy in copies:
+                copy.replace_all_uses_with(copy.args[0])
+                graph_module.graph.erase_node(copy)
+            absorbed[user_inputs.index(node.name)] = dims
+
+        return absorbed
+
+    def _absorb_outputs(self, graph_module) -> dict[int, tuple[int, ...]]:
+        output_node = graph_module.graph.output_node()
+        results = list(output_node.args[0])
+        specs = self.exported_program.graph_signature.output_specs
+        absorbed: dict[int, tuple[int, ...]] = {}
+
+        for index, result in enumerate(results):
+            if not isinstance(result, torch.fx.Node):
+                continue
+            found = self._backward_to_copy(result)
+            if found is None:
+                continue
+            interior, copy, source, dims = found
+
+            for member in interior:
+                member.meta["val"] = member.meta["val"].permute(_inverse(dims))
+            if interior:
+                interior[-1].replace_input_with(copy, source)
+            else:
+                results[index] = source
+                # The manager re-derives the signature, but the direct
+                # exported_program= path does not.
+                if index < len(specs) and getattr(specs[index].arg, "name", None) == (
+                    result.name
+                ):
+                    specs[index].arg.name = source.name
+            absorbed[index] = dims
+
+        if absorbed:
+            output_node.args = (results,)
+        return absorbed

--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -562,6 +562,40 @@ def define_common_targets():
         ],
     )
 
+    runtime.python_library(
+        name = "absorb_boundary_layout_copies",
+        srcs = [
+            "absorb_boundary_layout_copies.py",
+        ],
+        visibility = [
+            "//executorch/backends/...",
+        ],
+        deps = [
+            "//caffe2:torch",
+            ":channels_last_layout",
+            "//executorch/exir:lib",
+            "//executorch/exir:pass_base",
+            "//executorch/exir/dialects:lib",
+        ],
+    )
+
+    runtime.python_test(
+        name = "test_absorb_boundary_layout_copies",
+        srcs = [
+            "test/test_absorb_boundary_layout_copies.py",
+            # The permute-count matrix the absorption totals are measured on.
+            "test/test_to_contiguous_channels_last_pass.py",
+        ],
+        deps = [
+            "//caffe2:torch",
+            ":absorb_boundary_layout_copies",
+            ":to_contiguous_channels_last_pass",
+            "//executorch/exir:lib",
+            "//executorch/exir/dialects:lib",
+            "fbsource//third-party/pypi/pytest:pytest",
+        ],
+    )
+
     runtime.python_test(
         name = "test_replace_ops_with_channels_last_variants",
         srcs = [

--- a/backends/transforms/test/test_absorb_boundary_layout_copies.py
+++ b/backends/transforms/test/test_absorb_boundary_layout_copies.py
@@ -1,0 +1,228 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from executorch.backends.transforms.absorb_boundary_layout_copies import (
+    AbsorbBoundaryLayoutCopies,
+)
+from executorch.backends.transforms.to_contiguous_channels_last_pass import (
+    ToContiguousChannelsLastPass,
+)
+from executorch.exir import EdgeCompileConfig, to_edge
+from executorch.exir.dialects._ops import ops as exir_ops
+
+_LAYOUT_COPY = exir_ops.edge.channels_last.permute_copy.default
+
+
+class Conv(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(4, 4, 3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+class ResidualConvPool(torch.nn.Module):
+    """One input feeding two branches, so the region brackets it twice."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(4, 4, 3, padding=1)
+        self.pool = torch.nn.MaxPool2d(3, stride=1, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x) + self.pool(x)
+
+
+def _count(graph_module, target) -> int:
+    return sum(
+        node.op == "call_function" and node.target == target
+        for node in graph_module.graph.nodes
+    )
+
+
+def _lower(module, inputs):
+    module.eval()
+    with torch.no_grad():
+        exported = torch.export.export(module, inputs)
+        edge = to_edge(
+            exported,
+            compile_config=EdgeCompileConfig(
+                _check_ir_validity=False, _skip_dim_order=True
+            ),
+        )
+        edge = edge.transform([ToContiguousChannelsLastPass(edge.exported_program())])
+    return edge
+
+
+def _absorb(edge):
+    layout_pass = AbsorbBoundaryLayoutCopies(edge.exported_program())
+    return edge.transform([layout_pass]), layout_pass.contract
+
+
+def _run(edge, contract, inputs):
+    args = list(inputs)
+    for index, dims in contract.inputs.items():
+        args[index] = args[index].permute(list(dims)).contiguous()
+    result = edge.exported_program().module()(*args)
+    results = list(result) if isinstance(result, (tuple, list)) else [result]
+    for index, dims in contract.outputs.items():
+        results[index] = results[index].permute(list(dims))
+    return results[0] if len(results) == 1 else results
+
+
+@pytest.mark.parametrize("module", [Conv(), ResidualConvPool()])
+def test_boundary_copies_are_absorbed_and_numerics_hold(module) -> None:
+    inputs = (torch.randn(1, 4, 8, 8),)
+    expected = module.eval()(*inputs)
+    edge = _lower(module, inputs)
+    assert _count(edge.exported_program().graph_module, _LAYOUT_COPY) > 0
+
+    edge, contract = _absorb(edge)
+
+    assert contract.inputs and contract.outputs
+    assert _count(edge.exported_program().graph_module, _LAYOUT_COPY) == 0
+    assert torch.allclose(_run(edge, contract, inputs), expected, atol=1e-6)
+
+
+def test_fan_out_collapses_to_one_contract_entry() -> None:
+    """Both branches of a residual share the input, so one entry covers them."""
+    module = ResidualConvPool()
+    inputs = (torch.randn(1, 4, 8, 8),)
+    edge = _lower(module, inputs)
+    copies_on_input = [
+        node
+        for node in edge.exported_program().graph_module.graph.nodes
+        if node.op == "placeholder"
+        and node.name in edge.exported_program().graph_signature.user_inputs
+        for _ in node.users
+    ]
+    assert len(copies_on_input) > 1
+
+    _, contract = _absorb(edge)
+
+    assert list(contract.inputs) == [0]
+
+
+def test_mixed_users_are_left_alone() -> None:
+    """An input consumed both by a layout region and directly is not a boundary."""
+
+    class MixedUse(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv = torch.nn.Conv2d(4, 4, 3, padding=1)
+
+        def forward(self, x):
+            return self.conv(x) + x
+
+    inputs = (torch.randn(1, 4, 8, 8),)
+    module = MixedUse()
+    expected = module.eval()(*inputs)
+    edge = _lower(module, inputs)
+
+    edge, contract = _absorb(edge)
+
+    assert 0 not in contract.inputs
+    assert torch.allclose(_run(edge, contract, inputs), expected, atol=1e-6)
+
+
+def test_absorbing_is_idempotent() -> None:
+    inputs = (torch.randn(1, 4, 8, 8),)
+    edge = _lower(Conv(), inputs)
+    edge, first = _absorb(edge)
+    edge, second = _absorb(edge)
+
+    assert first
+    assert not second
+
+
+def test_signature_stays_valid() -> None:
+    inputs = (torch.randn(1, 4, 8, 8),)
+    edge = _lower(Conv(), inputs)
+    edge, contract = _absorb(edge)
+
+    assert contract
+    edge.exported_program()._validate()
+
+
+# The layout pass is measured against these 36 models in
+# test_to_contiguous_channels_last_pass.py, which pins its own per-case counts
+# but stops before absorption. These are the totals across that matrix.
+_MATRIX_BASELINE_PERMUTES = 138
+_MATRIX_LAYOUT_ONLY_PERMUTES = 156
+_MATRIX_ABSORBED_PERMUTES = 137
+
+# Absorption does not destroy 19 permutes, it moves them across the method
+# boundary: 17 become obligations on the caller. Pinning both numbers keeps the
+# in-graph count honest, since it could otherwise be driven to zero by handing
+# the caller unlimited work. The gap is the genuine saving, and it comes from
+# fan-out — one placeholder feeding several branches needs several copies but
+# only one contract entry.
+_MATRIX_CONTRACT_ENTRIES = 17
+
+# Cases still above baseline after absorbing. Every one of these is an internal
+# copy left by a region that a non-permutable op (batch_norm, linear) cut in
+# two, which is region-merging work rather than boundary work.
+_MATRIX_RESIDUAL_REGRESSIONS = {
+    "conv2d_rank3",
+    "model_1_conv_maxpool_residual_linear",
+    "model_8_conv_batchnorm_maxpool_residual",
+    "model_9_dilated_conv_batchnorm_avgpool_residual",
+    "views",
+}
+
+_PERMUTE_TARGETS = {
+    exir_ops.edge.aten.permute_copy.default,
+    exir_ops.edge.channels_last.permute_copy.default,
+}
+
+
+def _permutes(edge) -> int:
+    return sum(
+        node.op == "call_function" and node.target in _PERMUTE_TARGETS
+        for node in edge.exported_program().graph.nodes
+    )
+
+
+def test_absorption_pays_for_the_layout_pass_across_the_model_matrix() -> None:
+    from executorch.backends.transforms.test.test_to_contiguous_channels_last_pass import (
+        cases,
+    )
+
+    baseline = layout_only = absorbed = contract_entries = 0
+    regressions = set()
+    for name, case in cases.items():
+        case.module.eval()
+        with torch.no_grad():
+            exported = torch.export.export(case.module, case.inputs)
+            config = EdgeCompileConfig(_check_ir_validity=False, _skip_dim_order=True)
+            case_baseline = _permutes(to_edge(exported, compile_config=config))
+
+            edge = to_edge(exported, compile_config=config)
+            edge = edge.transform(
+                [ToContiguousChannelsLastPass(edge.exported_program())]
+            )
+            case_layout = _permutes(edge)
+
+            absorb = AbsorbBoundaryLayoutCopies(edge.exported_program())
+            edge = edge.transform([absorb])
+            case_absorbed = _permutes(edge)
+
+        baseline += case_baseline
+        layout_only += case_layout
+        absorbed += case_absorbed
+        contract_entries += len(absorb.contract.inputs) + len(absorb.contract.outputs)
+        if case_absorbed > case_baseline:
+            regressions.add(name)
+
+    assert baseline == _MATRIX_BASELINE_PERMUTES
+    assert layout_only == _MATRIX_LAYOUT_ONLY_PERMUTES
+    assert absorbed == _MATRIX_ABSORBED_PERMUTES
+    assert contract_entries == _MATRIX_CONTRACT_ENTRIES
+    assert regressions == _MATRIX_RESIDUAL_REGRESSIONS

--- a/backends/transforms/test/test_to_contiguous_channels_last_pass.py
+++ b/backends/transforms/test/test_to_contiguous_channels_last_pass.py
@@ -1001,7 +1001,6 @@ def test_one_sided_propagation_reaches_graph_boundary(
     assert torch.allclose(actual, expected, atol=1e-6)
 
     if isinstance(module, PadConv):
-        # The pad stays on the aten operator; only its argument is remapped.
         assert (
             _count(
                 transformed.exported_program().graph_module,


### PR DESCRIPTION
Add cortex_m::pad_contiguous beside the existing pad. The two differ only in
whether the kernel has to work out the layout for itself: the existing operator
infers it, while this one requires the dim order to say the tensor is contiguous
and then indexes the padding by logical axis.

Not named after an axis order, because padding does not interpret axes the way
convolution and pooling do -- it pads whatever it is told to. What distinguishes
this entry point is that it never guesses. It accepts ranks one to four for the
same reason, so it can replace the inferring operator outright once serialized
programs no longer need that one, rather than sitting beside it forever.

Leave the existing operator alone. Its layout predicate is tolerant on purpose:
the tolerance short-circuits before the dim order is consulted, which is what
keeps it agreeing with the AOT pass for shapes whose serialized dim order cannot
name the channel axis. Two regression cases cover that, since every pre-existing
channels-last pad test used more than one channel and so missed it.

Local Corstone-300 run of the full Cortex-M suite and lintrunner.

Authored with Codex.