### PR TITLE
Read dependent_cmake_flags from the build's CMake cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -844,7 +844,18 @@ class _BaseExtension(Extension):
             return Path(".")
 
     def is_cmake_artifact_used(self, installer: "InstallerBuildExt") -> bool:
-        cache_path = str(self._get_build_dir(installer) / "CMakeCache.txt")
+        # The flags name what the build turned on, so read them from the build's cache and
+        # not from wherever this entry's source lives. A source tree file resolves to the
+        # working directory, which holds no cache, so its flags were silently ignored.
+        cmake_cache_dir = getattr(
+            installer.get_finalized_command("build"), "cmake_cache_dir", None
+        )
+        if not cmake_cache_dir:
+            # CMake did not run, so there is nothing to test against. An entry that needs
+            # the build directory still fails in src_path right after this.
+            return True
+
+        cache_path = os.path.join(cmake_cache_dir, "CMakeCache.txt")
         if not os.path.exists(cache_path):
             # If this is not a CMake folder, then assume it's used.
             return True


### PR DESCRIPTION
### Summary

A wheel entry can declare the CMake options its file depends on, through `dependent_cmake_flags`, so that packaging skips the file when the build did not turn those options on. Those flags were read from a CMake cache resolved through the entry's own source path. For a file that CMake produces that is the build directory, which is right. For a file checked into the source tree it is the working directory, which holds no `CMakeCache.txt`, so `is_cmake_artifact_used()` took its "not a CMake folder, assume it is used" branch and every flag declared on such an entry was silently ignored.

Read the cache from the build command's `cmake_cache_dir` instead, the way `_cuda_libraries_built()` already does. The flags describe what the build turned on, so the build's cache is where to look no matter where the file itself came from.

No wheel changes today. Only two entries in `ext_modules` have a source tree path, `tools/wheel/pip_data_bin_init.py.in` and `backends/cuda/runtime/aoti_cuda_shims.lib`, and neither declares a flag. Every entry that does declare a flag resolves through `%CMAKE_CACHE_DIR%`, so it lands on the identical cache either way.

One edge moves. A `build` command with no `cmake_cache_dir` used to raise from `is_cmake_artifact_used()`. It now returns True there, and `src_path()` raises the same message immediately afterwards, so the error still surfaces with the same text.

### Test plan

Compared the result of `is_cmake_artifact_used()` before and after across all 25 wheel entries in five build shapes: a cache with the flag on, a cache with it off, a cache directory with nothing built in it, a build command with no cache directory, and a build command whose cache directory is None.

Results are identical for every entry in the three shapes a real build takes. In the two shapes where CMake never ran, the 23 entries that need the build directory now return True instead of raising, and `src_path()` raises the identical message right after, which was compared text for text.

Also ran the no cache directory shape with an unrelated `CMakeCache.txt` sitting in the working directory, to confirm the check does not read it.
