### PR TITLE
Promote commits to viable/strict on a schedule, not by commit count

### DIFF
--- a/.github/workflows/_ci-run-decision.yml
+++ b/.github/workflows/_ci-run-decision.yml
@@ -23,12 +23,14 @@ name: CI Run Decision
 # from a promotion tag: pull, trunk, apple, windows-msvc, riscv64,
 # qnn-windows-msvc and viable-strict-gate. Only four of those call this
 # workflow. The other seven callers (cuda, cuda-windows, cuda-perf,
-# metal, mlx, rocm, vulkan) have their own ciflow tags but not
-# ``ciflow/trunk``, so a promotion tag never starts them, and they hold
-# 32 of the 48 jobs whose ``if:`` gates on ``is-full-run``. Most of those
-# 32 also have a changed-files branch and still run on main when their
-# own paths are touched; the 12 in mlx.yml do not, so for those the depth
-# sample below is the only thing that ever runs them on main.
+# metal, mlx, rocm, vulkan) do have ciflow tags, but none of them listens
+# for ``ciflow/trunk``, so a promotion tag never starts them, and they
+# hold 32 of the 48 jobs whose ``if:`` gates on ``is-full-run``. Most of
+# those 32 also have a changed-files branch and still run on main when
+# their own paths are touched; the 12 in mlx.yml do not, so for those the
+# depth sample below is the only thing that runs them automatically on a
+# push to main. (``workflow_dispatch`` and ``ciflow/mlx`` can still force
+# them by hand, which is not a substitute for running on main.)
 
 on:
   workflow_call:

--- a/.github/workflows/_ci-run-decision.yml
+++ b/.github/workflows/_ci-run-decision.yml
@@ -14,9 +14,11 @@ name: CI Run Decision
 #   - pull_request / pull_request_target (use path filter instead)
 #   - push events not matching any of the above (path-filtered runs)
 #
-# See ``viable-strict-gate.yml``: viable/strict only advances on
-# commits where this is true, so the path-filtered fast path doesn't
-# silently advance partial signal.
+# viable/strict eligibility is not decided here. It follows from the
+# ``ciflow/trunk`` tag that ``promote-to-viable-strict.yml`` pushes; see
+# ``viable-strict-gate.yml``. The depth sample below only controls path
+# filtering, so a commit that misses it still gets full CI once it is
+# promoted.
 
 on:
   workflow_call:

--- a/.github/workflows/_ci-run-decision.yml
+++ b/.github/workflows/_ci-run-decision.yml
@@ -16,9 +16,16 @@ name: CI Run Decision
 #
 # viable/strict eligibility is not decided here. It follows from the
 # ``ciflow/trunk`` tag that ``promote-to-viable-strict.yml`` pushes; see
-# ``viable-strict-gate.yml``. The depth sample below only controls path
-# filtering, so a commit that misses it still gets full CI once it is
-# promoted.
+# ``viable-strict-gate.yml``.
+#
+# Do not assume promotion makes the depth sample redundant. Only the
+# workflows that list ``ciflow/trunk/*`` under ``on.push.tags`` re-run
+# from that tag: pull, trunk, apple, windows-msvc, riscv64,
+# qnn-windows-msvc. The other seven callers of this workflow (cuda,
+# cuda-windows, cuda-perf, metal, mlx, rocm, vulkan) have no tag trigger,
+# so for them the depth sample below is the only thing that ever produces
+# a full run on main. Removing it would drop 35 of the 56 jobs gated on
+# ``is-full-run`` from main entirely.
 
 on:
   workflow_call:

--- a/.github/workflows/_ci-run-decision.yml
+++ b/.github/workflows/_ci-run-decision.yml
@@ -18,14 +18,17 @@ name: CI Run Decision
 # ``ciflow/trunk`` tag that ``promote-to-viable-strict.yml`` pushes; see
 # ``viable-strict-gate.yml``.
 #
-# Do not assume promotion makes the depth sample redundant. Only the
-# workflows that list ``ciflow/trunk/*`` under ``on.push.tags`` re-run
-# from that tag: pull, trunk, apple, windows-msvc, riscv64,
-# qnn-windows-msvc. The other seven callers of this workflow (cuda,
-# cuda-windows, cuda-perf, metal, mlx, rocm, vulkan) have no tag trigger,
-# so for them the depth sample below is the only thing that ever produces
-# a full run on main. Removing it would drop 35 of the 56 jobs gated on
-# ``is-full-run`` from main entirely.
+# Do not assume promotion makes the depth sample redundant. Seven
+# workflows list ``ciflow/trunk/*`` under ``on.push.tags`` and so re-run
+# from a promotion tag: pull, trunk, apple, windows-msvc, riscv64,
+# qnn-windows-msvc and viable-strict-gate. Only four of those call this
+# workflow. The other seven callers (cuda, cuda-windows, cuda-perf,
+# metal, mlx, rocm, vulkan) have their own ciflow tags but not
+# ``ciflow/trunk``, so a promotion tag never starts them, and they hold
+# 32 of the 48 jobs whose ``if:`` gates on ``is-full-run``. Most of those
+# 32 also have a changed-files branch and still run on main when their
+# own paths are touched; the 12 in mlx.yml do not, so for those the depth
+# sample below is the only thing that ever runs them on main.
 
 on:
   workflow_call:

--- a/.github/workflows/promote-to-viable-strict.yml
+++ b/.github/workflows/promote-to-viable-strict.yml
@@ -1,38 +1,38 @@
 name: Promote commit to viable/strict
 
-# Manual escape hatch for the sampled-CI gating in
-# `_ci-run-decision.yml` + `viable-strict-gate.yml`.
+# Grants a commit eligibility for viable/strict by pushing a
+# `ciflow/trunk/<sha>` tag at it, which:
+#   1. Runs `pull.yml` / `trunk.yml` against that commit with
+#      ``is-full-run = true``, so every gated job runs regardless of the
+#      path filter.
+#   2. Runs `viable-strict-gate.yml`, whose presence is what
+#      `update-viablestrict` requires before it will advance.
 #
-# Pushes a `ciflow/trunk/<sha>` tag at a chosen commit, which:
-#   1. Re-triggers `pull.yml` / `trunk.yml` against that commit with
-#      ``is-full-run = true`` (every gated job runs regardless of
-#      path filter or SHA sample).
-#   2. Triggers `viable-strict-gate.yml` for that commit; the gate
-#      succeeds because tag pushes always count as a full-run.
+# This runs on a schedule, because landing a commit does not make it
+# eligible on its own. Without a periodic promotion the tip of main
+# would sit outside viable/strict until somebody promoted it by hand.
 #
-# Once those tag-triggered runs all pass, the next
-# `update-viablestrict` cron run will be able to advance viable/strict
-# to the chosen commit.
+# The schedule includes a tick several hours before the nightly branch
+# is cut, so the last commits of a quiet night still have time to run
+# full CI and reach that day's nightly build.
 #
-# Use cases:
-#   - Bisecting a regression on a non-sampled commit.
-#   - Pre-release validation: pin viable/strict to a specific commit
-#     (e.g. release branch tip) regardless of its SHA's sample bit.
-#   - Recovering when recent sampled commits all happen to be red.
+# Can also be dispatched by hand for a specific commit, for example to
+# bisect a regression or to pin a release branch tip.
 
 on:
+  schedule:
+    # Every 4 hours. The 08:00 UTC tick is the one that lands ahead of
+    # the nightly branch cut.
+    - cron: "0 0,4,8,12,16,20 * * *"
   workflow_dispatch:
     inputs:
       sha:
-        description: "Full 40-char SHA on main / release/* to promote"
-        required: true
+        description: "Full 40-char SHA on main / release/* to promote. Defaults to the tip of main."
+        required: false
         type: string
 
 permissions:
   contents: write
-  # Needed to delete the failed `viable-strict-gate` run that the
-  # original push triggered — see the "Delete failed gate runs" step.
-  actions: write
 
 concurrency:
   # One in-flight promotion at a time; safer than racing tag pushes.
@@ -44,15 +44,40 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-22.04
     steps:
+      # Checked before the tag is pushed rather than after, so a missing
+      # secret is reported as itself instead of as an opaque checkout
+      # error or, worse, a tag that silently starts nothing.
+      - name: Check the bot token is configured
+        env:
+          BOT_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+        run: |
+          set -eu
+          if [ -z "${BOT_TOKEN:-}" ]; then
+            echo "::error::Secret GH_PYTORCHBOT_TOKEN is not set on this repository. Promotion needs a bot token with contents write access, because a ref pushed with the default GITHUB_TOKEN does not start any workflow run and the tag would do nothing."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # A ref pushed with the default GITHUB_TOKEN does not start any
+          # workflow run, which would leave the tag below doing nothing.
+          # Push as the bot so the tag triggers full CI and the gate,
+          # which is the entire point of promoting a commit.
+          token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
 
       - name: Validate SHA and push ciflow tag
         env:
-          SHA: ${{ inputs.sha }}
+          INPUT_SHA: ${{ inputs.sha }}
         run: |
           set -euo pipefail
+
+          # A scheduled run has no inputs, so promote the tip of main.
+          SHA="${INPUT_SHA:-}"
+          if [ -z "$SHA" ]; then
+            SHA=$(git rev-parse origin/main)
+            echo "No SHA given; promoting the tip of main: $SHA"
+          fi
 
           # Reject anything that isn't a full 40-char lowercase hex SHA.
           if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -90,10 +115,19 @@ jobs:
             exit 1
           fi
 
+          # Nothing to promote if viable/strict already contains the
+          # commit. This is the common case for a scheduled tick that
+          # finds main unchanged since the last one.
+          if git merge-base --is-ancestor "$SHA" origin/viable/strict 2>/dev/null; then
+            echo "$SHA is already contained in viable/strict; nothing to do."
+            exit 0
+          fi
+
           TAG="ciflow/trunk/$SHA"
 
-          # If the tag already exists (e.g. someone already promoted
-          # this commit), exit cleanly — no-op is a valid outcome.
+          # If the tag already exists (e.g. an earlier tick promoted
+          # this same commit), exit cleanly. This is what keeps repeated
+          # ticks over a quiet period from re-running CI.
           if git ls-remote --tags --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists on origin; nothing to do."
             exit 0
@@ -105,41 +139,3 @@ jobs:
           git push origin "$TAG"
 
           echo "::notice::Pushed $TAG. Watch the tag-triggered workflow runs (pull / trunk / viable-strict-gate); once they pass, the next update-viablestrict cron (every 30 min) will advance viable/strict."
-
-      # Defense-in-depth: the push that originally landed this commit
-      # triggered a `viable-strict-gate` run that failed (because the
-      # commit wasn't sampled). The tag push above triggers a NEW run
-      # of the gate workflow that will succeed. Standard PyTorch viable/
-      # strict resolves multiple runs by taking the latest conclusion,
-      # so this is usually fine — but to remove ambiguity (and keep the
-      # commit's HUD row clean), explicitly delete any prior failed/
-      # cancelled gate runs on this SHA.
-      - name: Delete failed viable-strict-gate runs on this SHA
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SHA: ${{ inputs.sha }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # List all viable-strict-gate runs for the SHA, filter to
-          # those that completed unsuccessfully, and delete each one.
-          # Failures here are non-fatal: the tag push above is the
-          # primary mechanism; this cleanup is best-effort.
-          RUNS=$(gh api "repos/$REPO/actions/runs?head_sha=$SHA&per_page=100" \
-                   --jq '.workflow_runs[]
-                          | select(.name == "viable-strict-gate")
-                          | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")
-                          | .id' 2>/dev/null || true)
-
-          if [ -z "$RUNS" ]; then
-            echo "No prior failed viable-strict-gate runs to clean up."
-            exit 0
-          fi
-
-          while IFS= read -r RUN_ID; do
-            [ -z "$RUN_ID" ] && continue
-            echo "Deleting failed viable-strict-gate run $RUN_ID"
-            gh api -X DELETE "repos/$REPO/actions/runs/$RUN_ID" || \
-              echo "::warning::Failed to delete run $RUN_ID; continuing anyway."
-          done <<< "$RUNS"

--- a/.github/workflows/promote-to-viable-strict.yml
+++ b/.github/workflows/promote-to-viable-strict.yml
@@ -46,11 +46,17 @@ jobs:
     # GH_PYTORCHBOT_TOKEN is an environment secret, not a repository
     # secret, so a job that does not name the environment cannot read it
     # and would see an empty string. Same pattern as
-    # weekly-pytorch-pin-bump.yml and nightly.yml.
+    # weekly-pytorch-pin-bump.yml.
+    #
+    # This environment's deployment branch policy allows `main` only, so
+    # a hand dispatch from any other ref is refused before the first
+    # step. That also means this job cannot be exercised from a pull
+    # request branch; it is first live after merge.
     environment: update-commit-hash
     permissions:
-      # The tag is pushed with the bot token below, not with GITHUB_TOKEN,
-      # so GITHUB_TOKEN only needs to read the repository for checkout.
+      # Both the checkout and the tag push use the bot token below, so no
+      # step uses GITHUB_TOKEN at all. Declared read-only rather than
+      # omitted so that a future step cannot silently inherit write.
       contents: read
     steps:
       # Checked before the tag is pushed rather than after, so a missing
@@ -154,8 +160,11 @@ jobs:
           git push origin "$TAG"
 
           # Only the workflows that list ciflow/trunk/* under `on.push.tags`
-          # start from this tag. `lint` and `Build documentation` are also
-          # required by update-viablestrict but have no tag trigger, so
-          # their rows come from the earlier push to main; if either was
-          # cancelled on that push, this tag cannot revive it.
-          echo "::notice::Pushed $TAG. Workflow runs started by this tag: pull, trunk, Apple, viable-strict-gate, windows-msvc, riscv64, qnn-windows-msvc. The other two checks update-viablestrict requires, lint and Build documentation, do not trigger on tags and must already be green from the push to main. Once all of them pass, the next update-viablestrict cron (every 30 min) will advance viable/strict."
+          # start from this tag. Four of them are in update-viablestrict's
+          # required set; the other three run but do not gate. `lint` and
+          # `Build documentation` are required too, and neither has a
+          # ciflow/trunk trigger (`Build documentation` only runs on
+          # version tags), so their rows come from the earlier push to
+          # main; if either was cancelled on that push, this tag cannot
+          # revive it.
+          echo "::notice::Pushed $TAG. Workflow runs started by this tag: pull, trunk, Apple, viable-strict-gate, Windows MSVC Build, Test RISC-V Backend, Test QNN Windows MSVC build. Of those, update-viablestrict only requires pull, trunk, Apple and viable-strict-gate; the other three do not gate advancement. The two remaining required checks, lint and Build documentation, do not start from a ciflow/trunk tag and must already be green from the push to main. Once all six required checks are green, the next update-viablestrict cron (every 30 min) will advance viable/strict."

--- a/.github/workflows/promote-to-viable-strict.yml
+++ b/.github/workflows/promote-to-viable-strict.yml
@@ -17,7 +17,10 @@ name: Promote commit to viable/strict
 # full CI and reach that day's nightly build.
 #
 # Can also be dispatched by hand for a specific commit, for example to
-# bisect a regression or to pin a release branch tip.
+# force full CI on one commit while bisecting a regression. Note that
+# update-viablestrict is configured with `main-branch: main`, so
+# promoting a commit that is only on a release branch runs CI for it but
+# will never advance viable/strict.
 
 on:
   schedule:
@@ -31,9 +34,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
-
 concurrency:
   # One in-flight promotion at a time; safer than racing tag pushes.
   group: promote-to-viable-strict
@@ -43,6 +43,15 @@ jobs:
   push-ciflow-tag:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-22.04
+    # GH_PYTORCHBOT_TOKEN is an environment secret, not a repository
+    # secret, so a job that does not name the environment cannot read it
+    # and would see an empty string. Same pattern as
+    # weekly-pytorch-pin-bump.yml and nightly.yml.
+    environment: update-commit-hash
+    permissions:
+      # The tag is pushed with the bot token below, not with GITHUB_TOKEN,
+      # so GITHUB_TOKEN only needs to read the repository for checkout.
+      contents: read
     steps:
       # Checked before the tag is pushed rather than after, so a missing
       # secret is reported as itself instead of as an opaque checkout
@@ -53,7 +62,7 @@ jobs:
         run: |
           set -eu
           if [ -z "${BOT_TOKEN:-}" ]; then
-            echo "::error::Secret GH_PYTORCHBOT_TOKEN is not set on this repository. Promotion needs a bot token with contents write access, because a ref pushed with the default GITHUB_TOKEN does not start any workflow run and the tag would do nothing."
+            echo "::error::GH_PYTORCHBOT_TOKEN resolved to an empty string. It is an environment secret on the 'update-commit-hash' environment, so check that this job still declares that environment and that the secret is still present on it. Promotion needs a bot token with contents write access, because a ref pushed with the default GITHUB_TOKEN does not start any workflow run and the tag would do nothing."
             exit 1
           fi
 
@@ -118,7 +127,13 @@ jobs:
           # Nothing to promote if viable/strict already contains the
           # commit. This is the common case for a scheduled tick that
           # finds main unchanged since the last one.
-          if git merge-base --is-ancestor "$SHA" origin/viable/strict 2>/dev/null; then
+          #
+          # Only applied when we picked the SHA ourselves. Almost all of
+          # main is already an ancestor of viable/strict, so applying it
+          # to a hand-dispatched SHA would turn nearly every deliberate
+          # request into a silent no-op that still reports success.
+          if [ -z "${INPUT_SHA:-}" ] \
+             && git merge-base --is-ancestor "$SHA" origin/viable/strict 2>/dev/null; then
             echo "$SHA is already contained in viable/strict; nothing to do."
             exit 0
           fi
@@ -138,4 +153,9 @@ jobs:
           git tag "$TAG" "$SHA"
           git push origin "$TAG"
 
-          echo "::notice::Pushed $TAG. Watch the tag-triggered workflow runs (pull / trunk / viable-strict-gate); once they pass, the next update-viablestrict cron (every 30 min) will advance viable/strict."
+          # Only the workflows that list ciflow/trunk/* under `on.push.tags`
+          # start from this tag. `lint` and `Build documentation` are also
+          # required by update-viablestrict but have no tag trigger, so
+          # their rows come from the earlier push to main; if either was
+          # cancelled on that push, this tag cannot revive it.
+          echo "::notice::Pushed $TAG. Workflow runs started by this tag: pull, trunk, Apple, viable-strict-gate, windows-msvc, riscv64, qnn-windows-msvc. The other two checks update-viablestrict requires, lint and Build documentation, do not trigger on tags and must already be green from the push to main. Once all of them pass, the next update-viablestrict cron (every 30 min) will advance viable/strict."

--- a/.github/workflows/promote-to-viable-strict.yml
+++ b/.github/workflows/promote-to-viable-strict.yml
@@ -18,9 +18,12 @@ name: Promote commit to viable/strict
 #
 # Can also be dispatched by hand for a specific commit, for example to
 # force full CI on one commit while bisecting a regression. Note that
-# update-viablestrict is configured with `main-branch: main`, so
 # promoting a commit that is only on a release branch runs CI for it but
-# will never advance viable/strict.
+# will never advance viable/strict: the updater only considers commits
+# reachable from the branch it checks out, which is main. (The
+# `main-branch: main` line in update-viablestrict.yml looks like it
+# controls this, but the action does not declare that input and passes a
+# hardcoded value, so it has no effect either way.)
 
 on:
   schedule:
@@ -163,8 +166,7 @@ jobs:
           # start from this tag. Four of them are in update-viablestrict's
           # required set; the other three run but do not gate. `lint` and
           # `Build documentation` are required too, and neither has a
-          # ciflow/trunk trigger (`Build documentation` only runs on
-          # version tags), so their rows come from the earlier push to
-          # main; if either was cancelled on that push, this tag cannot
+          # ciflow/trunk trigger, so their rows come from the earlier push
+          # to main; if either was cancelled on that push, this tag cannot
           # revive it.
           echo "::notice::Pushed $TAG. Workflow runs started by this tag: pull, trunk, Apple, viable-strict-gate, Windows MSVC Build, Test RISC-V Backend, Test QNN Windows MSVC build. Of those, update-viablestrict only requires pull, trunk, Apple and viable-strict-gate; the other three do not gate advancement. The two remaining required checks, lint and Build documentation, do not start from a ciflow/trunk tag and must already be green from the push to main. Once all six required checks are green, the next update-viablestrict cron (every 30 min) will advance viable/strict."

--- a/.github/workflows/viable-strict-gate.yml
+++ b/.github/workflows/viable-strict-gate.yml
@@ -50,8 +50,10 @@ jobs:
       # header. So do not re-add ``push: branches`` above. Adding
       # ``workflow_dispatch`` is a different trap: it would make this
       # assertion pass and publish a viable-strict-gate success for a
-      # commit whose CI was path-filtered. ``schedule`` is the same trap
-      # by another name.
+      # commit whose CI was path-filtered. ``schedule`` is unsafe for the
+      # opposite reason: ``_ci-run-decision.yml`` returns false for a
+      # schedule event, so every tick would fail here and write a
+      # permanent failure row on the tip of main.
       - name: Check whether this commit is a full-coverage run
         env:
           IS_FULL_RUN: ${{ needs.run-decision.outputs.is-full-run }}

--- a/.github/workflows/viable-strict-gate.yml
+++ b/.github/workflows/viable-strict-gate.yml
@@ -50,7 +50,8 @@ jobs:
       # header. So do not re-add ``push: branches`` above. Adding
       # ``workflow_dispatch`` is a different trap: it would make this
       # assertion pass and publish a viable-strict-gate success for a
-      # commit whose CI was path-filtered.
+      # commit whose CI was path-filtered. ``schedule`` is the same trap
+      # by another name.
       - name: Check whether this commit is a full-coverage run
         env:
           IS_FULL_RUN: ${{ needs.run-decision.outputs.is-full-run }}

--- a/.github/workflows/viable-strict-gate.yml
+++ b/.github/workflows/viable-strict-gate.yml
@@ -41,9 +41,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       # Only tag pushes reach this workflow, so is-full-run is always
-      # true here. Kept as an assertion: if a trigger that does not
-      # force a full run is ever added above, this fails loudly rather
-      # than quietly making partial signal eligible.
+      # true here. Kept as an assertion against a future trigger that
+      # does not force a full run.
+      #
+      # Failing is the correct behaviour for a tag push, which is a
+      # deliberate request, but it is NOT a safe way to reject ordinary
+      # commits: a failure row here is permanent, for the reason in the
+      # header. So do not re-add ``push: branches`` above. Adding
+      # ``workflow_dispatch`` is a different trap: it would make this
+      # assertion pass and publish a viable-strict-gate success for a
+      # commit whose CI was path-filtered.
       - name: Check whether this commit is a full-coverage run
         env:
           IS_FULL_RUN: ${{ needs.run-decision.outputs.is-full-run }}

--- a/.github/workflows/viable-strict-gate.yml
+++ b/.github/workflows/viable-strict-gate.yml
@@ -1,27 +1,30 @@
 name: viable-strict-gate
 
-# Sampled-full-run gating for viable/strict advancement.
+# Marks a commit as eligible for viable/strict advancement.
 #
 # Path filtering on push to main saves runner cost but risks advancing
-# viable/strict on commits where many jobs were skipped — a partial
-# green from "no job ran" is indistinguishable from "everything passed"
-# at the workflow-conclusion level.
+# viable/strict on commits where many jobs were skipped: a partial green
+# from "no job ran" is indistinguishable from "everything passed" at the
+# workflow-conclusion level.
 #
-# This workflow runs on every push to main / release branches and
-# *fails* when ``_ci-run-decision.yml`` says this isn't a full-coverage
-# commit (i.e. the SHA isn't sampled and there's no ciflow/* tag).
-# Failure => the "viable-strict-gate" workflow conclusion is failure
-# => update-viablestrict refuses to advance viable/strict.
+# So this workflow runs only on ``ciflow/trunk/<sha>`` tags, for which
+# ``_ci-run-decision.yml`` always returns ``is-full-run = true``. A plain
+# push to main produces no run of this workflow at all, so
+# update-viablestrict reports the required check as missing and declines
+# to advance. Eligibility is granted by promoting a commit, never by
+# landing it. ``promote-to-viable-strict.yml`` pushes those tags, on a
+# schedule and on demand.
 #
-# To force a full run on a specific commit (e.g. before tagging a
-# release), push a ``ciflow/trunk/<sha>`` tag — on tag pushes
-# ``_ci-run-decision.yml`` always returns ``is-full-run = true``.
+# This workflow used to run on every push and fail on commits outside
+# the sample. That wrote a permanent failure: the viable/strict updater
+# reads one row per workflow *run* rather than per workflow, so a later
+# successful run sat beside the failed one instead of replacing it, and
+# a single failure anywhere is fatal. A commit that landed outside the
+# sample could therefore never be promoted afterwards. Producing no run
+# at all avoids that, because there is nothing to sit beside.
 
 on:
   push:
-    branches:
-      - main
-      - release/*
     tags:
       - ciflow/trunk/*
 
@@ -37,6 +40,10 @@ jobs:
     name: Full CI required for viable/strict
     runs-on: ubuntu-22.04
     steps:
+      # Only tag pushes reach this workflow, so is-full-run is always
+      # true here. Kept as an assertion: if a trigger that does not
+      # force a full run is ever added above, this fails loudly rather
+      # than quietly making partial signal eligible.
       - name: Check whether this commit is a full-coverage run
         env:
           IS_FULL_RUN: ${{ needs.run-decision.outputs.is-full-run }}
@@ -47,6 +54,5 @@ jobs:
             exit 0
           fi
           echo "::error::Non-full-run commit (path-filtered CI). viable/strict cannot advance from this commit."
-          echo "Full CI runs on every 4th commit on main / release/* (depth %% 4 == 0)."
-          echo "To force a full run on this commit, push a 'ciflow/trunk/${{ github.sha }}' tag."
+          echo "This workflow should only ever run on a 'ciflow/trunk/<sha>' tag, which always forces a full run."
           exit 1


### PR DESCRIPTION
# PR #22064: Promote commits to viable/strict on a schedule, not by commit count

## Problem

viable/strict only advanced from commits whose position in main's history happened to be
divisible by 4. Every other commit was permanently ineligible, and the manual escape
hatch for promoting one did not work, so a commit could sit outside viable/strict
indefinitely and miss the nightly build that is cut from it.

Two independent reasons the escape hatch did not work:

1. `viable-strict-gate` ran on every push and failed on commits outside the sample. The
   viable/strict updater reads one row per workflow **run** rather than per workflow, so
   pushing a `ciflow/trunk` tag afterwards added a second, successful row beside the
   failed one instead of replacing it. Any single failure is fatal, so the commit stayed
   ineligible forever. A comment in `promote-to-viable-strict.yml` claimed the updater
   "resolves multiple runs by taking the latest conclusion", which is not what it does.

2. `promote-to-viable-strict` pushed its tag using the default `GITHUB_TOKEN`. A ref
   pushed with that token does not start any workflow run, so the tag triggered neither
   the full CI it was meant to force nor the gate.

Counting commits is also the wrong unit. When the repository is busy, four commits can be
twenty minutes apart and full CI runs more often than it needs to. When it is quiet, four
commits can span two days. Measured over the last two weeks of main, the longest a commit
waited to become eligible was **56.7 hours**; over 30 days it was **58.0 hours**. Either
is long enough to miss a whole nightly build.

## Changes

- `viable-strict-gate` runs only on `ciflow/trunk` tags. A plain push produces no run of
  it, so the updater reports the required check as missing and declines to advance.
  The gate never writes a failure row, so it can no longer be the thing that poisons a
  commit. To be clear about the scope of that: the other five required checks still run
  on push and can still leave a permanent failure row, so this removes one source of
  poisoning rather than all of them.
- `promote-to-viable-strict` runs every 4 hours and promotes the tip of main. On a
  scheduled tick it exits without doing anything when viable/strict already contains the
  commit, and on any run it exits when the tag already exists, so repeated ticks over a
  quiet period do not re-run CI. One tick sits ahead of the nightly branch cut, so the
  last commits of a quiet night still reach that day's nightly build.
- `promote-to-viable-strict` checks out with a bot token so its tag push actually starts
  CI, and its `sha` input is now optional and defaults to the tip of main.
- Dropped the step that deleted failed gate runs. It could not help: the updater's data
  comes from webhook events, and deleting a run does not retract the row it already
  produced. With the gate no longer running on push there is nothing left to delete
  either.

The depth based sample in `_ci-run-decision.yml` is unchanged, and must stay. Seven
workflows re-run from a `ciflow/trunk` tag, but only four of them call
`_ci-run-decision.yml`. The other seven callers (cuda, cuda-windows, cuda-perf, metal,
mlx, rocm, vulkan) have their own ciflow tags but not `ciflow/trunk`, so a promotion tag
never starts them, and they hold 32 of the 48 jobs whose `if:` gates on `is-full-run`.
Most of those 32 also have a changed-files branch and still run on main when their own
paths are touched. The 12 in `mlx.yml` do not, so for those the depth sample is the only
thing that ever runs them on main.

## Cost and the alternative that was considered

`pull`, `trunk`, `Apple`, `Windows MSVC Build`, `Test RISC-V Backend` and
`Test QNN Windows MSVC build` trigger on both a push to main and a `ciflow/trunk` tag,
and their concurrency keys differ, so neither run cancels the other. A promoted commit
therefore runs those workflows twice.

The obvious cheaper alternative is to make `is-full-run` true for the first commit in
each 4 hour wall clock window, computed from committer timestamps, instead of every
fourth commit by depth. No tag, no new workflow, no token. Measured over main's history:

| | full-run events per day | vs today | longest observed wait to become eligible |
|---|---|---|---|
| today, every 4th commit | 4.14 | 1.00x | 56.7 h |
| this PR | 8.21 | 1.98x | 4 h plus CI time |
| first commit per 4 h window | 4.07 | 0.98x | 20.2 h |

Figures are over 14 days. Over 30 days: 3.30 / 7.30 / 4.00 events per day, 1.00x / 2.21x
/ 1.21x, and longest observed waits of 58.0 h / 4 h plus CI time / 28.3 h.

Three things about that table need saying, because a quick reading of it gets all three
wrong.

**The alternative does not actually fix the problem.** Its worst observed wait is 20 to
28 hours, not 4, and its true worst case is unbounded. A wall clock window only opens
when a commit arrives, so during a quiet night it promotes nothing, which is exactly the
case the nightly build cares about. This change promotes the tip of main on a timer
whether or not anything new landed, so a commit is eligible one tick after it lands.
That is the difference between missing a nightly and not missing one, and it is the
reason to prefer this approach despite the cost.

**The 4 hours is the cron spacing, not a guarantee.** Add CI wall clock and up to 30
minutes for the next updater tick, and GitHub can delay or drop scheduled runs under
load. On the one real promotion tag I could measure, all four required tag-started
workflows were green 2.2 hours after the tag, and that figure includes a hand re-run of
a cancelled `trunk` attempt, so it is not a clean unattended measurement. The 08:00 UTC
tick is about 3.5 hours ahead of the nightly cut, so the margin is real but it is not
large.

**The cost is worse than the event count suggests, not better.** A promotion tag does not
just re-run the jobs gated on `is-full-run`; it starts seven whole workflows over again.
Measured on commit `cff6f4dd`, which received a real `ciflow/trunk` tag: the tag run cost
6,046 runner-minutes (latest attempt of each job, skipped jobs excluded), and about 85
percent of that by runner-minutes, 82 percent by job count, repeated work the push to
main had already finished. Per event, a promotion is more expensive than a depth sample,
not less.

Where that lands in absolute terms: roughly 4.07 promotions a day at about 6,000
runner-minutes each is about 24,600 runner-minutes a day added, against roughly 128,000
a day for main CI today. So about **1.19x** on the total main CI bill. That is the honest
number, and it is smaller than 1.98x only because full runs are a minority of the bill,
not because the added events are cheap.

One further cost not in the table: a promoted commit produces roughly twice the job rows
the updater must find green, so it roughly doubles the exposure to a flake blocking
advancement.

If the cost is judged too high, the direction I would look first is not the wall clock
alternative but adding `ciflow/trunk/*` to the seven callers that do not listen for it,
so that a tag unlocks all 48 gated jobs instead of 16. A rough estimate puts that at
about 1.16x against this change's 1.19x, so the saving is real but small, and I have not
measured it properly. Note that it would not allow deleting the depth sample: the sample
guarantees at most 3 consecutive commits without a full run, whereas promoting only the
tip at each tick guarantees nothing within a window. The busiest 4 hour window in the
last two weeks held 16 commits.

## Correction to an earlier version of this description

An earlier version said `GH_PYTORCHBOT_TOKEN` was not set on this repository and asked
for it to be added as a repository secret. That was wrong on both counts.

The secret is set. It is an **environment** secret on the `update-commit-hash`
environment, alongside `UPDATEBOT_TOKEN`. The real defect was in this change: the promote
job did not declare `environment: update-commit-hash`, so it could not read the secret
and would have failed on every run. That is now fixed, following the same pattern as
`weekly-pytorch-pin-bump.yml`.

Adding it as a repository secret would also have been the wrong fix, because a repository
secret is readable by any workflow on any ref.

The earlier version also said `nightly.yml`, `cherry-pick.yml`, `ghstack_land.yml`,
`apple.yml` and `weekly-pytorch-pin-bump.yml` reference unset bot tokens. That was a
consequence of the same mistake and is not true. All five are correctly wired:
cherry-pick and ghstack_land use `GH_PYTORCHBOT_CHERRY_PICK_TOKEN` on the
`cherry-pick-bot` environment, weekly-pytorch-pin-bump uses `UPDATEBOT_TOKEN`, apple.yml
falls back to `GITHUB_TOKEN`, and nightly.yml already declares the environment. No action
is needed on any of them.

## Test plan

Ran the promote script against a real clone with the push and the remote tag lookup
stubbed out, covering every branch:

- No `sha` input, which is the scheduled path: resolves the tip of main, passes
  validation and reachability, and stops cleanly on the already existing tag. Exit 0.
- A hand dispatched SHA that is already contained in viable/strict: now proceeds to the
  tag push instead of exiting early. This was a real defect. 13272 of the 13274
  first-parent commits on main are already ancestors of viable/strict, so the old
  behaviour turned nearly every deliberate dispatch into a silent no-op that still
  reported success.
- A malformed SHA, and a well-formed SHA that is not a commit: both rejected with an
  explicit error before anything is pushed.
- All three workflow files parse as YAML and the extracted shell passes `bash -n`.

## Known limitation

The `update-commit-hash` environment's deployment branch policy allows `main` only, so
the promote job cannot be dispatched from this branch and is first exercised after merge.
Everything except the tag push and the secret read is covered by the runs above.
