### PR TITLE
Arm backend: Canonicalize view-chains

### DIFF
--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -665,6 +665,8 @@ class ArmPassManager(ExportedProgramPassManager):
                 # permute pairs they expose.
                 RemoveNoopPass(),
                 CanonicalizeViewCopyPermutePass(),
+                # Fuse views again after permutes may have been replaced by views.
+                FuseViewCopyTransformPass(),
                 InsertConstShapesPass(),
                 InsertDataLayoutCastsPass(),
             ]

--- a/backends/arm/test/passes/test_fuse_view_copy.py
+++ b/backends/arm/test/passes/test_fuse_view_copy.py
@@ -1,13 +1,43 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 
 import torch
+from executorch.backends.arm._passes import ConvertPermuteSingletonToViewPass
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
 from executorch.backends.transforms.fuse_view_copy import FuseViewCopyTransform
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+
+
+_VIEW = exir_ops.edge.aten.view_copy.default
+_PERMUTE = exir_ops.edge.aten.permute_copy.default
+
+
+def _count_node(
+    graph_module: torch.fx.GraphModule, target: torch.fx.node.Target
+) -> int:
+    return sum(
+        node.op == "call_function" and node.target == target
+        for node in graph_module.graph.nodes
+    )
+
+
+class _AssertAfterInitialFusePass(ExportPass):
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        assert _count_node(graph_module, _VIEW) == 1
+        assert _count_node(graph_module, _PERMUTE) == 1
+        return PassResult(graph_module, False)
+
+
+class _AssertAfterPermuteToViewPass(ExportPass):
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        assert _count_node(graph_module, _VIEW) == 2
+        assert _count_node(graph_module, _PERMUTE) == 0
+        return PassResult(graph_module, False)
 
 
 class FuseSequentialViews(torch.nn.Module):
@@ -62,6 +92,13 @@ class DontFuseBranchingViews(torch.nn.Module):
     }
 
 
+class FuseViewsIntroducedByLaterPass(torch.nn.Module):
+    def forward(self, x: torch.Tensor):
+        return x.view((1, 2, 1, 3, 4)).view((2, 1, 3, 4)).permute(0, 2, 3, 1)
+
+    data = (torch.randn(2, 1, 3, 4),)
+
+
 tests = {
     "fuse_sequential_views": FuseSequentialViews(),
     "fuse_sequential_with_noops_views": FuseSequentialWithNoopsViews(),
@@ -78,5 +115,32 @@ def test_fuse_view_copy_transform_tosa_FP(model):
         ops_before_pass=model.ops_before_pass,
         ops_after_pass=model.ops_after_pass,
         pass_list=[FuseViewCopyTransform],
+    )
+    pipeline.run()
+
+
+def test_fuse_view_copy_transform_runs_again_after_new_fusable_view_tosa_FP():
+    model = FuseViewsIntroducedByLaterPass()
+    pipeline = PassPipeline(
+        model,
+        model.data,
+        quantize=False,
+        ops_before_pass={
+            "executorch_exir_dialects_edge__ops_aten_view_copy": 2,
+            "executorch_exir_dialects_edge__ops_aten_permute_copy_default": 1,
+        },
+        ops_after_pass={
+            "executorch_exir_dialects_edge__ops_aten_view_copy": 1,
+        },
+        ops_not_after_pass=[
+            "executorch_exir_dialects_edge__ops_aten_permute_copy_default",
+        ],
+        pass_list=[
+            FuseViewCopyTransform,
+            _AssertAfterInitialFusePass,
+            ConvertPermuteSingletonToViewPass,
+            _AssertAfterPermuteToViewPass,
+            FuseViewCopyTransform,
+        ],
     )
     pipeline.run()


### PR DESCRIPTION
Run FuseViewCopyTransformPass late in the Arm TOSA pipeline, after CanonicalizeViewCopyPermutePass and before constant-shape insertion, so redundant view_copy chains exposed by earlier canonicalization are collapsed before TOSA legalization.

cc @digantdesai @freddan80 @per @zingo @mansnils @Sebastian-Larsson @robell @rascani