### PR TITLE
[MLX] Per-token positions and a shared pool

### DIFF
--- a/backends/mlx/runtime/MLXCache.h
+++ b/backends/mlx/runtime/MLXCache.h
@@ -36,14 +36,12 @@ class MLXCache {
  public:
   virtual ~MLXCache() = default;
 
-  // Write this step's K/V for `layer` at `position` (the run's logical start);
-  // return the window + mask kind. k/v are BHSD. `position` is a host int --
-  // the caller reads it off the graph so the cache stays pure graph + integer
-  // bookkeeping. The cache owns the mask: a multi-token chain is Causal, a
-  // single decode token is None.
+  // Write this step's K/V for `layer` at `positions`, one host int per query
+  // token, and return the window plus the mask kind. k/v are BHSD.
   virtual AttendSpec update_and_fetch(
       int layer,
-      int position,
+      const int32_t* positions,
+      int length,
       const Tensor& k,
       const Tensor& v,
       StreamOrDevice s) = 0;

--- a/backends/mlx/runtime/MLXCache.h
+++ b/backends/mlx/runtime/MLXCache.h
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
+#include <vector>
 
 #include "MLXExecutor.h" // Tensor, StreamOrDevice
 
@@ -40,8 +42,7 @@ class MLXCache {
   // token, and return the window plus the mask kind. k/v are BHSD.
   virtual AttendSpec update_and_fetch(
       int layer,
-      const int32_t* positions,
-      int length,
+      const std::vector<int32_t>& positions,
       const Tensor& k,
       const Tensor& v,
       StreamOrDevice s) = 0;

--- a/backends/mlx/runtime/MLXInterpreter.h
+++ b/backends/mlx/runtime/MLXInterpreter.h
@@ -11,6 +11,9 @@
 #include "MLXCache.h"
 #include "MLXExecutor.h"
 
+#include <algorithm>
+#include <vector>
+
 #include <mlx/array.h>
 #include <mlx/fast.h>
 #include <mlx/mlx.h>
@@ -310,20 +313,33 @@ inline void exec_update_and_attend(
   // The cache does the KV write + read and declares the mask; the handler owns
   // the query side (q, scale) and calls SDPA.
   const array& q = st.const_tensor_ref(n.q);
-  // The run's start is position[0], read host-side so the cache stays pure
-  // graph + integer bookkeeping. Every layer of a step reads the same position
+  // One position per query token, read host-side so the cache stays pure graph
+  // + integer bookkeeping. Every layer of a step reads the same position
   // tensor, so evaluating it in place costs one sync for the first layer and
   // nothing for the rest -- casting first would instead build a fresh array per
   // layer and sync on each one.
   auto pos = st.const_tensor_ref(n.position);
   eval(pos);
-  int position;
+  const int length = static_cast<int>(pos.size());
+  if (length != static_cast<int>(st.const_tensor_ref(n.k).shape(2))) {
+    throw std::runtime_error(
+        "update_and_attend: position must hold one entry per query token");
+  }
+  // int32 is passed straight through; only an int64 input needs narrowing.
+  std::vector<int32_t> int32_positions;
+  const int32_t* positions = nullptr;
   switch (pos.dtype()) {
     case ::mlx::core::int32:
-      position = pos.data<int32_t>()[0];
+      positions = pos.data<int32_t>();
       break;
     case ::mlx::core::int64:
-      position = static_cast<int>(pos.data<int64_t>()[0]);
+      int32_positions.resize(static_cast<size_t>(length));
+      std::transform(
+          pos.data<int64_t>(),
+          pos.data<int64_t>() + length,
+          int32_positions.begin(),
+          [](int64_t p) { return static_cast<int32_t>(p); });
+      positions = int32_positions.data();
       break;
     default:
       throw std::runtime_error(
@@ -332,7 +348,8 @@ inline void exec_update_and_attend(
   }
   AttendSpec spec = st.cache->update_and_fetch(
       *n.layer_id,
-      position,
+      positions,
+      length,
       st.const_tensor_ref(n.k),
       st.const_tensor_ref(n.v),
       s);

--- a/backends/mlx/runtime/MLXInterpreter.h
+++ b/backends/mlx/runtime/MLXInterpreter.h
@@ -316,30 +316,31 @@ inline void exec_update_and_attend(
   // One position per query token, read host-side so the cache stays pure graph
   // + integer bookkeeping. Every layer of a step reads the same position
   // tensor, so evaluating it in place costs one sync for the first layer and
-  // nothing for the rest -- casting first would instead build a fresh array per
-  // layer and sync on each one.
+  // nothing for the rest.
   auto pos = st.const_tensor_ref(n.position);
   eval(pos);
+  // The entries are read in order off the buffer, which a strided view would
+  // walk with the wrong stride.
+  if (!pos.flags().row_contiguous) {
+    throw std::runtime_error("update_and_attend: position must be contiguous");
+  }
   const int length = static_cast<int>(pos.size());
-  if (length != static_cast<int>(st.const_tensor_ref(n.k).shape(2))) {
+  if (length != static_cast<int>(q.shape(2))) {
     throw std::runtime_error(
         "update_and_attend: position must hold one entry per query token");
   }
-  // int32 is passed straight through; only an int64 input needs narrowing.
-  std::vector<int32_t> int32_positions;
-  const int32_t* positions = nullptr;
+  std::vector<int32_t> positions(static_cast<size_t>(length));
   switch (pos.dtype()) {
     case ::mlx::core::int32:
-      positions = pos.data<int32_t>();
+      std::copy(
+          pos.data<int32_t>(), pos.data<int32_t>() + length, positions.begin());
       break;
     case ::mlx::core::int64:
-      int32_positions.resize(static_cast<size_t>(length));
       std::transform(
           pos.data<int64_t>(),
           pos.data<int64_t>() + length,
-          int32_positions.begin(),
+          positions.begin(),
           [](int64_t p) { return static_cast<int32_t>(p); });
-      positions = int32_positions.data();
       break;
     default:
       throw std::runtime_error(
@@ -349,7 +350,6 @@ inline void exec_update_and_attend(
   AttendSpec spec = st.cache->update_and_fetch(
       *n.layer_id,
       positions,
-      length,
       st.const_tensor_ref(n.k),
       st.const_tensor_ref(n.v),
       s);
@@ -357,10 +357,9 @@ inline void exec_update_and_attend(
   // storage precision may differ from the compute dtype).
   array K = spec.K.dtype() == q.dtype() ? spec.K : astype(spec.K, q.dtype(), s);
   array V = spec.V.dtype() == q.dtype() ? spec.V : astype(spec.V, q.dtype(), s);
-  // MLX takes the mask as a mode string plus an optional tensor. Switch rather
-  // than test for Causal: None and Explicit both map to "" and are told apart
-  // only by spec.mask, so an Explicit with no mask would silently attend
-  // unmasked.
+  // MLX takes the mask as a mode string plus an optional tensor. Switch: None
+  // and Explicit both map to "" and are told apart only by spec.mask, so an
+  // Explicit with no mask would silently attend unmasked.
   std::string mask_mode;
   switch (spec.kind) {
     case AttendSpec::Mask::None:

--- a/backends/mlx/runtime/MLXPool.h
+++ b/backends/mlx/runtime/MLXPool.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
+#include "MLXExecutor.h" // Tensor, StreamOrDevice
+
+namespace executorch {
+namespace backends {
+namespace mlx {
+
+// Per-layer K or V store, SDPA-major [1, H, slots, D] (cells on axis 2). The
+// caller hands down physical slot ranges (it has already applied any ring
+// modulo), so the pool is layout-agnostic: policies differ only in how many
+// slots the layer asks for and how many ranges a step produces.
+class Pool {
+ public:
+  // initial_slots above max_slots is clamped, not rejected: the config default
+  // exceeds the cap of any smaller cache, so this is the normal path.
+  Pool(int initial_slots, int max_slots, int H, int D, ::mlx::core::Dtype dtype)
+      : dtype_(dtype),
+        max_slots_(max_slots),
+        buf_(::mlx::core::zeros(
+            ::mlx::core::Shape{1, H, std::min(initial_slots, max_slots), D},
+            dtype)) {}
+
+  // Place `update` at slot `start`, casting to the storage dtype if it differs.
+  void write(int start, int len, const Tensor& update, StreamOrDevice s) {
+    const int H = static_cast<int>(buf_.shape(1));
+    const int D = static_cast<int>(buf_.shape(3));
+    if (start < 0 || start + len > max_slots_) {
+      throw std::runtime_error("Pool::write: run out of bounds");
+    }
+    if (static_cast<int>(update.shape(2)) != len) {
+      throw std::runtime_error("Pool::write: update length != run length");
+    }
+    if (static_cast<int>(update.shape(1)) != H ||
+        static_cast<int>(update.shape(3)) != D) {
+      throw std::runtime_error("Pool::write: K/V heads/dim mismatch");
+    }
+    maybe_grow(start + len, s);
+    const Tensor u = update.dtype() == dtype_
+        ? update
+        : ::mlx::core::astype(update, dtype_, s);
+    buf_ = ::mlx::core::slice_update(
+        buf_,
+        u,
+        ::mlx::core::Shape{0, 0, start, 0},
+        ::mlx::core::Shape{1, H, start + len, D},
+        s);
+  }
+
+  // Slots [start, start+len). A ring read starts mid-pool, so the start matters
+  // here as much as it does for a write.
+  Tensor read(int start, int len, StreamOrDevice s) const {
+    const int H = static_cast<int>(buf_.shape(1));
+    const int D = static_cast<int>(buf_.shape(3));
+    if (start < 0 || start + len > slots()) {
+      throw std::runtime_error("Pool::read: run out of bounds");
+    }
+    return ::mlx::core::slice(
+        buf_,
+        ::mlx::core::Shape{0, 0, start, 0},
+        ::mlx::core::Shape{1, H, start + len, D},
+        ::mlx::core::Shape{1, 1, 1, 1},
+        s);
+  }
+
+  // Slots currently allocated; grows toward max_slots on demand.
+  int slots() const {
+    return static_cast<int>(buf_.shape(2));
+  }
+
+ private:
+  // Make room for `needed` slots, growing only if the pool is short: double
+  // until it fits, never past max_slots_. Cells keep their index, so growth is
+  // a zero-pad on the cell axis.
+  void maybe_grow(int needed, StreamOrDevice s) {
+    const int cur = slots();
+    if (needed <= cur) {
+      return;
+    }
+    int next = std::max(cur, 1); // an empty pool has nothing to double
+    while (next < needed) {
+      next *= 2;
+    }
+    // The last doubling can overshoot; write() already bounds `needed` by
+    // max_slots_, so clamping here cannot undershoot it.
+    next = std::min(next, max_slots_);
+    const int H = static_cast<int>(buf_.shape(1));
+    const int D = static_cast<int>(buf_.shape(3));
+    Tensor pad =
+        ::mlx::core::zeros(::mlx::core::Shape{1, H, next - cur, D}, dtype_);
+    buf_ = ::mlx::core::concatenate(std::vector<Tensor>{buf_, pad}, 2, s);
+  }
+
+  ::mlx::core::Dtype dtype_;
+  int max_slots_;
+  Tensor buf_;
+};
+
+} // namespace mlx
+} // namespace backends
+} // namespace executorch

--- a/backends/mlx/runtime/MLXSequenceCache.h
+++ b/backends/mlx/runtime/MLXSequenceCache.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -16,6 +15,7 @@
 
 #include "MLXCache.h" // AttendSpec, MLXCache
 #include "MLXExecutor.h" // resolve_dtype
+#include "MLXPool.h" // Pool
 
 #include <executorch/extension/llm/cache/cache.h>
 #include <executorch/extension/llm/cache/sequence_cache.h>
@@ -25,97 +25,6 @@ namespace backends {
 namespace mlx {
 
 namespace cache = ::executorch::extension::llm::cache;
-
-// Per-layer K or V store, SDPA-major [1, H, slots, D] (cells on axis 2). The
-// planner hands down physical runs (it has already applied any ring modulo), so
-// the pool is layout-agnostic: flat and ring differ only in how many slots the
-// layer asks for and how many runs a step produces.
-class Pool {
- public:
-  // initial_slots above max_slots is clamped, not rejected: the config default
-  // exceeds the cap of any smaller cache, so this is the normal path.
-  Pool(int initial_slots, int max_slots, int H, int D, ::mlx::core::Dtype dtype)
-      : dtype_(dtype),
-        max_slots_(max_slots),
-        buf_(::mlx::core::zeros(
-            ::mlx::core::Shape{1, H, std::min(initial_slots, max_slots), D},
-            dtype)) {}
-
-  // Place `update` at the run's physical start, casting to the storage dtype if
-  // it differs.
-  void write(const cache::Run& run, const Tensor& update, StreamOrDevice s) {
-    const int H = static_cast<int>(buf_.shape(1));
-    const int D = static_cast<int>(buf_.shape(3));
-    if (run.start < 0 || run.start + run.len > max_slots_) {
-      throw std::runtime_error("Pool::write: run out of bounds");
-    }
-    if (static_cast<int>(update.shape(2)) != run.len) {
-      throw std::runtime_error("Pool::write: update length != run length");
-    }
-    if (static_cast<int>(update.shape(1)) != H ||
-        static_cast<int>(update.shape(3)) != D) {
-      throw std::runtime_error("Pool::write: K/V heads/dim mismatch");
-    }
-    maybe_grow(run.start + run.len, s);
-    const Tensor u = update.dtype() == dtype_
-        ? update
-        : ::mlx::core::astype(update, dtype_, s);
-    buf_ = ::mlx::core::slice_update(
-        buf_,
-        u,
-        ::mlx::core::Shape{0, 0, run.start, 0},
-        ::mlx::core::Shape{1, H, run.start + run.len, D},
-        s);
-  }
-
-  // The run's cells, [start, start+len). Ring reads start mid-pool, so the run
-  // start matters here as much as it does for a write.
-  Tensor read(const cache::Run& run, StreamOrDevice s) const {
-    const int H = static_cast<int>(buf_.shape(1));
-    const int D = static_cast<int>(buf_.shape(3));
-    if (run.start < 0 || run.start + run.len > slots()) {
-      throw std::runtime_error("Pool::read: run out of bounds");
-    }
-    return ::mlx::core::slice(
-        buf_,
-        ::mlx::core::Shape{0, 0, run.start, 0},
-        ::mlx::core::Shape{1, H, run.start + run.len, D},
-        ::mlx::core::Shape{1, 1, 1, 1},
-        s);
-  }
-
-  // Slots currently allocated; grows toward max_slots on demand.
-  int slots() const {
-    return static_cast<int>(buf_.shape(2));
-  }
-
- private:
-  // Make room for `needed` slots, growing only if the pool is short: double
-  // until it fits, never past max_slots_. Cells keep their index, so growth is
-  // a zero-pad on the cell axis.
-  void maybe_grow(int needed, StreamOrDevice s) {
-    const int cur = slots();
-    if (needed <= cur) {
-      return;
-    }
-    int next = std::max(cur, 1); // an empty pool has nothing to double
-    while (next < needed) {
-      next *= 2;
-    }
-    // The last doubling can overshoot; write() already bounds `needed` by
-    // max_slots_, so clamping here cannot undershoot it.
-    next = std::min(next, max_slots_);
-    const int H = static_cast<int>(buf_.shape(1));
-    const int D = static_cast<int>(buf_.shape(3));
-    Tensor pad =
-        ::mlx::core::zeros(::mlx::core::Shape{1, H, next - cur, D}, dtype_);
-    buf_ = ::mlx::core::concatenate(std::vector<Tensor>{buf_, pad}, 2, s);
-  }
-
-  ::mlx::core::Dtype dtype_;
-  int max_slots_;
-  Tensor buf_;
-};
 
 // Bool mask [1, 1, T, S] for T queries over a span of S keys, where each query
 // attends at most `window` keys ending at itself. The span is right-aligned
@@ -172,7 +81,8 @@ class MLXSequenceCache : public cache::SequenceCache, public MLXCache {
 
   AttendSpec update_and_fetch(
       int layer,
-      int position,
+      const int32_t* positions,
+      int length,
       const Tensor& k,
       const Tensor& v,
       StreamOrDevice s) override {
@@ -181,7 +91,8 @@ class MLXSequenceCache : public cache::SequenceCache, public MLXCache {
     }
     const int T = static_cast<int>(k.shape(2)); // BHSD: seq axis is 2
 
-    std::optional<cache::SeqStepPlan> p = this->plan(layer, position, T);
+    std::optional<cache::SeqStepPlan> p =
+        this->plan(layer, run_start(positions, length, T), T);
     if (!p) {
       throw std::runtime_error(
           "update_and_fetch: step exceeds capacity or invalid layer");
@@ -216,6 +127,24 @@ class MLXSequenceCache : public cache::SequenceCache, public MLXCache {
   }
 
  private:
+  // A sequence cache holds one run of one sequence, so the step is described by
+  // where it starts; the remaining positions carry no information beyond
+  // confirming that. A step this cache cannot represent is refused rather than
+  // silently stored at the wrong positions.
+  static int run_start(const int32_t* positions, int length, int T) {
+    if (length != T) {
+      throw std::runtime_error(
+          "update_and_fetch: one position per query token expected");
+    }
+    for (int i = 1; i < length; ++i) {
+      if (positions[i] != positions[0] + i) {
+        throw std::runtime_error(
+            "update_and_fetch: sequence cache needs a contiguous run");
+      }
+    }
+    return positions[0];
+  }
+
   // Scatter `update` across the step's runs. Runs are in logical order, so
   // consecutive slices of `update` map to consecutive runs. A flat step is one
   // run; a ring step splits in two when it wraps the pool.
@@ -226,7 +155,7 @@ class MLXSequenceCache : public cache::SequenceCache, public MLXCache {
       const Tensor& update,
       StreamOrDevice s) {
     if (n == 1) {
-      pool.write(runs[0], update, s);
+      pool.write(runs[0].start, runs[0].len, update, s);
       return;
     }
     const int H = static_cast<int>(update.shape(1));
@@ -234,7 +163,8 @@ class MLXSequenceCache : public cache::SequenceCache, public MLXCache {
     int off = 0;
     for (int i = 0; i < n; ++i) {
       pool.write(
-          runs[i],
+          runs[i].start,
+          runs[i].len,
           ::mlx::core::slice(
               update,
               ::mlx::core::Shape{0, 0, off, 0},
@@ -250,12 +180,12 @@ class MLXSequenceCache : public cache::SequenceCache, public MLXCache {
   static Tensor
   read_runs(const Pool& pool, const cache::Run* runs, int n, StreamOrDevice s) {
     if (n == 1) {
-      return pool.read(runs[0], s);
+      return pool.read(runs[0].start, runs[0].len, s);
     }
     std::vector<Tensor> parts;
     parts.reserve(static_cast<size_t>(n));
     for (int i = 0; i < n; ++i) {
-      parts.push_back(pool.read(runs[i], s));
+      parts.push_back(pool.read(runs[i].start, runs[i].len, s));
     }
     return ::mlx::core::concatenate(parts, 2, s);
   }

--- a/backends/mlx/runtime/MLXSequenceCache.h
+++ b/backends/mlx/runtime/MLXSequenceCache.h
@@ -81,8 +81,7 @@ class MLXSequenceCache : public cache::SequenceCache, public MLXCache {
 
   AttendSpec update_and_fetch(
       int layer,
-      const int32_t* positions,
-      int length,
+      const std::vector<int32_t>& positions,
       const Tensor& k,
       const Tensor& v,
       StreamOrDevice s) override {
@@ -92,7 +91,7 @@ class MLXSequenceCache : public cache::SequenceCache, public MLXCache {
     const int T = static_cast<int>(k.shape(2)); // BHSD: seq axis is 2
 
     std::optional<cache::SeqStepPlan> p =
-        this->plan(layer, run_start(positions, length, T), T);
+        this->plan(layer, run_start(positions, T), T);
     if (!p) {
       throw std::runtime_error(
           "update_and_fetch: step exceeds capacity or invalid layer");
@@ -131,12 +130,12 @@ class MLXSequenceCache : public cache::SequenceCache, public MLXCache {
   // where it starts; the remaining positions carry no information beyond
   // confirming that. A step this cache cannot represent is refused rather than
   // silently stored at the wrong positions.
-  static int run_start(const int32_t* positions, int length, int T) {
-    if (length != T) {
+  static int run_start(const std::vector<int32_t>& positions, int T) {
+    if (static_cast<int>(positions.size()) != T) {
       throw std::runtime_error(
-          "update_and_fetch: one position per query token expected");
+          "update_and_fetch: one position per key/value token expected");
     }
-    for (int i = 1; i < length; ++i) {
+    for (int i = 1; i < T; ++i) {
       if (positions[i] != positions[0] + i) {
         throw std::runtime_error(
             "update_and_fetch: sequence cache needs a contiguous run");

--- a/backends/mlx/test/mlx_sequence_cache_test.cpp
+++ b/backends/mlx/test/mlx_sequence_cache_test.cpp
@@ -45,7 +45,7 @@ AttendSpec step(
   const int T = static_cast<int>(k.shape(2));
   std::vector<int32_t> positions(static_cast<size_t>(T));
   std::iota(positions.begin(), positions.end(), start);
-  return c.update_and_fetch(layer, positions.data(), T, k, v, s);
+  return c.update_and_fetch(layer, positions, k, v, s);
 }
 
 // Max absolute difference within tolerance. Computed in float32: item<float>()
@@ -177,13 +177,13 @@ TEST_F(MLXSequenceCacheTest, NonContiguousOrMiscountedPositionsThrow) {
   array k = randn(3, float16);
 
   const std::vector<int32_t> gap{0, 1, 3};
-  EXPECT_ANY_THROW(c.update_and_fetch(0, gap.data(), 3, k, k, s));
+  EXPECT_ANY_THROW(c.update_and_fetch(0, gap, k, k, s));
 
   const std::vector<int32_t> two_seqs{0, 0, 1};
-  EXPECT_ANY_THROW(c.update_and_fetch(0, two_seqs.data(), 3, k, k, s));
+  EXPECT_ANY_THROW(c.update_and_fetch(0, two_seqs, k, k, s));
 
   const std::vector<int32_t> short_run{0, 1};
-  EXPECT_ANY_THROW(c.update_and_fetch(0, short_run.data(), 2, k, k, s));
+  EXPECT_ANY_THROW(c.update_and_fetch(0, short_run, k, k, s));
 
   EXPECT_NO_THROW(step(c, 0, /*position=*/0, k, k, s));
 }

--- a/backends/mlx/test/mlx_sequence_cache_test.cpp
+++ b/backends/mlx/test/mlx_sequence_cache_test.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 
+#include <numeric>
 #include <optional>
 #include <vector>
 
@@ -31,6 +32,21 @@ namespace cache = ::executorch::extension::llm::cache;
 using ::mlx::core::array;
 
 namespace {
+
+// A step's positions: the contiguous run of k.shape(2) tokens starting at
+// `start`, which is what every single-sequence step is.
+AttendSpec step(
+    MLXSequenceCache& c,
+    int layer,
+    int start,
+    const array& k,
+    const array& v,
+    ::mlx::core::StreamOrDevice s) {
+  const int T = static_cast<int>(k.shape(2));
+  std::vector<int32_t> positions(static_cast<size_t>(T));
+  std::iota(positions.begin(), positions.end(), start);
+  return c.update_and_fetch(layer, positions.data(), T, k, v, s);
+}
 
 // Max absolute difference within tolerance. Computed in float32: item<float>()
 // reads sizeof(float) bytes, so calling it on an fp16 scalar misreads the
@@ -103,7 +119,7 @@ TEST_F(MLXSequenceCacheTest, PrefillIsCausal) {
   array k0 = randn(T0, float16);
   array v0 = randn(T0, float16);
 
-  AttendSpec spec0 = c.update_and_fetch(0, /*position=*/0, k0, v0, s);
+  AttendSpec spec0 = step(c, 0, /*position=*/0, k0, v0, s);
   EXPECT_EQ(spec0.kind, AttendSpec::Mask::Causal);
   EXPECT_TRUE(allclose(spec0.K, k0, 0.0f));
   EXPECT_TRUE(allclose(spec0.V, v0, 0.0f));
@@ -122,11 +138,11 @@ TEST_F(MLXSequenceCacheTest, DecodeReadsFullHistory) {
   const int T0 = 4;
   array k0 = randn(T0, float16);
   array v0 = randn(T0, float16);
-  c.update_and_fetch(0, /*position=*/0, k0, v0, s); // prefill
+  step(c, 0, /*position=*/0, k0, v0, s); // prefill
 
   array k1 = randn(1, float16);
   array v1 = randn(1, float16);
-  AttendSpec spec1 = c.update_and_fetch(0, /*position=*/T0, k1, v1, s);
+  AttendSpec spec1 = step(c, 0, /*position=*/T0, k1, v1, s);
   EXPECT_EQ(spec1.kind, AttendSpec::Mask::None);
   EXPECT_TRUE(
       allclose(spec1.K, concatenate(std::vector<array>{k0, k1}, 2, s), 0.0f));
@@ -144,7 +160,32 @@ TEST_F(MLXSequenceCacheTest, StepPastCapacityThrows) {
       D,
       static_cast<int>(ScalarType::Half)));
   array kx = randn(1, float16);
-  EXPECT_ANY_THROW(c.update_and_fetch(0, /*position=*/32, kx, kx, s));
+  EXPECT_ANY_THROW(step(c, 0, /*position=*/32, kx, kx, s));
+}
+
+// The step carries one position per query token, and this layout can only hold
+// a contiguous run of one sequence. Anything else names cells it cannot
+// address, so it is refused rather than stored at the wrong positions.
+TEST_F(MLXSequenceCacheTest, NonContiguousOrMiscountedPositionsThrow) {
+  using namespace ::mlx::core;
+  MLXSequenceCache c(flat_config(
+      /*capacity=*/32,
+      /*n_layers=*/1,
+      H,
+      D,
+      static_cast<int>(ScalarType::Half)));
+  array k = randn(3, float16);
+
+  const std::vector<int32_t> gap{0, 1, 3};
+  EXPECT_ANY_THROW(c.update_and_fetch(0, gap.data(), 3, k, k, s));
+
+  const std::vector<int32_t> two_seqs{0, 0, 1};
+  EXPECT_ANY_THROW(c.update_and_fetch(0, two_seqs.data(), 3, k, k, s));
+
+  const std::vector<int32_t> short_run{0, 1};
+  EXPECT_ANY_THROW(c.update_and_fetch(0, short_run.data(), 2, k, k, s));
+
+  EXPECT_NO_THROW(step(c, 0, /*position=*/0, k, k, s));
 }
 
 // Storage dtype != compute: fp32 input, fp16 storage. The cache casts on write,
@@ -160,7 +201,7 @@ TEST_F(MLXSequenceCacheTest, StorageDtypeDiffersCastsOnWrite) {
   const int T0 = 4;
   array k2 = randn(T0, float32);
   array v2 = randn(T0, float32);
-  AttendSpec spec2 = c16.update_and_fetch(0, /*position=*/0, k2, v2, s);
+  AttendSpec spec2 = step(c16, 0, /*position=*/0, k2, v2, s);
   EXPECT_EQ(spec2.K.dtype(), float16);
   EXPECT_EQ(spec2.V.dtype(), float16);
   EXPECT_TRUE(allclose(spec2.K, astype(k2, float16, s), 0.0f));
@@ -174,12 +215,12 @@ TEST_F(MLXSequenceCacheTest, PoolHonorsRunStart) {
   using namespace ::mlx::core;
   Pool p(/*initial_slots=*/8, /*max_slots=*/8, H, D, float16);
   array x = randn(3, float16);
-  p.write(cache::Run{/*start=*/2, /*len=*/3}, x, s);
+  p.write(/*start=*/2, /*len=*/3, x, s);
 
-  EXPECT_TRUE(allclose(p.read(cache::Run{2, 3}, s), x, 0.0f));
+  EXPECT_TRUE(allclose(p.read(2, 3, s), x, 0.0f));
   // The cells before the run are untouched, so reading from 0 is not the same
   // window -- the regression this guards against.
-  EXPECT_FALSE(allclose(p.read(cache::Run{0, 3}, s), x, 0.0f));
+  EXPECT_FALSE(allclose(p.read(0, 3, s), x, 0.0f));
 }
 
 // A partial per-layer list is rejected instead of indexing past the end.
@@ -209,7 +250,7 @@ TEST_F(MLXSequenceCacheTest, GrowsPastInitialCapacity) {
   const int T0 = 5; // > initial_capacity
   array k0 = randn(T0, float16);
   array v0 = randn(T0, float16);
-  AttendSpec spec0 = c.update_and_fetch(0, /*position=*/0, k0, v0, s);
+  AttendSpec spec0 = step(c, 0, /*position=*/0, k0, v0, s);
   EXPECT_EQ(spec0.K.shape(2), T0);
   EXPECT_TRUE(allclose(spec0.K, k0, 0.0f));
   EXPECT_TRUE(allclose(spec0.V, v0, 0.0f));
@@ -229,11 +270,11 @@ TEST_F(MLXSequenceCacheTest, GrowthPreservesExistingCells) {
 
   array k0 = randn(2, float16); // exactly fills the initial allocation
   array v0 = randn(2, float16);
-  c.update_and_fetch(0, /*position=*/0, k0, v0, s);
+  step(c, 0, /*position=*/0, k0, v0, s);
 
   array k1 = randn(1, float16); // crosses the boundary -> grows
   array v1 = randn(1, float16);
-  AttendSpec spec1 = c.update_and_fetch(0, /*position=*/2, k1, v1, s);
+  AttendSpec spec1 = step(c, 0, /*position=*/2, k1, v1, s);
   EXPECT_EQ(spec1.K.shape(2), 3);
   EXPECT_TRUE(
       allclose(spec1.K, concatenate(std::vector<array>{k0, k1}, 2, s), 0.0f));
@@ -247,12 +288,12 @@ TEST_F(MLXSequenceCacheTest, PoolDoublesAndClampsToMaxSlots) {
   using namespace ::mlx::core;
   Pool p(/*initial_slots=*/2, /*max_slots=*/32, H, D, float16);
   EXPECT_EQ(p.slots(), 2);
-  p.write(cache::Run{0, 5}, randn(5, float16), s); // 2 -> 4 -> 8
+  p.write(0, 5, randn(5, float16), s); // 2 -> 4 -> 8
   EXPECT_EQ(p.slots(), 8);
 
   // 16 -> 32 overshoots a cap of 20, so it clamps.
   Pool q(/*initial_slots=*/16, /*max_slots=*/20, H, D, float16);
-  q.write(cache::Run{0, 17}, randn(17, float16), s);
+  q.write(0, 17, randn(17, float16), s);
   EXPECT_EQ(q.slots(), 20);
 
   // initial_slots above the cap is clamped at construction.
@@ -272,7 +313,7 @@ TEST_F(MLXSequenceCacheTest, ZeroInitialCapacityGrowsOnFirstWrite) {
       /*initial_capacity=*/0));
   array k0 = randn(3, float16);
   array v0 = randn(3, float16);
-  AttendSpec spec0 = c.update_and_fetch(0, /*position=*/0, k0, v0, s);
+  AttendSpec spec0 = step(c, 0, /*position=*/0, k0, v0, s);
   EXPECT_TRUE(allclose(spec0.K, k0, 0.0f));
 }
 
@@ -323,7 +364,7 @@ TEST_F(MLXSequenceCacheTest, RingDecodeEvictsOldestAndNeedsNoMask) {
   }
   AttendSpec spec{toks[0], toks[0], AttendSpec::Mask::None, {}};
   for (int i = 0; i < 6; ++i) {
-    spec = c.update_and_fetch(0, /*position=*/i, toks[i], toks[i], s);
+    spec = step(c, 0, /*position=*/i, toks[i], toks[i], s);
   }
   EXPECT_EQ(spec.kind, AttendSpec::Mask::None);
   EXPECT_EQ(spec.K.shape(2), W);
@@ -345,7 +386,7 @@ TEST_F(MLXSequenceCacheTest, WindowWiderThanSpanStaysCausal) {
       D,
       static_cast<int>(ScalarType::Half)));
   array k = randn(2, float16); // span 2 < window 4
-  AttendSpec rspec = ring.update_and_fetch(0, /*position=*/0, k, k, s);
+  AttendSpec rspec = step(ring, 0, /*position=*/0, k, k, s);
   EXPECT_EQ(rspec.kind, AttendSpec::Mask::Causal);
   EXPECT_FALSE(rspec.mask.has_value());
 
@@ -355,7 +396,7 @@ TEST_F(MLXSequenceCacheTest, WindowWiderThanSpanStaysCausal) {
       H,
       D,
       static_cast<int>(ScalarType::Half)));
-  AttendSpec fspec = flat.update_and_fetch(0, /*position=*/0, k, k, s);
+  AttendSpec fspec = step(flat, 0, /*position=*/0, k, k, s);
   EXPECT_EQ(fspec.kind, AttendSpec::Mask::Causal);
   EXPECT_FALSE(fspec.mask.has_value());
 }
@@ -378,10 +419,10 @@ TEST_F(MLXSequenceCacheTest, RingStepWrapsAndRejoinsInOrder) {
   std::vector<array> toks;
   for (int i = 0; i < 4; ++i) {
     toks.push_back(randn(1, float16));
-    c.update_and_fetch(0, /*position=*/i, toks.back(), toks.back(), s);
+    step(c, 0, /*position=*/i, toks.back(), toks.back(), s);
   }
   array pair = randn(2, float16);
-  AttendSpec spec = c.update_and_fetch(0, /*position=*/4, pair, pair, s);
+  AttendSpec spec = step(c, 0, /*position=*/4, pair, pair, s);
 
   // The span is the union of the two queries' windows -- position 4 attends
   // 1..4 and position 5 attends 2..5 -- so it is window + T - 1 = 5 cells, not


### PR DESCRIPTION
**Summary**
Prepares the MLX byte layer to take a second cache implementation. No behaviour changes.

  `MLXCache::update_and_fetch` takes per-token positions instead of a run start.
  The position tensor already carries one entry per query token and the interpreter was reading element `[0]` and discarding the rest, so this stops truncation.  `Pool` moves to its own header and takes `(start, len)` instead of `cache::Run`,  so it no longer depends on the neutral cache header. 

  ## Files

  - `backends/mlx/runtime/MLXCache.h` — take per-token positions.
  - `backends/mlx/runtime/MLXInterpreter.h` — `eval` and the dtype switch keep  their shape; int32 now passes the tensor's own buffer with no copy, only int64 is narrowed, and `pos.size()` is checked against `k.shape(2)`.
  - `backends/mlx/runtime/MLXPool.h` — new; `Pool`, unchanged apart from the signature.
  - `backends/mlx/runtime/MLXSequenceCache.h` — `run_start`, and the five `Pool`  call sites.
  - `backends/mlx/test/mlx_sequence_cache_test.cpp` — a `step()` helper builds the run from `k.shape(2)`

  ## Testing

  `ctest --test-dir cmake-out -R mlx_sequence_cache`