### PR TITLE
Import profiling and threadpool test helpers from the extension module

### DIFF
--- a/extension/llm/custom_ops/BUCK
+++ b/extension/llm/custom_ops/BUCK
@@ -31,7 +31,7 @@ fbcode_target(_kind = runtime.python_test,
     ],
     deps = [
         "//caffe2:torch",
-        "//executorch/extension/pybindings:portable_lib",
+        "//executorch/extension/pybindings:_C",
     ],
 )
 
@@ -95,7 +95,7 @@ fbcode_target(_kind = runtime.python_test,
     ],
     deps = [
         "//caffe2:torch",
-        "//executorch/extension/pybindings:portable_lib",
+        "//executorch/extension/pybindings:_C",
     ],
 )
 

--- a/extension/llm/custom_ops/test_quantized_sdpa.py
+++ b/extension/llm/custom_ops/test_quantized_sdpa.py
@@ -12,7 +12,7 @@ import torch
 import torch.nn.functional as F
 
 from executorch.extension.llm.custom_ops import custom_ops  # noqa
-from executorch.extension.pybindings.portable_lib import _unsafe_reset_threadpool
+from executorch.extension.pybindings._C import _unsafe_reset_threadpool
 
 
 def is_fbcode():

--- a/extension/llm/custom_ops/test_sdpa_with_kv_cache.py
+++ b/extension/llm/custom_ops/test_sdpa_with_kv_cache.py
@@ -12,7 +12,7 @@ import torch
 import torch.nn.functional as F
 
 from executorch.extension.llm.custom_ops import custom_ops  # noqa
-from executorch.extension.pybindings.portable_lib import _unsafe_reset_threadpool
+from executorch.extension.pybindings._C import _unsafe_reset_threadpool
 
 
 def is_fbcode():

--- a/profiler/test/BUCK
+++ b/profiler/test/BUCK
@@ -18,7 +18,7 @@ fbcode_target(_kind = python_binary,
     deps = [
         "//executorch/exir:lib",
         "//executorch/exir/_serialize:lib",
-        "//executorch/extension/pybindings:portable_lib",
+        "//executorch/extension/pybindings:_C",
         "//executorch/profiler/fb:parse_profiler_library",
     ],
 )

--- a/profiler/test/test_profiler_e2e.py
+++ b/profiler/test/test_profiler_e2e.py
@@ -15,7 +15,7 @@ import torch
 
 from executorch.exir import to_edge
 
-from executorch.extension.pybindings.portable_lib import (
+from executorch.extension.pybindings._C import (
     _create_profile_block,
     _dump_profile_results,
     _load_for_executorch_from_buffer,


### PR DESCRIPTION
### Background: what portable_lib is actually for

ExecuTorch can build its Python extension against two different kernel sets, and this is a documented concept (see `ATen mode` in `docs/source/concepts.md`):

```
portable kernels   ExecuTorch's own small tensor type (ETensor mode)
ATen kernels       PyTorch's full at::Tensor (ATen mode)
```

`portable_lib` is the entry point for the first, and `aten_lib` is the entry point for the second. So `portable_lib` is a **kernel build selector**, not a general utility module.

### The problem

Three tests import private helpers from `portable_lib` that have nothing to do with choosing a kernel build:

```
profiler/test/test_profiler_e2e.py            _create_profile_block, _dump_profile_results,
                                              _reset_profile_results
extension/llm/custom_ops/test_sdpa_with_kv_cache.py   _unsafe_reset_threadpool
extension/llm/custom_ops/test_quantized_sdpa.py       _unsafe_reset_threadpool
```

None of these three ever reference `aten_lib` or a kernel mode. They have no fallback and no choice, so importing `portable_lib` already pinned them to the portable build. The import suggests a kernel-build decision that the tests do not actually make.

### The change

Import those helpers from the extension module directly. That is the same build these tests were already getting, stated plainly instead of implied. Build dependencies are updated to match.

```diff
-from executorch.extension.pybindings.portable_lib import _unsafe_reset_threadpool
+from executorch.extension.pybindings._C import _unsafe_reset_threadpool
```

### What is deliberately left alone

Two other tests keep importing `portable_lib`, because they use it for exactly what it is for: they try `portable_lib`, fall back to `aten_lib`, and record which kernel build they got.

```python
try:
    from executorch.extension.pybindings import portable_lib as runtime
    kernel_mode = "portable"
except Exception:
    from executorch.extension.pybindings import aten_lib as runtime
    kernel_mode = "aten"
```

Those are correct as written and are not touched here.

### Test plan

No behaviour change, verified rather than assumed:

- All five imported names are declared in the extension's type stub (`pybindings.pyi`).
- `torch` is imported before the extension in all three files, which the extension needs in order to load its dependencies.
- None of the three reference `aten_lib` or a kernel mode, so no kernel selection behaviour changes.
- `black`, `flake8` and `usort` clean.

Not verified locally: running these tests needs a compiled extension, which is not available on the machine this was prepared on. Left to CI.
