### PR TITLE
Qualcomm AI Engine Direct - Fix fp16 unit test

### DIFF
--- a/backends/qualcomm/tests/rework/conftest.py
+++ b/backends/qualcomm/tests/rework/conftest.py
@@ -476,11 +476,10 @@ def export_and_verify(
     quantizer: QnnQuantizer,
     compile_specs: List[Any],
     metrics: Metrics,
-    expected_targets: set = None,
 ):
     with calibrate(module, [inputs], quantizer) as exported_module:
-        nodes = {node.target for node in exported_module.graph.nodes}
         if quantizer is not None:
+            nodes = {node.target for node in exported_module.graph.nodes}
             q_and_dq = {
                 torch.ops.quantized_decomposed.quantize_per_tensor.default,
                 torch.ops.quantized_decomposed.dequantize_per_tensor.default,
@@ -490,10 +489,6 @@ def export_and_verify(
                 torch.ops.torchao.dequantize_affine.default,
             }
             assert nodes.intersection(q_and_dq), EXPECT_NOT_ANNOTATED
-        if expected_targets is not None:
-            assert (
-                expected_targets <= nodes
-            ), f"expected {expected_targets - nodes} in exported graph"
 
     delegated_prog = to_edge_transform_and_lower_to_qnn(
         module=exported_module,

--- a/backends/qualcomm/tests/rework/src/op.py
+++ b/backends/qualcomm/tests/rework/src/op.py
@@ -2244,7 +2244,6 @@ class Hadamard(torch.nn.Module):
             "matmul": (torch.randn(1, dim),),
             "conv": (torch.randn(1, dim, 4, 4),),
         }
-        target = torch.ops.qnn_custom.hadamard_transform.default
         for variant, inputs in cases.items():
             with subtests.test(msg=f"variant:{variant}"):
                 with expected as metrics:
@@ -2255,7 +2254,6 @@ class Hadamard(torch.nn.Module):
                         quantizer=quantizer,
                         compile_specs=compile_spec,
                         metrics=metrics,
-                        expected_targets={target},
                     )
 
 


### PR DESCRIPTION
### Summary

Since nn.Module has no graph, the fp16 unit test failed with error "AttributeError: object has no attribute 'graph'".
#21729 introduce the error. Per internal discussion, we don't want to extend the function to include everything.
Considering the pass already ensure the hadamard transform op exist, we will revert the change to add expected_target.

### Test plan
```
pytest backends/qualcomm/tests/rework/htp/op/v68/test.py
```
