### PR TITLE
Add Supertonic FP16 MLX export and native runner

### DIFF
--- a/.github/workflows/mlx.yml
+++ b/.github/workflows/mlx.yml
@@ -201,7 +201,6 @@ jobs:
         RUNNER=cmake-out/examples/models/supertonic/supertonic_runner
         test -x "${RUNNER}"
         test -f "$(dirname "${RUNNER}")/mlx.metallib"
-        "${RUNNER}" --helpshort > /dev/null
         echo "::endgroup::"
 
   test-mlx-qwen35-moe:

--- a/.github/workflows/mlx.yml
+++ b/.github/workflows/mlx.yml
@@ -16,6 +16,7 @@ on:
       - examples/models/gemma4_31b/**
       - examples/models/muse-glimmer/**
       - examples/models/parakeet/**
+      - examples/models/supertonic/**
       - examples/models/voxtral_realtime/**
       - examples/models/qwen3_5_moe/**
   workflow_dispatch:
@@ -113,6 +114,94 @@ jobs:
           echo "--- ${mod} ---"
           ${CONDA_RUN} python -m "${mod}" run -v
         done
+        echo "::endgroup::"
+
+  test-mlx-supertonic:
+    needs: run-decision
+    if: |
+      github.event_name == 'pull_request' ||
+      needs.run-decision.outputs.is-full-run == 'true'
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    with:
+      default-packages: ""
+      job-name: test-mlx-supertonic
+      runner: macos-14-xlarge
+      python-version: "3.12"
+      submodules: recursive
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      timeout: 90
+      script: |
+        set -eux
+
+        echo "::group::Install ExecuTorch and Supertonic requirements"
+        ${CONDA_RUN} python install_executorch.py > /dev/null
+        ${CONDA_RUN} pip install -r examples/models/supertonic/requirements.txt
+        echo "::endgroup::"
+
+        echo "::group::Run asset-independent Supertonic Python tests"
+        ${CONDA_RUN} python -m pytest examples/models/supertonic/tests -v
+        echo "::endgroup::"
+
+        echo "::group::Download pinned Supertonic assets"
+        SUPERTONIC_ASSETS=/tmp/supertonic-3
+        ${CONDA_RUN} python - <<'PY'
+        from huggingface_hub import snapshot_download
+
+        snapshot_download(
+            "Supertone/supertonic-3",
+            revision="3cadd1ee6394adea1bd021217a0e650ede09a323",
+            allow_patterns=(
+                "onnx/tts.json",
+                "onnx/duration_predictor.onnx",
+                "onnx/text_encoder.onnx",
+                "onnx/vector_estimator.onnx",
+                "onnx/vocoder.onnx",
+                "onnx/unicode_indexer.json",
+                "voice_styles/F1.json",
+                "LICENSE",
+            ),
+            local_dir="/tmp/supertonic-3",
+        )
+        PY
+        echo "::endgroup::"
+
+        echo "::group::Run published-model parity tests"
+        SUPERTONIC_MODEL_DIR="${SUPERTONIC_ASSETS}" \
+          ${CONDA_RUN} python -m pytest \
+            examples/models/supertonic/tests/test_checkpoint_loader.py \
+            examples/models/supertonic/tests/test_stage_parity.py \
+            -v
+        echo "::endgroup::"
+
+        echo "::group::Export the Supertonic PTE"
+        SUPERTONIC_PTE="${SUPERTONIC_ASSETS}/supertonic_fp16_mlx.pte"
+        ${CONDA_RUN} python -m examples.models.supertonic.export.export_supertonic \
+          --asset-dir "${SUPERTONIC_ASSETS}" \
+          --output "${SUPERTONIC_PTE}" \
+          --max-text-length 512 \
+          --max-latent-length 512 \
+          --flow-steps 5
+        echo "::endgroup::"
+
+        echo "::group::Build ExecuTorch and Supertonic with MLX"
+        ${CONDA_RUN} make supertonic-mlx
+        echo "::endgroup::"
+
+        echo "::group::Run Supertonic native tests"
+        pushd examples/models/supertonic
+        ${CONDA_RUN} cmake --preset supertonic-mlx \
+          -DSUPERTONIC_INTEGRATION_PTE="${SUPERTONIC_PTE}" \
+          -DSUPERTONIC_INTEGRATION_ASSET_DIR="${SUPERTONIC_ASSETS}" \
+          -DSUPERTONIC_INTEGRATION_STYLE="${SUPERTONIC_ASSETS}/voice_styles/F1.json"
+        ${CONDA_RUN} ctest --preset supertonic-mlx
+        popd
+        echo "::endgroup::"
+
+        echo "::group::Verify the Supertonic runner and MLX metallib"
+        RUNNER=cmake-out/examples/models/supertonic/supertonic_runner
+        test -x "${RUNNER}"
+        test -f "$(dirname "${RUNNER}")/mlx.metallib"
+        "${RUNNER}" --helpshort > /dev/null
         echo "::endgroup::"
 
   test-mlx-qwen35-moe:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@
 # - whisper:  Speech recognition model (CPU, CUDA, Metal)
 # - parakeet: Speech recognition model (CPU, CUDA, Metal, MLX)
 # - sortformer: Speaker diarization model (CPU, CUDA)
+# - supertonic: Text-to-speech model (MLX)
 # - silero_vad: Voice activity detection model (CPU)
 # - llama:    Text generation model (CPU)
 # - llava:    Vision + language model (CPU)
@@ -91,7 +92,7 @@
 #
 # ==============================================================================
 
-.PHONY: voxtral-cuda voxtral-cpu voxtral-metal voxtral-mlx voxtral_realtime-cuda voxtral_realtime-rocm voxtral_realtime-cpu voxtral_realtime-metal voxtral_realtime-mlx voxtral_tts-cpu voxtral_tts-cuda whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal parakeet-mlx parakeet-vulkan dinov2-cuda dinov2-cuda-debug sortformer-cuda sortformer-cpu silero-vad-cpu llama-cuda llama-cuda-debug llama-cpu lfm_2_5-mlx llava-cpu gemma3-cuda gemma3-cpu gemma4_31b-cuda gemma4_31b-mlx muse-glimmer-cuda muse-glimmer-mlx qwen3_5_moe-cuda qwen3_5_moe-metal qwen3_5_moe-mlx clean help
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal voxtral-mlx voxtral_realtime-cuda voxtral_realtime-rocm voxtral_realtime-cpu voxtral_realtime-metal voxtral_realtime-mlx voxtral_tts-cpu voxtral_tts-cuda whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal parakeet-mlx parakeet-vulkan dinov2-cuda dinov2-cuda-debug sortformer-cuda sortformer-cpu supertonic-mlx silero-vad-cpu llama-cuda llama-cuda-debug llama-cpu lfm_2_5-mlx llava-cpu gemma3-cuda gemma3-cpu gemma4_31b-cuda gemma4_31b-mlx muse-glimmer-cuda muse-glimmer-mlx qwen3_5_moe-cuda qwen3_5_moe-metal qwen3_5_moe-mlx clean help
 
 help:
 	@echo "This Makefile adds targets to build runners for various models on various backends. Run using \`make <target>\`. Available targets:"
@@ -120,6 +121,7 @@ help:
 	@echo "  dinov2-cuda-debug   - Build DINOv2 runner with CUDA backend (debug mode)"
 	@echo "  sortformer-cuda     - Build Sortformer runner with CUDA backend"
 	@echo "  sortformer-cpu      - Build Sortformer runner with CPU backend"
+	@echo "  supertonic-mlx      - Build Supertonic runner with MLX backend"
 	@echo "  silero-vad-cpu      - Build Silero VAD runner with CPU backend"
 	@echo "  llama-cuda          - Build Llama runner with CUDA backend"
 	@echo "  llama-cuda-debug    - Build Llama runner with CUDA backend (debug mode)"
@@ -299,6 +301,15 @@ sortformer-cpu:
 	@echo ""
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/sortformer/sortformer_runner"
+
+supertonic-mlx:
+	@echo "==> Building and installing ExecuTorch with MLX..."
+	cmake --workflow --preset mlx-release
+	@echo "==> Building Supertonic runner with MLX..."
+	cd examples/models/supertonic && cmake --workflow --preset supertonic-mlx
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/supertonic/supertonic_runner"
 
 voxtral_realtime-cpu:
 	@echo "==> Building and installing ExecuTorch..."

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ ExecuTorch powers on-device AI at scale across Meta's family of apps, VR/AR devi
 
 **Multimodal:** [Llava](examples/models/llava/README.md) (vision-language), [Voxtral](examples/models/voxtral/README.md) (audio-language), [Gemma](examples/models/gemma3) (vision-language)
 
-**Vision/Speech:** [MobileNetV2](https://github.com/meta-pytorch/executorch-examples/tree/main/mv2), [DeepLabV3](https://github.com/meta-pytorch/executorch-examples/tree/main/dl3), [YOLO26](examples/models/yolo26/README.md), [Whisper](examples/models/whisper/README.md) <!-- @lint-ignore -->
+**Vision/Speech:** [MobileNetV2](https://github.com/meta-pytorch/executorch-examples/tree/main/mv2), [DeepLabV3](https://github.com/meta-pytorch/executorch-examples/tree/main/dl3), [YOLO26](examples/models/yolo26/README.md), [Whisper](examples/models/whisper/README.md), [Supertonic](examples/models/supertonic/README.md) <!-- @lint-ignore -->
 
 **Resources:** [`examples/`](examples/) directory • [executorch-examples](https://github.com/meta-pytorch/executorch-examples) out-of-tree demos • [Optimum-ExecuTorch](https://github.com/huggingface/optimum-executorch) for HuggingFace models • [Unsloth](https://docs.unsloth.ai/new/deploy-llms-phone) for fine-tuned LLM deployment <!-- @lint-ignore -->
 

--- a/examples/models/supertonic/CMakeLists.txt
+++ b/examples/models/supertonic/CMakeLists.txt
@@ -1,0 +1,143 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.24)
+project(supertonic_runner)
+
+include(GNUInstallDirs)
+
+if(NOT APPLE)
+  message(FATAL_ERROR "The Supertonic MLX runner is supported only on Darwin.")
+endif()
+
+set(_supertonic_target_processor "${CMAKE_OSX_ARCHITECTURES}")
+if(NOT _supertonic_target_processor)
+  set(_supertonic_target_processor "${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+if(NOT _supertonic_target_processor STREQUAL "arm64")
+  message(
+    FATAL_ERROR
+      "The Supertonic MLX runner requires an arm64 Darwin target; detected '${_supertonic_target_processor}'."
+  )
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(EXECUTORCH_SOURCE_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+include(${EXECUTORCH_SOURCE_ROOT}/tools/cmake/Utils.cmake)
+
+set(_json_include
+    ${EXECUTORCH_SOURCE_ROOT}/extension/llm/tokenizers/third-party/json/single_include
+)
+find_library(COREFOUNDATION_FRAMEWORK CoreFoundation REQUIRED)
+
+set(_helper_sources runtime/supertonic_runner.cpp runtime/text_processor.cpp
+                    runtime/style_loader.cpp runtime/wav_writer.cpp
+)
+
+enable_testing()
+add_executable(
+  supertonic_runtime_test runtime/tests/supertonic_runtime_test.cpp
+                          ${_helper_sources}
+)
+target_compile_definitions(
+  supertonic_runtime_test PRIVATE SUPERTONIC_PURE_HELPERS_ONLY
+)
+target_include_directories(
+  supertonic_runtime_test PRIVATE runtime ${_json_include}
+)
+target_link_libraries(
+  supertonic_runtime_test PRIVATE ${COREFOUNDATION_FRAMEWORK}
+)
+add_test(NAME supertonic_runtime_helpers COMMAND supertonic_runtime_test)
+
+set(gflags_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party/gflags)
+find_package(gflags REQUIRED)
+
+list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
+find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
+executorch_target_link_options_shared_lib(executorch)
+
+if(NOT TARGET mlxdelegate OR NOT TARGET mlx)
+  message(
+    FATAL_ERROR
+      "ExecuTorch must be installed with the MLX delegate and runtime targets."
+  )
+endif()
+
+foreach(required_target extension_module extension_data_loader extension_tensor
+                        extension_flat_tensor
+)
+  if(NOT TARGET ${required_target})
+    message(
+      FATAL_ERROR
+        "ExecuTorch installation is missing required target ${required_target}."
+    )
+  endif()
+endforeach()
+
+add_executable(supertonic_runner runtime/main.cpp ${_helper_sources})
+target_compile_definitions(supertonic_runner PRIVATE EXECUTORCH_BUILD_MLX)
+target_include_directories(
+  supertonic_runner PRIVATE ${EXECUTORCH_SOURCE_ROOT}/.. runtime
+                            ${_json_include}
+)
+target_link_libraries(
+  supertonic_runner
+  PRIVATE executorch
+          extension_module
+          extension_data_loader
+          extension_tensor
+          extension_flat_tensor
+          mlxdelegate
+          mlx
+          gflags
+          ${COREFOUNDATION_FRAMEWORK}
+)
+executorch_target_link_options_shared_lib(mlxdelegate)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+  target_link_options_gc_sections(supertonic_runner)
+endif()
+set(EXECUTORCH_BUILD_MLX ON)
+if(NOT DEFINED MLX_METALLIB_PATH OR NOT EXISTS "${MLX_METALLIB_PATH}")
+  message(FATAL_ERROR "The installed MLX package did not provide mlx.metallib.")
+endif()
+executorch_target_copy_mlx_metallib(supertonic_runner)
+install(TARGETS supertonic_runner RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+  FILES "${MLX_METALLIB_PATH}"
+  DESTINATION ${CMAKE_INSTALL_BINDIR}
+  RENAME mlx.metallib
+)
+
+set(SUPERTONIC_INTEGRATION_PTE
+    ""
+    CACHE FILEPATH "Optional Supertonic PTE for the integration test."
+)
+set(SUPERTONIC_INTEGRATION_ASSET_DIR
+    ""
+    CACHE PATH "Optional published Supertonic asset directory for integration."
+)
+set(SUPERTONIC_INTEGRATION_STYLE
+    ""
+    CACHE FILEPATH "Optional published voice-style JSON for integration."
+)
+add_test(
+  NAME supertonic_integration
+  COMMAND
+    ${CMAKE_COMMAND} -DRUNNER=$<TARGET_FILE:supertonic_runner>
+    -DPTE=${SUPERTONIC_INTEGRATION_PTE}
+    -DASSET_DIR=${SUPERTONIC_INTEGRATION_ASSET_DIR}
+    -DSTYLE=${SUPERTONIC_INTEGRATION_STYLE}
+    -DOUTPUT=${CMAKE_CURRENT_BINARY_DIR}/supertonic-integration.wav -P
+    ${CMAKE_CURRENT_SOURCE_DIR}/runtime/tests/run_integration.cmake
+)
+set_tests_properties(
+  supertonic_integration
+  PROPERTIES TIMEOUT 1800 SKIP_REGULAR_EXPRESSION
+             "SKIP: Supertonic integration assets are unavailable"
+)

--- a/examples/models/supertonic/CMakePresets.json
+++ b/examples/models/supertonic/CMakePresets.json
@@ -1,0 +1,68 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "supertonic-base",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/../../../cmake-out/examples/models/supertonic",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CXX_STANDARD": "17",
+                "CMAKE_FIND_ROOT_PATH": "${sourceDir}/../../../cmake-out",
+                "CMAKE_PREFIX_PATH": "${sourceDir}/../../../cmake-out"
+            }
+        },
+        {
+            "name": "supertonic-mlx",
+            "displayName": "Supertonic runner (MLX)",
+            "inherits": ["supertonic-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_MLX": "ON"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "supertonic-mlx",
+            "displayName": "Build Supertonic runner and tests",
+            "configurePreset": "supertonic-mlx",
+            "configuration": "Release",
+            "targets": [
+                "supertonic_runner",
+                "supertonic_runtime_test"
+            ]
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "supertonic-mlx",
+            "displayName": "Test Supertonic runner",
+            "configurePreset": "supertonic-mlx",
+            "configuration": "Release",
+            "output": {
+                "outputOnFailure": true
+            }
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "supertonic-mlx",
+            "displayName": "Configure and build Supertonic runner (MLX)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "supertonic-mlx"
+                },
+                {
+                    "type": "build",
+                    "name": "supertonic-mlx"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/models/supertonic/NOTICE
+++ b/examples/models/supertonic/NOTICE
@@ -1,0 +1,31 @@
+Supertonic upstream attribution
+===============================
+
+The Supertonic architecture and portions of this example are adapted from:
+
+  https://github.com/supertone-inc/supertonic
+  Revision: 7e2804f96016a7028cb1ed627353c61c1e9dd281
+
+The upstream source is provided under the following license:
+
+MIT License
+
+Copyright (c) 2025 Supertone Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/models/supertonic/README.md
+++ b/examples/models/supertonic/README.md
@@ -1,0 +1,104 @@
+# Supertonic on ExecuTorch MLX
+
+This example exports [Supertonic 3](https://huggingface.co/Supertone/supertonic-3)
+to one dynamic FP16 ExecuTorch program and performs one-shot text-to-speech
+synthesis with the MLX delegate.
+
+Run all commands from the ExecuTorch repository root. Keep downloaded assets
+and generated programs outside the source tree:
+
+```bash
+export SUPERTONIC_ASSETS="${TMPDIR:-/tmp}/supertonic-3"
+export SUPERTONIC_PTE="${SUPERTONIC_ASSETS}/supertonic_fp16_mlx.pte"
+```
+
+## 1. Download the model assets
+
+Install this example's Python dependencies, then download the exact reviewed
+Hugging Face revision:
+
+```bash
+python -m pip install -r examples/models/supertonic/requirements.txt
+
+hf download Supertone/supertonic-3 \
+  --revision 3cadd1ee6394adea1bd021217a0e650ede09a323 \
+  --local-dir "${SUPERTONIC_ASSETS}"
+```
+
+The export reads `onnx/tts.json` and the four ONNX models. The native runner
+also reads `onnx/unicode_indexer.json` and one JSON file under `voice_styles/`.
+
+## 2. Export the ExecuTorch program
+
+```bash
+python -m examples.models.supertonic.export.export_supertonic \
+  --asset-dir "${SUPERTONIC_ASSETS}" \
+  --output "${SUPERTONIC_PTE}" \
+  --max-text-length 512 \
+  --max-latent-length 512 \
+  --flow-steps 5
+```
+
+The generated PTE embeds the model weights; it does not require a `.ptd`
+sidecar. Treat PTE files as trusted inputs: load only a PTE that you generated
+or obtained from a trusted source.
+
+## 3. Build the native runner
+
+```bash
+make supertonic-mlx
+```
+
+The runner is written to
+`cmake-out/examples/models/supertonic/supertonic_runner`, with the required
+`mlx.metallib` beside it.
+
+## 4. Synthesize one WAV
+
+```bash
+./cmake-out/examples/models/supertonic/supertonic_runner \
+  --pte="${SUPERTONIC_PTE}" \
+  --asset_dir="${SUPERTONIC_ASSETS}" \
+  --voice_style="${SUPERTONIC_ASSETS}/voice_styles/F1.json" \
+  --text="Hello from Supertonic." \
+  --language=en \
+  --speed=1.05 \
+  --seed=42 \
+  --output="${SUPERTONIC_ASSETS}/hello.wav"
+```
+
+The runner writes a mono PCM16 WAV at the sample rate recorded in the model
+metadata (44.1 kHz for the pinned assets).
+
+## Platform and model limits
+
+- This workflow requires an Apple silicon Mac, macOS, Xcode command-line
+  tools, CMake 3.24 or newer, and an ExecuTorch Python environment with the MLX
+  backend and custom operations available. The native runner supports only
+  arm64 Darwin and uses MLX GPU delegation with FP16 activations.
+- Exported programs use dynamic sequence lengths, five flow-matching steps,
+  batch size 1, and exactly one voice style.
+- The commands above export maximum text and latent lengths of 512. A single
+  sentence is never split, so a sentence that exceeds the exported text bound
+  is rejected.
+- Language tags and voice styles are limited to those provided by the pinned
+  Supertonic 3 release.
+
+## Provenance and licensing
+
+The Supertonic architecture and portions of this integration are adapted from
+[Supertone's Supertonic repository](https://github.com/supertone-inc/supertonic)
+at revision
+[`7e2804f96016a7028cb1ed627353c61c1e9dd281`](https://github.com/supertone-inc/supertonic/commit/7e2804f96016a7028cb1ed627353c61c1e9dd281),
+which is licensed under the MIT License. The complete upstream copyright and
+license notice is preserved in [`NOTICE`](NOTICE). ExecuTorch-specific code is
+licensed under the BSD-style license in the repository root.
+
+Model weights, voice styles, configuration, and other assets downloaded from
+[Hugging Face revision
+`3cadd1ee6394adea1bd021217a0e650ede09a323`](https://huggingface.co/Supertone/supertonic-3/tree/3cadd1ee6394adea1bd021217a0e650ede09a323)
+are separately licensed under the BigScience Open RAIL-M License included with
+that release. This repository does not redistribute those assets. Do not add
+the downloaded weights or an exported PTE containing them to the ExecuTorch
+repository; obtain the assets from Hugging Face and review their license and use
+restrictions before use or distribution.

--- a/examples/models/supertonic/__init__.py
+++ b/examples/models/supertonic/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/models/supertonic/export/__init__.py
+++ b/examples/models/supertonic/export/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/models/supertonic/export/common.py
+++ b/examples/models/supertonic/export/common.py
@@ -1,0 +1,349 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+import torch
+from torch import nn
+from torch.export import Dim
+
+from ..loaders import checkpoint_loader
+from ..model.config import TTSConfig
+
+
+METHOD_NAMES = (
+    "duration_predictor",
+    "text_encoder",
+    "vector_estimator",
+    "vocoder",
+)
+MAX_MODEL_POSITIONS = 1000
+DEFAULT_FLOW_STEPS = 5
+
+
+@dataclass(frozen=True)
+class ExportBounds:
+    text_max: int = 512
+    latent_max: int = 512
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("text", self.text_max),
+            ("latent", self.latent_max),
+        ):
+            if value < 2:
+                raise ValueError(f"{name} maximum must be at least 2")
+            if value > MAX_MODEL_POSITIONS:
+                raise ValueError(
+                    f"{name} maximum must not exceed {MAX_MODEL_POSITIONS}"
+                )
+
+
+@dataclass(frozen=True)
+class MethodContract:
+    input_names: tuple[str, ...]
+    output_name: str
+    output_shape: tuple[str | int, ...]
+    output_dtype: torch.dtype
+
+
+@dataclass(frozen=True)
+class SupertonicAssets:
+    config: Path
+    models: Mapping[str, Path]
+
+
+def method_contracts(config: TTSConfig) -> dict[str, MethodContract]:
+    latent_channels = config.ttl.latent_dim * config.ttl.chunk_compress_factor
+    samples_per_latent = config.ttl.chunk_compress_factor * config.ae.base_chunk_size
+    return {
+        "duration_predictor": MethodContract(
+            ("text_ids", "style_dp", "text_mask"),
+            "duration",
+            ("B",),
+            torch.float16,
+        ),
+        "text_encoder": MethodContract(
+            ("text_ids", "style_ttl", "text_mask"),
+            "text_emb",
+            ("B", 256, "T"),
+            torch.float16,
+        ),
+        "vector_estimator": MethodContract(
+            (
+                "noisy_latent",
+                "text_emb",
+                "style_ttl",
+                "latent_mask",
+                "text_mask",
+                "current_step",
+                "total_step",
+            ),
+            "latent",
+            ("B", latent_channels, "L"),
+            torch.float16,
+        ),
+        "vocoder": MethodContract(
+            ("latent",),
+            "waveform",
+            ("B", f"L*{samples_per_latent}"),
+            torch.float16,
+        ),
+    }
+
+
+def dynamic_shapes(bounds: ExportBounds) -> dict[str, tuple[dict | None, ...]]:
+    duration_text = Dim("duration_text_length", min=1, max=bounds.text_max)
+    encoder_text = Dim("encoder_text_length", min=1, max=bounds.text_max)
+    vector_text = Dim("vector_text_length", min=1, max=bounds.text_max)
+    vector_latent = Dim("vector_latent_length", min=1, max=bounds.latent_max)
+    vocoder_latent = Dim("vocoder_latent_length", min=1, max=bounds.latent_max)
+    return {
+        "duration_predictor": (
+            {1: duration_text},
+            None,
+            {2: duration_text},
+        ),
+        "text_encoder": (
+            {1: encoder_text},
+            None,
+            {2: encoder_text},
+        ),
+        "vector_estimator": (
+            {2: vector_latent},
+            {2: vector_text},
+            None,
+            {2: vector_latent},
+            {2: vector_text},
+            None,
+            None,
+        ),
+        "vocoder": ({2: vocoder_latent},),
+    }
+
+
+def validate_vector_inputs(
+    inputs: tuple[torch.Tensor, ...],
+    config: TTSConfig,
+    bounds: ExportBounds,
+) -> None:
+    """Validate the valid-domain boundary for direct vector PTE execution."""
+    if len(inputs) != 7:
+        raise ValueError("vector_estimator requires exactly 7 tensors")
+    names = (
+        "noisy_latent",
+        "text_emb",
+        "style_ttl",
+        "latent_mask",
+        "text_mask",
+        "current_step",
+        "total_step",
+    )
+    for name, value in zip(names, inputs):
+        if not isinstance(value, torch.Tensor):
+            raise ValueError(f"{name} must be a tensor")
+        if value.dtype != torch.float16:
+            raise ValueError(f"{name} must have dtype torch.float16")
+        if not value.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+
+    (
+        noisy_latent,
+        text_emb,
+        style_ttl,
+        latent_mask,
+        text_mask,
+        current_step,
+        total_step,
+    ) = inputs
+    latent_channels = config.ttl.latent_dim * config.ttl.chunk_compress_factor
+    if noisy_latent.ndim != 3 or noisy_latent.shape[1] != latent_channels:
+        raise ValueError(f"noisy_latent must have shape [1, {latent_channels}, L]")
+    if text_emb.ndim != 3 or text_emb.shape[1] != 256:
+        raise ValueError("text_emb must have shape [1, 256, T]")
+    if style_ttl.ndim != 3 or style_ttl.shape[1:] != (50, 256):
+        raise ValueError("style_ttl must have shape [1, 50, 256]")
+    if latent_mask.ndim != 3 or latent_mask.shape[1] != 1:
+        raise ValueError("latent_mask must have shape [1, 1, L]")
+    if text_mask.ndim != 3 or text_mask.shape[1] != 1:
+        raise ValueError("text_mask must have shape [1, 1, T]")
+    if current_step.ndim != 1 or total_step.ndim != 1:
+        raise ValueError("current_step and total_step must have shape [1]")
+    if any(value.shape[0] != 1 for value in inputs):
+        raise ValueError("vector_estimator batch size must be 1")
+
+    latent_length = noisy_latent.shape[2]
+    text_length = text_emb.shape[2]
+    if not 1 <= latent_length <= bounds.latent_max:
+        raise ValueError(f"latent length must be in [1, {bounds.latent_max}]")
+    if not 1 <= text_length <= bounds.text_max:
+        raise ValueError(f"text length must be in [1, {bounds.text_max}]")
+    if latent_mask.shape[2] != latent_length:
+        raise ValueError("noisy_latent and latent_mask latent lengths must match")
+    if text_mask.shape[2] != text_length:
+        raise ValueError("text_emb and text_mask text lengths must match")
+
+    latent_valid_counts = latent_mask.sum(dim=(1, 2))
+    if not torch.all(
+        torch.isfinite(latent_valid_counts) & (latent_valid_counts > 0)
+    ).item():
+        raise ValueError("latent_mask must contain a valid position")
+    text_valid_counts = text_mask.sum(dim=(1, 2))
+    if not torch.all(
+        torch.isfinite(text_valid_counts) & (text_valid_counts > 0)
+    ).item():
+        raise ValueError("text_mask must contain a valid position")
+    if not torch.all(torch.isfinite(current_step)).item():
+        raise ValueError("current_step must be finite")
+    if not torch.all(torch.isfinite(total_step) & (total_step > 0)).item():
+        raise ValueError("total_step must be finite and positive")
+
+
+def validate_flow_steps(flow_steps: int) -> None:
+    if flow_steps != DEFAULT_FLOW_STEPS:
+        raise ValueError(
+            f"flow steps must be {DEFAULT_FLOW_STEPS} for the native runner"
+        )
+
+
+def text_vocabulary_size(models: Mapping[str, nn.Module]) -> int:
+    try:
+        duration_size = models[
+            "duration_predictor"
+        ].sentence_encoder.text_embedder.char_embedder.num_embeddings
+        encoder_size = (
+            models["text_encoder"]
+            .text_encoder.text_embedder.char_embedder.num_embeddings
+        )
+    except (AttributeError, KeyError) as error:
+        raise ValueError("models do not expose the text vocabulary contract") from error
+    if duration_size <= 0 or duration_size != encoder_size:
+        raise ValueError("duration and text encoders must use the same vocabulary")
+    return int(duration_size)
+
+
+def example_inputs(
+    config: TTSConfig,
+    bounds: ExportBounds,
+    *,
+    flow_steps: int = DEFAULT_FLOW_STEPS,
+) -> dict[str, tuple[torch.Tensor, ...]]:
+    validate_flow_steps(flow_steps)
+    generator = torch.Generator().manual_seed(0)
+    text_length = bounds.text_max
+    latent_length = bounds.latent_max
+    latent_channels = config.ttl.latent_dim * config.ttl.chunk_compress_factor
+
+    def random(shape: tuple[int, ...]) -> torch.Tensor:
+        return torch.randn(shape, generator=generator, dtype=torch.float16)
+
+    def text_ids() -> torch.Tensor:
+        return torch.randint(
+            0, 256, (1, text_length), generator=generator, dtype=torch.int64
+        )
+
+    def text_mask() -> torch.Tensor:
+        return torch.ones((1, 1, text_length), dtype=torch.float16)
+
+    samples = {
+        "duration_predictor": (
+            text_ids(),
+            random((1, 8, 16)),
+            text_mask(),
+        ),
+        "text_encoder": (
+            text_ids(),
+            random((1, 50, 256)),
+            text_mask(),
+        ),
+        "vector_estimator": (
+            random((1, latent_channels, latent_length)),
+            random((1, 256, text_length)),
+            random((1, 50, 256)),
+            torch.ones((1, 1, latent_length), dtype=torch.float16),
+            text_mask(),
+            torch.tensor([0.0], dtype=torch.float16),
+            torch.tensor([float(flow_steps)], dtype=torch.float16),
+        ),
+        "vocoder": (random((1, latent_channels, latent_length)),),
+    }
+    validate_vector_inputs(samples["vector_estimator"], config, bounds)
+    return samples
+
+
+def runtime_metadata(
+    config: TTSConfig,
+    bounds: ExportBounds,
+    *,
+    text_vocabulary_size: int,
+    flow_steps: int = DEFAULT_FLOW_STEPS,
+) -> dict[str, object]:
+    validate_flow_steps(flow_steps)
+    if text_vocabulary_size <= 0:
+        raise ValueError("text vocabulary size must be positive")
+    return {
+        "get_sample_rate": config.ae.sample_rate,
+        "get_base_chunk_size": config.ae.base_chunk_size,
+        "get_chunk_compress_factor": config.ttl.chunk_compress_factor,
+        "get_flow_steps": flow_steps,
+        "get_text_vocabulary_size": text_vocabulary_size,
+        "get_latent_dim": config.ttl.latent_dim,
+        "get_latent_channels": (
+            config.ttl.latent_dim * config.ttl.chunk_compress_factor
+        ),
+        "get_max_text_length": bounds.text_max,
+        "get_max_latent_length": bounds.latent_max,
+        "get_batch_size": 1,
+        "get_activation_dtype": "float16",
+        "enable_dynamic_shape": True,
+    }
+
+
+def resolve_assets(asset_dir: str | Path) -> SupertonicAssets:
+    asset_dir = Path(asset_dir)
+    onnx_dir = asset_dir / "onnx"
+    config_path = onnx_dir / "tts.json"
+    model_paths = {name: onnx_dir / f"{name}.onnx" for name in METHOD_NAMES}
+    required = (config_path, *model_paths.values())
+    missing = [path for path in required if not path.is_file()]
+    if missing:
+        relative = ", ".join(str(path.relative_to(asset_dir)) for path in missing)
+        raise FileNotFoundError(f"missing Supertonic assets: {relative}")
+    return SupertonicAssets(config=config_path, models=model_paths)
+
+
+def load_models(
+    asset_dir: str | Path,
+) -> tuple[TTSConfig, dict[str, nn.Module]]:
+    assets = resolve_assets(asset_dir)
+    config = TTSConfig.from_json(assets.config)
+    models = {
+        name: getattr(checkpoint_loader, f"load_{name}")(
+            assets.models[name], config
+        ).eval()
+        for name in METHOD_NAMES
+    }
+    return config, models
+
+
+def convert_models_to_fp16(
+    models: Mapping[str, nn.Module],
+) -> Mapping[str, nn.Module]:
+    for model in models.values():
+        model.to(dtype=torch.float16)
+    return models
+
+
+def save_pte(et_program, output_path: str | Path) -> Path:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("wb") as output_file:
+        et_program.write_to_file(output_file)
+    if et_program._tensor_data:
+        et_program.write_tensor_data_to_file(str(output_path.parent))
+    return output_path

--- a/examples/models/supertonic/export/common.py
+++ b/examples/models/supertonic/export/common.py
@@ -127,7 +127,7 @@ def dynamic_shapes(bounds: ExportBounds) -> dict[str, tuple[dict | None, ...]]:
     }
 
 
-def validate_vector_inputs(
+def validate_vector_inputs(  # noqa: C901
     inputs: tuple[torch.Tensor, ...],
     config: TTSConfig,
     bounds: ExportBounds,
@@ -216,10 +216,9 @@ def text_vocabulary_size(models: Mapping[str, nn.Module]) -> int:
         duration_size = models[
             "duration_predictor"
         ].sentence_encoder.text_embedder.char_embedder.num_embeddings
-        encoder_size = (
-            models["text_encoder"]
-            .text_encoder.text_embedder.char_embedder.num_embeddings
-        )
+        encoder_size = models[
+            "text_encoder"
+        ].text_encoder.text_embedder.char_embedder.num_embeddings
     except (AttributeError, KeyError) as error:
         raise ValueError("models do not expose the text vocabulary contract") from error
     if duration_size <= 0 or duration_size != encoder_size:

--- a/examples/models/supertonic/export/export_supertonic.py
+++ b/examples/models/supertonic/export/export_supertonic.py
@@ -10,9 +10,8 @@ from typing import Mapping
 
 import torch
 from torch import nn
-from torch.export import ExportedProgram, export
+from torch.export import export, ExportedProgram
 
-from . import common
 from ..model.config import TTSConfig
 from ..source_transformations.mlx import (
     exportable_vector_estimator,
@@ -20,6 +19,11 @@ from ..source_transformations.mlx import (
     replace_same_padding,
     replace_vocoder_causal_padding,
 )
+
+from . import common
+
+
+_DEFAULT_EXPORT_BOUNDS = common.ExportBounds()
 
 
 def export_programs(
@@ -64,10 +68,7 @@ def lower_to_mlx(
 ):
     from executorch.backends.mlx import MLXPartitioner
     from executorch.backends.mlx.passes import get_default_passes
-    from executorch.exir import (
-        EdgeCompileConfig,
-        to_edge_transform_and_lower,
-    )
+    from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
 
     return to_edge_transform_and_lower(
         dict(programs),
@@ -96,7 +97,7 @@ def export_from_assets(
     asset_dir: str | Path,
     output_path: str | Path,
     *,
-    bounds: common.ExportBounds = common.ExportBounds(),
+    bounds: common.ExportBounds = _DEFAULT_EXPORT_BOUNDS,
     flow_steps: int = common.DEFAULT_FLOW_STEPS,
 ) -> Path:
     config, models = common.load_models(asset_dir)

--- a/examples/models/supertonic/export/export_supertonic.py
+++ b/examples/models/supertonic/export/export_supertonic.py
@@ -1,0 +1,146 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+from pathlib import Path
+from typing import Mapping
+
+import torch
+from torch import nn
+from torch.export import ExportedProgram, export
+
+from . import common
+from ..model.config import TTSConfig
+from ..source_transformations.mlx import (
+    exportable_vector_estimator,
+    replace_relative_attention,
+    replace_same_padding,
+    replace_vocoder_causal_padding,
+)
+
+
+def export_programs(
+    models: Mapping[str, nn.Module],
+    config: TTSConfig,
+    bounds: common.ExportBounds,
+    *,
+    flow_steps: int = common.DEFAULT_FLOW_STEPS,
+) -> dict[str, ExportedProgram]:
+    common.validate_flow_steps(flow_steps)
+    expected_methods = set(common.METHOD_NAMES)
+    if set(models) != expected_methods:
+        missing = sorted(expected_methods - set(models))
+        extra = sorted(set(models) - expected_methods)
+        raise ValueError(
+            f"models must contain the exact method set; missing={missing}, extra={extra}"
+        )
+    samples = common.example_inputs(config, bounds, flow_steps=flow_steps)
+    shapes = common.dynamic_shapes(bounds)
+    programs = {}
+    with torch.no_grad():
+        for method_name in common.METHOD_NAMES:
+            model = replace_same_padding(models[method_name].eval())
+            if method_name in ("duration_predictor", "text_encoder"):
+                model = replace_relative_attention(model)
+            elif method_name == "vector_estimator":
+                model = exportable_vector_estimator(model)
+            elif method_name == "vocoder":
+                model = replace_vocoder_causal_padding(model)
+            programs[method_name] = export(
+                model,
+                samples[method_name],
+                dynamic_shapes=shapes[method_name],
+                strict=True,
+            )
+    return programs
+
+
+def lower_to_mlx(
+    programs: Mapping[str, ExportedProgram],
+    metadata: Mapping[str, object],
+):
+    from executorch.backends.mlx import MLXPartitioner
+    from executorch.backends.mlx.passes import get_default_passes
+    from executorch.exir import (
+        EdgeCompileConfig,
+        to_edge_transform_and_lower,
+    )
+
+    return to_edge_transform_and_lower(
+        dict(programs),
+        transform_passes=get_default_passes(),
+        partitioner={method_name: [MLXPartitioner()] for method_name in programs},
+        # MLX lowers model buffers such as the vector-estimator frequencies as
+        # delegate constants. Edge validation and dim-order rewriting currently
+        # look them up as graph state and fail before partitioning.
+        compile_config=EdgeCompileConfig(
+            _check_ir_validity=False,
+            _skip_dim_order=True,
+        ),
+        constant_methods=dict(metadata),
+    )
+
+
+def to_executorch(edge_program):
+    from executorch.exir import ExecutorchBackendConfig
+
+    return edge_program.to_executorch(
+        config=ExecutorchBackendConfig(extract_delegate_segments=True)
+    )
+
+
+def export_from_assets(
+    asset_dir: str | Path,
+    output_path: str | Path,
+    *,
+    bounds: common.ExportBounds = common.ExportBounds(),
+    flow_steps: int = common.DEFAULT_FLOW_STEPS,
+) -> Path:
+    config, models = common.load_models(asset_dir)
+    vocabulary_size = common.text_vocabulary_size(models)
+    common.convert_models_to_fp16(models)
+    programs = export_programs(models, config, bounds, flow_steps=flow_steps)
+    edge_program = lower_to_mlx(
+        programs,
+        common.runtime_metadata(
+            config,
+            bounds,
+            text_vocabulary_size=vocabulary_size,
+            flow_steps=flow_steps,
+        ),
+    )
+    return common.save_pte(to_executorch(edge_program), output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Export one dynamic FP16 Supertonic MLX artifact."
+    )
+    parser.add_argument("--asset-dir", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--max-text-length", type=int, default=512)
+    parser.add_argument("--max-latent-length", type=int, default=512)
+    parser.add_argument(
+        "--flow-steps",
+        type=int,
+        choices=(common.DEFAULT_FLOW_STEPS,),
+        default=common.DEFAULT_FLOW_STEPS,
+    )
+    args = parser.parse_args()
+    bounds = common.ExportBounds(
+        text_max=args.max_text_length,
+        latent_max=args.max_latent_length,
+    )
+    export_from_assets(
+        args.asset_dir,
+        args.output,
+        bounds=bounds,
+        flow_steps=args.flow_steps,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/models/supertonic/loaders/__init__.py
+++ b/examples/models/supertonic/loaders/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/models/supertonic/loaders/checkpoint_loader.py
+++ b/examples/models/supertonic/loaders/checkpoint_loader.py
@@ -1,0 +1,562 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+from typing import Collection, Mapping
+
+import onnx
+import torch
+from onnx import numpy_helper
+from torch import nn
+
+from ..model.config import TTSConfig
+from ..model.duration_predictor import DurationPredictor
+from ..model.text_encoder import TextEncoder
+from ..model.vector_estimator import VectorEstimator
+from ..model.vocoder import Vocoder
+
+
+def _convnext_targets(prefix: str, num_layers: int) -> tuple[str, ...]:
+    fields = (
+        "gamma",
+        "dwconv.weight",
+        "dwconv.bias",
+        "norm.norm.weight",
+        "norm.norm.bias",
+        "pwconv1.weight",
+        "pwconv1.bias",
+        "pwconv2.weight",
+        "pwconv2.bias",
+    )
+    return tuple(
+        f"{prefix}.convnext.{layer}.{field}"
+        for layer in range(num_layers)
+        for field in fields
+    )
+
+
+def _attention_encoder_targets(prefix: str, num_layers: int) -> tuple[str, ...]:
+    attention_fields = (
+        "emb_rel_k",
+        "emb_rel_v",
+        "conv_q.weight",
+        "conv_q.bias",
+        "conv_k.weight",
+        "conv_k.bias",
+        "conv_v.weight",
+        "conv_v.bias",
+        "conv_o.weight",
+        "conv_o.bias",
+    )
+    targets = [
+        f"{prefix}.attn_layers.{layer}.{field}"
+        for layer in range(num_layers)
+        for field in attention_fields
+    ]
+    for family in ("norm_layers_1",):
+        for layer in range(num_layers):
+            targets.extend(
+                (
+                    f"{prefix}.{family}.{layer}.norm.weight",
+                    f"{prefix}.{family}.{layer}.norm.bias",
+                )
+            )
+    for layer in range(num_layers):
+        targets.extend(
+            (
+                f"{prefix}.ffn_layers.{layer}.conv_1.weight",
+                f"{prefix}.ffn_layers.{layer}.conv_1.bias",
+                f"{prefix}.ffn_layers.{layer}.conv_2.weight",
+                f"{prefix}.ffn_layers.{layer}.conv_2.bias",
+            )
+        )
+    for layer in range(num_layers):
+        targets.extend(
+            (
+                f"{prefix}.norm_layers_2.{layer}.norm.weight",
+                f"{prefix}.norm_layers_2.{layer}.norm.bias",
+            )
+        )
+    return tuple(targets)
+
+
+_DURATION_TARGETS = (
+    (
+        "sentence_encoder.sentence_token",
+        "sentence_encoder.text_embedder.char_embedder.weight",
+    )
+    + _convnext_targets("sentence_encoder.convnext", 6)
+    + _attention_encoder_targets("sentence_encoder.attn_encoder", 2)
+    + (
+        "sentence_encoder.proj_out.net.weight",
+        "predictor.layers.0.weight",
+        "predictor.layers.0.bias",
+        "predictor.layers.1.weight",
+        "predictor.layers.1.bias",
+        "predictor.activation.weight",
+    )
+)
+
+DURATION_PREDICTOR_INITIALIZER_MAP = {
+    target: f"tts.dp.{target}" for target in _DURATION_TARGETS
+}
+
+_TEXT_TARGETS = (
+    ("text_encoder.text_embedder.char_embedder.weight",)
+    + _convnext_targets("text_encoder.convnext", 6)
+    + _attention_encoder_targets("text_encoder.attn_encoder", 4)
+    + (
+        "style_encoder.style_token_layer.style_key",
+        "speech_prompted_text_encoder.attention1.W_query.linear.weight",
+        "speech_prompted_text_encoder.attention1.W_query.linear.bias",
+        "speech_prompted_text_encoder.attention1.W_key.linear.weight",
+        "speech_prompted_text_encoder.attention1.W_key.linear.bias",
+        "speech_prompted_text_encoder.attention1.W_value.linear.weight",
+        "speech_prompted_text_encoder.attention1.W_value.linear.bias",
+        "speech_prompted_text_encoder.attention1.out_fc.linear.weight",
+        "speech_prompted_text_encoder.attention1.out_fc.linear.bias",
+        "speech_prompted_text_encoder.attention2.W_query.linear.weight",
+        "speech_prompted_text_encoder.attention2.W_query.linear.bias",
+        "speech_prompted_text_encoder.attention2.W_key.linear.weight",
+        "speech_prompted_text_encoder.attention2.W_key.linear.bias",
+        "speech_prompted_text_encoder.attention2.W_value.linear.weight",
+        "speech_prompted_text_encoder.attention2.W_value.linear.bias",
+        "speech_prompted_text_encoder.attention2.out_fc.linear.weight",
+        "speech_prompted_text_encoder.attention2.out_fc.linear.bias",
+        "speech_prompted_text_encoder.norm.norm.weight",
+        "speech_prompted_text_encoder.norm.norm.bias",
+    )
+)
+
+TEXT_ENCODER_INITIALIZER_MAP = {target: f"tts.ttl.{target}" for target in _TEXT_TARGETS}
+for index, projection in enumerate(
+    (
+        "attention1.W_query",
+        "attention1.W_key",
+        "attention1.W_value",
+        "attention1.out_fc",
+        "attention2.W_query",
+        "attention2.W_key",
+        "attention2.W_value",
+        "attention2.out_fc",
+    ),
+    start=3680,
+):
+    target = f"speech_prompted_text_encoder.{projection}.linear.weight"
+    TEXT_ENCODER_INITIALIZER_MAP[target] = f"onnx::MatMul_{index}"
+
+
+def _linear_targets(prefix: str) -> tuple[str, ...]:
+    return tuple(
+        f"{prefix}.{projection}.linear.{field}"
+        for projection in ("W_query", "W_key", "W_value", "out_fc")
+        for field in ("weight", "bias")
+    )
+
+
+_VECTOR_TARGETS = [
+    "uncond_masker.text_special_token",
+    "uncond_masker.style_key_special_token",
+    "uncond_masker.style_value_special_token",
+    "style_key",
+    "vector_field.proj_in.net.weight",
+    "vector_field.time_encoder.mlp.0.linear.weight",
+    "vector_field.time_encoder.mlp.0.linear.bias",
+    "vector_field.time_encoder.mlp.2.linear.weight",
+    "vector_field.time_encoder.mlp.2.linear.bias",
+]
+for block in range(4):
+    offset = block * 6
+    _VECTOR_TARGETS.extend(
+        _convnext_targets(f"vector_field.main_blocks.{offset}", 4)
+    )
+    _VECTOR_TARGETS.extend(
+        (
+            f"vector_field.main_blocks.{offset + 1}.linear.linear.weight",
+            f"vector_field.main_blocks.{offset + 1}.linear.linear.bias",
+        )
+    )
+    _VECTOR_TARGETS.extend(
+        _convnext_targets(f"vector_field.main_blocks.{offset + 2}", 1)
+    )
+    text_prefix = f"vector_field.main_blocks.{offset + 3}"
+    _VECTOR_TARGETS.extend(_linear_targets(f"{text_prefix}.attn"))
+    _VECTOR_TARGETS.extend(
+        (
+            f"{text_prefix}.norm.norm.weight",
+            f"{text_prefix}.norm.norm.bias",
+        )
+    )
+    if block == 0:
+        _VECTOR_TARGETS.extend(
+            (f"{text_prefix}.attn.increments", f"{text_prefix}.attn.theta")
+        )
+    _VECTOR_TARGETS.extend(
+        _convnext_targets(f"vector_field.main_blocks.{offset + 4}", 1)
+    )
+    style_prefix = f"vector_field.main_blocks.{offset + 5}"
+    _VECTOR_TARGETS.extend(_linear_targets(f"{style_prefix}.attention"))
+    _VECTOR_TARGETS.extend(
+        (
+            f"{style_prefix}.norm.norm.weight",
+            f"{style_prefix}.norm.norm.bias",
+        )
+    )
+_VECTOR_TARGETS.extend(_convnext_targets("vector_field.last_convnext", 4))
+_VECTOR_TARGETS.append("vector_field.proj_out.net.weight")
+
+VECTOR_ESTIMATOR_INITIALIZER_MAP = {
+    target: f"vector_estimator.tts.ttl.{target}" for target in _VECTOR_TARGETS
+}
+VECTOR_ESTIMATOR_INITIALIZER_MAP["style_key"] = (
+    "/vector_estimator/Expand_output_0"
+)
+
+_VECTOR_MATMUL_WEIGHTS = {
+    1: 3384,
+    3: 3390,
+    5: 3405,
+    7: 3429,
+    9: 3435,
+    11: 3450,
+    13: 3474,
+    15: 3480,
+    17: 3495,
+    19: 3519,
+    21: 3525,
+    23: 3540,
+}
+for block_index, initializer_index in _VECTOR_MATMUL_WEIGHTS.items():
+    if block_index % 6 == 1:
+        target = f"vector_field.main_blocks.{block_index}.linear.linear.weight"
+        VECTOR_ESTIMATOR_INITIALIZER_MAP[target] = (
+            f"onnx::MatMul_{initializer_index}"
+        )
+        continue
+    attention_name = "attn" if block_index % 6 == 3 else "attention"
+    for projection, offset in (
+        ("W_query", 0),
+        ("W_key", 1),
+        ("W_value", 2),
+        ("out_fc", 9 if attention_name == "attn" else 3),
+    ):
+        target = (
+            f"vector_field.main_blocks.{block_index}.{attention_name}."
+            f"{projection}.linear.weight"
+        )
+        VECTOR_ESTIMATOR_INITIALIZER_MAP[target] = (
+            f"onnx::MatMul_{initializer_index + offset}"
+        )
+
+_VECTOR_GENERATED_STATIC = {
+    "/Constant_3_output_0",
+    "/Constant_4_output_0",
+    "/Constant_output_0",
+    "/vector_estimator/ConstantOfShape_2_output_0",
+    "/vector_estimator/Constant_10_output_0",
+    "/vector_estimator/Constant_12_output_0",
+    "/vector_estimator/Constant_6_output_0",
+    "/vector_estimator/Constant_7_output_0",
+    "/vector_estimator/Constant_output_0",
+    "/vector_estimator/Mul_output_0",
+    "/vector_estimator/vector_field/main_blocks.0/convnext.0/act/Constant_1_output_0",
+    "/vector_estimator/vector_field/main_blocks.0/convnext.0/act/Constant_2_output_0",
+    "/vector_estimator/vector_field/main_blocks.0/convnext.0/act/Constant_output_0",
+    "/vector_estimator/vector_field/main_blocks.0/convnext.0/dwconv/Cast_output_0",
+    "/vector_estimator/vector_field/main_blocks.0/convnext.1/dwconv/Cast_output_0",
+    "/vector_estimator/vector_field/main_blocks.0/convnext.2/dwconv/Cast_output_0",
+    "/vector_estimator/vector_field/main_blocks.0/convnext.3/dwconv/Cast_output_0",
+    "/vector_estimator/vector_field/main_blocks.3/attn/Constant_27_output_0",
+    "/vector_estimator/vector_field/main_blocks.3/attn/Constant_48_output_0",
+    "/vector_estimator/vector_field/main_blocks.3/attn/Constant_51_output_0",
+    "/vector_estimator/vector_field/main_blocks.3/attn/Constant_54_output_0",
+    "/vector_estimator/vector_field/main_blocks.3/attn/Constant_56_output_0",
+    "/vector_estimator/vector_field/main_blocks.3/attn/Mul_8_output_0",
+    "/vector_estimator/vector_field/main_blocks.3/attn/Mul_9_output_0",
+    "/vector_estimator/vector_field/main_blocks.5/attention/Constant_11_output_0",
+    "/vector_estimator/vector_field/main_blocks.5/attention/Constant_6_output_0",
+    "/vector_estimator/vector_field/time_encoder/sinusoidal/Constant_2_output_0",
+    "/vector_estimator/vector_field/time_encoder/sinusoidal/Constant_3_output_0",
+    "onnx::ReduceSum_1413",
+    "onnx::Tile_1065",
+}
+_VECTOR_GENERATED_SPLITS = {
+    f"/vector_estimator/vector_field/main_blocks.{block}/attn/"
+    f"{split}/{suffix}"
+    for block in (3, 9, 15, 21)
+    for split, suffixes in (
+        (
+            "Split",
+            (
+                "webgpu_axes",
+                "webgpu_ends",
+                "webgpu_head_shape",
+                "webgpu_starts",
+            ),
+        ),
+        (
+            "Split_1",
+            (
+                "webgpu_axes",
+                "webgpu_ends",
+                "webgpu_head_shape",
+                "webgpu_starts",
+            ),
+        ),
+        (
+            "Split_2",
+            (
+                "webgpu_axes",
+                "webgpu_ends",
+                "webgpu_head_shape",
+                "webgpu_starts",
+            ),
+        ),
+        (
+            "Split_3",
+            (
+                "webgpu_axes",
+                "webgpu_ends",
+                "webgpu_starts",
+                "webgpu_width",
+            ),
+        ),
+    )
+    for suffix in suffixes
+}
+VECTOR_ESTIMATOR_GENERATED_INITIALIZERS = frozenset(
+    _VECTOR_GENERATED_STATIC | _VECTOR_GENERATED_SPLITS
+)
+
+_VOCODER_TARGETS = [
+    "normalizer.scale",
+    "latent_mean",
+    "latent_std",
+    "decoder.embed.net.weight",
+    "decoder.embed.net.bias",
+]
+for layer in range(10):
+    _VOCODER_TARGETS.extend(
+        (
+            f"decoder.convnext.{layer}.gamma",
+            f"decoder.convnext.{layer}.dwconv.net.weight",
+            f"decoder.convnext.{layer}.dwconv.net.bias",
+            f"decoder.convnext.{layer}.norm.norm.weight",
+            f"decoder.convnext.{layer}.norm.norm.bias",
+            f"decoder.convnext.{layer}.pwconv1.weight",
+            f"decoder.convnext.{layer}.pwconv1.bias",
+            f"decoder.convnext.{layer}.pwconv2.weight",
+            f"decoder.convnext.{layer}.pwconv2.bias",
+        )
+    )
+_VOCODER_TARGETS.extend(
+    (
+        "decoder.final_norm.norm.weight",
+        "decoder.final_norm.norm.bias",
+        "decoder.final_norm.norm.running_mean",
+        "decoder.final_norm.norm.running_var",
+        "decoder.head.layer1.net.weight",
+        "decoder.head.layer1.net.bias",
+        "decoder.head.act.weight",
+        "decoder.head.layer2.weight",
+    )
+)
+
+VOCODER_INITIALIZER_MAP = {
+    target: f"tts.ae.{target}" for target in _VOCODER_TARGETS
+}
+VOCODER_INITIALIZER_MAP.update(
+    {
+        "normalizer.scale": "tts.ttl.normalizer.scale",
+        "latent_mean": "tts.ae.latent_mean",
+        "latent_std": "tts.ae.latent_std",
+        "decoder.embed.net.weight": "onnx::Conv_1441",
+        "decoder.embed.net.bias": "onnx::Conv_1442",
+        "decoder.head.act.weight": "onnx::PRelu_1506",
+    }
+)
+VOCODER_GENERATED_INITIALIZERS: frozenset[str] = frozenset()
+
+
+def _extract_initializers(model: onnx.ModelProto) -> dict[str, torch.Tensor]:
+    initializers: dict[str, torch.Tensor] = {}
+    for initializer in model.graph.initializer:
+        if initializer.name in initializers:
+            raise ValueError(f"duplicate initializer name: {initializer.name}")
+        initializers[initializer.name] = torch.from_numpy(
+            numpy_helper.to_array(initializer).copy()
+        )
+    return initializers
+
+
+def extract_initializers(model_path: str | Path) -> dict[str, torch.Tensor]:
+    return _extract_initializers(onnx.load(model_path))
+
+
+def transform_initializer(
+    initializer: torch.Tensor, operator: str, *, trans_b: int = 0
+) -> torch.Tensor:
+    if operator == "Conv":
+        return initializer
+    if operator == "MatMul" or (operator == "Gemm" and trans_b == 0):
+        if initializer.ndim < 2:
+            raise ValueError(f"{operator} weight must have at least two dimensions")
+        return initializer.transpose(-1, -2).contiguous()
+    if operator == "Gemm" and trans_b == 1:
+        return initializer
+    raise ValueError(f"unsupported initializer operator: {operator}")
+
+
+def _initializer_layout(
+    model: onnx.ModelProto, initializer_name: str
+) -> tuple[str, int] | None:
+    layouts: set[tuple[str, int]] = set()
+    for node in model.graph.node:
+        for input_index, input_name in enumerate(node.input):
+            if (
+                input_name != initializer_name
+                or input_index != 1
+                or node.op_type not in ("Conv", "Gemm", "MatMul")
+            ):
+                continue
+            trans_b = 0
+            if node.op_type == "Gemm":
+                trans_b = next(
+                    (
+                        attribute.i
+                        for attribute in node.attribute
+                        if attribute.name == "transB"
+                    ),
+                    0,
+                )
+            layouts.add((node.op_type, trans_b))
+    if len(layouts) > 1:
+        raise ValueError(
+            f"initializer has ambiguous operator layouts: {initializer_name}"
+        )
+    return next(iter(layouts), None)
+
+
+def load_onnx_initializers(
+    module: nn.Module,
+    model_path: str | Path,
+    name_mapping: Mapping[str, str] | None = None,
+    *,
+    reject_unused: bool = False,
+    allowed_unused: Collection[str] = (),
+) -> None:
+    model = onnx.load(model_path)
+    initializers = _extract_initializers(model)
+    model_state = module.state_dict()
+    mapping = (
+        dict(name_mapping)
+        if name_mapping is not None
+        else {name: name for name in model_state}
+    )
+
+    unknown_targets = sorted(set(mapping) - set(model_state))
+    if unknown_targets:
+        raise ValueError(f"unknown model weights: {', '.join(unknown_targets)}")
+
+    unmapped_targets = sorted(set(model_state) - set(mapping))
+    if unmapped_targets:
+        raise ValueError(f"unmapped model weights: {', '.join(unmapped_targets)}")
+
+    source_counts: dict[str, int] = {}
+    for initializer_name in mapping.values():
+        source_counts[initializer_name] = source_counts.get(initializer_name, 0) + 1
+    duplicate_sources = sorted(
+        name for name, count in source_counts.items() if count > 1
+    )
+    if duplicate_sources:
+        raise ValueError(
+            f"duplicate initializer mapping: {', '.join(duplicate_sources)}"
+        )
+
+    missing_sources = sorted(set(mapping.values()) - set(initializers))
+    if missing_sources:
+        raise ValueError(f"missing initializer: {', '.join(missing_sources)}")
+
+    if reject_unused:
+        unknown_allowed_unused = sorted(set(allowed_unused) - set(initializers))
+        if unknown_allowed_unused:
+            raise ValueError(
+                "allowed unused initializer not found: "
+                + ", ".join(unknown_allowed_unused)
+            )
+        unused_sources = sorted(set(initializers) - set(mapping.values()))
+        unexpected_unused = sorted(set(unused_sources) - set(allowed_unused))
+        if unexpected_unused:
+            raise ValueError(
+                f"unused initializer: {', '.join(unexpected_unused)}"
+            )
+
+    loaded_state: dict[str, torch.Tensor] = {}
+    for target_name, initializer_name in mapping.items():
+        value = initializers[initializer_name]
+        layout = _initializer_layout(model, initializer_name)
+        if layout is not None:
+            operator, trans_b = layout
+            value = transform_initializer(value, operator, trans_b=trans_b)
+        expected = model_state[target_name]
+        if value.shape != expected.shape:
+            raise ValueError(
+                f"shape mismatch for {target_name}: expected {tuple(expected.shape)}, "
+                f"received {tuple(value.shape)} from {initializer_name}"
+            )
+        loaded_state[target_name] = value.to(dtype=expected.dtype)
+
+    module.load_state_dict(loaded_state, strict=True)
+
+
+def load_duration_predictor(
+    model_path: str | Path, config: TTSConfig
+) -> DurationPredictor:
+    model = DurationPredictor(config)
+    load_onnx_initializers(
+        model,
+        model_path,
+        DURATION_PREDICTOR_INITIALIZER_MAP,
+        reject_unused=True,
+    )
+    return model
+
+
+def load_text_encoder(model_path: str | Path, config: TTSConfig) -> TextEncoder:
+    model = TextEncoder(config)
+    load_onnx_initializers(
+        model,
+        model_path,
+        TEXT_ENCODER_INITIALIZER_MAP,
+        reject_unused=True,
+    )
+    return model
+
+
+def load_vector_estimator(
+    model_path: str | Path, config: TTSConfig
+) -> VectorEstimator:
+    model = VectorEstimator(config)
+    load_onnx_initializers(
+        model,
+        model_path,
+        VECTOR_ESTIMATOR_INITIALIZER_MAP,
+        reject_unused=True,
+        allowed_unused=VECTOR_ESTIMATOR_GENERATED_INITIALIZERS,
+    )
+    return model
+
+
+def load_vocoder(model_path: str | Path, config: TTSConfig) -> Vocoder:
+    model = Vocoder(config)
+    load_onnx_initializers(
+        model,
+        model_path,
+        VOCODER_INITIALIZER_MAP,
+        reject_unused=True,
+        allowed_unused=VOCODER_GENERATED_INITIALIZERS,
+    )
+    return model

--- a/examples/models/supertonic/loaders/checkpoint_loader.py
+++ b/examples/models/supertonic/loaders/checkpoint_loader.py
@@ -170,9 +170,7 @@ _VECTOR_TARGETS = [
 ]
 for block in range(4):
     offset = block * 6
-    _VECTOR_TARGETS.extend(
-        _convnext_targets(f"vector_field.main_blocks.{offset}", 4)
-    )
+    _VECTOR_TARGETS.extend(_convnext_targets(f"vector_field.main_blocks.{offset}", 4))
     _VECTOR_TARGETS.extend(
         (
             f"vector_field.main_blocks.{offset + 1}.linear.linear.weight",
@@ -211,9 +209,7 @@ _VECTOR_TARGETS.append("vector_field.proj_out.net.weight")
 VECTOR_ESTIMATOR_INITIALIZER_MAP = {
     target: f"vector_estimator.tts.ttl.{target}" for target in _VECTOR_TARGETS
 }
-VECTOR_ESTIMATOR_INITIALIZER_MAP["style_key"] = (
-    "/vector_estimator/Expand_output_0"
-)
+VECTOR_ESTIMATOR_INITIALIZER_MAP["style_key"] = "/vector_estimator/Expand_output_0"
 
 _VECTOR_MATMUL_WEIGHTS = {
     1: 3384,
@@ -232,9 +228,7 @@ _VECTOR_MATMUL_WEIGHTS = {
 for block_index, initializer_index in _VECTOR_MATMUL_WEIGHTS.items():
     if block_index % 6 == 1:
         target = f"vector_field.main_blocks.{block_index}.linear.linear.weight"
-        VECTOR_ESTIMATOR_INITIALIZER_MAP[target] = (
-            f"onnx::MatMul_{initializer_index}"
-        )
+        VECTOR_ESTIMATOR_INITIALIZER_MAP[target] = f"onnx::MatMul_{initializer_index}"
         continue
     attention_name = "attn" if block_index % 6 == 3 else "attention"
     for projection, offset in (
@@ -284,8 +278,7 @@ _VECTOR_GENERATED_STATIC = {
     "onnx::Tile_1065",
 }
 _VECTOR_GENERATED_SPLITS = {
-    f"/vector_estimator/vector_field/main_blocks.{block}/attn/"
-    f"{split}/{suffix}"
+    f"/vector_estimator/vector_field/main_blocks.{block}/attn/" f"{split}/{suffix}"
     for block in (3, 9, 15, 21)
     for split, suffixes in (
         (
@@ -365,9 +358,7 @@ _VOCODER_TARGETS.extend(
     )
 )
 
-VOCODER_INITIALIZER_MAP = {
-    target: f"tts.ae.{target}" for target in _VOCODER_TARGETS
-}
+VOCODER_INITIALIZER_MAP = {target: f"tts.ae.{target}" for target in _VOCODER_TARGETS}
 VOCODER_INITIALIZER_MAP.update(
     {
         "normalizer.scale": "tts.ttl.normalizer.scale",
@@ -490,9 +481,7 @@ def load_onnx_initializers(
         unused_sources = sorted(set(initializers) - set(mapping.values()))
         unexpected_unused = sorted(set(unused_sources) - set(allowed_unused))
         if unexpected_unused:
-            raise ValueError(
-                f"unused initializer: {', '.join(unexpected_unused)}"
-            )
+            raise ValueError(f"unused initializer: {', '.join(unexpected_unused)}")
 
     loaded_state: dict[str, torch.Tensor] = {}
     for target_name, initializer_name in mapping.items():
@@ -536,9 +525,7 @@ def load_text_encoder(model_path: str | Path, config: TTSConfig) -> TextEncoder:
     return model
 
 
-def load_vector_estimator(
-    model_path: str | Path, config: TTSConfig
-) -> VectorEstimator:
+def load_vector_estimator(model_path: str | Path, config: TTSConfig) -> VectorEstimator:
     model = VectorEstimator(config)
     load_onnx_initializers(
         model,

--- a/examples/models/supertonic/loaders/voice_style_loader.py
+++ b/examples/models/supertonic/loaders/voice_style_loader.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+
+TTL_STYLE_DIMS = (1, 50, 256)
+DP_STYLE_DIMS = (1, 8, 16)
+
+
+@dataclass(frozen=True)
+class VoiceStyle:
+    ttl: NDArray[np.float32]
+    dp: NDArray[np.float32]
+
+
+def _validate_dimensions(style: dict[str, Any]) -> None:
+    ttl_dims = tuple(style["style_ttl"]["dims"])
+    dp_dims = tuple(style["style_dp"]["dims"])
+    if ttl_dims != TTL_STYLE_DIMS:
+        raise ValueError(
+            f"style_ttl.dims must be {TTL_STYLE_DIMS}, received {ttl_dims}"
+        )
+    if dp_dims != DP_STYLE_DIMS:
+        raise ValueError(f"style_dp.dims must be {DP_STYLE_DIMS}, received {dp_dims}")
+
+
+def load_voice_style(voice_style_paths: Sequence[str | Path]) -> VoiceStyle:
+    if len(voice_style_paths) == 0:
+        raise ValueError("expected at least one voice style path")
+
+    ttl_styles = []
+    dp_styles = []
+    for style_path in voice_style_paths:
+        with Path(style_path).open(encoding="utf-8") as style_file:
+            style = json.load(style_file)
+        _validate_dimensions(style)
+        ttl_styles.append(
+            np.asarray(style["style_ttl"]["data"], dtype=np.float32).reshape(
+                TTL_STYLE_DIMS[1:]
+            )
+        )
+        dp_styles.append(
+            np.asarray(style["style_dp"]["data"], dtype=np.float32).reshape(
+                DP_STYLE_DIMS[1:]
+            )
+        )
+
+    return VoiceStyle(ttl=np.stack(ttl_styles), dp=np.stack(dp_styles))

--- a/examples/models/supertonic/model/__init__.py
+++ b/examples/models/supertonic/model/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/models/supertonic/model/config.py
+++ b/examples/models/supertonic/model/config.py
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LatentConfig:
+    latent_dim: int
+    chunk_compress_factor: int
+
+
+@dataclass(frozen=True)
+class AutoencoderConfig:
+    sample_rate: int
+    base_chunk_size: int
+    chunk_compress_factor: int
+    latent_dim: int
+
+
+@dataclass(frozen=True)
+class TTSConfig:
+    tts_version: str
+    split: str
+    ttl: LatentConfig
+    ae: AutoencoderConfig
+    dp: LatentConfig
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TTSConfig":
+        ttl = data["ttl"]
+        ae = data["ae"]
+        dp = data["dp"]
+        return cls(
+            tts_version=data["tts_version"],
+            split=data["split"],
+            ttl=LatentConfig(
+                latent_dim=ttl["latent_dim"],
+                chunk_compress_factor=ttl["chunk_compress_factor"],
+            ),
+            ae=AutoencoderConfig(
+                sample_rate=ae["sample_rate"],
+                base_chunk_size=ae["base_chunk_size"],
+                chunk_compress_factor=ae["chunk_compress_factor"],
+                latent_dim=ae["ldim"],
+            ),
+            dp=LatentConfig(
+                latent_dim=dp["latent_dim"],
+                chunk_compress_factor=dp["chunk_compress_factor"],
+            ),
+        )
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> "TTSConfig":
+        with Path(path).open(encoding="utf-8") as config_file:
+            return cls.from_dict(json.load(config_file))

--- a/examples/models/supertonic/model/duration_predictor.py
+++ b/examples/models/supertonic/model/duration_predictor.py
@@ -1,0 +1,153 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch import nn
+
+from .config import TTSConfig
+from .layers import Conv1dProjection
+from .text_encoder import TextBackbone
+
+
+class SentenceEncoder(TextBackbone):
+    def __init__(
+        self,
+        vocab_size: int,
+        channels: int,
+        convnext_dilations: tuple[int, ...],
+        attention_layers: int,
+        attention_heads: int,
+        ff_channels: int,
+        relative_window: int,
+    ) -> None:
+        super().__init__(
+            vocab_size,
+            channels,
+            convnext_dilations,
+            attention_layers,
+            attention_heads,
+            ff_channels,
+            relative_window,
+        )
+        self.sentence_token = nn.Parameter(torch.randn(1, channels, 1))
+        self.proj_out = Conv1dProjection(channels, channels, 1, bias=False)
+
+    def forward(self, text_ids: torch.Tensor, text_mask: torch.Tensor) -> torch.Tensor:
+        text = self.text_embedder(text_ids, text_mask)
+        token = self.sentence_token.expand(text.shape[0], -1, -1)
+        hidden = torch.cat((token, text), dim=-1)
+        token_mask = torch.ones_like(text_mask[:, :, :1])
+        mask = torch.cat((token_mask, text_mask), dim=-1)
+        hidden = self.convnext(hidden, mask)
+        hidden = (hidden + self.attn_encoder(hidden, mask)) * mask
+        sentence = hidden[:, :, :1]
+        sentence_mask = mask[:, :, :1]
+        return self.proj_out(sentence) * sentence_mask
+
+
+class Predictor(nn.Module):
+    def __init__(
+        self,
+        sentence_channels: int,
+        style_tokens: int,
+        style_dim: int,
+        hidden_dim: int,
+    ) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [
+                nn.Linear(sentence_channels + style_tokens * style_dim, hidden_dim),
+                nn.Linear(hidden_dim, 1),
+            ]
+        )
+        self.activation = nn.PReLU()
+
+    def forward(self, sentence: torch.Tensor, style: torch.Tensor) -> torch.Tensor:
+        combined = torch.cat(
+            (
+                sentence.reshape(sentence.shape[0], -1),
+                style.reshape(style.shape[0], -1),
+            ),
+            dim=-1,
+        )
+        return torch.exp(
+            self.layers[1](self.activation(self.layers[0](combined)))
+        ).squeeze(-1)
+
+
+class DurationPredictor(nn.Module):
+    def __init__(
+        self,
+        config: TTSConfig,
+        *,
+        vocab_size: int = 8322,
+        channels: int = 64,
+        convnext_dilations: tuple[int, ...] = (1, 1, 1, 1, 1, 1),
+        attention_layers: int = 2,
+        attention_heads: int = 2,
+        ff_channels: int = 256,
+        relative_window: int = 4,
+        style_tokens: int = 8,
+        style_dim: int = 16,
+        hidden_dim: int = 128,
+    ) -> None:
+        super().__init__()
+        if config.dp.latent_dim <= 0 or config.dp.chunk_compress_factor <= 0:
+            raise ValueError("config.dp dimensions must be positive")
+        self.sentence_encoder = SentenceEncoder(
+            vocab_size,
+            channels,
+            convnext_dilations,
+            attention_layers,
+            attention_heads,
+            ff_channels,
+            relative_window,
+        )
+        self.predictor = Predictor(
+            channels,
+            style_tokens,
+            style_dim,
+            hidden_dim,
+        )
+        self.style_tokens = style_tokens
+        self.style_dim = style_dim
+
+    def _validate_inputs(
+        self,
+        text_ids: torch.Tensor,
+        style_dp: torch.Tensor,
+        text_mask: torch.Tensor,
+    ) -> None:
+        if text_ids.ndim != 2:
+            raise ValueError("text_ids must have shape [B, T]")
+        if style_dp.ndim != 3 or style_dp.shape[1:] != (
+            self.style_tokens,
+            self.style_dim,
+        ):
+            raise ValueError(
+                f"style_dp must have shape [B, {self.style_tokens}, {self.style_dim}]"
+            )
+        if text_mask.ndim != 3 or text_mask.shape[1] != 1:
+            raise ValueError("text_mask must have shape [B, 1, T]")
+        if (
+            text_ids.shape[0] != style_dp.shape[0]
+            or text_ids.shape[0] != text_mask.shape[0]
+        ):
+            raise ValueError("input batch sizes must match")
+        if text_ids.shape[1] != text_mask.shape[2]:
+            raise ValueError("text_ids and text_mask text lengths must match")
+
+    def forward(
+        self,
+        text_ids: torch.Tensor,
+        style_dp: torch.Tensor,
+        text_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        self._validate_inputs(text_ids, style_dp, text_mask)
+        return self.predictor(
+            self.sentence_encoder(text_ids, text_mask),
+            style_dp,
+        )

--- a/examples/models/supertonic/model/layers.py
+++ b/examples/models/supertonic/model/layers.py
@@ -1,0 +1,200 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+
+class SamePad1d(nn.Module):
+    def __init__(self, kernel_size: int, dilation: int = 1) -> None:
+        super().__init__()
+        total_padding = dilation * (kernel_size - 1)
+        self.padding = (total_padding // 2, total_padding - total_padding // 2)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return F.pad(inputs, self.padding, mode="replicate")
+
+
+class LayerNorm1d(nn.Module):
+    def __init__(self, channels: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.norm = nn.LayerNorm(channels, eps=eps)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return self.norm(inputs.transpose(1, 2)).transpose(1, 2)
+
+
+class LinearProjection(nn.Module):
+    def __init__(self, in_features: int, out_features: int, bias: bool = True) -> None:
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features, bias=bias)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return self.linear(inputs)
+
+
+class Conv1dProjection(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+        self.net = nn.Conv1d(
+            in_channels, out_channels, kernel_size=kernel_size, bias=bias
+        )
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return self.net(inputs)
+
+
+class ConvNeXtBlock(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        kernel_size: int,
+        dilation: int = 1,
+        expansion: int = 4,
+        layer_scale_init_value: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        self.pad = SamePad1d(kernel_size, dilation)
+        self.dwconv = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size=kernel_size,
+            dilation=dilation,
+            groups=channels,
+        )
+        self.norm = LayerNorm1d(channels)
+        self.pwconv1 = nn.Conv1d(channels, expansion * channels, kernel_size=1)
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Conv1d(expansion * channels, channels, kernel_size=1)
+        self.gamma = nn.Parameter(torch.full((1, channels, 1), layer_scale_init_value))
+
+    def forward(
+        self, inputs: torch.Tensor, mask: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        residual = inputs if mask is None else inputs * mask
+        hidden = self.dwconv(self.pad(residual))
+        if mask is not None:
+            hidden = hidden * mask
+        hidden = self.pwconv2(self.act(self.pwconv1(self.norm(hidden))))
+        output = residual + self.gamma * hidden
+        return output if mask is None else output * mask
+
+
+class ConvNeXt(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        num_layers: int,
+        kernel_size: int,
+        dilations: tuple[int, ...] | None = None,
+        expansion: int = 4,
+        layer_scale_init_value: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        if dilations is None:
+            dilations = (1,) * num_layers
+        if len(dilations) != num_layers:
+            raise ValueError("dilations must contain one value per layer")
+        self.convnext = nn.ModuleList(
+            [
+                ConvNeXtBlock(
+                    channels,
+                    kernel_size,
+                    dilation=dilation,
+                    expansion=expansion,
+                    layer_scale_init_value=layer_scale_init_value,
+                )
+                for dilation in dilations
+            ]
+        )
+
+    def forward(
+        self, inputs: torch.Tensor, mask: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        output = inputs
+        for block in self.convnext:
+            output = block(output, mask)
+        return output
+
+
+class MultiHeadAttention(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        num_heads: int,
+        context_channels: int | None = None,
+        attention_channels: int | None = None,
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+        context_channels = channels if context_channels is None else context_channels
+        attention_channels = (
+            channels if attention_channels is None else attention_channels
+        )
+        if attention_channels % num_heads != 0:
+            raise ValueError("attention_channels must be divisible by num_heads")
+        self.num_heads = num_heads
+        self.head_channels = attention_channels // num_heads
+        self.W_query = LinearProjection(channels, attention_channels, bias=bias)
+        self.W_key = LinearProjection(context_channels, attention_channels, bias=bias)
+        self.W_value = LinearProjection(context_channels, attention_channels, bias=bias)
+        self.out_fc = LinearProjection(attention_channels, channels, bias=bias)
+
+    def _split_heads(self, inputs: torch.Tensor) -> torch.Tensor:
+        batch, length, _ = inputs.shape
+        return inputs.reshape(
+            batch, length, self.num_heads, self.head_channels
+        ).transpose(1, 2)
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        context: torch.Tensor | None = None,
+        *,
+        query_mask: torch.Tensor | None = None,
+        key_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        context = inputs if context is None else context
+        query = self._split_heads(self.W_query(inputs))
+        key = self._split_heads(self.W_key(context))
+        value = self._split_heads(self.W_value(context))
+        scores = torch.matmul(query, key.transpose(-1, -2)) / (self.head_channels**0.5)
+        valid_keys = None
+        if key_mask is not None:
+            valid_keys = key_mask != 0
+            scores = scores.masked_fill(
+                ~valid_keys[:, None, None, :],
+                torch.finfo(scores.dtype).min,
+            )
+        weights = torch.softmax(scores, dim=-1)
+        if valid_keys is not None:
+            weights = weights * valid_keys[:, None, None, :]
+        attended = torch.matmul(weights, value)
+        attended = attended.transpose(1, 2).reshape(
+            inputs.shape[0], inputs.shape[1], -1
+        )
+        output = self.out_fc(attended)
+        if valid_keys is not None:
+            output = output * valid_keys.any(dim=-1)[:, None, None]
+        if query_mask is not None:
+            output = output * query_mask[:, :, None]
+        return output
+
+
+class AddConditioning(nn.Module):
+    def __init__(self, condition_features: int, channels: int) -> None:
+        super().__init__()
+        self.linear = LinearProjection(condition_features, channels)
+
+    def forward(self, inputs: torch.Tensor, condition: torch.Tensor) -> torch.Tensor:
+        return inputs + self.linear(condition).unsqueeze(-1)

--- a/examples/models/supertonic/model/text_encoder.py
+++ b/examples/models/supertonic/model/text_encoder.py
@@ -1,0 +1,346 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from .config import TTSConfig
+from .layers import ConvNeXt, LayerNorm1d, LinearProjection
+
+
+class TextEmbedder(nn.Module):
+    def __init__(self, vocab_size: int, channels: int) -> None:
+        super().__init__()
+        self.char_embedder = nn.Embedding(vocab_size, channels)
+
+    def forward(self, text_ids: torch.Tensor, text_mask: torch.Tensor) -> torch.Tensor:
+        return self.char_embedder(text_ids).transpose(1, 2) * text_mask
+
+
+class RelativeMultiHeadAttention(nn.Module):
+    def __init__(self, channels: int, num_heads: int, window_size: int = 4) -> None:
+        super().__init__()
+        if channels % num_heads != 0:
+            raise ValueError("channels must be divisible by num_heads")
+        self.channels = channels
+        self.num_heads = num_heads
+        self.head_channels = channels // num_heads
+        self.window_size = window_size
+        self.emb_rel_k = nn.Parameter(
+            torch.randn(1, 2 * window_size + 1, self.head_channels)
+            * (self.head_channels**-0.5)
+        )
+        self.emb_rel_v = nn.Parameter(
+            torch.randn(1, 2 * window_size + 1, self.head_channels)
+            * (self.head_channels**-0.5)
+        )
+        self.conv_q = nn.Conv1d(channels, channels, 1)
+        self.conv_k = nn.Conv1d(channels, channels, 1)
+        self.conv_v = nn.Conv1d(channels, channels, 1)
+        self.conv_o = nn.Conv1d(channels, channels, 1)
+
+    def _relative_embeddings(
+        self, embeddings: torch.Tensor, length: int
+    ) -> torch.Tensor:
+        pad_length = max(length - (self.window_size + 1), 0)
+        slice_start = max((self.window_size + 1) - length, 0)
+        slice_end = slice_start + 2 * length - 1
+        padded = F.pad(embeddings, (0, 0, pad_length, pad_length))
+        return padded[:, slice_start:slice_end]
+
+    @staticmethod
+    def _relative_to_absolute(inputs: torch.Tensor) -> torch.Tensor:
+        batch, heads, length, _ = inputs.shape
+        padded = F.pad(inputs, (0, 1))
+        flattened = padded.reshape(batch, heads, length * 2 * length)
+        flattened = F.pad(flattened, (0, length - 1))
+        final = flattened.reshape(batch, heads, length + 1, 2 * length - 1)
+        return final[:, :, :length, length - 1 :]
+
+    @staticmethod
+    def _absolute_to_relative(inputs: torch.Tensor) -> torch.Tensor:
+        batch, heads, length, _ = inputs.shape
+        padded = F.pad(inputs, (0, length - 1))
+        flattened = padded.reshape(batch, heads, length * (2 * length - 1))
+        flattened = F.pad(flattened, (length, 0))
+        final = flattened.reshape(batch, heads, length, 2 * length)
+        return final[:, :, :, 1:]
+
+    def forward(
+        self, inputs: torch.Tensor, attention_mask: torch.Tensor
+    ) -> torch.Tensor:
+        batch, _, length = inputs.shape
+        query = self.conv_q(inputs).reshape(
+            batch, self.num_heads, self.head_channels, length
+        )
+        key = self.conv_k(inputs).reshape(
+            batch, self.num_heads, self.head_channels, length
+        )
+        value = self.conv_v(inputs).reshape(
+            batch, self.num_heads, self.head_channels, length
+        )
+        query = query.transpose(2, 3) / math.sqrt(self.head_channels)
+        key = key.transpose(2, 3)
+        value = value.transpose(2, 3)
+
+        scores = torch.matmul(query, key.transpose(-2, -1))
+        relative_key = self._relative_embeddings(self.emb_rel_k, length)
+        relative_scores = torch.matmul(
+            query, relative_key.unsqueeze(0).transpose(-2, -1)
+        )
+        scores = scores + self._relative_to_absolute(relative_scores)
+        scores = scores.masked_fill(attention_mask == 0, -10000.0)
+        weights = torch.softmax(scores, dim=-1)
+
+        attended = torch.matmul(weights, value)
+        relative_weights = self._absolute_to_relative(weights)
+        relative_value = self._relative_embeddings(self.emb_rel_v, length)
+        attended = attended + torch.matmul(
+            relative_weights, relative_value.unsqueeze(0)
+        )
+        attended = attended.transpose(2, 3).reshape(batch, self.channels, length)
+        return self.conv_o(attended)
+
+
+class FeedForward(nn.Module):
+    def __init__(self, channels: int, filter_channels: int) -> None:
+        super().__init__()
+        self.conv_1 = nn.Conv1d(channels, filter_channels, 1)
+        self.conv_2 = nn.Conv1d(filter_channels, channels, 1)
+
+    def forward(self, inputs: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        hidden = self.conv_1(inputs * mask)
+        hidden = F.relu(hidden) * mask
+        return self.conv_2(hidden) * mask
+
+
+class AttentionEncoder(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        filter_channels: int,
+        num_heads: int,
+        num_layers: int,
+        relative_window: int,
+    ) -> None:
+        super().__init__()
+        self.attn_layers = nn.ModuleList(
+            [
+                RelativeMultiHeadAttention(channels, num_heads, relative_window)
+                for _ in range(num_layers)
+            ]
+        )
+        self.norm_layers_1 = nn.ModuleList(
+            [LayerNorm1d(channels) for _ in range(num_layers)]
+        )
+        self.ffn_layers = nn.ModuleList(
+            [FeedForward(channels, filter_channels) for _ in range(num_layers)]
+        )
+        self.norm_layers_2 = nn.ModuleList(
+            [LayerNorm1d(channels) for _ in range(num_layers)]
+        )
+
+    def forward(self, inputs: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        hidden = inputs * mask
+        attention_mask = mask.unsqueeze(2) * mask.unsqueeze(-1)
+        for attention, norm_1, feed_forward, norm_2 in zip(
+            self.attn_layers,
+            self.norm_layers_1,
+            self.ffn_layers,
+            self.norm_layers_2,
+        ):
+            hidden = norm_1(hidden + attention(hidden, attention_mask))
+            hidden = norm_2(hidden + feed_forward(hidden, mask))
+        return hidden * mask
+
+
+class TextBackbone(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        channels: int,
+        convnext_dilations: tuple[int, ...],
+        attention_layers: int,
+        attention_heads: int,
+        ff_channels: int,
+        relative_window: int,
+    ) -> None:
+        super().__init__()
+        self.text_embedder = TextEmbedder(vocab_size, channels)
+        self.convnext = ConvNeXt(
+            channels,
+            len(convnext_dilations),
+            kernel_size=5,
+            dilations=convnext_dilations,
+        )
+        self.attn_encoder = AttentionEncoder(
+            channels,
+            ff_channels,
+            attention_heads,
+            attention_layers,
+            relative_window,
+        )
+
+    def forward(self, text_ids: torch.Tensor, text_mask: torch.Tensor) -> torch.Tensor:
+        hidden = self.convnext(
+            self.text_embedder(text_ids, text_mask),
+            text_mask,
+        )
+        return (hidden + self.attn_encoder(hidden, text_mask)) * text_mask
+
+
+class StyleTokenLayer(nn.Module):
+    def __init__(self, style_tokens: int, channels: int) -> None:
+        super().__init__()
+        self.style_key = nn.Parameter(torch.randn(1, style_tokens, channels))
+
+
+class StyleEncoder(nn.Module):
+    def __init__(self, style_tokens: int, channels: int) -> None:
+        super().__init__()
+        self.style_token_layer = StyleTokenLayer(style_tokens, channels)
+
+
+class TanhKeyAttention(nn.Module):
+    def __init__(self, channels: int, num_heads: int) -> None:
+        super().__init__()
+        if channels % num_heads != 0:
+            raise ValueError("channels must be divisible by num_heads")
+        self.channels = channels
+        self.num_heads = num_heads
+        self.head_channels = channels // num_heads
+        self.W_query = LinearProjection(channels, channels)
+        self.W_key = LinearProjection(channels, channels)
+        self.W_value = LinearProjection(channels, channels)
+        self.out_fc = LinearProjection(channels, channels)
+
+    def _split_heads(self, inputs: torch.Tensor) -> torch.Tensor:
+        # The ONNX graph stacks feature chunks before the batch axis.
+        return torch.stack(torch.split(inputs, self.head_channels, dim=-1), dim=0)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        query_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        projected_query = self._split_heads(self.W_query(query))
+        projected_key = self._split_heads(self.W_key(key))
+        projected_value = self._split_heads(self.W_value(value))
+        # The graph scales by full width, not per-head width.
+        scores = torch.matmul(
+            projected_query,
+            torch.tanh(projected_key.transpose(-2, -1)),
+        ) / math.sqrt(self.channels)
+        weights = torch.softmax(scores, dim=-1)
+        weights = torch.where(
+            query_mask.transpose(1, 2).unsqueeze(0) == 0,
+            torch.zeros_like(weights),
+            weights,
+        )
+        attended = torch.matmul(weights, projected_value)
+        attended = torch.cat(torch.unbind(attended, dim=0), dim=-1)
+        return self.out_fc(attended) * query_mask.transpose(1, 2)
+
+
+class SpeechPromptedTextEncoder(nn.Module):
+    def __init__(self, channels: int, num_heads: int) -> None:
+        super().__init__()
+        self.attention1 = TanhKeyAttention(channels, num_heads)
+        self.attention2 = TanhKeyAttention(channels, num_heads)
+        self.norm = LayerNorm1d(channels)
+
+    def forward(
+        self,
+        text: torch.Tensor,
+        style_key: torch.Tensor,
+        style_value: torch.Tensor,
+        text_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        text_sequence = text.transpose(1, 2)
+        first = text_sequence + self.attention1(
+            text_sequence, style_key, style_value, text_mask
+        )
+        second = text_sequence + self.attention2(
+            first, style_key, style_value, text_mask
+        )
+        return self.norm(second.transpose(1, 2)) * text_mask
+
+
+class TextEncoder(nn.Module):
+    def __init__(
+        self,
+        config: TTSConfig,
+        *,
+        vocab_size: int = 8322,
+        channels: int = 256,
+        convnext_dilations: tuple[int, ...] = (1, 1, 2, 2, 4, 4),
+        attention_layers: int = 4,
+        attention_heads: int = 4,
+        ff_channels: int = 1024,
+        relative_window: int = 4,
+        style_tokens: int = 50,
+        style_attention_heads: int = 2,
+    ) -> None:
+        super().__init__()
+        if config.ttl.latent_dim <= 0 or config.ttl.chunk_compress_factor <= 0:
+            raise ValueError("config.ttl dimensions must be positive")
+        self.text_encoder = TextBackbone(
+            vocab_size,
+            channels,
+            convnext_dilations,
+            attention_layers,
+            attention_heads,
+            ff_channels,
+            relative_window,
+        )
+        self.style_encoder = StyleEncoder(style_tokens, channels)
+        self.speech_prompted_text_encoder = SpeechPromptedTextEncoder(
+            channels, style_attention_heads
+        )
+        self.style_tokens = style_tokens
+        self.style_channels = channels
+
+    def _validate_inputs(
+        self,
+        text_ids: torch.Tensor,
+        style_ttl: torch.Tensor,
+        text_mask: torch.Tensor,
+    ) -> None:
+        if text_ids.ndim != 2:
+            raise ValueError("text_ids must have shape [B, T]")
+        if style_ttl.ndim != 3 or style_ttl.shape[1:] != (
+            self.style_tokens,
+            self.style_channels,
+        ):
+            raise ValueError(
+                f"style_ttl must have shape [B, {self.style_tokens}, "
+                f"{self.style_channels}]"
+            )
+        if text_mask.ndim != 3 or text_mask.shape[1] != 1:
+            raise ValueError("text_mask must have shape [B, 1, T]")
+        if (
+            text_ids.shape[0] != style_ttl.shape[0]
+            or text_ids.shape[0] != text_mask.shape[0]
+        ):
+            raise ValueError("input batch sizes must match")
+        if text_ids.shape[1] != text_mask.shape[2]:
+            raise ValueError("text_ids and text_mask text lengths must match")
+
+    def forward(
+        self,
+        text_ids: torch.Tensor,
+        style_ttl: torch.Tensor,
+        text_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        self._validate_inputs(text_ids, style_ttl, text_mask)
+        text = self.text_encoder(text_ids, text_mask)
+        style_key = self.style_encoder.style_token_layer.style_key
+        return self.speech_prompted_text_encoder(text, style_key, style_ttl, text_mask)

--- a/examples/models/supertonic/model/vector_estimator.py
+++ b/examples/models/supertonic/model/vector_estimator.py
@@ -237,10 +237,13 @@ class StyleAttention(nn.Module):
         query = self._split_heads(self.W_query(inputs))
         projected_key = self._split_heads(self.W_key(key))
         projected_value = self._split_heads(self.W_value(value))
-        scores = torch.matmul(
-            query,
-            torch.tanh(projected_key.transpose(-2, -1)),
-        ) / self.score_scale
+        scores = (
+            torch.matmul(
+                query,
+                torch.tanh(projected_key.transpose(-2, -1)),
+            )
+            / self.score_scale
+        )
         weights = torch.softmax(scores, dim=-1)
         weights = torch.where(
             query_mask.transpose(1, 2).unsqueeze(0) != 0,
@@ -316,9 +319,7 @@ class VectorField(nn.Module):
         max_positions: int,
     ) -> None:
         super().__init__()
-        self.proj_in = Conv1dProjection(
-            latent_channels, hidden_channels, 1, bias=False
-        )
+        self.proj_in = Conv1dProjection(latent_channels, hidden_channels, 1, bias=False)
         self.time_encoder = TimeEncoder(time_dim, time_hidden_channels)
         blocks: list[nn.Module] = []
         for block_index in range(num_main_blocks):
@@ -384,13 +385,9 @@ class VectorField(nn.Module):
         for block_index in range(self.num_main_blocks):
             offset = block_index * 6
             hidden = self.main_blocks[offset](hidden, latent_mask)
-            hidden = self.main_blocks[offset + 1](
-                hidden, time_embedding, latent_mask
-            )
+            hidden = self.main_blocks[offset + 1](hidden, time_embedding, latent_mask)
             hidden = self.main_blocks[offset + 2](hidden, latent_mask)
-            hidden = self.main_blocks[offset + 3](
-                hidden, text, latent_mask, text_mask
-            )
+            hidden = self.main_blocks[offset + 3](hidden, text, latent_mask, text_mask)
             hidden = self.main_blocks[offset + 4](hidden, latent_mask)
             hidden = self.main_blocks[offset + 5](
                 hidden, style_key, style_value, latent_mask
@@ -422,15 +419,11 @@ class VectorEstimator(nn.Module):
         super().__init__()
         if config.ttl.latent_dim <= 0 or config.ttl.chunk_compress_factor <= 0:
             raise ValueError("config.ttl dimensions must be positive")
-        latent_channels = (
-            config.ttl.latent_dim * config.ttl.chunk_compress_factor
-        )
+        latent_channels = config.ttl.latent_dim * config.ttl.chunk_compress_factor
         self.uncond_masker = UnconditionalMasker(
             text_channels, style_tokens, style_channels
         )
-        self.style_key = nn.Parameter(
-            torch.randn(1, style_tokens, style_channels)
-        )
+        self.style_key = nn.Parameter(torch.randn(1, style_tokens, style_channels))
         self.vector_field = VectorField(
             latent_channels,
             hidden_channels,
@@ -453,7 +446,7 @@ class VectorEstimator(nn.Module):
         self.style_channels = style_channels
         self.max_positions = max_positions
 
-    def _validate_inputs(
+    def _validate_inputs(  # noqa: C901
         self,
         noisy_latent: torch.Tensor,
         text_emb: torch.Tensor,
@@ -463,17 +456,12 @@ class VectorEstimator(nn.Module):
         current_step: torch.Tensor,
         total_step: torch.Tensor,
     ) -> None:
-        if (
-            noisy_latent.ndim != 3
-            or noisy_latent.shape[1] != self.latent_channels
-        ):
+        if noisy_latent.ndim != 3 or noisy_latent.shape[1] != self.latent_channels:
             raise ValueError(
                 f"noisy_latent must have shape [B, {self.latent_channels}, L]"
             )
         if text_emb.ndim != 3 or text_emb.shape[1] != self.text_channels:
-            raise ValueError(
-                f"text_emb must have shape [B, {self.text_channels}, T]"
-            )
+            raise ValueError(f"text_emb must have shape [B, {self.text_channels}, T]")
         if style_ttl.ndim != 3 or style_ttl.shape[1:] != (
             self.style_tokens,
             self.style_channels,
@@ -521,9 +509,7 @@ class VectorEstimator(nn.Module):
         if not torch.all(
             torch.isfinite(latent_valid_counts) & (latent_valid_counts > 0)
         ).item():
-            raise ValueError(
-                "latent_mask must contain a valid position per sample"
-            )
+            raise ValueError("latent_mask must contain a valid position per sample")
         text_valid_counts = text_mask.sum(dim=(1, 2))
         if not torch.all(
             torch.isfinite(text_valid_counts) & (text_valid_counts > 0)
@@ -565,18 +551,14 @@ class VectorEstimator(nn.Module):
         style_key = torch.cat(
             (
                 self.style_key.expand(batch, -1, -1),
-                self.uncond_masker.style_key_special_token.expand(
-                    batch, -1, -1
-                ),
+                self.uncond_masker.style_key_special_token.expand(batch, -1, -1),
             ),
             dim=0,
         )
         style_value = torch.cat(
             (
                 style_ttl,
-                self.uncond_masker.style_value_special_token.expand(
-                    batch, -1, -1
-                ),
+                self.uncond_masker.style_value_special_token.expand(batch, -1, -1),
             ),
             dim=0,
         )

--- a/examples/models/supertonic/model/vector_estimator.py
+++ b/examples/models/supertonic/model/vector_estimator.py
@@ -1,0 +1,594 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from .config import TTSConfig
+from .layers import Conv1dProjection, ConvNeXt, LayerNorm1d, LinearProjection
+
+
+class Mish(nn.Module):
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return inputs * torch.tanh(F.softplus(inputs))
+
+
+class TimeEncoder(nn.Module):
+    def __init__(self, time_dim: int = 64, hidden_channels: int = 256) -> None:
+        super().__init__()
+        if time_dim <= 0 or time_dim % 2 != 0:
+            raise ValueError("time_dim must be a positive even number")
+        half_dim = time_dim // 2
+        frequencies = 10000.0 ** (
+            -torch.arange(half_dim, dtype=torch.float32) / max(half_dim - 1, 1)
+        )
+        self.register_buffer("frequencies", frequencies, persistent=False)
+        self.mlp = nn.ModuleList(
+            [
+                LinearProjection(time_dim, hidden_channels),
+                Mish(),
+                LinearProjection(hidden_channels, time_dim),
+            ]
+        )
+
+    def forward(self, time: torch.Tensor) -> torch.Tensor:
+        angles = time.reshape(-1, 1) * 1000.0 * self.frequencies
+        hidden = torch.cat((torch.sin(angles), torch.cos(angles)), dim=-1)
+        for layer in self.mlp:
+            hidden = layer(hidden)
+        return hidden.unsqueeze(-1)
+
+
+class TimeConditioning(nn.Module):
+    def __init__(self, channels: int, time_dim: int) -> None:
+        super().__init__()
+        self.linear = LinearProjection(time_dim, channels)
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        time_embedding: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        condition = self.linear(time_embedding.transpose(1, 2)).transpose(1, 2)
+        return (inputs + condition) * mask
+
+
+class RotaryCrossAttention(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        context_channels: int,
+        num_heads: int,
+        max_positions: int = 1000,
+        rotary_base: float = 10000.0,
+        rotary_scale: float = 10.0,
+        persistent_rotary_buffers: bool = True,
+    ) -> None:
+        super().__init__()
+        if channels % num_heads != 0:
+            raise ValueError("channels must be divisible by num_heads")
+        head_channels = channels // num_heads
+        if head_channels % 2 != 0:
+            raise ValueError("attention head width must be even")
+        self.num_heads = num_heads
+        self.head_channels = head_channels
+        self.score_scale = math.sqrt(context_channels)
+        self.W_query = LinearProjection(channels, channels)
+        self.W_key = LinearProjection(context_channels, channels)
+        self.W_value = LinearProjection(context_channels, channels)
+        self.out_fc = LinearProjection(channels, channels)
+        self.register_buffer(
+            "increments",
+            torch.arange(max_positions, dtype=torch.int64).reshape(1, -1, 1),
+            persistent=persistent_rotary_buffers,
+        )
+        theta = rotary_scale * rotary_base ** (
+            -torch.arange(head_channels // 2, dtype=torch.float32)
+            / (head_channels // 2)
+        )
+        self.register_buffer(
+            "theta",
+            theta.reshape(1, 1, -1),
+            persistent=persistent_rotary_buffers,
+        )
+
+    def _split_heads(self, inputs: torch.Tensor) -> torch.Tensor:
+        batch, length, _ = inputs.shape
+        return inputs.reshape(
+            batch, length, self.num_heads, self.head_channels
+        ).permute(2, 0, 1, 3)
+
+    @staticmethod
+    def _apply_rotary(
+        inputs: torch.Tensor,
+        sine: torch.Tensor,
+        cosine: torch.Tensor,
+    ) -> torch.Tensor:
+        first, second = inputs.chunk(2, dim=-1)
+        sine = sine.unsqueeze(0)
+        cosine = cosine.unsqueeze(0)
+        return torch.cat(
+            (
+                first * cosine - second * sine,
+                first * sine + second * cosine,
+            ),
+            dim=-1,
+        )
+
+    def _angles(self, mask: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        length = mask.shape[2]
+        positions = self.increments[:, :length].to(dtype=mask.dtype)
+        positions = positions / mask.sum(dim=(1, 2)).reshape(-1, 1, 1)
+        angles = positions * self.theta
+        return torch.sin(angles), torch.cos(angles)
+
+    def _scaled_scores(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.matmul(query, key.transpose(-2, -1)) / self.score_scale
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        context: torch.Tensor,
+        query_mask: torch.Tensor,
+        key_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        query = self._split_heads(self.W_query(inputs))
+        key = self._split_heads(self.W_key(context))
+        value = self._split_heads(self.W_value(context))
+        query_sine, query_cosine = self._angles(query_mask)
+        key_sine, key_cosine = self._angles(key_mask)
+        query = self._apply_rotary(query, query_sine, query_cosine)
+        key = self._apply_rotary(key, key_sine, key_cosine)
+        scores = self._scaled_scores(query, key)
+        valid_keys = key_mask[:, 0, :] != 0
+        scores = scores.masked_fill(
+            ~valid_keys.unsqueeze(0).unsqueeze(2),
+            float("-inf"),
+        )
+        weights = torch.softmax(scores, dim=-1)
+        valid_queries = query_mask[:, 0, :] != 0
+        weights = torch.where(
+            valid_queries.unsqueeze(0).unsqueeze(-1),
+            weights,
+            torch.zeros_like(weights),
+        )
+        attended = torch.matmul(weights, value)
+        attended = attended.permute(1, 2, 0, 3).reshape(
+            inputs.shape[0], inputs.shape[1], -1
+        )
+        return self.out_fc(attended) * query_mask.transpose(1, 2)
+
+
+class TextConditioning(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        text_channels: int,
+        num_heads: int,
+        max_positions: int,
+        persistent_rotary_buffers: bool,
+    ) -> None:
+        super().__init__()
+        self.attn = RotaryCrossAttention(
+            channels,
+            text_channels,
+            num_heads,
+            max_positions=max_positions,
+            persistent_rotary_buffers=persistent_rotary_buffers,
+        )
+        self.norm = LayerNorm1d(channels)
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        text: torch.Tensor,
+        latent_mask: torch.Tensor,
+        text_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        residual = inputs * latent_mask
+        attended = self.attn(
+            residual.transpose(1, 2),
+            text.transpose(1, 2),
+            latent_mask,
+            text_mask,
+        ).transpose(1, 2)
+        return self.norm(residual + attended) * latent_mask
+
+
+class StyleAttention(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        style_channels: int,
+        num_heads: int,
+    ) -> None:
+        super().__init__()
+        if style_channels % num_heads != 0:
+            raise ValueError("style_channels must be divisible by num_heads")
+        self.num_heads = num_heads
+        self.head_channels = style_channels // num_heads
+        self.score_scale = math.sqrt(style_channels)
+        self.W_query = LinearProjection(channels, style_channels)
+        self.W_key = LinearProjection(style_channels, style_channels)
+        self.W_value = LinearProjection(style_channels, style_channels)
+        self.out_fc = LinearProjection(style_channels, channels)
+
+    def _split_heads(self, inputs: torch.Tensor) -> torch.Tensor:
+        return torch.stack(torch.split(inputs, self.head_channels, dim=-1), dim=0)
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        query_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        query = self._split_heads(self.W_query(inputs))
+        projected_key = self._split_heads(self.W_key(key))
+        projected_value = self._split_heads(self.W_value(value))
+        scores = torch.matmul(
+            query,
+            torch.tanh(projected_key.transpose(-2, -1)),
+        ) / self.score_scale
+        weights = torch.softmax(scores, dim=-1)
+        weights = torch.where(
+            query_mask.transpose(1, 2).unsqueeze(0) != 0,
+            weights,
+            torch.zeros_like(weights),
+        )
+        attended = torch.matmul(weights, projected_value)
+        attended = torch.cat(torch.unbind(attended, dim=0), dim=-1)
+        return self.out_fc(attended) * query_mask.transpose(1, 2)
+
+
+class StyleConditioning(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        style_channels: int,
+        num_heads: int,
+    ) -> None:
+        super().__init__()
+        self.attention = StyleAttention(channels, style_channels, num_heads)
+        self.norm = LayerNorm1d(channels)
+
+    def forward(
+        self,
+        inputs: torch.Tensor,
+        style_key: torch.Tensor,
+        style_value: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> torch.Tensor:
+        residual = inputs * mask
+        attended = self.attention(
+            residual.transpose(1, 2),
+            style_key,
+            style_value,
+            mask,
+        ).transpose(1, 2)
+        return self.norm(residual + attended) * mask
+
+
+class UnconditionalMasker(nn.Module):
+    def __init__(
+        self,
+        text_channels: int,
+        style_tokens: int,
+        style_channels: int,
+    ) -> None:
+        super().__init__()
+        self.text_special_token = nn.Parameter(torch.randn(1, text_channels, 1))
+        self.style_key_special_token = nn.Parameter(
+            torch.randn(1, style_tokens, style_channels)
+        )
+        self.style_value_special_token = nn.Parameter(
+            torch.randn(1, style_tokens, style_channels)
+        )
+
+
+class VectorField(nn.Module):
+    def __init__(
+        self,
+        latent_channels: int,
+        hidden_channels: int,
+        time_dim: int,
+        time_hidden_channels: int,
+        num_main_blocks: int,
+        main_convnext_dilations: tuple[int, ...],
+        post_time_dilations: tuple[int, ...],
+        post_text_dilations: tuple[int, ...],
+        final_dilations: tuple[int, ...],
+        text_channels: int,
+        style_channels: int,
+        attention_heads: int,
+        style_attention_heads: int,
+        max_positions: int,
+    ) -> None:
+        super().__init__()
+        self.proj_in = Conv1dProjection(
+            latent_channels, hidden_channels, 1, bias=False
+        )
+        self.time_encoder = TimeEncoder(time_dim, time_hidden_channels)
+        blocks: list[nn.Module] = []
+        for block_index in range(num_main_blocks):
+            blocks.extend(
+                (
+                    ConvNeXt(
+                        hidden_channels,
+                        len(main_convnext_dilations),
+                        kernel_size=5,
+                        dilations=main_convnext_dilations,
+                    ),
+                    TimeConditioning(hidden_channels, time_dim),
+                    ConvNeXt(
+                        hidden_channels,
+                        len(post_time_dilations),
+                        kernel_size=5,
+                        dilations=post_time_dilations,
+                    ),
+                    TextConditioning(
+                        hidden_channels,
+                        text_channels,
+                        attention_heads,
+                        max_positions,
+                        block_index == 0,
+                    ),
+                    ConvNeXt(
+                        hidden_channels,
+                        len(post_text_dilations),
+                        kernel_size=5,
+                        dilations=post_text_dilations,
+                    ),
+                    StyleConditioning(
+                        hidden_channels,
+                        style_channels,
+                        style_attention_heads,
+                    ),
+                )
+            )
+        self.main_blocks = nn.ModuleList(blocks)
+        self.last_convnext = ConvNeXt(
+            hidden_channels,
+            len(final_dilations),
+            kernel_size=5,
+            dilations=final_dilations,
+        )
+        self.proj_out = Conv1dProjection(
+            hidden_channels, latent_channels, 1, bias=False
+        )
+        self.num_main_blocks = num_main_blocks
+
+    def forward(
+        self,
+        noisy_latent: torch.Tensor,
+        time: torch.Tensor,
+        text: torch.Tensor,
+        style_key: torch.Tensor,
+        style_value: torch.Tensor,
+        latent_mask: torch.Tensor,
+        text_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden = self.proj_in(noisy_latent) * latent_mask
+        time_embedding = self.time_encoder(time)
+        for block_index in range(self.num_main_blocks):
+            offset = block_index * 6
+            hidden = self.main_blocks[offset](hidden, latent_mask)
+            hidden = self.main_blocks[offset + 1](
+                hidden, time_embedding, latent_mask
+            )
+            hidden = self.main_blocks[offset + 2](hidden, latent_mask)
+            hidden = self.main_blocks[offset + 3](
+                hidden, text, latent_mask, text_mask
+            )
+            hidden = self.main_blocks[offset + 4](hidden, latent_mask)
+            hidden = self.main_blocks[offset + 5](
+                hidden, style_key, style_value, latent_mask
+            )
+        hidden = self.last_convnext(hidden, latent_mask)
+        return self.proj_out(hidden) * latent_mask
+
+
+class VectorEstimator(nn.Module):
+    def __init__(
+        self,
+        config: TTSConfig,
+        *,
+        hidden_channels: int = 512,
+        time_dim: int = 64,
+        time_hidden_channels: int = 256,
+        num_main_blocks: int = 4,
+        main_convnext_dilations: tuple[int, ...] = (1, 2, 4, 8),
+        post_time_dilations: tuple[int, ...] = (1,),
+        post_text_dilations: tuple[int, ...] = (1,),
+        final_dilations: tuple[int, ...] = (1, 1, 1, 1),
+        text_channels: int = 256,
+        style_tokens: int = 50,
+        style_channels: int = 256,
+        attention_heads: int = 8,
+        style_attention_heads: int = 2,
+        max_positions: int = 1000,
+    ) -> None:
+        super().__init__()
+        if config.ttl.latent_dim <= 0 or config.ttl.chunk_compress_factor <= 0:
+            raise ValueError("config.ttl dimensions must be positive")
+        latent_channels = (
+            config.ttl.latent_dim * config.ttl.chunk_compress_factor
+        )
+        self.uncond_masker = UnconditionalMasker(
+            text_channels, style_tokens, style_channels
+        )
+        self.style_key = nn.Parameter(
+            torch.randn(1, style_tokens, style_channels)
+        )
+        self.vector_field = VectorField(
+            latent_channels,
+            hidden_channels,
+            time_dim,
+            time_hidden_channels,
+            num_main_blocks,
+            main_convnext_dilations,
+            post_time_dilations,
+            post_text_dilations,
+            final_dilations,
+            text_channels,
+            style_channels,
+            attention_heads,
+            style_attention_heads,
+            max_positions,
+        )
+        self.latent_channels = latent_channels
+        self.text_channels = text_channels
+        self.style_tokens = style_tokens
+        self.style_channels = style_channels
+        self.max_positions = max_positions
+
+    def _validate_inputs(
+        self,
+        noisy_latent: torch.Tensor,
+        text_emb: torch.Tensor,
+        style_ttl: torch.Tensor,
+        latent_mask: torch.Tensor,
+        text_mask: torch.Tensor,
+        current_step: torch.Tensor,
+        total_step: torch.Tensor,
+    ) -> None:
+        if (
+            noisy_latent.ndim != 3
+            or noisy_latent.shape[1] != self.latent_channels
+        ):
+            raise ValueError(
+                f"noisy_latent must have shape [B, {self.latent_channels}, L]"
+            )
+        if text_emb.ndim != 3 or text_emb.shape[1] != self.text_channels:
+            raise ValueError(
+                f"text_emb must have shape [B, {self.text_channels}, T]"
+            )
+        if style_ttl.ndim != 3 or style_ttl.shape[1:] != (
+            self.style_tokens,
+            self.style_channels,
+        ):
+            raise ValueError(
+                f"style_ttl must have shape [B, {self.style_tokens}, "
+                f"{self.style_channels}]"
+            )
+        if latent_mask.ndim != 3 or latent_mask.shape[1] != 1:
+            raise ValueError("latent_mask must have shape [B, 1, L]")
+        if text_mask.ndim != 3 or text_mask.shape[1] != 1:
+            raise ValueError("text_mask must have shape [B, 1, T]")
+        if current_step.ndim != 1:
+            raise ValueError("current_step must have shape [B]")
+        if total_step.ndim != 1:
+            raise ValueError("total_step must have shape [B]")
+        batch = noisy_latent.shape[0]
+        if batch <= 0:
+            raise ValueError("batch size must be positive")
+        if noisy_latent.shape[2] <= 0:
+            raise ValueError("latent length must be positive")
+        if text_emb.shape[2] <= 0:
+            raise ValueError("text length must be positive")
+        if any(
+            value.shape[0] != batch
+            for value in (
+                text_emb,
+                style_ttl,
+                latent_mask,
+                text_mask,
+                current_step,
+                total_step,
+            )
+        ):
+            raise ValueError("input batch sizes must match")
+        if noisy_latent.shape[2] != latent_mask.shape[2]:
+            raise ValueError("noisy_latent and latent_mask latent lengths must match")
+        if text_emb.shape[2] != text_mask.shape[2]:
+            raise ValueError("text_emb and text_mask text lengths must match")
+        if noisy_latent.shape[2] > self.max_positions:
+            raise ValueError(f"latent length must not exceed {self.max_positions}")
+        if text_emb.shape[2] > self.max_positions:
+            raise ValueError(f"text length must not exceed {self.max_positions}")
+        latent_valid_counts = latent_mask.sum(dim=(1, 2))
+        if not torch.all(
+            torch.isfinite(latent_valid_counts) & (latent_valid_counts > 0)
+        ).item():
+            raise ValueError(
+                "latent_mask must contain a valid position per sample"
+            )
+        text_valid_counts = text_mask.sum(dim=(1, 2))
+        if not torch.all(
+            torch.isfinite(text_valid_counts) & (text_valid_counts > 0)
+        ).item():
+            raise ValueError("text_mask must contain a valid position per sample")
+        if not torch.all(torch.isfinite(current_step)).item():
+            raise ValueError("current_step must be finite")
+        if not torch.all(torch.isfinite(total_step) & (total_step > 0)).item():
+            raise ValueError("total_step must be finite and positive")
+
+    @staticmethod
+    def _apply_guidance(vector: torch.Tensor) -> torch.Tensor:
+        conditional, unconditional = vector.chunk(2, dim=0)
+        return 4.0 * conditional - 3.0 * unconditional
+
+    def forward(
+        self,
+        noisy_latent: torch.Tensor,
+        text_emb: torch.Tensor,
+        style_ttl: torch.Tensor,
+        latent_mask: torch.Tensor,
+        text_mask: torch.Tensor,
+        current_step: torch.Tensor,
+        total_step: torch.Tensor,
+    ) -> torch.Tensor:
+        self._validate_inputs(
+            noisy_latent,
+            text_emb,
+            style_ttl,
+            latent_mask,
+            text_mask,
+            current_step,
+            total_step,
+        )
+        batch = noisy_latent.shape[0]
+        text_unconditional = self.uncond_masker.text_special_token.expand(
+            batch, -1, text_emb.shape[2]
+        )
+        style_key = torch.cat(
+            (
+                self.style_key.expand(batch, -1, -1),
+                self.uncond_masker.style_key_special_token.expand(
+                    batch, -1, -1
+                ),
+            ),
+            dim=0,
+        )
+        style_value = torch.cat(
+            (
+                style_ttl,
+                self.uncond_masker.style_value_special_token.expand(
+                    batch, -1, -1
+                ),
+            ),
+            dim=0,
+        )
+        vector = self.vector_field(
+            noisy_latent.repeat(2, 1, 1),
+            (current_step / total_step).repeat(2),
+            torch.cat((text_emb, text_unconditional), dim=0),
+            style_key,
+            style_value,
+            latent_mask.repeat(2, 1, 1),
+            text_mask.repeat(2, 1, 1),
+        )
+        guided = self._apply_guidance(vector)
+        step = torch.reciprocal(total_step).reshape(-1, 1, 1)
+        return (noisy_latent + step * guided) * latent_mask

--- a/examples/models/supertonic/model/vocoder.py
+++ b/examples/models/supertonic/model/vocoder.py
@@ -189,9 +189,7 @@ class Vocoder(nn.Module):
 
     def _validate_input(self, latent: torch.Tensor) -> None:
         if latent.ndim != 3 or latent.shape[1] != self.latent_channels:
-            raise ValueError(
-                f"latent must have shape [B, {self.latent_channels}, L]"
-            )
+            raise ValueError(f"latent must have shape [B, {self.latent_channels}, L]")
         if latent.shape[2] <= 0:
             raise ValueError("latent length must be positive")
 

--- a/examples/models/supertonic/model/vocoder.py
+++ b/examples/models/supertonic/model/vocoder.py
@@ -1,0 +1,206 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from .config import TTSConfig
+from .layers import Conv1dProjection, LayerNorm1d
+
+
+class Normalizer(nn.Module):
+    def __init__(self, scale: float = 0.25) -> None:
+        super().__init__()
+        self.register_buffer("scale", torch.tensor(scale))
+
+
+class CausalPad1d(nn.Module):
+    def __init__(self, kernel_size: int, dilation: int = 1) -> None:
+        super().__init__()
+        self.padding = dilation * (kernel_size - 1)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return F.pad(inputs, (self.padding, 0), mode="replicate")
+
+
+class DecoderConvNeXtBlock(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        dilation: int,
+        expansion: int,
+    ) -> None:
+        super().__init__()
+        self.pad = CausalPad1d(7, dilation)
+        self.dwconv = Conv1dProjection(channels, channels, 7)
+        self.dwconv.net = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size=7,
+            dilation=dilation,
+            groups=channels,
+        )
+        self.norm = LayerNorm1d(channels)
+        self.pwconv1 = nn.Conv1d(channels, expansion * channels, 1)
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Conv1d(expansion * channels, channels, 1)
+        self.gamma = nn.Parameter(torch.full((1, channels, 1), 1e-6))
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        hidden = self.dwconv(self.pad(inputs))
+        hidden = self.pwconv2(self.act(self.pwconv1(self.norm(hidden))))
+        return inputs + self.gamma * hidden
+
+
+class InferenceBatchNorm1d(nn.Module):
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.norm = nn.Module()
+        self.norm.weight = nn.Parameter(torch.ones(channels))
+        self.norm.bias = nn.Parameter(torch.zeros(channels))
+        self.norm.register_buffer("running_mean", torch.zeros(channels))
+        self.norm.register_buffer("running_var", torch.ones(channels))
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return F.batch_norm(
+            inputs,
+            self.norm.running_mean,
+            self.norm.running_var,
+            self.norm.weight,
+            self.norm.bias,
+            training=False,
+            momentum=0.1,
+            eps=1e-5,
+        )
+
+
+class SharedPReLU(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor([[0.25]]))
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return torch.where(inputs >= 0, inputs, inputs * self.weight)
+
+
+class DecoderHead(nn.Module):
+    def __init__(
+        self,
+        channels: int = 512,
+        hidden_channels: int = 2048,
+        output_channels: int = 512,
+    ) -> None:
+        super().__init__()
+        self.pad = CausalPad1d(3)
+        self.layer1 = Conv1dProjection(channels, hidden_channels, 3)
+        self.act = SharedPReLU()
+        self.layer2 = nn.Conv1d(hidden_channels, output_channels, 1, bias=False)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        hidden = self.layer1(self.pad(inputs))
+        hidden = self.layer2(self.act(hidden))
+        return hidden.transpose(1, 2).reshape(hidden.shape[0], -1)
+
+
+class Decoder(nn.Module):
+    def __init__(
+        self,
+        latent_dim: int,
+        channels: int,
+        dilations: tuple[int, ...],
+        expansion: int,
+        head_hidden_channels: int,
+        output_channels: int,
+    ) -> None:
+        super().__init__()
+        self.embed_pad = CausalPad1d(7)
+        self.embed = Conv1dProjection(latent_dim, channels, 7)
+        self.convnext = nn.ModuleList(
+            [
+                DecoderConvNeXtBlock(channels, dilation, expansion)
+                for dilation in dilations
+            ]
+        )
+        self.final_norm = InferenceBatchNorm1d(channels)
+        self.head = DecoderHead(channels, head_hidden_channels, output_channels)
+
+    def forward(self, latent: torch.Tensor) -> torch.Tensor:
+        hidden = self.embed(self.embed_pad(latent))
+        for block in self.convnext:
+            hidden = block(hidden)
+        return self.head(self.final_norm(hidden))
+
+
+class Vocoder(nn.Module):
+    def __init__(
+        self,
+        config: TTSConfig,
+        *,
+        decoder_channels: int = 512,
+        decoder_dilations: tuple[int, ...] = (1, 2, 4, 1, 2, 4, 1, 1, 1, 1),
+        decoder_expansion: int = 4,
+        head_hidden_channels: int = 2048,
+    ) -> None:
+        super().__init__()
+        if config.ttl.latent_dim <= 0 or config.ttl.chunk_compress_factor <= 0:
+            raise ValueError("config.ttl dimensions must be positive")
+        if config.ae.latent_dim != config.ttl.latent_dim:
+            raise ValueError("config ttl and autoencoder latent dimensions must match")
+        if config.ae.base_chunk_size <= 0:
+            raise ValueError("config.ae.base_chunk_size must be positive")
+        self.normalizer = Normalizer()
+        self.register_buffer(
+            "latent_mean",
+            torch.zeros(1, config.ae.latent_dim, 1),
+        )
+        self.register_buffer(
+            "latent_std",
+            torch.ones(1, config.ae.latent_dim, 1),
+        )
+        self.decoder = Decoder(
+            config.ae.latent_dim,
+            decoder_channels,
+            decoder_dilations,
+            decoder_expansion,
+            head_hidden_channels,
+            config.ae.base_chunk_size,
+        )
+        self.latent_dim = config.ttl.latent_dim
+        self.compress_factor = config.ttl.chunk_compress_factor
+        self.latent_channels = self.latent_dim * self.compress_factor
+
+    @staticmethod
+    def _unpack_latent(
+        latent: torch.Tensor,
+        *,
+        latent_dim: int,
+        compress_factor: int,
+    ) -> torch.Tensor:
+        batch, _, length = latent.shape
+        return (
+            latent.reshape(batch, latent_dim, compress_factor, length)
+            .transpose(2, 3)
+            .reshape(batch, latent_dim, length * compress_factor)
+        )
+
+    def _validate_input(self, latent: torch.Tensor) -> None:
+        if latent.ndim != 3 or latent.shape[1] != self.latent_channels:
+            raise ValueError(
+                f"latent must have shape [B, {self.latent_channels}, L]"
+            )
+        if latent.shape[2] <= 0:
+            raise ValueError("latent length must be positive")
+
+    def forward(self, latent: torch.Tensor) -> torch.Tensor:
+        self._validate_input(latent)
+        latent = self._unpack_latent(
+            latent / self.normalizer.scale,
+            latent_dim=self.latent_dim,
+            compress_factor=self.compress_factor,
+        )
+        latent = latent * self.latent_std + self.latent_mean
+        return self.decoder(latent)

--- a/examples/models/supertonic/preprocessing.py
+++ b/examples/models/supertonic/preprocessing.py
@@ -132,7 +132,9 @@ class UnicodeProcessor:
             raise ValueError("text vocabulary size must be positive")
         with Path(unicode_indexer_path).open(encoding="utf-8") as indexer_file:
             self.indexer: Sequence[int] | dict[str, int] = json.load(indexer_file)
-        token_ids = self.indexer.values() if isinstance(self.indexer, dict) else self.indexer
+        token_ids = (
+            self.indexer.values() if isinstance(self.indexer, dict) else self.indexer
+        )
         if any(
             not isinstance(token_id, int)
             or isinstance(token_id, bool)
@@ -166,8 +168,7 @@ class UnicodeProcessor:
             raise ValueError("expected at least one text and language")
 
         processed = [
-            preprocess_text(text, language)
-            for text, language in zip(texts, languages)
+            preprocess_text(text, language) for text, language in zip(texts, languages)
         ]
         lengths = np.asarray([len(text) for text in processed], dtype=np.int64)
         text_ids = np.zeros((len(processed), int(lengths.max())), dtype=np.int64)

--- a/examples/models/supertonic/preprocessing.py
+++ b/examples/models/supertonic/preprocessing.py
@@ -1,0 +1,206 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import re
+import unicodedata
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+
+AVAILABLE_LANGUAGES = (
+    "en",
+    "ko",
+    "ja",
+    "ar",
+    "bg",
+    "cs",
+    "da",
+    "de",
+    "el",
+    "es",
+    "et",
+    "fi",
+    "fr",
+    "hi",
+    "hr",
+    "hu",
+    "id",
+    "it",
+    "lt",
+    "lv",
+    "nl",
+    "pl",
+    "pt",
+    "ro",
+    "ru",
+    "sk",
+    "sl",
+    "sv",
+    "tr",
+    "uk",
+    "vi",
+    "na",
+)
+
+_EMOJI_PATTERN = re.compile(
+    "[\U0001f600-\U0001f64f"
+    "\U0001f300-\U0001f5ff"
+    "\U0001f680-\U0001f6ff"
+    "\U0001f700-\U0001f77f"
+    "\U0001f780-\U0001f7ff"
+    "\U0001f800-\U0001f8ff"
+    "\U0001f900-\U0001f9ff"
+    "\U0001fa00-\U0001fa6f"
+    "\U0001fa70-\U0001faff"
+    "\u2600-\u26ff"
+    "\u2700-\u27bf"
+    "\U0001f1e6-\U0001f1ff]+"
+)
+_SENTENCE_BOUNDARY_PATTERN = re.compile(
+    r"(?<!Mr\.)(?<!Mrs\.)(?<!Ms\.)(?<!Dr\.)(?<!Prof\.)(?<!Sr\.)(?<!Jr\.)"
+    r"(?<!Ph\.D\.)(?<!etc\.)(?<!e\.g\.)(?<!i\.e\.)(?<!vs\.)(?<!Inc\.)"
+    r"(?<!Ltd\.)(?<!Co\.)(?<!Corp\.)(?<!St\.)(?<!Ave\.)(?<!Blvd\.)"
+    r"(?<!\b[A-Z]\.)(?:(?<=[.!?])\s+|(?<=[。！？])(?![。！？])\s*)"
+)
+
+
+def preprocess_text(text: str, language: str) -> str:
+    if language not in AVAILABLE_LANGUAGES:
+        raise ValueError(f"Invalid language: {language}")
+
+    text = unicodedata.normalize("NFKD", text)
+    text = _EMOJI_PATTERN.sub("", text)
+    for old, new in {
+        "–": "-",
+        "‑": "-",
+        "—": "-",
+        "_": " ",
+        "“": '"',
+        "”": '"',
+        "‘": "'",
+        "’": "'",
+        "´": "'",
+        "`": "'",
+        "[": " ",
+        "]": " ",
+        "|": " ",
+        "/": " ",
+        "#": " ",
+        "→": " ",
+        "←": " ",
+    }.items():
+        text = text.replace(old, new)
+    text = re.sub(r"[♥☆♡©\\]", "", text)
+    for old, new in {
+        "@": " at ",
+        "e.g.,": "for example, ",
+        "i.e.,": "that is, ",
+    }.items():
+        text = text.replace(old, new)
+    text = re.sub(r" ([,.!?;:'])", r"\1", text)
+    while '""' in text:
+        text = text.replace('""', '"')
+    while "''" in text:
+        text = text.replace("''", "'")
+    while "``" in text:
+        text = text.replace("``", "`")
+    text = re.sub(r"\s+", " ", text).strip()
+    if not re.search(r"[.!?！？，;:,'\"')\]}…。」』】〉》›»]$", text):
+        text += "."
+    return f"<{language}>{text}</{language}>"
+
+
+def length_to_mask(
+    lengths: NDArray[np.int64], max_length: int | None = None
+) -> NDArray[np.float32]:
+    max_length = max_length if max_length is not None else int(lengths.max())
+    positions = np.arange(max_length)
+    return (positions < lengths[:, None]).astype(np.float32)[:, None, :]
+
+
+class UnicodeProcessor:
+    def __init__(
+        self, unicode_indexer_path: str | Path, *, vocabulary_size: int
+    ) -> None:
+        if vocabulary_size <= 0:
+            raise ValueError("text vocabulary size must be positive")
+        with Path(unicode_indexer_path).open(encoding="utf-8") as indexer_file:
+            self.indexer: Sequence[int] | dict[str, int] = json.load(indexer_file)
+        token_ids = self.indexer.values() if isinstance(self.indexer, dict) else self.indexer
+        if any(
+            not isinstance(token_id, int)
+            or isinstance(token_id, bool)
+            or token_id < -1
+            or token_id >= vocabulary_size
+            for token_id in token_ids
+        ):
+            raise ValueError("Unicode indexer contains an invalid vocabulary token")
+        self.vocabulary_size = vocabulary_size
+
+    def _index(self, codepoint: int) -> int:
+        try:
+            if isinstance(self.indexer, dict):
+                token_id = self.indexer[str(codepoint)]
+            else:
+                token_id = self.indexer[codepoint]
+        except (IndexError, KeyError) as error:
+            raise ValueError(
+                f"Unicode indexer has no entry for codepoint {codepoint}"
+            ) from error
+        if token_id < 0:
+            raise ValueError(f"unsupported Unicode codepoint {codepoint}")
+        return token_id
+
+    def __call__(
+        self, texts: Sequence[str], languages: Sequence[str]
+    ) -> tuple[NDArray[np.int64], NDArray[np.float32]]:
+        if len(texts) != len(languages):
+            raise ValueError("texts and languages must have the same cardinality")
+        if len(texts) == 0:
+            raise ValueError("expected at least one text and language")
+
+        processed = [
+            preprocess_text(text, language)
+            for text, language in zip(texts, languages)
+        ]
+        lengths = np.asarray([len(text) for text in processed], dtype=np.int64)
+        text_ids = np.zeros((len(processed), int(lengths.max())), dtype=np.int64)
+        for index, text in enumerate(processed):
+            text_ids[index, : len(text)] = [self._index(ord(char)) for char in text]
+        return text_ids, length_to_mask(lengths)
+
+
+def chunk_text(text: str, max_len: int = 300) -> list[str]:
+    """Pack whole sentences using ``max_len`` as a soft threshold.
+
+    A sentence is never split, so one sentence may exceed ``max_len``.
+    """
+    paragraphs = [
+        paragraph.strip()
+        for paragraph in re.split(r"\n\s*\n+", text.strip())
+        if paragraph.strip()
+    ]
+    chunks: list[str] = []
+    for paragraph in paragraphs:
+        current_chunk = ""
+        for sentence in _SENTENCE_BOUNDARY_PATTERN.split(paragraph):
+            if len(current_chunk) + len(sentence) + 1 <= max_len:
+                current_chunk += (" " if current_chunk else "") + sentence
+            else:
+                if current_chunk:
+                    chunks.append(current_chunk.strip())
+                current_chunk = sentence
+        if current_chunk:
+            chunks.append(current_chunk.strip())
+    return chunks
+
+
+def chunk_text_for_language(text: str, language: str) -> list[str]:
+    """Use soft packing thresholds of 120 for ko/ja and 300 otherwise."""
+    return chunk_text(text, max_len=120 if language in ("ko", "ja") else 300)

--- a/examples/models/supertonic/requirements.txt
+++ b/examples/models/supertonic/requirements.txt
@@ -1,0 +1,3 @@
+onnx
+onnxruntime
+huggingface_hub

--- a/examples/models/supertonic/runtime/main.cpp
+++ b/examples/models/supertonic/runtime/main.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "supertonic_runner.h"
+#include "wav_writer.h"
+
+#include <gflags/gflags.h>
+
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+DEFINE_string(pte, "", "Path to the single Supertonic FP16 MLX .pte file.");
+DEFINE_string(
+    asset_dir,
+    "",
+    "Published Supertonic asset root containing onnx/unicode_indexer.json.");
+DEFINE_string(
+    voice_style,
+    "",
+    "Exactly one published batch-1 voice-style JSON path.");
+DEFINE_string(text, "", "Text to synthesize.");
+DEFINE_string(language, "en", "Published Supertonic language tag.");
+DEFINE_double(speed, 1.05, "Positive duration speed divisor.");
+DEFINE_uint64(seed, 42, "Portable xorshift64/Box-Muller latent seed.");
+DEFINE_string(output, "supertonic.wav", "Output mono PCM16 WAV path.");
+
+namespace {
+
+void require_file(const std::filesystem::path& path, const char* flag) {
+  if (!std::filesystem::is_regular_file(path)) {
+    throw std::invalid_argument(
+        std::string(flag) + " does not name a readable file: " + path.string());
+  }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  gflags::SetUsageMessage(
+      "Synthesize Supertonic speech with a batch-1 FP16 MLX PTE.");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  try {
+    if (FLAGS_pte.empty() || FLAGS_asset_dir.empty() ||
+        FLAGS_voice_style.empty() || FLAGS_text.empty()) {
+      throw std::invalid_argument(
+          "--pte, --asset_dir, --voice_style, and --text are required");
+    }
+    const std::filesystem::path pte(FLAGS_pte);
+    const std::filesystem::path indexer =
+        std::filesystem::path(FLAGS_asset_dir) / "onnx" /
+        "unicode_indexer.json";
+    require_file(pte, "--pte");
+    require_file(indexer, "--asset_dir");
+    const std::string style =
+        supertonic::require_single_voice_style_path({FLAGS_voice_style});
+    supertonic::validate_language(FLAGS_language);
+    if (!std::isfinite(FLAGS_speed) || FLAGS_speed <= 0.0 ||
+        FLAGS_speed > std::numeric_limits<float>::max()) {
+      throw std::invalid_argument(
+          "--speed must be finite, positive, and representable as float");
+    }
+    require_file(style, "--voice_style");
+
+    supertonic::SupertonicRunner runner(pte.string(), indexer.string());
+
+    supertonic::SynthesisOptions options;
+    options.text = FLAGS_text;
+    options.language = FLAGS_language;
+    options.voice_style_paths = {style};
+    options.speed = static_cast<float>(FLAGS_speed);
+    options.seed = FLAGS_seed;
+    auto result = runner.synthesize(options);
+    if (!supertonic::write_pcm16_wav(
+            FLAGS_output,
+            result.waveform,
+            static_cast<int>(runner.metadata().sample_rate))) {
+      throw std::runtime_error("failed to write output WAV: " + FLAGS_output);
+    }
+    const double audio_seconds = static_cast<double>(result.waveform.size()) /
+        runner.metadata().sample_rate;
+    std::cout << "Wrote " << result.waveform.size() << " samples ("
+              << audio_seconds << " s) at " << runner.metadata().sample_rate
+              << " Hz to " << FLAGS_output << "\n";
+    if (audio_seconds > 0.0) {
+      std::cout << "Synthesis " << result.elapsed_seconds << " s, RTF "
+                << result.elapsed_seconds / audio_seconds << "\n";
+    }
+    return 0;
+  } catch (const std::exception& error) {
+    std::cerr << "Supertonic synthesis failed: " << error.what() << "\n";
+    return 1;
+  }
+}

--- a/examples/models/supertonic/runtime/style_loader.cpp
+++ b/examples/models/supertonic/runtime/style_loader.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "style_loader.h"
+
+#include <nlohmann/json.hpp>
+
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+
+namespace supertonic {
+namespace {
+
+using Json = nlohmann::json;
+
+constexpr double kMaximumFp16 = 65504.0;
+
+std::string shape_string(const std::vector<int>& dimensions) {
+  std::string result = "[";
+  for (size_t index = 0; index < dimensions.size(); ++index) {
+    result += (index == 0 ? "" : ", ") + std::to_string(dimensions[index]);
+  }
+  return result + "]";
+}
+
+void read_exact_nested_data(
+    const Json& value,
+    const std::vector<int>& dimensions,
+    size_t depth,
+    const std::string& name,
+    std::vector<float>& output) {
+  if (depth == dimensions.size()) {
+    if (!value.is_number()) {
+      throw std::runtime_error(name + ".data must contain only numbers");
+    }
+    const double number = value.get<double>();
+    if (!std::isfinite(number) || std::abs(number) > kMaximumFp16) {
+      throw std::runtime_error(
+          name + ".data values must be within the finite FP16 range");
+    }
+    output.push_back(static_cast<float>(number));
+    return;
+  }
+  if (!value.is_array() ||
+      value.size() != static_cast<size_t>(dimensions[depth])) {
+    throw std::runtime_error(
+        name + ".data must have nested shape " + shape_string(dimensions));
+  }
+  for (const auto& child : value) {
+    read_exact_nested_data(child, dimensions, depth + 1, name, output);
+  }
+}
+
+std::vector<float> read_style_tensor(
+    const Json& root,
+    const char* name,
+    const std::vector<int>& expected_dimensions,
+    size_t expected_values) {
+  if (!root.contains(name) || !root.at(name).is_object()) {
+    throw std::runtime_error(std::string("missing ") + name);
+  }
+  const auto& tensor = root.at(name);
+  if (!tensor.contains("dims") ||
+      tensor.at("dims").get<std::vector<int>>() != expected_dimensions) {
+    throw std::runtime_error(std::string(name) + ".dims has an invalid shape");
+  }
+  if (!tensor.contains("data") || !tensor.at("data").is_array()) {
+    throw std::runtime_error(std::string(name) + ".data must be an array");
+  }
+  std::vector<float> values;
+  values.reserve(expected_values);
+  read_exact_nested_data(
+      tensor.at("data"), expected_dimensions, 0, name, values);
+  if (values.size() != expected_values) {
+    throw std::runtime_error(
+        std::string(name) + ".data must contain exactly " +
+        std::to_string(expected_values) + " values");
+  }
+  return values;
+}
+
+} // namespace
+
+std::string require_single_voice_style_path(
+    const std::vector<std::string>& style_paths) {
+  if (style_paths.size() != 1 || style_paths.front().empty()) {
+    throw std::invalid_argument("expected exactly one voice style path");
+  }
+  return style_paths.front();
+}
+
+VoiceStyle load_voice_style(const std::string& style_path) {
+  std::ifstream file(style_path);
+  if (!file) {
+    throw std::runtime_error("failed to open voice style: " + style_path);
+  }
+  Json style;
+  try {
+    style = Json::parse(file);
+  } catch (const std::exception& error) {
+    throw std::runtime_error(
+        "failed to parse voice style " + style_path + ": " + error.what());
+  }
+  return {
+      read_style_tensor(style, "style_ttl", {1, 50, 256}, 50 * 256),
+      read_style_tensor(style, "style_dp", {1, 8, 16}, 8 * 16)};
+}
+
+} // namespace supertonic

--- a/examples/models/supertonic/runtime/style_loader.h
+++ b/examples/models/supertonic/runtime/style_loader.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace supertonic {
+
+struct VoiceStyle {
+  std::vector<float> ttl;
+  std::vector<float> dp;
+};
+
+std::string require_single_voice_style_path(
+    const std::vector<std::string>& style_paths);
+VoiceStyle load_voice_style(const std::string& style_path);
+
+} // namespace supertonic

--- a/examples/models/supertonic/runtime/supertonic_runner.cpp
+++ b/examples/models/supertonic/runtime/supertonic_runner.cpp
@@ -1,0 +1,837 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "supertonic_runner.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
+
+#ifndef SUPERTONIC_PURE_HELPERS_ONLY
+#include <executorch/backends/mlx/runtime/backend_options.h>
+#include <executorch/extension/module/module.h>
+#include <executorch/extension/tensor/tensor.h>
+#include <executorch/runtime/backend/options.h>
+#include <executorch/runtime/core/evalue.h>
+#include <mlx/stream.h>
+#endif
+
+namespace supertonic {
+namespace {
+
+size_t element_count(const std::vector<int64_t>& shape) {
+  size_t count = 1;
+  for (int64_t dimension : shape) {
+    if (dimension <= 0 ||
+        count > std::numeric_limits<size_t>::max() /
+                static_cast<size_t>(dimension)) {
+      return 0;
+    }
+    count *= static_cast<size_t>(dimension);
+  }
+  return count;
+}
+
+void validate_tensor(
+    const TensorView& tensor,
+    const std::string& name,
+    const std::vector<int64_t>& expected_shape) {
+  if (tensor.dtype != TensorDtype::Float16) {
+    throw std::invalid_argument(name + " must have dtype float16");
+  }
+  if (!tensor.contiguous) {
+    throw std::invalid_argument(name + " must be contiguous");
+  }
+  if (tensor.shape != expected_shape) {
+    throw std::invalid_argument(name + " has an incompatible shape");
+  }
+  const size_t count = element_count(tensor.shape);
+  if (tensor.values == nullptr || tensor.values->size() != count) {
+    throw std::invalid_argument(name + " data does not match its shape");
+  }
+  for (float value : *tensor.values) {
+    if (!std::isfinite(value) || std::abs(value) > 65504.0f) {
+      throw std::invalid_argument(
+          name + " values must be within the finite FP16 range");
+    }
+  }
+}
+
+bool has_valid_mask(const TensorView& tensor) {
+  double sum = 0.0;
+  for (float value : *tensor.values) {
+    if (!std::isfinite(value)) {
+      return false;
+    }
+    sum += value;
+  }
+  return std::isfinite(sum) && sum > 0.0;
+}
+
+int64_t checked_sample_count(
+    float seconds,
+    int64_t sample_rate,
+    const char* label,
+    bool allow_zero = false) {
+  if (!std::isfinite(seconds) || seconds < 0.0f || sample_rate <= 0) {
+    throw std::invalid_argument(std::string("invalid ") + label);
+  }
+  const long double count =
+      static_cast<long double>(seconds) * static_cast<long double>(sample_rate);
+  if (!std::isfinite(count) ||
+      count > static_cast<long double>(std::numeric_limits<int64_t>::max())) {
+    throw std::overflow_error(
+        std::string(label) + " sample count is unrepresentable");
+  }
+  const int64_t result = static_cast<int64_t>(count);
+  if (!allow_zero && result <= 0) {
+    throw std::invalid_argument(std::string(label) + " produces no samples");
+  }
+  return result;
+}
+
+size_t checked_add_size(size_t first, size_t second, const char* label) {
+  if (first > std::numeric_limits<size_t>::max() - second) {
+    throw std::overflow_error(std::string(label) + " size is unrepresentable");
+  }
+  return first + second;
+}
+
+std::string joined_names(const std::set<std::string>& names) {
+  std::string result;
+  for (const auto& name : names) {
+    result += (result.empty() ? "" : ", ") + name;
+  }
+  return result;
+}
+
+} // namespace
+
+MetadataValue MetadataValue::integer(int64_t value) {
+  MetadataValue result{};
+  result.type = MetadataValueType::Integer;
+  result.integer_value = value;
+  return result;
+}
+
+MetadataValue MetadataValue::boolean(bool value) {
+  MetadataValue result{};
+  result.type = MetadataValueType::Boolean;
+  result.boolean_value = value;
+  return result;
+}
+
+MetadataValue MetadataValue::string(std::string value) {
+  MetadataValue result{};
+  result.type = MetadataValueType::String;
+  result.string_value = std::move(value);
+  return result;
+}
+
+RuntimeMetadata validate_metadata_contract(
+    const std::set<std::string>& method_names,
+    const std::map<std::string, MetadataValue>& metadata_values) {
+  const std::set<std::string> expected_methods = {
+      "duration_predictor",
+      "text_encoder",
+      "vector_estimator",
+      "vocoder",
+      "get_sample_rate",
+      "get_base_chunk_size",
+      "get_chunk_compress_factor",
+      "get_flow_steps",
+      "get_text_vocabulary_size",
+      "get_latent_dim",
+      "get_latent_channels",
+      "get_max_text_length",
+      "get_max_latent_length",
+      "get_batch_size",
+      "get_activation_dtype",
+      "enable_dynamic_shape"};
+  std::set<std::string> missing;
+  std::set_difference(
+      expected_methods.begin(),
+      expected_methods.end(),
+      method_names.begin(),
+      method_names.end(),
+      std::inserter(missing, missing.end()));
+  if (!missing.empty()) {
+    throw std::runtime_error("missing methods: " + joined_names(missing));
+  }
+  std::set<std::string> unexpected;
+  std::set_difference(
+      method_names.begin(),
+      method_names.end(),
+      expected_methods.begin(),
+      expected_methods.end(),
+      std::inserter(unexpected, unexpected.end()));
+  if (!unexpected.empty()) {
+    throw std::runtime_error("unexpected methods: " + joined_names(unexpected));
+  }
+
+  const auto require = [&](const char* name,
+                           MetadataValueType type) -> const MetadataValue& {
+    const auto found = metadata_values.find(name);
+    if (found == metadata_values.end()) {
+      throw std::runtime_error(std::string("missing metadata value: ") + name);
+    }
+    if (found->second.type != type) {
+      const char* expected = type == MetadataValueType::Integer
+          ? "an integer"
+          : (type == MetadataValueType::Boolean ? "a boolean" : "a string");
+      throw std::runtime_error(std::string(name) + " must be " + expected);
+    }
+    return found->second;
+  };
+  const auto integer = [&](const char* name) {
+    return require(name, MetadataValueType::Integer).integer_value;
+  };
+
+  RuntimeMetadata metadata;
+  metadata.sample_rate = integer("get_sample_rate");
+  metadata.base_chunk_size = integer("get_base_chunk_size");
+  metadata.chunk_compress_factor = integer("get_chunk_compress_factor");
+  metadata.flow_steps = integer("get_flow_steps");
+  metadata.text_vocabulary_size = integer("get_text_vocabulary_size");
+  metadata.latent_dim = integer("get_latent_dim");
+  metadata.latent_channels = integer("get_latent_channels");
+  metadata.max_text_length = integer("get_max_text_length");
+  metadata.max_latent_length = integer("get_max_latent_length");
+  metadata.batch_size = integer("get_batch_size");
+  metadata.activation_dtype =
+      require("get_activation_dtype", MetadataValueType::String).string_value;
+  metadata.dynamic_shapes =
+      require("enable_dynamic_shape", MetadataValueType::Boolean).boolean_value;
+  if (metadata.sample_rate != 44100 || metadata.base_chunk_size != 512 ||
+      metadata.chunk_compress_factor != 6 || metadata.flow_steps != 5 ||
+      metadata.text_vocabulary_size <= 0 || metadata.latent_dim != 24 ||
+      metadata.latent_channels != 144 || metadata.batch_size != 1 ||
+      metadata.activation_dtype != "float16" || !metadata.dynamic_shapes ||
+      metadata.max_text_length < 2 || metadata.max_text_length > 1000 ||
+      metadata.max_latent_length < 2 || metadata.max_latent_length > 1000) {
+    throw std::runtime_error(
+        "Supertonic PTE metadata is incompatible with the batch-1 FP16 "
+        "44.1 kHz five-step runner");
+  }
+  if (metadata.latent_dim > std::numeric_limits<int64_t>::max() /
+              metadata.chunk_compress_factor ||
+      metadata.latent_channels !=
+          metadata.latent_dim * metadata.chunk_compress_factor) {
+    throw std::runtime_error("Supertonic latent metadata is inconsistent");
+  }
+  return metadata;
+}
+
+void validate_vector_inputs(
+    const VectorInputs& inputs,
+    const RuntimeMetadata& metadata) {
+  const auto& latent_shape = inputs.noisy_latent.shape;
+  const auto& text_shape = inputs.text_emb.shape;
+  if (latent_shape.size() != 3 || text_shape.size() != 3) {
+    throw std::invalid_argument(
+        "noisy_latent and text_emb must be rank-three tensors");
+  }
+  const int64_t batch = latent_shape[0];
+  if (batch != 1 || text_shape[0] != 1) {
+    throw std::invalid_argument("vector_estimator batch size must be 1");
+  }
+  const int64_t latent_length = latent_shape[2];
+  const int64_t text_length = text_shape[2];
+  if (latent_length <= 0 || latent_length > metadata.max_latent_length) {
+    throw std::invalid_argument("latent length is outside the exported bounds");
+  }
+  if (text_length <= 0 || text_length > metadata.max_text_length) {
+    throw std::invalid_argument("text length is outside the exported bounds");
+  }
+  validate_tensor(
+      inputs.noisy_latent,
+      "noisy_latent",
+      {1, metadata.latent_channels, latent_length});
+  validate_tensor(inputs.text_emb, "text_emb", {1, 256, text_length});
+  validate_tensor(inputs.style_ttl, "style_ttl", {1, 50, 256});
+  if (inputs.latent_mask.shape != std::vector<int64_t>({1, 1, latent_length})) {
+    throw std::invalid_argument(
+        "noisy_latent and latent_mask latent lengths must match");
+  }
+  validate_tensor(inputs.latent_mask, "latent_mask", {1, 1, latent_length});
+  if (inputs.text_mask.shape != std::vector<int64_t>({1, 1, text_length})) {
+    throw std::invalid_argument(
+        "text_emb and text_mask text lengths must match");
+  }
+  validate_tensor(inputs.text_mask, "text_mask", {1, 1, text_length});
+  if (inputs.current_step.values != nullptr &&
+      inputs.current_step.values->size() == 1 &&
+      !std::isfinite(inputs.current_step.values->front())) {
+    throw std::invalid_argument("current_step must be finite");
+  }
+  if (inputs.total_step.values != nullptr &&
+      inputs.total_step.values->size() == 1 &&
+      (!std::isfinite(inputs.total_step.values->front()) ||
+       inputs.total_step.values->front() <= 0.0f)) {
+    throw std::invalid_argument("total_step must be finite and positive");
+  }
+  validate_tensor(inputs.current_step, "current_step", {1});
+  validate_tensor(inputs.total_step, "total_step", {1});
+  if (!has_valid_mask(inputs.latent_mask)) {
+    throw std::invalid_argument("latent_mask must contain a valid position");
+  }
+  if (!has_valid_mask(inputs.text_mask)) {
+    throw std::invalid_argument("text_mask must contain a valid position");
+  }
+}
+
+void invoke_validated_vector(
+    const VectorInputs& inputs,
+    const RuntimeMetadata& metadata,
+    const std::function<void()>& executor) {
+  validate_vector_inputs(inputs, metadata);
+  if (!executor) {
+    throw std::invalid_argument("vector executor callback must not be empty");
+  }
+  executor();
+}
+
+PortableNormalGenerator::PortableNormalGenerator(uint64_t seed)
+    : state_(seed == 0 ? 0x12345678abcdef01ULL : seed) {}
+
+uint64_t PortableNormalGenerator::next() {
+  state_ ^= state_ << 13;
+  state_ ^= state_ >> 7;
+  state_ ^= state_ << 17;
+  return state_;
+}
+
+double PortableNormalGenerator::uniform() {
+  return static_cast<double>(next() >> 11) * (1.0 / 9007199254740992.0);
+}
+
+float PortableNormalGenerator::normal() {
+  double first;
+  do {
+    first = uniform();
+  } while (first < 1e-30);
+  const double second = uniform();
+  return static_cast<float>(
+      std::sqrt(-2.0 * std::log(first)) *
+      std::cos(6.283185307179586476925286766559 * second));
+}
+
+float adjust_duration_for_speed(float duration, float speed) {
+  if (!std::isfinite(duration) || duration <= 0.0f) {
+    throw std::invalid_argument("duration must be finite and positive");
+  }
+  if (!std::isfinite(speed) || speed <= 0.0f) {
+    throw std::invalid_argument("speed must be finite and positive");
+  }
+  const double adjusted =
+      static_cast<double>(duration) / static_cast<double>(speed);
+  if (!std::isfinite(adjusted) ||
+      adjusted > std::numeric_limits<float>::max()) {
+    throw std::overflow_error("adjusted duration is unrepresentable");
+  }
+  return static_cast<float>(adjusted);
+}
+
+LatentLayout latent_layout(
+    float duration,
+    int64_t sample_rate,
+    int64_t base_chunk_size,
+    int64_t chunk_compress_factor,
+    int64_t max_latent_length) {
+  if (!std::isfinite(duration) || duration <= 0.0f || sample_rate <= 0 ||
+      base_chunk_size <= 0 || chunk_compress_factor <= 0 ||
+      max_latent_length <= 0) {
+    throw std::invalid_argument("invalid duration or latent layout constants");
+  }
+  const int64_t samples =
+      checked_sample_count(duration, sample_rate, "duration");
+  if (base_chunk_size >
+      std::numeric_limits<int64_t>::max() / chunk_compress_factor) {
+    throw std::overflow_error("latent chunk size is unrepresentable");
+  }
+  const int64_t chunk_size = base_chunk_size * chunk_compress_factor;
+  const int64_t latent_length =
+      samples / chunk_size + (samples % chunk_size == 0 ? 0 : 1);
+  if (latent_length <= 0) {
+    throw std::invalid_argument("duration produces no latent positions");
+  }
+  if (latent_length > max_latent_length) {
+    throw std::invalid_argument(
+        "predicted duration exceeds exported latent bound");
+  }
+  return {samples, latent_length};
+}
+
+std::vector<float> trim_waveform(
+    const std::vector<float>& waveform,
+    float duration,
+    int64_t sample_rate) {
+  if (!std::isfinite(duration) || duration < 0.0f || sample_rate <= 0) {
+    throw std::invalid_argument("invalid waveform trim duration");
+  }
+  const int64_t sample_count =
+      checked_sample_count(duration, sample_rate, "trim", true);
+  const size_t count =
+      std::min(waveform.size(), static_cast<size_t>(sample_count));
+  return std::vector<float>(waveform.begin(), waveform.begin() + count);
+}
+
+float accumulate_chunk_durations(
+    const std::vector<float>& durations,
+    float inter_chunk_silence) {
+  if (durations.empty()) {
+    throw std::invalid_argument("expected at least one chunk duration");
+  }
+  if (!std::isfinite(inter_chunk_silence) || inter_chunk_silence < 0.0f) {
+    throw std::invalid_argument(
+        "inter-chunk silence must be finite and nonnegative");
+  }
+  if (!std::isfinite(durations.front()) || durations.front() <= 0.0f) {
+    throw std::invalid_argument("chunk durations must be finite and positive");
+  }
+  float result = durations.front();
+  for (size_t index = 1; index < durations.size(); ++index) {
+    if (!std::isfinite(durations[index]) || durations[index] <= 0.0f) {
+      throw std::invalid_argument(
+          "chunk durations must be finite and positive");
+    }
+    const float increment = durations[index] + inter_chunk_silence;
+    result += increment;
+    if (!std::isfinite(increment) || !std::isfinite(result)) {
+      throw std::overflow_error("combined duration is unrepresentable");
+    }
+  }
+  return result;
+}
+
+std::vector<float> combine_vocoder_chunks(
+    const std::vector<std::vector<float>>& waveforms,
+    const std::vector<float>& durations,
+    int64_t sample_rate,
+    float inter_chunk_silence) {
+  if (waveforms.empty() || waveforms.size() != durations.size()) {
+    throw std::invalid_argument(
+        "waveforms and durations must have matching nonzero cardinality");
+  }
+  const int64_t silence_count =
+      checked_sample_count(inter_chunk_silence, sample_rate, "silence", true);
+  const float target_duration =
+      accumulate_chunk_durations(durations, inter_chunk_silence);
+  size_t combined_size = 0;
+  for (size_t index = 0; index < waveforms.size(); ++index) {
+    combined_size =
+        checked_add_size(combined_size, waveforms[index].size(), "combined");
+    if (index != 0) {
+      combined_size = checked_add_size(
+          combined_size, static_cast<size_t>(silence_count), "combined");
+    }
+  }
+  std::vector<float> combined;
+  combined.reserve(combined_size);
+  for (size_t index = 0; index < waveforms.size(); ++index) {
+    if (index != 0) {
+      combined.insert(combined.end(), static_cast<size_t>(silence_count), 0.0f);
+    }
+    combined.insert(
+        combined.end(), waveforms[index].begin(), waveforms[index].end());
+  }
+  return trim_waveform(combined, target_duration, sample_rate);
+}
+
+#ifndef SUPERTONIC_PURE_HELPERS_ONLY
+namespace {
+
+using ::executorch::aten::ScalarType;
+using ::executorch::aten::Tensor;
+using ::executorch::extension::from_blob;
+using ::executorch::extension::Module;
+using ::executorch::extension::TensorPtr;
+using ::executorch::runtime::BackendOptions;
+using ::executorch::runtime::Error;
+using ::executorch::runtime::EValue;
+using ::executorch::runtime::LoadBackendOptionsMap;
+
+std::vector<c10::Half> to_half(const std::vector<float>& values) {
+  std::vector<c10::Half> result;
+  result.reserve(values.size());
+  for (float value : values) {
+    if (!std::isfinite(value) || std::abs(value) > 65504.0f) {
+      throw std::invalid_argument(
+          "tensor values must be within the finite FP16 range");
+    }
+    result.emplace_back(value);
+  }
+  return result;
+}
+
+std::vector<float> copy_half_tensor(
+    const Tensor& tensor,
+    const std::vector<int64_t>& expected_shape,
+    const char* method) {
+  if (tensor.scalar_type() != ScalarType::Half ||
+      tensor.sizes().size() != expected_shape.size()) {
+    throw std::runtime_error(
+        std::string(method) + " returned an incompatible tensor");
+  }
+  for (size_t index = 0; index < expected_shape.size(); ++index) {
+    if (tensor.size(index) != expected_shape[index]) {
+      throw std::runtime_error(
+          std::string(method) + " returned an incompatible shape");
+    }
+  }
+  ::mlx::core::synchronize();
+  const auto* source = tensor.const_data_ptr<c10::Half>();
+  std::vector<float> result(tensor.numel());
+  for (size_t index = 0; index < result.size(); ++index) {
+    result[index] = static_cast<float>(source[index]);
+    if (!std::isfinite(result[index])) {
+      throw std::runtime_error(
+          std::string(method) + " returned a nonfinite FP16 value");
+    }
+  }
+  return result;
+}
+
+MetadataValue read_metadata_value(Module& module, const char* name) {
+  auto result = module.get(name);
+  if (!result.ok()) {
+    throw std::runtime_error(std::string("missing metadata value: ") + name);
+  }
+  if (result->isInt()) {
+    return MetadataValue::integer(result->toInt());
+  }
+  if (result->isBool()) {
+    return MetadataValue::boolean(result->toBool());
+  }
+  if (result->isString()) {
+    return MetadataValue::string(std::string(result->toString()));
+  }
+  throw std::runtime_error(
+      std::string("metadata value has unsupported EValue type: ") + name);
+}
+
+TensorView domain_view(
+    std::vector<int64_t> shape,
+    const std::vector<float>& values) {
+  return {std::move(shape), &values, true, TensorDtype::Float16};
+}
+
+} // namespace
+
+class SupertonicRunner::Impl {
+ public:
+  Impl(const std::string& pte_path, const std::string& unicode_indexer_path)
+      : processor_(unicode_indexer_path),
+        module_(std::make_unique<Module>(
+            pte_path,
+            Module::LoadMode::MmapUseMlockIgnoreErrors)) {
+    if (module_->load() != Error::Ok) {
+      throw std::runtime_error("failed to load Supertonic PTE: " + pte_path);
+    }
+    auto methods = module_->method_names();
+    if (!methods.ok()) {
+      throw std::runtime_error("failed to enumerate Supertonic PTE methods");
+    }
+    std::set<std::string> method_names;
+    for (const auto& method : *methods) {
+      method_names.insert(std::string(method));
+    }
+    std::map<std::string, MetadataValue> metadata_values;
+    for (const char* name :
+         {"get_sample_rate",
+          "get_base_chunk_size",
+          "get_chunk_compress_factor",
+          "get_flow_steps",
+          "get_text_vocabulary_size",
+          "get_latent_dim",
+          "get_latent_channels",
+          "get_max_text_length",
+          "get_max_latent_length",
+          "get_batch_size",
+          "get_activation_dtype",
+          "enable_dynamic_shape"}) {
+      metadata_values.emplace(name, read_metadata_value(*module_, name));
+    }
+    metadata_ = validate_metadata_contract(method_names, metadata_values);
+    processor_.configure_vocabulary(metadata_.text_vocabulary_size);
+
+    BackendOptions<1> options;
+    if (options.set_option(
+            ::executorch::backends::mlx::kClearCacheIntervalKey, 1) !=
+            Error::Ok ||
+        load_options_.set_options(
+            ::executorch::backends::mlx::kMLXBackendId, options.view()) !=
+            Error::Ok) {
+      throw std::runtime_error("failed to configure MLX backend options");
+    }
+    for (const char* method :
+         {"duration_predictor",
+          "text_encoder",
+          "vector_estimator",
+          "vocoder"}) {
+      if (module_->load_method(method, nullptr, nullptr, &load_options_) !=
+          Error::Ok) {
+        throw std::runtime_error(
+            std::string("failed to load Supertonic method: ") + method);
+      }
+    }
+  }
+
+  const RuntimeMetadata& metadata() const {
+    return metadata_;
+  }
+
+  SynthesisResult synthesize(const SynthesisOptions& options) {
+    if (options.text.empty()) {
+      throw std::invalid_argument("text must not be empty");
+    }
+    validate_language(options.language);
+    if (!std::isfinite(options.speed) || options.speed <= 0.0f) {
+      throw std::invalid_argument("speed must be finite and positive");
+    }
+    if (!std::isfinite(options.inter_chunk_silence) ||
+        options.inter_chunk_silence < 0.0f) {
+      throw std::invalid_argument(
+          "inter-chunk silence must be finite and nonnegative");
+    }
+    const VoiceStyle style = load_voice_style(
+        require_single_voice_style_path(options.voice_style_paths));
+    const auto chunks = chunk_text_for_language(options.text, options.language);
+    if (chunks.empty()) {
+      throw std::invalid_argument("text produced no synthesis chunks");
+    }
+    const auto synthesis_started = std::chrono::steady_clock::now();
+    PortableNormalGenerator generator(options.seed);
+    SynthesisResult result;
+    std::vector<std::vector<float>> waveforms;
+    std::vector<float> durations;
+    waveforms.reserve(chunks.size());
+    durations.reserve(chunks.size());
+    for (const auto& text : chunks) {
+      auto chunk = synthesize_chunk(
+          text, options.language, style, options.speed, generator);
+      waveforms.push_back(std::move(chunk.waveform));
+      durations.push_back(chunk.duration_seconds);
+    }
+    result.waveform = combine_vocoder_chunks(
+        waveforms,
+        durations,
+        metadata_.sample_rate,
+        options.inter_chunk_silence);
+    result.duration_seconds = static_cast<float>(
+        static_cast<double>(result.waveform.size()) / metadata_.sample_rate);
+    ::mlx::core::synchronize();
+    result.elapsed_seconds =
+        std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - synthesis_started)
+            .count();
+    if (result.waveform.empty() ||
+        !std::all_of(
+            result.waveform.begin(), result.waveform.end(), [](float value) {
+              return std::isfinite(value);
+            })) {
+      throw std::runtime_error(
+          "Supertonic synthesis produced an empty or nonfinite waveform");
+    }
+    return result;
+  }
+
+ private:
+  struct ChunkResult {
+    std::vector<float> waveform;
+    float duration_seconds;
+  };
+
+  std::vector<EValue> execute(
+      const char* method,
+      const std::vector<EValue>& inputs) {
+    auto outputs = module_->execute(method, inputs);
+    if (!outputs.ok()) {
+      throw std::runtime_error(std::string("PTE method failed: ") + method);
+    }
+    ::mlx::core::synchronize();
+    return std::move(outputs.get());
+  }
+
+  ChunkResult synthesize_chunk(
+      const std::string& text,
+      const std::string& language,
+      const VoiceStyle& style,
+      float speed,
+      PortableNormalGenerator& generator) {
+    const auto size = [](int64_t value) {
+      return static_cast<executorch::aten::SizesType>(value);
+    };
+    TextBatch text_batch = processor_.process({text}, {language});
+    const int64_t text_length = text_batch.shape[1];
+    if (text_length > metadata_.max_text_length) {
+      throw std::invalid_argument(
+          "preprocessed text exceeds exported text bound");
+    }
+    auto text_mask_half = to_half(text_batch.mask);
+    auto style_dp_half = to_half(style.dp);
+    auto ids_tensor = from_blob(
+        text_batch.ids.data(), {1, size(text_length)}, ScalarType::Long);
+    auto dp_tensor =
+        from_blob(style_dp_half.data(), {1, 8, 16}, ScalarType::Half);
+    auto text_mask_tensor = from_blob(
+        text_mask_half.data(), {1, 1, size(text_length)}, ScalarType::Half);
+    auto duration_outputs = execute(
+        "duration_predictor",
+        {EValue(ids_tensor), EValue(dp_tensor), EValue(text_mask_tensor)});
+    if (duration_outputs.size() != 1 || !duration_outputs[0].isTensor()) {
+      throw std::runtime_error("duration_predictor must return one tensor");
+    }
+    const auto duration_values = copy_half_tensor(
+        duration_outputs[0].toTensor(), {1}, "duration_predictor");
+    const float duration =
+        adjust_duration_for_speed(duration_values.front(), speed);
+    const LatentLayout layout = latent_layout(
+        duration,
+        metadata_.sample_rate,
+        metadata_.base_chunk_size,
+        metadata_.chunk_compress_factor,
+        metadata_.max_latent_length);
+
+    auto style_ttl_half = to_half(style.ttl);
+    auto ttl_tensor =
+        from_blob(style_ttl_half.data(), {1, 50, 256}, ScalarType::Half);
+    auto encoder_outputs = execute(
+        "text_encoder",
+        {EValue(ids_tensor), EValue(ttl_tensor), EValue(text_mask_tensor)});
+    if (encoder_outputs.size() != 1 || !encoder_outputs[0].isTensor()) {
+      throw std::runtime_error("text_encoder must return one tensor");
+    }
+    std::vector<float> text_embedding = copy_half_tensor(
+        encoder_outputs[0].toTensor(), {1, 256, text_length}, "text_encoder");
+
+    const size_t latent_channels =
+        static_cast<size_t>(metadata_.latent_channels);
+    const size_t latent_length = static_cast<size_t>(layout.latent_length);
+    if (latent_channels > std::numeric_limits<size_t>::max() / latent_length) {
+      throw std::overflow_error("latent tensor size is unrepresentable");
+    }
+    std::vector<float> latent(latent_channels * latent_length);
+    for (float& value : latent) {
+      value = generator.normal();
+    }
+    std::vector<float> latent_mask(layout.latent_length, 1.0f);
+    const int64_t valid_latents =
+        (layout.waveform_samples +
+         metadata_.base_chunk_size * metadata_.chunk_compress_factor - 1) /
+        (metadata_.base_chunk_size * metadata_.chunk_compress_factor);
+    for (int64_t position = valid_latents; position < layout.latent_length;
+         ++position) {
+      latent_mask[position] = 0.0f;
+      for (int64_t channel = 0; channel < metadata_.latent_channels;
+           ++channel) {
+        latent[channel * layout.latent_length + position] = 0.0f;
+      }
+    }
+    std::vector<float> current_step{0.0f};
+    std::vector<float> total_step{static_cast<float>(metadata_.flow_steps)};
+
+    for (int64_t step = 0; step < metadata_.flow_steps; ++step) {
+      current_step[0] = static_cast<float>(step);
+      VectorInputs domain{
+          domain_view(
+              {1, metadata_.latent_channels, layout.latent_length}, latent),
+          domain_view({1, 256, text_length}, text_embedding),
+          domain_view({1, 50, 256}, style.ttl),
+          domain_view({1, 1, layout.latent_length}, latent_mask),
+          domain_view({1, 1, text_length}, text_batch.mask),
+          domain_view({1}, current_step),
+          domain_view({1}, total_step)};
+      auto latent_half = to_half(latent);
+      auto embedding_half = to_half(text_embedding);
+      auto latent_mask_half = to_half(latent_mask);
+      auto current_half = to_half(current_step);
+      auto total_half = to_half(total_step);
+      auto latent_tensor = from_blob(
+          latent_half.data(),
+          {1, size(metadata_.latent_channels), size(layout.latent_length)},
+          ScalarType::Half);
+      auto embedding_tensor = from_blob(
+          embedding_half.data(), {1, 256, size(text_length)}, ScalarType::Half);
+      auto latent_mask_tensor = from_blob(
+          latent_mask_half.data(),
+          {1, 1, size(layout.latent_length)},
+          ScalarType::Half);
+      auto current_tensor =
+          from_blob(current_half.data(), {1}, ScalarType::Half);
+      auto total_tensor = from_blob(total_half.data(), {1}, ScalarType::Half);
+      std::vector<EValue> vector_outputs;
+      invoke_validated_vector(domain, metadata_, [&] {
+        vector_outputs = execute(
+            "vector_estimator",
+            {EValue(latent_tensor),
+             EValue(embedding_tensor),
+             EValue(ttl_tensor),
+             EValue(latent_mask_tensor),
+             EValue(text_mask_tensor),
+             EValue(current_tensor),
+             EValue(total_tensor)});
+      });
+      if (vector_outputs.size() != 1 || !vector_outputs[0].isTensor()) {
+        throw std::runtime_error("vector_estimator must return one tensor");
+      }
+      latent = copy_half_tensor(
+          vector_outputs[0].toTensor(),
+          {1, metadata_.latent_channels, layout.latent_length},
+          "vector_estimator");
+    }
+
+    auto latent_half = to_half(latent);
+    auto latent_tensor = from_blob(
+        latent_half.data(),
+        {1, size(metadata_.latent_channels), size(layout.latent_length)},
+        ScalarType::Half);
+    auto vocoder_outputs = execute("vocoder", {EValue(latent_tensor)});
+    if (vocoder_outputs.size() != 1 || !vocoder_outputs[0].isTensor()) {
+      throw std::runtime_error("vocoder must return one tensor");
+    }
+    const int64_t chunk_size =
+        metadata_.base_chunk_size * metadata_.chunk_compress_factor;
+    if (layout.latent_length >
+        std::numeric_limits<int64_t>::max() / chunk_size) {
+      throw std::overflow_error("vocoder sample count is unrepresentable");
+    }
+    const int64_t produced_samples = layout.latent_length * chunk_size;
+    auto waveform = copy_half_tensor(
+        vocoder_outputs[0].toTensor(), {1, produced_samples}, "vocoder");
+    return {std::move(waveform), duration};
+  }
+
+  UnicodeProcessor processor_;
+  std::unique_ptr<Module> module_;
+  LoadBackendOptionsMap load_options_;
+  RuntimeMetadata metadata_;
+};
+
+SupertonicRunner::SupertonicRunner(
+    const std::string& pte_path,
+    const std::string& unicode_indexer_path)
+    : impl_(std::make_unique<Impl>(pte_path, unicode_indexer_path)) {}
+
+SupertonicRunner::~SupertonicRunner() = default;
+
+const RuntimeMetadata& SupertonicRunner::metadata() const {
+  return impl_->metadata();
+}
+
+SynthesisResult SupertonicRunner::synthesize(const SynthesisOptions& options) {
+  return impl_->synthesize(options);
+}
+
+#endif
+
+} // namespace supertonic

--- a/examples/models/supertonic/runtime/supertonic_runner.h
+++ b/examples/models/supertonic/runtime/supertonic_runner.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "style_loader.h"
+#include "text_processor.h"
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace supertonic {
+
+struct RuntimeMetadata {
+  int64_t sample_rate = 44100;
+  int64_t base_chunk_size = 512;
+  int64_t chunk_compress_factor = 6;
+  int64_t flow_steps = 5;
+  int64_t text_vocabulary_size = 0;
+  int64_t latent_dim = 24;
+  int64_t latent_channels = 144;
+  int64_t max_text_length = 512;
+  int64_t max_latent_length = 512;
+  int64_t batch_size = 1;
+  std::string activation_dtype = "float16";
+  bool dynamic_shapes = true;
+};
+
+enum class MetadataValueType {
+  Integer,
+  Boolean,
+  String,
+};
+
+struct MetadataValue {
+  MetadataValueType type;
+  int64_t integer_value = 0;
+  bool boolean_value = false;
+  std::string string_value;
+
+  static MetadataValue integer(int64_t value);
+  static MetadataValue boolean(bool value);
+  static MetadataValue string(std::string value);
+};
+
+RuntimeMetadata validate_metadata_contract(
+    const std::set<std::string>& method_names,
+    const std::map<std::string, MetadataValue>& metadata_values);
+
+enum class TensorDtype {
+  Float16,
+  Other,
+};
+
+struct TensorView {
+  std::vector<int64_t> shape;
+  const std::vector<float>* values;
+  bool contiguous;
+  TensorDtype dtype;
+};
+
+struct VectorInputs {
+  TensorView noisy_latent;
+  TensorView text_emb;
+  TensorView style_ttl;
+  TensorView latent_mask;
+  TensorView text_mask;
+  TensorView current_step;
+  TensorView total_step;
+};
+
+void validate_vector_inputs(
+    const VectorInputs& inputs,
+    const RuntimeMetadata& metadata);
+void invoke_validated_vector(
+    const VectorInputs& inputs,
+    const RuntimeMetadata& metadata,
+    const std::function<void()>& executor);
+
+class PortableNormalGenerator {
+ public:
+  explicit PortableNormalGenerator(uint64_t seed);
+  float normal();
+
+ private:
+  uint64_t next();
+  double uniform();
+  uint64_t state_;
+};
+
+struct LatentLayout {
+  int64_t waveform_samples;
+  int64_t latent_length;
+};
+
+float adjust_duration_for_speed(float duration, float speed);
+LatentLayout latent_layout(
+    float duration,
+    int64_t sample_rate,
+    int64_t base_chunk_size,
+    int64_t chunk_compress_factor,
+    int64_t max_latent_length);
+std::vector<float> trim_waveform(
+    const std::vector<float>& waveform,
+    float duration,
+    int64_t sample_rate);
+float accumulate_chunk_durations(
+    const std::vector<float>& durations,
+    float inter_chunk_silence);
+std::vector<float> combine_vocoder_chunks(
+    const std::vector<std::vector<float>>& waveforms,
+    const std::vector<float>& durations,
+    int64_t sample_rate,
+    float inter_chunk_silence);
+
+struct SynthesisOptions {
+  std::string text;
+  std::string language = "en";
+  std::vector<std::string> voice_style_paths;
+  float speed = 1.05f;
+  uint64_t seed = 42;
+  float inter_chunk_silence = 0.3f;
+};
+
+struct SynthesisResult {
+  std::vector<float> waveform;
+  float duration_seconds = 0.0f;
+  double elapsed_seconds = 0.0;
+};
+
+class SupertonicRunner {
+ public:
+  SupertonicRunner(
+      const std::string& pte_path,
+      const std::string& unicode_indexer_path);
+  ~SupertonicRunner();
+
+  SupertonicRunner(const SupertonicRunner&) = delete;
+  SupertonicRunner& operator=(const SupertonicRunner&) = delete;
+
+  const RuntimeMetadata& metadata() const;
+  SynthesisResult synthesize(const SynthesisOptions& options);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace supertonic

--- a/examples/models/supertonic/runtime/tests/run_integration.cmake
+++ b/examples/models/supertonic/runtime/tests/run_integration.cmake
@@ -1,0 +1,58 @@
+foreach(required RUNNER PTE ASSET_DIR STYLE OUTPUT)
+  if(NOT DEFINED ${required})
+    message(FATAL_ERROR "Missing integration variable: ${required}")
+  endif()
+endforeach()
+
+if(NOT EXISTS "${PTE}"
+   OR NOT EXISTS "${ASSET_DIR}/onnx/unicode_indexer.json"
+   OR NOT EXISTS "${STYLE}"
+)
+  message("SKIP: Supertonic integration assets are unavailable")
+  return()
+endif()
+
+execute_process(
+  COMMAND
+    "${RUNNER}" "--pte=${PTE}" "--asset_dir=${ASSET_DIR}"
+    "--voice_style=${STYLE}" "--text=Hello." "--language=en" "--speed=1.05"
+    "--seed=42" "--output=${OUTPUT}"
+  RESULT_VARIABLE runner_result
+  OUTPUT_VARIABLE runner_output
+  ERROR_VARIABLE runner_error
+)
+if(NOT runner_result EQUAL 0)
+  message(
+    FATAL_ERROR
+      "Supertonic runner failed (${runner_result})\n${runner_output}${runner_error}"
+  )
+endif()
+
+file(SIZE "${OUTPUT}" output_size)
+if(output_size LESS 46)
+  message(FATAL_ERROR "Integration WAV is too small: ${output_size} bytes")
+endif()
+file(READ "${OUTPUT}" wav_hex HEX)
+string(TOLOWER "${wav_hex}" wav_hex)
+string(SUBSTRING "${wav_hex}" 0 8 riff_header)
+string(SUBSTRING "${wav_hex}" 16 8 wave_header)
+if(NOT riff_header STREQUAL "52494646" OR NOT wave_header STREQUAL "57415645")
+  message(FATAL_ERROR "Integration WAV lacks RIFF/WAVE header")
+endif()
+string(SUBSTRING "${wav_hex}" 44 4 channel_hex)
+string(SUBSTRING "${wav_hex}" 48 8 sample_rate_hex)
+string(SUBSTRING "${wav_hex}" 68 4 bits_hex)
+if(NOT channel_hex STREQUAL "0100"
+   OR NOT sample_rate_hex STREQUAL "44ac0000"
+   OR NOT bits_hex STREQUAL "1000"
+)
+  message(
+    FATAL_ERROR
+      "Integration WAV is not mono 44.1 kHz PCM16: channels=${channel_hex}, rate=${sample_rate_hex}, bits=${bits_hex}"
+  )
+endif()
+string(SUBSTRING "${wav_hex}" 88 -1 pcm_hex)
+if(pcm_hex MATCHES "^0*$")
+  message(FATAL_ERROR "Integration WAV PCM payload is entirely zero")
+endif()
+message("${runner_output}")

--- a/examples/models/supertonic/runtime/tests/supertonic_runtime_test.cpp
+++ b/examples/models/supertonic/runtime/tests/supertonic_runtime_test.cpp
@@ -1,0 +1,686 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../style_loader.h"
+#include "../supertonic_runner.h"
+#include "../text_processor.h"
+#include "../wav_writer.h"
+
+#include <nlohmann/json.hpp>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <random>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace supertonic;
+
+void check(bool condition, const std::string& message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+template <typename Function>
+void check_throws(Function&& function, const std::string& expected) {
+  try {
+    function();
+  } catch (const std::exception& error) {
+    check(
+        std::string(error.what()).find(expected) != std::string::npos,
+        "unexpected error: " + std::string(error.what()));
+    return;
+  }
+  throw std::runtime_error("expected error containing: " + expected);
+}
+
+class TempDirectory {
+ public:
+  TempDirectory() {
+    std::random_device random;
+    for (int attempt = 0; attempt < 100; ++attempt) {
+      path_ = std::filesystem::temp_directory_path() /
+          ("supertonic-runtime-" + std::to_string(random()) + "-" +
+           std::to_string(random()));
+      std::error_code error;
+      if (std::filesystem::create_directory(path_, error)) {
+        return;
+      }
+    }
+    throw std::runtime_error("failed to create temporary test directory");
+  }
+
+  ~TempDirectory() {
+    std::error_code error;
+    std::filesystem::remove_all(path_, error);
+  }
+
+  std::filesystem::path path(const std::string& name) const {
+    return path_ / name;
+  }
+
+ private:
+  std::filesystem::path path_;
+};
+
+TempDirectory& temp_directory() {
+  static TempDirectory directory;
+  return directory;
+}
+
+std::filesystem::path temp_path(const std::string& name) {
+  return temp_directory().path(name);
+}
+
+void write_ascii_indexer(const std::filesystem::path& path) {
+  std::ofstream file(path);
+  file << "[";
+  for (int index = 0; index < 1024; ++index) {
+    if (index != 0) {
+      file << ",";
+    }
+    file << index;
+  }
+  file << "]";
+}
+
+std::string style_json(float ttl_value, float dp_value) {
+  std::string result = R"({"style_ttl":{"dims":[1,50,256],"data":[)";
+  for (int index = 0; index < 50 * 256; ++index) {
+    result += (index == 0 ? "" : ",") + std::to_string(ttl_value);
+  }
+  result += R"(]},"style_dp":{"dims":[1,8,16],"data":[)";
+  for (int index = 0; index < 8 * 16; ++index) {
+    result += (index == 0 ? "" : ",") + std::to_string(dp_value);
+  }
+  return result + "]}}";
+}
+
+std::string nested_style_json(float value, bool ragged_dp = false) {
+  std::string result = R"({"style_ttl":{"dims":[1,50,256],"data":[[)";
+  for (int row = 0; row < 50; ++row) {
+    result += row == 0 ? "[" : ",[";
+    for (int column = 0; column < 256; ++column) {
+      result += (column == 0 ? "" : ",") + std::to_string(value);
+    }
+    result += "]";
+  }
+  result += R"(]]},"style_dp":{"dims":[1,8,16],"data":[[)";
+  for (int row = 0; row < 8; ++row) {
+    result += row == 0 ? "[" : ",[";
+    const int columns = ragged_dp && row == 7 ? 15 : 16;
+    for (int column = 0; column < columns; ++column) {
+      result += (column == 0 ? "" : ",") + std::to_string(value);
+    }
+    result += "]";
+  }
+  return result + "]]}}";
+}
+
+TensorView view(
+    std::vector<int64_t> shape,
+    const std::vector<float>& values,
+    bool contiguous = true,
+    TensorDtype dtype = TensorDtype::Float16) {
+  return TensorView{std::move(shape), &values, contiguous, dtype};
+}
+
+void test_preprocessing() {
+  check(
+      preprocess_text("Caf\xC3\xA9", "en") == "<en>Cafe\xCC\x81.</en>",
+      "NFKD preprocessing mismatch");
+  check(
+      preprocess_text(
+          "\xE2\x80\x9CHello\xE2\x80\x9D \xE2\x80\x94 world_"
+          "\xF0\x9F\x99\x82 @ x \xE2\x99\xA5 e.g., i.e., [done]",
+          "en") ==
+          "<en>\"Hello\" - world at x for example, that is, done.</en>",
+      "cleanup preprocessing mismatch");
+  check_throws(
+      [] { (void)preprocess_text("hello", "xx"); }, "Invalid language: xx");
+  check(
+      preprocess_text(
+          "one\xC2\xA0"
+          "two\xE2\x80\x83"
+          "three\xE2\x80\xA8"
+          "four",
+          "en") == "<en>one two three four.</en>",
+      "Unicode whitespace normalization mismatch");
+  check(
+      preprocess_text("word\t,", "en") == "<en>word ,</en>",
+      "tab-before-punctuation ordering mismatch");
+  check(
+      preprocess_text(
+          "word\xE2\x80\xA8"
+          ",",
+          "en") == "<en>word ,</en>",
+      "Unicode-whitespace-before-punctuation ordering mismatch");
+  check(
+      preprocess_text(
+          "one\ttwo\xE2\x80\xA8"
+          "three",
+          "en") == "<en>one two three.</en>",
+      "between-word Unicode whitespace mismatch");
+
+  const auto indexer = temp_path("indexer.json");
+  write_ascii_indexer(indexer);
+  UnicodeProcessor processor(indexer.string());
+  processor.configure_vocabulary(1024);
+  auto batch = processor.process({"A", "Hi!"}, {"en", "en"});
+  check(batch.shape == std::vector<int64_t>({2, 12}), "text shape mismatch");
+  check(
+      batch.ids[0] == 60 && batch.ids[10] == 62 && batch.ids[11] == 0,
+      "text ids mismatch");
+  check(batch.mask[10] == 1.0f && batch.mask[11] == 0.0f, "text mask mismatch");
+  check_throws([&] { (void)processor.process({}, {}); }, "at least one text");
+  check_throws(
+      [&] { (void)processor.process({"a", "b"}, {"en"}); }, "same cardinality");
+  const auto unsupported_indexer = temp_path("unsupported-indexer.json");
+  write_ascii_indexer(unsupported_indexer);
+  {
+    std::ifstream input(unsupported_indexer);
+    nlohmann::json values = nlohmann::json::parse(input);
+    values[65] = -1;
+    std::ofstream(unsupported_indexer) << values;
+  }
+  UnicodeProcessor unsupported(unsupported_indexer.string());
+  unsupported.configure_vocabulary(1024);
+  check_throws(
+      [&] { (void)unsupported.process({"A"}, {"en"}); },
+      "unsupported Unicode codepoint 65");
+  check_throws(
+      [&] { processor.configure_vocabulary(100); },
+      "outside the text vocabulary");
+
+  const auto invalid_type_indexer = temp_path("invalid-type-indexer.json");
+  write_ascii_indexer(invalid_type_indexer);
+  {
+    std::ifstream input(invalid_type_indexer);
+    nlohmann::json values = nlohmann::json::parse(input);
+    values[65] = true;
+    std::ofstream(invalid_type_indexer) << values;
+  }
+  check_throws(
+      [&] { UnicodeProcessor invalid(invalid_type_indexer.string()); },
+      "tokens must be integers");
+
+  std::filesystem::remove(indexer);
+  std::filesystem::remove(unsupported_indexer);
+  std::filesystem::remove(invalid_type_indexer);
+}
+
+void test_chunking() {
+  const std::string first(60, 'x');
+  const std::string second(60, 'y');
+  const std::string third(10, 'z');
+  const std::string text = first + ". " + second + ". " + third + ".";
+  const auto korean = chunk_text_for_language(text, "ko");
+  check(korean.size() == 2, "Korean threshold did not split");
+  check(korean[0] == first + ".", "first Korean chunk mismatch");
+  check(
+      korean[1] == second + ". " + third + ".", "second Korean chunk mismatch");
+  check(
+      chunk_text_for_language(text, "en") == std::vector<std::string>({text}),
+      "English threshold split unexpectedly");
+  const std::string oversized(301, 'q');
+  check(
+      chunk_text_for_language(oversized + ".", "en") ==
+          std::vector<std::string>({oversized + "."}),
+      "soft limit split one sentence");
+  check(
+      chunk_text("Dr. Smith left. Next sentence.", 20) ==
+          std::vector<std::string>({"Dr. Smith left.", "Next sentence."}),
+      "abbreviation sentence split mismatch");
+  const auto repeat = [](const std::string& value, size_t count) {
+    std::string result;
+    for (size_t index = 0; index < count; ++index) {
+      result += value;
+    }
+    return result;
+  };
+  const std::string ga = repeat("\xEA\xB0\x80", 60);
+  const std::string na = repeat("\xEB\x82\x98", 60);
+  const std::string da = repeat("\xEB\x8B\xA4", 10);
+  check(
+      chunk_text_for_language(ga + ". " + na + ". " + da + ".", "ko") ==
+          std::vector<std::string>({ga + ".", na + ". " + da + "."}),
+      "chunk threshold must count Unicode characters");
+  const std::string a = repeat("\xE3\x81\x82", 60) + "\xE3\x80\x82";
+  const std::string i = repeat("\xE3\x81\x84", 59) + "\xEF\xBC\x81\xEF\xBC\x9F";
+  const std::string u = repeat("\xE3\x81\x86", 10) + "\xEF\xBC\x9F";
+  check(
+      chunk_text_for_language(a + i + u, "ja") ==
+          std::vector<std::string>({a, i + " " + u}),
+      "CJK sentence terminators must split without spaces");
+}
+
+void test_style_loading(const std::string& published_style_path) {
+  const auto nested = temp_path("style-nested.json");
+  std::ofstream(nested) << nested_style_json(5.0f);
+  const VoiceStyle published = load_voice_style(nested.string());
+  check(
+      published.ttl.front() == 5.0f && published.dp.back() == 5.0f,
+      "published nested style data mismatch");
+  check_throws(
+      [] { (void)require_single_voice_style_path({}); },
+      "exactly one voice style");
+  check_throws(
+      [] { (void)require_single_voice_style_path({"a.json", "b.json"}); },
+      "exactly one voice style");
+
+  const auto flat = temp_path("style-flat.json");
+  std::ofstream(flat) << style_json(1.0f, 2.0f);
+  check_throws(
+      [&] { (void)load_voice_style(flat.string()); },
+      "style_ttl.data must have nested shape [1, 50, 256]");
+
+  const auto ragged = temp_path("style-ragged.json");
+  std::ofstream(ragged) << nested_style_json(1.0f, true);
+  check_throws(
+      [&] { (void)load_voice_style(ragged.string()); },
+      "style_dp.data must have nested shape [1, 8, 16]");
+
+  const auto overflow = temp_path("style-overflow.json");
+  std::ofstream(overflow) << nested_style_json(65505.0f);
+  check_throws(
+      [&] { (void)load_voice_style(overflow.string()); }, "finite FP16 range");
+
+  if (!published_style_path.empty()) {
+    const VoiceStyle actual = load_voice_style(published_style_path);
+    check(
+        actual.ttl.size() == 50 * 256 && actual.dp.size() == 8 * 16,
+        "published voice style tensor sizes mismatch");
+    const auto all_finite = [](const std::vector<float>& values) {
+      return std::all_of(values.begin(), values.end(), [](float value) {
+        return std::isfinite(value);
+      });
+    };
+    check(
+        all_finite(actual.ttl) && all_finite(actual.dp),
+        "published voice style contains nonfinite values");
+  }
+}
+
+void test_portable_normal_generator() {
+  PortableNormalGenerator generator(42);
+  const std::vector<float> expected = {
+      -4.44757128f,
+      0.608476877f,
+      -1.46980774f,
+      -0.868334234f,
+      -0.509428322f,
+      0.75734967f,
+      -0.881577611f,
+      -0.204967409f};
+  for (float value : expected) {
+    check(
+        std::abs(generator.normal() - value) < 1e-6f,
+        "seed-42 normal golden mismatch");
+  }
+  PortableNormalGenerator repeated(42);
+  check(
+      repeated.normal() == expected.front(), "normal generator not repeatable");
+}
+
+std::map<std::string, MetadataValue> valid_metadata_values() {
+  return {
+      {"get_sample_rate", MetadataValue::integer(44100)},
+      {"get_base_chunk_size", MetadataValue::integer(512)},
+      {"get_chunk_compress_factor", MetadataValue::integer(6)},
+      {"get_flow_steps", MetadataValue::integer(5)},
+      {"get_text_vocabulary_size", MetadataValue::integer(8322)},
+      {"get_latent_dim", MetadataValue::integer(24)},
+      {"get_latent_channels", MetadataValue::integer(144)},
+      {"get_max_text_length", MetadataValue::integer(512)},
+      {"get_max_latent_length", MetadataValue::integer(512)},
+      {"get_batch_size", MetadataValue::integer(1)},
+      {"get_activation_dtype", MetadataValue::string("float16")},
+      {"enable_dynamic_shape", MetadataValue::boolean(true)},
+  };
+}
+
+std::set<std::string> valid_method_names() {
+  return {
+      "duration_predictor",
+      "text_encoder",
+      "vector_estimator",
+      "vocoder",
+      "get_sample_rate",
+      "get_base_chunk_size",
+      "get_chunk_compress_factor",
+      "get_flow_steps",
+      "get_text_vocabulary_size",
+      "get_latent_dim",
+      "get_latent_channels",
+      "get_max_text_length",
+      "get_max_latent_length",
+      "get_batch_size",
+      "get_activation_dtype",
+      "enable_dynamic_shape",
+  };
+}
+
+void test_metadata_contract() {
+  const RuntimeMetadata metadata =
+      validate_metadata_contract(valid_method_names(), valid_metadata_values());
+  check(
+      metadata.sample_rate == 44100 && metadata.latent_channels == 144 &&
+          metadata.text_vocabulary_size == 8322,
+      "valid metadata contract mismatch");
+
+  auto missing_methods = valid_method_names();
+  missing_methods.erase("vocoder");
+  check_throws(
+      [&] {
+        (void)validate_metadata_contract(
+            missing_methods, valid_metadata_values());
+      },
+      "missing methods: vocoder");
+
+  missing_methods = valid_method_names();
+  missing_methods.erase("get_text_vocabulary_size");
+  check_throws(
+      [&] {
+        (void)validate_metadata_contract(
+            missing_methods, valid_metadata_values());
+      },
+      "missing methods: get_text_vocabulary_size");
+
+  auto unexpected_methods = valid_method_names();
+  unexpected_methods.insert("forward");
+  check_throws(
+      [&] {
+        (void)validate_metadata_contract(
+            unexpected_methods, valid_metadata_values());
+      },
+      "unexpected methods: forward");
+
+  auto wrong_type = valid_metadata_values();
+  wrong_type["get_sample_rate"] = MetadataValue::boolean(true);
+  check_throws(
+      [&] {
+        (void)validate_metadata_contract(valid_method_names(), wrong_type);
+      },
+      "get_sample_rate must be an integer");
+
+  auto invalid_vocabulary = valid_metadata_values();
+  invalid_vocabulary["get_text_vocabulary_size"] = MetadataValue::integer(0);
+  check_throws(
+      [&] {
+        (void)validate_metadata_contract(
+            valid_method_names(), invalid_vocabulary);
+      },
+      "PTE metadata is incompatible");
+
+  auto missing_value = valid_metadata_values();
+  missing_value.erase("get_flow_steps");
+  check_throws(
+      [&] {
+        (void)validate_metadata_contract(valid_method_names(), missing_value);
+      },
+      "missing metadata value: get_flow_steps");
+}
+
+void test_vector_domain_validation() {
+  RuntimeMetadata metadata;
+  metadata.latent_channels = 144;
+  metadata.max_text_length = 512;
+  metadata.max_latent_length = 512;
+
+  std::vector<float> latent(144 * 3, 0.5f);
+  std::vector<float> text_emb(256 * 4, 0.5f);
+  std::vector<float> style(50 * 256, 0.5f);
+  std::vector<float> latent_mask(3, 1.0f);
+  std::vector<float> text_mask(4, 1.0f);
+  std::vector<float> current_step{0.0f};
+  std::vector<float> total_step{5.0f};
+  VectorInputs inputs{
+      view({1, 144, 3}, latent),
+      view({1, 256, 4}, text_emb),
+      view({1, 50, 256}, style),
+      view({1, 1, 3}, latent_mask),
+      view({1, 1, 4}, text_mask),
+      view({1}, current_step),
+      view({1}, total_step)};
+  validate_vector_inputs(inputs, metadata);
+
+  VectorInputs invalid = inputs;
+  invalid.latent_mask.shape = {1, 1, 2};
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "latent lengths must match");
+  invalid = inputs;
+  std::vector<float> zeros(3, 0.0f);
+  invalid.latent_mask.values = &zeros;
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "latent_mask must contain a valid position");
+  invalid = inputs;
+  std::vector<float> no_text(4, 0.0f);
+  invalid.text_mask.values = &no_text;
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "text_mask must contain a valid position");
+  invalid = inputs;
+  std::vector<float> nan_step{std::numeric_limits<float>::quiet_NaN()};
+  invalid.current_step.values = &nan_step;
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "current_step must be finite");
+  invalid = inputs;
+  std::vector<float> zero_step{0.0f};
+  invalid.total_step.values = &zero_step;
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "total_step must be finite and positive");
+  invalid = inputs;
+  invalid.noisy_latent.shape = {2, 144, 3};
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "batch size must be 1");
+  invalid = inputs;
+  invalid.text_emb.contiguous = false;
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); }, "must be contiguous");
+  invalid = inputs;
+  invalid.noisy_latent.shape = {1, 144, 0};
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "latent length is outside");
+  invalid = inputs;
+  invalid.text_emb.shape = {1, 256, 513};
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "text length is outside");
+  invalid = inputs;
+  invalid.style_ttl.dtype = TensorDtype::Other;
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "style_ttl must have dtype float16");
+  invalid = inputs;
+  std::vector<float> nonfinite_latent = latent;
+  nonfinite_latent.front() = std::numeric_limits<float>::infinity();
+  invalid.noisy_latent.values = &nonfinite_latent;
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "noisy_latent values must be within the finite FP16 range");
+  invalid = inputs;
+  std::vector<float> infinite_total{std::numeric_limits<float>::infinity()};
+  invalid.total_step.values = &infinite_total;
+  check_throws(
+      [&] { validate_vector_inputs(invalid, metadata); },
+      "total_step must be finite and positive");
+
+  bool executor_called = false;
+  invalid = inputs;
+  invalid.current_step.values = &nan_step;
+  check_throws(
+      [&] {
+        invoke_validated_vector(
+            invalid, metadata, [&] { executor_called = true; });
+      },
+      "current_step must be finite");
+  check(!executor_called, "invalid vector input reached executor callback");
+  invoke_validated_vector(inputs, metadata, [&] { executor_called = true; });
+  check(executor_called, "valid vector input did not reach executor callback");
+}
+
+void test_duration_and_trim_helpers() {
+  const LatentLayout layout = latent_layout(1.0f, 44100, 512, 6, 512);
+  check(layout.waveform_samples == 44100, "waveform sample count mismatch");
+  check(layout.latent_length == 15, "latent length mismatch");
+  check(
+      adjust_duration_for_speed(2.1f, 1.05f) == 2.0f,
+      "speed adjustment mismatch");
+  check_throws(
+      [] { (void)adjust_duration_for_speed(1.0f, 0.0f); },
+      "speed must be finite and positive");
+  const auto trimmed = trim_waveform({1, 2, 3, 4}, 0.00005f, 44100);
+  check(trimmed == std::vector<float>({1, 2}), "waveform trim mismatch");
+  const auto combined = combine_vocoder_chunks(
+      {{1.0f, 2.0f, 9.0f, 9.0f}, {3.0f, 4.0f, 8.0f}}, {0.3f, 0.2f}, 10, 0.1f);
+  check(
+      combined == std::vector<float>({1, 2, 9, 9, 0, 3}),
+      "multi-chunk full-output concatenation mismatch");
+  const std::vector<float> boundary_durations(15, 0.1f);
+  check(
+      accumulate_chunk_durations(boundary_durations, 0.3f) ==
+          5.700000762939453f,
+      "duration accumulation must round after every float32-like chunk add");
+  const std::vector<std::vector<float>> boundary_waveforms(
+      15, std::vector<float>(20000, 1.0f));
+  check(
+      combine_vocoder_chunks(
+          boundary_waveforms, boundary_durations, 44100, 0.3f)
+              .size() == 251370,
+      "boundary duration accumulation produced the wrong final sample count");
+  check_throws(
+      [] {
+        (void)adjust_duration_for_speed(
+            std::numeric_limits<float>::max(),
+            std::numeric_limits<float>::min());
+      },
+      "adjusted duration is unrepresentable");
+  check_throws(
+      [] {
+        (void)latent_layout(
+            std::numeric_limits<float>::max(), 44100, 512, 6, 512);
+      },
+      "sample count is unrepresentable");
+  check_throws(
+      [] { (void)latent_layout(1.0f, 44100, 512, 6, 2); },
+      "exceeds exported latent bound");
+  check_throws(
+      [] {
+        (void)combine_vocoder_chunks(
+            {{1.0f}, {2.0f}},
+            {0.1f, 0.1f},
+            std::numeric_limits<int64_t>::max(),
+            std::numeric_limits<float>::max());
+      },
+      "silence sample count is unrepresentable");
+  check_throws(
+      [] {
+        (void)trim_waveform(
+            {1.0f},
+            std::numeric_limits<float>::max(),
+            std::numeric_limits<int64_t>::max());
+      },
+      "trim sample count is unrepresentable");
+}
+
+void test_wav_writer() {
+  const WavLayout layout = validate_wav_layout(5, 44100, 1);
+  check(
+      layout.data_bytes == 10 && layout.riff_size == 46 &&
+          layout.block_align == 2 && layout.byte_rate == 88200,
+      "WAV layout mismatch");
+  check_throws(
+      [] { (void)validate_wav_layout(2, 44100, 0); }, "channels must be in");
+  check_throws(
+      [] { (void)validate_wav_layout(32768, 44100, 32768); }, "block align");
+  check_throws(
+      [] { (void)validate_wav_layout(2, std::numeric_limits<int>::max(), 2); },
+      "byte rate");
+  check_throws(
+      [] {
+        (void)validate_wav_layout(std::numeric_limits<size_t>::max(), 44100, 1);
+      },
+      "data size");
+  check_throws(
+      [] { (void)validate_wav_layout(3, 44100, 2); }, "whole number of frames");
+  check(
+      !write_pcm16_wav(temp_directory().path("").string(), {0.0f}, 44100),
+      "WAV writer accepted a directory as a file");
+
+  const auto path = temp_path("audio.wav");
+  check(
+      write_pcm16_wav(path.string(), {-2.0f, -1.0f, 0.0f, 1.0f, 2.0f}, 44100),
+      "WAV write failed");
+  std::ifstream file(path, std::ios::binary);
+  const std::vector<unsigned char> bytes(
+      std::istreambuf_iterator<char>(file), {});
+  check(bytes.size() == 54, "WAV size mismatch");
+  check(
+      std::string(bytes.begin(), bytes.begin() + 4) == "RIFF", "missing RIFF");
+  check(
+      std::string(bytes.begin() + 8, bytes.begin() + 12) == "WAVE",
+      "missing WAVE");
+  auto u16 = [&](size_t offset) {
+    return static_cast<uint16_t>(
+        bytes[offset] | (static_cast<uint16_t>(bytes[offset + 1]) << 8));
+  };
+  auto u32 = [&](size_t offset) {
+    return static_cast<uint32_t>(
+        bytes[offset] | (static_cast<uint32_t>(bytes[offset + 1]) << 8) |
+        (static_cast<uint32_t>(bytes[offset + 2]) << 16) |
+        (static_cast<uint32_t>(bytes[offset + 3]) << 24));
+  };
+  check(u32(4) == 46 && u32(40) == 10, "RIFF sizes mismatch");
+  check(
+      u16(22) == 1 && u32(24) == 44100 && u16(34) == 16, "WAV format mismatch");
+  check(
+      static_cast<int16_t>(u16(44)) == -32768 &&
+          static_cast<int16_t>(u16(52)) == 32767,
+      "PCM clipping mismatch");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  try {
+    if (argc > 2) {
+      throw std::invalid_argument(
+          "usage: supertonic_runtime_test [published_voice_style.json]");
+    }
+    test_preprocessing();
+    test_chunking();
+    test_style_loading(argc == 2 ? argv[1] : "");
+    test_portable_normal_generator();
+    test_metadata_contract();
+    test_vector_domain_validation();
+    test_duration_and_trim_helpers();
+    test_wav_writer();
+    std::cout << "All Supertonic runtime helper tests passed\n";
+    return 0;
+  } catch (const std::exception& error) {
+    std::cerr << "FAILED: " << error.what() << "\n";
+    return 1;
+  }
+}

--- a/examples/models/supertonic/runtime/text_processor.cpp
+++ b/examples/models/supertonic/runtime/text_processor.cpp
@@ -1,0 +1,472 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "text_processor.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <stdexcept>
+#include <unordered_set>
+
+namespace supertonic {
+namespace {
+
+const std::unordered_set<std::string> kLanguages = {
+    "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et",
+    "fi", "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl",
+    "pt", "ro", "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na"};
+
+std::u32string decode_utf8(const std::string& text) {
+  std::u32string result;
+  for (size_t index = 0; index < text.size();) {
+    const auto first = static_cast<unsigned char>(text[index]);
+    char32_t codepoint;
+    size_t count;
+    if (first < 0x80) {
+      codepoint = first;
+      count = 1;
+    } else if ((first & 0xe0) == 0xc0) {
+      codepoint = first & 0x1f;
+      count = 2;
+    } else if ((first & 0xf0) == 0xe0) {
+      codepoint = first & 0x0f;
+      count = 3;
+    } else if ((first & 0xf8) == 0xf0) {
+      codepoint = first & 0x07;
+      count = 4;
+    } else {
+      throw std::runtime_error("text is not valid UTF-8");
+    }
+    if (index + count > text.size()) {
+      throw std::runtime_error("text is not valid UTF-8");
+    }
+    for (size_t offset = 1; offset < count; ++offset) {
+      const auto next = static_cast<unsigned char>(text[index + offset]);
+      if ((next & 0xc0) != 0x80) {
+        throw std::runtime_error("text is not valid UTF-8");
+      }
+      codepoint = (codepoint << 6) | (next & 0x3f);
+    }
+    result.push_back(codepoint);
+    index += count;
+  }
+  return result;
+}
+
+std::string encode_utf8(const std::u32string& text) {
+  std::string result;
+  for (char32_t codepoint : text) {
+    if (codepoint <= 0x7f) {
+      result.push_back(static_cast<char>(codepoint));
+    } else if (codepoint <= 0x7ff) {
+      result.push_back(static_cast<char>(0xc0 | (codepoint >> 6)));
+      result.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+    } else if (codepoint <= 0xffff) {
+      result.push_back(static_cast<char>(0xe0 | (codepoint >> 12)));
+      result.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
+      result.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+    } else {
+      result.push_back(static_cast<char>(0xf0 | (codepoint >> 18)));
+      result.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3f)));
+      result.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f)));
+      result.push_back(static_cast<char>(0x80 | (codepoint & 0x3f)));
+    }
+  }
+  return result;
+}
+
+std::string normalize_nfkd(const std::string& text) {
+  CFStringRef source = CFStringCreateWithBytes(
+      kCFAllocatorDefault,
+      reinterpret_cast<const UInt8*>(text.data()),
+      text.size(),
+      kCFStringEncodingUTF8,
+      false);
+  if (source == nullptr) {
+    throw std::runtime_error("text is not valid UTF-8");
+  }
+  CFMutableStringRef normalized =
+      CFStringCreateMutableCopy(kCFAllocatorDefault, 0, source);
+  CFRelease(source);
+  CFStringNormalize(normalized, kCFStringNormalizationFormKD);
+  const CFIndex length = CFStringGetLength(normalized);
+  const CFIndex capacity =
+      CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
+  std::vector<char> output(static_cast<size_t>(capacity));
+  if (!CFStringGetCString(
+          normalized, output.data(), capacity, kCFStringEncodingUTF8)) {
+    CFRelease(normalized);
+    throw std::runtime_error("failed to encode normalized text");
+  }
+  CFRelease(normalized);
+  return output.data();
+}
+
+bool is_emoji(char32_t value) {
+  return (value >= 0x1f300 && value <= 0x1f64f) ||
+      (value >= 0x1f680 && value <= 0x1f6ff) ||
+      (value >= 0x1f700 && value <= 0x1faff) ||
+      (value >= 0x2600 && value <= 0x27bf) ||
+      (value >= 0x1f1e6 && value <= 0x1f1ff);
+}
+
+bool is_unicode_whitespace(char32_t value) {
+  return CFCharacterSetIsLongCharacterMember(
+      CFCharacterSetGetPredefined(kCFCharacterSetWhitespaceAndNewline),
+      static_cast<UTF32Char>(value));
+}
+
+std::string canonicalize_whitespace(
+    const std::string& value,
+    bool preserve_newlines) {
+  auto decoded = decode_utf8(value);
+  for (char32_t& codepoint : decoded) {
+    if (is_unicode_whitespace(codepoint) &&
+        !(preserve_newlines && codepoint == U'\n')) {
+      codepoint = U' ';
+    }
+  }
+  return encode_utf8(decoded);
+}
+
+void replace_all(
+    std::string& text,
+    const std::string& old_value,
+    const std::string& new_value) {
+  for (size_t position = 0;
+       (position = text.find(old_value, position)) != std::string::npos;
+       position += new_value.size()) {
+    text.replace(position, old_value.size(), new_value);
+  }
+}
+
+std::string trim(const std::string& value) {
+  const auto decoded = decode_utf8(value);
+  size_t first = 0;
+  while (first < decoded.size() && is_unicode_whitespace(decoded[first])) {
+    ++first;
+  }
+  size_t last = decoded.size();
+  while (last > first && is_unicode_whitespace(decoded[last - 1])) {
+    --last;
+  }
+  return encode_utf8(decoded.substr(first, last - first));
+}
+
+std::string collapse_whitespace(const std::string& value) {
+  std::u32string result;
+  bool pending_space = false;
+  for (char32_t character : decode_utf8(value)) {
+    if (is_unicode_whitespace(character)) {
+      pending_space = !result.empty();
+    } else {
+      if (pending_space) {
+        result.push_back(U' ');
+      }
+      result.push_back(character);
+      pending_space = false;
+    }
+  }
+  return encode_utf8(result);
+}
+
+bool has_terminal_punctuation(const std::u32string& text) {
+  static const std::u32string terminals = U".!?！？，;:,'\"')]}…。」』】〉》›»";
+  return !text.empty() && terminals.find(text.back()) != std::u32string::npos;
+}
+
+bool is_abbreviation(const std::string& prefix) {
+  static const std::vector<std::string> suffixes = {
+      "Mr.",
+      "Mrs.",
+      "Ms.",
+      "Dr.",
+      "Prof.",
+      "Sr.",
+      "Jr.",
+      "Ph.D.",
+      "etc.",
+      "e.g.",
+      "i.e.",
+      "vs.",
+      "Inc.",
+      "Ltd.",
+      "Co.",
+      "Corp.",
+      "St.",
+      "Ave.",
+      "Blvd."};
+  for (const auto& suffix : suffixes) {
+    if (prefix.size() >= suffix.size() &&
+        prefix.compare(prefix.size() - suffix.size(), suffix.size(), suffix) ==
+            0) {
+      return true;
+    }
+  }
+  return prefix.size() >= 2 && prefix.back() == '.' &&
+      std::isupper(static_cast<unsigned char>(prefix[prefix.size() - 2])) &&
+      (prefix.size() == 2 ||
+       !std::isalpha(static_cast<unsigned char>(prefix[prefix.size() - 3])));
+}
+
+bool is_cjk_sentence_terminal(char32_t character) {
+  return character == U'。' || character == U'！' || character == U'？';
+}
+
+std::vector<std::string> split_sentences(const std::string& paragraph) {
+  const std::u32string decoded = decode_utf8(paragraph);
+  std::vector<std::string> result;
+  size_t start = 0;
+  for (size_t index = 0; index < decoded.size(); ++index) {
+    const char32_t character = decoded[index];
+    const bool ascii_terminal =
+        character == U'.' || character == U'!' || character == U'?';
+    const bool cjk_terminal = is_cjk_sentence_terminal(character);
+    if (!ascii_terminal && !cjk_terminal) {
+      continue;
+    }
+    const std::string prefix =
+        encode_utf8(decoded.substr(start, index - start + 1));
+    if (ascii_terminal && is_abbreviation(prefix)) {
+      continue;
+    }
+    size_t next = index + 1;
+    if (cjk_terminal && next < decoded.size() &&
+        is_cjk_sentence_terminal(decoded[next])) {
+      continue;
+    }
+    if (ascii_terminal &&
+        (next == decoded.size() || !is_unicode_whitespace(decoded[next]))) {
+      continue;
+    }
+    while (next < decoded.size() && is_unicode_whitespace(decoded[next])) {
+      ++next;
+    }
+    result.push_back(trim(prefix));
+    start = next;
+    index = next == 0 ? 0 : next - 1;
+  }
+  if (start < decoded.size()) {
+    result.push_back(trim(encode_utf8(decoded.substr(start))));
+  }
+  return result;
+}
+
+} // namespace
+
+void validate_language(const std::string& language) {
+  if (kLanguages.count(language) == 0) {
+    throw std::invalid_argument("Invalid language: " + language);
+  }
+}
+
+std::string preprocess_text(
+    const std::string& text,
+    const std::string& language) {
+  std::u32string values = decode_utf8(normalize_nfkd(text));
+  std::u32string cleaned;
+  for (char32_t value : values) {
+    if (is_emoji(value) || value == U'♥' || value == U'☆' || value == U'♡' ||
+        value == U'©' || value == U'\\') {
+      continue;
+    }
+    switch (value) {
+      case U'–':
+      case U'‑':
+      case U'—':
+        cleaned.push_back(U'-');
+        break;
+      case U'_':
+      case U'[':
+      case U']':
+      case U'|':
+      case U'/':
+      case U'#':
+      case U'→':
+      case U'←':
+        cleaned.push_back(U' ');
+        break;
+      case U'“':
+      case U'”':
+        cleaned.push_back(U'"');
+        break;
+      case U'‘':
+      case U'’':
+      case U'´':
+      case U'`':
+        cleaned.push_back(U'\'');
+        break;
+      default:
+        cleaned.push_back(value);
+    }
+  }
+  std::string result = encode_utf8(cleaned);
+  replace_all(result, "@", " at ");
+  replace_all(result, "e.g.,", "for example, ");
+  replace_all(result, "i.e.,", "that is, ");
+  for (const char punctuation : std::string(",.!?;:'")) {
+    replace_all(
+        result, std::string(" ") + punctuation, std::string(1, punctuation));
+  }
+  while (result.find("\"\"") != std::string::npos) {
+    replace_all(result, "\"\"", "\"");
+  }
+  while (result.find("''") != std::string::npos) {
+    replace_all(result, "''", "'");
+  }
+  result = collapse_whitespace(result);
+  if (!has_terminal_punctuation(decode_utf8(result))) {
+    result.push_back('.');
+  }
+  validate_language(language);
+  return "<" + language + ">" + result + "</" + language + ">";
+}
+
+std::vector<std::string> chunk_text(
+    const std::string& text,
+    size_t max_length) {
+  const std::string normalized_text = canonicalize_whitespace(text, true);
+  std::vector<std::string> paragraphs;
+  size_t start = 0;
+  for (size_t index = 0; index < normalized_text.size();) {
+    if (normalized_text[index] != '\n') {
+      ++index;
+      continue;
+    }
+    size_t next = index;
+    int newlines = 0;
+    while (next < normalized_text.size() &&
+           (normalized_text[next] == '\n' || normalized_text[next] == ' ')) {
+      if (normalized_text[next] == '\n') {
+        ++newlines;
+      }
+      ++next;
+    }
+    if (newlines >= 2) {
+      const auto paragraph = trim(normalized_text.substr(start, index - start));
+      if (!paragraph.empty()) {
+        paragraphs.push_back(paragraph);
+      }
+      start = next;
+    }
+    index = next;
+  }
+  const auto final_paragraph = trim(normalized_text.substr(start));
+  if (!final_paragraph.empty()) {
+    paragraphs.push_back(final_paragraph);
+  }
+
+  std::vector<std::string> chunks;
+  for (const auto& paragraph : paragraphs) {
+    std::string current;
+    for (const auto& sentence : split_sentences(paragraph)) {
+      const size_t packed_length =
+          decode_utf8(current).size() + decode_utf8(sentence).size() + 1;
+      if (packed_length <= max_length) {
+        current += (current.empty() ? "" : " ") + sentence;
+      } else {
+        if (!current.empty()) {
+          chunks.push_back(trim(current));
+        }
+        current = sentence;
+      }
+    }
+    if (!current.empty()) {
+      chunks.push_back(trim(current));
+    }
+  }
+  return chunks;
+}
+
+std::vector<std::string> chunk_text_for_language(
+    const std::string& text,
+    const std::string& language) {
+  return chunk_text(text, language == "ko" || language == "ja" ? 120 : 300);
+}
+
+UnicodeProcessor::UnicodeProcessor(const std::string& indexer_path) {
+  std::ifstream file(indexer_path);
+  if (!file) {
+    throw std::runtime_error("failed to open Unicode indexer: " + indexer_path);
+  }
+  const nlohmann::json data = nlohmann::json::parse(file);
+  if (!data.is_array()) {
+    throw std::runtime_error("Unicode indexer must be a JSON array");
+  }
+  indexer_.reserve(data.size());
+  for (const auto& token : data) {
+    if (!token.is_number_integer()) {
+      throw std::runtime_error("Unicode indexer tokens must be integers");
+    }
+    indexer_.push_back(token.get<int64_t>());
+  }
+}
+
+void UnicodeProcessor::configure_vocabulary(int64_t vocabulary_size) {
+  if (vocabulary_size <= 0) {
+    throw std::invalid_argument("text vocabulary size must be positive");
+  }
+  for (int64_t token_id : indexer_) {
+    if (token_id < -1 || token_id >= vocabulary_size) {
+      throw std::runtime_error(
+          "Unicode indexer contains a token outside the text vocabulary");
+    }
+  }
+  vocabulary_size_ = vocabulary_size;
+}
+
+TextBatch UnicodeProcessor::process(
+    const std::vector<std::string>& texts,
+    const std::vector<std::string>& languages) const {
+  if (vocabulary_size_ <= 0) {
+    throw std::runtime_error("Unicode processor vocabulary is not configured");
+  }
+  if (texts.size() != languages.size()) {
+    throw std::invalid_argument(
+        "texts and languages must have the same cardinality");
+  }
+  if (texts.empty()) {
+    throw std::invalid_argument("expected at least one text and language");
+  }
+  std::vector<std::u32string> processed;
+  size_t max_length = 0;
+  for (size_t index = 0; index < texts.size(); ++index) {
+    processed.push_back(
+        decode_utf8(preprocess_text(texts[index], languages[index])));
+    max_length = std::max(max_length, processed.back().size());
+  }
+  TextBatch batch;
+  batch.shape = {
+      static_cast<int64_t>(texts.size()), static_cast<int64_t>(max_length)};
+  batch.ids.assign(texts.size() * max_length, 0);
+  batch.mask.assign(texts.size() * max_length, 0.0f);
+  for (size_t row = 0; row < processed.size(); ++row) {
+    for (size_t column = 0; column < processed[row].size(); ++column) {
+      const auto codepoint = static_cast<size_t>(processed[row][column]);
+      if (codepoint >= indexer_.size()) {
+        throw std::runtime_error(
+            "Unicode indexer has no entry for codepoint " +
+            std::to_string(codepoint));
+      }
+      const int64_t token_id = indexer_[codepoint];
+      if (token_id < 0) {
+        throw std::invalid_argument(
+            "unsupported Unicode codepoint " + std::to_string(codepoint));
+      }
+      batch.ids[row * max_length + column] = token_id;
+      batch.mask[row * max_length + column] = 1.0f;
+    }
+  }
+  return batch;
+}
+
+} // namespace supertonic

--- a/examples/models/supertonic/runtime/text_processor.h
+++ b/examples/models/supertonic/runtime/text_processor.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace supertonic {
+
+struct TextBatch {
+  std::vector<int64_t> ids;
+  std::vector<float> mask;
+  std::vector<int64_t> shape;
+};
+
+void validate_language(const std::string& language);
+std::string preprocess_text(
+    const std::string& text,
+    const std::string& language);
+std::vector<std::string> chunk_text(const std::string& text, size_t max_length);
+std::vector<std::string> chunk_text_for_language(
+    const std::string& text,
+    const std::string& language);
+
+class UnicodeProcessor {
+ public:
+  explicit UnicodeProcessor(const std::string& indexer_path);
+
+  void configure_vocabulary(int64_t vocabulary_size);
+  TextBatch process(
+      const std::vector<std::string>& texts,
+      const std::vector<std::string>& languages) const;
+
+ private:
+  std::vector<int64_t> indexer_;
+  int64_t vocabulary_size_ = 0;
+};
+
+} // namespace supertonic

--- a/examples/models/supertonic/runtime/wav_writer.cpp
+++ b/examples/models/supertonic/runtime/wav_writer.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "wav_writer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+
+namespace supertonic {
+namespace {
+
+void write_u16(std::ostream& output, uint16_t value) {
+  const char bytes[2] = {
+      static_cast<char>(value & 0xff), static_cast<char>((value >> 8) & 0xff)};
+  output.write(bytes, sizeof(bytes));
+}
+
+void write_u32(std::ostream& output, uint32_t value) {
+  const char bytes[4] = {
+      static_cast<char>(value & 0xff),
+      static_cast<char>((value >> 8) & 0xff),
+      static_cast<char>((value >> 16) & 0xff),
+      static_cast<char>((value >> 24) & 0xff)};
+  output.write(bytes, sizeof(bytes));
+}
+
+int16_t pcm16(float sample) {
+  if (!std::isfinite(sample)) {
+    sample = 0.0f;
+  }
+  sample = std::clamp(sample, -1.0f, 1.0f);
+  return sample < 0.0f ? static_cast<int16_t>(std::lround(sample * 32768.0f))
+                       : static_cast<int16_t>(std::lround(sample * 32767.0f));
+}
+
+} // namespace
+
+WavLayout
+validate_wav_layout(size_t sample_count, int sample_rate, int channels) {
+  if (sample_rate <= 0) {
+    throw std::invalid_argument("sample rate must be positive");
+  }
+  if (channels <= 0 ||
+      channels > static_cast<int>(std::numeric_limits<uint16_t>::max())) {
+    throw std::invalid_argument(
+        "channels must be in the representable WAV range");
+  }
+  if (sample_count % static_cast<size_t>(channels) != 0) {
+    throw std::invalid_argument(
+        "sample count must contain a whole number of frames");
+  }
+  const uint64_t block_align =
+      static_cast<uint64_t>(channels) * sizeof(int16_t);
+  if (block_align > std::numeric_limits<uint16_t>::max()) {
+    throw std::overflow_error("WAV block align is unrepresentable");
+  }
+  const uint64_t byte_rate = static_cast<uint64_t>(sample_rate) * block_align;
+  if (byte_rate > std::numeric_limits<uint32_t>::max()) {
+    throw std::overflow_error("WAV byte rate is unrepresentable");
+  }
+  if (sample_count >
+      (std::numeric_limits<uint32_t>::max() - 36) / sizeof(int16_t)) {
+    throw std::overflow_error("WAV data size is unrepresentable");
+  }
+  const uint32_t data_bytes =
+      static_cast<uint32_t>(sample_count * sizeof(int16_t));
+  return {
+      data_bytes,
+      static_cast<uint32_t>(36 + data_bytes),
+      static_cast<uint16_t>(block_align),
+      static_cast<uint32_t>(byte_rate)};
+}
+
+bool write_pcm16_wav(
+    const std::string& path,
+    const std::vector<float>& samples,
+    int sample_rate,
+    int channels) {
+  WavLayout layout;
+  try {
+    layout = validate_wav_layout(samples.size(), sample_rate, channels);
+  } catch (const std::exception&) {
+    return false;
+  }
+  std::ofstream output(path, std::ios::binary);
+  if (!output) {
+    return false;
+  }
+  output.write("RIFF", 4);
+  write_u32(output, layout.riff_size);
+  output.write("WAVEfmt ", 8);
+  write_u32(output, 16);
+  write_u16(output, 1);
+  write_u16(output, static_cast<uint16_t>(channels));
+  write_u32(output, static_cast<uint32_t>(sample_rate));
+  write_u32(output, layout.byte_rate);
+  write_u16(output, layout.block_align);
+  write_u16(output, 16);
+  output.write("data", 4);
+  write_u32(output, layout.data_bytes);
+  for (float sample : samples) {
+    write_u16(output, static_cast<uint16_t>(pcm16(sample)));
+  }
+  return output.good();
+}
+
+} // namespace supertonic

--- a/examples/models/supertonic/runtime/wav_writer.h
+++ b/examples/models/supertonic/runtime/wav_writer.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace supertonic {
+
+struct WavLayout {
+  uint32_t data_bytes;
+  uint32_t riff_size;
+  uint16_t block_align;
+  uint32_t byte_rate;
+};
+
+WavLayout
+validate_wav_layout(size_t sample_count, int sample_rate, int channels);
+
+bool write_pcm16_wav(
+    const std::string& path,
+    const std::vector<float>& samples,
+    int sample_rate,
+    int channels = 1);
+
+} // namespace supertonic

--- a/examples/models/supertonic/source_transformations/__init__.py
+++ b/examples/models/supertonic/source_transformations/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/models/supertonic/source_transformations/mlx.py
+++ b/examples/models/supertonic/source_transformations/mlx.py
@@ -1,0 +1,245 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import torch
+from torch import nn
+
+from ..model.duration_predictor import DurationPredictor
+from ..model.layers import ConvNeXtBlock
+from ..model.text_encoder import RelativeMultiHeadAttention, TextEncoder
+from ..model.vector_estimator import VectorEstimator
+from ..model.vocoder import Vocoder
+
+
+class MLXCausalPad1d(nn.Module):
+    """Replicate the first frame without dynamic clamp bounds."""
+
+    def __init__(self, padding: int) -> None:
+        super().__init__()
+        self.padding = padding
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        if self.padding == 0:
+            return inputs
+        prefix = inputs[:, :, :1].expand(-1, -1, self.padding)
+        return torch.cat((prefix, inputs), dim=-1)
+
+
+class MLXSamePad1d(nn.Module):
+    """Replicate both boundary frames without dynamic clamp bounds."""
+
+    def __init__(self, padding: tuple[int, int]) -> None:
+        super().__init__()
+        self.padding = padding
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        left, right = self.padding
+        pieces = []
+        if left:
+            pieces.append(inputs[:, :, :1].expand(-1, -1, left))
+        pieces.append(inputs)
+        if right:
+            pieces.append(inputs[:, :, -1:].expand(-1, -1, right))
+        return torch.cat(pieces, dim=-1)
+
+
+class MLXRelativeMultiHeadAttention(nn.Module):
+    """Relative attention using dynamic-safe gather indices."""
+
+    @classmethod
+    def from_attention(
+        cls, attention: RelativeMultiHeadAttention
+    ) -> "MLXRelativeMultiHeadAttention":
+        transformed = cls.__new__(cls)
+        nn.Module.__init__(transformed)
+        transformed.channels = attention.channels
+        transformed.num_heads = attention.num_heads
+        transformed.head_channels = attention.head_channels
+        transformed.window_size = attention.window_size
+        transformed.emb_rel_k = attention.emb_rel_k
+        transformed.emb_rel_v = attention.emb_rel_v
+        transformed.conv_q = attention.conv_q
+        transformed.conv_k = attention.conv_k
+        transformed.conv_v = attention.conv_v
+        transformed.conv_o = attention.conv_o
+        return transformed
+
+    def _relative_embeddings(
+        self, embeddings: torch.Tensor, length: int
+    ) -> torch.Tensor:
+        offsets = torch.arange(2 * length - 1, device=embeddings.device) - (length - 1)
+        valid = (offsets >= -self.window_size) & (offsets <= self.window_size)
+        indices = torch.where(
+            valid,
+            offsets + self.window_size,
+            torch.zeros_like(offsets),
+        )
+        selected = torch.index_select(embeddings, 1, indices)
+        return selected * valid.reshape(1, -1, 1)
+
+    @staticmethod
+    def _relative_to_absolute(inputs: torch.Tensor) -> torch.Tensor:
+        length = inputs.shape[2]
+        positions = torch.arange(length, device=inputs.device)
+        relative_indices = positions.unsqueeze(0) - positions.unsqueeze(1) + length - 1
+        linear_indices = positions.unsqueeze(1) * (2 * length - 1) + relative_indices
+        selected = torch.index_select(
+            inputs.reshape(inputs.shape[0], inputs.shape[1], -1),
+            -1,
+            linear_indices.reshape(-1),
+        )
+        return selected.reshape(inputs.shape[0], inputs.shape[1], length, length)
+
+    @staticmethod
+    def _absolute_to_relative(inputs: torch.Tensor) -> torch.Tensor:
+        length = inputs.shape[2]
+        query_positions = torch.arange(length, device=inputs.device)
+        relative_positions = torch.arange(2 * length - 1, device=inputs.device)
+        key_indices = (
+            relative_positions.unsqueeze(0)
+            + query_positions.unsqueeze(1)
+            - (length - 1)
+        )
+        valid = (key_indices >= 0) & (key_indices < length)
+        safe_indices = torch.where(valid, key_indices, torch.zeros_like(key_indices))
+        linear_indices = query_positions.unsqueeze(1) * length + safe_indices
+        relative = torch.index_select(
+            inputs.reshape(inputs.shape[0], inputs.shape[1], -1),
+            -1,
+            linear_indices.reshape(-1),
+        ).reshape(
+            inputs.shape[0],
+            inputs.shape[1],
+            length,
+            2 * length - 1,
+        )
+        return relative * valid.reshape(1, 1, length, 2 * length - 1)
+
+    def forward(
+        self, inputs: torch.Tensor, attention_mask: torch.Tensor
+    ) -> torch.Tensor:
+        batch, _, length = inputs.shape
+        query = self.conv_q(inputs).reshape(
+            batch, self.num_heads, self.head_channels, length
+        )
+        key = self.conv_k(inputs).reshape(
+            batch, self.num_heads, self.head_channels, length
+        )
+        value = self.conv_v(inputs).reshape(
+            batch, self.num_heads, self.head_channels, length
+        )
+        query = query.transpose(2, 3) / math.sqrt(self.head_channels)
+        key = key.transpose(2, 3)
+        value = value.transpose(2, 3)
+
+        scores = torch.matmul(query, key.transpose(-2, -1))
+        relative_key = self._relative_embeddings(self.emb_rel_k, length)
+        relative_scores = torch.matmul(
+            query, relative_key.unsqueeze(0).transpose(-2, -1)
+        )
+        scores = scores + self._relative_to_absolute(relative_scores)
+        scores = scores.masked_fill(attention_mask == 0, -10000.0)
+        weights = torch.softmax(scores, dim=-1)
+
+        attended = torch.matmul(weights, value)
+        relative_weights = self._absolute_to_relative(weights)
+        relative_value = self._relative_embeddings(self.emb_rel_v, length)
+        attended = attended + torch.matmul(
+            relative_weights, relative_value.unsqueeze(0)
+        )
+        attended = attended.transpose(2, 3).reshape(batch, self.channels, length)
+        return self.conv_o(attended)
+
+
+class ExportableVectorEstimator(nn.Module):
+    """Valid-domain compute; host validation is required before every call."""
+
+    valid_domain_only = True
+
+    def __init__(self, model: VectorEstimator) -> None:
+        super().__init__()
+        self.model = model
+
+    def forward(
+        self,
+        noisy_latent: torch.Tensor,
+        text_emb: torch.Tensor,
+        style_ttl: torch.Tensor,
+        latent_mask: torch.Tensor,
+        text_mask: torch.Tensor,
+        current_step: torch.Tensor,
+        total_step: torch.Tensor,
+    ) -> torch.Tensor:
+        batch = noisy_latent.shape[0]
+        text_unconditional = self.model.uncond_masker.text_special_token.expand(
+            batch, -1, text_emb.shape[2]
+        )
+        style_key = torch.cat(
+            (
+                self.model.style_key.expand(batch, -1, -1),
+                self.model.uncond_masker.style_key_special_token.expand(batch, -1, -1),
+            ),
+            dim=0,
+        )
+        style_value = torch.cat(
+            (
+                style_ttl,
+                self.model.uncond_masker.style_value_special_token.expand(
+                    batch, -1, -1
+                ),
+            ),
+            dim=0,
+        )
+        vector = self.model.vector_field(
+            noisy_latent.repeat(2, 1, 1),
+            (current_step / total_step).repeat(2),
+            torch.cat((text_emb, text_unconditional), dim=0),
+            style_key,
+            style_value,
+            latent_mask.repeat(2, 1, 1),
+            text_mask.repeat(2, 1, 1),
+        )
+        conditional, unconditional = vector.chunk(2, dim=0)
+        guided = 4.0 * conditional - 3.0 * unconditional
+        step = torch.reciprocal(total_step).reshape(-1, 1, 1)
+        return (noisy_latent + step * guided) * latent_mask
+
+
+def exportable_vector_estimator(
+    model: VectorEstimator,
+) -> ExportableVectorEstimator:
+    return ExportableVectorEstimator(model)
+
+
+def replace_vocoder_causal_padding(model: Vocoder) -> Vocoder:
+    model.decoder.embed_pad = MLXCausalPad1d(model.decoder.embed_pad.padding)
+    for block in model.decoder.convnext:
+        block.pad = MLXCausalPad1d(block.pad.padding)
+    model.decoder.head.pad = MLXCausalPad1d(model.decoder.head.pad.padding)
+    return model
+
+
+def replace_relative_attention(
+    model: DurationPredictor | TextEncoder,
+) -> DurationPredictor | TextEncoder:
+    if isinstance(model, DurationPredictor):
+        encoder = model.sentence_encoder.attn_encoder
+    else:
+        encoder = model.text_encoder.attn_encoder
+    encoder.attn_layers = nn.ModuleList(
+        MLXRelativeMultiHeadAttention.from_attention(attention)
+        for attention in encoder.attn_layers
+    )
+    return model
+
+
+def replace_same_padding(model: nn.Module) -> nn.Module:
+    for module in model.modules():
+        if isinstance(module, ConvNeXtBlock):
+            module.pad = MLXSamePad1d(module.pad.padding)
+    return model

--- a/examples/models/supertonic/tests/__init__.py
+++ b/examples/models/supertonic/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/models/supertonic/tests/test_checkpoint_loader.py
+++ b/examples/models/supertonic/tests/test_checkpoint_loader.py
@@ -1,0 +1,483 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+import os
+from pathlib import Path
+
+import numpy as np
+import onnx
+import pytest
+import torch
+from onnx import helper, numpy_helper
+from torch import nn
+
+
+def _checkpoint_loader():
+    return importlib.import_module(
+        "examples.models.supertonic.loaders.checkpoint_loader"
+    )
+
+
+def _write_model(path, initializers, nodes=(), inputs=(), outputs=()) -> None:
+    graph = helper.make_graph(
+        list(nodes),
+        "test_graph",
+        list(inputs),
+        list(outputs),
+        initializer=list(initializers),
+    )
+    onnx.save(helper.make_model(graph), path)
+
+
+def test_extract_initializers_preserves_names_values_and_dtypes(tmp_path) -> None:
+    float_weight = np.arange(6, dtype=np.float32).reshape(2, 3)
+    integer_weight = np.asarray([2, 4], dtype=np.int64)
+    model_path = tmp_path / "weights.onnx"
+    _write_model(
+        model_path,
+        [
+            numpy_helper.from_array(float_weight, name="float_weight"),
+            numpy_helper.from_array(integer_weight, name="integer_weight"),
+        ],
+    )
+
+    initializers = _checkpoint_loader().extract_initializers(model_path)
+
+    assert set(initializers) == {"float_weight", "integer_weight"}
+    torch.testing.assert_close(
+        initializers["float_weight"], torch.from_numpy(float_weight)
+    )
+    torch.testing.assert_close(
+        initializers["integer_weight"], torch.from_numpy(integer_weight)
+    )
+
+
+def test_extract_initializers_rejects_duplicate_names(tmp_path) -> None:
+    model_path = tmp_path / "duplicate.onnx"
+    _write_model(
+        model_path,
+        [
+            numpy_helper.from_array(np.ones((2, 2), dtype=np.float32), name="weight"),
+            numpy_helper.from_array(np.zeros((2, 2), dtype=np.float32), name="weight"),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="duplicate initializer.*weight"):
+        _checkpoint_loader().extract_initializers(model_path)
+
+
+@pytest.mark.parametrize(
+    ("operator", "trans_b", "expected"),
+    [
+        ("MatMul", None, torch.tensor([[0.0, 3.0], [1.0, 4.0], [2.0, 5.0]])),
+        ("Gemm", 0, torch.tensor([[0.0, 3.0], [1.0, 4.0], [2.0, 5.0]])),
+        ("Gemm", 1, torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])),
+        ("Conv", None, torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])),
+    ],
+)
+def test_transform_initializer_converts_onnx_operator_layouts(
+    operator: str, trans_b: int | None, expected: torch.Tensor
+) -> None:
+    source = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    kwargs = {} if trans_b is None else {"trans_b": trans_b}
+
+    transformed = _checkpoint_loader().transform_initializer(source, operator, **kwargs)
+
+    torch.testing.assert_close(transformed, expected)
+
+
+class _TinyCheckpointModule(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = nn.Linear(3, 2)
+        self.conv = nn.Conv1d(1, 2, 3, bias=False)
+
+
+def _write_tiny_checkpoint(path) -> dict[str, torch.Tensor]:
+    linear_weight = torch.arange(6, dtype=torch.float32).reshape(3, 2)
+    linear_bias = torch.tensor([0.25, -0.5])
+    conv_weight = torch.arange(6, dtype=torch.float32).reshape(2, 1, 3)
+    nodes = [
+        helper.make_node("MatMul", ["linear_input", "source.linear"], ["linear_mm"]),
+        helper.make_node("Add", ["linear_mm", "source.linear_bias"], ["linear_output"]),
+        helper.make_node("Conv", ["conv_input", "source.conv"], ["conv_output"]),
+    ]
+    _write_model(
+        path,
+        [
+            numpy_helper.from_array(linear_weight.numpy(), name="source.linear"),
+            numpy_helper.from_array(linear_bias.numpy(), name="source.linear_bias"),
+            numpy_helper.from_array(conv_weight.numpy(), name="source.conv"),
+        ],
+        nodes=nodes,
+    )
+    return {
+        "linear.weight": linear_weight.T,
+        "linear.bias": linear_bias,
+        "conv.weight": conv_weight,
+    }
+
+
+def test_load_onnx_initializers_uses_explicit_mapping_and_operator_layouts(
+    tmp_path,
+) -> None:
+    model_path = tmp_path / "checkpoint.onnx"
+    expected = _write_tiny_checkpoint(model_path)
+    module = _TinyCheckpointModule()
+
+    _checkpoint_loader().load_onnx_initializers(
+        module,
+        model_path,
+        {
+            "linear.weight": "source.linear",
+            "linear.bias": "source.linear_bias",
+            "conv.weight": "source.conv",
+        },
+    )
+
+    for name, value in module.state_dict().items():
+        torch.testing.assert_close(value, expected[name])
+
+
+@pytest.mark.parametrize("trans_b", [0, 1])
+def test_load_onnx_initializers_extracts_gemm_trans_b_layout(
+    tmp_path, trans_b: int
+) -> None:
+    expected = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    source = expected.T if trans_b == 0 else expected
+    model_path = tmp_path / f"gemm-trans-b-{trans_b}.onnx"
+    _write_model(
+        model_path,
+        [numpy_helper.from_array(source.numpy(), name="source.weight")],
+        nodes=[
+            helper.make_node(
+                "Gemm",
+                ["input", "source.weight"],
+                ["output"],
+                transB=trans_b,
+            )
+        ],
+    )
+    module = nn.Linear(3, 2, bias=False)
+
+    _checkpoint_loader().load_onnx_initializers(
+        module, model_path, {"weight": "source.weight"}
+    )
+
+    torch.testing.assert_close(module.weight, expected)
+
+
+def test_load_onnx_initializers_rejects_ambiguous_graph_layouts(tmp_path) -> None:
+    model_path = tmp_path / "ambiguous-layout.onnx"
+    _write_model(
+        model_path,
+        [
+            numpy_helper.from_array(
+                np.arange(4, dtype=np.float32).reshape(2, 2),
+                name="source.weight",
+            )
+        ],
+        nodes=[
+            helper.make_node(
+                "Gemm",
+                ["gemm_input", "source.weight"],
+                ["gemm_output"],
+                transB=1,
+            ),
+            helper.make_node(
+                "MatMul",
+                ["matmul_input", "source.weight"],
+                ["matmul_output"],
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="ambiguous operator layouts.*source.weight"):
+        _checkpoint_loader().load_onnx_initializers(
+            nn.Linear(2, 2, bias=False),
+            model_path,
+            {"weight": "source.weight"},
+        )
+
+
+def test_load_onnx_initializers_rejects_missing_source_weight(tmp_path) -> None:
+    model_path = tmp_path / "checkpoint.onnx"
+    _write_tiny_checkpoint(model_path)
+
+    with pytest.raises(ValueError, match="missing initializer.*does.not.exist"):
+        _checkpoint_loader().load_onnx_initializers(
+            _TinyCheckpointModule(),
+            model_path,
+            {
+                "linear.weight": "does.not.exist",
+                "linear.bias": "source.linear_bias",
+                "conv.weight": "source.conv",
+            },
+        )
+
+
+def test_load_onnx_initializers_rejects_duplicate_source_mapping(tmp_path) -> None:
+    model_path = tmp_path / "checkpoint.onnx"
+    _write_tiny_checkpoint(model_path)
+
+    with pytest.raises(
+        ValueError, match="duplicate initializer mapping.*source.linear"
+    ):
+        _checkpoint_loader().load_onnx_initializers(
+            _TinyCheckpointModule(),
+            model_path,
+            {
+                "linear.weight": "source.linear",
+                "linear.bias": "source.linear",
+                "conv.weight": "source.conv",
+            },
+        )
+
+
+def test_load_onnx_initializers_rejects_shape_mismatch(tmp_path) -> None:
+    model_path = tmp_path / "checkpoint.onnx"
+    _write_tiny_checkpoint(model_path)
+
+    with pytest.raises(ValueError, match=r"shape mismatch.*linear\.weight"):
+        _checkpoint_loader().load_onnx_initializers(
+            _TinyCheckpointModule(),
+            model_path,
+            {
+                "linear.weight": "source.conv",
+                "linear.bias": "source.linear_bias",
+                "conv.weight": "source.linear",
+            },
+        )
+
+
+def test_load_onnx_initializers_rejects_unmapped_model_weights(tmp_path) -> None:
+    model_path = tmp_path / "checkpoint.onnx"
+    _write_tiny_checkpoint(model_path)
+
+    with pytest.raises(ValueError, match=r"unmapped model weights.*linear\.bias"):
+        _checkpoint_loader().load_onnx_initializers(
+            _TinyCheckpointModule(),
+            model_path,
+            {
+                "linear.weight": "source.linear",
+                "conv.weight": "source.conv",
+            },
+        )
+
+
+def test_load_onnx_initializers_rejects_unknown_model_weights(tmp_path) -> None:
+    model_path = tmp_path / "checkpoint.onnx"
+    _write_tiny_checkpoint(model_path)
+
+    with pytest.raises(ValueError, match=r"unknown model weights.*unused\.weight"):
+        _checkpoint_loader().load_onnx_initializers(
+            _TinyCheckpointModule(),
+            model_path,
+            {
+                "linear.weight": "source.linear",
+                "linear.bias": "source.linear_bias",
+                "conv.weight": "source.conv",
+                "unused.weight": "source.conv",
+            },
+        )
+
+
+def test_load_onnx_initializers_rejects_unused_initializer_when_requested(
+    tmp_path,
+) -> None:
+    model_path = tmp_path / "checkpoint.onnx"
+    expected = _write_tiny_checkpoint(model_path)
+    model = onnx.load(model_path)
+    model.graph.initializer.append(
+        numpy_helper.from_array(np.ones((1,), dtype=np.float32), name="unused")
+    )
+    onnx.save(model, model_path)
+
+    with pytest.raises(ValueError, match="unused initializer.*unused"):
+        _checkpoint_loader().load_onnx_initializers(
+            _TinyCheckpointModule(),
+            model_path,
+            {
+                "linear.weight": "source.linear",
+                "linear.bias": "source.linear_bias",
+                "conv.weight": "source.conv",
+            },
+            reject_unused=True,
+        )
+
+    assert set(expected) == {"linear.weight", "linear.bias", "conv.weight"}
+
+
+def test_load_onnx_initializers_rejects_unknown_allowed_unused_name(
+    tmp_path,
+) -> None:
+    model_path = tmp_path / "checkpoint.onnx"
+    _write_tiny_checkpoint(model_path)
+
+    with pytest.raises(
+        ValueError,
+        match="allowed unused initializer not found.*misspelled",
+    ):
+        _checkpoint_loader().load_onnx_initializers(
+            _TinyCheckpointModule(),
+            model_path,
+            {
+                "linear.weight": "source.linear",
+                "linear.bias": "source.linear_bias",
+                "conv.weight": "source.conv",
+            },
+            reject_unused=True,
+            allowed_unused={"misspelled"},
+        )
+
+
+_REAL_MODEL_DIR = os.environ.get("SUPERTONIC_MODEL_DIR")
+
+
+@pytest.mark.skipif(
+    _REAL_MODEL_DIR is None,
+    reason="set SUPERTONIC_MODEL_DIR for published ONNX contract checks",
+)
+@pytest.mark.parametrize(
+    ("filename", "inputs", "outputs"),
+    [
+        (
+            "duration_predictor.onnx",
+            {
+                "text_ids": ("INT64", ("batch_size", "text_length")),
+                "style_dp": ("FLOAT", ("batch_size", 8, 16)),
+                "text_mask": ("FLOAT", ("batch_size", 1, "text_length")),
+            },
+            {"duration": ("FLOAT", ("Squeezeduration_dim_0",))},
+        ),
+        (
+            "text_encoder.onnx",
+            {
+                "text_ids": ("INT64", ("batch_size", "text_length")),
+                "style_ttl": ("FLOAT", ("batch_size", 50, 256)),
+                "text_mask": ("FLOAT", ("batch_size", 1, "text_length")),
+            },
+            {
+                "text_emb": (
+                    "FLOAT",
+                    ("Multext_emb_dim_0", 256, "Multext_emb_dim_2"),
+                )
+            },
+        ),
+        (
+            "vector_estimator.onnx",
+            {
+                "noisy_latent": ("FLOAT", ("batch_size", 144, "latent_length")),
+                "text_emb": ("FLOAT", ("batch_size", 256, "text_length")),
+                "style_ttl": ("FLOAT", ("batch_size", 50, 256)),
+                "latent_mask": ("FLOAT", ("batch_size", 1, "latent_length")),
+                "text_mask": ("FLOAT", ("batch_size", 1, "text_length")),
+                "current_step": ("FLOAT", ("batch_size",)),
+                "total_step": ("FLOAT", ("batch_size",)),
+            },
+            {
+                "denoised_latent": (
+                    "FLOAT",
+                    ("batch_size", 144, "latent_length"),
+                )
+            },
+        ),
+        (
+            "vocoder.onnx",
+            {"latent": ("FLOAT", ("batch_size", 144, "latent_length"))},
+            {
+                "wav_tts": (
+                    "FLOAT",
+                    ("Reshapewav_tts_dim_0", "Reshapewav_tts_dim_1"),
+                )
+            },
+        ),
+    ],
+)
+def test_published_onnx_graph_contracts(
+    filename: str,
+    inputs: dict[str, tuple[str, tuple[str | int, ...]]],
+    outputs: dict[str, tuple[str, tuple[str | int, ...]]],
+) -> None:
+    model = onnx.load(
+        Path(_REAL_MODEL_DIR) / "onnx" / filename, load_external_data=False
+    )
+    initializer_names = {initializer.name for initializer in model.graph.initializer}
+
+    def contract(value) -> tuple[str, tuple[str | int, ...]]:
+        tensor_type = value.type.tensor_type
+        shape = tuple(
+            (
+                dimension.dim_param
+                if dimension.HasField("dim_param")
+                else dimension.dim_value
+            )
+            for dimension in tensor_type.shape.dim
+        )
+        return onnx.TensorProto.DataType.Name(tensor_type.elem_type), shape
+
+    assert {
+        value.name: contract(value)
+        for value in model.graph.input
+        if value.name not in initializer_names
+    } == inputs
+    assert {value.name: contract(value) for value in model.graph.output} == outputs
+
+
+@pytest.mark.skipif(
+    _REAL_MODEL_DIR is None,
+    reason="set SUPERTONIC_MODEL_DIR for published stage checkpoint checks",
+)
+def test_stage_initializer_maps_cover_every_published_initializer() -> None:
+    loader = _checkpoint_loader()
+    config_path = Path(_REAL_MODEL_DIR) / "onnx" / "tts.json"
+    from examples.models.supertonic.model.config import TTSConfig
+
+    config = TTSConfig.from_json(config_path)
+    cases = [
+        (
+            "duration_predictor.onnx",
+            loader.DURATION_PREDICTOR_INITIALIZER_MAP,
+            frozenset(),
+            loader.load_duration_predictor,
+            98,
+        ),
+        (
+            "text_encoder.onnx",
+            loader.TEXT_ENCODER_INITIALIZER_MAP,
+            frozenset(),
+            loader.load_text_encoder,
+            146,
+        ),
+        (
+            "vector_estimator.onnx",
+            loader.VECTOR_ESTIMATOR_INITIALIZER_MAP,
+            loader.VECTOR_ESTIMATOR_GENERATED_INITIALIZERS,
+            loader.load_vector_estimator,
+            352,
+        ),
+        (
+            "vocoder.onnx",
+            loader.VOCODER_INITIALIZER_MAP,
+            loader.VOCODER_GENERATED_INITIALIZERS,
+            loader.load_vocoder,
+            103,
+        ),
+    ]
+
+    for filename, mapping, generated, load_stage, expected_count in cases:
+        model_path = Path(_REAL_MODEL_DIR) / "onnx" / filename
+        initializer_names = {
+            initializer.name for initializer in onnx.load(model_path).graph.initializer
+        }
+
+        assert len(mapping) == expected_count
+        assert len(set(mapping.values())) == expected_count
+        assert set(mapping.values()).isdisjoint(generated)
+        assert set(mapping.values()) | set(generated) == initializer_names
+        stage = load_stage(model_path, config)
+        assert set(stage.state_dict()) == set(mapping)

--- a/examples/models/supertonic/tests/test_config.py
+++ b/examples/models/supertonic/tests/test_config.py
@@ -1,0 +1,168 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from examples.models.supertonic.loaders.voice_style_loader import load_voice_style
+from examples.models.supertonic.model.config import TTSConfig
+
+
+def test_tts_config_parses_published_runtime_values(tmp_path) -> None:
+    config_path = tmp_path / "tts.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "tts_version": "v1.7.3",
+                "split": "opensource-multilingual",
+                "ttl": {"latent_dim": 24, "chunk_compress_factor": 6},
+                "ae": {
+                    "sample_rate": 44100,
+                    "base_chunk_size": 512,
+                    "chunk_compress_factor": 1,
+                    "ldim": 24,
+                },
+                "dp": {"latent_dim": 24, "chunk_compress_factor": 6},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = TTSConfig.from_json(config_path)
+
+    assert config.tts_version == "v1.7.3"
+    assert config.split == "opensource-multilingual"
+    assert config.ttl.latent_dim == 24
+    assert config.ttl.chunk_compress_factor == 6
+    assert config.ae.sample_rate == 44100
+    assert config.ae.base_chunk_size == 512
+    assert config.ae.chunk_compress_factor == 1
+    assert config.ae.latent_dim == 24
+    assert config.dp.latent_dim == 24
+    assert config.dp.chunk_compress_factor == 6
+
+
+def test_voice_style_loader_batches_published_dimensions(tmp_path) -> None:
+    style_paths = []
+    for index in range(2):
+        style_path = tmp_path / f"style-{index}.json"
+        style_path.write_text(
+            json.dumps(
+                {
+                    "style_ttl": {
+                        "dims": [1, 50, 256],
+                        "data": [float(index)] * (50 * 256),
+                    },
+                    "style_dp": {
+                        "dims": [1, 8, 16],
+                        "data": [float(index + 2)] * (8 * 16),
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        style_paths.append(style_path)
+
+    style = load_voice_style(style_paths)
+
+    assert style.ttl.shape == (2, 50, 256)
+    assert style.dp.shape == (2, 8, 16)
+    assert style.ttl.dtype == np.float32
+    assert style.dp.dtype == np.float32
+    np.testing.assert_array_equal(style.ttl[:, 0, 0], [0.0, 1.0])
+    np.testing.assert_array_equal(style.dp[:, 0, 0], [2.0, 3.0])
+
+
+def test_voice_style_loader_rejects_unpublished_dimensions(tmp_path) -> None:
+    style_path = tmp_path / "invalid-style.json"
+    style_path.write_text(
+        json.dumps(
+            {
+                "style_ttl": {
+                    "dims": [1, 49, 256],
+                    "data": [0.0] * (49 * 256),
+                },
+                "style_dp": {"dims": [1, 8, 16], "data": [0.0] * (8 * 16)},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"style_ttl\.dims"):
+        load_voice_style([style_path])
+
+
+def test_voice_style_loader_validates_every_style_file(tmp_path) -> None:
+    style_paths = []
+    for name, ttl_dims in (
+        ("valid", [1, 50, 256]),
+        ("invalid", [1, 25, 512]),
+    ):
+        style_path = tmp_path / f"{name}.json"
+        style_path.write_text(
+            json.dumps(
+                {
+                    "style_ttl": {
+                        "dims": ttl_dims,
+                        "data": [0.0] * (50 * 256),
+                    },
+                    "style_dp": {
+                        "dims": [1, 8, 16],
+                        "data": [0.0] * (8 * 16),
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        style_paths.append(style_path)
+
+    with pytest.raises(ValueError, match=r"style_ttl\.dims"):
+        load_voice_style(style_paths)
+
+
+def _write_valid_style(path: Path, value: float) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "style_ttl": {
+                    "dims": [1, 50, 256],
+                    "data": [value] * (50 * 256),
+                },
+                "style_dp": {
+                    "dims": [1, 8, 16],
+                    "data": [value] * (8 * 16),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_voice_style_loader_rejects_empty_paths() -> None:
+    with pytest.raises(ValueError, match="at least one voice style path"):
+        load_voice_style([])
+
+
+def test_voice_style_loader_reads_each_file_once(tmp_path, monkeypatch) -> None:
+    style_paths = [tmp_path / "first.json", tmp_path / "second.json"]
+    for index, style_path in enumerate(style_paths):
+        _write_valid_style(style_path, float(index))
+
+    opened_paths = []
+    original_open = Path.open
+
+    def tracking_open(path, *args, **kwargs):
+        opened_paths.append(path)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", tracking_open)
+
+    load_voice_style(style_paths)
+
+    assert opened_paths == style_paths

--- a/examples/models/supertonic/tests/test_duration_predictor.py
+++ b/examples/models/supertonic/tests/test_duration_predictor.py
@@ -1,0 +1,127 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+
+import pytest
+import torch
+
+from examples.models.supertonic.model.config import TTSConfig
+
+
+def _duration_predictor():
+    return importlib.import_module(
+        "examples.models.supertonic.model.duration_predictor"
+    )
+
+
+def _config() -> TTSConfig:
+    return TTSConfig.from_dict(
+        {
+            "tts_version": "test",
+            "split": "test",
+            "ttl": {"latent_dim": 4, "chunk_compress_factor": 2},
+            "ae": {
+                "sample_rate": 16000,
+                "base_chunk_size": 4,
+                "chunk_compress_factor": 1,
+                "ldim": 4,
+            },
+            "dp": {"latent_dim": 4, "chunk_compress_factor": 2},
+        }
+    )
+
+
+def _small_model():
+    return (
+        _duration_predictor()
+        .DurationPredictor(
+            _config(),
+            vocab_size=32,
+            channels=8,
+            convnext_dilations=(1, 1),
+            attention_layers=1,
+            attention_heads=2,
+            ff_channels=16,
+            relative_window=2,
+            style_tokens=2,
+            style_dim=3,
+            hidden_dim=10,
+        )
+        .eval()
+    )
+
+
+def _contract_model():
+    return (
+        _duration_predictor()
+        .DurationPredictor(
+            _config(),
+            vocab_size=8,
+            channels=4,
+            convnext_dilations=(),
+            attention_layers=0,
+            attention_heads=1,
+            ff_channels=4,
+            style_tokens=8,
+            style_dim=16,
+            hidden_dim=4,
+        )
+        .eval()
+    )
+
+
+def test_duration_predictor_returns_one_finite_value_per_batch() -> None:
+    torch.manual_seed(0)
+    model = _small_model()
+
+    output = model(
+        torch.tensor([[1, 2, 3, 0], [4, 5, 0, 0]]),
+        torch.randn(2, 2, 3),
+        torch.tensor([[[1.0, 1.0, 1.0, 0.0]], [[1.0, 1.0, 0.0, 0.0]]]),
+    )
+
+    assert output.shape == (2,)
+    assert torch.isfinite(output).all()
+    assert (output > 0).all()
+
+
+def test_duration_predictor_ignores_masked_text_and_is_deterministic() -> None:
+    torch.manual_seed(1)
+    model = _small_model()
+    text_ids = torch.tensor([[1, 2, 3, 4]])
+    changed_ids = torch.tensor([[1, 2, 30, 31]])
+    style = torch.randn(1, 2, 3)
+    mask = torch.tensor([[[1.0, 1.0, 0.0, 0.0]]])
+
+    first = model(text_ids, style, mask)
+    second = model(changed_ids, style, mask)
+    repeated = model(text_ids, style, mask)
+
+    torch.testing.assert_close(first, second)
+    torch.testing.assert_close(first, repeated)
+
+
+@pytest.mark.parametrize(
+    ("text_shape", "style_shape", "mask_shape", "error"),
+    [
+        ((3,), (1, 8, 16), (1, 1, 3), r"text_ids.*\[B, T\]"),
+        ((1, 3), (1, 8, 15), (1, 1, 3), r"style_dp.*\[B, 8, 16\]"),
+        ((1, 3), (1, 8, 16), (1, 2, 3), r"text_mask.*\[B, 1, T\]"),
+        ((1, 3), (2, 8, 16), (1, 1, 3), "batch sizes must match"),
+        ((1, 3), (1, 8, 16), (1, 1, 2), "text lengths must match"),
+    ],
+)
+def test_duration_predictor_validates_public_input_contract_before_operators(
+    text_shape, style_shape, mask_shape, error: str
+) -> None:
+    model = _contract_model()
+    text_ids = torch.full(text_shape, 999, dtype=torch.long)
+    style = torch.zeros(style_shape)
+    mask = torch.ones(mask_shape)
+
+    with pytest.raises(ValueError, match=error):
+        model(text_ids, style, mask)

--- a/examples/models/supertonic/tests/test_export.py
+++ b/examples/models/supertonic/tests/test_export.py
@@ -1,0 +1,427 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+
+import pytest
+import torch
+from torch import nn
+
+from examples.models.supertonic.export import common
+from examples.models.supertonic.loaders import checkpoint_loader
+from examples.models.supertonic.model.config import TTSConfig
+
+
+def _config() -> TTSConfig:
+    return TTSConfig.from_dict(
+        {
+            "tts_version": "test",
+            "split": "test",
+            "ttl": {"latent_dim": 24, "chunk_compress_factor": 6},
+            "ae": {
+                "sample_rate": 44100,
+                "base_chunk_size": 512,
+                "chunk_compress_factor": 1,
+                "ldim": 24,
+            },
+            "dp": {"latent_dim": 24, "chunk_compress_factor": 6},
+        }
+    )
+
+
+def test_method_set_and_public_contracts_are_exact() -> None:
+    contracts = common.method_contracts(_config())
+
+    assert set(contracts) == {
+        "duration_predictor",
+        "text_encoder",
+        "vector_estimator",
+        "vocoder",
+    }
+    assert contracts["duration_predictor"] == common.MethodContract(
+        ("text_ids", "style_dp", "text_mask"), "duration", ("B",), torch.float16
+    )
+    assert contracts["text_encoder"] == common.MethodContract(
+        ("text_ids", "style_ttl", "text_mask"),
+        "text_emb",
+        ("B", 256, "T"),
+        torch.float16,
+    )
+    assert contracts["vector_estimator"] == common.MethodContract(
+        (
+            "noisy_latent",
+            "text_emb",
+            "style_ttl",
+            "latent_mask",
+            "text_mask",
+            "current_step",
+            "total_step",
+        ),
+        "latent",
+        ("B", 144, "L"),
+        torch.float16,
+    )
+    assert contracts["vocoder"] == common.MethodContract(
+        ("latent",), "waveform", ("B", "L*3072"), torch.float16
+    )
+
+
+def test_dynamic_shapes_share_only_binding_length_dimensions() -> None:
+    shapes = common.dynamic_shapes(common.ExportBounds(31, 47))
+
+    duration_text = shapes["duration_predictor"][0][1]
+    assert duration_text is shapes["duration_predictor"][2][2]
+    assert (duration_text.__name__, duration_text.min, duration_text.max) == (
+        "duration_text_length",
+        1,
+        31,
+    )
+
+    encoder_text = shapes["text_encoder"][0][1]
+    assert encoder_text is shapes["text_encoder"][2][2]
+    assert (encoder_text.__name__, encoder_text.min, encoder_text.max) == (
+        "encoder_text_length",
+        1,
+        31,
+    )
+
+    vector_latent = shapes["vector_estimator"][0][2]
+    vector_text = shapes["vector_estimator"][1][2]
+    assert vector_latent is shapes["vector_estimator"][3][2]
+    assert vector_text is shapes["vector_estimator"][4][2]
+    assert vector_latent is not vector_text
+    assert (vector_latent.__name__, vector_latent.min, vector_latent.max) == (
+        "vector_latent_length",
+        1,
+        47,
+    )
+    assert (vector_text.__name__, vector_text.min, vector_text.max) == (
+        "vector_text_length",
+        1,
+        31,
+    )
+
+    vocoder_latent = shapes["vocoder"][0][2]
+    assert (vocoder_latent.__name__, vocoder_latent.min, vocoder_latent.max) == (
+        "vocoder_latent_length",
+        1,
+        47,
+    )
+
+
+@pytest.mark.parametrize(
+    ("text_max", "latent_max", "error"),
+    [
+        (1, 8, "text maximum must be at least 2"),
+        (8, 1, "latent maximum must be at least 2"),
+        (1001, 8, "text maximum must not exceed 1000"),
+        (8, 1001, "latent maximum must not exceed 1000"),
+    ],
+)
+def test_invalid_dynamic_bounds_are_rejected_before_export(
+    text_max: int, latent_max: int, error: str
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        common.ExportBounds(text_max, latent_max)
+
+
+def test_example_inputs_are_deterministic_batch_one_fp16_with_integer_ids() -> None:
+    bounds = common.ExportBounds(text_max=11, latent_max=13)
+
+    first = common.example_inputs(_config(), bounds)
+    second = common.example_inputs(_config(), bounds)
+
+    assert set(first) == set(common.method_contracts(_config()))
+    for method_name in first:
+        assert len(first[method_name]) == len(second[method_name])
+        for actual, repeated in zip(first[method_name], second[method_name]):
+            torch.testing.assert_close(actual, repeated)
+            assert actual.shape[0] == 1
+
+    assert first["duration_predictor"][0].dtype == torch.int64
+    assert first["text_encoder"][0].dtype == torch.int64
+    for method_name, inputs in first.items():
+        for input_name, value in zip(
+            common.method_contracts(_config())[method_name].input_names, inputs
+        ):
+            if input_name != "text_ids":
+                assert value.dtype == torch.float16
+
+    assert first["duration_predictor"][0].shape == (1, 11)
+    assert first["text_encoder"][2].shape == (1, 1, 11)
+    assert first["vector_estimator"][0].shape == (1, 144, 13)
+    assert first["vector_estimator"][1].shape == (1, 256, 11)
+    assert first["vocoder"][0].shape == (1, 144, 13)
+
+
+def test_example_inputs_cross_the_public_vector_validation_boundary(
+    monkeypatch,
+) -> None:
+    calls = []
+
+    def record_validation(inputs, config, bounds) -> None:
+        calls.append((inputs, config, bounds))
+
+    monkeypatch.setattr(common, "validate_vector_inputs", record_validation)
+    config = _config()
+    bounds = common.ExportBounds(11, 13)
+
+    samples = common.example_inputs(config, bounds)
+
+    assert calls == [(samples["vector_estimator"], config, bounds)]
+
+
+def _valid_vector_inputs() -> tuple[torch.Tensor, ...]:
+    config = _config()
+    return common.example_inputs(config, common.ExportBounds(4, 3))["vector_estimator"]
+
+
+def test_example_inputs_reject_flow_steps_the_native_runner_cannot_execute() -> None:
+    with pytest.raises(ValueError, match="flow steps must be 5"):
+        common.example_inputs(
+            _config(), common.ExportBounds(4, 3), flow_steps=4
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "error"),
+    [
+        (lambda values: values[:-1], "exactly 7 tensors"),
+        (
+            lambda values: (values[0].repeat(2, 1, 1), *values[1:]),
+            "batch size must be 1",
+        ),
+        (
+            lambda values: (
+                values[0],
+                values[1].float(),
+                *values[2:],
+            ),
+            "text_emb must have dtype torch.float16",
+        ),
+        (
+            lambda values: (
+                values[0][:, :, :0],
+                values[1],
+                values[2],
+                values[3][:, :, :0],
+                *values[4:],
+            ),
+            "latent length must be in",
+        ),
+        (
+            lambda values: (
+                values[0],
+                values[1][:, :, :0],
+                values[2],
+                values[3],
+                values[4][:, :, :0],
+                *values[5:],
+            ),
+            "text length must be in",
+        ),
+        (
+            lambda values: (
+                torch.cat((values[0], values[0][:, :, :1]), dim=2),
+                values[1],
+                values[2],
+                torch.cat((values[3], values[3][:, :, :1]), dim=2),
+                *values[4:],
+            ),
+            "latent length must be in",
+        ),
+        (
+            lambda values: (
+                values[0],
+                values[1],
+                values[2],
+                torch.zeros_like(values[3]),
+                *values[4:],
+            ),
+            "latent_mask must contain a valid position",
+        ),
+        (
+            lambda values: (
+                *values[:6],
+                torch.zeros_like(values[6]),
+            ),
+            "total_step must be finite and positive",
+        ),
+        (
+            lambda values: (
+                values[0][:, :, ::2],
+                *values[1:],
+            ),
+            "noisy_latent must be contiguous",
+        ),
+    ],
+)
+def test_public_vector_validator_rejects_invalid_pte_domain_inputs(
+    mutate, error: str
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        common.validate_vector_inputs(
+            mutate(_valid_vector_inputs()),
+            _config(),
+            common.ExportBounds(4, 3),
+        )
+
+
+def test_text_vocabulary_size_requires_matching_model_embeddings() -> None:
+    class ModelPair(nn.Module):
+        def __init__(self, vocabulary_size: int) -> None:
+            super().__init__()
+            self.text_embedder = nn.Module()
+            self.text_embedder.char_embedder = nn.Embedding(vocabulary_size, 2)
+
+    duration = nn.Module()
+    duration.sentence_encoder = ModelPair(17)
+    encoder = nn.Module()
+    encoder.text_encoder = ModelPair(17)
+    models = {"duration_predictor": duration, "text_encoder": encoder}
+
+    assert common.text_vocabulary_size(models) == 17
+    encoder.text_encoder = ModelPair(18)
+    with pytest.raises(ValueError, match="must use the same vocabulary"):
+        common.text_vocabulary_size(models)
+
+
+def test_runtime_metadata_contains_host_pipeline_constants() -> None:
+    metadata = common.runtime_metadata(
+        _config(),
+        common.ExportBounds(31, 47),
+        text_vocabulary_size=8322,
+        flow_steps=5,
+    )
+
+    assert metadata == {
+        "get_sample_rate": 44100,
+        "get_base_chunk_size": 512,
+        "get_chunk_compress_factor": 6,
+        "get_flow_steps": 5,
+        "get_text_vocabulary_size": 8322,
+        "get_latent_dim": 24,
+        "get_latent_channels": 144,
+        "get_max_text_length": 31,
+        "get_max_latent_length": 47,
+        "get_batch_size": 1,
+        "get_activation_dtype": "float16",
+        "enable_dynamic_shape": True,
+    }
+
+    with pytest.raises(ValueError, match="flow steps must be 5"):
+        common.runtime_metadata(
+            _config(),
+            common.ExportBounds(),
+            text_vocabulary_size=8322,
+            flow_steps=4,
+        )
+    with pytest.raises(ValueError, match="text vocabulary size must be positive"):
+        common.runtime_metadata(
+            _config(), common.ExportBounds(), text_vocabulary_size=0
+        )
+
+
+def test_asset_paths_follow_the_published_layout_without_downloads(tmp_path) -> None:
+    onnx_dir = tmp_path / "onnx"
+    onnx_dir.mkdir()
+    (onnx_dir / "tts.json").write_text(
+        json.dumps(
+            {
+                "tts_version": "test",
+                "split": "test",
+                "ttl": {"latent_dim": 24, "chunk_compress_factor": 6},
+                "ae": {
+                    "sample_rate": 44100,
+                    "base_chunk_size": 512,
+                    "chunk_compress_factor": 1,
+                    "ldim": 24,
+                },
+                "dp": {"latent_dim": 24, "chunk_compress_factor": 6},
+            }
+        ),
+        encoding="utf-8",
+    )
+    for method_name in common.METHOD_NAMES:
+        (onnx_dir / f"{method_name}.onnx").touch()
+
+    assets = common.resolve_assets(tmp_path)
+
+    assert assets.config == onnx_dir / "tts.json"
+    assert assets.models == {
+        name: onnx_dir / f"{name}.onnx" for name in common.METHOD_NAMES
+    }
+
+
+def test_asset_paths_report_every_missing_required_file(tmp_path) -> None:
+    with pytest.raises(FileNotFoundError) as error:
+        common.resolve_assets(tmp_path)
+
+    message = str(error.value)
+    assert "onnx/tts.json" in message
+    for method_name in common.METHOD_NAMES:
+        assert f"onnx/{method_name}.onnx" in message
+
+
+def test_load_models_constructs_every_stage_from_the_same_config(
+    tmp_path, monkeypatch
+) -> None:
+    onnx_dir = tmp_path / "onnx"
+    onnx_dir.mkdir()
+    (onnx_dir / "tts.json").write_text(
+        json.dumps(
+            {
+                "tts_version": "test",
+                "split": "test",
+                "ttl": {"latent_dim": 24, "chunk_compress_factor": 6},
+                "ae": {
+                    "sample_rate": 44100,
+                    "base_chunk_size": 512,
+                    "chunk_compress_factor": 1,
+                    "ldim": 24,
+                },
+                "dp": {"latent_dim": 24, "chunk_compress_factor": 6},
+            }
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+    expected_models = {}
+    for method_name in common.METHOD_NAMES:
+        model_path = onnx_dir / f"{method_name}.onnx"
+        model_path.touch()
+        model = nn.Linear(1, 1)
+        model.train()
+        expected_models[method_name] = model
+
+        def fake_loader(path, config, *, _name=method_name, _model=model):
+            calls.append((_name, path, config))
+            return _model
+
+        monkeypatch.setattr(checkpoint_loader, f"load_{method_name}", fake_loader)
+
+    config, models = common.load_models(tmp_path)
+
+    assert config == _config()
+    assert models == expected_models
+    assert [name for name, _, _ in calls] == list(common.METHOD_NAMES)
+    assert all(path == onnx_dir / f"{name}.onnx" for name, path, _ in calls)
+    assert all(loaded_config is config for _, _, loaded_config in calls)
+    assert all(not model.training for model in models.values())
+
+
+def test_fp16_conversion_preserves_integer_tensors() -> None:
+    model = nn.Linear(2, 3)
+    model.register_buffer("float_buffer", torch.ones(2, dtype=torch.float32))
+    model.register_buffer("integer_buffer", torch.ones(2, dtype=torch.int64))
+
+    converted = common.convert_models_to_fp16({"stage": model})
+
+    assert converted["stage"] is model
+    assert model.weight.dtype == torch.float16
+    assert model.bias.dtype == torch.float16
+    assert model.float_buffer.dtype == torch.float16
+    assert model.integer_buffer.dtype == torch.int64

--- a/examples/models/supertonic/tests/test_export.py
+++ b/examples/models/supertonic/tests/test_export.py
@@ -8,11 +8,11 @@ import json
 
 import pytest
 import torch
-from torch import nn
 
 from examples.models.supertonic.export import common
 from examples.models.supertonic.loaders import checkpoint_loader
 from examples.models.supertonic.model.config import TTSConfig
+from torch import nn
 
 
 def _config() -> TTSConfig:
@@ -181,9 +181,7 @@ def _valid_vector_inputs() -> tuple[torch.Tensor, ...]:
 
 def test_example_inputs_reject_flow_steps_the_native_runner_cannot_execute() -> None:
     with pytest.raises(ValueError, match="flow steps must be 5"):
-        common.example_inputs(
-            _config(), common.ExportBounds(4, 3), flow_steps=4
-        )
+        common.example_inputs(_config(), common.ExportBounds(4, 3), flow_steps=4)
 
 
 @pytest.mark.parametrize(

--- a/examples/models/supertonic/tests/test_mlx_pipeline.py
+++ b/examples/models/supertonic/tests/test_mlx_pipeline.py
@@ -9,8 +9,7 @@ import platform
 import pytest
 import torch
 
-from examples.models.supertonic.export import common
-from examples.models.supertonic.export import export_supertonic
+from examples.models.supertonic.export import common, export_supertonic
 from examples.models.supertonic.model.config import TTSConfig
 from examples.models.supertonic.model.duration_predictor import DurationPredictor
 from examples.models.supertonic.model.text_encoder import TextEncoder
@@ -235,9 +234,7 @@ def test_saved_multi_method_pte_reloads_and_runs_dynamic_lengths(
     assert set(tmp_path.iterdir()) == {pte_path}
     program = Runtime.get().load_program(pte_path, verification=Verification.Minimal)
 
-    metadata = common.runtime_metadata(
-        config, BOUNDS, text_vocabulary_size=256
-    )
+    metadata = common.runtime_metadata(config, BOUNDS, text_vocabulary_size=256)
     assert program.method_names == set(common.METHOD_NAMES) | set(metadata)
     for method_name, expected in metadata.items():
         actual = program.load_method(method_name).execute([])[0]

--- a/examples/models/supertonic/tests/test_mlx_pipeline.py
+++ b/examples/models/supertonic/tests/test_mlx_pipeline.py
@@ -1,0 +1,271 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import platform
+
+import pytest
+import torch
+
+from examples.models.supertonic.export import common
+from examples.models.supertonic.export import export_supertonic
+from examples.models.supertonic.model.config import TTSConfig
+from examples.models.supertonic.model.duration_predictor import DurationPredictor
+from examples.models.supertonic.model.text_encoder import TextEncoder
+from examples.models.supertonic.model.vector_estimator import VectorEstimator
+from examples.models.supertonic.model.vocoder import Vocoder
+
+
+def _has_mlx() -> bool:
+    try:
+        import executorch.backends.mlx.custom_ops  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin" or not _has_mlx(),
+    reason="Darwin with the ExecuTorch MLX backend is required",
+)
+
+BOUNDS = common.ExportBounds(text_max=4, latent_max=3)
+VALID_LENGTHS = ((1, 1), (4, 1), (1, 3), (2, 2), (4, 3))
+
+
+def _config() -> TTSConfig:
+    return TTSConfig.from_dict(
+        {
+            "tts_version": "test",
+            "split": "test",
+            "ttl": {"latent_dim": 2, "chunk_compress_factor": 2},
+            "ae": {
+                "sample_rate": 16000,
+                "base_chunk_size": 4,
+                "chunk_compress_factor": 1,
+                "ldim": 2,
+            },
+            "dp": {"latent_dim": 2, "chunk_compress_factor": 2},
+        }
+    )
+
+
+def _models(config: TTSConfig) -> dict[str, torch.nn.Module]:
+    models = {
+        "duration_predictor": DurationPredictor(
+            config,
+            vocab_size=256,
+            channels=4,
+            convnext_dilations=(1,),
+            attention_layers=1,
+            attention_heads=1,
+            ff_channels=4,
+            style_tokens=8,
+            style_dim=16,
+            hidden_dim=4,
+        ),
+        "text_encoder": TextEncoder(
+            config,
+            vocab_size=256,
+            channels=256,
+            convnext_dilations=(1,),
+            attention_layers=1,
+            attention_heads=1,
+            ff_channels=4,
+            style_tokens=50,
+            style_attention_heads=2,
+        ),
+        "vector_estimator": VectorEstimator(
+            config,
+            hidden_channels=8,
+            time_dim=4,
+            time_hidden_channels=8,
+            num_main_blocks=1,
+            main_convnext_dilations=(1,),
+            post_time_dilations=(1,),
+            post_text_dilations=(1,),
+            final_dilations=(1,),
+            text_channels=256,
+            style_tokens=50,
+            style_channels=256,
+            attention_heads=1,
+            style_attention_heads=2,
+            max_positions=1000,
+        ),
+        "vocoder": Vocoder(
+            config,
+            decoder_channels=8,
+            decoder_dilations=(),
+            decoder_expansion=2,
+            head_hidden_channels=8,
+        ),
+    }
+    return dict(common.convert_models_to_fp16(models))
+
+
+def _inputs_at(
+    config: TTSConfig, *, text_length: int, latent_length: int
+) -> dict[str, tuple[torch.Tensor, ...]]:
+    samples = common.example_inputs(config, BOUNDS)
+    samples["duration_predictor"] = (
+        samples["duration_predictor"][0][:, :text_length].contiguous(),
+        samples["duration_predictor"][1],
+        samples["duration_predictor"][2][:, :, :text_length].contiguous(),
+    )
+    samples["text_encoder"] = (
+        samples["text_encoder"][0][:, :text_length].contiguous(),
+        samples["text_encoder"][1],
+        samples["text_encoder"][2][:, :, :text_length].contiguous(),
+    )
+    vector = samples["vector_estimator"]
+    vector_inputs = (
+        vector[0][:, :, :latent_length].contiguous(),
+        vector[1][:, :, :text_length].contiguous(),
+        vector[2],
+        vector[3][:, :, :latent_length].contiguous(),
+        vector[4][:, :, :text_length].contiguous(),
+        vector[5],
+        vector[6],
+    )
+    common.validate_vector_inputs(vector_inputs, config, BOUNDS)
+    samples["vector_estimator"] = vector_inputs
+    samples["vocoder"] = (samples["vocoder"][0][:, :, :latent_length].contiguous(),)
+    return samples
+
+
+@pytest.fixture(scope="module")
+def exported():
+    config = _config()
+    programs = export_supertonic.export_programs(_models(config), config, BOUNDS)
+    return config, programs
+
+
+@pytest.fixture(scope="module")
+def lowered(exported):
+    config, programs = exported
+    edge = export_supertonic.lower_to_mlx(
+        programs,
+        common.runtime_metadata(config, BOUNDS, text_vocabulary_size=256),
+    )
+    return config, edge
+
+
+def test_all_four_methods_export_together_with_dynamic_fp16_contracts(
+    exported,
+) -> None:
+    config, programs = exported
+
+    assert set(programs) == set(common.METHOD_NAMES)
+    for text_length, latent_length in VALID_LENGTHS:
+        inputs = _inputs_at(
+            config,
+            text_length=text_length,
+            latent_length=latent_length,
+        )
+        outputs = {
+            name: programs[name].module()(*inputs[name]) for name in common.METHOD_NAMES
+        }
+        assert outputs["duration_predictor"].shape == (1,)
+        assert outputs["text_encoder"].shape == (1, 256, text_length)
+        assert outputs["vector_estimator"].shape == (1, 4, latent_length)
+        assert outputs["vocoder"].shape == (1, latent_length * 8)
+        assert all(output.dtype == torch.float16 for output in outputs.values())
+
+
+def test_export_accepts_models_in_any_mapping_insertion_order() -> None:
+    config = _config()
+    models = _models(config)
+    reversed_models = dict(reversed(tuple(models.items())))
+
+    programs = export_supertonic.export_programs(reversed_models, config, BOUNDS)
+
+    assert set(programs) == set(common.METHOD_NAMES)
+
+
+def test_expected_tensor_ops_are_delegated_without_cpu_fallback(
+    exported, lowered
+) -> None:
+    _, programs = exported
+    _, edge = lowered
+    expected_ops = {
+        "duration_predictor": ("embedding", "linear"),
+        "text_encoder": ("embedding", "matmul"),
+        "vector_estimator": ("conv1d", "matmul", "softmax"),
+        "vocoder": ("conv1d", "batch_norm", "where"),
+    }
+
+    assert edge.methods == set(common.METHOD_NAMES)
+    for method_name in common.METHOD_NAMES:
+        aten_targets = {
+            str(node.target)
+            for node in programs[method_name].graph.nodes
+            if node.op == "call_function"
+        }
+        for expected in expected_ops[method_name]:
+            assert any(expected in target for target in aten_targets), (
+                method_name,
+                expected,
+                sorted(aten_targets),
+            )
+
+        edge_targets = [
+            str(node.target)
+            for node in edge.exported_program(method_name).graph.nodes
+            if node.op == "call_function"
+        ]
+        assert sum("executorch_call_delegate" in target for target in edge_targets) == 1
+        assert all(
+            "executorch_call_delegate" in target
+            or target == "<built-in function getitem>"
+            for target in edge_targets
+        )
+
+
+def test_saved_multi_method_pte_reloads_and_runs_dynamic_lengths(
+    lowered, tmp_path
+) -> None:
+    from executorch.runtime import Runtime, Verification
+
+    config, edge = lowered
+    et_program = export_supertonic.to_executorch(edge)
+    assert not et_program._tensor_data
+    pte_path = common.save_pte(et_program, tmp_path / "supertonic.pte")
+    assert set(tmp_path.iterdir()) == {pte_path}
+    program = Runtime.get().load_program(pte_path, verification=Verification.Minimal)
+
+    metadata = common.runtime_metadata(
+        config, BOUNDS, text_vocabulary_size=256
+    )
+    assert program.method_names == set(common.METHOD_NAMES) | set(metadata)
+    for method_name, expected in metadata.items():
+        actual = program.load_method(method_name).execute([])[0]
+        assert actual == expected
+        assert type(actual) is type(expected)
+
+    from executorch.backends.mlx.pte_inspector import parse_executorch_program
+
+    serialized = parse_executorch_program(pte_path.read_bytes())["program"]
+    plans = {plan["name"]: plan for plan in serialized["execution_plan"]}
+    assert set(plans) == program.method_names
+    for method_name in common.METHOD_NAMES:
+        assert len(plans[method_name].get("delegates", [])) == 1
+    for method_name in metadata:
+        assert plans[method_name].get("delegates", []) == []
+
+    for text_length, latent_length in VALID_LENGTHS:
+        inputs = _inputs_at(
+            config,
+            text_length=text_length,
+            latent_length=latent_length,
+        )
+        outputs = {
+            name: program.load_method(name).execute(list(inputs[name]))[0]
+            for name in common.METHOD_NAMES
+        }
+        assert outputs["duration_predictor"].shape == (1,)
+        assert outputs["text_encoder"].shape == (1, 256, text_length)
+        assert outputs["vector_estimator"].shape == (1, 4, latent_length)
+        assert outputs["vocoder"].shape == (1, latent_length * 8)
+        assert all(output.dtype == torch.float16 for output in outputs.values())

--- a/examples/models/supertonic/tests/test_model.py
+++ b/examples/models/supertonic/tests/test_model.py
@@ -1,0 +1,234 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+
+import pytest
+import torch
+from torch.nn import functional as F
+
+
+def _layers():
+    return importlib.import_module("examples.models.supertonic.model.layers")
+
+
+def test_same_pad_1d_matches_edge_padding_in_onnx_graphs() -> None:
+    values = torch.tensor([[[1.0, 2.0, 3.0]]])
+
+    padded = _layers().SamePad1d(kernel_size=5)(values)
+
+    torch.testing.assert_close(
+        padded, torch.tensor([[[1.0, 1.0, 1.0, 2.0, 3.0, 3.0, 3.0]]])
+    )
+
+
+def test_layer_norm_1d_normalizes_channels_last_and_restores_layout() -> None:
+    values = torch.tensor([[[1.0, 3.0], [2.0, 5.0], [7.0, 11.0]]], dtype=torch.float32)
+    layer = _layers().LayerNorm1d(3, eps=1e-6)
+    with torch.no_grad():
+        layer.norm.weight.copy_(torch.tensor([0.5, 1.0, 1.5]))
+        layer.norm.bias.copy_(torch.tensor([-1.0, 0.0, 1.0]))
+
+    output = layer(values)
+
+    expected = F.layer_norm(
+        values.transpose(1, 2),
+        (3,),
+        layer.norm.weight,
+        layer.norm.bias,
+        eps=1e-6,
+    ).transpose(1, 2)
+    torch.testing.assert_close(output, expected)
+
+
+def test_projection_wrappers_preserve_published_parameter_names() -> None:
+    linear = _layers().LinearProjection(3, 4)
+    convolution = _layers().Conv1dProjection(3, 4, kernel_size=1)
+
+    assert set(linear.state_dict()) == {"linear.weight", "linear.bias"}
+    assert set(convolution.state_dict()) == {"net.weight", "net.bias"}
+    assert linear(torch.ones(2, 5, 3)).shape == (2, 5, 4)
+    assert convolution(torch.ones(2, 3, 5)).shape == (2, 4, 5)
+
+
+def test_convnext_block_matches_published_residual_sequence() -> None:
+    block = _layers().ConvNeXtBlock(
+        channels=2, kernel_size=3, expansion=2, layer_scale_init_value=1.0
+    )
+    with torch.no_grad():
+        block.dwconv.weight.zero_()
+        block.dwconv.weight[:, 0, 1] = 1.0
+        block.dwconv.bias.zero_()
+        block.norm.norm.weight.fill_(1.0)
+        block.norm.norm.bias.zero_()
+        block.pwconv1.weight.zero_()
+        block.pwconv1.bias.zero_()
+        block.pwconv1.weight[0, 0, 0] = 1.0
+        block.pwconv1.weight[1, 1, 0] = 1.0
+        block.pwconv2.weight.zero_()
+        block.pwconv2.bias.zero_()
+        block.pwconv2.weight[0, 0, 0] = 1.0
+        block.pwconv2.weight[1, 1, 0] = 1.0
+        block.gamma.fill_(1.0)
+    values = torch.tensor([[[1.0, 4.0, 2.0], [3.0, 0.0, 5.0]]])
+
+    output = block(values)
+
+    normalized = F.layer_norm(values.transpose(1, 2), (2,), eps=1e-6).transpose(1, 2)
+    torch.testing.assert_close(output, values + F.gelu(normalized))
+
+
+def test_convnext_block_applies_published_dilation() -> None:
+    block = _layers().ConvNeXtBlock(
+        channels=1,
+        kernel_size=3,
+        dilation=2,
+        expansion=1,
+        layer_scale_init_value=0.0,
+    )
+
+    assert block.pad.padding == (2, 2)
+    assert block.dwconv.dilation == (2,)
+    assert block(torch.ones(1, 1, 5)).shape == (1, 1, 5)
+
+
+def test_convnext_masks_padding_before_and_after_each_block() -> None:
+    torch.manual_seed(0)
+    block = _layers().ConvNeXtBlock(channels=2, kernel_size=5)
+    mask = torch.tensor([[[1.0, 1.0, 0.0]]])
+    first = torch.randn(1, 2, 3)
+    second = first.clone()
+    second[:, :, -1] = 1000.0
+
+    first_output = block(first, mask)
+    second_output = block(second, mask)
+
+    torch.testing.assert_close(first_output, second_output)
+    torch.testing.assert_close(first_output[:, :, -1], torch.zeros(1, 2))
+
+
+def test_convnext_stack_preserves_published_parameter_hierarchy() -> None:
+    stack = _layers().ConvNeXt(channels=4, num_layers=2, kernel_size=5)
+
+    assert "convnext.0.gamma" in stack.state_dict()
+    assert "convnext.0.dwconv.weight" in stack.state_dict()
+    assert "convnext.0.norm.norm.weight" in stack.state_dict()
+    assert "convnext.1.pwconv2.bias" in stack.state_dict()
+    assert stack(torch.ones(1, 4, 6)).shape == (1, 4, 6)
+
+
+def test_multi_head_attention_matches_scaled_dot_product_attention() -> None:
+    attention = _layers().MultiHeadAttention(channels=4, num_heads=2, bias=False)
+    identity = torch.eye(4)
+    with torch.no_grad():
+        attention.W_query.linear.weight.copy_(identity)
+        attention.W_key.linear.weight.copy_(identity)
+        attention.W_value.linear.weight.copy_(identity)
+        attention.out_fc.linear.weight.copy_(identity)
+    values = torch.tensor([[[1.0, 0.0, 0.0, 1.0], [0.0, 1.0, 1.0, 0.0]]])
+
+    output = attention(values)
+
+    heads = values.reshape(1, 2, 2, 2).transpose(1, 2)
+    expected = F.scaled_dot_product_attention(heads, heads, heads)
+    expected = expected.transpose(1, 2).reshape(1, 2, 4)
+    torch.testing.assert_close(output, expected)
+
+
+def test_multi_head_attention_applies_key_and_query_masks() -> None:
+    torch.manual_seed(0)
+    attention = _layers().MultiHeadAttention(channels=4, num_heads=2)
+    query = torch.randn(1, 3, 4)
+    context = torch.randn(1, 3, 4)
+    changed_context = context.clone()
+    changed_context[:, -1] = 1000.0
+    key_mask = torch.tensor([[1.0, 1.0, 0.0]])
+    query_mask = torch.tensor([[1.0, 1.0, 0.0]])
+
+    output = attention(query, context, query_mask=query_mask, key_mask=key_mask)
+    changed_output = attention(
+        query, changed_context, query_mask=query_mask, key_mask=key_mask
+    )
+
+    torch.testing.assert_close(output, changed_output)
+    torch.testing.assert_close(output[:, -1], torch.zeros(1, 4))
+
+
+def test_multi_head_attention_returns_zero_when_all_keys_are_masked() -> None:
+    torch.manual_seed(0)
+    attention = _layers().MultiHeadAttention(channels=4, num_heads=2)
+    query = torch.randn(2, 3, 4)
+    context = torch.randn(2, 5, 4)
+    key_mask = torch.zeros(2, 5)
+
+    output = attention(query, context, key_mask=key_mask)
+
+    torch.testing.assert_close(output, torch.zeros_like(output))
+    assert torch.isfinite(output).all()
+
+
+def test_multi_head_attention_preserves_published_projection_names() -> None:
+    attention = _layers().MultiHeadAttention(channels=4, num_heads=2)
+
+    assert {
+        "W_query.linear.weight",
+        "W_query.linear.bias",
+        "W_key.linear.weight",
+        "W_key.linear.bias",
+        "W_value.linear.weight",
+        "W_value.linear.bias",
+        "out_fc.linear.weight",
+        "out_fc.linear.bias",
+    } == set(attention.state_dict())
+
+
+def test_multi_head_attention_supports_cross_attention_projection_widths() -> None:
+    attention = _layers().MultiHeadAttention(
+        channels=4,
+        context_channels=3,
+        attention_channels=2,
+        num_heads=1,
+    )
+
+    output = attention(torch.ones(1, 5, 4), torch.ones(1, 7, 3))
+
+    assert output.shape == (1, 5, 4)
+    assert attention.W_query.linear.weight.shape == (2, 4)
+    assert attention.W_key.linear.weight.shape == (2, 3)
+    assert attention.W_value.linear.weight.shape == (2, 3)
+    assert attention.out_fc.linear.weight.shape == (4, 2)
+
+
+def test_multi_head_attention_rejects_indivisible_attention_channels() -> None:
+    with pytest.raises(
+        ValueError,
+        match="attention_channels must be divisible by num_heads",
+    ):
+        _layers().MultiHeadAttention(
+            channels=4,
+            attention_channels=5,
+            num_heads=2,
+        )
+
+
+def test_add_conditioning_projects_and_broadcasts_over_sequence() -> None:
+    conditioning = _layers().AddConditioning(condition_features=2, channels=3)
+    with torch.no_grad():
+        conditioning.linear.linear.weight.copy_(
+            torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+        )
+        conditioning.linear.linear.bias.zero_()
+    values = torch.ones(1, 3, 4)
+    condition = torch.tensor([[2.0, 3.0]])
+
+    output = conditioning(values, condition)
+
+    expected_condition = torch.tensor([[[2.0], [3.0], [5.0]]])
+    torch.testing.assert_close(output, values + expected_condition)
+    assert set(conditioning.state_dict()) == {
+        "linear.linear.weight",
+        "linear.linear.bias",
+    }

--- a/examples/models/supertonic/tests/test_preprocessing.py
+++ b/examples/models/supertonic/tests/test_preprocessing.py
@@ -11,9 +11,9 @@ import pytest
 
 from examples.models.supertonic.preprocessing import (
     AVAILABLE_LANGUAGES,
-    UnicodeProcessor,
     chunk_text_for_language,
     preprocess_text,
+    UnicodeProcessor,
 )
 
 

--- a/examples/models/supertonic/tests/test_preprocessing.py
+++ b/examples/models/supertonic/tests/test_preprocessing.py
@@ -1,0 +1,169 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+
+import numpy as np
+import pytest
+
+from examples.models.supertonic.preprocessing import (
+    AVAILABLE_LANGUAGES,
+    UnicodeProcessor,
+    chunk_text_for_language,
+    preprocess_text,
+)
+
+
+def test_preprocess_text_normalizes_nfkd_and_adds_language_tags() -> None:
+    assert preprocess_text("Café", "en") == "<en>Cafe\u0301.</en>"
+
+
+def test_available_languages_match_published_model() -> None:
+    assert AVAILABLE_LANGUAGES == (
+        "en",
+        "ko",
+        "ja",
+        "ar",
+        "bg",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "es",
+        "et",
+        "fi",
+        "fr",
+        "hi",
+        "hr",
+        "hu",
+        "id",
+        "it",
+        "lt",
+        "lv",
+        "nl",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sk",
+        "sl",
+        "sv",
+        "tr",
+        "uk",
+        "vi",
+        "na",
+    )
+
+
+def test_preprocess_text_cleans_punctuation_emoji_and_expressions() -> None:
+    text = "“Hello” — world_🙂 @ x ♥ e.g., i.e., [done]"
+
+    assert (
+        preprocess_text(text, "en")
+        == '<en>"Hello" - world at x for example, that is, done.</en>'
+    )
+
+
+def test_preprocess_text_rejects_invalid_language() -> None:
+    with pytest.raises(ValueError, match="Invalid language: xx"):
+        preprocess_text("Hello", "xx")
+
+
+def test_unicode_processor_returns_deterministic_ids_and_masks(tmp_path) -> None:
+    indexer_path = tmp_path / "unicode_indexer.json"
+    indexer_path.write_text(json.dumps(list(range(128))), encoding="utf-8")
+    processor = UnicodeProcessor(indexer_path, vocabulary_size=128)
+
+    text_ids, text_mask = processor(["A", "Hi!"], ["en", "en"])
+
+    np.testing.assert_array_equal(
+        text_ids[0],
+        [60, 101, 110, 62, 65, 46, 60, 47, 101, 110, 62, 0],
+    )
+    np.testing.assert_array_equal(
+        text_ids[1],
+        [60, 101, 110, 62, 72, 105, 33, 60, 47, 101, 110, 62],
+    )
+    np.testing.assert_array_equal(text_mask[0, 0], [1] * 11 + [0])
+    np.testing.assert_array_equal(text_mask[1, 0], [1] * 12)
+    assert text_ids.dtype == np.int64
+    assert text_mask.dtype == np.float32
+
+
+def test_unicode_processor_rejects_empty_batch(tmp_path) -> None:
+    indexer_path = tmp_path / "unicode_indexer.json"
+    indexer_path.write_text(json.dumps(list(range(128))), encoding="utf-8")
+    processor = UnicodeProcessor(indexer_path, vocabulary_size=128)
+
+    with pytest.raises(ValueError, match="at least one text and language"):
+        processor([], [])
+
+
+def test_unicode_processor_rejects_mismatched_cardinality(tmp_path) -> None:
+    indexer_path = tmp_path / "unicode_indexer.json"
+    indexer_path.write_text(json.dumps(list(range(128))), encoding="utf-8")
+    processor = UnicodeProcessor(indexer_path, vocabulary_size=128)
+
+    with pytest.raises(ValueError, match="same cardinality"):
+        processor(["Hello", "World"], ["en"])
+
+
+def test_unicode_processor_rejects_unsupported_and_out_of_range_tokens(
+    tmp_path,
+) -> None:
+    unsupported = list(range(128))
+    unsupported[ord("A")] = -1
+    unsupported_path = tmp_path / "unsupported.json"
+    unsupported_path.write_text(json.dumps(unsupported), encoding="utf-8")
+    processor = UnicodeProcessor(unsupported_path, vocabulary_size=128)
+    with pytest.raises(ValueError, match="unsupported Unicode codepoint 65"):
+        processor(["A"], ["en"])
+
+    out_of_range = list(range(128))
+    out_of_range[ord("A")] = 128
+    out_of_range_path = tmp_path / "out_of_range.json"
+    out_of_range_path.write_text(json.dumps(out_of_range), encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid vocabulary token"):
+        UnicodeProcessor(out_of_range_path, vocabulary_size=128)
+
+    invalid_type = list(range(128))
+    invalid_type[ord("A")] = True
+    invalid_type_path = tmp_path / "invalid_type.json"
+    invalid_type_path.write_text(json.dumps(invalid_type), encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid vocabulary token"):
+        UnicodeProcessor(invalid_type_path, vocabulary_size=128)
+
+    with pytest.raises(ValueError, match="text vocabulary size must be positive"):
+        UnicodeProcessor(unsupported_path, vocabulary_size=0)
+
+
+def test_chunk_text_uses_120_for_korean_and_300_for_english() -> None:
+    text = f"{'가' * 60}. {'나' * 60}. {'다' * 10}."
+
+    assert chunk_text_for_language(text, "ko") == [
+        f"{'가' * 60}.",
+        f"{'나' * 60}. {'다' * 10}.",
+    ]
+    assert chunk_text_for_language(text, "en") == [text]
+
+
+def test_chunk_text_splits_cjk_terminators_without_spaces() -> None:
+    first = "あ" * 60 + "。"
+    second = "い" * 59 + "！？"
+    third = "う" * 10 + "？"
+
+    expected = [first, second + " " + third]
+    assert chunk_text_for_language(first + second + third, "ja") == expected
+    assert chunk_text_for_language(first + " \u3000" + second + third, "ja") == expected
+
+
+@pytest.mark.parametrize(("language", "threshold"), [("ko", 120), ("en", 300)])
+def test_chunk_text_keeps_a_single_sentence_over_soft_limit(
+    language: str, threshold: int
+) -> None:
+    sentence = f"{'x' * threshold}."
+
+    assert chunk_text_for_language(sentence, language) == [sentence]

--- a/examples/models/supertonic/tests/test_source_transformations.py
+++ b/examples/models/supertonic/tests/test_source_transformations.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from examples.models.supertonic.export import common
+from examples.models.supertonic.model.config import TTSConfig
+from examples.models.supertonic.model.layers import SamePad1d
+from examples.models.supertonic.model.text_encoder import RelativeMultiHeadAttention
+from examples.models.supertonic.model.vector_estimator import VectorEstimator
+from examples.models.supertonic.model.vocoder import Vocoder
+from examples.models.supertonic.source_transformations.mlx import (
+    exportable_vector_estimator,
+    MLXCausalPad1d,
+    MLXRelativeMultiHeadAttention,
+    MLXSamePad1d,
+    replace_vocoder_causal_padding,
+)
+
+
+BOUNDS = common.ExportBounds(text_max=4, latent_max=3)
+VALID_LENGTHS = ((1, 1), (4, 1), (1, 3), (2, 2), (4, 3))
+
+
+def _config() -> TTSConfig:
+    return TTSConfig.from_dict(
+        {
+            "tts_version": "test",
+            "split": "test",
+            "ttl": {"latent_dim": 2, "chunk_compress_factor": 2},
+            "ae": {
+                "sample_rate": 16000,
+                "base_chunk_size": 4,
+                "chunk_compress_factor": 1,
+                "ldim": 2,
+            },
+            "dp": {"latent_dim": 2, "chunk_compress_factor": 2},
+        }
+    )
+
+
+def _vector_model(config: TTSConfig) -> VectorEstimator:
+    return (
+        VectorEstimator(
+            config,
+            hidden_channels=8,
+            time_dim=4,
+            time_hidden_channels=8,
+            num_main_blocks=1,
+            main_convnext_dilations=(1,),
+            post_time_dilations=(1,),
+            post_text_dilations=(1,),
+            final_dilations=(1,),
+            text_channels=256,
+            style_tokens=50,
+            style_channels=256,
+            attention_heads=1,
+            style_attention_heads=2,
+            max_positions=1000,
+        )
+        .eval()
+        .half()
+    )
+
+
+def _vector_inputs_at(
+    config: TTSConfig, text_length: int, latent_length: int
+) -> tuple[torch.Tensor, ...]:
+    values = common.example_inputs(config, BOUNDS)["vector_estimator"]
+    inputs = (
+        values[0][:, :, :latent_length].contiguous(),
+        values[1][:, :, :text_length].contiguous(),
+        values[2],
+        values[3][:, :, :latent_length].contiguous(),
+        values[4][:, :, :text_length].contiguous(),
+        values[5],
+        values[6],
+    )
+    common.validate_vector_inputs(inputs, config, BOUNDS)
+    return inputs
+
+
+@pytest.mark.parametrize(("text_length", "latent_length"), VALID_LENGTHS)
+def test_vector_valid_domain_transform_matches_public_model(
+    text_length: int, latent_length: int
+) -> None:
+    torch.manual_seed(0)
+    config = _config()
+    model = _vector_model(config)
+    transformed = exportable_vector_estimator(model)
+    inputs = _vector_inputs_at(config, text_length, latent_length)
+
+    assert transformed.valid_domain_only is True
+    torch.testing.assert_close(transformed(*inputs), model(*inputs))
+
+
+def test_vector_transform_requires_host_validation_for_invalid_inputs() -> None:
+    config = _config()
+    model = _vector_model(config)
+    transformed = exportable_vector_estimator(model)
+    values = list(_vector_inputs_at(config, 2, 2))
+    values[-1] = torch.zeros_like(values[-1])
+
+    assert transformed.valid_domain_only is True
+    with pytest.raises(ValueError, match="total_step must be finite and positive"):
+        common.validate_vector_inputs(tuple(values), config, BOUNDS)
+
+
+def test_vocoder_export_transform_preserves_causal_padding_semantics() -> None:
+    config = _config()
+    model = (
+        Vocoder(
+            config,
+            decoder_channels=8,
+            decoder_dilations=(),
+            decoder_expansion=2,
+            head_hidden_channels=8,
+        )
+        .eval()
+        .half()
+    )
+    inputs = common.example_inputs(config, BOUNDS)["vocoder"]
+
+    expected = model(*inputs)
+    transformed = replace_vocoder_causal_padding(model)
+    actual = transformed(*inputs)
+
+    torch.testing.assert_close(actual, expected)
+    assert isinstance(transformed.decoder.embed_pad, MLXCausalPad1d)
+    assert isinstance(transformed.decoder.head.pad, MLXCausalPad1d)
+    assert all(
+        isinstance(block.pad, MLXCausalPad1d) for block in transformed.decoder.convnext
+    )
+
+
+@pytest.mark.parametrize("length", [1, 4])
+def test_same_padding_export_transform_preserves_eager_semantics(
+    length: int,
+) -> None:
+    inputs = torch.arange(length, dtype=torch.float32).reshape(1, 1, length)
+    expected = SamePad1d(kernel_size=5, dilation=2)(inputs)
+    actual = MLXSamePad1d((4, 4))(inputs)
+
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("length", [1, 2, 5])
+def test_relative_attention_export_transform_preserves_eager_semantics(
+    length: int,
+) -> None:
+    torch.manual_seed(0)
+    attention = RelativeMultiHeadAttention(
+        channels=8, num_heads=2, window_size=2
+    ).eval()
+    inputs = torch.randn(1, 8, length)
+    mask = torch.ones(1, 1, length, length)
+
+    expected = attention(inputs, mask)
+    actual = MLXRelativeMultiHeadAttention.from_attention(attention)(inputs, mask)
+
+    torch.testing.assert_close(actual, expected)

--- a/examples/models/supertonic/tests/test_stage_parity.py
+++ b/examples/models/supertonic/tests/test_stage_parity.py
@@ -73,7 +73,7 @@ def test_duration_predictor_matches_published_onnx() -> None:
     assert actual.shape == expected.shape
     assert np.isfinite(actual).all()
     assert metrics["max_error"] < 1e-6
-    assert metrics["mean_error"] < 1e-7
+    assert metrics["mean_error"] < 2e-7
     assert metrics["cosine"] > 0.9999999
     assert metrics["sqnr_db"] > 120.0
 
@@ -183,8 +183,7 @@ def test_vocoder_matches_published_onnx() -> None:
         np.corrcoef(actual.reshape(-1), expected.reshape(-1))[0, 1]
     )
     print(
-        "vocoder parity: "
-        f"{metrics | {'waveform_correlation': waveform_correlation}}"
+        "vocoder parity: " f"{metrics | {'waveform_correlation': waveform_correlation}}"
     )
 
     assert actual.shape == expected.shape

--- a/examples/models/supertonic/tests/test_stage_parity.py
+++ b/examples/models/supertonic/tests/test_stage_parity.py
@@ -1,0 +1,196 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from examples.models.supertonic.loaders.checkpoint_loader import (
+    load_duration_predictor,
+    load_text_encoder,
+    load_vector_estimator,
+    load_vocoder,
+)
+from examples.models.supertonic.model.config import TTSConfig
+
+_REAL_MODEL_DIR = os.environ.get("SUPERTONIC_MODEL_DIR")
+
+
+def _metrics(actual: np.ndarray, expected: np.ndarray) -> dict[str, float]:
+    error = actual.astype(np.float64) - expected.astype(np.float64)
+    signal_power = np.sum(expected.astype(np.float64) ** 2)
+    noise_power = np.sum(error**2)
+    cosine = np.dot(actual.reshape(-1), expected.reshape(-1)) / (
+        np.linalg.norm(actual) * np.linalg.norm(expected)
+    )
+    return {
+        "max_error": float(np.max(np.abs(error))),
+        "mean_error": float(np.mean(np.abs(error))),
+        "cosine": float(cosine),
+        "sqnr_db": float(10.0 * np.log10(signal_power / noise_power)),
+    }
+
+
+@pytest.mark.skipif(
+    _REAL_MODEL_DIR is None,
+    reason="set SUPERTONIC_MODEL_DIR for eager PyTorch/ONNX Runtime parity",
+)
+def test_duration_predictor_matches_published_onnx() -> None:
+    ort = pytest.importorskip("onnxruntime")
+    model_dir = Path(_REAL_MODEL_DIR) / "onnx"
+    config = TTSConfig.from_json(model_dir / "tts.json")
+    model_path = model_dir / "duration_predictor.onnx"
+    model = load_duration_predictor(model_path, config).eval()
+    rng = np.random.default_rng(1234)
+    inputs = {
+        "text_ids": rng.integers(0, 256, size=(2, 11), dtype=np.int64),
+        "style_dp": rng.standard_normal((2, 8, 16), dtype=np.float32),
+        "text_mask": np.asarray(
+            [
+                [[1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0]],
+                [[1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]],
+            ],
+            dtype=np.float32,
+        ),
+    }
+
+    expected = ort.InferenceSession(str(model_path)).run(None, inputs)[0]
+    with torch.no_grad():
+        actual = model(
+            torch.from_numpy(inputs["text_ids"]),
+            torch.from_numpy(inputs["style_dp"]),
+            torch.from_numpy(inputs["text_mask"]),
+        ).numpy()
+    metrics = _metrics(actual, expected)
+    print(f"duration predictor parity: {metrics}")
+
+    assert actual.shape == expected.shape
+    assert np.isfinite(actual).all()
+    assert metrics["max_error"] < 1e-6
+    assert metrics["mean_error"] < 1e-7
+    assert metrics["cosine"] > 0.9999999
+    assert metrics["sqnr_db"] > 120.0
+
+
+@pytest.mark.skipif(
+    _REAL_MODEL_DIR is None,
+    reason="set SUPERTONIC_MODEL_DIR for eager PyTorch/ONNX Runtime parity",
+)
+def test_text_encoder_matches_published_onnx() -> None:
+    ort = pytest.importorskip("onnxruntime")
+    model_dir = Path(_REAL_MODEL_DIR) / "onnx"
+    config = TTSConfig.from_json(model_dir / "tts.json")
+    model_path = model_dir / "text_encoder.onnx"
+    model = load_text_encoder(model_path, config).eval()
+    rng = np.random.default_rng(5678)
+    inputs = {
+        "text_ids": rng.integers(0, 256, size=(2, 11), dtype=np.int64),
+        "style_ttl": rng.standard_normal((2, 50, 256), dtype=np.float32),
+        "text_mask": np.asarray(
+            [
+                [[1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0]],
+                [[1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0]],
+            ],
+            dtype=np.float32,
+        ),
+    }
+
+    expected = ort.InferenceSession(str(model_path)).run(None, inputs)[0]
+    with torch.no_grad():
+        actual = model(
+            torch.from_numpy(inputs["text_ids"]),
+            torch.from_numpy(inputs["style_ttl"]),
+            torch.from_numpy(inputs["text_mask"]),
+        ).numpy()
+    metrics = _metrics(actual, expected)
+    print(f"text encoder parity: {metrics}")
+
+    assert actual.shape == expected.shape
+    assert np.isfinite(actual).all()
+    assert metrics["max_error"] < 1e-4
+    assert metrics["mean_error"] < 5e-6
+    assert metrics["cosine"] > 0.999999
+    assert metrics["sqnr_db"] > 90.0
+
+
+@pytest.mark.skipif(
+    _REAL_MODEL_DIR is None,
+    reason="set SUPERTONIC_MODEL_DIR for eager PyTorch/ONNX Runtime parity",
+)
+def test_vector_estimator_matches_published_onnx() -> None:
+    ort = pytest.importorskip("onnxruntime")
+    model_dir = Path(_REAL_MODEL_DIR) / "onnx"
+    config = TTSConfig.from_json(model_dir / "tts.json")
+    model_path = model_dir / "vector_estimator.onnx"
+    model = load_vector_estimator(model_path, config).eval()
+    rng = np.random.default_rng(9012)
+    inputs = {
+        "noisy_latent": rng.standard_normal((1, 144, 8), dtype=np.float32),
+        "text_emb": rng.standard_normal((1, 256, 7), dtype=np.float32),
+        "style_ttl": rng.standard_normal((1, 50, 256), dtype=np.float32),
+        "latent_mask": np.asarray(
+            [[[1, 1, 1, 1, 1, 1, 0, 0]]],
+            dtype=np.float32,
+        ),
+        "text_mask": np.asarray(
+            [[[1, 1, 1, 1, 1, 0, 0]]],
+            dtype=np.float32,
+        ),
+        "current_step": np.asarray([2.0], dtype=np.float32),
+        "total_step": np.asarray([5.0], dtype=np.float32),
+    }
+
+    expected = ort.InferenceSession(str(model_path)).run(None, inputs)[0]
+    with torch.no_grad():
+        actual = model(*(torch.from_numpy(value) for value in inputs.values())).numpy()
+    metrics = _metrics(actual, expected)
+    print(f"vector estimator parity: {metrics}")
+
+    assert actual.shape == expected.shape
+    assert np.isfinite(actual).all()
+    assert metrics["max_error"] < 1e-5
+    assert metrics["mean_error"] < 1e-6
+    assert metrics["cosine"] > 0.999999
+    assert metrics["sqnr_db"] > 110.0
+
+
+@pytest.mark.skipif(
+    _REAL_MODEL_DIR is None,
+    reason="set SUPERTONIC_MODEL_DIR for eager PyTorch/ONNX Runtime parity",
+)
+def test_vocoder_matches_published_onnx() -> None:
+    ort = pytest.importorskip("onnxruntime")
+    model_dir = Path(_REAL_MODEL_DIR) / "onnx"
+    config = TTSConfig.from_json(model_dir / "tts.json")
+    model_path = model_dir / "vocoder.onnx"
+    model = load_vocoder(model_path, config).eval()
+    rng = np.random.default_rng(3456)
+    inputs = {
+        "latent": rng.standard_normal((1, 144, 3), dtype=np.float32),
+    }
+
+    expected = ort.InferenceSession(str(model_path)).run(None, inputs)[0]
+    with torch.no_grad():
+        actual = model(torch.from_numpy(inputs["latent"])).numpy()
+    metrics = _metrics(actual, expected)
+    waveform_correlation = float(
+        np.corrcoef(actual.reshape(-1), expected.reshape(-1))[0, 1]
+    )
+    print(
+        "vocoder parity: "
+        f"{metrics | {'waveform_correlation': waveform_correlation}}"
+    )
+
+    assert actual.shape == expected.shape
+    assert np.isfinite(actual).all()
+    assert metrics["max_error"] < 2e-6
+    assert metrics["mean_error"] < 2e-7
+    assert metrics["cosine"] > 0.9999999
+    assert metrics["sqnr_db"] > 105.0
+    assert waveform_correlation > 0.9999999

--- a/examples/models/supertonic/tests/test_text_encoder.py
+++ b/examples/models/supertonic/tests/test_text_encoder.py
@@ -1,0 +1,153 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+
+import pytest
+import torch
+
+from examples.models.supertonic.model.config import TTSConfig
+
+
+def _text_encoder():
+    return importlib.import_module("examples.models.supertonic.model.text_encoder")
+
+
+def _config() -> TTSConfig:
+    return TTSConfig.from_dict(
+        {
+            "tts_version": "test",
+            "split": "test",
+            "ttl": {"latent_dim": 4, "chunk_compress_factor": 2},
+            "ae": {
+                "sample_rate": 16000,
+                "base_chunk_size": 4,
+                "chunk_compress_factor": 1,
+                "ldim": 4,
+            },
+            "dp": {"latent_dim": 4, "chunk_compress_factor": 2},
+        }
+    )
+
+
+def _small_model():
+    return (
+        _text_encoder()
+        .TextEncoder(
+            _config(),
+            vocab_size=32,
+            channels=8,
+            convnext_dilations=(1, 2),
+            attention_layers=1,
+            attention_heads=2,
+            ff_channels=16,
+            relative_window=2,
+            style_tokens=3,
+            style_attention_heads=2,
+        )
+        .eval()
+    )
+
+
+def _contract_model():
+    return (
+        _text_encoder()
+        .TextEncoder(
+            _config(),
+            vocab_size=8,
+            channels=256,
+            convnext_dilations=(),
+            attention_layers=0,
+            attention_heads=1,
+            ff_channels=4,
+            style_tokens=50,
+            style_attention_heads=2,
+        )
+        .eval()
+    )
+
+
+def test_text_encoder_returns_finite_channel_first_embeddings() -> None:
+    torch.manual_seed(0)
+    model = _small_model()
+
+    output = model(
+        torch.tensor([[1, 2, 3, 0], [4, 5, 0, 0]]),
+        torch.randn(2, 3, 8),
+        torch.tensor([[[1.0, 1.0, 1.0, 0.0]], [[1.0, 1.0, 0.0, 0.0]]]),
+    )
+
+    assert output.shape == (2, 8, 4)
+    assert torch.isfinite(output).all()
+
+
+def test_text_encoder_ignores_and_zeroes_masked_text_deterministically() -> None:
+    torch.manual_seed(1)
+    model = _small_model()
+    text_ids = torch.tensor([[1, 2, 3, 4]])
+    changed_ids = torch.tensor([[1, 2, 30, 31]])
+    style = torch.randn(1, 3, 8)
+    mask = torch.tensor([[[1.0, 1.0, 0.0, 0.0]]])
+
+    first = model(text_ids, style, mask)
+    second = model(changed_ids, style, mask)
+    repeated = model(text_ids, style, mask)
+
+    torch.testing.assert_close(first, second)
+    torch.testing.assert_close(first, repeated)
+    torch.testing.assert_close(first[:, :, 2:], torch.zeros_like(first[:, :, 2:]))
+
+
+@pytest.mark.parametrize(
+    ("text_shape", "style_shape", "mask_shape", "error"),
+    [
+        ((3,), (1, 50, 256), (1, 1, 3), r"text_ids.*\[B, T\]"),
+        ((1, 3), (1, 49, 256), (1, 1, 3), r"style_ttl.*\[B, 50, 256\]"),
+        ((1, 3), (1, 50, 256), (1, 2, 3), r"text_mask.*\[B, 1, T\]"),
+        ((1, 3), (2, 50, 256), (1, 1, 3), "batch sizes must match"),
+        ((1, 3), (1, 50, 256), (1, 1, 2), "text lengths must match"),
+    ],
+)
+def test_text_encoder_validates_public_input_contract_before_operators(
+    text_shape, style_shape, mask_shape, error: str
+) -> None:
+    model = _contract_model()
+    text_ids = torch.full(text_shape, 999, dtype=torch.long)
+    style = torch.zeros(style_shape)
+    mask = torch.ones(mask_shape)
+
+    with pytest.raises(ValueError, match=error):
+        model(text_ids, style, mask)
+
+
+def test_relative_position_conversions_round_trip_absolute_positions() -> None:
+    attention = _text_encoder().RelativeMultiHeadAttention(
+        channels=6, num_heads=2, window_size=2
+    )
+    absolute = torch.arange(2 * 2 * 3 * 3, dtype=torch.float32).reshape(2, 2, 3, 3)
+
+    relative = attention._absolute_to_relative(absolute)
+    restored_absolute = attention._relative_to_absolute(relative)
+    restored_relative = attention._absolute_to_relative(restored_absolute)
+
+    torch.testing.assert_close(restored_absolute, absolute)
+    torch.testing.assert_close(restored_relative, relative)
+
+
+def test_style_attention_splits_heads_on_leading_axis() -> None:
+    attention = _text_encoder().TanhKeyAttention(channels=4, num_heads=2)
+    values = torch.tensor(
+        [
+            [[1.0, 2.0, 3.0, 4.0]],
+            [[5.0, 6.0, 7.0, 8.0]],
+        ]
+    )
+
+    heads = attention._split_heads(values)
+
+    assert heads.shape == (2, 2, 1, 2)
+    torch.testing.assert_close(heads[0], values[:, :, :2])
+    torch.testing.assert_close(heads[1], values[:, :, 2:])

--- a/examples/models/supertonic/tests/test_vector_estimator.py
+++ b/examples/models/supertonic/tests/test_vector_estimator.py
@@ -1,0 +1,473 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+
+import pytest
+import torch
+
+from examples.models.supertonic.model.config import TTSConfig
+
+
+def _vector_estimator():
+    return importlib.import_module(
+        "examples.models.supertonic.model.vector_estimator"
+    )
+
+
+def _config(
+    *,
+    latent_dim: int = 2,
+    compress_factor: int = 2,
+    base_chunk_size: int = 4,
+) -> TTSConfig:
+    return TTSConfig.from_dict(
+        {
+            "tts_version": "test",
+            "split": "test",
+            "ttl": {
+                "latent_dim": latent_dim,
+                "chunk_compress_factor": compress_factor,
+            },
+            "ae": {
+                "sample_rate": 16000,
+                "base_chunk_size": base_chunk_size,
+                "chunk_compress_factor": 1,
+                "ldim": latent_dim,
+            },
+            "dp": {
+                "latent_dim": latent_dim,
+                "chunk_compress_factor": compress_factor,
+            },
+        }
+    )
+
+
+def _small_model():
+    return (
+        _vector_estimator()
+        .VectorEstimator(
+            _config(),
+            hidden_channels=8,
+            time_dim=4,
+            time_hidden_channels=8,
+            num_main_blocks=1,
+            main_convnext_dilations=(1,),
+            post_time_dilations=(1,),
+            post_text_dilations=(1,),
+            final_dilations=(1,),
+            text_channels=6,
+            style_tokens=3,
+            style_channels=6,
+            attention_heads=2,
+            style_attention_heads=2,
+            max_positions=16,
+        )
+        .eval()
+    )
+
+
+def _inputs():
+    return (
+        torch.randn(2, 4, 5),
+        torch.randn(2, 6, 4),
+        torch.randn(2, 3, 6),
+        torch.tensor(
+            [
+                [[1.0, 1.0, 1.0, 1.0, 0.0]],
+                [[1.0, 1.0, 1.0, 0.0, 0.0]],
+            ]
+        ),
+        torch.tensor(
+            [
+                [[1.0, 1.0, 1.0, 0.0]],
+                [[1.0, 1.0, 0.0, 0.0]],
+            ]
+        ),
+        torch.tensor([1.0, 2.0]),
+        torch.tensor([4.0, 4.0]),
+    )
+
+
+def test_vector_estimator_returns_finite_masked_latent_deterministically() -> None:
+    torch.manual_seed(0)
+    model = _small_model()
+    inputs = _inputs()
+
+    first = model(*inputs)
+    repeated = model(*inputs)
+
+    assert first.shape == (2, 4, 5)
+    assert torch.isfinite(first).all()
+    torch.testing.assert_close(first, repeated)
+    torch.testing.assert_close(
+        first * (1.0 - inputs[3]),
+        torch.zeros_like(first),
+    )
+
+
+def test_vector_estimator_ignores_masked_latent_and_text_values() -> None:
+    torch.manual_seed(1)
+    model = _small_model()
+    inputs = list(_inputs())
+    changed = [value.clone() for value in inputs]
+    changed[0] = torch.where(
+        inputs[3] == 0,
+        torch.full_like(inputs[0], 1000.0),
+        inputs[0],
+    )
+    changed[1] = torch.where(
+        inputs[4] == 0,
+        torch.full_like(inputs[1], -1000.0),
+        inputs[1],
+    )
+
+    torch.testing.assert_close(model(*inputs), model(*changed))
+
+
+def test_vector_estimator_uses_current_and_total_steps() -> None:
+    torch.manual_seed(2)
+    model = _small_model()
+    inputs = list(_inputs())
+    changed_current = [value.clone() for value in inputs]
+    changed_current[5] = inputs[5] + 1.0
+    changed_total = [value.clone() for value in inputs]
+    changed_total[6] = inputs[6] * 2.0
+
+    baseline = model(*inputs)
+
+    assert not torch.allclose(baseline, model(*changed_current))
+    assert not torch.allclose(baseline, model(*changed_total))
+
+
+@pytest.mark.parametrize(
+    ("transform", "error"),
+    [
+        (
+            lambda values: [value[:0] for value in values],
+            "batch size must be positive",
+        ),
+        (
+            lambda values: [
+                values[0][:, :, :0],
+                values[1],
+                values[2],
+                values[3][:, :, :0],
+                values[4],
+                values[5],
+                values[6],
+            ],
+            "latent length must be positive",
+        ),
+        (
+            lambda values: [
+                values[0],
+                values[1][:, :, :0],
+                values[2],
+                values[3],
+                values[4][:, :, :0],
+                values[5],
+                values[6],
+            ],
+            "text length must be positive",
+        ),
+        (
+            lambda values: [
+                values[0],
+                values[1],
+                values[2],
+                torch.cat(
+                    (torch.zeros_like(values[3][:1]), values[3][1:]),
+                    dim=0,
+                ),
+                values[4],
+                values[5],
+                values[6],
+            ],
+            "latent_mask must contain a valid position per sample",
+        ),
+        (
+            lambda values: [
+                values[0],
+                values[1],
+                values[2],
+                values[3],
+                torch.cat(
+                    (torch.zeros_like(values[4][:1]), values[4][1:]),
+                    dim=0,
+                ),
+                values[5],
+                values[6],
+            ],
+            "text_mask must contain a valid position per sample",
+        ),
+        (
+            lambda values: [
+                values[0],
+                values[1],
+                values[2],
+                torch.full_like(values[3], float("nan")),
+                values[4],
+                values[5],
+                values[6],
+            ],
+            "latent_mask must contain a valid position per sample",
+        ),
+        (
+            lambda values: [
+                values[0],
+                values[1],
+                values[2],
+                values[3],
+                torch.full_like(values[4], float("inf")),
+                values[5],
+                values[6],
+            ],
+            "text_mask must contain a valid position per sample",
+        ),
+        (
+            lambda values: values[:6] + [torch.tensor([0.0, 4.0])],
+            "total_step must be finite and positive",
+        ),
+        (
+            lambda values: values[:6] + [torch.tensor([-1.0, 4.0])],
+            "total_step must be finite and positive",
+        ),
+        (
+            lambda values: values[:6] + [torch.tensor([float("inf"), 4.0])],
+            "total_step must be finite and positive",
+        ),
+        (
+            lambda values: values[:6] + [torch.tensor([float("nan"), 4.0])],
+            "total_step must be finite and positive",
+        ),
+        (
+            lambda values: values[:5]
+            + [torch.tensor([float("inf"), 2.0]), values[6]],
+            "current_step must be finite",
+        ),
+        (
+            lambda values: values[:5]
+            + [torch.tensor([float("nan"), 2.0]), values[6]],
+            "current_step must be finite",
+        ),
+    ],
+)
+def test_vector_estimator_rejects_degenerate_public_inputs_before_operators(
+    transform, error: str
+) -> None:
+    model = _small_model()
+    inputs = transform(list(_inputs()))
+
+    with pytest.raises(ValueError, match=error):
+        model(*inputs)
+
+
+@pytest.mark.parametrize(
+    ("index", "replacement", "error"),
+    [
+        (0, torch.zeros(144, 3), r"noisy_latent.*\[B, 144, L\]"),
+        (0, torch.zeros(1, 143, 3), r"noisy_latent.*\[B, 144, L\]"),
+        (1, torch.zeros(1, 255, 4), r"text_emb.*\[B, 256, T\]"),
+        (2, torch.zeros(1, 49, 256), r"style_ttl.*\[B, 50, 256\]"),
+        (3, torch.ones(1, 2, 3), r"latent_mask.*\[B, 1, L\]"),
+        (4, torch.ones(1, 1, 3), "text lengths must match"),
+        (5, torch.zeros(1, 1), r"current_step.*\[B\]"),
+        (6, torch.zeros(2), "batch sizes must match"),
+    ],
+)
+def test_vector_estimator_validates_public_contract_before_operators(
+    index: int, replacement: torch.Tensor, error: str
+) -> None:
+    model = _vector_estimator().VectorEstimator(
+        _config(latent_dim=24, compress_factor=6),
+        hidden_channels=4,
+        time_dim=4,
+        time_hidden_channels=4,
+        num_main_blocks=0,
+        main_convnext_dilations=(),
+        post_time_dilations=(),
+        post_text_dilations=(),
+        final_dilations=(),
+        text_channels=256,
+        style_tokens=50,
+        style_channels=256,
+        attention_heads=1,
+        style_attention_heads=1,
+        max_positions=8,
+    )
+    inputs = [
+        torch.zeros(1, 144, 3),
+        torch.zeros(1, 256, 4),
+        torch.zeros(1, 50, 256),
+        torch.ones(1, 1, 3),
+        torch.ones(1, 1, 4),
+        torch.zeros(1),
+        torch.ones(1),
+    ]
+    inputs[index] = replacement
+
+    with pytest.raises(ValueError, match=error):
+        model(*inputs)
+
+
+def test_time_encoder_matches_exported_sinusoidal_and_mish_semantics() -> None:
+    module = _vector_estimator()
+    encoder = module.TimeEncoder(time_dim=4, hidden_channels=3)
+    with torch.no_grad():
+        encoder.mlp[0].linear.weight.copy_(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                ]
+            )
+        )
+        encoder.mlp[0].linear.bias.zero_()
+        encoder.mlp[2].linear.weight.copy_(
+            torch.tensor(
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                    [1.0, 1.0, 1.0],
+                ]
+            )
+        )
+        encoder.mlp[2].linear.bias.zero_()
+
+    time = torch.tensor([0.25])
+    frequencies = 10000.0 ** (-torch.arange(2, dtype=torch.float32))
+    sinusoidal = torch.cat(
+        (
+            torch.sin(time[:, None] * 1000.0 * frequencies),
+            torch.cos(time[:, None] * 1000.0 * frequencies),
+        ),
+        dim=-1,
+    )
+    hidden = sinusoidal[:, :3]
+    mish = hidden * torch.tanh(torch.nn.functional.softplus(hidden))
+    expected = torch.stack(
+        (mish[:, 0], mish[:, 1], mish[:, 2], mish.sum(dim=-1)),
+        dim=-1,
+    ).unsqueeze(-1)
+
+    torch.testing.assert_close(encoder(time), expected)
+
+
+def test_rotary_embedding_rotates_exported_feature_halves() -> None:
+    attention = _vector_estimator().RotaryCrossAttention(
+        channels=4,
+        context_channels=4,
+        num_heads=1,
+        max_positions=4,
+        rotary_base=10000.0,
+        rotary_scale=10.0,
+    )
+    values = torch.tensor([[[[1.0, 2.0, 3.0, 4.0]]]])
+    sine = torch.tensor([[[0.5, -0.25]]])
+    cosine = torch.tensor([[[0.75, 0.125]]])
+
+    rotated = attention._apply_rotary(values, sine, cosine)
+
+    torch.testing.assert_close(
+        rotated,
+        torch.tensor([[[[-0.75, 1.25, 2.75, 0.0]]]]),
+    )
+
+
+def test_cfg_uses_conditional_then_unconditional_batches_and_4_minus_3() -> None:
+    conditional = torch.tensor([[[1.0]], [[2.0]]])
+    unconditional = torch.tensor([[[10.0]], [[20.0]]])
+    vector = torch.cat((conditional, unconditional), dim=0)
+
+    guided = _vector_estimator().VectorEstimator._apply_guidance(vector)
+
+    torch.testing.assert_close(
+        guided,
+        4.0 * conditional - 3.0 * unconditional,
+    )
+
+
+def test_rotary_attention_uses_published_divide_by_16_score_scaling() -> None:
+    attention = _vector_estimator().RotaryCrossAttention(
+        channels=8,
+        context_channels=256,
+        num_heads=2,
+        max_positions=4,
+    )
+    query = torch.tensor([[[[1.0, 2.0, 3.0, 4.0]]]])
+    key = torch.tensor([[[[4.0, 3.0, 2.0, 1.0]]]])
+
+    scores = attention._scaled_scores(query, key)
+
+    torch.testing.assert_close(
+        scores,
+        torch.matmul(query, key.transpose(-2, -1)) / 16.0,
+    )
+
+
+def test_rotary_positions_normalize_per_sample_and_heads_lead_batch() -> None:
+    attention = _vector_estimator().RotaryCrossAttention(
+        channels=8,
+        context_channels=8,
+        num_heads=2,
+        max_positions=4,
+    )
+    values = torch.arange(16, dtype=torch.float32).reshape(2, 1, 8)
+    mask = torch.tensor(
+        [
+            [[1.0, 1.0, 0.0, 0.0]],
+            [[1.0, 1.0, 1.0, 1.0]],
+        ]
+    )
+
+    heads = attention._split_heads(values)
+    sine, cosine = attention._angles(mask)
+    positions = torch.tensor(
+        [
+            [[0.0], [0.5], [1.0], [1.5]],
+            [[0.0], [0.25], [0.5], [0.75]],
+        ]
+    )
+    expected_angles = positions * attention.theta
+
+    assert heads.shape == (2, 2, 1, 4)
+    torch.testing.assert_close(heads[0], values[:, :, :4])
+    torch.testing.assert_close(heads[1], values[:, :, 4:])
+    torch.testing.assert_close(sine, torch.sin(expected_angles))
+    torch.testing.assert_close(cosine, torch.cos(expected_angles))
+
+
+def test_rotary_attention_masks_keys_before_and_queries_after_softmax() -> None:
+    attention = _vector_estimator().RotaryCrossAttention(
+        channels=4,
+        context_channels=4,
+        num_heads=1,
+        max_positions=2,
+    )
+    with torch.no_grad():
+        attention.theta.zero_()
+        for projection in (
+            attention.W_query,
+            attention.W_key,
+            attention.W_value,
+            attention.out_fc,
+        ):
+            projection.linear.weight.copy_(torch.eye(4))
+            projection.linear.bias.zero_()
+    inputs = torch.tensor([[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]])
+    context = torch.tensor(
+        [[[2.0, 3.0, 4.0, 5.0], [1000.0, 1000.0, 1000.0, 1000.0]]]
+    )
+    query_mask = torch.tensor([[[1.0, 0.0]]])
+    key_mask = torch.tensor([[[1.0, 0.0]]])
+
+    output = attention(inputs, context, query_mask, key_mask)
+
+    torch.testing.assert_close(output[:, :1], context[:, :1])
+    torch.testing.assert_close(output[:, 1:], torch.zeros_like(output[:, 1:]))

--- a/examples/models/supertonic/tests/test_vector_estimator.py
+++ b/examples/models/supertonic/tests/test_vector_estimator.py
@@ -13,9 +13,7 @@ from examples.models.supertonic.model.config import TTSConfig
 
 
 def _vector_estimator():
-    return importlib.import_module(
-        "examples.models.supertonic.model.vector_estimator"
-    )
+    return importlib.import_module("examples.models.supertonic.model.vector_estimator")
 
 
 def _config(
@@ -245,13 +243,11 @@ def test_vector_estimator_uses_current_and_total_steps() -> None:
             "total_step must be finite and positive",
         ),
         (
-            lambda values: values[:5]
-            + [torch.tensor([float("inf"), 2.0]), values[6]],
+            lambda values: values[:5] + [torch.tensor([float("inf"), 2.0]), values[6]],
             "current_step must be finite",
         ),
         (
-            lambda values: values[:5]
-            + [torch.tensor([float("nan"), 2.0]), values[6]],
+            lambda values: values[:5] + [torch.tensor([float("nan"), 2.0]), values[6]],
             "current_step must be finite",
         ),
     ],
@@ -461,9 +457,7 @@ def test_rotary_attention_masks_keys_before_and_queries_after_softmax() -> None:
             projection.linear.weight.copy_(torch.eye(4))
             projection.linear.bias.zero_()
     inputs = torch.tensor([[[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]])
-    context = torch.tensor(
-        [[[2.0, 3.0, 4.0, 5.0], [1000.0, 1000.0, 1000.0, 1000.0]]]
-    )
+    context = torch.tensor([[[2.0, 3.0, 4.0, 5.0], [1000.0, 1000.0, 1000.0, 1000.0]]])
     query_mask = torch.tensor([[[1.0, 0.0]]])
     key_mask = torch.tensor([[[1.0, 0.0]]])
 

--- a/examples/models/supertonic/tests/test_vocoder.py
+++ b/examples/models/supertonic/tests/test_vocoder.py
@@ -1,0 +1,123 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import importlib
+
+import pytest
+import torch
+
+from examples.models.supertonic.model.config import TTSConfig
+
+
+def _vocoder():
+    return importlib.import_module("examples.models.supertonic.model.vocoder")
+
+
+def _config() -> TTSConfig:
+    return TTSConfig.from_dict(
+        {
+            "tts_version": "test",
+            "split": "test",
+            "ttl": {"latent_dim": 2, "chunk_compress_factor": 3},
+            "ae": {
+                "sample_rate": 16000,
+                "base_chunk_size": 4,
+                "chunk_compress_factor": 1,
+                "ldim": 2,
+            },
+            "dp": {"latent_dim": 2, "chunk_compress_factor": 3},
+        }
+    )
+
+
+def _small_model():
+    return (
+        _vocoder()
+        .Vocoder(
+            _config(),
+            decoder_channels=8,
+            decoder_dilations=(1, 2),
+            decoder_expansion=2,
+            head_hidden_channels=12,
+        )
+        .eval()
+    )
+
+
+def test_vocoder_returns_finite_waveform_with_exact_length_deterministically() -> None:
+    torch.manual_seed(0)
+    model = _small_model()
+    latent = torch.randn(2, 6, 5)
+
+    first = model(latent)
+    repeated = model(latent)
+
+    assert first.shape == (2, 5 * 3 * 4)
+    assert torch.isfinite(first).all()
+    torch.testing.assert_close(first, repeated)
+
+
+def test_vocoder_unpacks_compressed_latent_in_exported_order() -> None:
+    latent = torch.arange(24, dtype=torch.float32).reshape(1, 6, 4)
+
+    unpacked = _vocoder().Vocoder._unpack_latent(
+        latent,
+        latent_dim=2,
+        compress_factor=3,
+    )
+    expected = latent.reshape(1, 2, 3, 4).transpose(2, 3).reshape(1, 2, 12)
+
+    torch.testing.assert_close(unpacked, expected)
+
+
+def test_causal_padding_replicates_only_the_exported_left_context() -> None:
+    pad = _vocoder().CausalPad1d(kernel_size=3, dilation=2)
+    inputs = torch.tensor([[[1.0, 2.0, 3.0]]])
+
+    output = pad(inputs)
+
+    torch.testing.assert_close(
+        output,
+        torch.tensor([[[1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 3.0]]]),
+    )
+
+
+def test_decoder_head_applies_shared_prelu_and_flattens_time_major() -> None:
+    head = _vocoder().DecoderHead(
+        channels=1,
+        hidden_channels=1,
+        output_channels=2,
+    )
+    with torch.no_grad():
+        head.layer1.net.weight.zero_()
+        head.layer1.net.weight[:, :, 2] = 1.0
+        head.layer1.net.bias.zero_()
+        head.act.weight.fill_(0.25)
+        head.layer2.weight.copy_(torch.tensor([[[1.0]], [[-1.0]]]))
+
+    output = head(torch.tensor([[[-1.0, 2.0]]]))
+
+    torch.testing.assert_close(
+        output,
+        torch.tensor([[-0.25, 0.25, 2.0, -2.0]]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("shape", "error"),
+    [
+        ((6, 4), r"latent.*\[B, 6, L\]"),
+        ((1, 5, 4), r"latent.*\[B, 6, L\]"),
+        ((1, 6, 0), "latent length must be positive"),
+    ],
+)
+def test_vocoder_validates_public_input_contract_before_operators(
+    shape: tuple[int, ...], error: str
+) -> None:
+    model = _small_model()
+
+    with pytest.raises(ValueError, match=error):
+        model(torch.zeros(shape))


### PR DESCRIPTION
## Summary

Add an ExecuTorch MLX implementation of [Supertonic 3](https://github.com/supertone-inc/supertonic), Supertone's on-device multilingual TTS model.

```text
Published ONNX models
  -> export-only Python code
  -> one FP16 ExecuTorch PTE
  -> C++ runner with MLX
  -> 44.1 kHz PCM16 WAV
```

The Python model files translate the published ONNX architecture and weights into an ExecuTorch PTE. They are needed only when creating the PTE; the C++ runner does not use Python or the source ONNX model files.

This PR supports one-shot, batch-1, five-step synthesis on macOS arm64. It does not include model weights, generated PTEs, WAVs, a persistent server, benchmarks, or application integration.

## What to review

The 49 files do not need equal review depth.

### 1. Create the PTE (Python, export time only)

- `examples/models/supertonic/loaders/checkpoint_loader.py`
- `examples/models/supertonic/model/duration_predictor.py`
- `examples/models/supertonic/model/text_encoder.py`
- `examples/models/supertonic/model/vector_estimator.py`
- `examples/models/supertonic/model/vocoder.py`
- `examples/models/supertonic/export/common.py`
- `examples/models/supertonic/export/export_supertonic.py`
- `examples/models/supertonic/source_transformations/mlx.py`

These files define the four Supertonic stages in PyTorch, copy and convert the ONNX weights, apply MLX-compatible graph rewrites, and export four PTE methods: `duration_predictor`, `text_encoder`, `vector_estimator`, and `vocoder`.

Review the layer/weight mapping, equivalent outputs, dynamic bounds, FP16 conversion, metadata, and MLX delegation. The highest-signal tests are `test_checkpoint_loader.py`, `test_stage_parity.py`, and `test_mlx_pipeline.py`.

### 2. Run the PTE (C++)

- `examples/models/supertonic/runtime/supertonic_runner.cpp`
- `examples/models/supertonic/runtime/text_processor.cpp`
- `examples/models/supertonic/runtime/style_loader.cpp`
- `examples/models/supertonic/runtime/wav_writer.cpp`
- `examples/models/supertonic/runtime/main.cpp`

These files load the PTE, call its four methods, preprocess and chunk text, run five generation steps, trim the waveform, and write a WAV file. Review the PTE compatibility checks, Unicode handling, tensor flow, and output validation.

The highest-signal tests are `examples/models/supertonic/runtime/tests/supertonic_runtime_test.cpp` and `examples/models/supertonic/runtime/tests/run_integration.cmake`.

### 3. Build and CI

- `examples/models/supertonic/CMakeLists.txt`
- `examples/models/supertonic/CMakePresets.json`
- `.github/workflows/mlx.yml`
- `examples/models/supertonic/README.md`
- `examples/models/supertonic/NOTICE`

Review the macOS arm64 restriction, MLX runtime files, pinned-asset CI flow, usage, and licensing. The remaining unit tests, package files, and root README/Makefile entries are support changes that can be skimmed.

## Runtime files

After export, synthesis needs only `supertonic_runner`, `mlx.metallib`, the exported PTE, `unicode_indexer.json`, and one voice-style JSON file.

## Validation

- 151 Python tests and 2/2 native CTests passed, including real PTE synthesis.
- Local Apple M5 Max benchmark (batch-1 FP16, five steps): short-input median `45.9 ms`, RTF `0.0244` (`40.9x` real time).
- ONNX FP32 vs MLX FP16 waveform cosine/Pearson: `0.999603`; SQNR: `30.95 dB`.
- GitHub CI: 201 successful, 30 skipped, 1 neutral, 0 failed.

## Provenance

- Source: [supertone-inc/supertonic](https://github.com/supertone-inc/supertonic) at `7e2804f96016a7028cb1ed627353c61c1e9dd281` (MIT).
- Model assets: `Supertone/supertonic-3` at `3cadd1ee6394adea1bd021217a0e650ede09a323` (BigScience Open RAIL-M).
- Assets are downloaded separately and are not redistributed. Exported PTEs remain subject to the model asset license.

