### PR TITLE
Ship the CUDA Windows import library only in CUDA builds

### DIFF
--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -2343,6 +2343,41 @@ def test_shipped_library_names_are_expected() -> None:
     print(f"✓ {len(shipped)} shipped libraries have expected names and identities")
 
 
+def test_windows_import_library_tracks_the_cuda_delegate() -> None:
+    """The Windows import library ships exactly where the CUDA delegate does.
+
+    It is the link input the delegate uses when lowering for a Windows target, so a
+    wheel without the delegate has no use for it and a CUDA wheel cannot do that
+    lowering without it. Checked here rather than by the symbol tests above, because
+    it is an archive of import stubs rather than a shared object, so nothing that
+    scans shipped libraries sees it. It is also checked in rather than built, which
+    is how it came to ship in every wheel with nothing noticing.
+
+    Keyed on the shim library the wheel actually ships rather than on the version
+    label, because only a published wheel carries a +cuXXX local version and a
+    locally built CUDA wheel would otherwise be told to drop a file it needs. Both
+    files are packaged behind EXECUTORCH_BUILD_CUDA alone, so they arrive together.
+    """
+    package_dir = _installed_package_dir()
+    import_library = package_dir / "data" / "lib" / "aoti_cuda_shims.lib"
+    shim_library = _library_file_name("libaoti_cuda_shims")
+    present = import_library.is_file()
+    if any(
+        path.name.startswith(shim_library)
+        for path in _shipped_shared_objects(package_dir)
+    ):
+        assert present, (
+            f"this CUDA wheel ships no {import_library.name}, so lowering the "
+            "delegate for a Windows target has nothing to link against."
+        )
+    else:
+        assert not present, (
+            f"this wheel ships {import_library.name} but no CUDA delegate, so it "
+            "carries a link stub for a library it does not contain."
+        )
+    print(f"✓ {import_library.name} {'ships' if present else 'is absent'} as expected")
+
+
 _PARITY_MODEL = '''
 import json
 import sys
@@ -2559,6 +2594,7 @@ def run_tests(work_dir: Path) -> None:
     test_declared_dependencies_match_the_wheel_tag()
     test_extension_contains_no_component()
     test_shipped_library_names_are_expected()
+    test_windows_import_library_tracks_the_cuda_delegate()
     test_shipped_libraries_load()
     test_shipped_libraries_resolve_without_build_tree()
     test_custom_op_compiles(work_dir)

--- a/backends/cuda/cuda_backend.py
+++ b/backends/cuda/cuda_backend.py
@@ -801,6 +801,16 @@ class CudaBackend(AotiBackend, BackendDetails):
 
             if shim_library_path is None:
                 lib_dir = resources.files("executorch").joinpath("data/lib")
+                # Only a CUDA build ships the import library, and a package directory
+                # that does not exist still reads back as an ordinary path rather than
+                # raising, so without this the failure surfaces from the linker instead.
+                if not lib_dir.joinpath("aoti_cuda_shims.lib").is_file():
+                    raise RuntimeError(
+                        "Lowering for Windows links against aoti_cuda_shims.lib, which "
+                        "only a CUDA build of executorch ships. Install a CUDA build, "
+                        "or pass a shim_library_path compile spec naming a directory "
+                        "that holds the import library."
+                    )
                 shim_library_path = str(lib_dir)
             options.update(
                 {

--- a/setup.py
+++ b/setup.py
@@ -2390,11 +2390,13 @@ setup(
                     is_dynamic_lib=True,
                     dependent_cmake_flags=["EXECUTORCH_BUILD_KERNELS_LLM_AOT"],
                 ),
+                # A Windows import library for the delegate's shim DLL. Lowering for
+                # Windows is a cross compile, so a Linux CUDA build needs it too.
                 BuiltFile(
                     src_dir="backends/cuda/runtime/",
                     src_name="aoti_cuda_shims.lib",
                     dst="executorch/data/lib/",
-                    dependent_cmake_flags=[],
+                    dependent_cmake_flags=["EXECUTORCH_BUILD_CUDA"],
                 ),
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/backends/cuda/%BUILD_TYPE%/",


### PR DESCRIPTION
Depends on #22053, which is what makes a flag declared on a source tree file take effect. That one has landed and this branch is rebased on top of it.

### Summary

`backends/cuda/runtime/aoti_cuda_shims.lib` is a Windows import library: the small link stub a Windows program links against so its calls reach the CUDA delegate's shim DLL at run time. Lowering for Windows is a cross compile, so a Linux CUDA build needs it too, not only a Windows build.

Unlike the other files the wheel picks up, it is checked into the source tree rather than built, and its packaging entry declared no CMake options, so it went into every published wheel. On the most recent nightly cut that is all 50 rows: the 30 CUDA rows, which can use it, and the 20 CPU rows, which cannot. Five of those CPU rows are macOS, where the CUDA delegate cannot exist at all. Those wheels carry a link stub for a library they do not contain.

Declare `EXECUTORCH_BUILD_CUDA` on the entry, the same option that gates the delegate's own shared library, which is the very next entry in `ext_modules`. The import library now ships when the delegate does and not otherwise.

The code that reads it back needs a matching check, because this change is what makes that directory disappear. When lowering for a Windows target, `cuda_backend` defaults the shim library path to the installed package's `data/lib` directory. On a CPU wheel today the import library is the only file in there, so once it stops shipping, the directory stops existing. `executorch.data.lib` is not a declared package, so nothing else creates it, and a directory that is not there still reads back as an ordinary path instead of raising. Without a check, a CPU install would pass a missing directory straight into the AOTInductor link options and the failure would surface far from its cause. It now fails where the assumption breaks, and names both the fix and the `shim_library_path` compile spec that overrides the default.

### Test plan

Called `get_aoti_compile_options()` with a `windows` platform compile spec against a package directory with no `data/lib`, one with an empty `data/lib`, one holding the import library, and one with no `data/lib` but an explicit `shim_library_path` spec. The first two raise and the last two return the expected path. Ran the same four without the new check and all four returned a path, including the one that does not exist.

The new wheel test asks whether the wheel ships the `aoti_cuda_shims` shared library, not whether its version carries a `+cuXXX` label, because only a published wheel carries that label and a locally built CUDA wheel would otherwise be told to drop a file it needs. Both files are packaged behind `EXECUTORCH_BUILD_CUDA` alone, so they arrive together. Ran it in all four combinations of the shim library present or absent and the import library present or absent, and it passes only on the two that match. Ran it against today's published nightly wheels: the CPU wheel fails, which is the case this change removes, and the CUDA wheel passes. Removing the import library from the CPU wheel, which is what this change does, turns that failure into a pass and leaves the CUDA wheel passing.

That test runs from the wheel test entry point used by the Linux, Linux aarch64, macOS and CUDA Linux jobs, so it covers 45 of the 50 wheels published today. The Windows job does not use that entry point, so the 5 Windows wheels are not covered by it.

The same packaging change was built by the wheel jobs on #22049. Unzipping six of those wheels: the CPU, macOS and Windows wheels lose `executorch/data/lib/aoti_cuda_shims.lib` and nothing else, and the CUDA wheels are unchanged file for file.
