### PR TITLE
Skip the CUDA Windows import library in wheels without the CUDA delegate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -844,7 +844,14 @@ class _BaseExtension(Extension):
             return Path(".")
 
     def is_cmake_artifact_used(self, installer: "InstallerBuildExt") -> bool:
-        cache_path = str(self._get_build_dir(installer) / "CMakeCache.txt")
+        # The flags name what the build turned on, so they are read from the build's cache
+        # rather than from wherever this entry's source happens to live. A file checked into
+        # the source tree resolves against the project root, which holds no cache, so every
+        # flag declared on such a file was silently ignored and the file always shipped.
+        cmake_cache_dir = getattr(
+            installer.get_finalized_command("build"), "cmake_cache_dir", None
+        )
+        cache_path = os.path.join(cmake_cache_dir or "", "CMakeCache.txt")
         if not os.path.exists(cache_path):
             # If this is not a CMake folder, then assume it's used.
             return True
@@ -2379,11 +2386,16 @@ setup(
                     is_dynamic_lib=True,
                     dependent_cmake_flags=["EXECUTORCH_BUILD_KERNELS_LLM_AOT"],
                 ),
+                # The import library AOTInductor links generated code against when the CUDA
+                # delegate lowers for Windows. That is a cross compile, so it is needed on a
+                # Linux CUDA host too, but it is useless without the delegate: it is checked
+                # in rather than built, so a CPU wheel, including every macOS wheel, shipped
+                # a stub for a library it does not carry. Same flag as the library itself.
                 BuiltFile(
                     src_dir="backends/cuda/runtime/",
                     src_name="aoti_cuda_shims.lib",
                     dst="executorch/data/lib/",
-                    dependent_cmake_flags=[],
+                    dependent_cmake_flags=["EXECUTORCH_BUILD_CUDA"],
                 ),
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/backends/cuda/%BUILD_TYPE%/",


### PR DESCRIPTION
### Summary

`backends/cuda/runtime/aoti_cuda_shims.lib` is the import library that AOTInductor links generated code against when the CUDA delegate lowers a model for Windows. It ships to `executorch/data/lib/` in the wheel, and `backends/cuda/cuda_backend.py` reads it back from there. Lowering for Windows is a cross compile, so it is needed on a Linux CUDA host too, not only on Windows.

Because it is checked into the source tree rather than built, it shipped in every wheel. On the most recent nightly cut that is all 50 rows: the 30 CUDA rows, which can use it, and also the 20 CPU rows, which cannot. Five of those CPU rows are macOS, where the CUDA delegate cannot exist at all. Those wheels carry a link stub for a library they do not contain.

The shared library the stub refers to is the very next entry in `ext_modules` and is already gated on `EXECUTORCH_BUILD_CUDA`. This change puts the same flag on the stub so the two agree.

### Why the flag did not already work

`dependent_cmake_flags` was read from a CMake cache resolved through `_BaseExtension._get_build_dir()`. For a source path containing `%CMAKE_CACHE_DIR%` that is the build directory, which is correct. For a file checked into the source tree it is the project root, which holds no `CMakeCache.txt`, so `is_cmake_artifact_used()` took its "not a CMake folder, assume it is used" branch and every flag declared on such an entry was silently ignored.

`is_cmake_artifact_used()` now reads the cache from the build's `cmake_cache_dir` directly, the same way `_cuda_libraries_built()` already does. The flags describe what the build turned on, so the build's cache is the right place to look no matter where the file itself came from.

This is not a behaviour change for any other entry. Only two entries in `ext_modules` have a source-tree path, this one and `tools/wheel/pip_data_bin_init.py.in`, and before this change both declared no flags. Every entry that does declare a flag already resolves through `%CMAKE_CACHE_DIR%`, so it resolves to the identical path either way.

One edge shifts. A `build` command with no `cmake_cache_dir` at all used to raise from `is_cmake_artifact_used()`. It now returns True there, and `src_path()` raises the same message immediately afterwards, so the error still surfaces with the same text.

### Test plan

Exercised `is_cmake_artifact_used()` against a CPU cache (`EXECUTORCH_BUILD_CUDA:BOOL=OFF`), a CUDA cache (`ON`), a cache directory with nothing built in it, and a build command with no cache directory at all.

| build | .lib before | .lib after | .so, unchanged |
| --- | --- | --- | --- |
| CPU wheel | ships | skipped | skipped |
| CUDA wheel | ships | ships | ships |
| nothing built | ships | ships | ships |

Before this change the two entries disagreed on a CPU wheel, the stub shipping while the library it names did not. After it they agree in every case.

`tools/wheel/pip_data_bin_init.py.in` ships in all four cases, before and after.

Nothing else in the repository reads `executorch/data/lib`. `executorch.data.lib` is not a declared package, so a CPU wheel simply will not create the directory.
