### PR TITLE
Finish adding Python 3.14 to the published CUDA wheel set

### DIFF
--- a/.ci/scripts/tests/test_filter_cuda_matrix.py
+++ b/.ci/scripts/tests/test_filter_cuda_matrix.py
@@ -251,7 +251,7 @@ class TestPublishedSets(unittest.TestCase):
 
     def test_published_python_versions(self):
         self.assertEqual(
-            FILTER.SUPPORTED_PYTHON_VERSIONS, ["3.10", "3.11", "3.12", "3.13"]
+            FILTER.SUPPORTED_PYTHON_VERSIONS, ["3.10", "3.11", "3.12", "3.13", "3.14"]
         )
 
     def test_the_workflows_offer_exactly_the_published_pythons(self):

--- a/docs/source/using-executorch-cpp.md
+++ b/docs/source/using-executorch-cpp.md
@@ -307,8 +307,7 @@ pip install executorch torch \
   --extra-index-url https://pypi.org/simple
 ```
 
-CUDA wheels are built for Python 3.10 through 3.13. On a newer Python there is no CUDA wheel to
-install, so pip falls back to the CPU one.
+CUDA wheels are built for Python 3.10 through 3.14, which is every Python this project supports.
 
 The second index is required: a bare `--index-url` replaces PyPI rather than adding to it, and some
 dependencies are only on PyPI. The torch you install has to come from the same CUDA index, because


### PR DESCRIPTION
#22010 added Python 3.14 to `SUPPORTED_PYTHON_VERSIONS` in `.github/scripts/filter_cuda_matrix.py`, but two other places restate that same published set and neither was updated. This fixes both.

### 1. The test pin, which is breaking CI

`.ci/scripts/tests/test_filter_cuda_matrix.py` keeps its own copy of the published list, and it still stops at 3.13, so `TestPublishedSets::test_published_python_versions` fails:

```
AssertionError: Lists differ: ['3.10', '3.11', '3.12', '3.13', '3.14'] != ['3.10', '3.11', '3.12', '3.13']
First list contains 1 additional elements.
First extra element 4:
'3.14'
```

That is red on `unittest`, `unittest-editable` and `unittest-release`, on Linux, macOS and Windows. Nine jobs, all failing on this one assertion and nothing else.

The pin is intentional, and the class docstring says why: every other case in that file builds its fixture from the filter's own lists, so shrinking a list shrinks the fixture with it and every gate still passes. The published set is a promise to users rather than an implementation detail, so adding or dropping a Python has to be a deliberate edit here too. This is that edit.

### 2. The C++ guide, which now tells readers the wrong thing

`docs/source/using-executorch-cpp.md` said:

> CUDA wheels are built for Python 3.10 through 3.13. On a newer Python there is no CUDA wheel to install, so pip falls back to the CPU one.

Both sentences are now wrong. The published set reaches 3.14, and `pyproject.toml` sets `requires-python = ">=3.10,<3.15"`, so no supported Python is left to fall back to the CPU wheel. A reader on 3.14 would skip the CUDA index for no reason.

### Everything else was already correct

I checked the rest of the repository for the same staleness. All six `build-wheels-*.yml` workflows already offer 3.14, `pyproject.toml` already carries the 3.14 classifier and the matching `requires-python`, `setup.py` already gates coremltools with `python_version < '3.14'`, and both wheel smoke tests already branch on `sys.version_info < (3, 14)`. These two were the only places left.

The workflow half of #22010 was already correct, so `test_the_workflows_offer_exactly_the_published_pythons` passes and is untouched.

## Test plan

Ran the 20 tests in `.ci/scripts/tests/test_filter_cuda_matrix.py`. All pass. Before this change, 19 pass and `test_published_python_versions` fails with the error above.

The documentation change is prose only.
