### PR TITLE
[Vulkan] Add the off-graph flat KV cache and update_and_attend op

### DIFF
--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -17,6 +17,7 @@
 #include <executorch/backends/vulkan/runtime/api/api.h>
 
 #include <executorch/backends/vulkan/runtime/graph/GraphConfig.h>
+#include <executorch/backends/vulkan/runtime/graph/VulkanCache.h>
 
 #include <executorch/backends/vulkan/runtime/graph/containers/SharedObject.h>
 #include <executorch/backends/vulkan/runtime/graph/containers/Value.h>
@@ -223,6 +224,9 @@ class ComputeGraph final {
 
   // Flag to indicate if re-encoding is required
   bool requires_reencode_ = false;
+
+  // Off-graph KV cache, installed by the backend before the graph is built.
+  VulkanCache* kv_cache_ = nullptr;
 
  protected:
   size_t values_in_use_ = 0;
@@ -1178,6 +1182,14 @@ class ComputeGraph final {
   // Set the flag to indicate that re-encoding is required
   inline void set_requires_reencode() noexcept {
     requires_reencode_ = true;
+  }
+
+  inline void set_kv_cache(VulkanCache* cache) noexcept {
+    kv_cache_ = cache;
+  }
+
+  inline VulkanCache* kv_cache() const noexcept {
+    return kv_cache_;
   }
 
   //

--- a/backends/vulkan/runtime/graph/VulkanCache.h
+++ b/backends/vulkan/runtime/graph/VulkanCache.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <executorch/backends/vulkan/runtime/vk_api/Types.h>
+#include <executorch/backends/vulkan/runtime/vk_api/memory/Buffer.h>
+
+namespace vkcompute {
+
+// Graph-facing view of the off-graph KV cache. The host installs one before the
+// graph is built; the op function reads each layer's pool shape and wraps the
+// pool buffer. Pools are [B, S, H, D], the layout the SDPA shaders index.
+class VulkanCache {
+ public:
+  virtual ~VulkanCache() = default;
+
+  // Pool shape for `layer`, in this backend's layout.
+  virtual std::vector<int64_t> pool_sizes(int layer) const = 0;
+
+  // Element type the pools store K/V in.
+  virtual vkapi::ScalarType pool_dtype() const = 0;
+
+  // Layers the cache was built for; the op function bounds `layer` by this.
+  virtual int num_layers() const = 0;
+
+  // The pools themselves, for the graph to wrap.
+  virtual const vkapi::VulkanBuffer& k_buffer(int layer) const = 0;
+  virtual const vkapi::VulkanBuffer& v_buffer(int layer) const = 0;
+};
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/graph/VulkanSequenceCache.h
+++ b/backends/vulkan/runtime/graph/VulkanSequenceCache.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// The Vulkan byte layer behind the neutral SequenceCache. Holds one buffer
+// pool per layer for K and one for V, allocated at construction.
+//
+// Flat layers only: every dispatch here assumes slot == position, which a ring
+// layer breaks.
+
+#include <memory>
+#include <vector>
+
+#include <executorch/backends/vulkan/runtime/api/containers/Tensor.h>
+#include <executorch/backends/vulkan/runtime/graph/VulkanCache.h>
+#include <executorch/extension/llm/cache/cache.h>
+#include <executorch/extension/llm/cache/sequence_cache.h>
+#include <executorch/runtime/core/error.h>
+#include <executorch/runtime/core/portable_type/scalar_type.h>
+#include <executorch/runtime/core/result.h>
+
+namespace vkcompute {
+
+namespace cache = ::executorch::extension::llm::cache;
+namespace runtime = ::executorch::runtime;
+
+class VulkanSequenceCache : public cache::SequenceCache, public VulkanCache {
+ public:
+  static runtime::Result<std::unique_ptr<VulkanSequenceCache>> create(
+      const cache::CacheConfig& cfg) {
+    ET_CHECK_OR_RETURN_ERROR(
+        cache::valid(cfg),
+        InvalidArgument,
+        "VulkanSequenceCache: invalid config");
+    for (const cache::LayerConfig& lc : cfg.layers) {
+      ET_CHECK_OR_RETURN_ERROR(
+          lc.policy.kind == cache::LayerPolicy::Kind::Flat,
+          NotSupported,
+          "VulkanSequenceCache: only flat layers are supported");
+      ET_CHECK_OR_RETURN_ERROR(
+          lc.n_kv_heads > 0 && lc.head_dim > 0,
+          InvalidArgument,
+          "VulkanSequenceCache: n_kv_heads and head_dim must be positive");
+    }
+    // The SDPA shaders are only generated for fp32 and fp16.
+    using EtScalarType = ::executorch::runtime::etensor::ScalarType;
+    vkapi::ScalarType pool_dtype;
+    switch (static_cast<EtScalarType>(cfg.kv_dtype)) {
+      case EtScalarType::Float:
+        pool_dtype = vkapi::kFloat;
+        break;
+      case EtScalarType::Half:
+        pool_dtype = vkapi::kHalf;
+        break;
+      default:
+        ET_LOG(Error, "VulkanSequenceCache: unsupported kv_dtype");
+        return runtime::Error::NotSupported;
+    }
+    return std::unique_ptr<VulkanSequenceCache>(
+        new VulkanSequenceCache(cfg, pool_dtype));
+  }
+
+  // [B, S, H, D], the layout the SDPA shaders index. S is the allocated depth.
+  std::vector<int64_t> pool_sizes(int layer) const override {
+    const cache::LayerConfig& lc = layers_[static_cast<size_t>(layer)];
+    return {1, capacity(), lc.n_kv_heads, lc.head_dim};
+  }
+
+  vkapi::ScalarType pool_dtype() const override {
+    return pool_dtype_;
+  }
+
+  int num_layers() const override {
+    return static_cast<int>(layers_.size());
+  }
+
+  const vkapi::VulkanBuffer& k_buffer(int layer) const override {
+    return kpool_[static_cast<size_t>(layer)].buffer();
+  }
+  const vkapi::VulkanBuffer& v_buffer(int layer) const override {
+    return vpool_[static_cast<size_t>(layer)].buffer();
+  }
+
+ private:
+  VulkanSequenceCache(
+      const cache::CacheConfig& cfg,
+      const vkapi::ScalarType pool_dtype)
+      : cache::SequenceCache(cfg), pool_dtype_(pool_dtype) {
+    layers_.reserve(static_cast<size_t>(cfg.n_layers));
+    for (int l = 0; l < cfg.n_layers; ++l) {
+      // layers size 1 = one config broadcast to every layer, else per-layer.
+      layers_.push_back(
+          cfg.layers.size() == 1 ? cfg.layers.front() : cfg.layers[l]);
+    }
+    // The global context outlives every graph.
+    kpool_.reserve(static_cast<size_t>(cfg.n_layers));
+    vpool_.reserve(static_cast<size_t>(cfg.n_layers));
+    for (int l = 0; l < cfg.n_layers; ++l) {
+      for (auto* pool : {&kpool_, &vpool_}) {
+        pool->emplace_back(
+            api::context(),
+            pool_sizes(l),
+            pool_dtype_,
+            utils::kBuffer,
+            utils::kWidthPacked);
+      }
+    }
+  }
+
+  std::vector<cache::LayerConfig> layers_;
+  vkapi::ScalarType pool_dtype_;
+  std::vector<api::vTensor> kpool_;
+  std::vector<api::vTensor> vpool_;
+};
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_coop.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_coop.glsl
@@ -32,6 +32,7 @@ $if K_CACHE_STORAGE == "buffer":
 #define NUM_WORKERS_PER_OUT 64
 
 ${define_required_extensions(IO_STORAGE, DTYPE)}
+${define_required_extensions(K_CACHE_STORAGE, DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_coop.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_coop.yaml
@@ -18,6 +18,7 @@ sdpa_compute_attn_weights_coop:
         - parameter_values: [texture3d, texture3d]
         - parameter_values: [buffer, texture3d]
         - parameter_values: [buffer, buffer]
+        - parameter_values: [texture3d, buffer]
     DTYPE:
       - VALUE: float
       - VALUE: half

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_tiled.glsl
@@ -46,6 +46,7 @@ $if HAS_BIAS:
 #define TILE_N ${TILE_N4 * 4}
 
 ${define_required_extensions(IO_STORAGE, [IN_DTYPE, OUT_DTYPE])}
+${define_required_extensions(K_CACHE_STORAGE, [IN_DTYPE, OUT_DTYPE])}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_tiled.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_attn_weights_tiled.yaml
@@ -22,6 +22,7 @@ sdpa_compute_attn_weights_tiled:
         - parameter_values: [texture3d, texture3d]
         - parameter_values: [buffer, texture3d]
         - parameter_values: [buffer, buffer]
+        - parameter_values: [texture3d, buffer]
     combination1:
       parameter_names: [IN_DTYPE, OUT_DTYPE]
       combos:

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_coop.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_coop.glsl
@@ -43,6 +43,7 @@ $if GQA:
   #define MAX_GROUP_SIZE 8
 
 ${define_required_extensions(IO_STORAGE, DTYPE)}
+${define_required_extensions(V_CACHE_STORAGE, DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_coop.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_coop.yaml
@@ -19,6 +19,7 @@ sdpa_compute_out_coop:
         - parameter_values: [texture3d, texture3d]
         - parameter_values: [buffer, texture3d]
         - parameter_values: [buffer, buffer]
+        - parameter_values: [texture3d, buffer]
     DTYPE:
       - VALUE: float
       - VALUE: half

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_tiled.glsl
@@ -38,6 +38,7 @@ $else:
 #define TILE_N ${TILE_N4 * 4}
 
 ${define_required_extensions(IO_STORAGE, DTYPE)}
+${define_required_extensions(V_CACHE_STORAGE, DTYPE)}
 
 layout(std430) buffer;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_tiled.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_compute_out_tiled.yaml
@@ -20,6 +20,7 @@ sdpa_compute_out_tiled:
         - parameter_values: [texture3d, texture3d]
         - parameter_values: [buffer, texture3d]
         - parameter_values: [buffer, buffer]
+        - parameter_values: [texture3d, buffer]
     DTYPE:
       - VALUE: float
       - VALUE: half

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_kv_cache_update.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_kv_cache_update.glsl
@@ -3,6 +3,7 @@
 #define PRECISION ${PRECISION}
 
 #define IN_VEC4_T ${texel_load_type(DTYPE, INPUT_STORAGE)}
+#define OUT_VEC4_T ${texel_load_type(DTYPE, OUTPUT_STORAGE)}
 #define T ${buffer_scalar_type(DTYPE)}
 
 $if OUTPUT_STORAGE == "buffer":
@@ -11,6 +12,7 @@ $if INPUT_STORAGE == "buffer":
   #define INPUT_BUFFER
 
 ${define_required_extensions(INPUT_STORAGE, DTYPE)}
+${define_required_extensions(OUTPUT_STORAGE, DTYPE)}
 
 layout(std430) buffer;
 
@@ -65,7 +67,7 @@ void write_cache_d4(
     const int C,
     const int H) {
 #ifdef OUTPUT_BUFFER
-  t_cache[(c * H * D4) + (h * D4) + d4] = texel;
+  t_cache[(c * H * D4) + (h * D4) + d4] = OUT_VEC4_T(texel);
 #else
   imageStore(t_cache, ivec3(d4, h, c), texel);
 #endif

--- a/backends/vulkan/runtime/graph/ops/glsl/sdpa_kv_cache_update.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/sdpa_kv_cache_update.yaml
@@ -16,6 +16,7 @@ sdpa_kv_cache_update:
         - parameter_values: [texture3d, texture3d]
         - parameter_values: [texture3d, buffer]
         - parameter_values: [buffer, buffer]
+        - parameter_values: [buffer, texture3d]
     DTYPE:
       - VALUE: half
       - VALUE: float

--- a/backends/vulkan/runtime/graph/ops/impl/SDPA.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/SDPA.cpp
@@ -705,7 +705,6 @@ void sdpa_impl(ComputeGraph& graph, const std::vector<ValueRef>& args) {
   VK_CHECK_COND(
       graph.val_is_none(dropout_p) ||
       graph.extract_scalar<double>(dropout_p) == 0);
-  VK_CHECK_COND(graph.val_is_none(scale));
   // is_causal is assumed to be true in the current implementation.
   VK_CHECK_COND(
       graph.val_is_none(is_causal) || graph.extract_scalar<bool>(is_causal));
@@ -772,7 +771,9 @@ void sdpa_impl(ComputeGraph& graph, const std::vector<ValueRef>& args) {
       utils::kWidthPacked);
 
   const int32_t head_dim_size = graph.size_at<int32_t>(-1, q_projected);
-  const float scale_val = 1.0f / std::sqrt(static_cast<float>(head_dim_size));
+  const float scale_val = graph.val_is_none(scale)
+      ? 1.0f / std::sqrt(static_cast<float>(head_dim_size))
+      : static_cast<float>(graph.extract_scalar<double>(scale));
 
   add_sdpa_compute_attn_weights_node(
       graph,
@@ -843,6 +844,60 @@ void sdpa_with_kv_cache_impl(
        attn_mask,
        dropout_p,
        is_causal,
+       scale,
+       out});
+}
+
+// Writes this step's K/V into the installed cache's pools and attends over
+// them. Pool shape and dtype come from the cache, so the graph carries neither.
+void update_and_attend_impl(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args) {
+  int arg_idx = 0;
+  const ValueRef q_projected = args[arg_idx++];
+  const ValueRef k_projected = args[arg_idx++];
+  const ValueRef v_projected = args[arg_idx++];
+  const ValueRef input_pos_symint = args[arg_idx++];
+  const ValueRef layer_id = args[arg_idx++];
+  const ValueRef scale = args[arg_idx++];
+  // `out` already carries this dtype; unpacked to keep the arg positions.
+  const ValueRef out_dtype = args[arg_idx++];
+  const ValueRef out = args[arg_idx++];
+  (void)out_dtype;
+
+  VulkanCache* cache = graph.kv_cache();
+  VK_CHECK_COND(cache != nullptr, "update_and_attend: no KV cache installed");
+
+  const int layer = graph.extract_scalar<int>(layer_id);
+  VK_CHECK_COND(
+      layer >= 0 && layer < cache->num_layers(),
+      "update_and_attend: layer out of range");
+
+  const std::vector<int64_t> cache_sizes = cache->pool_sizes(layer);
+
+  const ValueRef k_cache = graph.add_tensor(
+      cache_sizes,
+      cache->pool_dtype(),
+      utils::kWidthPacked,
+      cache->k_buffer(layer));
+  const ValueRef v_cache = graph.add_tensor(
+      cache_sizes,
+      cache->pool_dtype(),
+      utils::kWidthPacked,
+      cache->v_buffer(layer));
+
+  update_cache_impl(graph, {k_projected, k_cache, input_pos_symint, -1});
+  update_cache_impl(graph, {v_projected, v_cache, input_pos_symint, -1});
+
+  sdpa_impl(
+      graph,
+      {q_projected,
+       k_cache,
+       v_cache,
+       input_pos_symint,
+       kDummyValueRef, // attn_mask: LLM mode derives causality from input_pos
+       kDummyValueRef, // dropout_p
+       kDummyValueRef, // is_causal
        scale,
        out});
 }
@@ -1006,6 +1061,7 @@ REGISTER_OPERATORS {
       testing.compute_attn_weight_with_kv_cache.default,
       compute_attn_weight_with_kv_cache_impl);
   VK_REGISTER_OP(et_vk.sdpa.default, fused_sdpa_impl);
+  VK_REGISTER_OP(kvcache.update_and_attend.default, update_and_attend_impl);
 }
 
 } // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/SDPA.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/SDPA.cpp
@@ -13,6 +13,7 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/MatMul.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Permute.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/RepeatInterleave.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Slice.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Softmax.h>
@@ -886,12 +887,52 @@ void update_and_attend_impl(
       utils::kWidthPacked,
       cache->v_buffer(layer));
 
-  update_cache_impl(graph, {k_projected, k_cache, input_pos_symint, -1});
-  update_cache_impl(graph, {v_projected, v_cache, input_pos_symint, -1});
+  // q/k/v/out are [B, H, S, D] while the pools and the SDPA shaders index
+  // [B, S, H, D], so each crossing swaps the head and sequence dims. The swap
+  // is its own inverse, so one permute_dims value serves both directions.
+  const ValueRef hs_swap = graph.add_scalar_list<int64_t>({0, 2, 1, 3});
+
+  auto swap_hs = [&graph](const ValueRef t) {
+    std::vector<int64_t> sizes = graph.sizes_of(t);
+    std::swap(sizes.at(1), sizes.at(2));
+    return sizes;
+  };
+
+  TmpTensor q_bshd(
+      &graph,
+      swap_hs(q_projected),
+      graph.dtype_of(q_projected),
+      graph.storage_type_of(q_projected),
+      utils::kWidthPacked);
+  TmpTensor k_bshd(
+      &graph,
+      swap_hs(k_projected),
+      graph.dtype_of(k_projected),
+      graph.storage_type_of(k_projected),
+      utils::kWidthPacked);
+  TmpTensor v_bshd(
+      &graph,
+      swap_hs(v_projected),
+      graph.dtype_of(v_projected),
+      graph.storage_type_of(v_projected),
+      utils::kWidthPacked);
+  TmpTensor out_bshd(
+      &graph,
+      swap_hs(out),
+      graph.dtype_of(out),
+      graph.storage_type_of(out),
+      utils::kWidthPacked);
+
+  add_permute_node(graph, q_projected, hs_swap, q_bshd);
+  add_permute_node(graph, k_projected, hs_swap, k_bshd);
+  add_permute_node(graph, v_projected, hs_swap, v_bshd);
+
+  update_cache_impl(graph, {k_bshd, k_cache, input_pos_symint, -1});
+  update_cache_impl(graph, {v_bshd, v_cache, input_pos_symint, -1});
 
   sdpa_impl(
       graph,
-      {q_projected,
+      {q_bshd,
        k_cache,
        v_cache,
        input_pos_symint,
@@ -899,7 +940,9 @@ void update_and_attend_impl(
        kDummyValueRef, // dropout_p
        kDummyValueRef, // is_causal
        scale,
-       out});
+       out_bshd});
+
+  add_permute_node(graph, out_bshd, hs_swap, out);
 }
 
 void compute_attn_weight_with_kv_cache_impl(

--- a/backends/vulkan/test/op_tests/sdpa_test.cpp
+++ b/backends/vulkan/test/op_tests/sdpa_test.cpp
@@ -12,6 +12,7 @@
 
 #include <executorch/backends/vulkan/runtime/api/api.h>
 #include <executorch/backends/vulkan/runtime/graph/ComputeGraph.h>
+#include <executorch/backends/vulkan/runtime/graph/VulkanSequenceCache.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
 
 #include <executorch/extension/aten_util/make_aten_functor_from_et_functor.h>
@@ -27,7 +28,7 @@
 // SDPA Mode Enum
 //
 
-enum class SDPAMode { DECOMPOSED, FUSED, ATTN_WEIGHT_ONLY };
+enum class SDPAMode { DECOMPOSED, FUSED, ATTN_WEIGHT_ONLY, OFFGRAPH };
 
 std::ostream& operator<<(std::ostream& os, const SDPAMode& mode) {
   switch (mode) {
@@ -37,6 +38,8 @@ std::ostream& operator<<(std::ostream& os, const SDPAMode& mode) {
       return os << "FUSED";
     case SDPAMode::ATTN_WEIGHT_ONLY:
       return os << "ATTN_WEIGHT_ONLY";
+    case SDPAMode::OFFGRAPH:
+      return os << "OFFGRAPH";
   }
   return os;
 }
@@ -327,8 +330,26 @@ void test_vulkan_sdpa(
   // Build Vulkan SDPA graph
   using namespace vkcompute;
 
+  std::unique_ptr<VulkanSequenceCache> offgraph_cache;
+  if (mode == SDPAMode::OFFGRAPH) {
+    cache::CacheConfig cfg;
+    cfg.capacity = max_seq_len + 128;
+    cfg.n_layers = 1;
+    cfg.layers = {cache::LayerConfig{{}, num_kv_heads, head_dim}};
+    cfg.kv_dtype = static_cast<int>(
+        dtype == at::kFloat ? ::executorch::runtime::etensor::ScalarType::Float
+                            : ::executorch::runtime::etensor::ScalarType::Half);
+    auto created = VulkanSequenceCache::create(cfg);
+    ASSERT_EQ(created.error(), executorch::runtime::Error::Ok);
+    offgraph_cache = std::move(created.get());
+  }
+
   GraphConfig config;
   ComputeGraph graph(config);
+
+  if (offgraph_cache) {
+    graph.set_kv_cache(offgraph_cache.get());
+  }
 
   // "Data" variant for vulkan initialization
 
@@ -358,6 +379,20 @@ void test_vulkan_sdpa(
       out.sizes().vec(), from_at_scalartype(out.scalar_type()), storage_type);
 
   switch (mode) {
+    case SDPAMode::OFFGRAPH:
+      VK_GET_OP_FN("kvcache.update_and_attend.default")
+      (graph,
+       {
+           r_q.value,
+           r_k.value,
+           r_v.value,
+           r_input_pos_symint,
+           graph.add_scalar<int64_t>(0), // layer_id
+           graph.add_scalar<double>(1.0 / std::sqrt((double)head_dim)), // scale
+           kDummyValueRef, // out_dtype
+           r_out,
+       });
+      break;
     case SDPAMode::DECOMPOSED: {
       const ValueRef r_k_cache = graph.add_tensor(
           k_cache_data.sizes().vec(),
@@ -589,7 +624,10 @@ void test_vulkan_sdpa(
     const int batch_size,
     at::ScalarType dtype = at::kFloat) {
   for (SDPAMode mode :
-       {SDPAMode::ATTN_WEIGHT_ONLY, SDPAMode::DECOMPOSED, SDPAMode::FUSED}) {
+       {SDPAMode::ATTN_WEIGHT_ONLY,
+        SDPAMode::DECOMPOSED,
+        SDPAMode::FUSED,
+        SDPAMode::OFFGRAPH}) {
     // Test texture
     test_vulkan_sdpa(
         start_input_pos,

--- a/backends/vulkan/test/op_tests/sdpa_test.cpp
+++ b/backends/vulkan/test/op_tests/sdpa_test.cpp
@@ -351,6 +351,20 @@ void test_vulkan_sdpa(
     graph.set_kv_cache(offgraph_cache.get());
   }
 
+  // The off-graph op takes and returns [B, H, S, D]; every other mode below is
+  // [B, S, H, D]. The harness stays [B, S, H, D] and swaps at the boundary.
+  const bool bhsd_io = mode == SDPAMode::OFFGRAPH;
+  auto io_sizes = [bhsd_io](const at::Tensor& t) {
+    std::vector<int64_t> sizes = t.sizes().vec();
+    if (bhsd_io) {
+      std::swap(sizes.at(1), sizes.at(2));
+    }
+    return sizes;
+  };
+  auto io_tensor = [bhsd_io](const at::Tensor& t) {
+    return bhsd_io ? t.transpose(1, 2).contiguous() : t;
+  };
+
   // "Data" variant for vulkan initialization
 
   at::Tensor k_cache_data = at::zeros_like(k_cache);
@@ -367,7 +381,7 @@ void test_vulkan_sdpa(
 
 #define MAKE_INPUT_FOR(x)                    \
   IOValueRef r_##x = graph.add_input_tensor( \
-      x.sizes().vec(), from_at_scalartype(x.scalar_type()), storage_type);
+      io_sizes(x), from_at_scalartype(x.scalar_type()), storage_type);
 
   MAKE_INPUT_FOR(q);
   MAKE_INPUT_FOR(k);
@@ -376,7 +390,7 @@ void test_vulkan_sdpa(
 
   const ValueRef r_input_pos_symint = graph.add_symint(start_input_pos);
   const ValueRef r_out = graph.add_tensor(
-      out.sizes().vec(), from_at_scalartype(out.scalar_type()), storage_type);
+      io_sizes(out), from_at_scalartype(out.scalar_type()), storage_type);
 
   switch (mode) {
     case SDPAMode::OFFGRAPH:
@@ -484,20 +498,26 @@ void test_vulkan_sdpa(
   // Run model
   //
 
-#define COPY_INPUT(x)                     \
-  graph.maybe_cast_and_copy_into_staging( \
-      r_##x.staging,                      \
-      x.const_data_ptr(),                 \
-      x.numel(),                          \
-      from_at_scalartype(x.scalar_type()));
+#define COPY_INPUT(x)                              \
+  {                                                \
+    at::Tensor io_##x = io_tensor(x);              \
+    graph.maybe_cast_and_copy_into_staging(        \
+        r_##x.staging,                             \
+        io_##x.const_data_ptr(),                   \
+        io_##x.numel(),                            \
+        from_at_scalartype(io_##x.scalar_type())); \
+  }
 
-#define EXTRACT_TENSOR(x)                             \
-  at::Tensor vk_##x = at::zeros_like(x).contiguous(); \
-  graph.maybe_cast_and_copy_from_staging(             \
-      staging_##x,                                    \
-      vk_##x.mutable_data_ptr(),                      \
-      vk_##x.numel(),                                 \
-      from_at_scalartype(vk_##x.scalar_type()));
+#define EXTRACT_TENSOR(x)                                  \
+  at::Tensor vk_##x = at::zeros(io_sizes(x), x.options()); \
+  graph.maybe_cast_and_copy_from_staging(                  \
+      staging_##x,                                         \
+      vk_##x.mutable_data_ptr(),                           \
+      vk_##x.numel(),                                      \
+      from_at_scalartype(vk_##x.scalar_type()));           \
+  if (bhsd_io) {                                           \
+    vk_##x = vk_##x.transpose(1, 2).contiguous();          \
+  }
 
   torch::manual_seed(0);
 
@@ -515,9 +535,9 @@ void test_vulkan_sdpa(
         q, k, v, k_cache, v_cache, input_pos, seq_len, {}, 0.0, true, {}, mode);
 
     graph.set_symint(r_input_pos_symint, input_pos);
-    graph.resize_input(0, q.sizes().vec());
-    graph.resize_input(1, k.sizes().vec());
-    graph.resize_input(2, v.sizes().vec());
+    graph.resize_input(0, io_sizes(q));
+    graph.resize_input(1, io_sizes(k));
+    graph.resize_input(2, io_sizes(v));
     graph.propagate_resize();
 
     // Run Vulkan SDPA


### PR DESCRIPTION
Adds the off-graph KV cache to the Vulkan backend, behind the neutral `kvcache::update_and_attend` op. The cache is runtime state the host installs before the graph is built; it owns one buffer pool per layer for K and one for V, and the op function wraps them using the external-storage path. Pools are buffers.

Added the missing shader variants — [texture3d, buffer] for the SDPA shaders and [buffer, texture3d] for the cache update so a buffer pool works inside the default texture-storage graph.

  `sdpa_impl` asserted `scale` was None and then hardcoded `1/sqrt(head_dim)`. The op contract makes `scale` a required float, so it now uses the supplied value when there is one.

  ## Files

  - `backends/vulkan/runtime/graph/VulkanCache.h` — graph-facing interface: pool shape, dtype, layer count, pool buffers.
  - `backends/vulkan/runtime/graph/VulkanSequenceCache.h` — the byte layer; allocates pools at construction from the global context. Flat layers only.
  - `backends/vulkan/runtime/graph/ComputeGraph.h` — the installed cache, set before the graph is built.
  - `backends/vulkan/runtime/graph/ops/impl/SDPA.cpp` — `update_and_attend_impl`, and `scale` in `sdpa_impl`.
  - `backends/vulkan/runtime/graph/ops/glsl/sdpa_*.{glsl,yaml}` — the missing storage-type variants.
  - `backends/vulkan/test/op_tests/sdpa_test.cpp` — `OFFGRAPH` mode.

  ## Testing

  `vulkan_sdpa_test` — `OFFGRAPH` runs through the existing driver, so it covers all four configurations and both storage types: prefill, single-token decode, mid-sequence chunks, four GQA ratios and four head dims, each step compared against the ATen reference. 

cc @SS-JIA @manuelcandales @digantdesai @cbilgin