### PR TITLE
Repoint dead TOSA links from mlplatform.org to their current homes

### DIFF
--- a/backends/arm/README.md
+++ b/backends/arm/README.md
@@ -21,7 +21,7 @@ In addition, the following deployment paths are supported by this backend:
   - Full testing is available in tree using Corstone&trade; Fixed Virtual Platforms (FVP).
 - Linux target support for VGF capable targets, using the executor_runner.
 
-More information on TOSA can be found here: https://www.mlplatform.org/tosa/tosa_spec.html.
+More information on TOSA can be found here: https://github.com/arm/tosa-specification.
 
 ## Public API Boundary
 

--- a/backends/arm/_passes/insert_table_ops.py
+++ b/backends/arm/_passes/insert_table_ops.py
@@ -197,7 +197,7 @@ class InsertTableOpsPass(ArmPass):
     ) -> tuple[torch.Tensor, int]:
         """Compute LUT values for a INT16 TOSA.TABLE with 32 bit output.
         In practice the output is 23 bits that should be interpreted as 16 'whole' bits and 7 fractional bits, see
-        the specification: https://www.mlplatform.org/tosa/tosa_spec.html#_table. This means that the output
+        the specification: https://github.com/arm/tosa-specification/blob/main/chapters/ewise_binary.adoc#table. This means that the output
         will interpreted as 2**7=128 times too large unless accounted for by rescaling down the table output.
 
         Quantization can be either int16 or int32 which means that the op output could be larger than the 23 bits from

--- a/backends/arm/operators/op_tosa_rescale.py
+++ b/backends/arm/operators/op_tosa_rescale.py
@@ -31,7 +31,7 @@ def _compute_multiplier_and_shift(
     precision. The RESCALE operator is defined using an integer multiply, add,
     and shift. This utility function is for calculating the multiplier and shift
     given a scale.
-    Ref: https://www.mlplatform.org/tosa/tosa_spec.html#_precision_scaling
+    Ref: https://github.com/arm/tosa-specification/blob/main/chapters/introduction.adoc#precision-scaling
 
     Args:
         scales (list[float]): Scale factors to decompose into multiplier and

--- a/backends/arm/scripts/docgen/ethos-u/backends-arm-ethos-u-overview.md.in
+++ b/backends/arm/scripts/docgen/ethos-u/backends-arm-ethos-u-overview.md.in
@@ -2,7 +2,7 @@
 
 The Arm&reg; Ethos&trade;-U backend targets Edge/IoT-type AI use-cases by enabling optimal execution of quantized models on
 [Arm&reg; Ethos&trade;-U55 NPU](https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u55), [Arm&reg; Ethos&trade;-U65 NPU](https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u65), and
-[Arm&reg; Ethos&trade;-U85 NPU](https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u85), leveraging [TOSA](https://www.mlplatform.org/tosa/) and the
+[Arm&reg; Ethos&trade;-U85 NPU](https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u85), leveraging [TOSA](https://github.com/arm/tosa-specification) and the
 [ethos-u-vela](https://pypi.org/project/ethos-u-vela/) graph compiler. This document is a technical reference for using the Ethos-U backend, for a top level view with code examples
 please refer to the [Arm Ethos-U Backend Tutorial](tutorials/ethos-u-getting-started.md). <!-- @lint-ignore -->
 
@@ -24,7 +24,7 @@ All requirements can be downloaded using `examples/arm/setup.sh --i-agree-to-the
 ```
 
 For the AOT flow, compilation of a model to `.pte` format using the Ethos-U backend, the requirements are:
-- [TOSA Serialization Library](https://www.mlplatform.org/tosa/software.html) for serializing the Exir IR graph into TOSA IR.
+- [TOSA Serialization Library](https://gitlab.arm.com/tosa/tosa-tools) for serializing the Exir IR graph into TOSA IR.
 - [Ethos-U Vela graph compiler](https://pypi.org/project/ethos-u-vela/) for compiling TOSA flatbuffers into an Ethos-U command stream.
 
 And for building and running the example application available in `examples/arm/executor_runner/` through the standalone CMake entry point:

--- a/backends/arm/scripts/docgen/ethos-u/ethos-u-getting-started-tutorial.md.in
+++ b/backends/arm/scripts/docgen/ethos-u/ethos-u-getting-started-tutorial.md.in
@@ -43,7 +43,7 @@ To install Ethos-U dependencies, run
 ./examples/arm/setup.sh --i-agree-to-the-contained-eula
 ```
 This will install:
-- [TOSA Serialization Library](https://www.mlplatform.org/tosa/software.html) for serializing the Exir IR graph into TOSA IR.
+- [TOSA Serialization Library](https://gitlab.arm.com/tosa/tosa-tools) for serializing the Exir IR graph into TOSA IR.
 - [Ethos-U Vela graph compiler](https://pypi.org/project/ethos-u-vela/) for compiling TOSA flatbuffers into a Ethos-U command stream.
 - [Arm GNU Toolchain](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) for cross compilation.
 - [Corstone SSE-300 FVP](https://developer.arm.com/documentation/100966/1128/Arm--Corstone-SSE-300-FVP) for testing on Ethos-U55 reference design.

--- a/backends/arm/scripts/docgen/vgf/backends-arm-vgf-overview.md.in
+++ b/backends/arm/scripts/docgen/vgf/backends-arm-vgf-overview.md.in
@@ -21,7 +21,7 @@ All requirements can be downloaded using `examples/arm/setup.sh --enable-mlsdk-d
 ```
 
 For the AOT flow, compilation of a model to `.pte` format using the VGF backend, the requirements are:
-- [TOSA Serialization Library](https://www.mlplatform.org/tosa/software.html) for serializing the Exir IR graph into TOSA IR.
+- [TOSA Serialization Library](https://gitlab.arm.com/tosa/tosa-tools) for serializing the Exir IR graph into TOSA IR.
 - [ML SDK Model Converter](https://github.com/arm/ai-ml-sdk-model-converter) for converting TOSA flatbuffers to VGF files.
 
 And for building and running your application using the generic executor_runner:

--- a/backends/arm/scripts/docgen/vgf/vgf-getting-started-tutorial.md.in
+++ b/backends/arm/scripts/docgen/vgf/vgf-getting-started-tutorial.md.in
@@ -48,7 +48,7 @@ In addition to this, you need to install a number of SDK dependencies for genera
 ./examples/arm/setup.sh --i-agree-to-the-contained-eula --disable-ethos-u-deps --enable-mlsdk-deps
 ```
 This will install:
-- [TOSA Serialization Library](https://www.mlplatform.org/tosa/software.html) for serializing the Exir IR graph into TOSA IR.
+- [TOSA Serialization Library](https://gitlab.arm.com/tosa/tosa-tools) for serializing the Exir IR graph into TOSA IR.
 - [ML SDK Model Converter](https://github.com/arm/ai-ml-sdk-model-converter) for converting TOSA flatbuffers to VGF files.
 - [Vulkan API](https://www.vulkan.org) should be set up locally for GPU execution support.
 - [ML Emulation Layer for Vulkan](https://github.com/arm/ai-ml-emulation-layer-for-vulkan) for testing on Vulkan API.

--- a/docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md
+++ b/docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md
@@ -2,7 +2,7 @@
 
 The Arm&reg; Ethos&trade;-U backend targets Edge/IoT-type AI use-cases by enabling optimal execution of quantized models on
 [Arm&reg; Ethos&trade;-U55 NPU](https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u55), [Arm&reg; Ethos&trade;-U65 NPU](https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u65), and
-[Arm&reg; Ethos&trade;-U85 NPU](https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u85), leveraging [TOSA](https://www.mlplatform.org/tosa/) and the
+[Arm&reg; Ethos&trade;-U85 NPU](https://www.arm.com/products/silicon-ip-cpu/ethos/ethos-u85), leveraging [TOSA](https://github.com/arm/tosa-specification) and the
 [ethos-u-vela](https://pypi.org/project/ethos-u-vela/) graph compiler. This document is a technical reference for using the Ethos-U backend, for a top level view with code examples
 please refer to the [Arm Ethos-U Backend Tutorial](tutorials/ethos-u-getting-started.md). <!-- @lint-ignore -->
 
@@ -24,7 +24,7 @@ All requirements can be downloaded using `examples/arm/setup.sh --i-agree-to-the
 ```
 
 For the AOT flow, compilation of a model to `.pte` format using the Ethos-U backend, the requirements are:
-- [TOSA Serialization Library](https://www.mlplatform.org/tosa/software.html) for serializing the Exir IR graph into TOSA IR.
+- [TOSA Serialization Library](https://gitlab.arm.com/tosa/tosa-tools) for serializing the Exir IR graph into TOSA IR.
 - [Ethos-U Vela graph compiler](https://pypi.org/project/ethos-u-vela/) for compiling TOSA flatbuffers into an Ethos-U command stream.
 
 And for building and running the example application available in `examples/arm/executor_runner/` through the standalone CMake entry point:

--- a/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
+++ b/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
@@ -43,7 +43,7 @@ To install Ethos-U dependencies, run
 ./examples/arm/setup.sh --i-agree-to-the-contained-eula
 ```
 This will install:
-- [TOSA Serialization Library](https://www.mlplatform.org/tosa/software.html) for serializing the Exir IR graph into TOSA IR.
+- [TOSA Serialization Library](https://gitlab.arm.com/tosa/tosa-tools) for serializing the Exir IR graph into TOSA IR.
 - [Ethos-U Vela graph compiler](https://pypi.org/project/ethos-u-vela/) for compiling TOSA flatbuffers into a Ethos-U command stream.
 - [Arm GNU Toolchain](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) for cross compilation.
 - [Corstone SSE-300 FVP](https://developer.arm.com/documentation/100966/1128/Arm--Corstone-SSE-300-FVP) for testing on Ethos-U55 reference design.

--- a/docs/source/backends/arm-vgf/arm-vgf-overview.md
+++ b/docs/source/backends/arm-vgf/arm-vgf-overview.md
@@ -21,7 +21,7 @@ All requirements can be downloaded using `examples/arm/setup.sh --enable-mlsdk-d
 ```
 
 For the AOT flow, compilation of a model to `.pte` format using the VGF backend, the requirements are:
-- [TOSA Serialization Library](https://www.mlplatform.org/tosa/software.html) for serializing the Exir IR graph into TOSA IR.
+- [TOSA Serialization Library](https://gitlab.arm.com/tosa/tosa-tools) for serializing the Exir IR graph into TOSA IR.
 - [ML SDK Model Converter](https://github.com/arm/ai-ml-sdk-model-converter) for converting TOSA flatbuffers to VGF files.
 
 And for building and running your application using the generic executor_runner:

--- a/docs/source/backends/arm-vgf/tutorials/vgf-getting-started.md
+++ b/docs/source/backends/arm-vgf/tutorials/vgf-getting-started.md
@@ -48,7 +48,7 @@ In addition to this, you need to install a number of SDK dependencies for genera
 ./examples/arm/setup.sh --i-agree-to-the-contained-eula --disable-ethos-u-deps --enable-mlsdk-deps
 ```
 This will install:
-- [TOSA Serialization Library](https://www.mlplatform.org/tosa/software.html) for serializing the Exir IR graph into TOSA IR.
+- [TOSA Serialization Library](https://gitlab.arm.com/tosa/tosa-tools) for serializing the Exir IR graph into TOSA IR.
 - [ML SDK Model Converter](https://github.com/arm/ai-ml-sdk-model-converter) for converting TOSA flatbuffers to VGF files.
 - [Vulkan API](https://www.vulkan.org) should be set up locally for GPU execution support.
 - [ML Emulation Layer for Vulkan](https://github.com/arm/ai-ml-emulation-layer-for-vulkan) for testing on Vulkan API.


### PR DESCRIPTION
### Summary

The website `www.mlplatform.org` is gone. Its DNS records were removed: the `mlplatform.org` zone is still published and `git.mlplatform.org` still resolves, but neither `www.mlplatform.org` nor the bare `mlplatform.org` has an address record any more, so nothing can connect to the website.

This repository links to three pages on that website from 13 places in 11 files, all in the Arm backend and its documentation. The URL linter (`scripts/lint_urls.sh`) reports all 13 as hard failures. Two things break as a result:

1. The nightly whole-tree link check is red every night.
2. `link-check / lint-urls` is a required check, and on a pull request it only extracts URLs from the lines that pull request adds. So any pull request that adds or rewrites one of these 13 link lines cannot merge, even when its actual purpose has nothing to do with links. Editing an unrelated line in the same file is not affected.

### Where the content went

It did not disappear, it moved. The last published copies of those three pages say where:

* The TOSA software page was an index of repositories on Arm's GitLab. Its "TOSA Serialization Library" entry pointed at `https://gitlab.arm.com/tosa/tosa-serialization`. That repository is itself deprecated now. Its README says it is no longer maintained and names `https://gitlab.arm.com/tosa/tosa-tools` as the new location, and its text still refers readers to the dead site. So these 8 links go to TOSA Tools instead. Arm folded three repositories into TOSA Tools, and serialization is one of them, so the reference is the same one at its current address. `tosa-reference-model` and `tosa-mlir-translator` carry the same deprecation notice.
* The TOSA overview and specification pages both name `https://github.com/arm/tosa-specification` as the home of the specification. That repository is public and actively updated.

So the links are repointed rather than suppressed:

| old (dead) | uses | new |
| --- | --- | --- |
| `/tosa/software.html` | 8 | `https://gitlab.arm.com/tosa/tosa-tools` |
| `/tosa/` and `/tosa/tosa_spec.html` | 3 | `https://github.com/arm/tosa-specification` |
| `/tosa/tosa_spec.html#_precision_scaling` | 1 | `.../blob/main/chapters/introduction.adoc#precision-scaling` |
| `/tosa/tosa_spec.html#_table` | 1 | `.../blob/main/chapters/ewise_binary.adoc#table` |

TOSA Tools is also what this repository already builds against: `.ci/scripts/unittest-linux-cmake.sh` clones `tosa-tools`, and the Arm backend pins the `tosa-tools` package.

The last two rows keep their deep link. The old site served a rendered HTML build of the specification, which no longer exists anywhere, but GitHub renders the AsciiDoc sources and generates heading anchors from the section titles, so those two fragments still land on the right sections.

The pages under `docs/source/backends/arm-ethos-u` and `docs/source/backends/arm-vgf` are generated from the templates in `backends/arm/scripts/docgen`, so both the template and the generated page are updated. Otherwise the next docgen run would undo this.

### Test plan

Ran the linter's whole-tree URL extractor against the tree before and after this change. Both runs find 2011 URLs, and the difference is exactly the 13 expected one for one replacements. No `www.mlplatform.org` reference remains, and no other URL is added, removed, or altered.

Checked each of the four new URLs the way the linter checks them, a HEAD request followed by a ranged GET, following redirects. All four answer 200.

For `gitlab.arm.com` a 200 does not on its own prove the page exists: that host answers 200 with a sign-in page for any path, including one made up as a control for this check. The GitLab target was therefore confirmed a second way, by fetching its README through the raw file endpoint, which does return 404 for a path that does not exist. `tosa-tools` returns its README, describing the serialization component. The same fetch against `tosa-serialization` is what returned the deprecation notice quoted above.

Confirmed that the two section fragments match anchors GitHub actually generates for those two files.

### Note for reviewers

All 11 files belong to the Arm backend, so please sanity check the choice of replacement targets.

One related link is left alone. `backends/arm/tosa/schemas/README.md` records that the FlatBuffer schema files originate from `https://git.mlplatform.org/tosa/reference_model.git/`. That host still resolves, so it is not failing CI, and it should stay as it is even if that host later goes away. It is a licence provenance statement about where the vendored files came from, not a pointer for a reader to follow, so repointing it at the reference model's current home in `https://gitlab.arm.com/tosa/tosa-tools` would state an origin that never happened. If it ever does start failing the linter, the right edit is to keep the original origin and note the current home beside it.
