### PR TITLE
Validate 4D input tensor memory layout against method metadata.

### DIFF
--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -794,22 +794,58 @@ struct PyModule final {
         input_strides.emplace_back(
             at_tensor.strides().begin(), at_tensor.strides().end());
 
-        // Only works for MemoryFormat::Contiguous or MemoryFormat::ChannelsLast
-        // inputs
+        auto method_meta_res = module_->method_meta(method_name);
+        if (!method_meta_res.ok()) {
+          throw std::runtime_error(
+              "Failed to get metadata for method " + method_name);
+        }
+        auto tensor_meta_res = method_meta_res.get().input_tensor_meta(i);
+        if (!tensor_meta_res.ok()) {
+          throw std::runtime_error(
+              "Failed to get tensor metadata for input " + std::to_string(i));
+        }
+        auto expected_dim_order = tensor_meta_res.get().dim_order();
+
+        // check if the model expects channel_last or contiguous 4d tensor
+        bool expected_channels_last =
+            (expected_dim_order.size() == 4 && expected_dim_order[0] == 0 &&
+             expected_dim_order[1] == 2 && expected_dim_order[2] == 3 &&
+             expected_dim_order[3] == 1);
+
+        bool expected_contiguous = true;
+        for (size_t d = 0; d < expected_dim_order.size(); ++d) {
+          if (expected_dim_order[d] != d) {
+            expected_contiguous = false;
+            break;
+          }
+        }
+
+        // validate the passed eager tensor matches the exported graph's
+        // expectations
         std::vector<torch::executor::Tensor::DimOrderType> dim_order;
-        if (at_tensor.is_contiguous()) {
+        if (expected_contiguous) {
+          if (!at_tensor.is_contiguous()) {
+            throw std::runtime_error(
+                "Input " + std::to_string(i) + " for method " + method_name +
+                " expected contiguous memory layout but received a different layout.");
+          }
           for (size_t cur_dim = 0; cur_dim < dim; cur_dim++) {
             dim_order.push_back(cur_dim);
           }
-        } else if (
-            at_tensor.is_contiguous(at::MemoryFormat::ChannelsLast) &&
-            at_tensor.dim() == 4) {
+        } else if (expected_channels_last) {
+          if (!at_tensor.is_contiguous(at::MemoryFormat::ChannelsLast) ||
+              dim != 4) {
+            throw std::runtime_error(
+                "Input " + std::to_string(i) + " for method " + method_name +
+                " expected channels-last memory layout but received a different layout.");
+          }
           dim_order = decltype(dim_order)({0, 2, 3, 1});
         } else {
-          auto error_msg = "Input " + std::to_string(i) + " for method " +
-              method_name + " should be contiguous or channels-last.";
-          throw std::runtime_error(error_msg);
+          throw std::runtime_error(
+              "Input " + std::to_string(i) + " for method " + method_name +
+              " expects an unsupported memory format.");
         }
+
         input_dim_order.push_back(std::move(dim_order));
         // The runtime has two device types, so a device outside that pair
         // cannot be represented at all and the tensor would carry a label that
@@ -1167,22 +1203,52 @@ struct PyMethod final {
         std::vector<int> strides(
             at_tensor.strides().begin(), at_tensor.strides().end());
 
-        // Only works for MemoryFormat::Contiguous or MemoryFormat::ChannelsLast
-        // inputs
+        const std::string method_name = method_->method_meta().name();
+        auto tensor_meta_res = method_->method_meta().input_tensor_meta(i);
+        if (!tensor_meta_res.ok()) {
+          throw std::runtime_error(
+              "Failed to get tensor metadata for input " + std::to_string(i));
+        }
+        auto expected_dim_order = tensor_meta_res.get().dim_order();
+
+        // check if the model expects channel_last or contiguous 4d tensor
+        bool expected_channels_last =
+            (expected_dim_order.size() == 4 && expected_dim_order[0] == 0 &&
+             expected_dim_order[1] == 2 && expected_dim_order[2] == 3 &&
+             expected_dim_order[3] == 1);
+
+        bool expected_contiguous = true;
+        for (size_t d = 0; d < expected_dim_order.size(); ++d) {
+          if (expected_dim_order[d] != d) {
+            expected_contiguous = false;
+            break;
+          }
+        }
+
+        // validate the passed eager tensor matches the exported graph's
+        // expectations
         std::vector<torch::executor::Tensor::DimOrderType> dim_order;
-        if (at_tensor.is_contiguous()) {
+        if (expected_contiguous) {
+          if (!at_tensor.is_contiguous()) {
+            throw std::runtime_error(
+                "Input " + std::to_string(i) + " for method " + method_name +
+                " expected contiguous memory layout but received a different layout.");
+          }
           for (size_t cur_dim = 0; cur_dim < dim; cur_dim++) {
             dim_order.push_back(cur_dim);
           }
-        } else if (
-            at_tensor.is_contiguous(at::MemoryFormat::ChannelsLast) &&
-            at_tensor.dim() == 4) {
+        } else if (expected_channels_last) {
+          if (!at_tensor.is_contiguous(at::MemoryFormat::ChannelsLast) ||
+              dim != 4) {
+            throw std::runtime_error(
+                "Input " + std::to_string(i) + " for method " + method_name +
+                " expected channels-last memory layout but received a different layout.");
+          }
           dim_order = decltype(dim_order)({0, 2, 3, 1});
         } else {
-          auto error_msg = "Input " + std::to_string(i) + " for method " +
-              method_->method_meta().name() +
-              " should be contiguous or channels-last.";
-          throw std::runtime_error(error_msg);
+          throw std::runtime_error(
+              "Input " + std::to_string(i) + " for method " + method_name +
+              " expects an unsupported memory format.");
         }
         // Record where the buffer actually lives. The conversion copied every
         // other property and left the device at CPU, so an accelerator buffer


### PR DESCRIPTION
### Summary

Current runtime accepts either contiguous or channel_last tensor unconditionally. This produces silent numerical corruption if a method was exported assuming contiguous strides and a channels-last tensor is passed at runtime (and vice versa).

This patch adds a 4D tensor layout validation check against the method metadata at runtime. If the input tensor layout does not match the expected layout, an error is raised.

Fixes: #21837 
cc @larryliu0820 @JacobSzwejbka @lucylq @john-rocky 

### Test plan
Manually tested for both export configurations:

```python
import torch
from executorch.exir import to_edge_transform_and_lower
from executorch.runtime import Runtime


class M(torch.nn.Module):
    def forward(self, x):
        return x * x


contig = torch.arange(12, dtype=torch.float32).reshape(1, 3, 2, 2)
chlast = contig.to(memory_format=torch.channels_last)
assert torch.equal(contig, chlast)

ep = torch.export.export(M(), (contig,))
open("/tmp/r.pte", "wb").write(
    to_edge_transform_and_lower(ep, partitioner=[]).to_executorch().buffer)
m = Runtime.get().load_program("/tmp/r.pte").load_method("forward")

try:
    print("expected     :", (contig ** 2).flatten().tolist())
    print("contiguous   :", m.execute([contig])[0].flatten().tolist())
    print("channels_last:", m.execute([chlast])[0].flatten().tolist())
except Exception as e:
    print("[ERROR]", e)

ep = torch.export.export(M(), (chlast,))
open("/tmp/r.pte", "wb").write(
    to_edge_transform_and_lower(ep, partitioner=[]).to_executorch().buffer)
m = Runtime.get().load_program("/tmp/r.pte").load_method("forward")

try:
    print("expected     :", (chlast ** 2).flatten().tolist())
    print("channels_last:", m.execute([chlast])[0].flatten().tolist())
    print("contiguous   :", m.execute([contig])[0].flatten().tolist())
except Exception as e:
    print("[ERROR]", e)
```

output:
```bash
expected     : [0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0, 100.0, 121.0]
contiguous   : [0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0, 100.0, 121.0]
[ERROR] Input 0 for method forward expected contiguous memory layout but received a different layout.
expected     : [0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0, 100.0, 121.0]
channels_last: [0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0, 100.0, 121.0]
[ERROR] Input 0 for method forward expected channels-last memory layout but received a different layout.
```