### PR TITLE
Avoid per-node GraphModule retracing in view/permute propagation (#22066)

### DIFF
--- a/backends/arm/test/passes/test_propagate_permutes_views_pass.py
+++ b/backends/arm/test/passes/test_propagate_permutes_views_pass.py
@@ -555,6 +555,25 @@ def test_up_pass_refreshes_permute_meta_before_view_slice_swap() -> None:
     assert slice_node.args == (view, 0, 0, 1)
 
 
+class ViewPermutePropagationMRE(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = torch.ops.aten.slice_copy.Tensor(x, 1, 0, 1, 1)
+        x = torch.ops.aten.permute_copy.default(x, [2, 1, 0])
+        return torch.ops.aten.view_copy.default(x, [8, 1])
+
+    data = (torch.arange(24, dtype=torch.float32).reshape(2, 3, 4),)
+
+
+def test_up_pass_preserves_slice_permute_view_output() -> None:
+    pipeline = PassPipeline[input_t](
+        ViewPermutePropagationMRE(),
+        ViewPermutePropagationMRE.data,
+        quantize=False,
+        pass_list=[PropagateViewCopyPermuteUpPass],
+    )
+    pipeline.run()
+
+
 def test_up_pass_keeps_scatter_input_view_after_slice() -> None:
     graph = torch.fx.Graph()
     x = graph.placeholder("x")

--- a/backends/transforms/propagate_view_copy_permute_pass.py
+++ b/backends/transforms/propagate_view_copy_permute_pass.py
@@ -107,22 +107,29 @@ class PropagateViewCopyPermutePass(ExportPass, ABC):
 
         while True:
             iteration_modified = False
+            # A rewrite invalidates metadata along its path and downstream.
+            # Defer that region while still batching independent branches.
+            stale_nodes: set[torch.fx.Node] = set()
             for node in list(graph_module.graph.nodes):
+                if node in stale_nodes:
+                    continue
                 if node.target in self._targets:
                     if len(node.users) == 0:
                         continue
-                    if self._propagate(node):
+                    if self._propagate(node, stale_nodes):
                         iteration_modified = True
-                        break
 
             if iteration_modified:
+                modified = True
                 graph_module = self._retrace(graph_module)
-                result = self.fuse_horizontal(graph_module)
-                graph_module = result.graph_module
-                iteration_modified |= result.modified
-                result = self.fuse_vertical(graph_module)
-                graph_module = result.graph_module
-                iteration_modified |= result.modified
+                continue
+
+            result = self.fuse_horizontal(graph_module)
+            graph_module = result.graph_module
+            iteration_modified = result.modified
+            result = self.fuse_vertical(graph_module)
+            graph_module = result.graph_module
+            iteration_modified |= result.modified
 
             modified |= iteration_modified
             if not iteration_modified:
@@ -133,55 +140,103 @@ class PropagateViewCopyPermutePass(ExportPass, ABC):
 
         return PassResult(graph_module, modified)
 
+    @staticmethod
+    def _mark_downstream_nodes_stale(
+        node: torch.fx.Node, stale_nodes: set[torch.fx.Node]
+    ) -> None:
+        pending = [node]
+        while pending:
+            current = pending.pop()
+            if current in stale_nodes:
+                continue
+            stale_nodes.add(current)
+            pending.extend(current.users)
+
+    def _mark_stale_region(
+        self,
+        nodes: Iterable[torch.fx.Node],
+        stale_nodes: set[torch.fx.Node],
+    ) -> None:
+        for node in nodes:
+            self._mark_downstream_nodes_stale(node, stale_nodes)
+
     def _retrace(self, graph_module: torch.fx.GraphModule) -> torch.fx.GraphModule:
         graph_module.graph.eliminate_dead_code()
         graph_module.graph.lint()
         return super().call(graph_module).graph_module
 
-    def _propagate(self, node: torch.fx.Node) -> bool:
-        """Propagate a single permute/view node."""
+    def _validated_next_nodes(
+        self,
+        node: torch.fx.Node,
+        frontier: torch.fx.Node,
+        stale_nodes: set[torch.fx.Node],
+    ) -> list[torch.fx.Node] | None:
+        next_nodes = list(self._get_next_nodes(frontier))
+        if not next_nodes:
+            assert frontier.op in (
+                "placeholder",
+                "output",
+            ), f"{self.__class__.__name__} reached an endpoint node which is not a placeholder or output: {frontier}"
+            return None
+
+        if any(next_node in stale_nodes for next_node in next_nodes):
+            return None
+
+        if not self._can_cross_next_nodes(frontier, next_nodes):
+            return None
+
+        if self.blocks_moving(node, frontier, next_nodes):
+            return None
+
+        return next_nodes
+
+    def _advance_through_next_node(
+        self,
+        node: torch.fx.Node,
+        frontier: torch.fx.Node,
+        next_node: torch.fx.Node,
+    ) -> bool:
+        if self._can_move_through_elementwise(node, frontier, next_node):
+            return True
+
+        if not self.is_swappable(next_node):
+            return False
+
+        swapped_args = self._maybe_swap_args(node, next_node)
+        if swapped_args is None:
+            return False
+
+        node.args = swapped_args[0]
+        next_node.args = swapped_args[1]
+        return True
+
+    def _propagate(self, node: torch.fx.Node, stale_nodes: set[torch.fx.Node]) -> bool:
+        """Propagate one node without consulting metadata invalidated this
+        scan.
+        """
 
         frontier = node
         previous_frontier = None
+        propagation_path = [node]
         moved = False
         while True:
-            next_nodes = list(self._get_next_nodes(frontier))
-
-            if len(next_nodes) == 0:
-                assert frontier.op in (
-                    "placeholder",
-                    "output",
-                ), f"{self.__class__.__name__} reached an endpoint node which is not a placeholder or output: {frontier}"
-                break
-
-            if not self._can_cross_next_nodes(frontier, next_nodes):
-                break
-
-            if self.blocks_moving(node, frontier, next_nodes):
+            next_nodes = self._validated_next_nodes(node, frontier, stale_nodes)
+            if next_nodes is None:
                 break
 
             if len(next_nodes) > 1:
-                if self._maybe_split_fork(
+                if not self._maybe_split_fork(
                     node, frontier, previous_frontier, next_nodes
                 ):
-                    return True
-                break
+                    break
+                self._mark_stale_region((*propagation_path, *next_nodes), stale_nodes)
+                return True
 
             next_node = next_nodes[0]
-            if self._can_move_through_elementwise(node, frontier, next_node):
+            if self._advance_through_next_node(node, frontier, next_node):
                 previous_frontier = frontier
                 frontier = next_node
-                moved = True
-                continue
-
-            if self.is_swappable(next_node):
-                swapped_args = self._maybe_swap_args(node, next_node)
-                if swapped_args is None:
-                    break
-                node.args = swapped_args[0]
-                next_node.args = swapped_args[1]
-                previous_frontier = frontier
-                frontier = next_node
+                propagation_path.append(next_node)
                 moved = True
                 continue
 
@@ -189,6 +244,7 @@ class PropagateViewCopyPermutePass(ExportPass, ABC):
             # Perform the swap directly in this case and return.
             # Otherwise break and move the node before the concat
             if self._maybe_split_upwards_cat_fanout(node, next_node):
+                self._mark_stale_region((*propagation_path, next_node), stale_nodes)
                 return True
 
             # Unhandled case, stop propagation
@@ -199,6 +255,7 @@ class PropagateViewCopyPermutePass(ExportPass, ABC):
 
         assert previous_frontier is not None
         self._move_node(node, frontier, previous_frontier)
+        self._mark_stale_region(propagation_path, stale_nodes)
         return True
 
     def duplicate_user_fusion_exclusions(self) -> frozenset:


### PR DESCRIPTION
Summary:

This diff significantly speeds up the ExecuTorch ARM lowering pass for large graphs with many local view/permute rewrites. Rather than retracing and repairing the entire graph after every edit, it batches edits that are independent. On an existing ~1M param ensemble model in A16W8 mode, this reduces end-to-end blobgen time from ~4 hours to ~30 min.

The conservative schedule for graph rewriting is: select one edit, apply it, retrace the graph to refresh tensor metadata, and only then select the next edit. This is safe because every rewrite decision observes metadata describing the current graph. It is expensive because each of E local edits can trigger an O(V) whole-graph repair; when the number of edits grows with graph size, this approaches quadratic work.

Batching every eligible edit without an intervening retrace is not safe. The first edit can invalidate metadata on the rewritten region and its downstream users, and a later edit can then make a decision using metadata that describes the pre-edit graph. The added `slice_copy` -> `permute_copy` -> `view_copy` regression exercises exactly this failure.

This diff retains the serial safety invariant where dependencies require it while batching elsewhere. Its safety argument relies on three properties of these rewrites:

- Every graph mutation is included in the propagation region recorded by the pass.
- Tensor metadata depends on upstream dataflow, so invalidation is confined to that changed region and its downstream closure; it does not flow into unrelated branches.
- A later candidate that neither starts in nor crosses that stale closure cannot observe metadata invalidated by the earlier edit.

After each edit, the pass marks the changed region and its downstream closure stale. Candidates touching that region are deferred, while candidates on independent branches continue in the same scan. The pass then retraces once, clears the stale set, and begins the next fixed-point scan. Each scan is therefore a conflict-serializable wave: dependency-connected edits behave as if applied serially, while independent edits are batched.

Reviewed By: JakeStevens

Differential Revision: D117110269


