### PR TITLE
Add bounded LLM worker cancellation

### DIFF
--- a/examples/llm_server/README.md
+++ b/examples/llm_server/README.md
@@ -32,7 +32,7 @@ decoding `temperature = 0` they are accepted but have no effect, and an omitted
 `seed` uses the worker's unset/random value), Hermes tool calling by default
 (`<tool_call>...</tool_call>` JSON, complete calls only; model-specific launchers
 may select the Qwen XML format) with `tool_choice="none"`,
-structured API errors, and best-effort cancellation. One worker process with
+structured API errors, and bounded request cancellation. One worker process with
 serialized execution; a worker can host isolated sessions on one weight load when its engine reports
 capacity > 1 (with warm append-only resume across turns). KV/prefix state lives inside the
 worker/session, not the control plane. Unsupported params (including
@@ -95,6 +95,10 @@ Supported contract for pi:
 
 Reliability guidance:
 
+- On POSIX, workers that advertise cancellation stop disconnected requests at a
+  token boundary. If cooperative stop does not finish within the grace period,
+  the server terminates the worker, reports `/health` as unavailable, and
+  requires a supervisor restart rather than silently reloading model weights.
 - Use the model's real HF `chat_template` (`--hf-tokenizer`) for tool use, kept
   aligned with the exported tokenizer/model.
 - If tool calls come back as plain text, confirm the model is emitting the

--- a/examples/llm_server/cpp/CMakeLists.txt
+++ b/examples/llm_server/cpp/CMakeLists.txt
@@ -26,8 +26,14 @@ set(_json_include
 # executorch
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
 find_package(executorch CONFIG REQUIRED FIND_ROOT_PATH_BOTH)
+find_package(Threads REQUIRED)
 executorch_target_link_options_shared_lib(executorch)
 
+# Older installed packages may omit this header-only interface target.
+if(NOT TARGET extension_llm_session)
+  add_library(extension_llm_session INTERFACE)
+  target_link_libraries(extension_llm_session INTERFACE executorch_core)
+endif()
 set(test_link_libraries executorch extension_llm_session tokenizers::tokenizers)
 
 # Pure unit test for the warm-resume prefill planner (worker_prefill_plan.h). No
@@ -47,5 +53,7 @@ add_executable(test_worker_loop test_worker_loop.cpp)
 target_include_directories(
   test_worker_loop PUBLIC ${_common_include_directories} ${_json_include}
 )
-target_link_libraries(test_worker_loop PUBLIC ${test_link_libraries})
+target_link_libraries(
+  test_worker_loop PUBLIC ${test_link_libraries} Threads::Threads
+)
 add_test(NAME worker_loop COMMAND test_worker_loop)

--- a/examples/llm_server/cpp/test_worker_loop.cpp
+++ b/examples/llm_server/cpp/test_worker_loop.cpp
@@ -15,21 +15,34 @@
 #include <executorch/examples/llm_server/cpp/worker_loop.h>
 
 #include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <iostream>
 #include <iterator>
 #include <limits>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
+
+#if defined(__unix__) || defined(__APPLE__)
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 using executorch::extension::llm::DecodeResult;
 using executorch::extension::llm::LLMEngine;
 using executorch::extension::llm::LLMServingCapacity;
 using executorch::extension::llm::LLMSession;
 using executorch::extension::llm::SamplingConfig;
+using executorch::extension::llm::worker_cancel_request_id;
 using executorch::extension::llm::worker_handle_request;
+using executorch::extension::llm::WorkerCancellationController;
+using executorch::extension::llm::WorkerCancellationState;
 using executorch::extension::llm::WorkerSessions;
 using executorch::extension::llm::WorkerSessionState;
 using ETError = ::executorch::runtime::Error;
@@ -69,6 +82,12 @@ class FakeSession : public LLMSession {
   std::vector<SamplingConfig> decode_sampling;
   int reset_calls = 0;
   bool fail_reset = false;
+  std::atomic<int> stop_calls{0};
+  std::atomic<bool> stop_requested{false};
+  std::atomic<bool> block_prefill{false};
+  std::atomic<bool> prefill_entered{false};
+  std::atomic<bool> release_prefill{false};
+  std::atomic<bool> decode_saw_stop{false};
 
   ETError prefill_tokens(
       const std::vector<uint64_t>& tokens,
@@ -81,12 +100,23 @@ class FakeSession : public LLMSession {
     if (prefill_calls++ == fail_prefill_on) {
       return ETError::Internal; // failed AFTER (notionally) mutating state
     }
+    prefill_entered.store(true, std::memory_order_release);
+    while (block_prefill.load(std::memory_order_acquire) &&
+           !release_prefill.load(std::memory_order_acquire)) {
+      std::this_thread::yield();
+    }
     pos += static_cast<int64_t>(tokens.size());
+    // Real sessions may clear a cooperative stop while setting up prefill.
+    stop_requested.store(false, std::memory_order_release);
     return ETError::Ok;
   }
 
   ETResult<DecodeResult> decode_one(const SamplingConfig& sampling) override {
     decode_sampling.push_back(sampling);
+    if (stop_requested.exchange(false, std::memory_order_acq_rel)) {
+      decode_saw_stop.store(true, std::memory_order_release);
+      return DecodeResult{0, "", false, true};
+    }
     if (decode_calls++ == fail_decode_on) {
       return ETError::Internal;
     }
@@ -110,9 +140,13 @@ class FakeSession : public LLMSession {
     }
     pos = 0;
     step_i = 0;
+    stop_requested.store(false, std::memory_order_release);
     return ETError::Ok;
   }
-  void stop() override {}
+  void stop() override {
+    stop_calls.fetch_add(1, std::memory_order_acq_rel);
+    stop_requested.store(true, std::memory_order_release);
+  }
 };
 
 // ---- Fake Tokenizer: only needed to satisfy the signature; tests use {ids}
@@ -186,15 +220,22 @@ Emitted run(
     const nlohmann::json& req,
     const std::unordered_map<std::string, int64_t>& md = {},
     const std::vector<uint64_t>& prefix = {},
-    const nlohmann::json& additional_terminal_stats =
-        nlohmann::json::object()) {
+    const nlohmann::json& additional_terminal_stats = nlohmann::json::object(),
+    WorkerCancellationState* cancellation = nullptr) {
   static FakeTokenizer tok;
   std::ostringstream cap;
   std::streambuf* old = std::cout.rdbuf(cap.rdbuf());
   Emitted em;
   try {
     worker_handle_request(
-        st, warm, tok, md, req, prefix, additional_terminal_stats);
+        st,
+        warm,
+        tok,
+        md,
+        req,
+        prefix,
+        additional_terminal_stats,
+        cancellation);
   } catch (const std::exception&) {
     em.threw = true;
   }
@@ -228,6 +269,36 @@ FakeSession& fake(WorkerSessionState& st) {
 nlohmann::json idsReq(std::vector<uint64_t> ids, int64_t max_new = 8) {
   return {{"max_new_tokens", max_new}, {"prompt_segments", {{{"ids", ids}}}}};
 }
+
+#if defined(__unix__) || defined(__APPLE__)
+std::array<uint8_t, sizeof(uint64_t)> cancelFrame(uint64_t request_id) {
+  std::array<uint8_t, sizeof(uint64_t)> bytes{};
+  for (size_t index = 0; index < bytes.size(); ++index) {
+    bytes[index] = static_cast<uint8_t>(request_id >> (index * 8));
+  }
+  return bytes;
+}
+
+bool writeBytes(int descriptor, const uint8_t* bytes, size_t count) {
+  return ::write(descriptor, bytes, count) == static_cast<ssize_t>(count);
+}
+
+bool writeCancelFrame(int descriptor, uint64_t request_id) {
+  const auto bytes = cancelFrame(request_id);
+  return writeBytes(descriptor, bytes.data(), bytes.size());
+}
+
+template <typename Predicate>
+bool waitFor(Predicate predicate) {
+  for (int attempt = 0; attempt < 200; ++attempt) {
+    if (predicate()) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+  return predicate();
+}
+#endif
 
 bool sameSampling(
     const SamplingConfig& sampling,
@@ -434,6 +505,447 @@ void test_stop_string_marks_dirty_and_omits_ids() {
   check("stop: session marked dirty", st.dirty);
 }
 
+void test_cancel_request_id_validation() {
+  check(
+      "cancel id: legacy request accepted without capability",
+      !worker_cancel_request_id(idsReq({1}), false).has_value());
+  check(
+      "cancel id: positive signed integer accepted",
+      worker_cancel_request_id({{"cancel_request_id", 7}}, true) ==
+          std::optional<uint64_t>(7));
+  check(
+      "cancel id: full uint64 range accepted",
+      worker_cancel_request_id(
+          {{"cancel_request_id", std::numeric_limits<uint64_t>::max()}},
+          true) ==
+          std::optional<uint64_t>(std::numeric_limits<uint64_t>::max()));
+
+  for (const auto& request : std::vector<nlohmann::json>{
+           {{"cancel_request_id", 0}},
+           {{"cancel_request_id", -1}},
+           {{"cancel_request_id", 1.0}},
+           {{"cancel_request_id", "1"}},
+           {{"cancel_request_id", true}},
+       }) {
+    bool threw = false;
+    try {
+      (void)worker_cancel_request_id(request, true);
+    } catch (const std::exception&) {
+      threw = true;
+    }
+    check("cancel id: invalid value rejected", threw);
+  }
+
+  bool unsupported_threw = false;
+  try {
+    (void)worker_cancel_request_id({{"cancel_request_id", 1}}, false);
+  } catch (const std::exception&) {
+    unsupported_threw = true;
+  }
+  check("cancel id: capability required", unsupported_threw);
+}
+
+void test_cancellation_state_seals_once() {
+  auto cancelled_session = makeState();
+  WorkerCancellationState cancelled;
+  check(
+      "cancel state: first request wins",
+      cancelled.request_cancel(fake(cancelled_session)));
+  check(
+      "cancel state: duplicate ignored",
+      !cancelled.request_cancel(fake(cancelled_session)));
+  check(
+      "cancel state: pre-decode request is only latched",
+      fake(cancelled_session).stop_calls == 0);
+  cancelled.enter_decode(fake(cancelled_session));
+  check(
+      "cancel state: decode entry delivers stop once",
+      fake(cancelled_session).stop_calls == 1);
+  check("cancel state: seal reports cancellation", cancelled.seal());
+  check(
+      "cancel state: late request ignored",
+      !cancelled.request_cancel(fake(cancelled_session)));
+  check("cancel state: second seal is not cancelled", !cancelled.seal());
+
+  auto completed_session = makeState();
+  WorkerCancellationState completed;
+  completed.enter_decode(fake(completed_session));
+  check("cancel state: clean seal reports completion", !completed.seal());
+  check(
+      "cancel state: completed request stays sealed",
+      !completed.request_cancel(fake(completed_session)));
+}
+
+void test_cancelled_terminal_metadata_and_dirty_reset() {
+  auto st = makeState();
+  fake(st).steps = {{10, "a", false, false}};
+  WorkerCancellationState cancellation;
+  check(
+      "cancel terminal: cancellation requested",
+      cancellation.request_cancel(fake(st)));
+  auto em =
+      run(st,
+          true,
+          idsReq({1, 2}),
+          {},
+          {},
+          nlohmann::json::object(),
+          &cancellation);
+  check("cancel terminal: request succeeds", !em.threw);
+  check("cancel terminal: stop reasserted once", fake(st).stop_calls == 1);
+  check("cancel terminal: decode observes stop", fake(st).decode_saw_stop);
+  check(
+      "cancel terminal: metadata emitted",
+      em.done["finish_reason"] == "stop" && em.done["cancelled"] == true);
+  check(
+      "cancel terminal: generated ids omitted",
+      !em.done.contains("generated_token_ids"));
+  check("cancel terminal: session marked dirty", st.dirty);
+
+  fake(st).steps = {{0, "", true, true}};
+  fake(st).prefill_sizes.clear();
+  auto next = run(st, true, idsReq({1, 2, 3}));
+  check(
+      "cancel terminal: next request resets dirty session",
+      next.done["session_reset_reason"] == "dirty" &&
+          fake(st).prefill_sizes == std::vector<size_t>{3} && !st.dirty);
+}
+
+#if defined(__unix__) || defined(__APPLE__)
+void test_controller_partial_zero_duplicate_and_conflicting_frames() {
+  int descriptors[2] = {-1, -1};
+  const bool pipe_ok = ::pipe(descriptors) == 0;
+  check("controller frames: pipe created", pipe_ok);
+  if (!pipe_ok) {
+    return;
+  }
+  {
+    WorkerCancellationController controller(descriptors[0]);
+    auto active_state = makeState();
+    auto other_state = makeState();
+    WorkerCancellationState cancellation;
+    auto active = controller.activate(42, active_state, cancellation);
+    cancellation.enter_decode(fake(active_state));
+    check(
+        "controller frames: valid descriptor supported",
+        controller.supported());
+
+    check(
+        "controller frames: zero written", writeCancelFrame(descriptors[1], 0));
+    const auto conflicting_frame = cancelFrame(43);
+    check(
+        "controller frames: seven partial bytes written",
+        writeBytes(
+            descriptors[1],
+            conflicting_frame.data(),
+            conflicting_frame.size() - 1));
+    check(
+        "controller frames: zero consumed before partial assertion",
+        waitFor([&]() {
+          return controller.processed_frame_count_for_testing() == 1;
+        }));
+    check(
+        "controller frames: zero and partial frame ignored",
+        fake(active_state).stop_calls == 0 && !cancellation.cancelled());
+
+    check(
+        "controller frames: final conflicting byte written",
+        writeBytes(
+            descriptors[1],
+            conflicting_frame.data() + conflicting_frame.size() - 1,
+            1));
+    check(
+        "controller frames: matching frame written as FIFO barrier",
+        writeCancelFrame(descriptors[1], 42));
+    check(
+        "controller frames: conflict and match consumed in FIFO order",
+        waitFor([&]() {
+          return controller.processed_frame_count_for_testing() == 3;
+        }));
+    check(
+        "controller frames: only matching frame cancels selected session",
+        fake(active_state).stop_calls == 1 && cancellation.cancelled() &&
+            fake(other_state).stop_calls == 0);
+    active.reset();
+
+    WorkerCancellationState conflicting_cancellation;
+    auto conflicting =
+        controller.activate(43, other_state, conflicting_cancellation);
+    conflicting_cancellation.enter_decode(fake(other_state));
+    check(
+        "controller frames: active conflict was not queued",
+        !conflicting_cancellation.cancelled() &&
+            fake(other_state).stop_calls == 0);
+    check(
+        "controller frames: duplicate matching frames written",
+        writeCancelFrame(descriptors[1], 43) &&
+            writeCancelFrame(descriptors[1], 43));
+    check(
+        "controller frames: duplicate matching frames consumed", waitFor([&]() {
+          return controller.processed_frame_count_for_testing() == 5;
+        }));
+    check(
+        "controller frames: duplicate matching frames stop exactly once",
+        fake(other_state).stop_calls == 1 &&
+            conflicting_cancellation.cancelled());
+  }
+  if (descriptors[1] >= 0) {
+    ::close(descriptors[1]);
+  }
+}
+
+void test_controller_bounded_pending_and_preactivation_match() {
+  int descriptors[2] = {-1, -1};
+  const bool pipe_ok = ::pipe(descriptors) == 0;
+  check("controller pending: pipe created", pipe_ok);
+  if (!pipe_ok) {
+    return;
+  }
+
+  std::array<uint8_t, sizeof(uint64_t) * 8> frames{};
+  for (uint64_t request_id = 100; request_id < 108; ++request_id) {
+    const auto frame = cancelFrame(request_id);
+    const size_t offset = static_cast<size_t>(request_id - 100) * frame.size();
+    std::copy(frame.begin(), frame.end(), frames.begin() + offset);
+  }
+  check(
+      "controller pending: burst written before construction",
+      writeBytes(descriptors[1], frames.data(), frames.size()));
+
+  {
+    WorkerCancellationController controller(descriptors[0]);
+    auto first_state = makeState();
+    WorkerCancellationState first_cancellation;
+    auto first = controller.activate(100, first_state, first_cancellation);
+    check(
+        "controller pending: prequeued match is latched before decode",
+        first_cancellation.cancelled() && fake(first_state).stop_calls == 0);
+    first_cancellation.enter_decode(fake(first_state));
+    check(
+        "controller pending: decode entry invokes stop once",
+        fake(first_state).stop_calls == 1);
+    first.reset();
+    bool stale_request_threw = false;
+    try {
+      controller.validate_request_id(100);
+    } catch (const std::exception&) {
+      stale_request_threw = true;
+    }
+    check(
+        "controller pending: completed request ID rejected",
+        stale_request_threw);
+
+    auto ignored_state = makeState();
+    WorkerCancellationState ignored_cancellation;
+    auto ignored =
+        controller.activate(107, ignored_state, ignored_cancellation);
+    ignored_cancellation.enter_decode(fake(ignored_state));
+    check(
+        "controller pending: conflicting burst IDs were not accumulated",
+        !ignored_cancellation.cancelled() &&
+            fake(ignored_state).stop_calls == 0);
+    ignored.reset();
+
+    const uint64_t frames_before_stale =
+        controller.processed_frame_count_for_testing();
+    check(
+        "controller pending: stale completed ID written",
+        writeCancelFrame(descriptors[1], 100));
+    check("controller pending: stale completed ID consumed", waitFor([&]() {
+            return controller.processed_frame_count_for_testing() ==
+                frames_before_stale + 1;
+          }));
+    auto next_state = makeState();
+    WorkerCancellationState next_cancellation;
+    auto next = controller.activate(108, next_state, next_cancellation);
+    next_cancellation.enter_decode(fake(next_state));
+    check(
+        "controller pending: stale ID does not cancel next request",
+        !next_cancellation.cancelled() && fake(next_state).stop_calls == 0);
+  }
+  ::close(descriptors[1]);
+}
+
+void test_controller_reasserts_cancel_after_prefill() {
+  int descriptors[2] = {-1, -1};
+  const bool pipe_ok = ::pipe(descriptors) == 0;
+  check("controller prefill: pipe created", pipe_ok);
+  if (!pipe_ok) {
+    return;
+  }
+  {
+    WorkerCancellationController controller(descriptors[0]);
+    auto st = makeState();
+    fake(st).block_prefill.store(true);
+    WorkerCancellationState cancellation;
+    auto active = controller.activate(200, st, cancellation);
+    Emitted em;
+    std::thread request([&]() {
+      em =
+          run(st,
+              true,
+              idsReq({1, 2}),
+              {},
+              {},
+              nlohmann::json::object(),
+              &cancellation);
+    });
+    const bool entered = waitFor([&]() {
+      return fake(st).prefill_entered.load(std::memory_order_acquire);
+    });
+    check("controller prefill: request reached prefill", entered);
+    check(
+        "controller prefill: matching frame written",
+        writeCancelFrame(descriptors[1], 200));
+    const bool cancellation_latched =
+        waitFor([&]() { return cancellation.cancelled(); });
+    check(
+        "controller prefill: cancellation is latched without an early stop",
+        cancellation_latched && fake(st).stop_calls == 0);
+    const uint64_t frames_before_duplicate =
+        controller.processed_frame_count_for_testing();
+    check(
+        "controller prefill: duplicate frame written",
+        writeCancelFrame(descriptors[1], 200));
+    check("controller prefill: duplicate frame consumed", waitFor([&]() {
+            return controller.processed_frame_count_for_testing() ==
+                frames_before_duplicate + 1;
+          }));
+    check(
+        "controller prefill: duplicate remains latched without an early stop",
+        fake(st).stop_calls == 0);
+
+    fake(st).release_prefill.store(true, std::memory_order_release);
+    request.join();
+    check(
+        "controller prefill: exactly one stop at the decode boundary",
+        fake(st).stop_calls == 1);
+    check(
+        "controller prefill: stop delivered before decode",
+        fake(st).stop_calls == 1 && fake(st).decode_saw_stop);
+    check(
+        "controller prefill: request terminates as cancelled",
+        !em.threw && em.done["cancelled"] == true &&
+            em.done["finish_reason"] == "stop" && st.dirty);
+  }
+  ::close(descriptors[1]);
+}
+
+void test_controller_seal_blocks_late_cancel_and_next_request() {
+  int descriptors[2] = {-1, -1};
+  const bool pipe_ok = ::pipe(descriptors) == 0;
+  check("controller seal: pipe created", pipe_ok);
+  if (!pipe_ok) {
+    return;
+  }
+  {
+    WorkerCancellationController controller(descriptors[0]);
+    auto completed_state = makeState();
+    fake(completed_state).steps = {{0, "", true, true}};
+    WorkerCancellationState completed_cancellation;
+    auto completed =
+        controller.activate(300, completed_state, completed_cancellation);
+    const auto em =
+        run(completed_state,
+            true,
+            idsReq({1}),
+            {},
+            {},
+            nlohmann::json::object(),
+            &completed_cancellation);
+    check(
+        "controller seal: normal terminal seals cleanly",
+        !em.done.contains("cancelled") && !completed_state.dirty);
+    const uint64_t frames_before_late =
+        controller.processed_frame_count_for_testing();
+    check(
+        "controller seal: late matching frame written",
+        writeCancelFrame(descriptors[1], 300));
+    check("controller seal: late matching frame consumed", waitFor([&]() {
+            return controller.processed_frame_count_for_testing() ==
+                frames_before_late + 1;
+          }));
+    check(
+        "controller seal: late match cannot stop or dirty completed request",
+        fake(completed_state).stop_calls == 0 && !completed_state.dirty);
+    completed.reset();
+
+    auto next_state = makeState();
+    WorkerCancellationState next_cancellation;
+    auto next = controller.activate(301, next_state, next_cancellation);
+    next_cancellation.enter_decode(fake(next_state));
+    const uint64_t frames_before_stale =
+        controller.processed_frame_count_for_testing();
+    check(
+        "controller seal: stale prior frame written during next request",
+        writeCancelFrame(descriptors[1], 300));
+    check("controller seal: stale prior frame consumed", waitFor([&]() {
+            return controller.processed_frame_count_for_testing() ==
+                frames_before_stale + 1;
+          }));
+    check(
+        "controller seal: prior request cannot contaminate next request",
+        fake(next_state).stop_calls == 0 && !next_cancellation.cancelled() &&
+            !next_state.dirty);
+    check(
+        "controller seal: matching next frame written",
+        writeCancelFrame(descriptors[1], 301));
+    check(
+        "controller seal: matching active request still cancels",
+        waitFor([&]() { return fake(next_state).stop_calls.load() == 1; }) &&
+            next_cancellation.cancelled());
+  }
+  ::close(descriptors[1]);
+}
+
+void test_controller_invalid_descriptor_is_unsupported() {
+  int descriptors[2] = {-1, -1};
+  const bool pipe_ok = ::pipe(descriptors) == 0;
+  check("controller invalid fd: pipe created", pipe_ok);
+  if (!pipe_ok) {
+    return;
+  }
+  {
+    WorkerCancellationController controller(descriptors[1]);
+    descriptors[1] = -1; // rejected descriptors are still controller-owned
+    check(
+        "controller invalid fd: write-only descriptor unsupported",
+        !controller.supported());
+  }
+  ::close(descriptors[0]);
+
+  const int regular_fd = ::open("/dev/null", O_RDONLY);
+  check("controller invalid fd: regular descriptor opened", regular_fd >= 0);
+  if (regular_fd >= 0) {
+    WorkerCancellationController controller(regular_fd);
+    check(
+        "controller invalid fd: non-pipe descriptor unsupported",
+        !controller.supported());
+  }
+}
+
+void test_controller_shutdown_joins_with_open_writer() {
+  int descriptors[2] = {-1, -1};
+  const bool pipe_ok = ::pipe(descriptors) == 0;
+  check("controller shutdown: pipe created", pipe_ok);
+  if (!pipe_ok) {
+    return;
+  }
+  {
+    WorkerCancellationController controller(descriptors[0]);
+    check("controller shutdown: descriptor supported", controller.supported());
+  }
+  check(
+      "controller shutdown: writer remains independently closable",
+      ::close(descriptors[1]) == 0);
+}
+#else
+void test_non_posix_controller_is_unsupported() {
+  WorkerCancellationController controller(-1);
+  check("controller: non-POSIX build is unsupported", !controller.supported());
+}
+#endif
+
 void test_prefill_failure_marks_dirty() {
   auto st = makeState();
   fake(st).fail_prefill_on = 0;
@@ -544,6 +1056,19 @@ int main() {
   test_generated_token_ids_excludes_terminal();
   test_prompt_prefix_ids_prepend_text_prompt_once();
   test_stop_string_marks_dirty_and_omits_ids();
+  test_cancel_request_id_validation();
+  test_cancellation_state_seals_once();
+  test_cancelled_terminal_metadata_and_dirty_reset();
+#if defined(__unix__) || defined(__APPLE__)
+  test_controller_partial_zero_duplicate_and_conflicting_frames();
+  test_controller_bounded_pending_and_preactivation_match();
+  test_controller_reasserts_cancel_after_prefill();
+  test_controller_seal_blocks_late_cancel_and_next_request();
+  test_controller_invalid_descriptor_is_unsupported();
+  test_controller_shutdown_joins_with_open_writer();
+#else
+  test_non_posix_controller_is_unsupported();
+#endif
   test_prefill_failure_marks_dirty();
   test_decode_failure_marks_dirty();
   test_utf8_split_across_pieces_emits_once_intact();

--- a/examples/llm_server/cpp/worker_loop.h
+++ b/examples/llm_server/cpp/worker_loop.h
@@ -30,10 +30,11 @@
 // Protocol (one JSON object per line; matches worker_client.py). stdout carries
 // ONLY protocol JSON; logs go to stderr (ET_LOG):
 //   worker -> stdout, once:    {"ready": true, "max_sessions": int,
-//                               "max_named_sessions": int}
+//                               "max_named_sessions": int,
+//                               "supports_cancel": bool}
 //   client -> stdin:
 //     generate: {"max_new_tokens": int, "temperature": float, "stop":
-//     [str,...],
+//     [str,...], "cancel_request_id"?: positive uint64,
 //                "session_id"?: str, and exactly one prompt form:
 //                  "prompt": str
 //                  "prompt_segments": [{"text": str} | {"ids": [int,...]}]}
@@ -47,7 +48,9 @@
 //                (new|exact_prefix|mismatch|dirty|equal),
 //                "prefill_ms": float, "decode_ms": float, "total_ms": float,
 //                "prefill_tok_s": float, "decode_tok_s": float,
-//                "generated_token_ids"?: [int,...],  // omitted if stop-trimmed
+//                "cancelled"?: true, // omitted unless cancelled out of band
+//                "generated_token_ids"?: [int,...],  // omitted if not
+//                resumable
 //                ...optional model-specific terminal stats}
 //     open/close/reset: {"opened"|"closed"|"reset": true, "session_id": str}
 //     error:    {"error": str, "code"?: str}  // capacity_exhausted |
@@ -62,17 +65,36 @@
 #include <pytorch/tokenizers/tokenizer.h>
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <unordered_map>
+#include <utility>
 #include <vector>
+
+#if defined(__unix__) || defined(__APPLE__)
+#define EXECUTORCH_LLM_WORKER_POSIX_CONTROL 1
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <cerrno>
+#include <climits>
+#else
+#define EXECUTORCH_LLM_WORKER_POSIX_CONTROL 0
+#endif
 
 namespace executorch {
 namespace extension {
@@ -101,6 +123,400 @@ struct WorkerSessionState {
   bool dirty = false;
 };
 
+// Cancellation state belongs to one request. The controller thread only moves
+// it from active to cancelled; the request thread seals it at terminal
+// completion before constructing the terminal response.
+class WorkerCancellationState {
+ public:
+  bool request_cancel(LLMSession& session) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (sealed_ || cancel_requested_) {
+      return false;
+    }
+    cancel_requested_ = true;
+    deliver_stop_locked(session);
+    return true;
+  }
+
+  // reset()/prefill_tokens() may clear a stop flag. Defer delivery until both
+  // have completed, then deliver it exactly once at the decode boundary.
+  void enter_decode(LLMSession& session) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    decode_started_ = true;
+    deliver_stop_locked(session);
+  }
+
+  bool cancelled() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return cancel_requested_;
+  }
+
+  // Returns true exactly when cancellation won the race with terminal
+  // completion. Further cancellation attempts cannot change the result.
+  bool seal() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (sealed_) {
+      return false;
+    }
+    sealed_ = true;
+    return cancel_requested_;
+  }
+
+ private:
+  void deliver_stop_locked(LLMSession& session) {
+    if (cancel_requested_ && decode_started_ && !stop_delivered_ && !sealed_) {
+      stop_delivered_ = true;
+      session.stop();
+    }
+  }
+
+  mutable std::mutex mutex_;
+  bool cancel_requested_ = false;
+  bool decode_started_ = false;
+  bool stop_delivered_ = false;
+  bool sealed_ = false;
+};
+
+// Reads fixed-width little-endian cancellation IDs from the inherited control
+// descriptor. Parser state is bounded to one partial frame and one pending ID.
+class WorkerCancellationController {
+ public:
+  static constexpr const char* kControlFdEnv =
+      "EXECUTORCH_LLM_WORKER_CONTROL_FD";
+
+  class ActiveRequest {
+   public:
+    ActiveRequest() = default;
+    ActiveRequest(
+        WorkerCancellationController* controller,
+        WorkerSessionState* worker_state,
+        WorkerCancellationState* cancellation_state)
+        : controller_(controller),
+          worker_state_(worker_state),
+          cancellation_state_(cancellation_state) {}
+    ActiveRequest(const ActiveRequest&) = delete;
+    ActiveRequest& operator=(const ActiveRequest&) = delete;
+    ActiveRequest(ActiveRequest&& other) noexcept
+        : controller_(std::exchange(other.controller_, nullptr)),
+          worker_state_(std::exchange(other.worker_state_, nullptr)),
+          cancellation_state_(
+              std::exchange(other.cancellation_state_, nullptr)) {}
+    ActiveRequest& operator=(ActiveRequest&& other) noexcept {
+      if (this != &other) {
+        reset();
+        controller_ = std::exchange(other.controller_, nullptr);
+        worker_state_ = std::exchange(other.worker_state_, nullptr);
+        cancellation_state_ = std::exchange(other.cancellation_state_, nullptr);
+      }
+      return *this;
+    }
+    ~ActiveRequest() {
+      reset();
+    }
+
+    void reset() {
+      if (controller_ != nullptr) {
+        controller_->detach(worker_state_, cancellation_state_);
+        controller_ = nullptr;
+        worker_state_ = nullptr;
+        cancellation_state_ = nullptr;
+      }
+    }
+
+   private:
+    WorkerCancellationController* controller_ = nullptr;
+    WorkerSessionState* worker_state_ = nullptr;
+    WorkerCancellationState* cancellation_state_ = nullptr;
+  };
+
+  WorkerCancellationController()
+      : WorkerCancellationController(control_fd_from_environment()) {}
+
+  explicit WorkerCancellationController(int control_fd) {
+#if EXECUTORCH_LLM_WORKER_POSIX_CONTROL
+    if (control_fd < 0) {
+      return;
+    }
+    struct stat descriptor_stat {};
+    const int status_flags = ::fcntl(control_fd, F_GETFL, 0);
+    const int descriptor_flags = ::fcntl(control_fd, F_GETFD, 0);
+    if (control_fd <= STDERR_FILENO ||
+        ::fstat(control_fd, &descriptor_stat) < 0 ||
+        !S_ISFIFO(descriptor_stat.st_mode) || status_flags < 0 ||
+        descriptor_flags < 0 || (status_flags & O_ACCMODE) == O_WRONLY ||
+        ::fcntl(control_fd, F_SETFL, status_flags | O_NONBLOCK) < 0 ||
+        ::fcntl(control_fd, F_SETFD, descriptor_flags | FD_CLOEXEC) < 0) {
+      ::close(control_fd);
+      return;
+    }
+    control_fd_ = control_fd;
+    // Consume frames queued before worker startup deterministically. The reader
+    // is nonblocking, so this cannot delay readiness.
+    if (!read_available()) {
+      ::close(control_fd_);
+      control_fd_ = -1;
+      return;
+    }
+    try {
+      thread_ = std::thread([this]() { run(); });
+    } catch (...) {
+      ::close(control_fd_);
+      control_fd_ = -1;
+    }
+#else
+    (void)control_fd;
+#endif
+  }
+
+  WorkerCancellationController(const WorkerCancellationController&) = delete;
+  WorkerCancellationController& operator=(const WorkerCancellationController&) =
+      delete;
+
+  ~WorkerCancellationController() {
+    shutdown();
+  }
+
+  bool supported() const {
+    return control_fd_ >= 0;
+  }
+
+  uint64_t processed_frame_count_for_testing() const {
+    return processed_frame_count_.load(std::memory_order_acquire);
+  }
+
+  // Reject a stale/duplicate request ID before its session is selected. Control
+  // frames with such IDs are still ignored silently by handle_frame().
+  void validate_request_id(uint64_t request_id) {
+    if (!supported() || request_id == 0) {
+      throw std::runtime_error("invalid cancel_request_id");
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (request_id <= last_completed_request_id_) {
+      throw std::runtime_error("cancel_request_id is stale or duplicate");
+    }
+  }
+
+  ActiveRequest activate(
+      uint64_t request_id,
+      WorkerSessionState& worker_state,
+      WorkerCancellationState& cancellation_state) {
+    if (!supported() || request_id == 0) {
+      return {};
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (active_session_ != nullptr) {
+      throw std::runtime_error("worker cancellation request already active");
+    }
+    if (request_id <= last_completed_request_id_) {
+      throw std::runtime_error("cancel_request_id is stale or duplicate");
+    }
+
+    active_request_id_ = request_id;
+    active_session_ = worker_state.session.get();
+    active_cancellation_state_ = &cancellation_state;
+    if (pending_request_id_.has_value()) {
+      const bool matches = *pending_request_id_ == request_id;
+      pending_request_id_.reset();
+      if (matches) {
+        cancel_active_locked();
+      }
+    }
+    return ActiveRequest(this, &worker_state, &cancellation_state);
+  }
+
+  void shutdown() {
+    stopping_.store(true, std::memory_order_release);
+    if (thread_.joinable()) {
+      thread_.join();
+    }
+#if EXECUTORCH_LLM_WORKER_POSIX_CONTROL
+    if (control_fd_ >= 0) {
+      ::close(control_fd_);
+    }
+#endif
+    control_fd_ = -1;
+  }
+
+ private:
+  static int control_fd_from_environment() {
+#if EXECUTORCH_LLM_WORKER_POSIX_CONTROL
+    const char* raw = std::getenv(kControlFdEnv);
+    if (raw == nullptr || *raw == '\0') {
+      return -1;
+    }
+    for (const char* cursor = raw; *cursor != '\0'; ++cursor) {
+      if (*cursor < '0' || *cursor > '9') {
+        ::unsetenv(kControlFdEnv);
+        return -1;
+      }
+    }
+    errno = 0;
+    char* end = nullptr;
+    const long value = std::strtol(raw, &end, 10);
+    const bool valid = errno == 0 && end != raw && *end == '\0' && value >= 0 &&
+        value <= INT_MAX;
+    ::unsetenv(kControlFdEnv);
+    return valid ? static_cast<int>(value) : -1;
+#else
+    return -1;
+#endif
+  }
+
+  void detach(
+      WorkerSessionState* worker_state,
+      WorkerCancellationState* cancellation_state) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (active_cancellation_state_ != cancellation_state) {
+      return;
+    }
+    // Seal on exceptional exits too. Only the request thread mutates dirty.
+    if (cancellation_state->seal()) {
+      worker_state->dirty = true;
+    }
+    last_completed_request_id_ =
+        std::max(last_completed_request_id_, active_request_id_);
+    if (pending_request_id_.has_value() &&
+        *pending_request_id_ <= last_completed_request_id_) {
+      pending_request_id_.reset();
+    }
+    active_request_id_ = 0;
+    active_session_ = nullptr;
+    active_cancellation_state_ = nullptr;
+  }
+
+  void cancel_active_locked() {
+    if (active_session_ != nullptr && active_cancellation_state_ != nullptr) {
+      // The request state defers delivery during prefill and guarantees exactly
+      // one stop() call after decode begins.
+      active_cancellation_state_->request_cancel(*active_session_);
+    }
+  }
+
+  void handle_frame(uint64_t request_id) {
+    if (request_id == 0) {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (active_session_ != nullptr) {
+      if (request_id == active_request_id_) {
+        cancel_active_locked();
+      }
+      return; // conflicting active IDs are never queued for a later request
+    }
+    if (request_id <= last_completed_request_id_) {
+      return;
+    }
+    if (!pending_request_id_.has_value()) {
+      pending_request_id_ = request_id;
+    }
+    // A duplicate or conflicting preactivation frame is ignored. The first
+    // complete, non-stale ID owns the single bounded pending slot.
+  }
+
+#if EXECUTORCH_LLM_WORKER_POSIX_CONTROL
+  void consume_bytes(const uint8_t* bytes, size_t count) {
+    for (size_t index = 0; index < count; ++index) {
+      if (partial_frame_size_ < partial_frame_.size()) {
+        partial_frame_[partial_frame_size_++] = bytes[index];
+        continue;
+      }
+      uint64_t request_id = static_cast<uint64_t>(bytes[index]) << 56;
+      for (size_t byte = 0; byte < partial_frame_.size(); ++byte) {
+        request_id |= static_cast<uint64_t>(partial_frame_[byte]) << (byte * 8);
+      }
+      partial_frame_size_ = 0;
+      handle_frame(request_id);
+      processed_frame_count_.fetch_add(1, std::memory_order_release);
+    }
+  }
+
+  bool read_available() {
+    std::array<uint8_t, 64> bytes{};
+    while (true) {
+      const ssize_t count = ::read(control_fd_, bytes.data(), bytes.size());
+      if (count > 0) {
+        consume_bytes(bytes.data(), static_cast<size_t>(count));
+        return true;
+      }
+      if (count == 0) {
+        return false;
+      }
+      if (errno == EINTR) {
+        continue;
+      }
+      return errno == EAGAIN || errno == EWOULDBLOCK;
+    }
+  }
+
+  void run() {
+    while (!stopping_.load(std::memory_order_acquire)) {
+      pollfd descriptor{control_fd_, POLLIN, 0};
+      const int poll_result = ::poll(&descriptor, 1, 50);
+      if (poll_result < 0) {
+        if (errno == EINTR) {
+          continue;
+        }
+        break;
+      }
+      if (poll_result == 0) {
+        continue;
+      }
+      if ((descriptor.revents & POLLIN) != 0) {
+        if (!read_available()) {
+          break;
+        }
+        continue;
+      }
+      if ((descriptor.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+        break;
+      }
+    }
+  }
+#endif
+
+  int control_fd_ = -1;
+  std::atomic<bool> stopping_{false};
+  std::atomic<uint64_t> processed_frame_count_{0};
+  std::thread thread_;
+  std::mutex mutex_;
+  uint64_t active_request_id_ = 0;
+  uint64_t last_completed_request_id_ = 0;
+  std::optional<uint64_t> pending_request_id_;
+  std::array<uint8_t, sizeof(uint64_t) - 1> partial_frame_{};
+  size_t partial_frame_size_ = 0;
+  LLMSession* active_session_ = nullptr;
+  WorkerCancellationState* active_cancellation_state_ = nullptr;
+};
+
+// Strictly validate the optional protocol field. Legacy requests remain valid;
+// a cancellation ID is accepted only when the worker advertised the capability.
+inline std::optional<uint64_t> worker_cancel_request_id(
+    const nlohmann::json& request,
+    bool supports_cancel) {
+  if (!request.contains("cancel_request_id")) {
+    return std::nullopt;
+  }
+  if (!supports_cancel) {
+    throw std::runtime_error("cancel_request_id is not supported");
+  }
+  const auto& value = request.at("cancel_request_id");
+  uint64_t request_id = 0;
+  if (value.is_number_unsigned()) {
+    request_id = value.get<uint64_t>();
+  } else if (value.is_number_integer()) {
+    const int64_t signed_id = value.get<int64_t>();
+    if (signed_id > 0) {
+      request_id = static_cast<uint64_t>(signed_id);
+    }
+  } else {
+    throw std::runtime_error("cancel_request_id must be a positive uint64");
+  }
+  if (request_id == 0) {
+    throw std::runtime_error("cancel_request_id must be a positive uint64");
+  }
+  return request_id;
+}
+
 // One generation request against a session. Encodes the prompt, chooses a
 // prefill plan (warm suffix reuse for named sessions, or a full reset+prefill),
 // then streams complete-UTF-8 text pieces from decode_one(). A terminal step
@@ -114,8 +530,8 @@ inline void worker_handle_request(
     const std::unordered_map<std::string, int64_t>& metadata,
     const nlohmann::json& req,
     const std::vector<uint64_t>& prompt_prefix_ids = {},
-    const nlohmann::json& additional_terminal_stats =
-        nlohmann::json::object()) {
+    const nlohmann::json& additional_terminal_stats = nlohmann::json::object(),
+    WorkerCancellationState* cancellation = nullptr) {
   if (!additional_terminal_stats.is_object()) {
     throw std::runtime_error("additional terminal stats must be a JSON object");
   }
@@ -127,6 +543,7 @@ inline void worker_handle_request(
       "reused_prompt_tokens",
       "prefilled_prompt_tokens",
       "session_reset_reason",
+      "cancelled",
       "generated_token_ids",
       "prefill_ms",
       "decode_ms",
@@ -269,6 +686,12 @@ inline void worker_handle_request(
   // suffix, or the whole prompt). Keep the invariant
   // resident.size()==position().
   st.resident_token_ids = ids;
+  // reset()/prefill_tokens() may clear a stop requested before or during
+  // prefill. Entering decode delivers a latched request exactly once; later
+  // cancellation is delivered directly by the controller thread.
+  if (cancellation != nullptr) {
+    cancellation->enter_decode(session);
+  }
   const auto decode_start = std::chrono::steady_clock::now();
 
   std::string buf; // bytes not yet forming a complete UTF-8 prefix
@@ -276,7 +699,22 @@ inline void worker_handle_request(
   int64_t num_generated = 0;
   std::string finish = "length"; // EOS or stop string -> "stop"
   bool stop_string = false; // a request stop string was matched
+  bool cancelled = false;
+  bool cancellation_sealed = false;
+  auto seal_cancellation = [&]() {
+    if (!cancellation_sealed) {
+      cancelled = cancellation != nullptr && cancellation->seal();
+      cancellation_sealed = true;
+      if (cancelled) {
+        // Seal can precede fallible token bookkeeping/output on a terminal
+        // iteration. Mark dirty immediately so exceptions cannot expose a
+        // partially mutated session as warm-resumable.
+        st.dirty = true;
+      }
+    }
+  };
   for (int64_t step = 0; step < max_new; ++step) {
+    const bool reached_length = step + 1 == max_new;
     auto step_result = session.decode_one(sampling);
     if (step_result.error() != ::executorch::runtime::Error::Ok) {
       st.dirty = true;
@@ -284,6 +722,7 @@ inline void worker_handle_request(
     }
     const auto& d = step_result.get();
     if (d.is_terminal) {
+      seal_cancellation();
       finish = "stop";
       // Terminal step (EOS / cooperative stop): the terminal token is neither
       // emitted as text nor counted in num_generated -> completion_tokens. This
@@ -291,6 +730,9 @@ inline void worker_handle_request(
       // client received, not internal forward steps; an EOS the user never sees
       // is not part of that count.
       break;
+    }
+    if (reached_length) {
+      seal_cancellation();
     }
     // The token was forwarded into the cache (pos advanced); track it so the
     // resident-ids/position invariant holds. EOS/terminal tokens are not
@@ -305,6 +747,11 @@ inline void worker_handle_request(
     }
     bool stop_hit = false;
     const size_t safe = stop_safe_prefix_len(pending, stops, stop_hit);
+    if (stop_hit) {
+      // The request is terminal as soon as the stop sequence is recognized.
+      // Seal before worker_emit(), which may block while flushing stdout.
+      seal_cancellation();
+    }
     if (safe > 0) {
       worker_emit({{"token", pending.substr(0, safe)}});
       pending.erase(0, safe);
@@ -325,16 +772,23 @@ inline void worker_handle_request(
       break;
     }
   }
+  // Seal at the terminal decision, before formatting or emitting the terminal
+  // event. A late frame can no longer relabel or dirty this request.
+  seal_cancellation();
+  if (cancelled) {
+    finish = "stop";
+    st.dirty = true;
+  }
   if (!stop_string) {
-    // EOS or length: flush held-back text + any trailing incomplete bytes
+    // EOS, length, or cancellation: flush held-back text + any trailing bytes
     // (replaced if invalid). A stop-string hit drops the remainder instead.
     pending += buf;
     if (!pending.empty()) {
       worker_emit({{"token", pending}});
     }
   }
-  // finish_reason: "stop" if the model emitted EOS or hit a stop string, else
-  // "length" -- it ran to max_new (possibly clamped to the context window).
+  // finish_reason: "stop" if the model emitted EOS, hit a stop string, or was
+  // cancelled; otherwise "length" after max_new (possibly context-clamped).
   // reused/prefilled sum to prompt_tokens; session_reset_reason explains the
   // prefill plan (for measuring warm-resume hit rate).
   nlohmann::json done = {
@@ -345,6 +799,9 @@ inline void worker_handle_request(
       {"reused_prompt_tokens", reused},
       {"prefilled_prompt_tokens", prefilled},
       {"session_reset_reason", plan.reason}};
+  if (cancelled) {
+    done["cancelled"] = true;
+  }
   // generated_token_ids = the (non-terminal) tokens made resident this turn,
   // for the control plane to splice back as an `ids` segment. Only emit them
   // when they faithfully decode to the emitted text: a stop-string trim kept
@@ -352,7 +809,7 @@ inline void worker_handle_request(
   // them would inject text the client never saw. Omitting them makes the
   // control plane record this turn as not resumable (falls back to a text
   // re-render).
-  if (!stop_string) {
+  if (!stop_string && !cancelled) {
     done["generated_token_ids"] = std::vector<uint64_t>(
         st.resident_token_ids.end() - num_generated,
         st.resident_token_ids.end());
@@ -483,12 +940,14 @@ inline int run_worker_stdio_loop(
     bool enable_warm_resume = true,
     const std::vector<uint64_t>& prompt_prefix_ids = {}) {
   WorkerSessions sessions(engine);
+  WorkerCancellationController cancellation_controller;
   worker_emit(
       {{"ready", true},
        {"max_sessions",
         engine.serving_capacity()
             .max_physical_sessions_without_weight_duplication},
-       {"max_named_sessions", sessions.max_named()}});
+       {"max_named_sessions", sessions.max_named()},
+       {"supports_cancel", cancellation_controller.supported()}});
 
   std::string line;
   while (std::getline(std::cin, line)) {
@@ -532,6 +991,11 @@ inline int run_worker_stdio_loop(
       // Generation. A session_id routes to its named session (admitted on first
       // use, warm-resumable); its absence uses the shared scratch session,
       // which is always reset per request.
+      const auto cancel_request_id =
+          worker_cancel_request_id(req, cancellation_controller.supported());
+      if (cancel_request_id.has_value()) {
+        cancellation_controller.validate_request_id(*cancel_request_id);
+      }
       const std::string id = req.value("session_id", std::string{});
       WorkerSessionState* st = nullptr;
       bool warm = false;
@@ -549,8 +1013,23 @@ inline int run_worker_stdio_loop(
         }
         warm = enable_warm_resume;
       }
+      WorkerCancellationState cancellation;
+      WorkerCancellationController::ActiveRequest active_request;
+      WorkerCancellationState* cancellation_ptr = nullptr;
+      if (cancel_request_id.has_value()) {
+        active_request = cancellation_controller.activate(
+            *cancel_request_id, *st, cancellation);
+        cancellation_ptr = &cancellation;
+      }
       worker_handle_request(
-          *st, warm, tokenizer, metadata, req, prompt_prefix_ids);
+          *st,
+          warm,
+          tokenizer,
+          metadata,
+          req,
+          prompt_prefix_ids,
+          nlohmann::json::object(),
+          cancellation_ptr);
     } catch (const std::exception& e) { // report and keep serving
       worker_emit({{"error", std::string(e.what())}});
     }
@@ -561,3 +1040,5 @@ inline int run_worker_stdio_loop(
 } // namespace llm
 } // namespace extension
 } // namespace executorch
+
+#undef EXECUTORCH_LLM_WORKER_POSIX_CONTROL

--- a/examples/llm_server/python/README.md
+++ b/examples/llm_server/python/README.md
@@ -113,7 +113,7 @@ persistent per-conversation session:
 Two layers, both contract-focused (assert on the wire, not internals):
 
 ```bash
-# 1. Hermetic unit tests — fake worker, no model/GPU/subprocess, fast (CI-friendly).
+# 1. Model-free tests — unit coverage plus loopback disconnect integration.
 pip install pytest httpx
 pytest tests/
 
@@ -121,9 +121,11 @@ pytest tests/
 OPENAI_BASE_URL=http://127.0.0.1:8000/v1 pytest ../conformance/test_openai_contract.py
 ```
 
-`tests/` builds a `SessionRuntime` over a single `FakeRunner` worker, so the
+Most of `tests/` builds a `SessionRuntime` over a single `FakeRunner`, so the
 real server/protocol/streaming code is tested over HTTP without a `.pte`. The
-worker JSONL protocol is covered separately by `tests/test_worker_client.py`.
+worker JSONL protocol is covered separately by `tests/test_worker_client.py`,
+and `tests/test_stream_disconnect.py` uses real loopback Uvicorn/TCP plus a
+model-free subprocess to verify disconnect cancellation end to end.
 
 ## Architecture
 
@@ -139,7 +141,10 @@ The JSONL protocol — `generate` / `open` / `close` / `reset` ops, the `prompt`
 `prompt_segments` prompt forms, warm-resume stats, and `generated_token_ids` — is
 defined in `cpp/worker_loop.h` (the worker side, the canonical reference) and
 driven by `worker_client.py` (the Python transport); stdout carries protocol JSON
-only, logs go to stderr.
+only, logs go to stderr. On POSIX, the server also passes a private inherited
+control pipe. Workers advertise it with `supports_cancel`; cancellable generation
+requests carry a monotonically increasing `cancel_request_id`, and cancellation
+writes that ID as one fixed 8-byte little-endian frame.
 
 Process isolation is the reliable shape for CUDA/AOTI models: executing the model
 inside a live asyncio server process can segfault (validated with Qwen3.5-MoE);
@@ -180,15 +185,22 @@ Workers that report capacity 1 serve only the anonymous scratch session (no name
 `session_id`s, no warm resume). Named sessions, warm resume, and token-ID
 splicing activate only when the worker's engine reports capacity > 1.
 
-**Cancellation is best-effort, and it head-of-line blocks.** `WorkerClient.stop()`
-is a no-op, and `SessionRuntime.generate_stream()` holds the single worker lock until
-the worker naturally finishes. On client disconnect/cancellation the server calls
-`stop()` then awaits the in-flight worker request, so the abandoned generation runs to
-completion **and blocks every other session on that worker until it does** — a long or
-runaway generation stalls all concurrent requests (including a subagent fan-out).
-A disconnected client does **not** interrupt the C++ worker mid-generation. Real
-interruption needs a future protocol change — e.g. a control pipe, non-blocking stdin
-polling between decode steps, or request ids plus an out-of-band cancel op.
+**Cancellation is cooperative at token boundaries.** On client disconnect or
+async-generator close, the control plane sends the active request ID over the
+out-of-band control pipe. The worker calls `LLMSession::stop()` once and keeps the
+model resident when generation finishes within the grace period. A cancelled
+session is marked dirty and fully reset before later reuse; its terminal response
+reports `finish_reason="stop"` and `cancelled=true`, and omits
+`generated_token_ids`.
+
+`stop()` cannot interrupt an active backend call, prefill, image decoding, or
+vision encoding. If the worker does not finish within the bounded grace period,
+the control plane terminates, kills if necessary, and reaps it. The runtime then
+fails queued and future operations without additional JSONL writes, and `/health`
+returns 503 until an external supervisor restarts the server. The control plane
+does not reload model weights automatically. Older and non-POSIX workers can still
+serve requests but do not advertise `supports_cancel`; disconnect cancellation
+therefore escalates to the same bounded process termination path.
 
 **Warm resume needs true turn terminators surfaced as EOS/terminal token ids, not just
 string stops.** The worker treats every *string* stop the same — it trims the output,

--- a/examples/llm_server/python/server.py
+++ b/examples/llm_server/python/server.py
@@ -95,6 +95,8 @@ def build_app(serving: ServingChat, model_id: str) -> FastAPI:
 
     @app.get("/health")
     async def health():
+        if not serving.healthy:
+            return JSONResponse({"status": "unavailable"}, status_code=503)
         return {"status": "ok"}
 
     @app.get("/v1/models")

--- a/examples/llm_server/python/serving_chat.py
+++ b/examples/llm_server/python/serving_chat.py
@@ -101,6 +101,11 @@ class ServingChat:
         # clearing both on reset/close.
         self._transcript = OpenAITranscriptState(template)
 
+    @property
+    def healthy(self) -> bool:
+        """Whether the underlying model worker can accept new requests."""
+        return self._runtime.healthy
+
     @staticmethod
     def _tool_schemas(req: ChatCompletionRequest) -> dict[str, dict]:
         """Map each defined tool name to its JSON-schema ``parameters`` object.

--- a/examples/llm_server/python/session_runtime.py
+++ b/examples/llm_server/python/session_runtime.py
@@ -27,9 +27,13 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import AsyncIterator, Optional
 
+from .worker_client import WorkerError
+
 logger = logging.getLogger(__name__)
 
 _SENTINEL = object()
+_DEFAULT_CANCEL_GRACE_SECONDS = 2.0
+_DEFAULT_ABORT_TIMEOUT_SECONDS = 12.0
 
 
 @dataclass
@@ -83,6 +87,7 @@ class GenStats:
     # Exact token ids generated this turn, for an adapter's transcript
     # store. Empty when the worker doesn't report them (e.g. a stop-trimmed turn).
     generated_token_ids: list = field(default_factory=list)
+    cancelled: bool = False
 
 
 # Forwarded to WorkerClient.generate() as the per-request config it reads fields
@@ -102,22 +107,33 @@ class _WorkerRequest:
 
 class _GenerationBridge:
     def __init__(
-        self, worker, prompt_text: str, request: _WorkerRequest, stats: GenStats
+        self,
+        worker,
+        prompt_text: str,
+        request: _WorkerRequest,
+        stats: GenStats,
+        request_id: Optional[int],
     ):
         self._worker = worker
         self._prompt_text = prompt_text
         self._request = request
         self._stats = stats
+        self._request_id = request_id
         self._loop = asyncio.get_running_loop()
         self.queue: asyncio.Queue = asyncio.Queue()
         self.drop_tokens = threading.Event()
+        self.worker_done = threading.Event()
 
     def _enqueue_if_live(self, item) -> None:
         if not self.drop_tokens.is_set():
             self.queue.put_nowait(item)
 
+    def _enqueue_terminal(self, item) -> None:
+        if not self._loop.is_closed():
+            self.queue.put_nowait(item)
+
     def token_cb(self, token: str) -> None:
-        if not self.drop_tokens.is_set():
+        if not self.drop_tokens.is_set() and not self._loop.is_closed():
             self._loop.call_soon_threadsafe(self._enqueue_if_live, token)
 
     def stats_cb(self, s) -> None:
@@ -133,17 +149,28 @@ class _GenerationBridge:
         self._stats.prefill_tok_s = getattr(s, "prefill_tok_s", 0.0)
         self._stats.decode_tok_s = getattr(s, "decode_tok_s", 0.0)
         self._stats.vision_encoder_ms = getattr(s, "vision_encoder_ms", None)
+        self._stats.cancelled = getattr(s, "cancelled", False)
         self._stats.generated_token_ids = getattr(s, "generated_token_ids", [])
 
     def run(self) -> None:
         try:
+            kwargs = {}
+            if self._request_id is not None:
+                kwargs["request_id"] = self._request_id
             self._worker.generate(
-                self._prompt_text, self._request, self.token_cb, self.stats_cb
+                self._prompt_text,
+                self._request,
+                self.token_cb,
+                self.stats_cb,
+                **kwargs,
             )
-        except Exception as e:  # noqa: BLE001 - surface to the stream consumer
-            self._loop.call_soon_threadsafe(self.queue.put_nowait, e)
+        except Exception as error:  # noqa: BLE001 - surface to the stream consumer
+            if not self._loop.is_closed():
+                self._loop.call_soon_threadsafe(self._enqueue_terminal, error)
         finally:
-            self._loop.call_soon_threadsafe(self.queue.put_nowait, _SENTINEL)
+            self.worker_done.set()
+            if not self._loop.is_closed():
+                self._loop.call_soon_threadsafe(self._enqueue_terminal, _SENTINEL)
 
     async def items(self) -> AsyncIterator[str]:
         while True:
@@ -161,60 +188,139 @@ class _GenerationBridge:
             except asyncio.QueueEmpty:
                 return
 
-    async def finish_after_cancel(self, fut: asyncio.Future) -> None:
-        self.drop_tokens.set()
-        task = asyncio.current_task()
-        uncancel = getattr(task, "uncancel", None) if task else None
-        if uncancel is not None:
-            uncancel()
-        await fut
-        self.drain()
-
-    async def finish(self, fut: asyncio.Future) -> None:
-        if not fut.done():
-            await fut
-        self.drop_tokens.set()
-        self.drain()
-
 
 class SessionRuntime:
-    """Stateful runtime over a single worker. `worker` is a WorkerClient (a fake
-    in tests) exposing generate()/stop()/close() and the session ops
-    open_session/reset_session/close_session."""
+    """Stateful runtime over one single-in-flight WorkerClient.
 
-    def __init__(self, worker):
+    Cancellation first requests a cooperative token-boundary stop. If the
+    request does not finish within the grace period, the worker is aborted and
+    this runtime remains failed until its owning server is restarted.
+    """
+
+    def __init__(
+        self,
+        worker,
+        *,
+        cancel_grace_seconds: float = _DEFAULT_CANCEL_GRACE_SECONDS,
+        abort_timeout_seconds: float = _DEFAULT_ABORT_TIMEOUT_SECONDS,
+    ):
+        if cancel_grace_seconds < 0.0 or abort_timeout_seconds <= 0.0:
+            raise ValueError("cancellation timeouts must be nonnegative and positive")
         self._worker = worker
-        # One executor thread; the lock guarantees the worker is never driven by
-        # two requests at once (it is single-in-flight).
         self._executor = ThreadPoolExecutor(max_workers=1)
         self._lock = asyncio.Lock()
+        self._cancel_grace_seconds = cancel_grace_seconds
+        self._abort_timeout_seconds = abort_timeout_seconds
+        self._failure: Optional[WorkerError] = None
+
+    @property
+    def healthy(self) -> bool:
+        if self._failure is not None:
+            return False
+        worker_health = getattr(self._worker, "healthy", True)
+        return bool(worker_health() if callable(worker_health) else worker_health)
+
+    def _ensure_healthy(self) -> None:
+        if self._failure is not None:
+            raise self._failure
+        if not self.healthy:
+            self._failure = WorkerError("model worker is unavailable; restart the server")
+            raise self._failure
+
+    def _mark_failed(self, message: str) -> WorkerError:
+        if self._failure is None:
+            self._failure = WorkerError(message)
+        return self._failure
 
     async def open(self, session_id: str) -> None:
-        """Admit a named session before generation so a capacity refusal surfaces
-        up front (the adapter maps it to an HTTP status) rather than mid-stream.
-        Idempotent."""
+        """Admit a named session before generation so capacity errors are early."""
         await self._session_op("open_session", session_id)
 
     async def reset(self, session_id: str) -> None:
-        """Clear a named session's context (KV/recurrent + resident ids) but keep
-        its capacity slot. Idempotent."""
+        """Clear a named session's context while keeping its capacity slot."""
         await self._session_op("reset_session", session_id)
 
     async def close(self, session_id: str) -> None:
-        """Destroy a named session, freeing its state and slot. Idempotent."""
+        """Destroy a named session and free its state and capacity slot."""
         await self._session_op("close_session", session_id)
 
     async def _session_op(self, method: str, session_id: str) -> None:
         op = getattr(self._worker, method, None)
         if op is None:
-            return  # worker doesn't support sessions (e.g. a minimal fake)
+            return
+        self._ensure_healthy()
         loop = asyncio.get_running_loop()
         async with self._lock:
+            self._ensure_healthy()
             await loop.run_in_executor(self._executor, op, session_id)
 
-    def stop(self) -> None:
-        """Request the in-flight generation stop at the next token boundary."""
-        self._worker.stop()
+    def stop(self) -> bool:
+        """Request an in-flight generation stop at the next token boundary."""
+        return bool(self._worker.stop())
+
+    async def _wait_for_worker(
+        self, future: asyncio.Future, timeout: float
+    ) -> bool:
+        try:
+            await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
+
+    async def _cancel_generation(
+        self,
+        bridge: _GenerationBridge,
+        future: asyncio.Future,
+        uses_reservation: bool,
+    ) -> None:
+        bridge.drop_tokens.set()
+        try:
+            stop_result = self._worker.stop()
+            # Legacy in-process test workers return None after synchronously
+            # releasing their generation gate. Real WorkerClient returns bool.
+            delivered = bool(stop_result) if uses_reservation else True
+        except Exception:  # noqa: BLE001 - escalation handles failed stop delivery
+            delivered = False
+
+        # A false delivery result can race with normal worker completion after
+        # it clears the active request. Always allow the same bounded grace
+        # period before declaring the transport unusable.
+        if await self._wait_for_worker(future, self._cancel_grace_seconds):
+            bridge.drain()
+            return
+        if not delivered:
+            logger.warning("Worker cancellation signal was not delivered")
+
+        self._mark_failed("model worker cancellation timed out; restart the server")
+        abort = getattr(self._worker, "abort", None)
+        if abort is not None:
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(abort), timeout=self._abort_timeout_seconds
+                )
+            except Exception as error:  # noqa: BLE001 - worker is already failed
+                logger.error("Failed to abort model worker cleanly: %s", error)
+
+        if not future.done():
+            await self._wait_for_worker(future, self._cancel_grace_seconds)
+        if not future.done():
+            # The executor thread may be an uncooperative test double. Retrieve
+            # any eventual exception without allowing this stale future to block
+            # the runtime lock or a later shutdown.
+            future.add_done_callback(
+                lambda done: done.exception() if not done.cancelled() else None
+            )
+        bridge.drain()
+
+    @staticmethod
+    async def _finish_cleanup(cleanup: asyncio.Task) -> None:
+        """Wait for cleanup even if the caller task is cancelled repeatedly."""
+        while not cleanup.done():
+            try:
+                await asyncio.shield(cleanup)
+            except asyncio.CancelledError:
+                continue
+        await cleanup
 
     async def generate_stream(
         self,
@@ -223,12 +329,9 @@ class SessionRuntime:
         options: GenerationOptions,
         stats: Optional[GenStats] = None,
     ) -> AsyncIterator[str]:
-        """Yield generated text pieces from the worker, holding the worker lock
-        for the whole generation. `stats` (if given) is filled in place with the
-        worker's terminal metadata (per-request, so concurrent callers don't
-        race). session_id None routes to the worker's anonymous scratch session."""
+        """Yield generated text while holding the one-worker serialization lock."""
         out_stats = stats if stats is not None else GenStats()
-        req = _WorkerRequest(
+        request = _WorkerRequest(
             max_new_tokens=options.max_new_tokens,
             temperature=options.temperature,
             top_p=options.top_p,
@@ -238,23 +341,51 @@ class SessionRuntime:
             session_id=session_id,
             prompt_segments=prompt.segments,
         )
-        bridge = _GenerationBridge(self._worker, prompt.text or "", req, out_stats)
 
+        self._ensure_healthy()
         async with self._lock:
+            self._ensure_healthy()
+            reserve = getattr(self._worker, "reserve_request", None)
+            release = getattr(self._worker, "release_request", None)
+            uses_reservation = callable(reserve)
+            request_id = reserve() if uses_reservation else None
+            bridge = _GenerationBridge(
+                self._worker, prompt.text or "", request, out_stats, request_id
+            )
             loop = asyncio.get_running_loop()
-            fut = loop.run_in_executor(self._executor, bridge.run)
+            try:
+                future = loop.run_in_executor(self._executor, bridge.run)
+            except BaseException:
+                if request_id is not None and callable(release):
+                    release(request_id)
+                raise
+
+            completed = False
+            cleanup: Optional[asyncio.Task] = None
             try:
                 async for item in bridge.items():
                     yield item
-            except asyncio.CancelledError:
-                self._worker.stop()
-                await bridge.finish_after_cancel(fut)
+                completed = True
+            except BaseException:
+                if not bridge.worker_done.is_set():
+                    cleanup = asyncio.create_task(
+                        self._cancel_generation(bridge, future, uses_reservation)
+                    )
+                    await self._finish_cleanup(cleanup)
                 raise
             finally:
-                await bridge.finish(fut)
+                if completed or bridge.worker_done.is_set():
+                    await asyncio.shield(future)
+                    bridge.drop_tokens.set()
+                    bridge.drain()
+                elif cleanup is None and not future.done():
+                    cleanup = asyncio.create_task(
+                        self._cancel_generation(bridge, future, uses_reservation)
+                    )
+                    await self._finish_cleanup(cleanup)
 
     def close_worker(self) -> None:
-        """Shut the worker process down and the executor (called at shutdown)."""
+        """Shut down the worker process and executor during server shutdown."""
         close = getattr(self._worker, "close", None)
         if close is not None:
             close()

--- a/examples/llm_server/python/session_runtime.py
+++ b/examples/llm_server/python/session_runtime.py
@@ -224,7 +224,9 @@ class SessionRuntime:
         if self._failure is not None:
             raise self._failure
         if not self.healthy:
-            self._failure = WorkerError("model worker is unavailable; restart the server")
+            self._failure = WorkerError(
+                "model worker is unavailable; restart the server"
+            )
             raise self._failure
 
     def _mark_failed(self, message: str) -> WorkerError:
@@ -258,9 +260,7 @@ class SessionRuntime:
         """Request an in-flight generation stop at the next token boundary."""
         return bool(self._worker.stop())
 
-    async def _wait_for_worker(
-        self, future: asyncio.Future, timeout: float
-    ) -> bool:
+    async def _wait_for_worker(self, future: asyncio.Future, timeout: float) -> bool:
         try:
             await asyncio.wait_for(asyncio.shield(future), timeout=timeout)
             return True

--- a/examples/llm_server/python/tests/test_contract.py
+++ b/examples/llm_server/python/tests/test_contract.py
@@ -32,7 +32,17 @@ def _sse_chunks(text):
 
 def test_health(make_client):
     client, _ = make_client()
-    assert client.get("/health").json() == {"status": "ok"}
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_health_reports_unavailable_worker(make_client):
+    client, worker = make_client()
+    worker.healthy = False
+    response = client.get("/health")
+    assert response.status_code == 503
+    assert response.json() == {"status": "unavailable"}
 
 
 def test_models_listing_shape(make_client):

--- a/examples/llm_server/python/tests/test_session_runtime.py
+++ b/examples/llm_server/python/tests/test_session_runtime.py
@@ -414,8 +414,9 @@ def test_repeated_cancellation_does_not_interrupt_cleanup():
             await pending
         return runtime.healthy, worker.abort_count, worker.finished.is_set()
 
-    import pytest
     import time
+
+    import pytest
 
     assert asyncio.run(scenario()) == (False, 1, True)
 

--- a/examples/llm_server/python/tests/test_session_runtime.py
+++ b/examples/llm_server/python/tests/test_session_runtime.py
@@ -34,6 +34,7 @@ class _Worker:
     def __init__(self):
         self.opened, self.reset_ids, self.closed_ids = [], [], []
         self.proc_closed = False
+        self.healthy = True
 
     def open_session(self, sid):
         self.opened.append(sid)
@@ -271,6 +272,253 @@ def test_cancellation_drops_late_worker_tokens(monkeypatch):
     stopped, put_count = asyncio.run(scenario())
     assert stopped
     assert put_count < 10
+
+
+def test_reserves_request_before_executor_submission():
+    class _Reserved(_Worker):
+        def __init__(self):
+            super().__init__()
+            self.reserved = False
+            self.request_id = None
+
+        def reserve_request(self):
+            self.reserved = True
+            return 17
+
+        def release_request(self, request_id):
+            self.reserved = False
+            return request_id == 17
+
+        def generate(
+            self,
+            prompt,
+            config,
+            token_callback=None,
+            stats_callback=None,
+            request_id=None,
+        ):
+            assert self.reserved
+            self.request_id = request_id
+
+    async def scenario():
+        worker = _Reserved()
+        runtime = SessionRuntime(worker)
+        async for _ in runtime.generate_stream(None, _text(), _OPTS):
+            pass
+        return worker
+
+    worker = asyncio.run(scenario())
+    assert worker.request_id == 17
+
+
+def test_cooperative_cancellation_keeps_runtime_healthy():
+    class _Cooperative(_Worker):
+        def __init__(self):
+            super().__init__()
+            self._gate = threading.Event()
+            self._next_id = 1
+            self.abort_count = 0
+
+        def reserve_request(self):
+            request_id = self._next_id
+            self._next_id += 1
+            return request_id
+
+        def release_request(self, request_id):
+            return True
+
+        def stop(self):
+            self._gate.set()
+            return True
+
+        def abort(self):
+            self.abort_count += 1
+            self.healthy = False
+
+        def generate(
+            self,
+            prompt,
+            config,
+            token_callback=None,
+            stats_callback=None,
+            request_id=None,
+        ):
+            token_callback("TOKEN")
+            self._gate.wait(timeout=5)
+            self._gate.clear()
+
+    async def scenario():
+        worker = _Cooperative()
+        runtime = SessionRuntime(worker, cancel_grace_seconds=0.5)
+        generator = runtime.generate_stream(None, _text(), _OPTS)
+        assert await generator.__anext__() == "TOKEN"
+        await generator.aclose()
+        assert runtime.healthy
+        assert worker.abort_count == 0
+        second = runtime.generate_stream(None, _text(), _OPTS)
+        assert await second.__anext__() == "TOKEN"
+        await second.aclose()
+        return worker.abort_count
+
+    assert asyncio.run(scenario()) == 0
+
+
+def test_repeated_cancellation_does_not_interrupt_cleanup():
+    class _SlowAbort(_Worker):
+        def __init__(self):
+            super().__init__()
+            self.started = threading.Event()
+            self.finished = threading.Event()
+            self.abort_started = threading.Event()
+            self.abort_count = 0
+
+        def reserve_request(self):
+            return 1
+
+        def release_request(self, request_id):
+            return True
+
+        def stop(self):
+            return True
+
+        def abort(self):
+            self.abort_count += 1
+            self.abort_started.set()
+            time.sleep(0.03)
+            self.healthy = False
+            self.finished.set()
+
+        def generate(
+            self,
+            prompt,
+            config,
+            token_callback=None,
+            stats_callback=None,
+            request_id=None,
+        ):
+            self.started.set()
+            self.finished.wait(timeout=5)
+
+    async def scenario():
+        worker = _SlowAbort()
+        runtime = SessionRuntime(
+            worker, cancel_grace_seconds=0.01, abort_timeout_seconds=0.5
+        )
+        generator = runtime.generate_stream(None, _text(), _OPTS)
+        pending = asyncio.create_task(generator.__anext__())
+        await asyncio.to_thread(worker.started.wait, 1)
+        pending.cancel()
+        await asyncio.to_thread(worker.abort_started.wait, 1)
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        return runtime.healthy, worker.abort_count, worker.finished.is_set()
+
+    import pytest
+    import time
+
+    assert asyncio.run(scenario()) == (False, 1, True)
+
+
+def test_stop_false_completion_race_keeps_runtime_healthy():
+    class _AlreadyCompleted(_Worker):
+        def __init__(self):
+            super().__init__()
+            self.finished = threading.Event()
+            self.abort_count = 0
+
+        def reserve_request(self):
+            return 1
+
+        def release_request(self, request_id):
+            return True
+
+        def stop(self):
+            self.finished.set()
+            return False
+
+        def abort(self):
+            self.abort_count += 1
+            self.healthy = False
+
+        def generate(
+            self,
+            prompt,
+            config,
+            token_callback=None,
+            stats_callback=None,
+            request_id=None,
+        ):
+            token_callback("TOKEN")
+            self.finished.wait(timeout=5)
+
+    async def scenario():
+        worker = _AlreadyCompleted()
+        runtime = SessionRuntime(worker, cancel_grace_seconds=0.5)
+        generator = runtime.generate_stream(None, _text(), _OPTS)
+        assert await generator.__anext__() == "TOKEN"
+        await generator.aclose()
+        return runtime.healthy, worker.abort_count
+
+    assert asyncio.run(scenario()) == (True, 0)
+
+
+def test_noncooperative_cancellation_aborts_and_fails_fast():
+    class _Noncooperative(_Worker):
+        def __init__(self):
+            super().__init__()
+            self.started = threading.Event()
+            self.finished = threading.Event()
+            self.abort_count = 0
+            self._next_id = 1
+
+        def reserve_request(self):
+            request_id = self._next_id
+            self._next_id += 1
+            return request_id
+
+        def release_request(self, request_id):
+            return True
+
+        def stop(self):
+            return True
+
+        def abort(self):
+            self.abort_count += 1
+            self.healthy = False
+            self.finished.set()
+
+        def generate(
+            self,
+            prompt,
+            config,
+            token_callback=None,
+            stats_callback=None,
+            request_id=None,
+        ):
+            self.started.set()
+            self.finished.wait(timeout=5)
+
+    async def scenario():
+        worker = _Noncooperative()
+        runtime = SessionRuntime(
+            worker, cancel_grace_seconds=0.02, abort_timeout_seconds=0.5
+        )
+        generator = runtime.generate_stream(None, _text(), _OPTS)
+        pending = asyncio.create_task(generator.__anext__())
+        await asyncio.to_thread(worker.started.wait, 1)
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        assert worker.abort_count == 1
+        assert not runtime.healthy
+        with pytest.raises(WorkerError, match="restart the server"):
+            await anext(runtime.generate_stream(None, _text(), _OPTS))
+
+    import pytest
+    from executorch.examples.llm_server.python.worker_client import WorkerError
+
+    asyncio.run(scenario())
 
 
 def test_close_worker_shuts_down_worker():

--- a/examples/llm_server/python/tests/test_stream_disconnect.py
+++ b/examples/llm_server/python/tests/test_stream_disconnect.py
@@ -8,7 +8,6 @@
 
 import json
 import os
-from pathlib import Path
 import socket
 import sys
 import threading
@@ -80,7 +79,9 @@ def _wait_until(predicate, timeout=10.0):
     return False
 
 
-@pytest.mark.skipif(os.name != "posix", reason="cancellation control pipe is POSIX-only")
+@pytest.mark.skipif(
+    os.name != "posix", reason="cancellation control pipe is POSIX-only"
+)
 def test_socket_disconnect_cancels_matching_worker_request(tmp_path):
     worker_script = tmp_path / "fake_worker.py"
     marker = tmp_path / "cancelled.json"

--- a/examples/llm_server/python/tests/test_stream_disconnect.py
+++ b/examples/llm_server/python/tests/test_stream_disconnect.py
@@ -1,0 +1,175 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Real-socket coverage for HTTP disconnect -> worker cancellation."""
+
+import json
+import os
+from pathlib import Path
+import socket
+import sys
+import threading
+import time
+
+import httpx
+import pytest
+import uvicorn
+
+from executorch.examples.llm_server.python.chat_template import ChatTemplate
+from executorch.examples.llm_server.python.server import build_app
+from executorch.examples.llm_server.python.serving_chat import ServingChat
+from executorch.examples.llm_server.python.session_runtime import SessionRuntime
+from executorch.examples.llm_server.python.worker_client import spawn_worker
+
+
+_FAKE_WORKER = r"""
+import json
+import os
+from pathlib import Path
+import select
+import sys
+
+control_fd = int(os.environ["EXECUTORCH_LLM_WORKER_CONTROL_FD"])
+marker = Path(sys.argv[1])
+print(json.dumps({"ready": True, "supports_cancel": True}), flush=True)
+for line in sys.stdin:
+    request = json.loads(line)
+    if "op" in request:
+        op = request["op"]
+        print(json.dumps({op + "ed": True, "session_id": request["session_id"]}), flush=True)
+        continue
+    request_id = request["cancel_request_id"]
+    print(json.dumps({"token": "worker-token-visible-content"}), flush=True)
+    readable, _, _ = select.select([control_fd], [], [], 10)
+    if not readable:
+        marker.write_text(json.dumps({"request_id": request_id, "error": "timeout"}))
+        sys.exit(2)
+    frame = b""
+    while len(frame) < 8:
+        chunk = os.read(control_fd, 8 - len(frame))
+        if not chunk:
+            marker.write_text(json.dumps({"request_id": request_id, "error": "eof"}))
+            sys.exit(3)
+        frame += chunk
+    cancel_id = int.from_bytes(frame, "little")
+    marker.write_text(json.dumps({"request_id": request_id, "cancel_id": cancel_id}))
+    print(
+        json.dumps(
+            {
+                "done": True,
+                "finish_reason": "stop",
+                "cancelled": True,
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+            }
+        ),
+        flush=True,
+    )
+"""
+
+
+def _wait_until(predicate, timeout=10.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+@pytest.mark.skipif(os.name != "posix", reason="cancellation control pipe is POSIX-only")
+def test_socket_disconnect_cancels_matching_worker_request(tmp_path):
+    worker_script = tmp_path / "fake_worker.py"
+    marker = tmp_path / "cancelled.json"
+    worker_script.write_text(_FAKE_WORKER)
+
+    worker = spawn_worker([sys.executable, "-u", str(worker_script), str(marker)])
+    runtime = SessionRuntime(worker, cancel_grace_seconds=1.0)
+    serving = ServingChat(
+        runtime,
+        ChatTemplate(hf_tokenizer_path=None, allow_fallback=True),
+        "test-model",
+    )
+    app = build_app(serving, "test-model")
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    port = listener.getsockname()[1]
+    server = uvicorn.Server(
+        uvicorn.Config(app, log_level="error", lifespan="off", access_log=False)
+    )
+    server_thread = threading.Thread(
+        target=server.run, kwargs={"sockets": [listener]}, daemon=True
+    )
+    server_thread.start()
+
+    client = None
+    try:
+        assert _wait_until(lambda: server.started), "Uvicorn did not start"
+        body = json.dumps(
+            {
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": True,
+                "max_tokens": 8,
+            }
+        ).encode()
+        request = (
+            f"POST /v1/chat/completions HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{port}\r\n"
+            "Content-Type: application/json\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            "Connection: close\r\n\r\n"
+        ).encode() + body
+
+        client = socket.create_connection(("127.0.0.1", port), timeout=5)
+        client.sendall(request)
+        response = b""
+        while b"worker-token" not in response:
+            try:
+                chunk = client.recv(4096)
+            except TimeoutError as error:
+                phase = marker.read_text() if marker.exists() else "no worker marker"
+                raise AssertionError(
+                    f"stream stalled before worker token; marker={phase}; "
+                    f"response={response!r}"
+                ) from error
+            assert chunk, "stream ended before the worker token"
+            response += chunk
+        client.shutdown(socket.SHUT_RDWR)
+        client.close()
+        client = None
+
+        observed = None
+
+        def read_cancel_marker():
+            nonlocal observed
+            try:
+                candidate = json.loads(marker.read_text())
+            except (FileNotFoundError, json.JSONDecodeError):
+                return False
+            if "cancel_id" not in candidate:
+                return False
+            observed = candidate
+            return True
+
+        assert _wait_until(read_cancel_marker), "worker did not receive cancellation"
+        assert observed["cancel_id"] == observed["request_id"]
+        assert observed["request_id"] > 0
+
+        health = httpx.get(f"http://127.0.0.1:{port}/health", timeout=5)
+        assert health.status_code == 200
+        assert health.json() == {"status": "ok"}
+    finally:
+        if client is not None:
+            client.close()
+        server.should_exit = True
+        server_thread.join(timeout=5)
+        listener.close()
+        runtime.close_worker()
+        assert not server_thread.is_alive()

--- a/examples/llm_server/python/tests/test_worker_client.py
+++ b/examples/llm_server/python/tests/test_worker_client.py
@@ -10,10 +10,15 @@ A fake process stands in for the C++ worker: it records what the client writes
 and replays a scripted sequence of JSONL response lines.
 """
 
+import errno
 import json
+import os
+import subprocess
+import threading
 from dataclasses import dataclass, field
 
 import pytest
+from executorch.examples.llm_server.python import worker_client as worker_client_mod
 from executorch.examples.llm_server.python.worker_client import (
     spawn_worker,
     WorkerClient,
@@ -24,36 +29,69 @@ from executorch.examples.llm_server.python.worker_client import (
 class _FakeStdin:
     def __init__(self):
         self.written = []
+        self.closed = False
 
     def write(self, s):
         self.written.append(s)
+        return len(s)
 
     def flush(self):
         pass
 
     def close(self):
-        pass
+        self.closed = True
 
 
 class _FakeStdout:
     def __init__(self, lines):
         self._lines = list(lines)
+        self.closed = False
 
     def readline(self):
         return self._lines.pop(0) if self._lines else ""
 
+    def close(self):
+        self.closed = True
+
 
 class _FakeProc:
-    def __init__(self, stdout_lines, returncode=None):
+    def __init__(self, stdout_lines, returncode=None, wait_results=None):
         self.stdin = _FakeStdin()
         self.stdout = _FakeStdout(stdout_lines)
         self._returncode = returncode
+        self._wait_results = list(wait_results or [])
+        self.terminated = False
+        self.killed = False
+        self.waited = False
+        self.events = []
+        self.wait_timeouts = []
 
     def poll(self):
         return self._returncode
 
     @property
     def returncode(self):
+        return self._returncode
+
+    def terminate(self):
+        self.events.append("terminate")
+        self.terminated = True
+        self._returncode = -15
+
+    def kill(self):
+        self.events.append("kill")
+        self.killed = True
+        self._returncode = -9
+
+    def wait(self, timeout=None):
+        self.events.append("wait")
+        self.waited = True
+        self.wait_timeouts.append(timeout)
+        if self._wait_results:
+            result = self._wait_results.pop(0)
+            if isinstance(result, BaseException):
+                raise result
+            self._returncode = result
         return self._returncode
 
 
@@ -275,3 +313,400 @@ def test_spawn_worker_no_output_raises():
     proc = _FakeProc([])
     with pytest.raises(WorkerError, match="failed to start"):
         spawn_worker(["/fake/worker"], popen=lambda *a, **k: proc)
+
+
+def test_reservation_is_active_before_generation_submission():
+    read_fd, write_fd = os.pipe()
+    proc = _FakeProc(_lines({"done": True}))
+    client = WorkerClient(proc, control_fd=write_fd)
+    try:
+        request_id = client.reserve_request()
+        assert request_id == 1
+        assert client.stop() is True
+        assert os.read(read_fd, 8) == (1).to_bytes(8, "little")
+
+        client.generate("hi", _Cfg(), request_id=request_id)
+        assert json.loads(proc.stdin.written[0])["cancel_request_id"] == request_id
+    finally:
+        client.close()
+        os.close(read_fd)
+
+
+def test_release_request_handles_failed_executor_submission():
+    client = WorkerClient(_FakeProc([]))
+    request_id = client.reserve_request()
+    assert client.release_request(request_id + 1) is False
+    assert client.release_request(request_id) is True
+    assert client.reserve_request() == request_id + 1
+    client.close()
+
+
+def test_stop_writes_one_little_endian_frame_and_caches_success(monkeypatch):
+    read_fd, write_fd = os.pipe()
+    client = WorkerClient(_FakeProc([]), control_fd=write_fd)
+    frames = []
+
+    def record_write(fd, frame):
+        assert fd == write_fd
+        frames.append(frame)
+        return len(frame)
+
+    monkeypatch.setattr(os, "write", record_write)
+    try:
+        request_id = client.reserve_request()
+        with client._lock:
+            assert client.stop() is True
+            assert client.stop() is True
+        assert frames == [request_id.to_bytes(8, "little")]
+    finally:
+        client.close()
+        os.close(read_fd)
+
+
+def test_stop_is_false_for_unsupported_worker_and_old_request_shape():
+    proc = _FakeProc(_lines({"done": True}))
+    client = WorkerClient(proc)
+    request_id = client.reserve_request()
+    assert client.supports_cancel is False
+    assert client.stop() is False
+    client.generate("hi", _Cfg(), request_id=request_id)
+    assert "cancel_request_id" not in json.loads(proc.stdin.written[0])
+    client.close()
+
+
+def test_stop_eagain_is_cached_without_poisoning_channel(monkeypatch):
+    read_fd, write_fd = os.pipe()
+    client = WorkerClient(_FakeProc([]), control_fd=write_fd)
+    attempts = []
+
+    def would_block(fd, frame):
+        attempts.append((fd, frame))
+        raise BlockingIOError(errno.EAGAIN, "full")
+
+    monkeypatch.setattr(os, "write", would_block)
+    try:
+        client.reserve_request()
+        assert client.stop() is False
+        assert client.stop() is False
+        assert len(attempts) == 1
+        assert client.supports_cancel is True
+    finally:
+        client.close()
+        os.close(read_fd)
+
+
+@pytest.mark.parametrize("written", [0, 4])
+def test_stop_short_write_is_cached_and_poisons_channel(monkeypatch, written):
+    read_fd, write_fd = os.pipe()
+    client = WorkerClient(_FakeProc([]), control_fd=write_fd)
+    attempts = []
+
+    def short_write(fd, frame):
+        attempts.append((fd, frame))
+        return written
+
+    monkeypatch.setattr(os, "write", short_write)
+    client.reserve_request()
+    assert client.stop() is False
+    assert client.stop() is False
+    assert len(attempts) == 1
+    assert client.supports_cancel is False
+    with pytest.raises(OSError):
+        os.fstat(write_fd)
+    client.close()
+    os.close(read_fd)
+
+
+def test_stop_epipe_is_cached_and_poisons_channel(monkeypatch):
+    read_fd, write_fd = os.pipe()
+    client = WorkerClient(_FakeProc([]), control_fd=write_fd)
+    attempts = []
+
+    def broken_pipe(fd, frame):
+        attempts.append((fd, frame))
+        raise BrokenPipeError(errno.EPIPE, "closed")
+
+    monkeypatch.setattr(os, "write", broken_pipe)
+    client.reserve_request()
+    assert client.stop() is False
+    assert client.stop() is False
+    assert len(attempts) == 1
+    assert client.supports_cancel is False
+    with pytest.raises(OSError):
+        os.fstat(write_fd)
+    client.close()
+    os.close(read_fd)
+
+
+def test_request_ids_reach_uint64_max_then_fail_permanently():
+    client = WorkerClient(_FakeProc([]))
+    client._next_request_id = worker_client_mod._UINT64_MAX
+    request_id = client.reserve_request()
+    assert request_id == worker_client_mod._UINT64_MAX
+    assert client.release_request(request_id) is True
+
+    with pytest.raises(WorkerError, match="request ids exhausted") as first:
+        client.reserve_request()
+    with pytest.raises(WorkerError) as second:
+        client.reserve_request()
+    assert second.value is first.value
+    assert client.failed is True
+    assert client.healthy is False
+    client.close()
+
+
+def test_generation_exit_only_clears_matching_active_request():
+    class _BlockingStdout:
+        def __init__(self):
+            self.started = threading.Event()
+            self.release = threading.Event()
+            self.closed = False
+
+        def readline(self):
+            self.started.set()
+            assert self.release.wait(timeout=5)
+            return json.dumps({"done": True}) + "\n"
+
+        def close(self):
+            self.closed = True
+
+    read_fd, write_fd = os.pipe()
+    proc = _FakeProc([])
+    proc.stdout = _BlockingStdout()
+    client = WorkerClient(proc, control_fd=write_fd)
+    request_id = client.reserve_request()
+    errors = []
+
+    def generate():
+        try:
+            client.generate("hi", _Cfg(), request_id=request_id)
+        except (AssertionError, WorkerError) as error:  # pragma: no cover
+            errors.append(error)
+
+    thread = threading.Thread(target=generate)
+    thread.start()
+    assert proc.stdout.started.wait(timeout=5)
+    successor_id = request_id + 1
+    with client._state_lock:
+        client._active_request_id = successor_id
+        client._cancel_delivery = None
+    proc.stdout.release.set()
+    thread.join(timeout=5)
+
+    try:
+        assert not thread.is_alive()
+        assert errors == []
+        assert client.stop() is True
+        assert os.read(read_fd, 8) == successor_id.to_bytes(8, "little")
+    finally:
+        client.close()
+        os.close(read_fd)
+
+
+def test_protocol_failure_is_permanent_and_fail_fast():
+    proc = _FakeProc(["worker log on stdout\n", *_lines({"done": True})])
+    client = WorkerClient(proc)
+    with pytest.raises(WorkerError, match="invalid worker JSON") as first:
+        client.generate("hi", _Cfg())
+    with pytest.raises(WorkerError) as second:
+        client.generate("again", _Cfg())
+    with pytest.raises(WorkerError) as third:
+        client.open_session("session")
+
+    assert second.value is first.value
+    assert third.value is first.value
+    assert len(proc.stdin.written) == 1
+    assert client.failed is True
+    assert client.closed is False
+    assert client.healthy is False
+    assert client.stop() is False
+    client.abort()
+
+
+def test_abort_is_idempotent_and_terminates_then_kills_and_reaps():
+    timeout = subprocess.TimeoutExpired("worker", 5)
+    proc = _FakeProc([], wait_results=[timeout, -9])
+    stdin = proc.stdin
+    stdout = proc.stdout
+    read_fd, write_fd = os.pipe()
+    client = WorkerClient(proc, control_fd=write_fd)
+
+    client.abort()
+    first_events = list(proc.events)
+    client.abort()
+
+    assert first_events == ["terminate", "wait", "kill", "wait"]
+    assert proc.events == first_events
+    assert proc.wait_timeouts == [5, 5]
+    assert proc.stdin is None
+    assert proc.stdout is None
+    assert stdin.closed is True
+    assert stdout.closed is True
+    assert client.failed is True
+    assert client.healthy is False
+    with pytest.raises(OSError):
+        os.fstat(write_fd)
+    os.close(read_fd)
+
+
+def test_concurrent_abort_waits_for_cleanup_owner(monkeypatch):
+    proc = _FakeProc([])
+    client = WorkerClient(proc)
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+
+    def blocking_shutdown(process, streams):
+        assert process is proc
+        assert streams == (proc.stdin, proc.stdout)
+        cleanup_started.set()
+        assert release_cleanup.wait(timeout=5)
+        return True
+
+    monkeypatch.setattr(worker_client_mod, "_shutdown_process", blocking_shutdown)
+    first = threading.Thread(target=client.abort)
+    second = threading.Thread(target=client.abort)
+    first.start()
+    assert cleanup_started.wait(timeout=5)
+    second.start()
+    second.join(timeout=0.05)
+    assert second.is_alive()
+
+    release_cleanup.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+    assert not first.is_alive()
+    assert not second.is_alive()
+
+
+def test_abort_retries_cleanup_after_failed_final_reap():
+    timeout = subprocess.TimeoutExpired("worker", 5)
+    proc = _FakeProc([], wait_results=[timeout, timeout, 0])
+    client = WorkerClient(proc)
+
+    client.abort()
+    assert proc.events == ["terminate", "wait", "kill", "wait"]
+    client.abort()
+    assert proc.events == ["terminate", "wait", "kill", "wait", "wait"]
+    client.abort()
+    assert proc.events == ["terminate", "wait", "kill", "wait", "wait"]
+
+
+def test_close_is_idempotent_and_invalidates_all_transports():
+    proc = _FakeProc([])
+    stdin = proc.stdin
+    stdout = proc.stdout
+    read_fd, write_fd = os.pipe()
+    client = WorkerClient(proc, control_fd=write_fd)
+
+    client.close()
+    first_events = list(proc.events)
+    client.close()
+
+    assert proc.events == first_events == ["terminate", "wait"]
+    assert proc.stdin is None
+    assert proc.stdout is None
+    assert stdin.closed is True
+    assert stdout.closed is True
+    assert client.closed is True
+    assert client.failed is False
+    assert client.healthy is False
+    with pytest.raises(WorkerError, match="closed"):
+        client.reserve_request()
+    with pytest.raises(OSError):
+        os.fstat(write_fd)
+    os.close(read_fd)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="pass_fds is POSIX-only")
+def test_spawn_worker_negotiates_nonblocking_control_pipe_and_cleans_on_close(
+    monkeypatch,
+):
+    descriptors = os.pipe()
+    proc = _FakeProc(_lines({"ready": True, "supports_cancel": True}))
+    captured = {}
+    monkeypatch.setattr(os, "pipe", lambda: descriptors)
+
+    def fake_popen(*args, **kwargs):
+        captured.update(kwargs)
+        return proc
+
+    client = spawn_worker(["/fake/worker"], popen=fake_popen)
+    read_fd, write_fd = descriptors
+    assert captured["pass_fds"] == (read_fd,)
+    assert captured["env"]["EXECUTORCH_LLM_WORKER_CONTROL_FD"] == str(read_fd)
+    assert os.get_blocking(write_fd) is False
+    with pytest.raises(OSError):
+        os.fstat(read_fd)
+
+    client.close()
+    with pytest.raises(OSError):
+        os.fstat(write_fd)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="pass_fds is POSIX-only")
+def test_spawn_worker_popen_failure_closes_both_control_descriptors(monkeypatch):
+    descriptors = os.pipe()
+    monkeypatch.setattr(os, "pipe", lambda: descriptors)
+
+    def fail_popen(*args, **kwargs):
+        raise RuntimeError("spawn failed")
+
+    with pytest.raises(RuntimeError, match="spawn failed"):
+        spawn_worker(["/fake/worker"], popen=fail_popen)
+    for descriptor in descriptors:
+        with pytest.raises(OSError):
+            os.fstat(descriptor)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="pass_fds is POSIX-only")
+def test_spawn_worker_readiness_failure_closes_descriptors_and_reaps(monkeypatch):
+    descriptors = os.pipe()
+    proc = _FakeProc(_lines({"not_ready": True}))
+    monkeypatch.setattr(os, "pipe", lambda: descriptors)
+
+    with pytest.raises(WorkerError, match="did not report ready"):
+        spawn_worker(["/fake/worker"], popen=lambda *args, **kwargs: proc)
+
+    for descriptor in descriptors:
+        with pytest.raises(OSError):
+            os.fstat(descriptor)
+    assert proc.events == ["terminate", "wait"]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="pass_fds is POSIX-only")
+def test_spawn_worker_old_ready_closes_writer_and_keeps_old_request_shape(monkeypatch):
+    descriptors = os.pipe()
+    proc = _FakeProc(_lines({"ready": True}, {"done": True}))
+    monkeypatch.setattr(os, "pipe", lambda: descriptors)
+
+    client = spawn_worker(["/fake/worker"], popen=lambda *args, **kwargs: proc)
+    assert client.supports_cancel is False
+    with pytest.raises(OSError):
+        os.fstat(descriptors[0])
+    with pytest.raises(OSError):
+        os.fstat(descriptors[1])
+
+    request_id = client.reserve_request()
+    client.generate("hi", _Cfg(), request_id=request_id)
+    assert "cancel_request_id" not in json.loads(proc.stdin.written[0])
+    assert client.stop() is False
+    client.close()
+
+
+def test_spawn_worker_non_posix_keeps_normal_jsonl_behavior(monkeypatch):
+    proc = _FakeProc(
+        _lines({"ready": True, "max_named_sessions": 2, "supports_cancel": True})
+    )
+    captured = {}
+    monkeypatch.setattr(worker_client_mod.os, "name", "nt")
+
+    def fake_popen(*args, **kwargs):
+        captured.update(kwargs)
+        return proc
+
+    client = spawn_worker(["C:\\fake-worker.exe"], env={"BASE": "1"}, popen=fake_popen)
+    assert "pass_fds" not in captured
+    assert captured["env"] == {"BASE": "1"}
+    assert client.supports_cancel is False
+    assert client.stop() is False
+    client.close()

--- a/examples/llm_server/python/worker_client.py
+++ b/examples/llm_server/python/worker_client.py
@@ -108,6 +108,23 @@ def _close_fd(fd: Optional[int]) -> None:
         pass
 
 
+def _try_process_call(call, *args, **kwargs) -> bool:
+    try:
+        call(*args, **kwargs)
+        return True
+    except Exception:  # noqa: BLE001 - process shutdown remains best-effort
+        return False
+
+
+def _close_process_streams(streams: tuple) -> None:
+    # Closing buffered stdout while another thread is reading it can block, so
+    # callers invoke this only after the process has been reaped.
+    for stream in streams:
+        close = getattr(stream, "close", None)
+        if close is not None:
+            _try_process_call(close)
+
+
 def _shutdown_process(proc: subprocess.Popen, streams: Optional[tuple] = None) -> bool:
     """Invalidate process pipes and synchronously reap a child, best effort."""
     if streams is None:
@@ -118,45 +135,23 @@ def _shutdown_process(proc: subprocess.Popen, streams: Optional[tuple] = None) -
     except Exception:  # noqa: BLE001 - fake/foreign Popen objects may be immutable
         pass
 
-    reaped = False
     try:
-        try:
-            running = proc.poll() is None
-        except Exception:  # noqa: BLE001 - still attempt bounded termination
-            running = True
-        if running:
-            try:
-                proc.terminate()
-            except Exception:  # noqa: BLE001 - wait/kill below remain best-effort
-                pass
-        try:
-            proc.wait(timeout=_PROCESS_WAIT_TIMEOUT_SECONDS)
-            reaped = True
-        except Exception:  # noqa: BLE001 - escalate to kill, preserving caller error
-            pass
-        if reaped:
-            return True
-        try:
-            proc.kill()
-        except Exception:  # noqa: BLE001 - final reap attempt still matters
-            pass
-        try:
-            proc.wait(timeout=_PROCESS_WAIT_TIMEOUT_SECONDS)
-            reaped = True
-        except Exception:  # noqa: BLE001 - caller may retry process cleanup
-            pass
-    finally:
-        # Closing a buffered stdout while another thread is reading it can block.
-        # The client references are already invalidated; close detached streams
-        # only after reap, and leave an unsuccessful cleanup retryable.
-        if reaped:
-            for stream in streams:
-                try:
-                    close = getattr(stream, "close", None)
-                    if close is not None:
-                        close()
-                except Exception:  # noqa: BLE001 - shutdown remains best-effort
-                    pass
+        running = proc.poll() is None
+    except Exception:  # noqa: BLE001 - still attempt bounded termination
+        running = True
+    if running:
+        _try_process_call(proc.terminate)
+
+    reaped = _try_process_call(
+        proc.wait, timeout=_PROCESS_WAIT_TIMEOUT_SECONDS
+    )
+    if not reaped:
+        _try_process_call(proc.kill)
+        reaped = _try_process_call(
+            proc.wait, timeout=_PROCESS_WAIT_TIMEOUT_SECONDS
+        )
+    if reaped:
+        _close_process_streams(streams)
     return reaped
 
 
@@ -384,7 +379,7 @@ class WorkerClient:
             if written is not None and written != len(payload):
                 raise OSError("short write to worker stdin")
             stdin.flush()
-        except (BrokenPipeError, OSError, ValueError) as error:
+        except (OSError, ValueError) as error:
             failure = self._record_failure(WorkerError("worker stdin is closed"))
             raise failure from error
 

--- a/examples/llm_server/python/worker_client.py
+++ b/examples/llm_server/python/worker_client.py
@@ -26,14 +26,21 @@ hosts one engine and routes requests to per-session_id state (anonymous requests
 share a scratch session); execution is synchronous.
 """
 
+import errno
 import json
 import logging
+import os
 import subprocess
 import threading
 from dataclasses import dataclass, field
 from typing import Callable, Optional, Sequence
 
 logger = logging.getLogger(__name__)
+
+_CONTROL_FD_ENV = "EXECUTORCH_LLM_WORKER_CONTROL_FD"
+_CANCEL_FRAME_BYTES = 8
+_UINT64_MAX = (1 << 64) - 1
+_PROCESS_WAIT_TIMEOUT_SECONDS = 5
 
 
 @dataclass
@@ -62,8 +69,11 @@ class WorkerStats:
     # The exact (non-terminal) token ids generated this turn. The control plane
     # stores these per session and splices them back as an `ids` prompt segment
     # next turn, so a prior assistant span is an exact token extension instead of
-    # a lossy chat-template re-render. Empty on older workers.
+    # a lossy chat-template re-render. Empty on older workers and cancelled turns.
     generated_token_ids: list = field(default_factory=list)
+    # True when an out-of-band cancellation ended this request. Older workers
+    # omit the field and therefore report False.
+    cancelled: bool = False
 
 
 class WorkerError(RuntimeError):
@@ -82,42 +92,273 @@ class WorkerError(RuntimeError):
 def _decode_worker_json(line: str) -> dict:
     try:
         msg = json.loads(line)
-    except json.JSONDecodeError as e:
-        raise WorkerError(f"invalid worker JSON: {line.rstrip()!r}") from e
+    except json.JSONDecodeError as error:
+        raise WorkerError(f"invalid worker JSON: {line.rstrip()!r}") from error
     if not isinstance(msg, dict):
         raise WorkerError(f"invalid worker message: expected object, got {msg!r}")
     return msg
 
 
-class WorkerClient:
-    """Drives one model-execution worker process over JSONL (raw transport).
+def _close_fd(fd: Optional[int]) -> None:
+    if fd is None:
+        return
+    try:
+        os.close(fd)
+    except OSError:
+        pass
 
-    Exposes ``generate(prompt, config, token_callback, stats_callback)`` /
-    ``stop()`` plus the session ops ``open_session`` / ``close_session`` /
-    ``reset_session`` that SessionRuntime drives. Calls are serialized by a lock
-    and by SessionRuntime (one in-flight request). The control plane never
-    executes model code.
+
+def _shutdown_process(proc: subprocess.Popen, streams: Optional[tuple] = None) -> bool:
+    """Invalidate process pipes and synchronously reap a child, best effort."""
+    if streams is None:
+        streams = (getattr(proc, "stdin", None), getattr(proc, "stdout", None))
+    try:
+        proc.stdin = None
+        proc.stdout = None
+    except Exception:  # noqa: BLE001 - fake/foreign Popen objects may be immutable
+        pass
+
+    reaped = False
+    try:
+        try:
+            running = proc.poll() is None
+        except Exception:  # noqa: BLE001 - still attempt bounded termination
+            running = True
+        if running:
+            try:
+                proc.terminate()
+            except Exception:  # noqa: BLE001 - wait/kill below remain best-effort
+                pass
+        try:
+            proc.wait(timeout=_PROCESS_WAIT_TIMEOUT_SECONDS)
+            reaped = True
+        except Exception:  # noqa: BLE001 - escalate to kill, preserving caller error
+            pass
+        if reaped:
+            return True
+        try:
+            proc.kill()
+        except Exception:  # noqa: BLE001 - final reap attempt still matters
+            pass
+        try:
+            proc.wait(timeout=_PROCESS_WAIT_TIMEOUT_SECONDS)
+            reaped = True
+        except Exception:  # noqa: BLE001 - caller may retry process cleanup
+            pass
+    finally:
+        # Closing a buffered stdout while another thread is reading it can block.
+        # The client references are already invalidated; close detached streams
+        # only after reap, and leave an unsuccessful cleanup retryable.
+        if reaped:
+            for stream in streams:
+                try:
+                    close = getattr(stream, "close", None)
+                    if close is not None:
+                        close()
+                except Exception:  # noqa: BLE001 - shutdown remains best-effort
+                    pass
+    return reaped
+
+
+class WorkerClient:
+    """Drives one model-execution worker process over synchronous JSONL.
+
+    SessionRuntime should call ``reserve_request()`` synchronously before
+    submitting generation to its executor, then pass the returned id as
+    ``generate(..., request_id=request_id)``. If executor submission itself
+    fails, ``release_request(request_id)`` releases the unused reservation.
+    Direct callers may omit ``request_id``; generate then reserves internally.
+
+    Session operations and generation are serialized by the JSONL lock. Request
+    reservation, cancellation, health, and shutdown use a separate state lock,
+    so ``stop()`` never waits behind a blocking stdout read.
     """
 
-    def __init__(self, proc: subprocess.Popen, max_named_sessions: int = 0):
+    def __init__(
+        self,
+        proc: subprocess.Popen,
+        max_named_sessions: int = 0,
+        control_fd: Optional[int] = None,
+    ):
         self._proc = proc
         self._lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._control_fd = control_fd
+        self._next_request_id = 1
+        self._active_request_id: Optional[int] = None
+        self._generating_request_id: Optional[int] = None
+        self._cancel_delivery: Optional[bool] = None
+        self._terminal_error: Optional[WorkerError] = None
+        self._failed = False
+        self._closed = False
+        self._cleanup_in_progress = False
+        self._cleanup_complete = False
+        self._cleanup_done = threading.Event()
+        self._streams_to_close = (
+            getattr(proc, "stdin", None),
+            getattr(proc, "stdout", None),
+        )
         # Named sessions this worker can host (0 = scratch-only / single session).
         self.max_named_sessions = max_named_sessions
+        # spawn_worker only passes the descriptor after positive negotiation.
+        self.supports_cancel = control_fd is not None
+
+    @property
+    def healthy(self) -> bool:
+        """Whether this client can accept work without a known terminal failure."""
+        with self._state_lock:
+            if self._terminal_error is not None:
+                return False
+        try:
+            return self._proc.poll() is None
+        except Exception:  # noqa: BLE001 - a broken process handle is unhealthy
+            return False
+
+    @property
+    def failed(self) -> bool:
+        with self._state_lock:
+            return self._failed
+
+    @property
+    def closed(self) -> bool:
+        with self._state_lock:
+            return self._closed
+
+    def _record_failure(self, error: WorkerError) -> WorkerError:
+        """Record and return the first terminal WorkerError for stable re-raises."""
+        with self._state_lock:
+            if self._terminal_error is None:
+                self._terminal_error = error
+                self._failed = True
+            return self._terminal_error
+
+    def _ensure_usable(self) -> None:
+        with self._state_lock:
+            terminal_error = self._terminal_error
+        if terminal_error is not None:
+            raise terminal_error
+        try:
+            returncode = self._proc.poll()
+        except Exception as error:  # noqa: BLE001 - process state is now ambiguous
+            failure = self._record_failure(
+                WorkerError("failed to query worker process state")
+            )
+            raise failure from error
+        if returncode is not None:
+            raise self._record_failure(
+                WorkerError(f"worker exited (code {returncode}); restart the server")
+            )
 
     def reset(self) -> None:
         # Legacy no-op; reset is explicit via reset_session, or handled by the
-        # worker's prefill plan.
-        pass
+        # worker's prefill plan. It still observes the terminal lifecycle.
+        self._ensure_usable()
 
-    def stop(self) -> None:
-        # No-op: a worker request is synchronous over the JSONL pipe and is
-        # NOT interruptible mid-generation. The in-flight request runs to
-        # completion and head-of-line blocks every other session on this worker
-        # until it finishes. Real cancellation needs a protocol change (a control
-        # pipe, non-blocking stdin polling between decode steps, or request ids +
-        # an out-of-band cancel op).
-        pass
+    def reserve_request(self) -> int:
+        """Reserve the next cancellation id before executor submission.
+
+        IDs are process-lifetime monotonic uint64 values. Exhaustion is terminal:
+        wrapping could make a stale cancellation target a different request.
+        """
+        self._ensure_usable()
+        with self._state_lock:
+            if self._terminal_error is not None:
+                raise self._terminal_error
+            if self._active_request_id is not None:
+                raise WorkerError("a worker request is already reserved")
+            if self._next_request_id > _UINT64_MAX:
+                error = WorkerError("worker cancellation request ids exhausted")
+                self._terminal_error = error
+                self._failed = True
+                raise error
+            request_id = self._next_request_id
+            self._next_request_id += 1
+            self._active_request_id = request_id
+            self._cancel_delivery = None
+            return request_id
+
+    def release_request(self, request_id: int) -> bool:
+        """Release a reservation when generation was never submitted.
+
+        Returns False for a stale/non-matching id or once generation has begun.
+        """
+        with self._state_lock:
+            if self._terminal_error is not None:
+                raise self._terminal_error
+            if (
+                self._active_request_id != request_id
+                or self._generating_request_id is not None
+            ):
+                return False
+            self._active_request_id = None
+            self._cancel_delivery = None
+            return True
+
+    def _begin_generation(self, request_id: int) -> None:
+        if not isinstance(request_id, int) or isinstance(request_id, bool):
+            raise WorkerError("request_id must be a uint64")
+        if request_id <= 0 or request_id > _UINT64_MAX:
+            raise WorkerError("request_id must be in [1, UINT64_MAX]")
+        self._ensure_usable()
+        with self._state_lock:
+            if self._terminal_error is not None:
+                raise self._terminal_error
+            if self._active_request_id != request_id:
+                raise WorkerError(f"request id {request_id} is not reserved")
+            if self._generating_request_id is not None:
+                raise WorkerError("a worker generation is already active")
+            self._generating_request_id = request_id
+
+    def _finish_generation(self, request_id: int) -> None:
+        with self._state_lock:
+            if self._generating_request_id == request_id:
+                self._generating_request_id = None
+            # A stale generation must never clear a newer reservation.
+            if self._active_request_id == request_id:
+                self._active_request_id = None
+                self._cancel_delivery = None
+
+    def _poison_control_locked(self) -> None:
+        control_fd = self._control_fd
+        self._control_fd = None
+        self.supports_cancel = False
+        _close_fd(control_fd)
+
+    def stop(self) -> bool:
+        """Deliver one cancellation frame for the active request, at most once.
+
+        The cached bool reports whether a complete 8-byte little-endian frame was
+        written. Unsupported, inactive, closed, and failed clients return False.
+        EAGAIN is a per-request delivery failure; partial writes and other OS
+        errors also disable the channel because framing or descriptor health is
+        no longer trustworthy.
+        """
+        with self._state_lock:
+            if self._terminal_error is not None:
+                return False
+            control_fd = self._control_fd
+            request_id = self._active_request_id
+            if not self.supports_cancel or control_fd is None or request_id is None:
+                return False
+            if self._cancel_delivery is not None:
+                return self._cancel_delivery
+            frame = request_id.to_bytes(_CANCEL_FRAME_BYTES, "little")
+            try:
+                written = os.write(control_fd, frame)
+            except BlockingIOError:
+                self._cancel_delivery = False
+                return False
+            except OSError as error:
+                self._cancel_delivery = False
+                if error.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    self._poison_control_locked()
+                return False
+            if written != len(frame):
+                self._cancel_delivery = False
+                self._poison_control_locked()
+                return False
+            self._cancel_delivery = True
+            return True
 
     def open_session(self, session_id: str) -> None:
         """Admit a named session (idempotent). Raises WorkerError with a `code`
@@ -133,26 +374,48 @@ class WorkerClient:
         keep its capacity slot allocated (idempotent)."""
         self._op({"op": "reset", "session_id": session_id}, ack_key="reset")
 
+    def _write_request(self, request: dict) -> None:
+        payload = json.dumps(request) + "\n"
+        stdin = self._proc.stdin
+        if stdin is None:
+            raise self._record_failure(WorkerError("worker stdin is closed"))
+        try:
+            written = stdin.write(payload)
+            if written is not None and written != len(payload):
+                raise OSError("short write to worker stdin")
+            stdin.flush()
+        except (BrokenPipeError, OSError, ValueError) as error:
+            failure = self._record_failure(WorkerError("worker stdin is closed"))
+            raise failure from error
+
+    def _read_message(self) -> dict:
+        stdout = self._proc.stdout
+        if stdout is None:
+            raise self._record_failure(WorkerError("worker stdout is closed"))
+        try:
+            line = stdout.readline()
+        except (OSError, ValueError) as error:
+            failure = self._record_failure(WorkerError("worker stdout is closed"))
+            raise failure from error
+        if not line:
+            raise self._record_failure(WorkerError("worker exited mid-request"))
+        try:
+            return _decode_worker_json(line)
+        except WorkerError as error:
+            raise self._record_failure(error)
+
     def _op(self, request: dict, ack_key: str) -> None:
         with self._lock:
-            if self._proc.poll() is not None:
-                raise WorkerError(
-                    f"worker exited (code {self._proc.returncode}); restart the server"
-                )
-            try:
-                self._proc.stdin.write(json.dumps(request) + "\n")
-                self._proc.stdin.flush()
-            except (BrokenPipeError, ValueError) as e:
-                raise WorkerError("worker stdin is closed") from e
-            line = self._proc.stdout.readline()
-            if not line:
-                raise WorkerError("worker exited mid-request")
-            msg = _decode_worker_json(line)
+            self._ensure_usable()
+            self._write_request(request)
+            msg = self._read_message()
             if msg.get(ack_key):
                 return
             if "error" in msg:
-                raise WorkerError(msg["error"], code=msg.get("code"))
-            raise WorkerError(f"unexpected worker response: {msg}")
+                raise WorkerError(str(msg["error"]), code=msg.get("code"))
+            raise self._record_failure(
+                WorkerError(f"unexpected worker response: {msg}")
+            )
 
     @staticmethod
     def _on_done(msg: dict, stats_callback) -> None:
@@ -179,11 +442,43 @@ class WorkerClient:
                     prefill_tok_s=msg.get("prefill_tok_s", 0.0),
                     decode_tok_s=msg.get("decode_tok_s", 0.0),
                     vision_encoder_ms=msg.get("vision_encoder_ms"),
+                    cancelled=bool(msg.get("cancelled", False)),
                     generated_token_ids=msg.get("generated_token_ids", []),
                 )
             )
 
-    def generate(self, prompt, config, token_callback=None, stats_callback=None):
+    def _generate_locked(self, request: dict, token_callback, stats_callback) -> None:
+        self._ensure_usable()
+        self._write_request(request)
+        while True:
+            msg = self._read_message()
+            if "token" in msg:
+                if token_callback is not None:
+                    try:
+                        token_callback(msg["token"])
+                    except Exception as error:
+                        failure = self._record_failure(
+                            WorkerError("token callback failed during worker response")
+                        )
+                        raise failure from error
+            elif msg.get("done"):
+                self._on_done(msg, stats_callback)
+                return
+            elif "error" in msg:
+                raise WorkerError(str(msg["error"]), code=msg.get("code"))
+            else:
+                raise self._record_failure(
+                    WorkerError(f"unexpected worker response: {msg}")
+                )
+
+    def generate(
+        self,
+        prompt,
+        config,
+        token_callback=None,
+        stats_callback=None,
+        request_id: Optional[int] = None,
+    ):
         request = {
             "max_new_tokens": getattr(config, "max_new_tokens", -1),
             "temperature": getattr(config, "temperature", 0.0),
@@ -204,47 +499,89 @@ class WorkerClient:
         session_id = getattr(config, "session_id", None)
         if session_id:
             request["session_id"] = session_id
-        with self._lock:
-            if self._proc.poll() is not None:
-                raise WorkerError(
-                    f"worker exited (code {self._proc.returncode}); restart the server"
-                )
-            try:
-                self._proc.stdin.write(json.dumps(request) + "\n")
-                self._proc.stdin.flush()
-            except (BrokenPipeError, ValueError) as e:
-                raise WorkerError("worker stdin is closed") from e
 
-            while True:
-                line = self._proc.stdout.readline()
-                if not line:
-                    raise WorkerError("worker exited mid-request")
-                msg = _decode_worker_json(line)
-                if "token" in msg:
-                    if token_callback is not None:
-                        token_callback(msg["token"])
-                elif msg.get("done"):
-                    self._on_done(msg, stats_callback)
-                    return
-                elif "error" in msg:
-                    raise WorkerError(msg["error"], code=msg.get("code"))
-                else:
-                    raise WorkerError(f"unexpected worker response: {msg}")
+        if request_id is None:
+            # Preserve direct-caller serialization: allocate only after earlier
+            # JSONL work releases the lock.
+            with self._lock:
+                request_id = self.reserve_request()
+                self._begin_generation(request_id)
+                try:
+                    with self._state_lock:
+                        if self.supports_cancel:
+                            request["cancel_request_id"] = request_id
+                    self._generate_locked(request, token_callback, stats_callback)
+                finally:
+                    self._finish_generation(request_id)
+            return
+
+        self._begin_generation(request_id)
+        try:
+            with self._state_lock:
+                if self.supports_cancel:
+                    request["cancel_request_id"] = request_id
+            with self._lock:
+                self._generate_locked(request, token_callback, stats_callback)
+        finally:
+            self._finish_generation(request_id)
+
+    def _start_cleanup(
+        self, terminal_error: WorkerError, failed: bool
+    ) -> tuple[bool, threading.Event]:
+        """Enter a terminal state and choose one process-cleanup owner."""
+        control_fd = None
+        with self._state_lock:
+            if self._terminal_error is None:
+                self._terminal_error = terminal_error
+                self._failed = failed
+            elif failed and not self._closed:
+                self._failed = True
+            if not failed:
+                self._closed = True
+            if self._cleanup_complete:
+                return False, self._cleanup_done
+            if self._cleanup_in_progress:
+                return False, self._cleanup_done
+            self._cleanup_in_progress = True
+            self._cleanup_done = threading.Event()
+            control_fd = self._control_fd
+            self._control_fd = None
+            self.supports_cancel = False
+            self._active_request_id = None
+            self._generating_request_id = None
+            self._cancel_delivery = None
+            cleanup_done = self._cleanup_done
+        _close_fd(control_fd)
+        return True, cleanup_done
+
+    def _finish_cleanup(self, reaped: bool, cleanup_done: threading.Event) -> None:
+        with self._state_lock:
+            self._cleanup_in_progress = False
+            self._cleanup_complete = reaped
+            if reaped:
+                self._streams_to_close = (None, None)
+            cleanup_done.set()
+
+    def _cleanup(self, terminal_error: WorkerError, failed: bool) -> None:
+        owner, cleanup_done = self._start_cleanup(terminal_error, failed)
+        if not owner:
+            cleanup_done.wait()
+            return
+        reaped = False
+        try:
+            reaped = _shutdown_process(self._proc, self._streams_to_close)
+        finally:
+            self._finish_cleanup(reaped, cleanup_done)
+        if not reaped:
+            logger.error("Model worker could not be reaped after termination")
+
+    def abort(self) -> None:
+        """Idempotently terminate and reap an unusable worker process."""
+        self._cleanup(WorkerError("worker client aborted"), failed=True)
 
     def close(self) -> None:
-        """Terminate the worker process (called at server shutdown)."""
-        if self._proc.poll() is not None:
-            return
-        try:
-            if self._proc.stdin is not None:
-                self._proc.stdin.close()
-        except OSError:
-            pass
-        try:
-            self._proc.terminate()
-            self._proc.wait(timeout=5)
-        except Exception:  # noqa: BLE001 - shutdown best-effort
-            self._proc.kill()
+        """Idempotently terminate and reap the worker during normal shutdown."""
+        self._cleanup(WorkerError("worker client is closed"), failed=False)
 
 
 def spawn_worker(
@@ -253,28 +590,70 @@ def spawn_worker(
     cwd: Optional[str] = None,
     popen: Callable[..., subprocess.Popen] = subprocess.Popen,
 ) -> WorkerClient:
-    """Start a worker process and block until it reports ``{"ready": true}``.
+    """Start a worker and wait for its additive readiness negotiation.
 
-    `cmd` is the worker binary and its launch args (model/tokenizer paths). The
-    worker loads the model once before reporting ready, so a slow load surfaces
-    here rather than on the first request.
+    POSIX workers inherit the read end of a cancellation pipe through
+    ``EXECUTORCH_LLM_WORKER_CONTROL_FD``. The parent retains a nonblocking writer
+    only when readiness includes ``{"supports_cancel": true}``; old workers keep
+    their original JSONL request shape and behavior.
     """
     logger.info("Starting model worker: %s", cmd[0])
-    proc = popen(
-        list(cmd),
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        text=True,
-        bufsize=1,
-        env=env,
-        cwd=cwd,
-    )
-    line = proc.stdout.readline()
-    if not line:
-        raise WorkerError("worker failed to start (no output; check its stderr).")
-    msg = _decode_worker_json(line)
-    if not msg.get("ready"):
-        raise WorkerError(f"worker did not report ready: {msg}")
-    max_named = int(msg.get("max_named_sessions", 0))
-    logger.info("Model worker ready (max_named_sessions=%d).", max_named)
-    return WorkerClient(proc, max_named_sessions=max_named)
+    control_read_fd: Optional[int] = None
+    control_write_fd: Optional[int] = None
+    proc: Optional[subprocess.Popen] = None
+    popen_kwargs = {
+        "stdin": subprocess.PIPE,
+        "stdout": subprocess.PIPE,
+        "text": True,
+        "bufsize": 1,
+        "env": env,
+        "cwd": cwd,
+    }
+
+    try:
+        if os.name == "posix":
+            control_read_fd, control_write_fd = os.pipe()
+            os.set_blocking(control_write_fd, False)
+            child_env = dict(os.environ if env is None else env)
+            child_env[_CONTROL_FD_ENV] = str(control_read_fd)
+            popen_kwargs["env"] = child_env
+            popen_kwargs["pass_fds"] = (control_read_fd,)
+        proc = popen(list(cmd), **popen_kwargs)
+    except Exception:
+        _close_fd(control_write_fd)
+        if proc is not None:
+            _shutdown_process(proc)
+        raise
+    finally:
+        _close_fd(control_read_fd)
+
+    try:
+        if proc.stdout is None:
+            raise WorkerError("worker failed to start (no stdout pipe).")
+        line = proc.stdout.readline()
+        if not line:
+            raise WorkerError("worker failed to start (no output; check its stderr).")
+        msg = _decode_worker_json(line)
+        if not msg.get("ready"):
+            raise WorkerError(f"worker did not report ready: {msg}")
+        max_named = int(msg.get("max_named_sessions", 0))
+        supports_cancel = msg.get("supports_cancel") is True
+        if not supports_cancel:
+            _close_fd(control_write_fd)
+            control_write_fd = None
+        logger.info(
+            "Model worker ready (max_named_sessions=%d, supports_cancel=%s).",
+            max_named,
+            supports_cancel and control_write_fd is not None,
+        )
+        client = WorkerClient(
+            proc,
+            max_named_sessions=max_named,
+            control_fd=control_write_fd,
+        )
+        control_write_fd = None  # ownership transferred to WorkerClient
+        return client
+    except Exception:
+        _close_fd(control_write_fd)
+        _shutdown_process(proc)
+        raise

--- a/examples/llm_server/python/worker_client.py
+++ b/examples/llm_server/python/worker_client.py
@@ -142,14 +142,10 @@ def _shutdown_process(proc: subprocess.Popen, streams: Optional[tuple] = None) -
     if running:
         _try_process_call(proc.terminate)
 
-    reaped = _try_process_call(
-        proc.wait, timeout=_PROCESS_WAIT_TIMEOUT_SECONDS
-    )
+    reaped = _try_process_call(proc.wait, timeout=_PROCESS_WAIT_TIMEOUT_SECONDS)
     if not reaped:
         _try_process_call(proc.kill)
-        reaped = _try_process_call(
-            proc.wait, timeout=_PROCESS_WAIT_TIMEOUT_SECONDS
-        )
+        reaped = _try_process_call(proc.wait, timeout=_PROCESS_WAIT_TIMEOUT_SECONDS)
     if reaped:
         _close_process_streams(streams)
     return reaped

--- a/examples/models/gemma4_31b/CMakeLists.txt
+++ b/examples/models/gemma4_31b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(_json_include
 # gflags
 set(gflags_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party/gflags)
 find_package(gflags REQUIRED)
+find_package(Threads REQUIRED)
 
 # executorch
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
@@ -72,7 +73,9 @@ add_executable(gemma4_31b_worker gemma4_31b_worker.cpp gemma4_31b_engine.cpp)
 target_include_directories(
   gemma4_31b_worker PUBLIC ${_common_include_directories} ${_json_include}
 )
-target_link_libraries(gemma4_31b_worker PUBLIC ${link_libraries})
+target_link_libraries(
+  gemma4_31b_worker PUBLIC ${link_libraries} Threads::Threads
+)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_link_options_gc_sections(gemma4_31b_runner)

--- a/examples/models/muse-glimmer/CMakeLists.txt
+++ b/examples/models/muse-glimmer/CMakeLists.txt
@@ -26,6 +26,7 @@ set(_json_include
 # gflags
 set(gflags_DIR ${EXECUTORCH_ROOT}/cmake-out/third-party/gflags)
 find_package(gflags REQUIRED)
+find_package(Threads REQUIRED)
 
 # executorch
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../../..)
@@ -157,7 +158,9 @@ endif()
 target_include_directories(
   muse_glimmer_worker PUBLIC ${_common_include_directories} ${_json_include}
 )
-target_link_libraries(muse_glimmer_worker PUBLIC ${link_libraries})
+target_link_libraries(
+  muse_glimmer_worker PUBLIC ${link_libraries} Threads::Threads
+)
 
 if(EXECUTORCH_BUILD_CUDA
    AND NOT APPLE

--- a/examples/models/muse-glimmer/runtime/runners/muse_glimmer_worker.cpp
+++ b/examples/models/muse-glimmer/runtime/runners/muse_glimmer_worker.cpp
@@ -171,13 +171,15 @@ void handle_session_operation(
 
 int run_muse_glimmer_worker_loop(llm::MuseGlimmerEngine& engine) {
   llm::WorkerSessions sessions(engine);
+  llm::WorkerCancellationController cancellation_controller;
   llm::worker_emit(
       {{"ready", true},
        {"max_sessions",
         engine.serving_capacity()
             .max_physical_sessions_without_weight_duplication},
        {"max_named_sessions", sessions.max_named()},
-       {"supports_image", engine.has_vision()}});
+       {"supports_image", engine.has_vision()},
+       {"supports_cancel", cancellation_controller.supported()}});
 
   std::string line;
   while (std::getline(std::cin, line)) {
@@ -192,6 +194,11 @@ int run_muse_glimmer_worker_loop(llm::MuseGlimmerEngine& engine) {
         continue;
       }
 
+      const auto cancel_request_id = llm::worker_cancel_request_id(
+          request, cancellation_controller.supported());
+      if (cancel_request_id.has_value()) {
+        cancellation_controller.validate_request_id(*cancel_request_id);
+      }
       const std::string id = request.value("session_id", std::string{});
       llm::WorkerSessionState* state = nullptr;
       bool warm = false;
@@ -208,6 +215,15 @@ int run_muse_glimmer_worker_loop(llm::MuseGlimmerEngine& engine) {
           continue;
         }
         warm = FLAGS_warm_resume;
+      }
+
+      llm::WorkerCancellationState cancellation;
+      llm::WorkerCancellationController::ActiveRequest active_request;
+      llm::WorkerCancellationState* cancellation_ptr = nullptr;
+      if (cancel_request_id.has_value()) {
+        active_request = cancellation_controller.activate(
+            *cancel_request_id, *state, cancellation);
+        cancellation_ptr = &cancellation;
       }
 
       std::vector<uint64_t> prefix = {static_cast<uint64_t>(FLAGS_bos_id)};
@@ -251,7 +267,8 @@ int run_muse_glimmer_worker_loop(llm::MuseGlimmerEngine& engine) {
             engine.metadata(),
             request,
             prefix,
-            additional_terminal_stats);
+            additional_terminal_stats,
+            cancellation_ptr);
       } catch (...) {
         if (multimodal != nullptr) {
           multimodal->clear_staged_image();

--- a/examples/models/qwen3_5_moe/CMakeLists.txt
+++ b/examples/models/qwen3_5_moe/CMakeLists.txt
@@ -22,6 +22,7 @@ set(_json_include
 # gflags
 set(gflags_DIR ${CMAKE_CURRENT_BINARY_DIR}/../../../third-party/gflags)
 find_package(gflags REQUIRED)
+find_package(Threads REQUIRED)
 
 # executorch
 list(APPEND CMAKE_FIND_ROOT_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../..)
@@ -78,7 +79,9 @@ add_executable(qwen3_5_moe_worker qwen35_moe_worker.cpp qwen35_moe_engine.cpp)
 target_include_directories(
   qwen3_5_moe_worker PUBLIC ${_common_include_directories} ${_json_include}
 )
-target_link_libraries(qwen3_5_moe_worker PUBLIC ${link_libraries})
+target_link_libraries(
+  qwen3_5_moe_worker PUBLIC ${link_libraries} Threads::Threads
+)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_link_options_gc_sections(qwen3_5_moe_runner)


### PR DESCRIPTION
### Summary

Add bounded cancellation for the existing process-isolated LLM worker protocol.

- Negotiate `supports_cancel` and pass monotonically increasing request IDs over JSONL.
- Deliver cancellation out of band through an inherited POSIX pipe, so `stop()` never waits behind the blocking request/response lock.
- Cooperatively call `LLMSession::stop()` once at the next decode boundary. Cancelled sessions are marked dirty and reset before reuse.
- If cooperative cancellation misses its grace period, terminate/kill/reap the worker, fail queued and future work, and report `/health` as unavailable. Model reload remains the supervisor's responsibility.
- Keep older and non-POSIX workers compatible; they do not advertise cancellation and use the bounded process-termination fallback.

Review guide:

1. Python transport and process lifecycle: `examples/llm_server/python/worker_client.py`.
2. Async cancellation, escalation, and health: `examples/llm_server/python/session_runtime.py`, `serving_chat.py`, and `server.py`.
3. Native request controller and dirty-on-cancel semantics: `examples/llm_server/cpp/worker_loop.h`.
4. MuseGlimmer custom-loop integration: `examples/models/muse-glimmer/runtime/runners/muse_glimmer_worker.cpp`.
5. The remaining changes are focused tests, documentation, and thread linkage for worker targets that include the shared controller.

Cancellation remains token-boundary cooperative: it cannot interrupt active prefill, vision preparation, or an in-progress backend invocation. The process fallback provides the bound in those cases.

### Test plan

- `pytest -q examples/llm_server/python/tests` (`229 passed, 6 skipped`)
- Built and ran `test_worker_loop` and `test_worker_prefill_plan` (`2/2` CTests passed)
- Built and linked the MLX `muse_glimmer_worker`, `qwen3_5_moe_worker`, and `gemma4_31b_worker` targets
- Ran the real loopback Uvicorn/socket disconnect test five consecutive times
- Ran exact-file Python, C++, CMake, and documentation linters
