### PR TITLE
Fix device placement for memory-planned buffers in Runtime.load_program

### DIFF
--- a/.ci/scripts/test-cuda-build.sh
+++ b/.ci/scripts/test-cuda-build.sh
@@ -80,11 +80,6 @@ except Exception as e:
     exit(1)
 "
 
-    # The pybindings loader only asks for device memory on a build that has a
-    # device allocator registered, so this job is the only place that path runs.
-    python -m unittest -v \
-        executorch.extension.pybindings.test.test_pybindings.PybindingsTest.test_device_planned_method_allocates_on_the_device
-
     echo "SUCCESS: ExecuTorch CUDA ${cuda_version} build and verification completed successfully"
 }
 

--- a/.ci/scripts/test-cuda-build.sh
+++ b/.ci/scripts/test-cuda-build.sh
@@ -80,6 +80,11 @@ except Exception as e:
     exit(1)
 "
 
+    # The pybindings loader only asks for device memory on a build that has a
+    # device allocator registered, so this job is the only place that path runs.
+    python -m unittest -v \
+        executorch.extension.pybindings.test.test_pybindings.PybindingsTest.test_device_planned_method_allocates_on_the_device
+
     echo "SUCCESS: ExecuTorch CUDA ${cuda_version} build and verification completed successfully"
 }
 

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -200,7 +200,24 @@ jobs:
         # a device allocator registered, so this test cannot run in the CPU
         # jobs. It needs the install above and nothing built below, so run it
         # here and fail before the long builds.
-        python -m unittest -v executorch.extension.pybindings.test.test_pybindings.PybindingsTest.test_device_planned_method_allocates_on_the_device
+        #
+        # unittest exits 0 when a test skips, and this test skips when the CUDA
+        # backend is missing or no GPU is visible. Both are the prerequisites
+        # this job exists to provide, so treat a skip as a failure rather than
+        # let a packaging regression pass silently. `tee` would otherwise hide
+        # the real exit status behind its own, so read it back explicitly.
+        set +e
+        python -m unittest -v executorch.extension.pybindings.test.test_pybindings.PybindingsTest.test_device_planned_method_allocates_on_the_device 2>&1 | tee /tmp/pybindings_device_test.log
+        pybindings_device_status=${PIPESTATUS[0]}
+        set -e
+        if [ "${pybindings_device_status}" -ne 0 ]; then
+          echo "::error::the pybindings device test failed"
+          exit "${pybindings_device_status}"
+        fi
+        if grep -qE "^OK \(skipped=|skipped=[1-9]" /tmp/pybindings_device_test.log; then
+          echo "::error::the pybindings device test skipped in the CUDA job, which means the CUDA backend or a visible GPU is missing"
+          exit 1
+        fi
 
         # Build ExecuTorch with CUDA support
         cmake --workflow --preset llm-release-cuda

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -26,6 +26,8 @@ on:
       - .ci/scripts/export_model_artifact.sh
       - .ci/scripts/test_model_e2e.sh
       - examples/models/muse-glimmer/**
+      - extension/pybindings/**
+      - runtime/__init__.py
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -162,6 +162,8 @@ jobs:
   unittest-cuda:
     name: unittest-cuda
     needs: [changed-files, run-decision]
+    # This job runs the pybindings device test, so it also has to fire on the
+    # two pybindings paths the workflow filter lists.
     if: |
       contains(needs.changed-files.outputs.changed-files, 'backends/cuda') ||
       contains(needs.changed-files.outputs.changed-files, 'backends/aoti') ||
@@ -169,6 +171,8 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.ci/scripts/test-cuda-build.sh') ||
       contains(needs.changed-files.outputs.changed-files, '.ci/scripts/export_model_artifact.sh') ||
       contains(needs.changed-files.outputs.changed-files, '.ci/scripts/test_model_e2e.sh') ||
+      contains(needs.changed-files.outputs.changed-files, 'extension/pybindings') ||
+      contains(needs.changed-files.outputs.changed-files, 'runtime/__init__.py') ||
       needs.run-decision.outputs.is-full-run == 'true'
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     permissions:
@@ -191,6 +195,12 @@ jobs:
         # which the default system libstdc++ doesn't have. Install a newer one.
         conda install -y -c conda-forge 'libstdcxx-ng>=12'
         export LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
+
+        # The pybindings loader only asks for device memory on a build that has
+        # a device allocator registered, so this test cannot run in the CPU
+        # jobs. It needs the install above and nothing built below, so run it
+        # here and fail before the long builds.
+        python -m unittest -v executorch.extension.pybindings.test.test_pybindings.PybindingsTest.test_device_planned_method_allocates_on_the_device
 
         # Build ExecuTorch with CUDA support
         cmake --workflow --preset llm-release-cuda

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <algorithm>
+#include <cinttypes>
 #include <cstdio>
 #include <iostream>
 #include <memory>
@@ -31,6 +32,7 @@
 #include <executorch/extension/threadpool/threadpool.h>
 #include <executorch/runtime/backend/interface.h>
 #include <executorch/runtime/core/data_loader.h>
+#include <executorch/runtime/core/device_memory_buffer.h>
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 #include <executorch/runtime/executor/method.h>
 #include <executorch/runtime/executor/program.h>
@@ -81,6 +83,7 @@ using ::executorch::ET_RUNTIME_NAMESPACE::get_num_registered_backends;
 using ::executorch::ET_RUNTIME_NAMESPACE::get_registered_kernels;
 using ::executorch::ET_RUNTIME_NAMESPACE::Kernel;
 using ::executorch::ET_RUNTIME_NAMESPACE::Method;
+using ::executorch::ET_RUNTIME_NAMESPACE::MethodMeta;
 using ::executorch::ET_RUNTIME_NAMESPACE::Program;
 using ::executorch::extension::BufferDataLoader;
 using ::executorch::extension::MallocMemoryAllocator;
@@ -88,6 +91,7 @@ using ::executorch::extension::MmapDataLoader;
 using ::executorch::extension::ET_BUNDLED_MODULE_NAMESPACE::BundledModule;
 using ::executorch::extension::pybindings::PyDataLoader;
 using ::executorch::runtime::DataLoader;
+using ::executorch::runtime::DeviceMemoryBuffer;
 using ::executorch::runtime::Error;
 using ::executorch::runtime::EValue;
 using ::executorch::runtime::EventTracerDebugLogLevel;
@@ -1077,17 +1081,27 @@ inline std::shared_ptr<ProgramState> load_program(
 /// A wrapper/util class for executorch memory allocations/manager.
 class ProgramMemory {
  public:
-  explicit ProgramMemory(std::vector<std::vector<uint8_t>>&& non_const_buffers)
+  /// `devices` is empty when every buffer is on the host, which keeps
+  /// `MemoryManager::has_device_memory()` false for CPU-only programs.
+  /// Otherwise it holds one entry per buffer, indexed like `sizes`.
+  ProgramMemory(
+      std::vector<int64_t>&& sizes,
+      std::vector<runtime::etensor::Device>&& devices)
       : runtime_allocator_(),
-        non_const_buffers_(std::move(non_const_buffers)),
+        planned_sizes_(std::move(sizes)),
+        planned_devices_(std::move(devices)),
+        non_const_buffers_(allocate_host_buffers()),
+        device_buffers_(allocate_device_buffers()),
         non_const_spans_(create_non_const_spans()),
-        non_const_allocator_(
-            {non_const_spans_.data(), non_const_spans_.size()}),
+        non_const_allocator_(create_non_const_allocator()),
         mem_manager_(
             &const_allocator_,
             &non_const_allocator_,
             &runtime_allocator_,
             &temp_allocator_) {}
+
+  explicit ProgramMemory(std::vector<int64_t>&& sizes)
+      : ProgramMemory(std::move(sizes), {}) {}
 
   /// Returns a pointer to the internal memory manager, the Memory instance
   /// must outlive this pointer.
@@ -1105,7 +1119,17 @@ class ProgramMemory {
 
   MallocMemoryAllocator temp_allocator_{};
 
+  std::vector<int64_t> planned_sizes_;
+
+  std::vector<runtime::etensor::Device> planned_devices_;
+
+  // Backs CPU-tagged buffers; the entry is empty for a device-tagged buffer.
   std::vector<std::vector<uint8_t>> non_const_buffers_;
+
+  // Backs device-tagged buffers; the entry is empty for a CPU-tagged buffer.
+  // Parallel to non_const_buffers_ so both index by planned buffer id. Empty
+  // for an all-host program.
+  std::vector<DeviceMemoryBuffer> device_buffers_;
 
   std::vector<Span<uint8_t>> non_const_spans_;
 
@@ -1113,15 +1137,107 @@ class ProgramMemory {
 
   MemoryManager mem_manager_;
 
-  std::vector<Span<uint8_t>> create_non_const_spans() {
-    std::vector<Span<uint8_t>> result;
-    for (size_t i = 0; i < non_const_buffers_.size(); i++) {
-      result.push_back(
-          {non_const_buffers_[i].data(), non_const_buffers_[i].size()});
+  bool is_device_buffer(size_t index) const {
+    return index < planned_devices_.size() && !planned_devices_[index].is_cpu();
+  }
+
+  std::vector<std::vector<uint8_t>> allocate_host_buffers() {
+    std::vector<std::vector<uint8_t>> result;
+    result.reserve(planned_sizes_.size());
+    for (size_t i = 0; i < planned_sizes_.size(); i++) {
+      if (is_device_buffer(i)) {
+        result.emplace_back();
+      } else {
+        result.emplace_back(planned_sizes_[i]);
+      }
     }
     return result;
   }
+
+  std::vector<DeviceMemoryBuffer> allocate_device_buffers() {
+    std::vector<DeviceMemoryBuffer> result;
+    if (planned_devices_.empty()) {
+      return result;
+    }
+    result.reserve(planned_sizes_.size());
+    for (size_t i = 0; i < planned_sizes_.size(); i++) {
+      if (!is_device_buffer(i)) {
+        result.emplace_back();
+        continue;
+      }
+      auto buffer = DeviceMemoryBuffer::create(
+          planned_sizes_[i],
+          planned_devices_[i].type(),
+          planned_devices_[i].index());
+      THROW_IF_ERROR(
+          buffer.error(),
+          "Failed to allocate %" PRId64 " bytes for buffer %zu on device %d:%d",
+          planned_sizes_[i],
+          i,
+          static_cast<int>(planned_devices_[i].type()),
+          static_cast<int>(planned_devices_[i].index()));
+      result.emplace_back(std::move(buffer.get()));
+    }
+    return result;
+  }
+
+  std::vector<Span<uint8_t>> create_non_const_spans() {
+    std::vector<Span<uint8_t>> result;
+    result.reserve(planned_sizes_.size());
+    for (size_t i = 0; i < planned_sizes_.size(); i++) {
+      if (is_device_buffer(i)) {
+        result.push_back(device_buffers_[i].as_span());
+      } else {
+        result.push_back(
+            {non_const_buffers_[i].data(), non_const_buffers_[i].size()});
+      }
+    }
+    return result;
+  }
+
+  HierarchicalAllocator create_non_const_allocator() {
+    Span<Span<uint8_t>> buffers(
+        non_const_spans_.data(), non_const_spans_.size());
+    return planned_devices_.empty()
+        ? HierarchicalAllocator(buffers)
+        : HierarchicalAllocator(
+              buffers, {planned_devices_.data(), planned_devices_.size()});
+  }
 };
+
+/// True if any of the method's memory-planned buffers must live off the host.
+bool has_device_buffers(const MethodMeta& method_meta) {
+  for (size_t i = 0; i < method_meta.num_memory_planned_buffers(); i++) {
+    auto device = method_meta.memory_planned_buffer_device(i);
+    THROW_IF_ERROR(
+        device.error(), "Failed to get device of planned buffer %zu", i);
+    if (!device.get().is_cpu()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Arenas sized and placed for a single method, used when that method's
+/// buffers cannot come from the program-wide host arenas.
+std::shared_ptr<ProgramMemory> make_method_memory(
+    const MethodMeta& method_meta) {
+  const size_t num_buffers = method_meta.num_memory_planned_buffers();
+  std::vector<int64_t> sizes;
+  std::vector<runtime::etensor::Device> devices;
+  sizes.reserve(num_buffers);
+  devices.reserve(num_buffers);
+  for (size_t i = 0; i < num_buffers; i++) {
+    auto size = method_meta.memory_planned_buffer_size(i);
+    THROW_IF_ERROR(size.error(), "Failed to get size of planned buffer %zu", i);
+    auto device = method_meta.memory_planned_buffer_device(i);
+    THROW_IF_ERROR(
+        device.error(), "Failed to get device of planned buffer %zu", i);
+    sizes.push_back(size.get());
+    devices.push_back(device.get());
+  }
+  return std::make_shared<ProgramMemory>(std::move(sizes), std::move(devices));
+}
 
 struct PyMethod final {
   explicit PyMethod(
@@ -1423,8 +1539,13 @@ struct PyProgram final {
     for (size_t i = 0; i < state_->program_->num_methods(); ++i) {
       auto name = state_->program_->get_method_name(i).get();
       auto method_meta = state_->program_->method_meta(name).get();
-      for (size_t j = 0; j < method_meta.num_non_const_buffers(); j++) {
-        int64_t buffer_size = method_meta.non_const_buffer_size(j).get();
+      // A device-planned method gets its own arenas in load_method, so its
+      // sizes must not inflate the shared host arenas nobody will read.
+      if (has_device_buffers(method_meta)) {
+        continue;
+      }
+      for (size_t j = 0; j < method_meta.num_memory_planned_buffers(); j++) {
+        int64_t buffer_size = method_meta.memory_planned_buffer_size(j).get();
         if (non_const_buffer_sizes.find(j) == non_const_buffer_sizes.end()) {
           non_const_buffer_sizes.insert({j, buffer_size});
         } else {
@@ -1434,16 +1555,14 @@ struct PyProgram final {
       }
     }
 
-    // Allocate the arenas. Using vector because we need to remember the size as
-    // well, so vector is easier then unique_ptr.
-    std::vector<std::vector<uint8_t>> non_const_buffers_;
-    for (std::map<size_t, int64_t>::iterator i = non_const_buffer_sizes.begin();
-         i != non_const_buffer_sizes.end();
-         i++) {
-      non_const_buffers_.push_back(std::vector<uint8_t>(i->second));
+    // Allocate the shared host arenas.
+    std::vector<int64_t> planned_sizes;
+    planned_sizes.reserve(non_const_buffer_sizes.size());
+    for (const auto& entry : non_const_buffer_sizes) {
+      planned_sizes.push_back(entry.second);
     }
 
-    memory_ = std::make_shared<ProgramMemory>(std::move(non_const_buffers_));
+    memory_ = std::make_shared<ProgramMemory>(std::move(planned_sizes));
     if (event_tracer_ && debug_buffer_size > 0) {
       // If a debug buffer was requested for the ETDump, allocate it and make
       // sure its lifetime is as long as the event_tracer.
@@ -1508,9 +1627,21 @@ struct PyProgram final {
   }
 
   std::unique_ptr<PyMethod> load_method(const std::string& method_name) {
+    Result<MethodMeta> meta =
+        state_->program_->method_meta(method_name.c_str());
+    THROW_IF_ERROR(
+        meta.error(),
+        "Failed to get method meta for method %s, error: 0x:%" PRIx32,
+        method_name.c_str(),
+        static_cast<uint32_t>(meta.error()));
+    // Device memory is claimed here rather than at program load so that one
+    // accelerator method cannot make the rest of the program unloadable.
+    auto memory = has_device_buffers(meta.get())
+        ? make_method_memory(meta.get())
+        : memory_;
     Result<Method> res = state_->program_->load_method(
         method_name.c_str(),
-        memory_->mem_manager(),
+        memory->mem_manager(),
         event_tracer_.get(),
         state_->data_map_.get());
     THROW_IF_ERROR(
@@ -1519,7 +1650,9 @@ struct PyProgram final {
         method_name.c_str(),
         static_cast<uint32_t>(res.error()));
     return std::make_unique<PyMethod>(
-        memory_, state_, std::make_unique<Method>(std::move(res.get())));
+        std::move(memory),
+        state_,
+        std::make_unique<Method>(std::move(res.get())));
   }
 
   Span<uint8_t> get_etdump_debug_buffer() {

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -1087,9 +1087,8 @@ class ProgramMemory {
   ///
   /// Members initialize in declaration order and each one reads the members
   /// declared before it, so that order is load-bearing. Device buffers come
-  /// first because they hold the only allocation that can fail, and throwing
-  /// before the host arenas exist avoids zero-filling memory that is about to
-  /// be discarded.
+  /// first so that a device that is missing or out of memory throws before the
+  /// host arenas are allocated and zero-filled, rather than after.
   ProgramMemory(
       std::vector<int64_t>&& sizes,
       std::vector<runtime::etensor::Device>&& devices)
@@ -1165,9 +1164,9 @@ class ProgramMemory {
     if (planned_devices_.empty()) {
       return result;
     }
-    // HierarchicalAllocator aborts rather than throws if the span count and
-    // the device count disagree, so reject that here where a Python caller can
-    // still catch it.
+    // Both vectors are filled in lockstep today, so this only fires if a
+    // future caller breaks that. HierarchicalAllocator aborts on a mismatch,
+    // so check here instead, where a Python caller can catch it.
     THROW_IF_ERROR(
         planned_devices_.size() == planned_sizes_.size()
             ? Error::Ok
@@ -1562,8 +1561,9 @@ struct PyProgram final {
     for (size_t i = 0; i < state_->program_->num_methods(); ++i) {
       auto name = state_->program_->get_method_name(i).get();
       auto method_meta = state_->program_->method_meta(name).get();
-      // A device-planned method gets its own arenas in load_method, so its
-      // sizes must not inflate the shared host arenas nobody will read.
+      // A device-planned method gets its own arenas in load_method and never
+      // reads these, so letting its sizes in would only grow the host arenas
+      // the other methods share.
       if (has_device_buffers(method_meta)) {
         continue;
       }

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -1568,7 +1568,10 @@ struct PyProgram final {
         continue;
       }
       for (size_t j = 0; j < method_meta.num_memory_planned_buffers(); j++) {
-        int64_t buffer_size = method_meta.memory_planned_buffer_size(j).get();
+        auto size = method_meta.memory_planned_buffer_size(j);
+        THROW_IF_ERROR(
+            size.error(), "Failed to get size of planned buffer %zu", j);
+        int64_t buffer_size = size.get();
         if (non_const_buffer_sizes.find(j) == non_const_buffer_sizes.end()) {
           non_const_buffer_sizes.insert({j, buffer_size});
         } else {

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -1165,6 +1165,16 @@ class ProgramMemory {
     if (planned_devices_.empty()) {
       return result;
     }
+    // HierarchicalAllocator aborts rather than throws if the span count and
+    // the device count disagree, so reject that here where a Python caller can
+    // still catch it.
+    THROW_IF_ERROR(
+        planned_devices_.size() == planned_sizes_.size()
+            ? Error::Ok
+            : Error::InvalidArgument,
+        "Have %zu planned buffer sizes but %zu device tags",
+        planned_sizes_.size(),
+        planned_devices_.size());
     result.reserve(planned_sizes_.size());
     for (size_t i = 0; i < planned_sizes_.size(); i++) {
       if (!is_device_buffer(i)) {

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -1149,7 +1149,7 @@ class ProgramMemory {
   std::vector<std::vector<uint8_t>> allocate_host_buffers() {
     std::vector<std::vector<uint8_t>> result;
     result.reserve(planned_sizes_.size());
-    for (size_t i = 0; i < planned_sizes_.size(); i++) {
+    for (size_t i = 0; i < planned_sizes_.size(); ++i) {
       if (is_device_buffer(i)) {
         result.emplace_back();
       } else {
@@ -1175,7 +1175,7 @@ class ProgramMemory {
         planned_sizes_.size(),
         planned_devices_.size());
     result.reserve(planned_sizes_.size());
-    for (size_t i = 0; i < planned_sizes_.size(); i++) {
+    for (size_t i = 0; i < planned_sizes_.size(); ++i) {
       if (!is_device_buffer(i)) {
         result.emplace_back();
         continue;
@@ -1199,7 +1199,7 @@ class ProgramMemory {
   std::vector<Span<uint8_t>> create_non_const_spans() {
     std::vector<Span<uint8_t>> result;
     result.reserve(planned_sizes_.size());
-    for (size_t i = 0; i < planned_sizes_.size(); i++) {
+    for (size_t i = 0; i < planned_sizes_.size(); ++i) {
       if (is_device_buffer(i)) {
         result.push_back(device_buffers_[i].as_span());
       } else {
@@ -1222,7 +1222,7 @@ class ProgramMemory {
 
 /// True if any of the method's memory-planned buffers must live off the host.
 bool has_device_buffers(const MethodMeta& method_meta) {
-  for (size_t i = 0; i < method_meta.num_memory_planned_buffers(); i++) {
+  for (size_t i = 0; i < method_meta.num_memory_planned_buffers(); ++i) {
     auto device = method_meta.memory_planned_buffer_device(i);
     THROW_IF_ERROR(
         device.error(), "Failed to get device of planned buffer %zu", i);
@@ -1245,7 +1245,7 @@ std::shared_ptr<ProgramMemory> make_method_memory(
   sizes.reserve(num_buffers);
   devices.reserve(num_buffers);
   bool needs_device_memory = false;
-  for (size_t i = 0; i < num_buffers; i++) {
+  for (size_t i = 0; i < num_buffers; ++i) {
     auto size = method_meta.memory_planned_buffer_size(i);
     THROW_IF_ERROR(size.error(), "Failed to get size of planned buffer %zu", i);
     auto device = method_meta.memory_planned_buffer_device(i);
@@ -1567,7 +1567,7 @@ struct PyProgram final {
       if (has_device_buffers(method_meta)) {
         continue;
       }
-      for (size_t j = 0; j < method_meta.num_memory_planned_buffers(); j++) {
+      for (size_t j = 0; j < method_meta.num_memory_planned_buffers(); ++j) {
         auto size = method_meta.memory_planned_buffer_size(j);
         THROW_IF_ERROR(
             size.error(), "Failed to get size of planned buffer %zu", j);

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -1084,14 +1084,20 @@ class ProgramMemory {
   /// `devices` is empty when every buffer is on the host, which keeps
   /// `MemoryManager::has_device_memory()` false for CPU-only programs.
   /// Otherwise it holds one entry per buffer, indexed like `sizes`.
+  ///
+  /// Members initialize in declaration order and each one reads the members
+  /// declared before it, so that order is load-bearing. Device buffers come
+  /// first because they hold the only allocation that can fail, and throwing
+  /// before the host arenas exist avoids zero-filling memory that is about to
+  /// be discarded.
   ProgramMemory(
       std::vector<int64_t>&& sizes,
       std::vector<runtime::etensor::Device>&& devices)
       : runtime_allocator_(),
         planned_sizes_(std::move(sizes)),
         planned_devices_(std::move(devices)),
-        non_const_buffers_(allocate_host_buffers()),
         device_buffers_(allocate_device_buffers()),
+        non_const_buffers_(allocate_host_buffers()),
         non_const_spans_(create_non_const_spans()),
         non_const_allocator_(create_non_const_allocator()),
         mem_manager_(
@@ -1123,13 +1129,13 @@ class ProgramMemory {
 
   std::vector<runtime::etensor::Device> planned_devices_;
 
-  // Backs CPU-tagged buffers; the entry is empty for a device-tagged buffer.
-  std::vector<std::vector<uint8_t>> non_const_buffers_;
-
   // Backs device-tagged buffers; the entry is empty for a CPU-tagged buffer.
   // Parallel to non_const_buffers_ so both index by planned buffer id. Empty
   // for an all-host program.
   std::vector<DeviceMemoryBuffer> device_buffers_;
+
+  // Backs CPU-tagged buffers; the entry is empty for a device-tagged buffer.
+  std::vector<std::vector<uint8_t>> non_const_buffers_;
 
   std::vector<Span<uint8_t>> non_const_spans_;
 

--- a/extension/pybindings/pybindings.cpp
+++ b/extension/pybindings/pybindings.cpp
@@ -1235,7 +1235,9 @@ bool has_device_buffers(const MethodMeta& method_meta) {
 }
 
 /// Arenas sized and placed for a single method, used when that method's
-/// buffers cannot come from the program-wide host arenas.
+/// buffers cannot come from the program-wide host arenas. Returns nullptr when
+/// every buffer is on the host, so one pass over the metadata answers both
+/// whether the method needs its own arenas and how big they are.
 std::shared_ptr<ProgramMemory> make_method_memory(
     const MethodMeta& method_meta) {
   const size_t num_buffers = method_meta.num_memory_planned_buffers();
@@ -1243,14 +1245,19 @@ std::shared_ptr<ProgramMemory> make_method_memory(
   std::vector<runtime::etensor::Device> devices;
   sizes.reserve(num_buffers);
   devices.reserve(num_buffers);
+  bool needs_device_memory = false;
   for (size_t i = 0; i < num_buffers; i++) {
     auto size = method_meta.memory_planned_buffer_size(i);
     THROW_IF_ERROR(size.error(), "Failed to get size of planned buffer %zu", i);
     auto device = method_meta.memory_planned_buffer_device(i);
     THROW_IF_ERROR(
         device.error(), "Failed to get device of planned buffer %zu", i);
+    needs_device_memory |= !device.get().is_cpu();
     sizes.push_back(size.get());
     devices.push_back(device.get());
+  }
+  if (!needs_device_memory) {
+    return nullptr;
   }
   return std::make_shared<ProgramMemory>(std::move(sizes), std::move(devices));
 }
@@ -1651,10 +1658,11 @@ struct PyProgram final {
         method_name.c_str(),
         static_cast<uint32_t>(meta.error()));
     // Device memory is claimed here rather than at program load so that one
-    // accelerator method cannot make the rest of the program unloadable.
-    auto memory = has_device_buffers(meta.get())
-        ? make_method_memory(meta.get())
-        : memory_;
+    // accelerator method cannot make the rest of the program unloadable. A
+    // host-only method keeps sharing the program-wide arenas, so its planned
+    // memory is not isolated from the other host-only methods of this program.
+    auto method_memory = make_method_memory(meta.get());
+    auto memory = method_memory ? std::move(method_memory) : memory_;
     Result<Method> res = state_->program_->load_method(
         method_name.c_str(),
         memory->mem_manager(),

--- a/extension/pybindings/test/BUCK
+++ b/extension/pybindings/test/BUCK
@@ -26,6 +26,7 @@ fbcode_target(
         "//executorch/exir:pass_manager",
         "//executorch/exir:scalar_type",
         "//executorch/exir/_serialize:lib",
+        "//executorch/exir/backend:partitioner",
         "//executorch/exir/emit:lib",
         "//executorch/exir/passes:lib",
         "//executorch/runtime/core:core",
@@ -39,6 +40,7 @@ fbcode_target(
     preload_deps = ["//executorch/kernels/quantized:aot_lib"],
     deps = [
         ":make_test",
+        "//executorch/exir/backend/test:device_util",
         "//executorch/extension/pybindings:portable_lib",
     ],
 )
@@ -50,6 +52,7 @@ fbcode_target(
     preload_deps = ["//executorch/kernels/quantized:aot_lib"],
     deps = [
         ":make_test",
+        "//executorch/exir/backend/test:device_util",
         "//executorch/extension/pybindings:aten_lib",
         "//executorch/kernels/quantized:aot_lib",
     ],
@@ -61,6 +64,7 @@ fbcode_target(
     srcs = ["test_pybindings.py"],
     deps = [
         ":make_test",
+        "//executorch/exir/backend/test:device_util",
     ],
 )
 

--- a/extension/pybindings/test/BUCK
+++ b/extension/pybindings/test/BUCK
@@ -40,6 +40,7 @@ fbcode_target(
     preload_deps = ["//executorch/kernels/quantized:aot_lib"],
     deps = [
         ":make_test",
+        "//executorch/exir:schema",
         "//executorch/exir/backend/test:device_util",
         "//executorch/extension/pybindings:portable_lib",
     ],
@@ -52,6 +53,7 @@ fbcode_target(
     preload_deps = ["//executorch/kernels/quantized:aot_lib"],
     deps = [
         ":make_test",
+        "//executorch/exir:schema",
         "//executorch/exir/backend/test:device_util",
         "//executorch/extension/pybindings:aten_lib",
         "//executorch/kernels/quantized:aot_lib",
@@ -64,6 +66,7 @@ fbcode_target(
     srcs = ["test_pybindings.py"],
     deps = [
         ":make_test",
+        "//executorch/exir:schema",
         "//executorch/exir/backend/test:device_util",
     ],
 )

--- a/extension/pybindings/test/make_test.py
+++ b/extension/pybindings/test/make_test.py
@@ -6,10 +6,11 @@
 
 # pyre-unsafe
 
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 from executorch.exir import ExecutorchBackendConfig, ExecutorchProgramManager, to_edge
+from executorch.exir.backend.partitioner import Partitioner
 from torch.export import export
 
 
@@ -151,6 +152,7 @@ class ModuleLinear(torch.nn.Module):
 def create_program(
     eager_module: torch.nn.Module,
     et_config: Optional[ExecutorchBackendConfig] = None,
+    partitioner: Optional[Dict[str, Partitioner]] = None,
 ) -> Tuple[ExecutorchProgramManager, Tuple[Any, ...]]:
     """Returns an executorch program based on ModuleAdd, along with inputs."""
 
@@ -179,7 +181,10 @@ def create_program(
         wrapped_mod = WrapperModule(getattr(eager_module, method_name))
         exported_methods[method_name] = export(wrapped_mod, method_input, strict=True)
 
-    exec_prog = to_edge(exported_methods).to_executorch(config=et_config)
+    edge_prog = to_edge(exported_methods)
+    if partitioner is not None:
+        edge_prog = edge_prog.to_backend(partitioner)
+    exec_prog = edge_prog.to_executorch(config=et_config)
 
     # Create the ExecuTorch program from the graph.
     exec_prog.dump_executorch_program(verbose=True)

--- a/extension/pybindings/test/test_pybindings.py
+++ b/extension/pybindings/test/test_pybindings.py
@@ -13,7 +13,9 @@ from io import StringIO
 import torch
 
 from executorch.exir import ExecutorchBackendConfig, to_edge
+from executorch.exir.backend.test.device_util import DeviceAwarePartitioner
 from executorch.exir.passes import MemoryPlanningPass
+from executorch.exir.schema import DeviceType
 from executorch.extension.pybindings.test.make_test import (
     create_program,
     ModuleAdd,
@@ -786,3 +788,44 @@ class PybindingsTest(unittest.TestCase):
         message = str(caught.exception)
         self.assertIn("is on device meta", message)
         self.assertIn("only CPU and CUDA tensors", message)
+
+    def test_program_loads_when_one_method_is_device_planned(self):
+        # Linking the CUDA backend registers a CUDA allocator at static init, and the
+        # registry has no way to drop one, so there the device load would succeed with
+        # or without the fix and this test could not tell them apart.
+        if "CudaBackend" in self.runtime._get_registered_backend_names():
+            self.skipTest("a registered CUDA allocator satisfies the device load")
+
+        exported_program, inputs = create_program(
+            ModuleMulti(),
+            et_config=ExecutorchBackendConfig(enable_non_cpu_memory_planning=True),
+            partitioner={"forward2": DeviceAwarePartitioner()},
+        )
+
+        # Without this the test would quietly become a second copy of
+        # test_method_multiple_entry if the planner stopped tagging devices.
+        planned_devices = {
+            plan.name: [
+                buffer.device_type for buffer in (plan.non_const_buffer_device or [])
+            ]
+            for plan in exported_program.executorch_program.execution_plan
+        }
+        self.assertIn(DeviceType.CUDA, planned_devices["forward2"])
+        self.assertNotIn(DeviceType.CUDA, planned_devices["forward"])
+
+        program = self.load_prog_fn(exported_program.buffer)
+        self.assertEqual(program.num_methods(), 2)
+
+        method = program.load_method("forward")
+        self.assertTrue(torch.allclose(method.call(inputs)[0], torch.ones(2, 2) * 2))
+
+        # Asking for device memory at all is what this asserts. Before the fix the
+        # loader put every planned buffer in host memory, so the device-planned method
+        # never asked and simply loaded. Now it asks, and with no device allocator
+        # registered the request is refused.
+        with self.assertRaises(RuntimeError) as caught:
+            program.load_method("forward2")
+        self.assertIn("on device", str(caught.exception))
+
+        # A failed load must leave the method that already loaded usable.
+        self.assertTrue(torch.allclose(method.call(inputs)[0], torch.ones(2, 2) * 2))

--- a/extension/pybindings/test/test_pybindings.py
+++ b/extension/pybindings/test/test_pybindings.py
@@ -6,7 +6,9 @@
 
 # pyre-unsafe
 
+import os
 import sys
+import tempfile
 import unittest
 from io import StringIO
 
@@ -829,3 +831,112 @@ class PybindingsTest(unittest.TestCase):
 
         # A failed load must leave the method that already loaded usable.
         self.assertTrue(torch.allclose(method.call(inputs)[0], torch.ones(2, 2) * 2))
+
+    def test_device_planned_method_allocates_on_the_device(self):
+        # The other device test covers the refusal. This one covers what the
+        # refusal is protecting: on a build that does have a device allocator,
+        # the arena has to come off the device, not out of host memory. It needs
+        # a real accelerator, so it only runs where one is present.
+        if "CudaBackend" not in self.runtime._get_registered_backend_names():
+            self.skipTest("needs a build with the CUDA backend linked in")
+        if not torch.cuda.is_available():
+            self.skipTest("needs a visible CUDA device")
+
+        from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
+        from executorch.exir import to_edge_transform_and_lower
+        from executorch.exir.backend.compile_spec_schema import CompileSpec
+
+        # Large enough that the arena is far bigger than the noise in
+        # mem_get_info, which moves by a few MiB as contexts are created.
+        side = 2048
+        inputs = (torch.ones(side, side), torch.ones(side, side))
+
+        class HostOnly(torch.nn.Module):
+            def forward(self, x, y):
+                return x + y
+
+        class Delegated(torch.nn.Module):
+            def forward(self, x, y):
+                return (x + y) * 2.0
+
+        edge = to_edge_transform_and_lower(
+            {
+                "forward": export(HostOnly(), inputs, strict=True),
+                "forward2": export(Delegated(), inputs, strict=True),
+            },
+            partitioner={
+                "forward2": [CudaPartitioner([CompileSpec("method_name", b"forward2")])]
+            },
+        )
+        exported_program = edge.to_executorch(
+            config=ExecutorchBackendConfig(enable_non_cpu_memory_planning=True)
+        )
+
+        plans = {
+            plan.name: plan
+            for plan in exported_program.executorch_program.execution_plan
+        }
+        device_buffers = {
+            buffer.buffer_idx
+            for buffer in (plans["forward2"].non_const_buffer_device or [])
+        }
+        self.assertTrue(device_buffers, "the planner tagged nothing for the device")
+        self.assertFalse(plans["forward"].non_const_buffer_device or [])
+        device_bytes = sum(
+            size
+            for index, size in enumerate(plans["forward2"].non_const_buffer_sizes)
+            if index in device_buffers
+        )
+
+        # The CUDA backend keeps its weights in a separate file, so the program
+        # has to be loaded from disk with that file alongside it.
+        with tempfile.TemporaryDirectory() as directory:
+            pte_path = os.path.join(directory, "program.pte")
+            with open(pte_path, "wb") as pte_file:
+                exported_program.write_to_file(pte_file)
+            data_names = sorted(exported_program._tensor_data or {})
+            exported_program.write_tensor_data_to_file(directory)
+            data_path = (
+                os.path.join(directory, data_names[0] + ".ptd") if data_names else None
+            )
+
+            torch.cuda.init()
+            program = self.runtime._load_program(pte_path, data_path=data_path)
+
+            torch.cuda.synchronize()
+            free_before, _ = torch.cuda.mem_get_info()
+
+            # The host-only method must not touch the device at all.
+            host_method = program.load_method("forward")
+            torch.cuda.synchronize()
+            free_after_host, _ = torch.cuda.mem_get_info()
+            self.assertLess(free_before - free_after_host, device_bytes // 2)
+
+            device_method = program.load_method("forward2")
+            torch.cuda.synchronize()
+            free_after_device, _ = torch.cuda.mem_get_info()
+            self.assertGreaterEqual(
+                free_after_host - free_after_device, device_bytes * 0.9
+            )
+
+            # Before the fix this ran on a host pointer and the backend rejected
+            # it, so getting the right answer back is itself part of the check.
+            expected = (inputs[0] + inputs[1]) * 2.0
+            self.assertTrue(
+                torch.allclose(device_method.call(inputs)[0].cpu(), expected)
+            )
+            self.assertTrue(
+                torch.allclose(host_method.call(inputs)[0].cpu(), inputs[0] + inputs[1])
+            )
+            # The device arenas are private, so running the host method in
+            # between must not disturb them.
+            self.assertTrue(
+                torch.allclose(device_method.call(inputs)[0].cpu(), expected)
+            )
+
+            del device_method
+            del host_method
+            del program
+            torch.cuda.synchronize()
+            free_at_end, _ = torch.cuda.mem_get_info()
+            self.assertGreaterEqual(free_at_end - free_after_device, device_bytes * 0.9)

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -197,6 +197,13 @@ class Program:
         than the whole program, but whatever it does claim stays claimed for
         every method loaded after it.
 
+        A program exported with ``share_mutable_buffers=True`` relies on every
+        method reading its shared mutable state from one allocation. A method
+        with accelerator-placed buffers gets its own arenas instead, so it also
+        gets its own copy of that state and will not observe writes made through
+        another method. Export without ``share_mutable_buffers`` if a method
+        needs both accelerator memory and shared state.
+
         Args:
             name: The name of the method to load.
 

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -190,10 +190,12 @@ class Program:
         other's intermediate values. Outputs are copied out on every call, so
         that sharing does not change what execute returns. A method with any
         buffer placed on an accelerator gets its own arenas instead, claimed
-        when that method is first loaded and held until the program is
-        released. A missing or exhausted accelerator therefore fails that one
-        load rather than the whole program, but whatever it does claim stays
-        claimed for every method loaded after it.
+        when that method is first loaded and owned by that method until the
+        method itself is released. This program caches every method it loads,
+        so in normal use those arenas live as long as the program does. A
+        missing or exhausted accelerator therefore fails that one load rather
+        than the whole program, but whatever it does claim stays claimed for
+        every method loaded after it.
 
         Args:
             name: The name of the method to load.

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -186,11 +186,14 @@ class Program:
         Memory-planned buffers are allocated differently depending on where the
         program placed them. A method whose buffers are all on the host shares
         one set of arenas with every other host-only method of this program,
-        sized to the largest of them, so running a second host-only method may
-        overwrite the intermediate and output values of the first. A method
-        with any buffer placed on an accelerator gets its own arenas instead,
-        claimed on the first load of that method, so a missing or exhausted
-        accelerator affects only that method and not the rest of the program.
+        sized to the largest of them, so two such methods overwrite each
+        other's intermediate values. Outputs are copied out on every call, so
+        that sharing does not change what execute returns. A method with any
+        buffer placed on an accelerator gets its own arenas instead, claimed
+        when that method is first loaded and held until the program is
+        released. A missing or exhausted accelerator therefore fails that one
+        load rather than the whole program, but whatever it does claim stays
+        claimed for every method loaded after it.
 
         Args:
             name: The name of the method to load.

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -183,6 +183,15 @@ class Program:
     def load_method(self, name: str) -> Optional[Method]:
         """Loads a method from the program.
 
+        Memory-planned buffers are allocated differently depending on where the
+        program placed them. A method whose buffers are all on the host shares
+        one set of arenas with every other host-only method of this program,
+        sized to the largest of them, so running a second host-only method may
+        overwrite the intermediate and output values of the first. A method
+        with any buffer placed on an accelerator gets its own arenas instead,
+        claimed on the first load of that method, so a missing or exhausted
+        accelerator affects only that method and not the rest of the program.
+
         Args:
             name: The name of the method to load.
 

--- a/shim_et/xplat/executorch/extension/pybindings/pybindings.bzl
+++ b/shim_et/xplat/executorch/extension/pybindings/pybindings.bzl
@@ -10,6 +10,7 @@ MODELS_ATEN_OPS_LEAN_MODE_GENERATED_LIB = [
 PORTABLE_MODULE_DEPS = [
     "//executorch/runtime/kernel:operator_registry",
     "//executorch/runtime/executor:program",
+    "//executorch/runtime/core:device_memory_buffer",
     "//executorch/devtools/bundled_program/schema:bundled_program_schema_fbs",
     "//executorch/extension/aten_util:aten_bridge",
     "//executorch/devtools/bundled_program:runtime",
@@ -27,6 +28,7 @@ PORTABLE_MODULE_DEPS = [
 ATEN_MODULE_DEPS = [
     "//executorch/runtime/kernel:operator_registry_aten",
     "//executorch/runtime/executor:program_aten",
+    "//executorch/runtime/core:device_memory_buffer",
     "//executorch/runtime/core/exec_aten:lib_aten",
     "//executorch/devtools/bundled_program/schema:bundled_program_schema_fbs",
     "//executorch/extension/data_loader:buffer_data_loader",


### PR DESCRIPTION
# Fix device placement for memory-planned buffers in Runtime.load_program

Replaces #22057. That pull request was force-pushed to a commit with no
history in common with main, which made GitHub close it permanently. Same
branch, same change, correct history.

## The problem

ExecuTorch has two ways to load a model from Python. With the CUDA backend, one
of them works and the other crashes. Same `.pte` file, same `.ptd` weights file,
same default export settings. Only the loader differs.

```python
# works
_load_for_executorch(pte_path, ptd_path).forward([x])

# crashes
Runtime.get().load_program(pte_path, data_path=ptd_path) \
    .load_method("forward").execute([x])
```

The crash looks like this:

```
[cuda_backend.cpp:548] Tensor 0 has device_type=CUDA but its data pointer
0x... is not backed by CUDA device memory
(cudaPointerGetAttributes err=0, cudaMemoryType=0).
RuntimeError: method->execute() failed with error 0x12
```

## Why it happens

A `.pte` file records where each memory-planned buffer has to live, on the host
or on an accelerator. That is the `non_const_buffer_device` field in the plan.

`ProgramMemory` in `extension/pybindings/pybindings.cpp` never read that field.
It allocated every planned buffer as host memory (`std::vector<uint8_t>`). So a
program that asked for device memory received a host pointer. The CUDA backend
checked the pointer, saw it was not device memory, and refused to run.

```
.pte says:  buffer 0 -> CUDA:0
before:     buffer 0 -> std::vector<uint8_t>        (host)   -> backend rejects
after:      buffer 0 -> DeviceMemoryBuffer::create  (device) -> backend accepts
```

## The fix

`extension/module/module.cpp` hits the same problem in the C++ `Module` API and
answers it differently, because it has a `share_memory_arenas` flag and this
loader has none. `Module` refuses to load a device-planned method when that flag
is set, and otherwise builds per-method arenas for every method.
`Runtime.load_program` shares arenas unconditionally today and offers no way to
turn that off, so refusing would stop files loading that load now. It keeps the
shared host arenas for host methods and gives a device-planned method its own.

1. `ProgramMemory` now receives the per-buffer device list alongside the sizes,
   and allocates each buffer on the device it is tagged for. Host-tagged buffers
   keep using `std::vector<uint8_t>`, exactly as before.
2. Buffer indices are plan local. Buffer 0 of one method has nothing to do with
   buffer 0 of another, so one set of arenas shared by index cannot describe a
   file where one method plans onto the host and another onto an accelerator. A
   method with any device-tagged buffer therefore gets its own arenas, and every
   other method keeps using the shared host arenas.
3. Those arenas are built in `load_method`, not when the program is loaded. A
   file containing one accelerator method still opens on a machine without that
   accelerator, still lists its methods, and its host methods still load and
   run. Only loading the accelerator method fails, and it fails naming the
   buffer and the device it could not allocate.
4. The caller reads the device for each buffer through
   `MethodMeta::memory_planned_buffer_device`.
5. Two deprecated calls were replaced with their current names. Both are plain
   forwarders, so behavior is unchanged.

`Program.load_method` in `runtime/__init__.py` documents all of this, including
the part that is not new: two host-only methods of the same program share one
set of arenas and therefore overwrite each other's intermediate values.

## Existing programs are unaffected

`non_const_buffer_device` is optional. `MethodMeta::memory_planned_buffer_device`
returns `Device{CPU, 0}` when the field is absent, which is the case for
CPU-only programs and for `.pte` files produced before the field existed. Such a
program keeps the shared arenas, the host allocation path, and the single
argument `HierarchicalAllocator`, so `MemoryManager::has_device_memory()` stays
false for it as that constructor documents.

## Test plan

Two tests in `extension/pybindings/test/test_pybindings.py`.

**`test_program_loads_when_one_method_is_device_planned`** covers the refusal
path and needs no GPU, so it runs in the existing CPU-only job. It exports a two
method program where one method has a device-tagged planned buffer and the other
has none, then checks that the program loads, that the host method runs, that
loading the device method reaches the device allocator and is refused there, and
that the host method still runs afterwards. It first asserts that the exported
program really does carry a CUDA-tagged planned buffer, so it cannot quietly
degrade into a plain multi-method test if planning stops tagging devices. It
skips itself on a build that links the CUDA backend, because that registers a
CUDA allocator at static init, the registry has no way to drop one, and the
request would then be satisfied with or without this change.

**`test_device_planned_method_allocates_on_the_device`** covers what the refusal
is protecting: on a build that does have a device allocator, the arena has to
come off the device rather than out of host memory. It builds a two method
program where one method is lowered to the CUDA backend and the other is not,
then measures free device memory with `torch.cuda.mem_get_info` around each
`load_method` call. It asserts that loading the host method takes no device
memory, that loading the device method takes at least 90 percent of the planned
device bytes, that both methods return correct numbers, that running the host
method in between does not disturb the device method, and that the memory is
returned once the methods and the program are all dropped. The test deletes both
methods before releasing the program: each method owns its own memory, so a method
kept alive after the program is released still holds its allocation. It skips
unless the build links the CUDA backend and a device is visible.

That second test can only run where a device allocator is registered, so this
pull request also wires it into the job that has one. The `unittest-cuda` job in
`.github/workflows/cuda.yml` runs it, right after the install that job already
does and before its builds, since the test needs nothing they produce. That
workflow now triggers on changes under `extension/pybindings/` and to
`runtime/__init__.py`, and the job condition lists the same two paths so the job
actually fires on them. Before this, no job in the repository built the Python
extension with a device allocator and then ran the pybindings tests, which is
exactly why this class of defect was invisible.

### Measured

Linux x86_64, NVIDIA A100 80GB, compute capability 8.0, CUDA 13.0, Python 3.12,
torch 2.13.0. Two builds from one source tree, one CPU only and one with the
CUDA backend. The before column is the merge base with `main`, produced by
swapping only `pybindings.cpp` and rebuilding, so both columns are the same
machine, the same model files and the same everything else.

Two methods in one program, `forward` on the host and `forward2` lowered to
CUDA, planned device bytes 50331648 (48 MiB):

| Measurement | Before | After |
| --- | --- | --- |
| Device memory taken by `load_program` | 0 MiB | 0 MiB |
| Device memory taken by loading the host method | 0 MiB | 0 MiB |
| Device memory taken by loading the CUDA method | 0 MiB | 48 MiB |
| CUDA method produces correct numbers | no, error 0x12 | yes |
| Host method produces correct numbers | yes | yes |
| CUDA method still correct after running the host method | not reached | yes |
| Device memory returned once the methods and program are dropped | nothing to return | 48 MiB |

The before column is not a generic failure. The CUDA backend names the defect
itself:

```
[cuda_backend.cpp:548] Tensor 0 has device_type=CUDA but its data pointer
0x7f5842fff010 is not backed by CUDA device memory
(cudaPointerGetAttributes err=0, cudaMemoryType=0).
[method.cpp:1528] CALL_DELEGATE execute failed at instruction 2: 0x12
```

Suites, on the same two builds:

| Suite | CUDA build | CPU-only build |
| --- | --- | --- |
| `extension/pybindings/test/test_pybindings.py` | 39 passed, 1 skipped, 2 failed | 39 passed, 1 skipped, 2 failed |
| the same file filtered to `-k device` | 4 passed, refusal test skipped | 4 passed, success test skipped |
| `test_device_planned_method_allocates_on_the_device` alone, run the way the CI script runs it | passed | skipped |

The two failures are `test_method_quantized_ops` and `test_quantized_ops`. They
are pre-existing and unrelated: they need the quantized AOT library preloaded,
which the Buck target does and a bare `pytest` invocation does not. They
reproduce identically at the merge base.

Linux aarch64, Jetson Orin Nano, Python 3.10, CPU-only build: identical counts to
the x86_64 CPU-only column above, including the device tests and the same two
pre-existing quantized-op failures. The CUDA success path is not reachable on
that board, because its GPU needs a PyTorch build pinned to a different version
than this repository requires, so only the host paths and the refusal path are
covered there.

## Landing order

This should land after or together with #22095. The device arenas added here are
allocated through the device allocator, and ETDump can be handed pointers into
them when a delegate logs its arguments. `BufferDataSink::write` does a plain host
`memcpy`, so recording a CUDA tensor would read device memory from the host.
#22095 is the fix for that path: it routes non-CPU tensors through a device copy
before writing. Landing this one first leaves that combination reachable whenever
event tracing is on.

## Not covered

- Leaving a device-planned method out of the shared host arenas is not covered
  by any test. Delete that skip and both tests still pass, because nothing in
  Python can observe the shared arena sizes. What it saves is host memory that
  nothing reads, which grows with the model, so it is worth a C++ test later.
- The device path is measured on one accelerator, an A100 with compute
  capability 8.0. Not measured on a Jetson board or on any non-CUDA
  accelerator.
- `has_device_buffers` and `make_method_memory` ask `MethodMeta` for one buffer
  at a time, and `MethodMeta::memory_planned_buffer_device` scans the sparse
  device list on each call, so the cost is the buffer count times the device
  entry count. Real programs measured here have 2 or 3 buffers and 1 device
  entry, and `extension/module/module.cpp` already reads the same metadata the
  same way, but both counts come from the file. Removing the concern properly
  means a bulk accessor on `MethodMeta`, which would fix both callers at once
  and belongs in its own change.

