### PR TITLE
Fix boolean scalar support in portable arange

### DIFF
--- a/kernels/portable/cpu/op_arange.cpp
+++ b/kernels/portable/cpu/op_arange.cpp
@@ -20,10 +20,22 @@ namespace torch {
 namespace executor {
 namespace native {
 
+namespace {
+
+bool extract_arange_scalar(const Scalar& scalar, double* out) {
+  if (scalar.isBoolean()) {
+    *out = static_cast<double>(scalar.to<bool>());
+    return true;
+  }
+  return utils::extract_scalar(scalar, out);
+}
+
+} // namespace
+
 Tensor& arange_out(KernelRuntimeContext& ctx, const Scalar& end, Tensor& out) {
   double end_val = 0;
   ET_KERNEL_CHECK(
-      ctx, utils::extract_scalar(end, &end_val), InvalidArgument, out);
+      ctx, extract_arange_scalar(end, &end_val), InvalidArgument, out);
 
   ET_KERNEL_CHECK(
       ctx, check_arange_args(0.0, end_val, 1.0, out), InvalidArgument, out);
@@ -53,15 +65,15 @@ Tensor& arange_start_out(
 
   double d_start = 0;
   ET_KERNEL_CHECK(
-      ctx, utils::extract_scalar(start, &d_start), InvalidArgument, out);
+      ctx, extract_arange_scalar(start, &d_start), InvalidArgument, out);
 
   double d_end = 0;
   ET_KERNEL_CHECK(
-      ctx, utils::extract_scalar(end, &d_end), InvalidArgument, out);
+      ctx, extract_arange_scalar(end, &d_end), InvalidArgument, out);
 
   double d_step = 0;
   ET_KERNEL_CHECK(
-      ctx, utils::extract_scalar(step, &d_step), InvalidArgument, out);
+      ctx, extract_arange_scalar(step, &d_step), InvalidArgument, out);
 
   ET_KERNEL_CHECK(
       ctx,

--- a/kernels/test/op_arange_test.cpp
+++ b/kernels/test/op_arange_test.cpp
@@ -113,6 +113,15 @@ TEST_F(OpArangeOutTest, FloatNumberNotEqualIntSupport) {
   EXPECT_TENSOR_EQ(out, expected);
 }
 
+TEST_F(OpArangeOutTest, BooleanEndSupported) {
+  TensorFactory<ScalarType::Long> tf;
+
+  Tensor out = tf.zeros({1});
+  Tensor expected = tf.make({1}, {0});
+
+  EXPECT_TENSOR_EQ(op_arange_out(Scalar(true), out), expected);
+}
+
 TEST_F(OpArangeOutTest, OutDimUnsupportedDie) {
   ET_SKIP_IF(
       torch::executor::testing::SupportedFeatures::get()->is_aten,
@@ -193,6 +202,17 @@ TEST_F(OpArangeStartOutTest, FloatNumberNotEqualIntSupport) {
   Tensor expected = tf.make({6}, {0.0, 1.0, 2.0, 3.0, 4.0, 5.0});
 
   EXPECT_TENSOR_EQ(out, expected);
+}
+
+TEST_F(OpArangeStartOutTest, BooleanStartAndStepSupported) {
+  TensorFactory<ScalarType::Long> tf;
+
+  Tensor out = tf.zeros({3});
+  Tensor expected = tf.make({3}, {0, 1, 2});
+
+  EXPECT_TENSOR_EQ(
+      op_arange_start_out(Scalar(false), Scalar(3), Scalar(true), out),
+      expected);
 }
 
 TEST_F(OpArangeStartOutTest, OutDimUnsupportedDie) {


### PR DESCRIPTION
### Summary

- accept boolean scalar arguments in the portable `arange` kernels by converting them to numeric `0`/`1` values locally
- preserve the existing numeric scalar extraction behavior for non-boolean arguments
- add regression coverage for boolean `end`, `start`, and `step` arguments

Fixes #13580

### Test plan

- `cmake --build cmake-out -j 8 --target portable_kernels_test`
- `./cmake-out/kernels/test/portable_kernels_test --gtest_filter='OpArangeOutTest.*:OpArangeStartOutTest.*'` (14 passed, 2 skipped)
- `./cmake-out/kernels/test/portable_kernels_test` (1527 passed, 104 skipped)
- `.venv/bin/clang-format --dry-run --Werror kernels/portable/cpu/op_arange.cpp kernels/test/op_arange_test.cpp`
- `git diff --check`

cc @larryliu0820 @manuelcandales @JakeStevens