### PR TITLE
Import the pybindings extension directly from executorch.runtime

### DIFF
--- a/extension/pybindings/BUCK
+++ b/extension/pybindings/BUCK
@@ -63,10 +63,22 @@ fbcode_target(_kind = executorch_pybindings,
 )
 
 fbcode_target(_kind = runtime.python_library,
-    name = "portable_lib",
-    srcs = ["portable_lib.py"],
+    name = "_bootstrap",
+    srcs = ["_bootstrap.py"],
     visibility = ["PUBLIC"],
     deps = [
+        ":_C",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
+    name = "portable_lib",
+    srcs = [
+        "portable_lib.py",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        ":_bootstrap",
         ":_C",
         "//executorch/exir:_warnings",
     ],

--- a/extension/pybindings/BUCK
+++ b/extension/pybindings/BUCK
@@ -68,6 +68,7 @@ fbcode_target(_kind = runtime.python_library,
     visibility = ["PUBLIC"],
     deps = [
         ":_C",
+        "//caffe2:torch",
     ],
 )
 

--- a/extension/pybindings/_bootstrap.py
+++ b/extension/pybindings/_bootstrap.py
@@ -8,10 +8,11 @@
 
 """Prepares the process so the pybindings extension module can be imported.
 
-The extension links libtorch and dlopens backend libraries, so a few things have to happen
-before the import: torch has to be resident, the OpenVINO backend needs a path to its C
-library, and Windows needs the extension's directory on the DLL search path. Importing the
-extension without these fails to resolve symbols at load time.
+Two of these have to happen before the extension is imported: torch is made resident so the
+extension resolves libtorch symbols at load time, and on Windows the extension's directory is
+added to the DLL search path. The third, pointing the OpenVINO backend at its C library, is
+only read when that backend is first used, but it is set here so a single import prepares
+everything.
 
 Private. Import the extension through `executorch.runtime` instead.
 """
@@ -22,9 +23,11 @@ import logging
 import os
 import sys
 
-# Importing torch loads libtorch and its dependencies, so the extension can resolve them
-# when it is imported next. A pip-installed wheel has no other way to find them. Kept out of
-# the sorted block because the order is load-bearing.
+# Importing torch first loads libtorch, so the extension resolves against the same copy the
+# rest of the process uses. The wheel also records an rpath to torch/lib (see
+# _python_extension_rpath in CMakeLists.txt), so this is not the only way libtorch is found,
+# but it keeps the resident copy authoritative. Kept out of the sorted block because the
+# order is load-bearing.
 import torch as _torch  # noqa: F401  # usort: skip
 
 logger = logging.getLogger(__name__)

--- a/extension/pybindings/_bootstrap.py
+++ b/extension/pybindings/_bootstrap.py
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Prepares the process so the pybindings extension module can be imported.
+
+The extension links libtorch and dlopens backend libraries, so a few things have to happen
+before the import: torch has to be resident, the OpenVINO backend needs a path to its C
+library, and Windows needs the extension's directory on the DLL search path. Importing the
+extension without these fails to resolve symbols at load time.
+
+Private. Import the extension through `executorch.runtime` instead.
+"""
+
+import glob
+import importlib.util
+import logging
+import os
+import sys
+
+# Importing torch loads libtorch and its dependencies, so the extension can resolve them
+# when it is imported next. A pip-installed wheel has no other way to find them. Kept out of
+# the sorted block because the order is load-bearing.
+import torch as _torch  # noqa: F401  # usort: skip
+
+logger = logging.getLogger(__name__)
+
+
+def _discover_openvino_library() -> None:
+    """Point the OpenVINO backend at the C library inside the pip-installed package.
+
+    The backend calls dlopen("libopenvino_c.so"), which only resolves if the library is on
+    the loader path. Finding it here means a user who pip-installed openvino does not have
+    to set LD_LIBRARY_PATH or OPENVINO_LIB_PATH by hand.
+    """
+    if os.environ.get("OPENVINO_LIB_PATH"):
+        return
+
+    try:
+        spec = importlib.util.find_spec("openvino")
+        if spec is None or not spec.submodule_search_locations:
+            return
+
+        directory = spec.submodule_search_locations[0]
+        libraries = sorted(
+            glob.glob(os.path.join(directory, "libs", "libopenvino_c.so*"))
+        )
+        if libraries:
+            os.environ["OPENVINO_LIB_PATH"] = libraries[0]
+        else:
+            logger.warning(
+                "OpenVINO package found but libopenvino_c.so not in %s; "
+                "set OPENVINO_LIB_PATH manually if needed",
+                os.path.join(directory, "libs"),
+            )
+    except Exception as e:
+        logger.debug("OpenVINO auto-discovery failed: %s", e)
+
+
+def _add_extension_directory_to_dll_path() -> None:
+    """Let Windows find the extension's own DLLs, which sit next to this file."""
+    if sys.platform != "win32":
+        return
+
+    try:
+        os.add_dll_directory(os.path.dirname(os.path.abspath(__file__)))
+    except Exception as e:
+        logger.error(
+            "Failed to add the pybinding extension DLL to the search path. "
+            "The extension may not work: %s",
+            e,
+        )
+
+
+_discover_openvino_library()
+_add_extension_directory_to_dll_path()

--- a/extension/pybindings/portable_lib.py
+++ b/extension/pybindings/portable_lib.py
@@ -13,9 +13,6 @@
     This API is experimental and subject to change without notice.
 """
 
-import logging
-import os
-import sys
 import warnings as _warnings
 
 import executorch.exir._warnings as _exir_warnings
@@ -25,52 +22,10 @@ _warnings.warn(
     _exir_warnings.ExperimentalWarning,
 )
 
-# When installed as a pip wheel, we must import `torch` before trying to import
-# the pybindings shared library extension. This will load libtorch.so and
-# related libs, ensuring that the pybindings lib can resolve those runtime
-# dependencies.
-import torch as _torch
-
-logger = logging.getLogger(__name__)
-
-# Auto-discover the OpenVINO C library path from the pip-installed openvino
-# package so the C++ backend's dlopen("libopenvino_c.so") works without the
-# user having to set LD_LIBRARY_PATH or OPENVINO_LIB_PATH manually.
-if not os.environ.get("OPENVINO_LIB_PATH"):
-    try:
-        import glob
-        import importlib.util
-
-        spec = importlib.util.find_spec("openvino")
-        if spec is not None and spec.submodule_search_locations:
-            _ov_dir = spec.submodule_search_locations[0]
-            _ov_libs = sorted(
-                glob.glob(os.path.join(_ov_dir, "libs", "libopenvino_c.so*"))
-            )
-            if _ov_libs:
-                os.environ["OPENVINO_LIB_PATH"] = _ov_libs[0]
-            else:
-                logger.warning(
-                    "OpenVINO package found but libopenvino_c.so not in %s; "
-                    "set OPENVINO_LIB_PATH manually if needed",
-                    os.path.join(_ov_dir, "libs"),
-                )
-            del _ov_libs, _ov_dir, spec
-    except Exception as e:
-        logger.debug("OpenVINO auto-discovery failed: %s", e)
-
-# Update the DLL search path on Windows. This is the recommended way to handle native
-# extensions.
-if sys.platform == "win32":
-    try:
-        # The extension DLL should be in the same directory as this file.
-        pybindings_dir = os.path.dirname(os.path.abspath(__file__))
-        os.add_dll_directory(pybindings_dir)
-    except Exception as e:
-        logger.error(
-            "Failed to add the pybinding extension DLL to the search path. The extension may not work.",
-            e,
-        )
+# Prepares the process for the extension import below: torch resident, OpenVINO library
+# located, Windows DLL path set. Must precede the _C import, so it is kept out of the sorted
+# block.
+import executorch.extension.pybindings._bootstrap  # noqa: F401  # usort: skip
 
 # Let users import everything from the C++ _C extension as if this
 # python file defined them. Although we could import these dynamically, it
@@ -103,6 +58,5 @@ from executorch.extension.pybindings._C import (  # noqa: F401
 
 # Clean up so that `dir(portable_lib)` is the same as `dir(_C)`
 # (apart from some __dunder__ names).
-del _torch
 del _exir_warnings
 del _warnings

--- a/runtime/BUCK
+++ b/runtime/BUCK
@@ -8,6 +8,7 @@ fbcode_target(
     name = "runtime",
     srcs = ["__init__.py"],
     deps = [
+        "//executorch/extension/pybindings:_C",
         "//executorch/extension/pybindings:_bootstrap",
     ],
     visibility = ["PUBLIC"],

--- a/runtime/BUCK
+++ b/runtime/BUCK
@@ -8,7 +8,7 @@ fbcode_target(
     name = "runtime",
     srcs = ["__init__.py"],
     deps = [
-        "//executorch/extension/pybindings:portable_lib",
+        "//executorch/extension/pybindings:_bootstrap",
     ],
     visibility = ["PUBLIC"],
 )

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -114,7 +114,9 @@ from types import ModuleType
 from typing import Any, BinaryIO, Dict, List, Optional, Sequence, Set, Union
 
 try:
-    from executorch.extension.pybindings.portable_lib import (  # type: ignore[import-not-found]
+    import executorch.extension.pybindings._bootstrap  # noqa: F401  # usort: skip
+
+    from executorch.extension.pybindings._C import (  # type: ignore[import-not-found]
         ExecuTorchMethod,
         ExecuTorchProgram,
         MethodMeta,
@@ -271,7 +273,7 @@ class Runtime:
     @functools.lru_cache(maxsize=1)
     def get() -> "Runtime":
         """Gets the Runtime singleton."""
-        import executorch.extension.pybindings.portable_lib as legacy_module  # type: ignore[import-not-found]
+        import executorch.extension.pybindings._C as legacy_module  # type: ignore[import-not-found]
 
         return Runtime(legacy_module=legacy_module)
 


### PR DESCRIPTION
### The problem

Loading the C++ extension module (`_C`) needs three things to happen first:

1. `torch` has to be imported, so `libtorch.so` is already loaded and the extension can resolve its symbols.
2. The OpenVINO backend needs a path to its C library, otherwise its `dlopen("libopenvino_c.so")` fails.
3. On Windows, the extension's own directory has to be on the DLL search path.

All three lived inside `extension/pybindings/portable_lib.py`. So anything that wanted the extension had to import `portable_lib` to get that setup, even if it did not want anything else from it.

That is why `executorch.runtime`, the public API, imported `portable_lib`. Note that `portable_lib` is not a private helper: it is the entry point for the portable kernel build, the counterpart to `aten_lib`, which selects the ATen kernel build (see `ATen mode` in `docs/source/concepts.md`). So the runtime was reaching through a kernel build selector just to get import setup, which is a layering problem rather than a naming one.

One side effect: `portable_lib` warns at import time that it is experimental, and the public `executorch.runtime` reached that warning through it. `ExperimentalWarning` derives from `DeprecationWarning` (`exir/_warnings.py:18`), so it is hidden under Python's default filters. It becomes visible when warnings are enabled, for example under `pytest` or `python -W`:

```python
$ python -W always::DeprecationWarning -c 'from executorch.runtime import Runtime'
ExperimentalWarning: This API is experimental and subject to change without notice.
```

### The fix

Move those three setup steps into `extension/pybindings/_bootstrap.py`, and have both `portable_lib` and `executorch.runtime` use it.

```
before                                  after

runtime/__init__.py                     runtime/__init__.py
  -> portable_lib                         -> _bootstrap
       -> torch, openvino, dll             -> _C
       -> _C
                                        portable_lib.py
                                          -> _bootstrap
                                          -> _C
```

`executorch.runtime` now imports the extension directly, so the experimental warning is no longer on the public API's import path at all. `portable_lib` keeps its own warning unchanged for callers who import it directly. The error it already raised when the extension is missing now names the module it actually imports.

### What this does not change

No API change. `portable_lib` still re-exports the same names and is **not** deprecated here. Every existing import keeps working exactly as before.

Also fixes a logging call that passed an exception with no matching format specifier, so the reason a DLL directory could not be added was dropped from the message.

### Test plan

Verified by running, not by reading:

- OpenVINO discovery sets `OPENVINO_LIB_PATH` when the package is present, leaves an already-set value alone, and does not raise when `openvino` is absent.
- `torch` is imported before the two setup calls, and the bootstrap import precedes the extension import in `portable_lib`.
- Every function the runtime reads off the extension (`_get_registered_backend_names`, `_is_available`, `_get_operator_names`, `_load_program`, `_load_program_from_buffer`) is declared in the type stub.
- No build target reached `portable_lib` only through the runtime target, so severing that edge does not break a transitive dependency.
- `black`, `flake8` and `usort` clean on all changed files.

Not verified locally: importing the real built extension, since that needs a compiled wheel. That path is left to CI.


