### PR TITLE
Revert unintended change from pr 21893

### DIFF
--- a/backends/arm/CMakeLists.txt
+++ b/backends/arm/CMakeLists.txt
@@ -1,5 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
 # Copyright 2023, 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the


### PR DESCRIPTION
Summary:
Revert incorrect copyright.  This change was missed in pr 21893

Test Plan:
comment-only change

Reviewers:

Subscribers:

Tasks:

Tags:

### Summary
Revert incorrect copyright.  This change was missed in pr 21893

### Test plan
comment-only change

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani