### PR TITLE
Log the reason the DLL directory could not be added on Windows

### DIFF
--- a/extension/pybindings/portable_lib.py
+++ b/extension/pybindings/portable_lib.py
@@ -68,7 +68,8 @@ if sys.platform == "win32":
         os.add_dll_directory(pybindings_dir)
     except Exception as e:
         logger.error(
-            "Failed to add the pybinding extension DLL to the search path. The extension may not work.",
+            "Failed to add the pybinding extension DLL to the search path. "
+            "The extension may not work: %s",
             e,
         )
 


### PR DESCRIPTION
### The bug

`extension/pybindings/portable_lib.py:69-73` passes the caught exception to `logger.error()`, but the format string has no placeholder for it:

```python
logger.error(
    "Failed to add the pybinding extension DLL to the search path. The extension may not work.",
    e,
)
```

Python's logging formats the record lazily, so the mismatch is not caught at the call site. When the handler actually runs, `record.getMessage()` does `msg % self.args` and raises `TypeError: not all arguments converted during string formatting`. Logging catches that internally and prints a `--- Logging error ---` traceback instead of the message.

The result is that the message is lost, the exception text is lost, and stderr gets a traceback about logging rather than about the DLL search path — precisely when someone is trying to work out why the extension will not load on Windows.

### Reproduction

```
$ python -c "
import logging; logging.basicConfig()
try: raise OSError('path not found')
except Exception as e:
    logging.getLogger('t').error('The extension may not work.', e)
"
--- Logging error ---
TypeError: not all arguments converted during string formatting
Message: 'The extension may not work.'
Arguments: (OSError('path not found'),)
```

### The fix

Add the placeholder, so the exception is interpolated into the message:

```
ERROR:t:Failed to add the pybinding extension DLL to the search path. The extension may not work: path not found
```

### Test plan

- Reproduced the `TypeError` and the swallowed message with the exact call from `:70-73`.
- Confirmed the fixed call logs one ERROR line containing the exception text, with no logging error raised.
- Windows-only path, so this cannot be exercised on a Linux or macOS CI job. Verified by reproducing the logging behaviour directly rather than by triggering a real `os.add_dll_directory` failure.
