### PR TITLE
Qualcomm AI Engine Direct - test framework refactor

### DIFF
--- a/backends/qualcomm/_passes/backends/lpai/qnn_lpai_pass_manager.py
+++ b/backends/qualcomm/_passes/backends/lpai/qnn_lpai_pass_manager.py
@@ -51,17 +51,18 @@ class QnnLpaiPassManager(QnnPassManager):
             {
                 DecomposeHardsigmoid: [RemoveRedundancy],
                 DecomposeReciprocal: [RemoveRedundancy],
-                LpaiPartitionFallbackSupport: [TagQuantIO],
-                ResolveDebugHandle: [LpaiPartitionFallbackSupport],
+                LpaiPartitionFallbackSupport: [TagQuantIO, ResolveDebugHandle],
             }
         )
         return deps
 
     def _validate_edge_passes(self) -> None:
-        super()._validate_edge_passes()
         assert isinstance(
-            self.passes[-2], LpaiPartitionFallbackSupport
-        ), "Please ensure LpaiPartitionFallbackSupport is the last edge pass before ResolveDebugHandle."
+            self.passes[-2], ResolveDebugHandle
+        ), "Please ensure ResolveDebugHandle is the last edge pass before LpaiPartitionFallbackSupport."
+        assert isinstance(
+            self.passes[-1], LpaiPartitionFallbackSupport
+        ), "Please ensure LpaiPartitionFallbackSupport is the last pass."
 
     @classmethod
     def get_annotation_passes(cls):

--- a/backends/qualcomm/_passes/lpai_partition_fallback_support.py
+++ b/backends/qualcomm/_passes/lpai_partition_fallback_support.py
@@ -254,7 +254,9 @@ class LpaiPartitionFallbackSupport(ExportPass):
                 output_dq_node.meta[QCOM_BYPASS_NODE] = True
         graph_module.graph.eliminate_dead_code()
 
-    def handle_back_to_back_nodes(self, graph_module: torch.fx.GraphModule):
+    def handle_back_to_back_nodes(
+        self, graph_module: torch.fx.GraphModule, unsupported_nodes: set[torch.fx.Node]
+    ):
         """
         This function takes care of following cases:
         1. When 2 contiguous fall back nodes ``a`` and ``b`` (both
@@ -279,6 +281,7 @@ class LpaiPartitionFallbackSupport(ExportPass):
                     input_node
                     for input_node in node.all_input_nodes
                     if input_node.op == "call_function"
+                    and input_node not in unsupported_nodes
                 ]
                 assert all(
                     input_node.target in dq_ops for input_node in input_call_func_nodes
@@ -327,7 +330,7 @@ class LpaiPartitionFallbackSupport(ExportPass):
         unsupported_nodes = self.get_unsupported_nodes(graph_module)
         for node in unsupported_nodes:
             self.insert_partition_qdq(graph_module, node)
-        self.handle_back_to_back_nodes(graph_module)
+        self.handle_back_to_back_nodes(graph_module, unsupported_nodes)
         graph_module.graph.eliminate_dead_code()
         graph_module.recompile()
-        return PassResult(graph_module, bool(unsupported_nodes))
+        return PassResult(graph_module, True)

--- a/backends/qualcomm/_passes/qnn_pass_manager.py
+++ b/backends/qualcomm/_passes/qnn_pass_manager.py
@@ -323,9 +323,7 @@ class QnnPassManager(PassManager):
             RecomposePixelUnshuffle: [RemoveRedundancy],
             RecomposeRmsNorm: [RemoveRedundancy],
             TagQuantIO: [LayoutTransform],
-            ResolveDebugHandle: [
-                TagQuantIO
-            ],  # IMPORTANT: Please always ensure ResolveDebugHandle is the last executed pass.
+            ResolveDebugHandle: [TagQuantIO],
         }
 
     @classmethod

--- a/backends/qualcomm/builders/op_batch_norm.py
+++ b/backends/qualcomm/builders/op_batch_norm.py
@@ -29,6 +29,7 @@ class BatchNorm(NodeVisitor):
     target = [
         "aten._native_batch_norm_legit_no_training.default",
         "aten._native_batch_norm_legit.no_stats",
+        "aten._native_batch_norm_legit_functional.default",
     ]
 
     def __init__(self, *args) -> None:

--- a/backends/qualcomm/qnn_preprocess.py
+++ b/backends/qualcomm/qnn_preprocess.py
@@ -243,6 +243,7 @@ class QnnBackend(BackendDetails):
                             (handle_id := node.meta.get(DEBUG_HANDLE_KEY))
                             and QCOM_TENSOR_NAME in node.meta
                             and len(node.meta[QCOM_TENSOR_NAME]) == 1
+                            and node.op == "call_function"
                         ):
                             debug_handle_builder.insert_delegate_mapping_entry(
                                 handles=handle_id,

--- a/backends/qualcomm/quantizer/annotators/lpai_rules.py
+++ b/backends/qualcomm/quantizer/annotators/lpai_rules.py
@@ -129,7 +129,7 @@ class AvgPool2d(GeneralOpDef):
 
 # TODO: Batch_norm op cannot directly map to QNN OpBatchnorm due to the number of input doesn't match.
 @register_annotator(
-    [torch.ops.aten.batch_norm.default, torch.ops.aten.instance_norm.default],
+    [torch.ops.aten.batch_norm.default],
     qnn_op=None,
 )
 class BatchNorm(GeneralOpDef):
@@ -420,7 +420,8 @@ class GetItem(GeneralOpDef):
             torch.ops.aten.topk.default,
             torch.ops.aten.sort.default,
         ):
-            out_act_quantization_spec = SharedQuantizationSpec(node.args[0])
+            # assign to None since they are not supported so far
+            out_act_quantization_spec = None
         node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
             output_qspec=out_act_quantization_spec,
             _annotated=True,
@@ -807,21 +808,6 @@ class ReluMinMax(GeneralOpDef):
     pass
 
 
-# TODO: Expand_as op cannot directly map to QNN OpTile due to the number of input doesn't match.
-@register_annotator(
-    [
-        torch.ops.aten.expand_as.default,
-    ],
-    qnn_op=None,
-)
-class ExpandAs(GeneralOpDef):
-    @staticmethod
-    def annotate(node: Node, quantization_config: QuantizationConfig) -> None:
-        annotate_in_out_obs_sharing_op(node, quantization_config)
-        if not _is_annotated([node]):
-            annotate_single_in_share_out(node, quantization_config)
-
-
 @register_annotator(
     [
         torch.ops.aten.flatten.using_ints,
@@ -854,7 +840,6 @@ class RmsNorm(GeneralOpDef):
             return
 
         act_node = node.args[0]
-        weight_node = node.args[2]
 
         # TODO current only support 16a16w
         annotate_input_qspec_map(
@@ -863,92 +848,21 @@ class RmsNorm(GeneralOpDef):
             quantization_config.input_activation,
         )
 
-        annotate_input_qspec_map(
-            node,
-            weight_node,
-            quantization_config.input_activation,
-        )
+        if len(node.args) > 2 and node.args[2] is not None:
+            weight_node = node.args[2]
+            annotate_input_qspec_map(
+                node,
+                weight_node,
+                quantization_config.input_activation,
+            )
         nodes_to_mark_annotated = [node]
         annotate_output_qspec(node, quantization_config.output_activation)
         _mark_nodes_as_annotated(nodes_to_mark_annotated)
 
 
-# TODO: There is a bug in the BackendOpInfo library, so it is bypassed now.
-@register_annotator([torch.ops.aten.rsqrt.default], qnn_op=None)
-class Rsqrt(GeneralOpDef):
-    pass
-
-
 @register_annotator([torch.ops.aten.scaled_dot_product_attention.default], qnn_op=None)
 class ScaledDotProductAttention(GeneralOpDef):
     pass
-
-
-@register_annotator(
-    [
-        torch.ops.aten.scatter.src,
-        torch.ops.aten.scatter.value,
-        torch.ops.aten.scatter_add.default,
-        torch.ops.aten.scatter_reduce.two,
-    ],
-    qnn_op=None,
-)
-class ScatterElements(GeneralOpDef):
-    @staticmethod
-    def annotate(node: Node, quantization_config: QuantizationConfig) -> None:
-        if _is_annotated([node]):
-            return
-
-        input_act = node.args[0]
-        if not isinstance(input_act, Node) or not _is_float_tensor(input_act):
-            return
-
-        input_qspec_map = {}
-        input_qspec_map[input_act] = quantization_config.input_activation
-
-        if (
-            len(node.args) > 3
-            and isinstance(node.args[3], Node)
-            and _is_float_tensor(node.args[3])
-        ):
-            input_qspec_map[node.args[3]] = SharedQuantizationSpec((input_act, node))
-
-        output_act_qspec = (
-            SharedQuantizationSpec((input_act, node))
-            if _is_float_tensor(node)
-            else None
-        )
-
-        if len(input_qspec_map) > 0 or output_act_qspec is not None:
-            node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
-                input_qspec_map=input_qspec_map,
-                output_qspec=output_act_qspec,
-                _annotated=True,
-            )
-
-
-@register_annotator([torch.ops.aten.sort.default], QnnConstants.OpTopK.op_name)
-class Sort(GeneralOpDef):
-    @staticmethod
-    def annotate(node: Node, quantization_config: QuantizationConfig) -> None:
-        if _is_annotated([node]):
-            return
-
-        input_qspec_map = {}
-        input_act_qspec = quantization_config.input_activation
-        out_act_quantization_spec = None
-        if input_act_qspec is not None:
-            if _is_float_tensor(node.args[0]):
-                input_act = node.args[0]
-                assert isinstance(input_act, Node)
-                input_qspec_map[input_act] = input_act_qspec
-                out_act_quantization_spec = SharedQuantizationSpec((input_act, node))
-
-        node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
-            input_qspec_map=input_qspec_map,
-            output_qspec=out_act_quantization_spec,
-            _annotated=True,
-        )
 
 
 @register_annotator(

--- a/backends/qualcomm/tests/models.py
+++ b/backends/qualcomm/tests/models.py
@@ -2943,6 +2943,16 @@ class Threshold(torch.nn.Module):
         )
 
 
+class ConvRelu(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 8, kernel_size=3, padding=1)
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, x):
+        return self.relu(self.conv(x))
+
+
 class TopKandIndex(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/backends/qualcomm/tests/rework/conftest.py
+++ b/backends/qualcomm/tests/rework/conftest.py
@@ -32,6 +32,7 @@ from executorch.backends.qualcomm.export_utils import (
     get_qnn_context_binary_alignment,
     prepare_pt2e,
     QnnConfig,
+    QnnExecuTorchBackendType,
     QnnQuantizer,
     setup_common_args_and_variables,
     SimpleADB,
@@ -269,7 +270,7 @@ def qnn_config(global_setup, request):
             f'invalid configuration detected, fall back to emulator workload:\n"{e}"'
         )
         config = QnnConfig(
-            soc_model="unknown", build_folder="build-x86", compile_only=True
+            soc_model="unknown", build_folder="build-x86", enable_x86_64=True
         )
 
     return config
@@ -349,6 +350,7 @@ def invoke_remote(
     qnn_config: QnnConfig,
     executorch_prog: ExecutorchProgramManager,
     callback: callable,
+    inputs: Tuple[torch.Tensor] = None,
 ):
     with tempfile.TemporaryDirectory() as tmp_dir:
         pte_fname = f"{tmp_dir}/qnn_executorch_test.pte"
@@ -363,7 +365,7 @@ def invoke_remote(
             pte_path=[pte_fname],
             workspace=f"/data/local/tmp/{device_workspace}",
         )
-        adb.push()
+        adb.push(inputs=[inputs] if inputs is not None else None)
         callback(adb)
 
 
@@ -478,7 +480,23 @@ def export_and_verify(
     metrics: Metrics,
 ):
     with calibrate(module, [inputs], quantizer) as exported_module:
-        if quantizer is not None:
+        fake_tensors = (
+            [
+                node.meta["val"]
+                for node in exported_module.graph.nodes
+                if node.op == "call_function" and "val" in node.meta
+            ]
+            if quantizer
+            else []
+        )
+        dtypes = set()
+        for tensor in fake_tensors:
+            if isinstance(tensor, (tuple, list)):
+                dtypes.update([n.dtype for n in tensor])
+            else:
+                dtypes.add(tensor.dtype)
+
+        if quantizer and {torch.float, torch.float32} & dtypes:
             nodes = {node.target for node in exported_module.graph.nodes}
             q_and_dq = {
                 torch.ops.quantized_decomposed.quantize_per_tensor.default,
@@ -505,15 +523,34 @@ def export_and_verify(
         )
     )
     execution_plan = executorch_prog.executorch_program.execution_plan[0]
+
+    def validate():
+        match qnn_config.backend:
+            case QnnExecuTorchBackendType.kHtpBackend:
+                return len(execution_plan.operators) == 0
+            case QnnExecuTorchBackendType.kGpuBackend:
+                return len(execution_plan.operators) == 0
+            case QnnExecuTorchBackendType.kLpaiBackend:
+                aten_op_names = {
+                    op.name
+                    for op in execution_plan.operators
+                    if "quantize" not in op.name
+                }
+                return len(aten_op_names) == 0
+            case _:
+                return True
+
     assert all(
         [
-            len(execution_plan.delegates) == 1,
-            execution_plan.delegates[0].id == "QnnBackend",
-            len(execution_plan.operators) == 0,
+            (
+                len(execution_plan.delegates) == 1
+                and execution_plan.delegates[0].id == "QnnBackend"
+            ),
+            validate(),
         ]
     ), EXPECT_NOT_FULLY_DELEGATED
 
-    mode = "emulator" if qnn_config.build_folder == "build-x86" else "remote"
+    mode = "emulator" if qnn_config.enable_x86_64 else "remote"
     globals()[f"verify_output_{mode}"](
         module=module,
         inputs=inputs,

--- a/backends/qualcomm/tests/rework/gpu/conftest.py
+++ b/backends/qualcomm/tests/rework/gpu/conftest.py
@@ -3,3 +3,40 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from typing import Any
+
+import pytest
+
+from executorch.backends.qualcomm.export_utils import (
+    generate_gpu_compiler_spec,
+    generate_qnn_executorch_compiler_spec,
+    QcomChipset,
+)
+
+
+def with_gpu_context(func):
+    def wrapper(request, kwargs):
+        preserved = {k: kwargs.pop(k) for k in ["expected"]}
+        qnn_config = request.getfixturevalue("qnn_config")
+        fixtures = {
+            "quantizer": None,
+            "compile_spec": generate_qnn_executorch_compiler_spec(
+                soc_model=getattr(QcomChipset, qnn_config.soc_model),
+                backend_options=generate_gpu_compiler_spec(),
+                online_prepare=True,
+            ),
+        }
+        return func(request, fixtures | preserved)
+
+    return wrapper
+
+
+def enumerate_fp_dtype(metric: Any):
+    def wrapper(test_body):
+        return pytest.mark.parametrize(
+            "kwargs",
+            [pytest.param({"act": None, "expected": metric}, id="fp")],
+        )(test_body)
+
+    return wrapper

--- a/backends/qualcomm/tests/rework/gpu/feature/conftest.py
+++ b/backends/qualcomm/tests/rework/gpu/feature/conftest.py
@@ -1,0 +1,37 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import inspect
+from functools import lru_cache
+
+import pytest
+
+from executorch.backends.qualcomm.export_utils import (
+    generate_gpu_compiler_spec,
+    generate_qnn_executorch_compiler_spec,
+)
+
+
+@pytest.fixture(scope="session")
+def compile_specs():
+    @lru_cache()
+    def _build(kwargs_config):
+        kwargs = dict(kwargs_config)
+        et_compile_spec_sig = set(
+            inspect.signature(generate_qnn_executorch_compiler_spec).parameters.keys()
+        )
+        et_compile_spec_kwargs = {
+            k: kwargs[k] for k in kwargs.keys() if k in et_compile_spec_sig
+        }
+        for k in et_compile_spec_kwargs.keys():
+            kwargs.pop(k)
+
+        return generate_qnn_executorch_compiler_spec(
+            backend_options=generate_gpu_compiler_spec(**kwargs),
+            **et_compile_spec_kwargs,
+        )
+
+    return lambda kwargs_config: _build(kwargs_config)

--- a/backends/qualcomm/tests/rework/gpu/feature/test.py
+++ b/backends/qualcomm/tests/rework/gpu/feature/test.py
@@ -3,3 +3,85 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import Tolerance
+from executorch.backends.qualcomm.tests.rework.src.feature import *  # noqa: F403
+
+
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_logging(request, kwargs):
+    Logging.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.skip(reason="multiple graphs is not supported with online-prepare")
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_multi_graph_inference(request, kwargs):
+    MultiGraph.test_inference(request, kwargs)  # noqa: F405
+
+
+# GPU requires online_prepare=True
+@pytest.mark.parametrize("kwargs", [pytest.param({"expected": Tolerance()}, id="e2e")])
+def test_online_prepare(request, kwargs):
+    OnlinePrepare.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_performance(request, kwargs):
+    Performance.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_profile(request, kwargs):
+    Profile.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_saver(request, kwargs):
+    Saver.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize("kwargs", [pytest.param({"expected": Tolerance()}, id="e2e")])
+def test_shared_buffer(request, kwargs):
+    SharedBuffer.test(request, kwargs)  # noqa: F405
+
+
+# SpillFill is HTP-specific (uses use_multi_contexts / SRAM spill-fill)
+@pytest.mark.skip(reason="SpillFill is HTP-specific; not applicable to GPU backend")
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_spill_fill(request, kwargs):
+    SpillFill.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.skip(reason="TBD on native GPU support")
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_tensor_dump(request, kwargs):
+    TensorDump.test(request, kwargs)  # noqa: F405
+
+
+# MultiGraph weight sharing is not supported on GPU
+@pytest.mark.skip(
+    reason="Weight sharing across multiple graphs is not supported on GPU backend"
+)
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_multi_graph_weight_sharing(request, kwargs):
+    MultiGraph.test_weight_sharing(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/gpu/op/test.py
+++ b/backends/qualcomm/tests/rework/gpu/op/test.py
@@ -3,3 +3,1282 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import (
+    check_exception,
+    EXCEPTION_EXIR_PROGRAM,
+    EXCEPTION_FROM_PASSES,
+    EXPECT_NOT_FULLY_DELEGATED,
+    Tolerance,
+)
+from executorch.backends.qualcomm.tests.rework.src.op import *  # noqa: F403
+from executorch.backends.qualcomm.tests.rework.gpu.conftest import (
+    enumerate_fp_dtype,
+    with_gpu_context,
+)
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_abs(request, kwargs):
+    Abs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_acos(request, kwargs):
+    ACos.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "expected": pytest.raises(
+                    Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)
+                ),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_adaptive_avg_pool_1d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_1d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_adaptive_avg_pool_1d(request, kwargs):
+    AdaptiveAvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "expected": pytest.raises(
+                    Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)
+                ),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_adaptive_avg_pool_2d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_2d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_adaptive_avg_pool_2d(request, kwargs):
+    AdaptiveAvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "expected": pytest.raises(
+                    AssertionError, match=EXPECT_NOT_FULLY_DELEGATED
+                ),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_adaptive_avg_pool_3d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_3d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+# 3D pooling is not supported on GPU
+@enumerate_fp_dtype(pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED))
+@with_gpu_context
+def test_adaptive_avg_pool_3d(request, kwargs):
+    AdaptiveAvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_adaptive_max_pool_2d(request, kwargs):
+    AdaptiveMaxPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED))
+@with_gpu_context
+def test_adaptive_max_pool_2d_with_indices(request, kwargs):
+    AdaptiveMaxPool.test_2d_with_indices(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_add(request, kwargs):
+    Add.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_addmm(request, kwargs):
+    AddMM.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_alias(request, kwargs):
+    Alias.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_amax(request, kwargs):
+    AMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_amin(request, kwargs):
+    AMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_any(request, kwargs):
+    Any.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_arange_dtype_int(request, kwargs):
+    Arange.test_dtype_int(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_arange_dtype_float(request, kwargs):
+    Arange.test_dtype_float(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_argmax(request, kwargs):
+    ArgMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_argmin(request, kwargs):
+    ArgMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_asin(request, kwargs):
+    ASin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_atan(request, kwargs):
+    ATan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_atan2(request, kwargs):
+    ATan2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_avgpool_1d(request, kwargs):
+    AvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_avgpool_2d(request, kwargs):
+    AvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+# 3D pooling is not supported on GPU
+@enumerate_fp_dtype(pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED))
+@with_gpu_context
+def test_avgpool_3d(request, kwargs):
+    AvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_batchnorm_2d(request, kwargs):
+    BatchNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_bitwise_and_numeric(request, kwargs):
+    BitwiseOp.test_and_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_bitwise_and_bool(request, kwargs):
+    BitwiseOp.test_and_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_bitwise_or_numeric(request, kwargs):
+    BitwiseOp.test_or_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_bitwise_or_bool(request, kwargs):
+    BitwiseOp.test_or_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_bitwise_xor_numeric(request, kwargs):
+    BitwiseOp.test_xor_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_bitwise_xor_bool(request, kwargs):
+    BitwiseOp.test_xor_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_bmm(request, kwargs):
+    Bmm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_cast(request, kwargs):
+    Cast.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_cat(request, kwargs):
+    Cat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_cdist(request, kwargs):
+    CDist.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_ceil(request, kwargs):
+    Ceil.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_channel_shuffle(request, kwargs):
+    ChannelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_chunk(request, kwargs):
+    Chunk.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_clamp(request, kwargs):
+    Clamp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_clamp_max(request, kwargs):
+    ClampMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_clamp_min(request, kwargs):
+    ClampMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_clone(request, kwargs):
+    Clone.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_conv1d(request, kwargs):
+    Conv.test_1d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_conv1d_transpose(request, kwargs):
+    Conv.test_1d_transpose(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_conv2d(request, kwargs):
+    Conv.test_2d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_conv2d_transpose(request, kwargs):
+    Conv.test_2d_transpose(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_conv2d_linear_like(request, kwargs):
+    Conv.test_2d_linear_like(request, kwargs)  # noqa: F405
+
+
+# 3D convolution is not supported on GPU
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": pytest.raises(
+                    AssertionError, match=EXPECT_NOT_FULLY_DELEGATED
+                ),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_conv3d(request, kwargs):
+    Conv.test_3d(request, kwargs)  # noqa: F405
+
+
+# 3D convolution is not supported on GPU
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": pytest.raises(
+                    AssertionError, match=EXPECT_NOT_FULLY_DELEGATED
+                ),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_conv3d_transpose(request, kwargs):
+    Conv.test_3d_transpose(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_cos(request, kwargs):
+    Cos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_cumsum(request, kwargs):
+    CumSum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_div(request, kwargs):
+    Div.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_div_with_rounding_mode(request, kwargs):
+    DivWithRoundingMode.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_einsum(request, kwargs):
+    Einsum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_elu(request, kwargs):
+    Elu.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_embedding(request, kwargs):
+    Embedding.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_equal(request, kwargs):
+    Equal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_exp(request, kwargs):
+    Exp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_expand(request, kwargs):
+    Expand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_expand_as(request, kwargs):
+    ExpandAs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_expm1(request, kwargs):
+    ExpM1.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_fill(request, kwargs):
+    Fill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_flip(request, kwargs):
+    Flip.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_floor(request, kwargs):
+    Floor.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_floor_divide(request, kwargs):
+    FloorDivide.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_fold(request, kwargs):
+    Fold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(
+    pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES))
+)
+@with_gpu_context
+def test_fold_unsupported_parameters(request, kwargs):
+    Fold.test_unsupported_parameters(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_full(request, kwargs):
+    Full.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_full_like(request, kwargs):
+    FullLike.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_gather(request, kwargs):
+    Gather.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_gelu(request, kwargs):
+    Gelu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_glu(request, kwargs):
+    Glu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_greater(request, kwargs):
+    Greater.test_gt(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_greater_equal(request, kwargs):
+    Greater.test_ge(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_grid_sample_4d(request, kwargs):
+    GridSample.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_grid_sample_5d(request, kwargs):
+    GridSample.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_group_norm(request, kwargs):
+    GroupNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_hardsigmoid(request, kwargs):
+    HardSigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_hardswish(request, kwargs):
+    HardSwish.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_hardtanh(request, kwargs):
+    HardTanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_index(request, kwargs):
+    Index.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_index_copy(request, kwargs):
+    IndexCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_index_put(request, kwargs):
+    IndexPut.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_index_select(request, kwargs):
+    IndexSelect.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_instance_norm_2d(request, kwargs):
+    InstanceNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_interpolate_bicubic(request, kwargs):
+    Interpolate.test_bicubic(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_interpolate_bilinear(request, kwargs):
+    Interpolate.test_bilinear(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_interpolate_nearest(request, kwargs):
+    Interpolate.test_nearest(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_is_inf(request, kwargs):
+    IsInf.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance())
+@with_gpu_context
+def test_is_nan(request, kwargs):
+    IsNan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_layer_norm(request, kwargs):
+    LayerNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_leaky_relu(request, kwargs):
+    LeakyReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_less_equal(request, kwargs):
+    LessEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_less_than(request, kwargs):
+    LessThan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_linalg_vector_norm(request, kwargs):
+    LinalgVectorNorm.test(request, kwargs)  # noqa: F405
+
+
+# test_linear_block_quant has no fp variant (lpbq is quantization-specific)
+@pytest.mark.skip(reason="LPBQ quantization is not applicable to GPU fp mode")
+@pytest.mark.parametrize("kwargs", [pytest.param({}, id="16a4w_lpbq")])
+@with_gpu_context
+def test_linear_block_quant(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_linear_general(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_gpu_context
+def test_linear_non_constant_weight(request, kwargs):
+    LinearNonConstantWeight.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_log(request, kwargs):
+    Log.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_log10(request, kwargs):
+    Log10.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_log1p(request, kwargs):
+    Log1p.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_log2(request, kwargs):
+    Log2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_log_softmax(request, kwargs):
+    LogSoftmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_logical_and(request, kwargs):
+    LogicalAnd.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_logical_not(request, kwargs):
+    LogicalNot.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_masked_fill(request, kwargs):
+    MaskedFill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_max_dim(request, kwargs):
+    MaxDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_maximum(request, kwargs):
+    Maximum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_maxpool_2d(request, kwargs):
+    MaxPool2d.test(request, kwargs)  # noqa: F405
+
+
+# 3D pooling is not supported on GPU
+@enumerate_fp_dtype(pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED))
+@with_gpu_context
+def test_maxpool_3d(request, kwargs):
+    MaxPool3d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_mean(request, kwargs):
+    Mean.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_mha(request, kwargs):
+    MultiheadAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_min_dim(request, kwargs):
+    MinDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_minimum(request, kwargs):
+    Minimum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_narrow(request, kwargs):
+    Narrow.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_neg(request, kwargs):
+    Neg.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_not_equal(request, kwargs):
+    NotEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_pad_constant(request, kwargs):
+    Pad.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_pad_reflect(request, kwargs):
+    Pad.test_reflect(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_permute(request, kwargs):
+    Permute.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_pixel_shuffle(request, kwargs):
+    PixelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_pixel_unshuffle(request, kwargs):
+    PixelUnshuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_pow_scalar(request, kwargs):
+    PowScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_pow_tensor_scalar(request, kwargs):
+    PowTensorScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_prelu(request, kwargs):
+    PReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED))
+@with_gpu_context
+def test_rand(request, kwargs):
+    Rand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_reciprocal(request, kwargs):
+    Reciprocal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_reflection_pad_1d(request, kwargs):
+    ReflectionPad.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_reflection_pad_2d(request, kwargs):
+    ReflectionPad.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_reflection_pad_3d(request, kwargs):
+    ReflectionPad.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_relu(request, kwargs):
+    Relu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_relu6(request, kwargs):
+    Relu6.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_remainder(request, kwargs):
+    Remainder.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_repeat(request, kwargs):
+    Repeat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_reshape_2d_to_4d_random_reshape(request, kwargs):
+    Reshape.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_reshape_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_reshape_5d_random_reshape(request, kwargs):
+    Reshape.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_reshape_5d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_rms_norm(request, kwargs):
+    RmsNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_roll(request, kwargs):
+    Roll.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_round(request, kwargs):
+    Round.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_rsqrt(request, kwargs):
+    Rsqrt.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_sdpa(request, kwargs):
+    ScaledDotProductAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_scatter_src(request, kwargs):
+    ScatterSrc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_select_copy(request, kwargs):
+    SelectCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_select_scatter(request, kwargs):
+    SelectScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_sigmoid(request, kwargs):
+    Sigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_sign(request, kwargs):
+    Sign.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_sin(request, kwargs):
+    Sin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_slice_copy(request, kwargs):
+    SliceCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_slice_scatter(request, kwargs):
+    SliceScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(pytest.raises(AssertionError))
+@with_gpu_context
+def test_scatter_value(request, kwargs):
+    ScatterValue.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_softmax(request, kwargs):
+    Softmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(pytest.raises(AssertionError))
+@with_gpu_context
+def test_sort(request, kwargs):
+    Sort.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_split(request, kwargs):
+    Split.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_square(request, kwargs):
+    Square.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_squeeze(request, kwargs):
+    Squeeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_stack(request, kwargs):
+    Stack.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_sum_int_list(request, kwargs):
+    SumIntList.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_swapaxes(request, kwargs):
+    SwapAxes.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_tan(request, kwargs):
+    Tan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_tanh(request, kwargs):
+    Tanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_threshold(request, kwargs):
+    Threshold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_triu(request, kwargs):
+    Triu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_triu_constant(request, kwargs):
+    Triu.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_trunc(request, kwargs):
+    Trunc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_topk(request, kwargs):
+    TopK.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_unbind(request, kwargs):
+    Unbind.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_unflatten(request, kwargs):
+    Unflatten.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_unfold(request, kwargs):
+    Unfold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(
+    pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES))
+)
+@with_gpu_context
+def test_unfold_unsupported(request, kwargs):
+    Unfold.test_unsupported(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_unsqueeze(request, kwargs):
+    Unsqueeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_view_2d_to_4d_random_reshape(request, kwargs):
+    View.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_view_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    View.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_view_5d_random_reshape(request, kwargs):
+    View.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_view_5d_flatten_last_two_dims(request, kwargs):
+    View.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_where(request, kwargs):
+    Where.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_fp_dtype(Tolerance(rtol=1e-1))
+@with_gpu_context
+def test_var(request, kwargs):
+    Var.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/feature/v69/test.py
+++ b/backends/qualcomm/tests/rework/htp/feature/v69/test.py
@@ -3,3 +3,110 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import Tolerance
+from executorch.backends.qualcomm.tests.rework.src.feature import *  # noqa: F403
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_logging(request, kwargs):
+    Logging.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_multi_graph_weight_sharing(request, kwargs):
+    MultiGraph.test_weight_sharing(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_multi_graph_inference(request, kwargs):
+    MultiGraph.test_inference(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_online_prepare(request, kwargs):
+    OnlinePrepare.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_performance(request, kwargs):
+    Performance.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_profile(request, kwargs):
+    Profile.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_saver(request, kwargs):
+    Saver.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_shared_buffer(request, kwargs):
+    SharedBuffer.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_spill_fill(request, kwargs):
+    SpillFill.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_tensor_dump(request, kwargs):
+    TensorDump.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/feature/v73/test.py
+++ b/backends/qualcomm/tests/rework/htp/feature/v73/test.py
@@ -3,3 +3,110 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import Tolerance
+from executorch.backends.qualcomm.tests.rework.src.feature import *  # noqa: F403
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_logging(request, kwargs):
+    Logging.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_multi_graph_weight_sharing(request, kwargs):
+    MultiGraph.test_weight_sharing(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_multi_graph_inference(request, kwargs):
+    MultiGraph.test_inference(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_online_prepare(request, kwargs):
+    OnlinePrepare.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_performance(request, kwargs):
+    Performance.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_profile(request, kwargs):
+    Profile.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_saver(request, kwargs):
+    Saver.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_shared_buffer(request, kwargs):
+    SharedBuffer.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_spill_fill(request, kwargs):
+    SpillFill.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_tensor_dump(request, kwargs):
+    TensorDump.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/feature/v75/test.py
+++ b/backends/qualcomm/tests/rework/htp/feature/v75/test.py
@@ -3,3 +3,110 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import Tolerance
+from executorch.backends.qualcomm.tests.rework.src.feature import *  # noqa: F403
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_logging(request, kwargs):
+    Logging.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_multi_graph_weight_sharing(request, kwargs):
+    MultiGraph.test_weight_sharing(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_multi_graph_inference(request, kwargs):
+    MultiGraph.test_inference(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_online_prepare(request, kwargs):
+    OnlinePrepare.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_performance(request, kwargs):
+    Performance.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_profile(request, kwargs):
+    Profile.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_saver(request, kwargs):
+    Saver.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_shared_buffer(request, kwargs):
+    SharedBuffer.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_spill_fill(request, kwargs):
+    SpillFill.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_tensor_dump(request, kwargs):
+    TensorDump.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/feature/v79/test.py
+++ b/backends/qualcomm/tests/rework/htp/feature/v79/test.py
@@ -3,3 +3,110 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import Tolerance
+from executorch.backends.qualcomm.tests.rework.src.feature import *  # noqa: F403
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_logging(request, kwargs):
+    Logging.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_multi_graph_weight_sharing(request, kwargs):
+    MultiGraph.test_weight_sharing(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_multi_graph_inference(request, kwargs):
+    MultiGraph.test_inference(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_online_prepare(request, kwargs):
+    OnlinePrepare.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_performance(request, kwargs):
+    Performance.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_profile(request, kwargs):
+    Profile.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_saver(request, kwargs):
+    Saver.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_shared_buffer(request, kwargs):
+    SharedBuffer.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_spill_fill(request, kwargs):
+    SpillFill.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_tensor_dump(request, kwargs):
+    TensorDump.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/feature/v81/test.py
+++ b/backends/qualcomm/tests/rework/htp/feature/v81/test.py
@@ -3,3 +3,110 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import Tolerance
+from executorch.backends.qualcomm.tests.rework.src.feature import *  # noqa: F403
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_logging(request, kwargs):
+    Logging.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_multi_graph_weight_sharing(request, kwargs):
+    MultiGraph.test_weight_sharing(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_multi_graph_inference(request, kwargs):
+    MultiGraph.test_inference(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_online_prepare(request, kwargs):
+    OnlinePrepare.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_performance(request, kwargs):
+    Performance.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_profile(request, kwargs):
+    Profile.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_saver(request, kwargs):
+    Saver.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_shared_buffer(request, kwargs):
+    SharedBuffer.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_spill_fill(request, kwargs):
+    SpillFill.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"expected": nullcontext()}, id="e2e"),
+    ],
+)
+def test_tensor_dump(request, kwargs):
+    TensorDump.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/op/v68/test.py
+++ b/backends/qualcomm/tests/rework/htp/op/v68/test.py
@@ -15,7 +15,6 @@ from executorch.backends.qualcomm.tests.rework.conftest import (
     CosineSimilarity,
     EXCEPTION_EXIR_PROGRAM,
     EXCEPTION_FROM_PASSES,
-    EXPECT_NOT_ANNOTATED,
     EXPECT_NOT_FULLY_DELEGATED,
     SkipOutputCheck,
     Tolerance,
@@ -151,25 +150,13 @@ def test_amin(request, kwargs):
     AMin.test(request, kwargs)  # noqa: F405
 
 
-@enumerate_activation_dtype(
-    [
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        Tolerance(rtol=1e-1),
-    ]
-)
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
 @with_htp_context
 def test_any(request, kwargs):
     Any.test(request, kwargs)  # noqa: F405
 
 
-@enumerate_activation_dtype(
-    [
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        Tolerance(rtol=1e-1),
-    ]
-)
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
 @with_htp_context
 def test_arange_dtype_int(request, kwargs):
     Arange.test_dtype_int(request, kwargs)  # noqa: F405
@@ -255,8 +242,8 @@ def test_batchnorm_2d(request, kwargs):
 
 @enumerate_activation_dtype(
     [
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
         pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
     ]
 )
@@ -265,13 +252,7 @@ def test_bitwise_and_numeric(request, kwargs):
     BitwiseOp.test_and_numeric(request, kwargs)  # noqa: F405
 
 
-@enumerate_activation_dtype(
-    [
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        Tolerance(rtol=1e-1),
-    ]
-)
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
 @with_htp_context
 def test_bitwise_and_bool(request, kwargs):
     BitwiseOp.test_and_bool(request, kwargs)  # noqa: F405
@@ -279,8 +260,8 @@ def test_bitwise_and_bool(request, kwargs):
 
 @enumerate_activation_dtype(
     [
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
         pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
     ]
 )
@@ -289,13 +270,7 @@ def test_bitwise_or_numeric(request, kwargs):
     BitwiseOp.test_or_numeric(request, kwargs)  # noqa: F405
 
 
-@enumerate_activation_dtype(
-    [
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        Tolerance(rtol=1e-1),
-    ]
-)
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
 @with_htp_context
 def test_bitwise_or_bool(request, kwargs):
     BitwiseOp.test_or_bool(request, kwargs)  # noqa: F405
@@ -303,8 +278,8 @@ def test_bitwise_or_bool(request, kwargs):
 
 @enumerate_activation_dtype(
     [
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
         pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
     ]
 )
@@ -313,13 +288,7 @@ def test_bitwise_xor_numeric(request, kwargs):
     BitwiseOp.test_xor_numeric(request, kwargs)  # noqa: F405
 
 
-@enumerate_activation_dtype(
-    [
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        Tolerance(rtol=1e-1),
-    ]
-)
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
 @with_htp_context
 def test_bitwise_xor_bool(request, kwargs):
     BitwiseOp.test_xor_bool(request, kwargs)  # noqa: F405
@@ -818,25 +787,13 @@ def test_interpolate_nearest(request, kwargs):
     Interpolate.test_nearest(request, kwargs)  # noqa: F405
 
 
-@enumerate_activation_dtype(
-    [
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        Tolerance(rtol=1e-1),
-    ]
-)
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
 @with_htp_context
 def test_is_inf(request, kwargs):
     IsInf.test(request, kwargs)  # noqa: F405
 
 
-@enumerate_activation_dtype(
-    [
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
-        Tolerance(),
-    ]
-)
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance()])
 @with_htp_context
 def test_is_nan(request, kwargs):
     IsNan.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/op/v69/test.py
+++ b/backends/qualcomm/tests/rework/htp/op/v69/test.py
@@ -3,3 +3,1411 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+import re
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import (
+    check_exception,
+    CosineSimilarity,
+    EXCEPTION_EXIR_PROGRAM,
+    EXCEPTION_FROM_PASSES,
+    EXPECT_NOT_FULLY_DELEGATED,
+    SkipOutputCheck,
+    Tolerance,
+)
+from executorch.backends.qualcomm.tests.rework.src.op import *  # noqa: F403
+from executorch.backends.qualcomm.tests.rework.htp.conftest import (
+    enumerate_activation_dtype,
+    with_htp_context,
+)
+
+# e.g. get 69 from ".../rework/htp/unit_test/op/v69/test.py"
+HTP_ARCH = int(re.search(r".*v([0-9]+)$", Path(__file__).parent.name).group(1))
+with_htp_context = partial(with_htp_context, hw_arch=HTP_ARCH)
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_abs(request, kwargs):
+    Abs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_acos(request, kwargs):
+    ACos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_1d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_1d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_1d(request, kwargs):
+    AdaptiveAvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_2d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_2d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_2d(request, kwargs):
+    AdaptiveAvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_3d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_3d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_3d(request, kwargs):
+    AdaptiveAvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_max_pool_2d(request, kwargs):
+    AdaptiveMaxPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_adaptive_max_pool_2d_with_indices(request, kwargs):
+    AdaptiveMaxPool.test_2d_with_indices(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_add(request, kwargs):
+    Add.test(request, kwargs)  # noqa: F405
+
+
+# addmm 16a requires V73+; still fails on V69
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        Tolerance(rtol=1e-1),
+    ]
+)
+@with_htp_context
+def test_addmm(request, kwargs):
+    AddMM.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_alias(request, kwargs):
+    Alias.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_amax(request, kwargs):
+    AMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_amin(request, kwargs):
+    AMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_any(request, kwargs):
+    Any.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_arange_dtype_int(request, kwargs):
+    Arange.test_dtype_int(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_arange_dtype_float(request, kwargs):
+    Arange.test_dtype_float(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_argmax(request, kwargs):
+    ArgMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_argmin(request, kwargs):
+    ArgMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_asin(request, kwargs):
+    ASin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_atan(request, kwargs):
+    ATan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_atan2(request, kwargs):
+    ATan2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_1d(request, kwargs):
+    AvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_2d(request, kwargs):
+    AvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_3d(request, kwargs):
+    AvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_batchnorm_2d(request, kwargs):
+    BatchNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_and_numeric(request, kwargs):
+    BitwiseOp.test_and_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_and_bool(request, kwargs):
+    BitwiseOp.test_and_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_or_numeric(request, kwargs):
+    BitwiseOp.test_or_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_or_bool(request, kwargs):
+    BitwiseOp.test_or_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_xor_numeric(request, kwargs):
+    BitwiseOp.test_xor_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_xor_bool(request, kwargs):
+    BitwiseOp.test_xor_bool(request, kwargs)  # noqa: F405
+
+
+# bmm 16a requires V73+; still fails on V69
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        Tolerance(rtol=1e-1),
+    ]
+)
+@with_htp_context
+def test_bmm(request, kwargs):
+    Bmm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cast(request, kwargs):
+    Cast.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cat(request, kwargs):
+    Cat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cdist(request, kwargs):
+    CDist.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_ceil(request, kwargs):
+    Ceil.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_channel_shuffle(request, kwargs):
+    ChannelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_chunk(request, kwargs):
+    Chunk.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp(request, kwargs):
+    Clamp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp_max(request, kwargs):
+    ClampMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp_min(request, kwargs):
+    ClampMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clone(request, kwargs):
+    Clone.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv1d(request, kwargs):
+    Conv.test_1d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv1d_transpose(request, kwargs):
+    Conv.test_1d_transpose(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv2d(request, kwargs):
+    Conv.test_2d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv2d_transpose(request, kwargs):
+    Conv.test_2d_transpose(request, kwargs)  # noqa: F405
+
+
+# LPBQ (QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION) requires V69+; enabled here
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 4,
+                "lpbq": True,
+                "block_sz_map": {"conv2d": (1, 32, 1, 1)},
+                "expected": Tolerance(),
+            },
+            id="16a4w_lpbq",
+        ),
+        pytest.param(
+            {"act": "fp16", "param": 8, "pcq": True, "expected": Tolerance()},
+            id="fp16a8w_pcq",
+        ),
+    ],
+)
+@with_htp_context
+def test_conv2d_linear_like(request, kwargs):
+    Conv.test_2d_linear_like(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            # no bitwidth support for conv3d
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv3d(request, kwargs):
+    Conv.test_3d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            # no bitwidth support for conv3d
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv3d_transpose(request, kwargs):
+    Conv.test_3d_transpose(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cos(request, kwargs):
+    Cos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cumsum(request, kwargs):
+    CumSum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_div(request, kwargs):
+    Div.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_div_with_rounding_mode(request, kwargs):
+    DivWithRoundingMode.test(request, kwargs)  # noqa: F405
+
+
+# einsum 16a requires V73+; still fails on V69
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        Tolerance(rtol=1e-1),
+    ]
+)
+@with_htp_context
+def test_einsum(request, kwargs):
+    Einsum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_elu(request, kwargs):
+    Elu.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, False, Tolerance(), "8a8w_ptq"),
+            (16, 16, False, Tolerance(), "16a16w_ptq"),
+            (16, 8, True, Tolerance(), "16a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_embedding(request, kwargs):
+    Embedding.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_equal(request, kwargs):
+    Equal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_exp(request, kwargs):
+    Exp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expand(request, kwargs):
+    Expand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expand_as(request, kwargs):
+    ExpandAs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expm1(request, kwargs):
+    ExpM1.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_fill(request, kwargs):
+    Fill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_flip(request, kwargs):
+    Flip.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_floor(request, kwargs):
+    Floor.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_floor_divide(request, kwargs):
+    FloorDivide.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_fold(request, kwargs):
+    Fold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_htp_context
+def test_fold_unsupported_parameters(request, kwargs):
+    Fold.test_unsupported_parameters(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_full(request, kwargs):
+    Full.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_full_like(request, kwargs):
+    FullLike.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_gather(request, kwargs):
+    Gather.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_gelu(request, kwargs):
+    Gelu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_glu(request, kwargs):
+    Glu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_greater(request, kwargs):
+    Greater.test_gt(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_greater_equal(request, kwargs):
+    Greater.test_ge(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_grid_sample_4d(request, kwargs):
+    GridSample.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        CosineSimilarity(0.95),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_grid_sample_5d(request, kwargs):
+    GridSample.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_group_norm(request, kwargs):
+    GroupNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardsigmoid(request, kwargs):
+    HardSigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardswish(request, kwargs):
+    HardSwish.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardtanh(request, kwargs):
+    HardTanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index(request, kwargs):
+    Index.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_copy(request, kwargs):
+    IndexCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_put(request, kwargs):
+    IndexPut.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_select(request, kwargs):
+    IndexSelect.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_instance_norm_2d(request, kwargs):
+    InstanceNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_bicubic(request, kwargs):
+    Interpolate.test_bicubic(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_bilinear(request, kwargs):
+    Interpolate.test_bilinear(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_nearest(request, kwargs):
+    Interpolate.test_nearest(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_is_inf(request, kwargs):
+    IsInf.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance()])
+@with_htp_context
+def test_is_nan(request, kwargs):
+    IsNan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_layer_norm(request, kwargs):
+    LayerNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_leaky_relu(request, kwargs):
+    LeakyReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_less_equal(request, kwargs):
+    LessEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_less_than(request, kwargs):
+    LessThan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_linalg_vector_norm(request, kwargs):
+    LinalgVectorNorm.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 4,
+                "pcq": False,
+                "lpbq": True,
+                "block_sz_map": {"linear": (1, 32)},
+                "expected": Tolerance(),
+            },
+            id="16a4w_lpbq",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_block_quant(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 16, "param": 16, "pcq": False, "expected": Tolerance()},
+            id="16a16w_ptq",
+        ),
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 4, "pcq": True, "expected": CosineSimilarity(0.95)},
+            id="16a4w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="16a8w_pcq",
+        ),
+        pytest.param(
+            {"act": "fp16", "param": 8, "pcq": True, "expected": Tolerance()},
+            id="fp16a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 2, "pcq": True, "expected": CosineSimilarity(0.9)},
+            id="16a2w_pcq",
+        ),
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_general(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 16,
+                "pcq": False,
+                "expected": pytest.raises(AssertionError, match=Tolerance()),
+            },
+            id="16a16w_ptq",
+        ),
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_non_constant_weight(request, kwargs):
+    LinearNonConstantWeight.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log(request, kwargs):
+    Log.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log10(request, kwargs):
+    Log10.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log1p(request, kwargs):
+    Log1p.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log2(request, kwargs):
+    Log2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log_softmax(request, kwargs):
+    LogSoftmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_logical_and(request, kwargs):
+    LogicalAnd.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_logical_not(request, kwargs):
+    LogicalNot.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_masked_fill(request, kwargs):
+    MaskedFill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_max_dim(request, kwargs):
+    MaxDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maximum(request, kwargs):
+    Maximum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maxpool_2d(request, kwargs):
+    MaxPool2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maxpool_3d(request, kwargs):
+    MaxPool3d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_mean(request, kwargs):
+    Mean.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_mha(request, kwargs):
+    MultiheadAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_min_dim(request, kwargs):
+    MinDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_minimum(request, kwargs):
+    Minimum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_narrow(request, kwargs):
+    Narrow.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_neg(request, kwargs):
+    Neg.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_not_equal(request, kwargs):
+    NotEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pad_constant(request, kwargs):
+    Pad.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pad_reflect(request, kwargs):
+    Pad.test_reflect(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_permute(request, kwargs):
+    Permute.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pixel_shuffle(request, kwargs):
+    PixelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pixel_unshuffle(request, kwargs):
+    PixelUnshuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pow_scalar(request, kwargs):
+    PowScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pow_tensor_scalar(request, kwargs):
+    PowTensorScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_prelu(request, kwargs):
+    PReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        SkipOutputCheck(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_rand(request, kwargs):
+    Rand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reciprocal(request, kwargs):
+    Reciprocal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_1d(request, kwargs):
+    ReflectionPad.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_2d(request, kwargs):
+    ReflectionPad.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_3d(request, kwargs):
+    ReflectionPad.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_relu(request, kwargs):
+    Relu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_relu6(request, kwargs):
+    Relu6.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_remainder(request, kwargs):
+    Remainder.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_repeat(request, kwargs):
+    Repeat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_2d_to_4d_random_reshape(request, kwargs):
+    Reshape.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_5d_random_reshape(request, kwargs):
+    Reshape.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_5d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_rms_norm(request, kwargs):
+    RmsNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_roll(request, kwargs):
+    Roll.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_round(request, kwargs):
+    Round.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_rsqrt(request, kwargs):
+    Rsqrt.test(request, kwargs)  # noqa: F405
+
+
+# sdpa 16a requires V73+; still fails on V69
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        Tolerance(rtol=1e-1),
+    ]
+)
+@with_htp_context
+def test_sdpa(request, kwargs):
+    ScaledDotProductAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_scatter_src(request, kwargs):
+    ScatterSrc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_select_copy(request, kwargs):
+    SelectCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_select_scatter(request, kwargs):
+    SelectScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sigmoid(request, kwargs):
+    Sigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sign(request, kwargs):
+    Sign.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sin(request, kwargs):
+    Sin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_slice_copy(request, kwargs):
+    SliceCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_slice_scatter(request, kwargs):
+    SliceScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_scatter_value(request, kwargs):
+    ScatterValue.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_softmax(request, kwargs):
+    Softmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_sort(request, kwargs):
+    Sort.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_split(request, kwargs):
+    Split.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_square(request, kwargs):
+    Square.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_squeeze(request, kwargs):
+    Squeeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_stack(request, kwargs):
+    Stack.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sum_int_list(request, kwargs):
+    SumIntList.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_swapaxes(request, kwargs):
+    SwapAxes.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_tan(request, kwargs):
+    Tan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_tanh(request, kwargs):
+    Tanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_threshold(request, kwargs):
+    Threshold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_triu(request, kwargs):
+    Triu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_triu_constant(request, kwargs):
+    Triu.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_trunc(request, kwargs):
+    Trunc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_topk(request, kwargs):
+    TopK.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unbind(request, kwargs):
+    Unbind.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unflatten(request, kwargs):
+    Unflatten.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unfold(request, kwargs):
+    Unfold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_htp_context
+def test_unfold_unsupported(request, kwargs):
+    Unfold.test_unsupported(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unsqueeze(request, kwargs):
+    Unsqueeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_2d_to_4d_random_reshape(request, kwargs):
+    View.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    View.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_5d_random_reshape(request, kwargs):
+    View.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_5d_flatten_last_two_dims(request, kwargs):
+    View.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_where(request, kwargs):
+    Where.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_var(request, kwargs):
+    Var.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/op/v73/test.py
+++ b/backends/qualcomm/tests/rework/htp/op/v73/test.py
@@ -3,3 +3,1387 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+import re
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import (
+    check_exception,
+    CosineSimilarity,
+    EXCEPTION_EXIR_PROGRAM,
+    EXCEPTION_FROM_PASSES,
+    EXPECT_NOT_FULLY_DELEGATED,
+    SkipOutputCheck,
+    Tolerance,
+)
+from executorch.backends.qualcomm.tests.rework.src.op import *  # noqa: F403
+from executorch.backends.qualcomm.tests.rework.htp.conftest import (
+    enumerate_activation_dtype,
+    with_htp_context,
+)
+
+# e.g. get 73 from ".../rework/htp/unit_test/op/v73/test.py"
+HTP_ARCH = int(re.search(r".*v([0-9]+)$", Path(__file__).parent.name).group(1))
+with_htp_context = partial(with_htp_context, hw_arch=HTP_ARCH)
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_abs(request, kwargs):
+    Abs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_acos(request, kwargs):
+    ACos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_1d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_1d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_1d(request, kwargs):
+    AdaptiveAvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_2d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_2d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_2d(request, kwargs):
+    AdaptiveAvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_3d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_3d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_3d(request, kwargs):
+    AdaptiveAvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_max_pool_2d(request, kwargs):
+    AdaptiveMaxPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_adaptive_max_pool_2d_with_indices(request, kwargs):
+    AdaptiveMaxPool.test_2d_with_indices(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_add(request, kwargs):
+    Add.test(request, kwargs)  # noqa: F405
+
+
+# addmm 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_addmm(request, kwargs):
+    AddMM.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_alias(request, kwargs):
+    Alias.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_amax(request, kwargs):
+    AMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_amin(request, kwargs):
+    AMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_any(request, kwargs):
+    Any.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_arange_dtype_int(request, kwargs):
+    Arange.test_dtype_int(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_arange_dtype_float(request, kwargs):
+    Arange.test_dtype_float(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_argmax(request, kwargs):
+    ArgMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_argmin(request, kwargs):
+    ArgMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_asin(request, kwargs):
+    ASin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_atan(request, kwargs):
+    ATan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_atan2(request, kwargs):
+    ATan2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_1d(request, kwargs):
+    AvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_2d(request, kwargs):
+    AvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_3d(request, kwargs):
+    AvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_batchnorm_2d(request, kwargs):
+    BatchNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_and_numeric(request, kwargs):
+    BitwiseOp.test_and_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_and_bool(request, kwargs):
+    BitwiseOp.test_and_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_or_numeric(request, kwargs):
+    BitwiseOp.test_or_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_or_bool(request, kwargs):
+    BitwiseOp.test_or_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_xor_numeric(request, kwargs):
+    BitwiseOp.test_xor_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_xor_bool(request, kwargs):
+    BitwiseOp.test_xor_bool(request, kwargs)  # noqa: F405
+
+
+# bmm 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bmm(request, kwargs):
+    Bmm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cast(request, kwargs):
+    Cast.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cat(request, kwargs):
+    Cat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cdist(request, kwargs):
+    CDist.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_ceil(request, kwargs):
+    Ceil.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_channel_shuffle(request, kwargs):
+    ChannelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_chunk(request, kwargs):
+    Chunk.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp(request, kwargs):
+    Clamp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp_max(request, kwargs):
+    ClampMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp_min(request, kwargs):
+    ClampMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clone(request, kwargs):
+    Clone.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv1d(request, kwargs):
+    Conv.test_1d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv1d_transpose(request, kwargs):
+    Conv.test_1d_transpose(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv2d(request, kwargs):
+    Conv.test_2d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv2d_transpose(request, kwargs):
+    Conv.test_2d_transpose(request, kwargs)  # noqa: F405
+
+
+# LPBQ (QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION) requires V69+; enabled here
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 4,
+                "lpbq": True,
+                "block_sz_map": {"conv2d": (1, 32, 1, 1)},
+                "expected": Tolerance(),
+            },
+            id="16a4w_lpbq",
+        ),
+        pytest.param(
+            {"act": "fp16", "param": 8, "pcq": True, "expected": Tolerance()},
+            id="fp16a8w_pcq",
+        ),
+    ],
+)
+@with_htp_context
+def test_conv2d_linear_like(request, kwargs):
+    Conv.test_2d_linear_like(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            # no bitwidth support for conv3d
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv3d(request, kwargs):
+    Conv.test_3d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            # no bitwidth support for conv3d
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv3d_transpose(request, kwargs):
+    Conv.test_3d_transpose(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cos(request, kwargs):
+    Cos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cumsum(request, kwargs):
+    CumSum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_div(request, kwargs):
+    Div.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_div_with_rounding_mode(request, kwargs):
+    DivWithRoundingMode.test(request, kwargs)  # noqa: F405
+
+
+# einsum 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_einsum(request, kwargs):
+    Einsum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_elu(request, kwargs):
+    Elu.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, False, Tolerance(), "8a8w_ptq"),
+            (16, 16, False, Tolerance(), "16a16w_ptq"),
+            (16, 8, True, Tolerance(), "16a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_embedding(request, kwargs):
+    Embedding.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_equal(request, kwargs):
+    Equal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_exp(request, kwargs):
+    Exp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expand(request, kwargs):
+    Expand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expand_as(request, kwargs):
+    ExpandAs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expm1(request, kwargs):
+    ExpM1.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_fill(request, kwargs):
+    Fill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_flip(request, kwargs):
+    Flip.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_floor(request, kwargs):
+    Floor.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_floor_divide(request, kwargs):
+    FloorDivide.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_fold(request, kwargs):
+    Fold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_htp_context
+def test_fold_unsupported_parameters(request, kwargs):
+    Fold.test_unsupported_parameters(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_full(request, kwargs):
+    Full.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_full_like(request, kwargs):
+    FullLike.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_gather(request, kwargs):
+    Gather.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_gelu(request, kwargs):
+    Gelu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_glu(request, kwargs):
+    Glu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_greater(request, kwargs):
+    Greater.test_gt(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_greater_equal(request, kwargs):
+    Greater.test_ge(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_grid_sample_4d(request, kwargs):
+    GridSample.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        CosineSimilarity(0.95),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_grid_sample_5d(request, kwargs):
+    GridSample.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_group_norm(request, kwargs):
+    GroupNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardsigmoid(request, kwargs):
+    HardSigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardswish(request, kwargs):
+    HardSwish.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardtanh(request, kwargs):
+    HardTanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index(request, kwargs):
+    Index.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_copy(request, kwargs):
+    IndexCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_put(request, kwargs):
+    IndexPut.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_select(request, kwargs):
+    IndexSelect.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_instance_norm_2d(request, kwargs):
+    InstanceNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_bicubic(request, kwargs):
+    Interpolate.test_bicubic(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_bilinear(request, kwargs):
+    Interpolate.test_bilinear(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_nearest(request, kwargs):
+    Interpolate.test_nearest(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_is_inf(request, kwargs):
+    IsInf.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance()])
+@with_htp_context
+def test_is_nan(request, kwargs):
+    IsNan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_layer_norm(request, kwargs):
+    LayerNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_leaky_relu(request, kwargs):
+    LeakyReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_less_equal(request, kwargs):
+    LessEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_less_than(request, kwargs):
+    LessThan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_linalg_vector_norm(request, kwargs):
+    LinalgVectorNorm.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 4,
+                "pcq": False,
+                "lpbq": True,
+                "block_sz_map": {"linear": (1, 32)},
+                "expected": Tolerance(),
+            },
+            id="16a4w_lpbq",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_block_quant(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 16, "param": 16, "pcq": False, "expected": Tolerance()},
+            id="16a16w_ptq",
+        ),
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 4, "pcq": True, "expected": CosineSimilarity(0.95)},
+            id="16a4w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="16a8w_pcq",
+        ),
+        pytest.param(
+            {"act": "fp16", "param": 8, "pcq": True, "expected": Tolerance()},
+            id="fp16a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 2, "pcq": True, "expected": CosineSimilarity(0.9)},
+            id="16a2w_pcq",
+        ),
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_general(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 16,
+                "pcq": False,
+                "expected": pytest.raises(AssertionError, match=Tolerance()),
+            },
+            id="16a16w_ptq",
+        ),
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_non_constant_weight(request, kwargs):
+    LinearNonConstantWeight.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log(request, kwargs):
+    Log.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log10(request, kwargs):
+    Log10.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log1p(request, kwargs):
+    Log1p.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log2(request, kwargs):
+    Log2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log_softmax(request, kwargs):
+    LogSoftmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_logical_and(request, kwargs):
+    LogicalAnd.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_logical_not(request, kwargs):
+    LogicalNot.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_masked_fill(request, kwargs):
+    MaskedFill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_max_dim(request, kwargs):
+    MaxDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maximum(request, kwargs):
+    Maximum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maxpool_2d(request, kwargs):
+    MaxPool2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maxpool_3d(request, kwargs):
+    MaxPool3d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_mean(request, kwargs):
+    Mean.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_mha(request, kwargs):
+    MultiheadAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_min_dim(request, kwargs):
+    MinDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_minimum(request, kwargs):
+    Minimum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_narrow(request, kwargs):
+    Narrow.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_neg(request, kwargs):
+    Neg.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_not_equal(request, kwargs):
+    NotEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pad_constant(request, kwargs):
+    Pad.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pad_reflect(request, kwargs):
+    Pad.test_reflect(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_permute(request, kwargs):
+    Permute.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pixel_shuffle(request, kwargs):
+    PixelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pixel_unshuffle(request, kwargs):
+    PixelUnshuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pow_scalar(request, kwargs):
+    PowScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pow_tensor_scalar(request, kwargs):
+    PowTensorScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_prelu(request, kwargs):
+    PReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        SkipOutputCheck(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_rand(request, kwargs):
+    Rand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reciprocal(request, kwargs):
+    Reciprocal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_1d(request, kwargs):
+    ReflectionPad.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_2d(request, kwargs):
+    ReflectionPad.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_3d(request, kwargs):
+    ReflectionPad.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_relu(request, kwargs):
+    Relu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_relu6(request, kwargs):
+    Relu6.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_remainder(request, kwargs):
+    Remainder.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_repeat(request, kwargs):
+    Repeat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_2d_to_4d_random_reshape(request, kwargs):
+    Reshape.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_5d_random_reshape(request, kwargs):
+    Reshape.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_5d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_rms_norm(request, kwargs):
+    RmsNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_roll(request, kwargs):
+    Roll.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_round(request, kwargs):
+    Round.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_rsqrt(request, kwargs):
+    Rsqrt.test(request, kwargs)  # noqa: F405
+
+
+# sdpa 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sdpa(request, kwargs):
+    ScaledDotProductAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_scatter_src(request, kwargs):
+    ScatterSrc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_select_copy(request, kwargs):
+    SelectCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_select_scatter(request, kwargs):
+    SelectScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sigmoid(request, kwargs):
+    Sigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sign(request, kwargs):
+    Sign.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sin(request, kwargs):
+    Sin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_slice_copy(request, kwargs):
+    SliceCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_slice_scatter(request, kwargs):
+    SliceScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_scatter_value(request, kwargs):
+    ScatterValue.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_softmax(request, kwargs):
+    Softmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_sort(request, kwargs):
+    Sort.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_split(request, kwargs):
+    Split.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_square(request, kwargs):
+    Square.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_squeeze(request, kwargs):
+    Squeeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_stack(request, kwargs):
+    Stack.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sum_int_list(request, kwargs):
+    SumIntList.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_swapaxes(request, kwargs):
+    SwapAxes.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_tan(request, kwargs):
+    Tan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_tanh(request, kwargs):
+    Tanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_threshold(request, kwargs):
+    Threshold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_triu(request, kwargs):
+    Triu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_triu_constant(request, kwargs):
+    Triu.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_trunc(request, kwargs):
+    Trunc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_topk(request, kwargs):
+    TopK.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unbind(request, kwargs):
+    Unbind.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unflatten(request, kwargs):
+    Unflatten.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unfold(request, kwargs):
+    Unfold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_htp_context
+def test_unfold_unsupported(request, kwargs):
+    Unfold.test_unsupported(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unsqueeze(request, kwargs):
+    Unsqueeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_2d_to_4d_random_reshape(request, kwargs):
+    View.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    View.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_5d_random_reshape(request, kwargs):
+    View.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_5d_flatten_last_two_dims(request, kwargs):
+    View.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_where(request, kwargs):
+    Where.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_var(request, kwargs):
+    Var.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/op/v75/test.py
+++ b/backends/qualcomm/tests/rework/htp/op/v75/test.py
@@ -3,3 +3,1387 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+import re
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import (
+    check_exception,
+    CosineSimilarity,
+    EXCEPTION_EXIR_PROGRAM,
+    EXCEPTION_FROM_PASSES,
+    EXPECT_NOT_FULLY_DELEGATED,
+    SkipOutputCheck,
+    Tolerance,
+)
+from executorch.backends.qualcomm.tests.rework.src.op import *  # noqa: F403
+from executorch.backends.qualcomm.tests.rework.htp.conftest import (
+    enumerate_activation_dtype,
+    with_htp_context,
+)
+
+# e.g. get 73 from ".../rework/htp/unit_test/op/v73/test.py"
+HTP_ARCH = int(re.search(r".*v([0-9]+)$", Path(__file__).parent.name).group(1))
+with_htp_context = partial(with_htp_context, hw_arch=HTP_ARCH)
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_abs(request, kwargs):
+    Abs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_acos(request, kwargs):
+    ACos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_1d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_1d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_1d(request, kwargs):
+    AdaptiveAvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_2d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_2d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_2d(request, kwargs):
+    AdaptiveAvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_3d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_3d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_3d(request, kwargs):
+    AdaptiveAvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_max_pool_2d(request, kwargs):
+    AdaptiveMaxPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_adaptive_max_pool_2d_with_indices(request, kwargs):
+    AdaptiveMaxPool.test_2d_with_indices(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_add(request, kwargs):
+    Add.test(request, kwargs)  # noqa: F405
+
+
+# addmm 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_addmm(request, kwargs):
+    AddMM.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_alias(request, kwargs):
+    Alias.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_amax(request, kwargs):
+    AMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_amin(request, kwargs):
+    AMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_any(request, kwargs):
+    Any.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_arange_dtype_int(request, kwargs):
+    Arange.test_dtype_int(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_arange_dtype_float(request, kwargs):
+    Arange.test_dtype_float(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_argmax(request, kwargs):
+    ArgMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_argmin(request, kwargs):
+    ArgMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_asin(request, kwargs):
+    ASin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_atan(request, kwargs):
+    ATan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_atan2(request, kwargs):
+    ATan2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_1d(request, kwargs):
+    AvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_2d(request, kwargs):
+    AvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_3d(request, kwargs):
+    AvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_batchnorm_2d(request, kwargs):
+    BatchNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_and_numeric(request, kwargs):
+    BitwiseOp.test_and_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_and_bool(request, kwargs):
+    BitwiseOp.test_and_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_or_numeric(request, kwargs):
+    BitwiseOp.test_or_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_or_bool(request, kwargs):
+    BitwiseOp.test_or_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_xor_numeric(request, kwargs):
+    BitwiseOp.test_xor_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_xor_bool(request, kwargs):
+    BitwiseOp.test_xor_bool(request, kwargs)  # noqa: F405
+
+
+# bmm 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bmm(request, kwargs):
+    Bmm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cast(request, kwargs):
+    Cast.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cat(request, kwargs):
+    Cat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cdist(request, kwargs):
+    CDist.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_ceil(request, kwargs):
+    Ceil.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_channel_shuffle(request, kwargs):
+    ChannelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_chunk(request, kwargs):
+    Chunk.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp(request, kwargs):
+    Clamp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp_max(request, kwargs):
+    ClampMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp_min(request, kwargs):
+    ClampMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clone(request, kwargs):
+    Clone.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv1d(request, kwargs):
+    Conv.test_1d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv1d_transpose(request, kwargs):
+    Conv.test_1d_transpose(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv2d(request, kwargs):
+    Conv.test_2d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv2d_transpose(request, kwargs):
+    Conv.test_2d_transpose(request, kwargs)  # noqa: F405
+
+
+# LPBQ (QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION) requires V69+; enabled here
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 4,
+                "lpbq": True,
+                "block_sz_map": {"conv2d": (1, 32, 1, 1)},
+                "expected": Tolerance(),
+            },
+            id="16a4w_lpbq",
+        ),
+        pytest.param(
+            {"act": "fp16", "param": 8, "pcq": True, "expected": Tolerance()},
+            id="fp16a8w_pcq",
+        ),
+    ],
+)
+@with_htp_context
+def test_conv2d_linear_like(request, kwargs):
+    Conv.test_2d_linear_like(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            # no bitwidth support for conv3d
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv3d(request, kwargs):
+    Conv.test_3d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            # no bitwidth support for conv3d
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv3d_transpose(request, kwargs):
+    Conv.test_3d_transpose(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cos(request, kwargs):
+    Cos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cumsum(request, kwargs):
+    CumSum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_div(request, kwargs):
+    Div.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_div_with_rounding_mode(request, kwargs):
+    DivWithRoundingMode.test(request, kwargs)  # noqa: F405
+
+
+# einsum 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_einsum(request, kwargs):
+    Einsum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_elu(request, kwargs):
+    Elu.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, False, Tolerance(), "8a8w_ptq"),
+            (16, 16, False, Tolerance(), "16a16w_ptq"),
+            (16, 8, True, Tolerance(), "16a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_embedding(request, kwargs):
+    Embedding.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_equal(request, kwargs):
+    Equal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_exp(request, kwargs):
+    Exp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expand(request, kwargs):
+    Expand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expand_as(request, kwargs):
+    ExpandAs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expm1(request, kwargs):
+    ExpM1.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_fill(request, kwargs):
+    Fill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_flip(request, kwargs):
+    Flip.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_floor(request, kwargs):
+    Floor.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_floor_divide(request, kwargs):
+    FloorDivide.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_fold(request, kwargs):
+    Fold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_htp_context
+def test_fold_unsupported_parameters(request, kwargs):
+    Fold.test_unsupported_parameters(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_full(request, kwargs):
+    Full.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_full_like(request, kwargs):
+    FullLike.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_gather(request, kwargs):
+    Gather.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_gelu(request, kwargs):
+    Gelu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_glu(request, kwargs):
+    Glu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_greater(request, kwargs):
+    Greater.test_gt(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_greater_equal(request, kwargs):
+    Greater.test_ge(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_grid_sample_4d(request, kwargs):
+    GridSample.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        CosineSimilarity(0.95),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_grid_sample_5d(request, kwargs):
+    GridSample.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_group_norm(request, kwargs):
+    GroupNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardsigmoid(request, kwargs):
+    HardSigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardswish(request, kwargs):
+    HardSwish.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardtanh(request, kwargs):
+    HardTanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index(request, kwargs):
+    Index.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_copy(request, kwargs):
+    IndexCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_put(request, kwargs):
+    IndexPut.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_select(request, kwargs):
+    IndexSelect.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_instance_norm_2d(request, kwargs):
+    InstanceNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_bicubic(request, kwargs):
+    Interpolate.test_bicubic(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_bilinear(request, kwargs):
+    Interpolate.test_bilinear(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_nearest(request, kwargs):
+    Interpolate.test_nearest(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_is_inf(request, kwargs):
+    IsInf.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance()])
+@with_htp_context
+def test_is_nan(request, kwargs):
+    IsNan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_layer_norm(request, kwargs):
+    LayerNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_leaky_relu(request, kwargs):
+    LeakyReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_less_equal(request, kwargs):
+    LessEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_less_than(request, kwargs):
+    LessThan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_linalg_vector_norm(request, kwargs):
+    LinalgVectorNorm.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 4,
+                "pcq": False,
+                "lpbq": True,
+                "block_sz_map": {"linear": (1, 32)},
+                "expected": Tolerance(),
+            },
+            id="16a4w_lpbq",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_block_quant(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 16, "param": 16, "pcq": False, "expected": Tolerance()},
+            id="16a16w_ptq",
+        ),
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 4, "pcq": True, "expected": CosineSimilarity(0.95)},
+            id="16a4w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="16a8w_pcq",
+        ),
+        pytest.param(
+            {"act": "fp16", "param": 8, "pcq": True, "expected": Tolerance()},
+            id="fp16a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 2, "pcq": True, "expected": CosineSimilarity(0.9)},
+            id="16a2w_pcq",
+        ),
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_general(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 16,
+                "pcq": False,
+                "expected": pytest.raises(AssertionError, match=Tolerance()),
+            },
+            id="16a16w_ptq",
+        ),
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_non_constant_weight(request, kwargs):
+    LinearNonConstantWeight.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log(request, kwargs):
+    Log.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log10(request, kwargs):
+    Log10.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log1p(request, kwargs):
+    Log1p.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log2(request, kwargs):
+    Log2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log_softmax(request, kwargs):
+    LogSoftmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_logical_and(request, kwargs):
+    LogicalAnd.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_logical_not(request, kwargs):
+    LogicalNot.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_masked_fill(request, kwargs):
+    MaskedFill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_max_dim(request, kwargs):
+    MaxDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maximum(request, kwargs):
+    Maximum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maxpool_2d(request, kwargs):
+    MaxPool2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maxpool_3d(request, kwargs):
+    MaxPool3d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_mean(request, kwargs):
+    Mean.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_mha(request, kwargs):
+    MultiheadAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_min_dim(request, kwargs):
+    MinDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_minimum(request, kwargs):
+    Minimum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_narrow(request, kwargs):
+    Narrow.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_neg(request, kwargs):
+    Neg.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_not_equal(request, kwargs):
+    NotEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pad_constant(request, kwargs):
+    Pad.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pad_reflect(request, kwargs):
+    Pad.test_reflect(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_permute(request, kwargs):
+    Permute.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pixel_shuffle(request, kwargs):
+    PixelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pixel_unshuffle(request, kwargs):
+    PixelUnshuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pow_scalar(request, kwargs):
+    PowScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pow_tensor_scalar(request, kwargs):
+    PowTensorScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_prelu(request, kwargs):
+    PReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        SkipOutputCheck(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_rand(request, kwargs):
+    Rand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reciprocal(request, kwargs):
+    Reciprocal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_1d(request, kwargs):
+    ReflectionPad.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_2d(request, kwargs):
+    ReflectionPad.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_3d(request, kwargs):
+    ReflectionPad.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_relu(request, kwargs):
+    Relu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_relu6(request, kwargs):
+    Relu6.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_remainder(request, kwargs):
+    Remainder.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_repeat(request, kwargs):
+    Repeat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_2d_to_4d_random_reshape(request, kwargs):
+    Reshape.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_5d_random_reshape(request, kwargs):
+    Reshape.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_5d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_rms_norm(request, kwargs):
+    RmsNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_roll(request, kwargs):
+    Roll.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_round(request, kwargs):
+    Round.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_rsqrt(request, kwargs):
+    Rsqrt.test(request, kwargs)  # noqa: F405
+
+
+# sdpa 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sdpa(request, kwargs):
+    ScaledDotProductAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_scatter_src(request, kwargs):
+    ScatterSrc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_select_copy(request, kwargs):
+    SelectCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_select_scatter(request, kwargs):
+    SelectScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sigmoid(request, kwargs):
+    Sigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sign(request, kwargs):
+    Sign.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sin(request, kwargs):
+    Sin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_slice_copy(request, kwargs):
+    SliceCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_slice_scatter(request, kwargs):
+    SliceScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_scatter_value(request, kwargs):
+    ScatterValue.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_softmax(request, kwargs):
+    Softmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_sort(request, kwargs):
+    Sort.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_split(request, kwargs):
+    Split.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_square(request, kwargs):
+    Square.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_squeeze(request, kwargs):
+    Squeeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_stack(request, kwargs):
+    Stack.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sum_int_list(request, kwargs):
+    SumIntList.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_swapaxes(request, kwargs):
+    SwapAxes.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_tan(request, kwargs):
+    Tan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_tanh(request, kwargs):
+    Tanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_threshold(request, kwargs):
+    Threshold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_triu(request, kwargs):
+    Triu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_triu_constant(request, kwargs):
+    Triu.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_trunc(request, kwargs):
+    Trunc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_topk(request, kwargs):
+    TopK.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unbind(request, kwargs):
+    Unbind.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unflatten(request, kwargs):
+    Unflatten.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unfold(request, kwargs):
+    Unfold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_htp_context
+def test_unfold_unsupported(request, kwargs):
+    Unfold.test_unsupported(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unsqueeze(request, kwargs):
+    Unsqueeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_2d_to_4d_random_reshape(request, kwargs):
+    View.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    View.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_5d_random_reshape(request, kwargs):
+    View.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_5d_flatten_last_two_dims(request, kwargs):
+    View.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_where(request, kwargs):
+    Where.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_var(request, kwargs):
+    Var.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/op/v79/test.py
+++ b/backends/qualcomm/tests/rework/htp/op/v79/test.py
@@ -3,3 +3,1387 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+import re
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import (
+    check_exception,
+    CosineSimilarity,
+    EXCEPTION_EXIR_PROGRAM,
+    EXCEPTION_FROM_PASSES,
+    EXPECT_NOT_FULLY_DELEGATED,
+    SkipOutputCheck,
+    Tolerance,
+)
+from executorch.backends.qualcomm.tests.rework.src.op import *  # noqa: F403
+from executorch.backends.qualcomm.tests.rework.htp.conftest import (
+    enumerate_activation_dtype,
+    with_htp_context,
+)
+
+# e.g. get 73 from ".../rework/htp/unit_test/op/v73/test.py"
+HTP_ARCH = int(re.search(r".*v([0-9]+)$", Path(__file__).parent.name).group(1))
+with_htp_context = partial(with_htp_context, hw_arch=HTP_ARCH)
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_abs(request, kwargs):
+    Abs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_acos(request, kwargs):
+    ACos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_1d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_1d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_1d(request, kwargs):
+    AdaptiveAvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_2d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_2d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_2d(request, kwargs):
+    AdaptiveAvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_3d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_3d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_3d(request, kwargs):
+    AdaptiveAvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_max_pool_2d(request, kwargs):
+    AdaptiveMaxPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_adaptive_max_pool_2d_with_indices(request, kwargs):
+    AdaptiveMaxPool.test_2d_with_indices(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_add(request, kwargs):
+    Add.test(request, kwargs)  # noqa: F405
+
+
+# addmm 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_addmm(request, kwargs):
+    AddMM.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_alias(request, kwargs):
+    Alias.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_amax(request, kwargs):
+    AMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_amin(request, kwargs):
+    AMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_any(request, kwargs):
+    Any.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_arange_dtype_int(request, kwargs):
+    Arange.test_dtype_int(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_arange_dtype_float(request, kwargs):
+    Arange.test_dtype_float(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_argmax(request, kwargs):
+    ArgMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_argmin(request, kwargs):
+    ArgMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_asin(request, kwargs):
+    ASin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_atan(request, kwargs):
+    ATan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_atan2(request, kwargs):
+    ATan2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_1d(request, kwargs):
+    AvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_2d(request, kwargs):
+    AvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_3d(request, kwargs):
+    AvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_batchnorm_2d(request, kwargs):
+    BatchNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_and_numeric(request, kwargs):
+    BitwiseOp.test_and_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_and_bool(request, kwargs):
+    BitwiseOp.test_and_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_or_numeric(request, kwargs):
+    BitwiseOp.test_or_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_or_bool(request, kwargs):
+    BitwiseOp.test_or_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_xor_numeric(request, kwargs):
+    BitwiseOp.test_xor_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_xor_bool(request, kwargs):
+    BitwiseOp.test_xor_bool(request, kwargs)  # noqa: F405
+
+
+# bmm 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bmm(request, kwargs):
+    Bmm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cast(request, kwargs):
+    Cast.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cat(request, kwargs):
+    Cat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cdist(request, kwargs):
+    CDist.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_ceil(request, kwargs):
+    Ceil.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_channel_shuffle(request, kwargs):
+    ChannelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_chunk(request, kwargs):
+    Chunk.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp(request, kwargs):
+    Clamp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp_max(request, kwargs):
+    ClampMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp_min(request, kwargs):
+    ClampMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clone(request, kwargs):
+    Clone.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv1d(request, kwargs):
+    Conv.test_1d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv1d_transpose(request, kwargs):
+    Conv.test_1d_transpose(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv2d(request, kwargs):
+    Conv.test_2d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv2d_transpose(request, kwargs):
+    Conv.test_2d_transpose(request, kwargs)  # noqa: F405
+
+
+# LPBQ (QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION) requires V69+; enabled here
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 4,
+                "lpbq": True,
+                "block_sz_map": {"conv2d": (1, 32, 1, 1)},
+                "expected": Tolerance(),
+            },
+            id="16a4w_lpbq",
+        ),
+        pytest.param(
+            {"act": "fp16", "param": 8, "pcq": True, "expected": Tolerance()},
+            id="fp16a8w_pcq",
+        ),
+    ],
+)
+@with_htp_context
+def test_conv2d_linear_like(request, kwargs):
+    Conv.test_2d_linear_like(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            # no bitwidth support for conv3d
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv3d(request, kwargs):
+    Conv.test_3d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            # no bitwidth support for conv3d
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv3d_transpose(request, kwargs):
+    Conv.test_3d_transpose(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cos(request, kwargs):
+    Cos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cumsum(request, kwargs):
+    CumSum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_div(request, kwargs):
+    Div.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_div_with_rounding_mode(request, kwargs):
+    DivWithRoundingMode.test(request, kwargs)  # noqa: F405
+
+
+# einsum 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_einsum(request, kwargs):
+    Einsum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_elu(request, kwargs):
+    Elu.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, False, Tolerance(), "8a8w_ptq"),
+            (16, 16, False, Tolerance(), "16a16w_ptq"),
+            (16, 8, True, Tolerance(), "16a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_embedding(request, kwargs):
+    Embedding.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_equal(request, kwargs):
+    Equal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_exp(request, kwargs):
+    Exp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expand(request, kwargs):
+    Expand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expand_as(request, kwargs):
+    ExpandAs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expm1(request, kwargs):
+    ExpM1.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_fill(request, kwargs):
+    Fill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_flip(request, kwargs):
+    Flip.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_floor(request, kwargs):
+    Floor.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_floor_divide(request, kwargs):
+    FloorDivide.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_fold(request, kwargs):
+    Fold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_htp_context
+def test_fold_unsupported_parameters(request, kwargs):
+    Fold.test_unsupported_parameters(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_full(request, kwargs):
+    Full.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_full_like(request, kwargs):
+    FullLike.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_gather(request, kwargs):
+    Gather.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_gelu(request, kwargs):
+    Gelu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_glu(request, kwargs):
+    Glu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_greater(request, kwargs):
+    Greater.test_gt(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_greater_equal(request, kwargs):
+    Greater.test_ge(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_grid_sample_4d(request, kwargs):
+    GridSample.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        CosineSimilarity(0.95),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_grid_sample_5d(request, kwargs):
+    GridSample.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_group_norm(request, kwargs):
+    GroupNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardsigmoid(request, kwargs):
+    HardSigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardswish(request, kwargs):
+    HardSwish.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardtanh(request, kwargs):
+    HardTanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index(request, kwargs):
+    Index.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_copy(request, kwargs):
+    IndexCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_put(request, kwargs):
+    IndexPut.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_select(request, kwargs):
+    IndexSelect.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_instance_norm_2d(request, kwargs):
+    InstanceNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_bicubic(request, kwargs):
+    Interpolate.test_bicubic(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_bilinear(request, kwargs):
+    Interpolate.test_bilinear(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_nearest(request, kwargs):
+    Interpolate.test_nearest(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_is_inf(request, kwargs):
+    IsInf.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance()])
+@with_htp_context
+def test_is_nan(request, kwargs):
+    IsNan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_layer_norm(request, kwargs):
+    LayerNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_leaky_relu(request, kwargs):
+    LeakyReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_less_equal(request, kwargs):
+    LessEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_less_than(request, kwargs):
+    LessThan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_linalg_vector_norm(request, kwargs):
+    LinalgVectorNorm.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 4,
+                "pcq": False,
+                "lpbq": True,
+                "block_sz_map": {"linear": (1, 32)},
+                "expected": Tolerance(),
+            },
+            id="16a4w_lpbq",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_block_quant(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 16, "param": 16, "pcq": False, "expected": Tolerance()},
+            id="16a16w_ptq",
+        ),
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 4, "pcq": True, "expected": CosineSimilarity(0.95)},
+            id="16a4w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="16a8w_pcq",
+        ),
+        pytest.param(
+            {"act": "fp16", "param": 8, "pcq": True, "expected": Tolerance()},
+            id="fp16a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 2, "pcq": True, "expected": CosineSimilarity(0.9)},
+            id="16a2w_pcq",
+        ),
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_general(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 16,
+                "pcq": False,
+                "expected": pytest.raises(AssertionError, match=Tolerance()),
+            },
+            id="16a16w_ptq",
+        ),
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_non_constant_weight(request, kwargs):
+    LinearNonConstantWeight.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log(request, kwargs):
+    Log.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log10(request, kwargs):
+    Log10.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log1p(request, kwargs):
+    Log1p.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log2(request, kwargs):
+    Log2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log_softmax(request, kwargs):
+    LogSoftmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_logical_and(request, kwargs):
+    LogicalAnd.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_logical_not(request, kwargs):
+    LogicalNot.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_masked_fill(request, kwargs):
+    MaskedFill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_max_dim(request, kwargs):
+    MaxDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maximum(request, kwargs):
+    Maximum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maxpool_2d(request, kwargs):
+    MaxPool2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maxpool_3d(request, kwargs):
+    MaxPool3d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_mean(request, kwargs):
+    Mean.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_mha(request, kwargs):
+    MultiheadAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_min_dim(request, kwargs):
+    MinDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_minimum(request, kwargs):
+    Minimum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_narrow(request, kwargs):
+    Narrow.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_neg(request, kwargs):
+    Neg.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_not_equal(request, kwargs):
+    NotEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pad_constant(request, kwargs):
+    Pad.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pad_reflect(request, kwargs):
+    Pad.test_reflect(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_permute(request, kwargs):
+    Permute.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pixel_shuffle(request, kwargs):
+    PixelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pixel_unshuffle(request, kwargs):
+    PixelUnshuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pow_scalar(request, kwargs):
+    PowScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pow_tensor_scalar(request, kwargs):
+    PowTensorScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_prelu(request, kwargs):
+    PReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        SkipOutputCheck(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_rand(request, kwargs):
+    Rand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reciprocal(request, kwargs):
+    Reciprocal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_1d(request, kwargs):
+    ReflectionPad.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_2d(request, kwargs):
+    ReflectionPad.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_3d(request, kwargs):
+    ReflectionPad.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_relu(request, kwargs):
+    Relu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_relu6(request, kwargs):
+    Relu6.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_remainder(request, kwargs):
+    Remainder.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_repeat(request, kwargs):
+    Repeat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_2d_to_4d_random_reshape(request, kwargs):
+    Reshape.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_5d_random_reshape(request, kwargs):
+    Reshape.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_5d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_rms_norm(request, kwargs):
+    RmsNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_roll(request, kwargs):
+    Roll.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_round(request, kwargs):
+    Round.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_rsqrt(request, kwargs):
+    Rsqrt.test(request, kwargs)  # noqa: F405
+
+
+# sdpa 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sdpa(request, kwargs):
+    ScaledDotProductAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_scatter_src(request, kwargs):
+    ScatterSrc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_select_copy(request, kwargs):
+    SelectCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_select_scatter(request, kwargs):
+    SelectScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sigmoid(request, kwargs):
+    Sigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sign(request, kwargs):
+    Sign.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sin(request, kwargs):
+    Sin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_slice_copy(request, kwargs):
+    SliceCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_slice_scatter(request, kwargs):
+    SliceScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_scatter_value(request, kwargs):
+    ScatterValue.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_softmax(request, kwargs):
+    Softmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_sort(request, kwargs):
+    Sort.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_split(request, kwargs):
+    Split.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_square(request, kwargs):
+    Square.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_squeeze(request, kwargs):
+    Squeeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_stack(request, kwargs):
+    Stack.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sum_int_list(request, kwargs):
+    SumIntList.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_swapaxes(request, kwargs):
+    SwapAxes.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_tan(request, kwargs):
+    Tan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_tanh(request, kwargs):
+    Tanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_threshold(request, kwargs):
+    Threshold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_triu(request, kwargs):
+    Triu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_triu_constant(request, kwargs):
+    Triu.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_trunc(request, kwargs):
+    Trunc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_topk(request, kwargs):
+    TopK.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unbind(request, kwargs):
+    Unbind.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unflatten(request, kwargs):
+    Unflatten.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unfold(request, kwargs):
+    Unfold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_htp_context
+def test_unfold_unsupported(request, kwargs):
+    Unfold.test_unsupported(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unsqueeze(request, kwargs):
+    Unsqueeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_2d_to_4d_random_reshape(request, kwargs):
+    View.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    View.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_5d_random_reshape(request, kwargs):
+    View.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_5d_flatten_last_two_dims(request, kwargs):
+    View.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_where(request, kwargs):
+    Where.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_var(request, kwargs):
+    Var.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/htp/op/v81/test.py
+++ b/backends/qualcomm/tests/rework/htp/op/v81/test.py
@@ -3,3 +3,1387 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+import re
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import (
+    check_exception,
+    CosineSimilarity,
+    EXCEPTION_EXIR_PROGRAM,
+    EXCEPTION_FROM_PASSES,
+    EXPECT_NOT_FULLY_DELEGATED,
+    SkipOutputCheck,
+    Tolerance,
+)
+from executorch.backends.qualcomm.tests.rework.src.op import *  # noqa: F403
+from executorch.backends.qualcomm.tests.rework.htp.conftest import (
+    enumerate_activation_dtype,
+    with_htp_context,
+)
+
+# e.g. get 73 from ".../rework/htp/unit_test/op/v73/test.py"
+HTP_ARCH = int(re.search(r".*v([0-9]+)$", Path(__file__).parent.name).group(1))
+with_htp_context = partial(with_htp_context, hw_arch=HTP_ARCH)
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_abs(request, kwargs):
+    Abs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_acos(request, kwargs):
+    ACos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_1d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_1d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_1d(request, kwargs):
+    AdaptiveAvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_2d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_2d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_2d(request, kwargs):
+    AdaptiveAvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_adaptive_avg_pool_3d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_3d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_avg_pool_3d(request, kwargs):
+    AdaptiveAvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_adaptive_max_pool_2d(request, kwargs):
+    AdaptiveMaxPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_adaptive_max_pool_2d_with_indices(request, kwargs):
+    AdaptiveMaxPool.test_2d_with_indices(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_add(request, kwargs):
+    Add.test(request, kwargs)  # noqa: F405
+
+
+# addmm 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_addmm(request, kwargs):
+    AddMM.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_alias(request, kwargs):
+    Alias.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_amax(request, kwargs):
+    AMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_amin(request, kwargs):
+    AMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_any(request, kwargs):
+    Any.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_arange_dtype_int(request, kwargs):
+    Arange.test_dtype_int(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_arange_dtype_float(request, kwargs):
+    Arange.test_dtype_float(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_argmax(request, kwargs):
+    ArgMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_argmin(request, kwargs):
+    ArgMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_asin(request, kwargs):
+    ASin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_atan(request, kwargs):
+    ATan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_atan2(request, kwargs):
+    ATan2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_1d(request, kwargs):
+    AvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_2d(request, kwargs):
+    AvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_avgpool_3d(request, kwargs):
+    AvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_batchnorm_2d(request, kwargs):
+    BatchNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_and_numeric(request, kwargs):
+    BitwiseOp.test_and_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_and_bool(request, kwargs):
+    BitwiseOp.test_and_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_or_numeric(request, kwargs):
+    BitwiseOp.test_or_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_or_bool(request, kwargs):
+    BitwiseOp.test_or_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_bitwise_xor_numeric(request, kwargs):
+    BitwiseOp.test_xor_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bitwise_xor_bool(request, kwargs):
+    BitwiseOp.test_xor_bool(request, kwargs)  # noqa: F405
+
+
+# bmm 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_bmm(request, kwargs):
+    Bmm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cast(request, kwargs):
+    Cast.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cat(request, kwargs):
+    Cat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cdist(request, kwargs):
+    CDist.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_ceil(request, kwargs):
+    Ceil.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_channel_shuffle(request, kwargs):
+    ChannelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_chunk(request, kwargs):
+    Chunk.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp(request, kwargs):
+    Clamp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp_max(request, kwargs):
+    ClampMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clamp_min(request, kwargs):
+    ClampMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_clone(request, kwargs):
+    Clone.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv1d(request, kwargs):
+    Conv.test_1d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv1d_transpose(request, kwargs):
+    Conv.test_1d_transpose(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv2d(request, kwargs):
+    Conv.test_2d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (16, 4, True, CosineSimilarity(0.95), "16a4w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv2d_transpose(request, kwargs):
+    Conv.test_2d_transpose(request, kwargs)  # noqa: F405
+
+
+# LPBQ (QNN_QUANTIZATION_ENCODING_BLOCKWISE_EXPANSION) requires V69+; enabled here
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 4,
+                "lpbq": True,
+                "block_sz_map": {"conv2d": (1, 32, 1, 1)},
+                "expected": Tolerance(),
+            },
+            id="16a4w_lpbq",
+        ),
+        pytest.param(
+            {"act": "fp16", "param": 8, "pcq": True, "expected": Tolerance()},
+            id="fp16a8w_pcq",
+        ),
+    ],
+)
+@with_htp_context
+def test_conv2d_linear_like(request, kwargs):
+    Conv.test_2d_linear_like(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            # no bitwidth support for conv3d
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv3d(request, kwargs):
+    Conv.test_3d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            # no bitwidth support for conv3d
+            (8, 8, True, Tolerance(), "8a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_conv3d_transpose(request, kwargs):
+    Conv.test_3d_transpose(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cos(request, kwargs):
+    Cos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_cumsum(request, kwargs):
+    CumSum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_div(request, kwargs):
+    Div.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_div_with_rounding_mode(request, kwargs):
+    DivWithRoundingMode.test(request, kwargs)  # noqa: F405
+
+
+# einsum 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_einsum(request, kwargs):
+    Einsum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_elu(request, kwargs):
+    Elu.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": act, "param": param, "pcq": pcq, "expected": expected},
+            id=id,
+        )
+        for act, param, pcq, expected, id in [
+            (8, 8, False, Tolerance(), "8a8w_ptq"),
+            (16, 16, False, Tolerance(), "16a16w_ptq"),
+            (16, 8, True, Tolerance(), "16a8w_pcq"),
+            (None, None, False, Tolerance(rtol=1e-1), "fp"),
+        ]
+    ],
+)
+@with_htp_context
+def test_embedding(request, kwargs):
+    Embedding.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_equal(request, kwargs):
+    Equal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_exp(request, kwargs):
+    Exp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expand(request, kwargs):
+    Expand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expand_as(request, kwargs):
+    ExpandAs.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_expm1(request, kwargs):
+    ExpM1.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_fill(request, kwargs):
+    Fill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_flip(request, kwargs):
+    Flip.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_floor(request, kwargs):
+    Floor.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_floor_divide(request, kwargs):
+    FloorDivide.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_fold(request, kwargs):
+    Fold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_htp_context
+def test_fold_unsupported_parameters(request, kwargs):
+    Fold.test_unsupported_parameters(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_full(request, kwargs):
+    Full.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_full_like(request, kwargs):
+    FullLike.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_gather(request, kwargs):
+    Gather.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_gelu(request, kwargs):
+    Gelu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_glu(request, kwargs):
+    Glu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_greater(request, kwargs):
+    Greater.test_gt(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_greater_equal(request, kwargs):
+    Greater.test_ge(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_grid_sample_4d(request, kwargs):
+    GridSample.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        CosineSimilarity(0.95),
+        Tolerance(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_grid_sample_5d(request, kwargs):
+    GridSample.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_group_norm(request, kwargs):
+    GroupNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardsigmoid(request, kwargs):
+    HardSigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardswish(request, kwargs):
+    HardSwish.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_hardtanh(request, kwargs):
+    HardTanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index(request, kwargs):
+    Index.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_copy(request, kwargs):
+    IndexCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_put(request, kwargs):
+    IndexPut.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_index_select(request, kwargs):
+    IndexSelect.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_instance_norm_2d(request, kwargs):
+    InstanceNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_bicubic(request, kwargs):
+    Interpolate.test_bicubic(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_bilinear(request, kwargs):
+    Interpolate.test_bilinear(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_interpolate_nearest(request, kwargs):
+    Interpolate.test_nearest(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_is_inf(request, kwargs):
+    IsInf.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance()])
+@with_htp_context
+def test_is_nan(request, kwargs):
+    IsNan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_layer_norm(request, kwargs):
+    LayerNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_leaky_relu(request, kwargs):
+    LeakyReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_less_equal(request, kwargs):
+    LessEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_less_than(request, kwargs):
+    LessThan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_linalg_vector_norm(request, kwargs):
+    LinalgVectorNorm.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 4,
+                "pcq": False,
+                "lpbq": True,
+                "block_sz_map": {"linear": (1, 32)},
+                "expected": Tolerance(),
+            },
+            id="16a4w_lpbq",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_block_quant(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 16, "param": 16, "pcq": False, "expected": Tolerance()},
+            id="16a16w_ptq",
+        ),
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 4, "pcq": True, "expected": CosineSimilarity(0.95)},
+            id="16a4w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="16a8w_pcq",
+        ),
+        pytest.param(
+            {"act": "fp16", "param": 8, "pcq": True, "expected": Tolerance()},
+            id="fp16a8w_pcq",
+        ),
+        pytest.param(
+            {"act": 16, "param": 2, "pcq": True, "expected": CosineSimilarity(0.9)},
+            id="16a2w_pcq",
+        ),
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_general(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {
+                "act": 16,
+                "param": 16,
+                "pcq": False,
+                "expected": pytest.raises(AssertionError, match=Tolerance()),
+            },
+            id="16a16w_ptq",
+        ),
+        pytest.param(
+            {
+                "act": None,
+                "param": None,
+                "pcq": False,
+                "expected": Tolerance(rtol=1e-1),
+            },
+            id="fp",
+        ),
+    ],
+)
+@with_htp_context
+def test_linear_non_constant_weight(request, kwargs):
+    LinearNonConstantWeight.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log(request, kwargs):
+    Log.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log10(request, kwargs):
+    Log10.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log1p(request, kwargs):
+    Log1p.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log2(request, kwargs):
+    Log2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_log_softmax(request, kwargs):
+    LogSoftmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_logical_and(request, kwargs):
+    LogicalAnd.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_logical_not(request, kwargs):
+    LogicalNot.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_masked_fill(request, kwargs):
+    MaskedFill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_max_dim(request, kwargs):
+    MaxDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maximum(request, kwargs):
+    Maximum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maxpool_2d(request, kwargs):
+    MaxPool2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_maxpool_3d(request, kwargs):
+    MaxPool3d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_mean(request, kwargs):
+    Mean.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_mha(request, kwargs):
+    MultiheadAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_min_dim(request, kwargs):
+    MinDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_minimum(request, kwargs):
+    Minimum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_narrow(request, kwargs):
+    Narrow.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_neg(request, kwargs):
+    Neg.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_not_equal(request, kwargs):
+    NotEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pad_constant(request, kwargs):
+    Pad.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pad_reflect(request, kwargs):
+    Pad.test_reflect(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_permute(request, kwargs):
+    Permute.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pixel_shuffle(request, kwargs):
+    PixelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pixel_unshuffle(request, kwargs):
+    PixelUnshuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pow_scalar(request, kwargs):
+    PowScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_pow_tensor_scalar(request, kwargs):
+    PowTensorScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_prelu(request, kwargs):
+    PReLU.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        SkipOutputCheck(),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_htp_context
+def test_rand(request, kwargs):
+    Rand.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reciprocal(request, kwargs):
+    Reciprocal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_1d(request, kwargs):
+    ReflectionPad.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_2d(request, kwargs):
+    ReflectionPad.test_4d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reflection_pad_3d(request, kwargs):
+    ReflectionPad.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_relu(request, kwargs):
+    Relu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_relu6(request, kwargs):
+    Relu6.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_remainder(request, kwargs):
+    Remainder.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_repeat(request, kwargs):
+    Repeat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_2d_to_4d_random_reshape(request, kwargs):
+    Reshape.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_5d_random_reshape(request, kwargs):
+    Reshape.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_reshape_5d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_rms_norm(request, kwargs):
+    RmsNorm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_roll(request, kwargs):
+    Roll.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_round(request, kwargs):
+    Round.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_rsqrt(request, kwargs):
+    Rsqrt.test(request, kwargs)  # noqa: F405
+
+
+# sdpa 16a requires V73+; enabled here
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sdpa(request, kwargs):
+    ScaledDotProductAttention.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_scatter_src(request, kwargs):
+    ScatterSrc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_select_copy(request, kwargs):
+    SelectCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_select_scatter(request, kwargs):
+    SelectScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sigmoid(request, kwargs):
+    Sigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sign(request, kwargs):
+    Sign.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sin(request, kwargs):
+    Sin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_slice_copy(request, kwargs):
+    SliceCopy.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_slice_scatter(request, kwargs):
+    SliceScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_scatter_value(request, kwargs):
+    ScatterValue.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_softmax(request, kwargs):
+    Softmax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        Tolerance(),
+        Tolerance(),
+        pytest.raises(AssertionError),
+    ]
+)
+@with_htp_context
+def test_sort(request, kwargs):
+    Sort.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_split(request, kwargs):
+    Split.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_square(request, kwargs):
+    Square.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_squeeze(request, kwargs):
+    Squeeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_stack(request, kwargs):
+    Stack.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_sum_int_list(request, kwargs):
+    SumIntList.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_swapaxes(request, kwargs):
+    SwapAxes.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_tan(request, kwargs):
+    Tan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_tanh(request, kwargs):
+    Tanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_threshold(request, kwargs):
+    Threshold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_triu(request, kwargs):
+    Triu.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_triu_constant(request, kwargs):
+    Triu.test_constant(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_trunc(request, kwargs):
+    Trunc.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_topk(request, kwargs):
+    TopK.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unbind(request, kwargs):
+    Unbind.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unflatten(request, kwargs):
+    Unflatten.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unfold(request, kwargs):
+    Unfold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_htp_context
+def test_unfold_unsupported(request, kwargs):
+    Unfold.test_unsupported(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_unsqueeze(request, kwargs):
+    Unsqueeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_2d_to_4d_random_reshape(request, kwargs):
+    View.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    View.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_5d_random_reshape(request, kwargs):
+    View.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_view_5d_flatten_last_two_dims(request, kwargs):
+    View.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_where(request, kwargs):
+    Where.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance(), Tolerance(), Tolerance(rtol=1e-1)])
+@with_htp_context
+def test_var(request, kwargs):
+    Var.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/lpai/conftest.py
+++ b/backends/qualcomm/tests/rework/lpai/conftest.py
@@ -3,3 +3,100 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from functools import lru_cache
+from typing import Any, List
+
+import pytest
+
+from executorch.backends.qualcomm.export_utils import (
+    generate_lpai_compiler_spec,
+    generate_qnn_executorch_compiler_spec,
+    make_quantizer,
+    QcomChipset,
+    QnnExecuTorchBackendType,
+    QuantDtype,
+)
+from executorch.backends.qualcomm.serialization.qc_schema import (
+    LpaiHardwareVersion,
+    QnnExecuTorchLpaiTargetEnv,
+)
+
+
+def with_lpai_context(func, hw_arch):
+    def wrapper(request, kwargs):
+        # extend this if necessary
+        preserved = {k: kwargs.pop(k) for k in ["expected"]}
+        callbacks_and_args = {
+            # extract objects from callback
+            "quantizers": {"arch": hw_arch} | kwargs,
+            "compile_specs": {"arch": hw_arch},
+        }
+        fixtures = {
+            k[:-1]: request.getfixturevalue(k)(**v)
+            for k, v in callbacks_and_args.items()
+        }
+        return func(request, fixtures | preserved)
+
+    return wrapper
+
+
+def enumerate_activation_dtype(metrics: List[Any]):
+    def wrapper(test_body):
+        return pytest.mark.parametrize(
+            "kwargs",
+            [
+                pytest.param({"act": act, "expected": metrics[i]}, id=id)
+                for i, (act, id) in enumerate(
+                    [
+                        (8, "8a"),
+                    ]
+                )
+            ],
+        )(test_body)
+
+    return wrapper
+
+
+def _get_lpai_arch():
+    # hardcoded lpai architecture with corresponding premium soc
+    return [
+        (LpaiHardwareVersion.V6, "SM8850"),
+    ]
+
+
+@pytest.fixture(scope="session")
+def quantizers():
+    arch_to_soc = dict(_get_lpai_arch())
+
+    @lru_cache()
+    def _build(arch, act, param, per_ch):
+        attr = f"use_{act}a{param}w"
+        if quant_dtype := getattr(QuantDtype, attr, None):
+            return make_quantizer(
+                quant_dtype=quant_dtype,
+                per_channel_conv=per_ch,
+                per_channel_linear=per_ch,
+                backend=QnnExecuTorchBackendType.kLpaiBackend,
+                soc_model=arch_to_soc[arch],
+            )
+
+    def get_quantizer(arch, act, param=None, pcq=False, **_):
+        param = 8 if (param is None and act is not None) else param
+        return _build(arch, act, param, pcq)
+
+    return get_quantizer
+
+
+@pytest.fixture(scope="session")
+def compile_specs():
+    compile_spec = {
+        arch: generate_qnn_executorch_compiler_spec(
+            soc_model=getattr(QcomChipset, soc_model),
+            backend_options=generate_lpai_compiler_spec(
+                target_env=QnnExecuTorchLpaiTargetEnv.kX86,
+            ),
+        )
+        for (arch, soc_model) in _get_lpai_arch()
+    }
+    return lambda arch: compile_spec[arch]

--- a/backends/qualcomm/tests/rework/lpai/feature/conftest.py
+++ b/backends/qualcomm/tests/rework/lpai/feature/conftest.py
@@ -1,0 +1,37 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import inspect
+from functools import lru_cache
+
+import pytest
+
+from executorch.backends.qualcomm.export_utils import (
+    generate_lpai_compiler_spec,
+    generate_qnn_executorch_compiler_spec,
+)
+
+
+@pytest.fixture(scope="session")
+def compile_specs():
+    @lru_cache()
+    def _build(kwargs_config):
+        kwargs = dict(kwargs_config)
+        et_compile_spec_sig = set(
+            inspect.signature(generate_qnn_executorch_compiler_spec).parameters.keys()
+        )
+        et_compile_spec_kwargs = {
+            k: kwargs[k] for k in kwargs.keys() if k in et_compile_spec_sig
+        }
+        for k in et_compile_spec_kwargs.keys():
+            kwargs.pop(k)
+
+        return generate_qnn_executorch_compiler_spec(
+            backend_options=generate_lpai_compiler_spec(**kwargs),
+            **et_compile_spec_kwargs,
+        )
+
+    return lambda kwargs_config: _build(kwargs_config)

--- a/backends/qualcomm/tests/rework/lpai/feature/v6/test.py
+++ b/backends/qualcomm/tests/rework/lpai/feature/v6/test.py
@@ -3,3 +3,85 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import Tolerance
+from executorch.backends.qualcomm.tests.rework.src.feature import *  # noqa: F403
+
+
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_logging(request, kwargs):
+    Logging.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize("kwargs", [pytest.param({"expected": Tolerance()}, id="e2e")])
+def test_multi_graph_inference(request, kwargs):
+    MultiGraph.test_inference(request, kwargs)  # noqa: F405
+
+
+# LPAI forbids online_prepare=True at runtime
+@pytest.mark.skip(
+    reason="LPAI backend only supports offline_prepare; online_prepare is forbidden"
+)
+@pytest.mark.parametrize("kwargs", [pytest.param({"expected": Tolerance()}, id="e2e")])
+def test_online_prepare(request, kwargs):
+    OnlinePrepare.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_performance(request, kwargs):
+    Performance.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.skip(reason="TBD on native LPAI support")
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_profile(request, kwargs):
+    Profile.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_saver(request, kwargs):
+    Saver.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize("kwargs", [pytest.param({"expected": Tolerance()}, id="e2e")])
+def test_shared_buffer(request, kwargs):
+    SharedBuffer.test(request, kwargs)  # noqa: F405
+
+
+# SpillFill is HTP-specific (uses use_multi_contexts / SRAM spill-fill)
+@pytest.mark.skip(reason="SpillFill is HTP-specific; not applicable to LPAI backend")
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_spill_fill(request, kwargs):
+    SpillFill.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_tensor_dump(request, kwargs):
+    TensorDump.test(request, kwargs)  # noqa: F405
+
+
+# MultiGraph weight sharing requires use_weight_sharing in generate_lpai_compiler_spec (not supported)
+@pytest.mark.skip(
+    reason="Weight sharing across multiple graphs is not supported on LPAI backend"
+)
+@pytest.mark.parametrize(
+    "kwargs", [pytest.param({"expected": nullcontext()}, id="e2e")]
+)
+def test_multi_graph_weight_sharing(request, kwargs):
+    MultiGraph.test_weight_sharing(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/lpai/op/v6/test.py
+++ b/backends/qualcomm/tests/rework/lpai/op/v6/test.py
@@ -3,3 +3,1611 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+import re
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from executorch.backends.qualcomm.tests.rework.conftest import (
+    check_exception,
+    EXCEPTION_EXIR_PROGRAM,
+    EXCEPTION_FROM_PASSES,
+    EXPECT_NOT_ANNOTATED,
+    EXPECT_NOT_FULLY_DELEGATED,
+    Tolerance,
+)
+from executorch.backends.qualcomm.tests.rework.src.op import *  # noqa: F403
+from executorch.backends.qualcomm.tests.rework.lpai.conftest import (
+    enumerate_activation_dtype,
+    with_lpai_context,
+)
+
+
+# e.g. get 68 from ".../rework/htp/unit_test/op/v68/test.py"
+LPAI_ARCH = int(re.search(r".*v([0-9]+)$", Path(__file__).parent.name).group(1))
+with_lpai_context = partial(with_lpai_context, hw_arch=LPAI_ARCH)
+
+
+# abs not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_abs(request, kwargs):
+    Abs.test(request, kwargs)  # noqa: F405
+
+
+# acos not in lpai_rules but will be decomposed into equivalent ops
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_acos(request, kwargs):
+    ACos.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_adaptive_avg_pool_1d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_1d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_adaptive_avg_pool_1d(request, kwargs):
+    AdaptiveAvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_adaptive_avg_pool_2d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_2d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_adaptive_avg_pool_2d(request, kwargs):
+    AdaptiveAvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_adaptive_avg_pool_3d_unsupported_io_shape(request, kwargs):
+    AdaptiveAvgPool.test_3d_unsupported_io_shape(request, kwargs)  # noqa: F405
+
+
+# adaptive_avg_pool3d not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_adaptive_avg_pool_3d(request, kwargs):
+    AdaptiveAvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_adaptive_max_pool_2d(request, kwargs):
+    AdaptiveMaxPool.test_2d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_adaptive_max_pool_2d_with_indices(request, kwargs):
+    AdaptiveMaxPool.test_2d_with_indices(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_add(request, kwargs):
+    Add.test(request, kwargs)  # noqa: F405
+
+
+# addmm decomposes to mm+add before annotation; both in lpai_rules
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_addmm(request, kwargs):
+    AddMM.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_alias(request, kwargs):
+    Alias.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_amax(request, kwargs):
+    AMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_amin(request, kwargs):
+    AMin.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_any(request, kwargs):
+    Any.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_arange_dtype_int(request, kwargs):
+    Arange.test_dtype_int(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_arange_dtype_float(request, kwargs):
+    Arange.test_dtype_float(request, kwargs)  # noqa: F405
+
+
+# int64 cast for indices is not supported by lpai
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_argmax(request, kwargs):
+    ArgMax.test(request, kwargs)  # noqa: F405
+
+
+# int64 cast for indices is not supported by lpai
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_argmin(request, kwargs):
+    ArgMin.test(request, kwargs)  # noqa: F405
+
+
+# asin not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_asin(request, kwargs):
+    ASin.test(request, kwargs)  # noqa: F405
+
+
+# some decomposed ops are not supported by lpai
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_atan(request, kwargs):
+    ATan.test(request, kwargs)  # noqa: F405
+
+
+# some decomposed ops are not supported by lpai
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_atan2(request, kwargs):
+    ATan2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_avgpool_1d(request, kwargs):
+    AvgPool.test_1d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_avgpool_2d(request, kwargs):
+    AvgPool.test_2d(request, kwargs)  # noqa: F405
+
+
+# avg_pool3d not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_avgpool_3d(request, kwargs):
+    AvgPool.test_3d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_batchnorm_2d(request, kwargs):
+    BatchNorm2d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_bitwise_and_numeric(request, kwargs):
+    BitwiseOp.test_and_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_bitwise_and_bool(request, kwargs):
+    BitwiseOp.test_and_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_bitwise_or_numeric(request, kwargs):
+    BitwiseOp.test_or_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_bitwise_or_bool(request, kwargs):
+    BitwiseOp.test_or_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_bitwise_xor_numeric(request, kwargs):
+    BitwiseOp.test_xor_numeric(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_bitwise_xor_bool(request, kwargs):
+    BitwiseOp.test_xor_bool(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_bmm(request, kwargs):
+    Bmm.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_cast(request, kwargs):
+    Cast.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_cat(request, kwargs):
+    Cat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_cdist(request, kwargs):
+    CDist.test(request, kwargs)  # noqa: F405
+
+
+# ceil not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_ceil(request, kwargs):
+    Ceil.test(request, kwargs)  # noqa: F405
+
+
+# channel_shuffle not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_channel_shuffle(request, kwargs):
+    ChannelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_chunk(request, kwargs):
+    Chunk.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_clamp(request, kwargs):
+    Clamp.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_clamp_max(request, kwargs):
+    ClampMax.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_clamp_min(request, kwargs):
+    ClampMin.test(request, kwargs)  # noqa: F405
+
+
+# clone not in lpai_rules but will be omitted
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_clone(request, kwargs):
+    Clone.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": False, "expected": Tolerance()},
+            id="8a8w_ptq",
+        ),
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+    ],
+)
+@with_lpai_context
+def test_conv1d(request, kwargs):
+    Conv.test_1d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": False, "expected": Tolerance()},
+            id="8a8w_ptq",
+        ),
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+    ],
+)
+@with_lpai_context
+def test_conv1d_transpose(request, kwargs):
+    Conv.test_1d_transpose(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": False, "expected": Tolerance()},
+            id="8a8w_ptq",
+        ),
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+    ],
+)
+@with_lpai_context
+def test_conv2d(request, kwargs):
+    Conv.test_2d(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": False, "expected": Tolerance()},
+            id="8a8w_ptq",
+        ),
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+    ],
+)
+@with_lpai_context
+def test_conv2d_transpose(request, kwargs):
+    Conv.test_2d_transpose(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+    ],
+)
+@with_lpai_context
+def test_conv2d_linear_like(request, kwargs):
+    Conv.test_2d_linear_like(request, kwargs)  # noqa: F405
+
+
+# conv3d not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_conv3d(request, kwargs):
+    Conv.test_3d(request, kwargs)  # noqa: F405
+
+
+# conv3d_transpose not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_conv3d_transpose(request, kwargs):
+    Conv.test_3d_transpose(request, kwargs)  # noqa: F405
+
+
+# cos not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_cos(request, kwargs):
+    Cos.test(request, kwargs)  # noqa: F405
+
+
+# cumsum not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_cumsum(request, kwargs):
+    CumSum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_div(request, kwargs):
+    Div.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_div_with_rounding_mode(request, kwargs):
+    DivWithRoundingMode.test(request, kwargs)  # noqa: F405
+
+
+# einsum decomposes to bmm/matmul before annotation; both in lpai_rules
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_einsum(request, kwargs):
+    Einsum.test(request, kwargs)  # noqa: F405
+
+
+# elu not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_elu(request, kwargs):
+    Elu.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": False, "expected": Tolerance()},
+            id="8a8w_ptq",
+        ),
+    ],
+)
+@with_lpai_context
+def test_embedding(request, kwargs):
+    Embedding.test(request, kwargs)  # noqa: F405
+
+
+# equal not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_equal(request, kwargs):
+    Equal.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_exp(request, kwargs):
+    Exp.test(request, kwargs)  # noqa: F405
+
+
+# expand not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_expand(request, kwargs):
+    Expand.test(request, kwargs)  # noqa: F405
+
+
+# expand_as not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_expand_as(request, kwargs):
+    ExpandAs.test(request, kwargs)  # noqa: F405
+
+
+# expm1 not in lpai_rules but will be decomposed
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_expm1(request, kwargs):
+    ExpM1.test(request, kwargs)  # noqa: F405
+
+
+# fill translates to static tensor in QNN; backend-agnostic
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_fill(request, kwargs):
+    Fill.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_flip(request, kwargs):
+    Flip.test(request, kwargs)  # noqa: F405
+
+
+# floor not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_floor(request, kwargs):
+    Floor.test(request, kwargs)  # noqa: F405
+
+
+# floor_divide not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_floor_divide(request, kwargs):
+    FloorDivide.test(request, kwargs)  # noqa: F405
+
+
+# fold uses col2im which is in lpai_rules (ColIm, qnn_op=None)
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_fold(request, kwargs):
+    Fold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_lpai_context
+def test_fold_unsupported_parameters(request, kwargs):
+    Fold.test_unsupported_parameters(request, kwargs)  # noqa: F405
+
+
+# full/full_like translate to static tensors in QNN; backend-agnostic
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_full(request, kwargs):
+    Full.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_full_like(request, kwargs):
+    FullLike.test(request, kwargs)  # noqa: F405
+
+
+# gather is in lpai_rules (Embedding class handles index/gather/index_select)
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_gather(request, kwargs):
+    Gather.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_gelu(request, kwargs):
+    Gelu.test(request, kwargs)  # noqa: F405
+
+
+# glu decomposes to chunk+sigmoid+mul before annotation; all in lpai_rules
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_glu(request, kwargs):
+    Glu.test(request, kwargs)  # noqa: F405
+
+
+# greater not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_greater(request, kwargs):
+    Greater.test_gt(request, kwargs)  # noqa: F405
+
+
+# greater_equal not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_greater_equal(request, kwargs):
+    Greater.test_ge(request, kwargs)  # noqa: F405
+
+
+# grid_sample not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_grid_sample_4d(request, kwargs):
+    GridSample.test_4d(request, kwargs)  # noqa: F405
+
+
+# grid_sample not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_grid_sample_5d(request, kwargs):
+    GridSample.test_5d(request, kwargs)  # noqa: F405
+
+
+# group_norm not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_group_norm(request, kwargs):
+    GroupNorm.test(request, kwargs)  # noqa: F405
+
+
+# hardsigmoid: DecomposeHardsigmoid runs before annotation; decomposed ops in lpai_rules
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_hardsigmoid(request, kwargs):
+    HardSigmoid.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_hardswish(request, kwargs):
+    HardSwish.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_hardtanh(request, kwargs):
+    HardTanh.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_index(request, kwargs):
+    Index.test(request, kwargs)  # noqa: F405
+
+
+# decomposed ops might not be supported by lpai
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_index_copy(request, kwargs):
+    IndexCopy.test(request, kwargs)  # noqa: F405
+
+
+# decomposed ops might not be supported by lpai
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_index_put(request, kwargs):
+    IndexPut.test(request, kwargs)  # noqa: F405
+
+
+# decomposed ops might not be supported by lpai
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_index_select(request, kwargs):
+    IndexSelect.test(request, kwargs)  # noqa: F405
+
+
+# instance_norm not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_instance_norm_2d(request, kwargs):
+    InstanceNorm2d.test(request, kwargs)  # noqa: F405
+
+
+# registered by the partitioner to not be decomposed but failed to be delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_lpai_context
+def test_interpolate_bicubic(request, kwargs):
+    Interpolate.test_bicubic(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_interpolate_bilinear(request, kwargs):
+    Interpolate.test_bilinear(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_interpolate_nearest(request, kwargs):
+    Interpolate.test_nearest(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_is_inf(request, kwargs):
+    IsInf.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_is_nan(request, kwargs):
+    IsNan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_layer_norm(request, kwargs):
+    LayerNorm.test(request, kwargs)  # noqa: F405
+
+
+# maps to prelu
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_leaky_relu(request, kwargs):
+    LeakyReLU.test(request, kwargs)  # noqa: F405
+
+
+# less_equal not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_less_equal(request, kwargs):
+    LessEqual.test(request, kwargs)  # noqa: F405
+
+
+# less_than not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_less_than(request, kwargs):
+    LessThan.test(request, kwargs)  # noqa: F405
+
+
+# decomposed ops are not fully delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_linalg_vector_norm(request, kwargs):
+    LinalgVectorNorm.test(request, kwargs)  # noqa: F405
+
+
+# LPBQ not applicable to LPAI v6 (requires HTP V69+ feature)
+@pytest.mark.skip(reason="LPBQ quantization is not supported on LPAI v6")
+@with_lpai_context
+def test_linear_block_quant(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": False, "expected": Tolerance()},
+            id="8a8w_ptq",
+        ),
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": True, "expected": Tolerance()},
+            id="8a8w_pcq",
+        ),
+    ],
+)
+@with_lpai_context
+def test_linear_general(request, kwargs):
+    Linear.test(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param(
+            {"act": 8, "param": 8, "pcq": False, "expected": Tolerance()},
+            id="8a8w_ptq",
+        ),
+    ],
+)
+@with_lpai_context
+def test_linear_non_constant_weight(request, kwargs):
+    LinearNonConstantWeight.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_log(request, kwargs):
+    Log.test(request, kwargs)  # noqa: F405
+
+
+# log10 not in lpai_rules but will be decomposed
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_log10(request, kwargs):
+    Log10.test(request, kwargs)  # noqa: F405
+
+
+# log1p not in lpai_rules but will be decomposed
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_log1p(request, kwargs):
+    Log1p.test(request, kwargs)  # noqa: F405
+
+
+# log2 not in lpai_rules but will be decomposed
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_log2(request, kwargs):
+    Log2.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_log_softmax(request, kwargs):
+    LogSoftmax.test(request, kwargs)  # noqa: F405
+
+
+# logical_and not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_logical_and(request, kwargs):
+    LogicalAnd.test(request, kwargs)  # noqa: F405
+
+
+# logical_not not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_logical_not(request, kwargs):
+    LogicalNot.test(request, kwargs)  # noqa: F405
+
+
+# decomposed ops are not supported with invalid weight fallback triggered
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_lpai_context
+def test_masked_fill(request, kwargs):
+    MaskedFill.test(request, kwargs)  # noqa: F405
+
+
+# cast op for indices is not supported
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_max_dim(request, kwargs):
+    MaxDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_maximum(request, kwargs):
+    Maximum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_maxpool_2d(request, kwargs):
+    MaxPool2d.test(request, kwargs)  # noqa: F405
+
+
+# max_pool3d not in lpai_rules and the decomposed ops are not fully delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_maxpool_3d(request, kwargs):
+    MaxPool3d.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_mean(request, kwargs):
+    Mean.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_mha(request, kwargs):
+    MultiheadAttention.test(request, kwargs)  # noqa: F405
+
+
+# cast op for indices is not supported
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_min_dim(request, kwargs):
+    MinDim.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_minimum(request, kwargs):
+    Minimum.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_narrow(request, kwargs):
+    Narrow.test(request, kwargs)  # noqa: F405
+
+
+# neg not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_neg(request, kwargs):
+    Neg.test(request, kwargs)  # noqa: F405
+
+
+# not_equal not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_not_equal(request, kwargs):
+    NotEqual.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_pad_constant(request, kwargs):
+    Pad.test_constant(request, kwargs)  # noqa: F405
+
+
+# registered by the partitioner to not be decomposed but failed to be delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_lpai_context
+def test_pad_reflect(request, kwargs):
+    Pad.test_reflect(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_permute(request, kwargs):
+    Permute.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_pixel_shuffle(request, kwargs):
+    PixelShuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_pixel_unshuffle(request, kwargs):
+    PixelUnshuffle.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_pow_scalar(request, kwargs):
+    PowScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_pow_tensor_scalar(request, kwargs):
+    PowTensorScalar.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_prelu(request, kwargs):
+    PReLU.test(request, kwargs)  # noqa: F405
+
+
+# rand not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_rand(request, kwargs):
+    Rand.test(request, kwargs)  # noqa: F405
+
+
+# reciprocal: DecomposeReciprocal decomposes to div(1, x); div is in lpai_rules
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_reciprocal(request, kwargs):
+    Reciprocal.test(request, kwargs)  # noqa: F405
+
+
+# registered by the partitioner to not be decomposed but failed to be delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_lpai_context
+def test_reflection_pad_1d(request, kwargs):
+    ReflectionPad.test_3d(request, kwargs)  # noqa: F405
+
+
+# registered by the partitioner to not be decomposed but failed to be delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_EXIR_PROGRAM)),
+    ]
+)
+@with_lpai_context
+def test_reflection_pad_2d(request, kwargs):
+    ReflectionPad.test_4d(request, kwargs)  # noqa: F405
+
+
+# reflection_pad3d not in lpai_rules but will be decomposed
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_reflection_pad_3d(request, kwargs):
+    ReflectionPad.test_5d(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_relu(request, kwargs):
+    Relu.test(request, kwargs)  # noqa: F405
+
+
+# relu6 decomposes to hardtanh(0, 6); hardtanh is in lpai_rules (ReluMinMax)
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_relu6(request, kwargs):
+    Relu6.test(request, kwargs)  # noqa: F405
+
+
+# decomposed ops are not fully delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_remainder(request, kwargs):
+    Remainder.test(request, kwargs)  # noqa: F405
+
+
+# repeat not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_repeat(request, kwargs):
+    Repeat.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_reshape_2d_to_4d_random_reshape(request, kwargs):
+    Reshape.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_reshape_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_reshape_5d_random_reshape(request, kwargs):
+    Reshape.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_reshape_5d_flatten_last_two_dims(request, kwargs):
+    Reshape.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_rms_norm(request, kwargs):
+    RmsNorm.test(request, kwargs)  # noqa: F405
+
+
+# roll not in lpai_rules but decomposed ops are fully delegated
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_roll(request, kwargs):
+    Roll.test(request, kwargs)  # noqa: F405
+
+
+# round not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_round(request, kwargs):
+    Round.test(request, kwargs)  # noqa: F405
+
+
+# rsqrt not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_rsqrt(request, kwargs):
+    Rsqrt.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_sdpa(request, kwargs):
+    ScaledDotProductAttention.test(request, kwargs)  # noqa: F405
+
+
+# scatter.src not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_scatter_src(request, kwargs):
+    ScatterSrc.test(request, kwargs)  # noqa: F405
+
+
+# select_copy maps to aten.select.int which is in lpai_rules (StrideSlice)
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_select_copy(request, kwargs):
+    SelectCopy.test(request, kwargs)  # noqa: F405
+
+
+# select_scatter not in lpai_rules and decomposed ops are not fully delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_select_scatter(request, kwargs):
+    SelectScatter.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_sigmoid(request, kwargs):
+    Sigmoid.test(request, kwargs)  # noqa: F405
+
+
+# sign not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_sign(request, kwargs):
+    Sign.test(request, kwargs)  # noqa: F405
+
+
+# sin not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_sin(request, kwargs):
+    Sin.test(request, kwargs)  # noqa: F405
+
+
+# slice_copy maps to aten.slice.Tensor which is in lpai_rules (StrideSlice)
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_slice_copy(request, kwargs):
+    SliceCopy.test(request, kwargs)  # noqa: F405
+
+
+# slice_scatter not in lpai_rules and decomposed ops are not fully delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_slice_scatter(request, kwargs):
+    SliceScatter.test(request, kwargs)  # noqa: F405
+
+
+# scatter not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_scatter_value(request, kwargs):
+    ScatterValue.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_softmax(request, kwargs):
+    Softmax.test(request, kwargs)  # noqa: F405
+
+
+# sort not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_sort(request, kwargs):
+    Sort.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_split(request, kwargs):
+    Split.test(request, kwargs)  # noqa: F405
+
+
+# square is in lpai_rules (Pow class handles square.default)
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_square(request, kwargs):
+    Square.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_squeeze(request, kwargs):
+    Squeeze.test(request, kwargs)  # noqa: F405
+
+
+# stack maps to OpPack which is HTP-specific
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_stack(request, kwargs):
+    Stack.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_sum_int_list(request, kwargs):
+    SumIntList.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_swapaxes(request, kwargs):
+    SwapAxes.test(request, kwargs)  # noqa: F405
+
+
+# tan not in lpai_rules and the decomposed ops are not fully delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_tan(request, kwargs):
+    Tan.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_tanh(request, kwargs):
+    Tanh.test(request, kwargs)  # noqa: F405
+
+
+# threshold not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_ANNOTATED),
+    ]
+)
+@with_lpai_context
+def test_threshold(request, kwargs):
+    Threshold.test(request, kwargs)  # noqa: F405
+
+
+# triu not in lpai_rulesdecomposed ops are not fully delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_triu(request, kwargs):
+    Triu.test(request, kwargs)  # noqa: F405
+
+
+# triu not in lpai_rulesdecomposed ops are not fully delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_triu_constant(request, kwargs):
+    Triu.test_constant(request, kwargs)  # noqa: F405
+
+
+# trunc not in lpai_rules and decomposed ops are not fully delegated
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_trunc(request, kwargs):
+    Trunc.test(request, kwargs)  # noqa: F405
+
+
+# topk not in lpai_rules, use EXPECT_NOT_FULLY_DELEGATED for there are
+# other ops in the test body
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_topk(request, kwargs):
+    TopK.test(request, kwargs)  # noqa: F405
+
+
+# unbind maps to OpUnpack which is HTP-specific
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_unbind(request, kwargs):
+    Unbind.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_unflatten(request, kwargs):
+    Unflatten.test(request, kwargs)  # noqa: F405
+
+
+# unfold uses im2col which is in lpai_rules (ColIm, qnn_op=None)
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_unfold(request, kwargs):
+    Unfold.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype(
+    [
+        pytest.raises(Exception, check=check_exception(EXCEPTION_FROM_PASSES)),
+    ]
+)
+@with_lpai_context
+def test_unfold_unsupported(request, kwargs):
+    Unfold.test_unsupported(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_unsqueeze(request, kwargs):
+    Unsqueeze.test(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_view_2d_to_4d_random_reshape(request, kwargs):
+    View.test_2d_to_4d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_view_2d_to_4d_flatten_last_two_dims(request, kwargs):
+    View.test_2d_to_4d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_view_5d_random_reshape(request, kwargs):
+    View.test_5d_random_reshape(request, kwargs)  # noqa: F405
+
+
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_view_5d_flatten_last_two_dims(request, kwargs):
+    View.test_5d_flatten_last_two_dims(request, kwargs)  # noqa: F405
+
+
+# where not in lpai_rules
+@enumerate_activation_dtype(
+    [
+        pytest.raises(AssertionError, match=EXPECT_NOT_FULLY_DELEGATED),
+    ]
+)
+@with_lpai_context
+def test_where(request, kwargs):
+    Where.test(request, kwargs)  # noqa: F405
+
+
+# var not in lpai_rules but will be decomposed
+@enumerate_activation_dtype([Tolerance()])
+@with_lpai_context
+def test_var(request, kwargs):
+    Var.test(request, kwargs)  # noqa: F405

--- a/backends/qualcomm/tests/rework/src/feature.py
+++ b/backends/qualcomm/tests/rework/src/feature.py
@@ -14,15 +14,24 @@ import pytest
 
 import torch
 
+from executorch.backends.qualcomm.debugger.qcom_numerical_comparator_sample import (
+    QcomCosineSimilarityComparator,
+)
+from executorch.backends.qualcomm.debugger.qnn_intermediate_debugger import (
+    QNNIntermediateDebugger,
+)
 from executorch.backends.qualcomm.export_utils import (
     make_quantizer,
     QcomChipset,
+    QnnConfig,
     QnnExecuTorchBackendType,
     QnnExecuTorchHtpPerformanceMode,
     SimpleADB,
     to_edge_transform_and_lower_to_qnn,
 )
 from executorch.backends.qualcomm.serialization.qc_schema import (
+    QnnExecuTorchGpuPerformanceMode,
+    QnnExecuTorchLpaiClientPerf,
     QnnExecuTorchProfileLevel,
 )
 from executorch.backends.qualcomm.tests.rework.conftest import (
@@ -51,6 +60,17 @@ def unpack_fixtures(func):
     return wrapper
 
 
+def get_quantizer(qnn_config: QnnConfig):
+    return (
+        make_quantizer(
+            backend=qnn_config.backend,
+            soc_model=qnn_config.soc_model,
+        )
+        if qnn_config.backend != QnnExecuTorchBackendType.kGpuBackend
+        else None
+    )
+
+
 class Logging:
     class Model(torch.nn.Module):
         def __init__(self):
@@ -61,6 +81,15 @@ class Logging:
 
         def forward(self, x):
             return torch.nn.ReLU()(x)
+
+    @staticmethod
+    def _get_log_pattern(backend):
+        return {
+            QnnExecuTorchBackendType.kHtpBackend: "QnnDsp <V>",
+            QnnExecuTorchBackendType.kGpuBackend: "OpenCL",
+            # looks like no special keyword appears
+            QnnExecuTorchBackendType.kLpaiBackend: "",
+        }[backend]
 
     @staticmethod
     def _test(qnn_config, compile_specs, expected, aot):
@@ -78,9 +107,7 @@ class Logging:
             model = __class__.Model()
             inputs = model.example_inputs()
             # perform ptq
-            with calibrate(
-                model, [inputs], make_quantizer(soc_model=qnn_config.soc_model)
-            ) as model:
+            with calibrate(model, [inputs], get_quantizer(qnn_config)) as model:
                 # start lowering
                 executorch_prog_mgr = to_edge_transform_and_lower_to_qnn(
                     module=model,
@@ -91,28 +118,28 @@ class Logging:
                 invoke_remote(
                     qnn_config=qnn_config,
                     executorch_prog=executorch_prog_mgr,
-                    callback=partial(callback, pattern="QnnDsp <V>"),
+                    callback=partial(
+                        callback,
+                        pattern=Logging._get_log_pattern(qnn_config.backend),
+                    ),
                 )
 
     @staticmethod
     @unpack_fixtures
     def test(subtests, qnn_config, compile_specs, expected):
-        # extend this for other backends
+        soc_model = getattr(QcomChipset, qnn_config.soc_model)
         backend_compile_specs = {
             QnnExecuTorchBackendType.kHtpBackend: [
-                compile_specs(tuple(d.items()))
-                for d in [
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "debug": True,
-                        "use_fp16": False,
-                    },
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "debug": False,
-                        "use_fp16": False,
-                    },
-                ]
+                {"soc_model": soc_model, "debug": True, "use_fp16": False},
+                {"soc_model": soc_model, "debug": False, "use_fp16": False},
+            ],
+            QnnExecuTorchBackendType.kGpuBackend: [
+                {"soc_model": soc_model, "debug": True, "online_prepare": True},
+                {"soc_model": soc_model, "debug": False, "online_prepare": True},
+            ],
+            QnnExecuTorchBackendType.kLpaiBackend: [
+                {"soc_model": soc_model, "debug": True},
+                {"soc_model": soc_model, "debug": False},
             ],
         }
 
@@ -120,7 +147,9 @@ class Logging:
             with subtests.test(msg=config):
                 __class__._test(
                     qnn_config=qnn_config,
-                    compile_specs=backend_compile_specs[qnn_config.backend][i],
+                    compile_specs=compile_specs(
+                        tuple(backend_compile_specs[qnn_config.backend][i].items())
+                    ),
                     expected=expected,
                     aot=config == "compile_time_option",
                 )
@@ -152,7 +181,7 @@ class MultiGraph:
                 with calibrate(
                     models[i],
                     [inputs],
-                    make_quantizer(soc_model=qnn_config.soc_model),
+                    get_quantizer(qnn_config),
                 ) as model:
                     modules_dict[graph_name] = model
                     sample_inputs_dict[graph_name] = inputs
@@ -221,21 +250,24 @@ class MultiGraph:
     @staticmethod
     @unpack_fixtures
     def test_inference(qnn_config, compile_specs, expected):
-        # extend this for other backends
+        soc_model = getattr(QcomChipset, qnn_config.soc_model)
         backend_compile_specs = {
-            QnnExecuTorchBackendType.kHtpBackend: compile_specs(
-                tuple(
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "use_fp16": False,
-                    }.items()
-                )
-            ),
+            QnnExecuTorchBackendType.kHtpBackend: {
+                "soc_model": soc_model,
+                "use_fp16": False,
+            },
+            QnnExecuTorchBackendType.kGpuBackend: {
+                "soc_model": soc_model,
+                "online_prepare": True,
+            },
+            QnnExecuTorchBackendType.kLpaiBackend: {"soc_model": soc_model},
         }
 
         __class__._test(
             qnn_config=qnn_config,
-            compile_specs=backend_compile_specs[qnn_config.backend],
+            compile_specs=compile_specs(
+                tuple(backend_compile_specs[qnn_config.backend].items())
+            ),
             expected=expected,
         )
 
@@ -254,27 +286,28 @@ class OnlinePrepare:
     @staticmethod
     @unpack_fixtures
     def test(qnn_config, compile_specs, expected):
-        # extend this for other backends
+        soc_model = getattr(QcomChipset, qnn_config.soc_model)
         backend_compile_specs = {
-            QnnExecuTorchBackendType.kHtpBackend: compile_specs(
-                tuple(
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "online_prepare": True,
-                        "use_fp16": False,
-                    }.items()
-                )
-            ),
+            QnnExecuTorchBackendType.kHtpBackend: {
+                "soc_model": soc_model,
+                "online_prepare": True,
+                "use_fp16": False,
+            },
+            QnnExecuTorchBackendType.kGpuBackend: {
+                "soc_model": soc_model,
+                "online_prepare": True,
+            },
         }
 
         module = __class__.Model()
-        qnn_config.online_prepare = True
         export_and_verify(
             module=module,
             inputs=module.example_inputs(),
             qnn_config=qnn_config,
-            quantizer=make_quantizer(soc_model=qnn_config.soc_model),
-            compile_specs=backend_compile_specs[qnn_config.backend],
+            quantizer=get_quantizer(qnn_config),
+            compile_specs=compile_specs(
+                tuple(backend_compile_specs[qnn_config.backend].items())
+            ),
             metrics=expected,
         )
 
@@ -304,53 +337,82 @@ class Performance:
             adb.extra_cmds += "" if aot else " --htp_performance_mode 6"
             adb.execute(output_callback=verify)
 
+        # TODO: extend performance check for following backends
+        def callback_gpu(adb: SimpleADB):
+            adb.execute()
+
+        def callback_lpai(adb: SimpleADB):
+            adb.execute()
+
         with expected:
             # model declaration
             model = __class__.Model()
             inputs = model.example_inputs()
             # perform ptq
-            with calibrate(
-                model, [inputs], make_quantizer(soc_model=qnn_config.soc_model)
-            ) as model:
+            with calibrate(model, [inputs], get_quantizer(qnn_config)) as model:
                 # start lowering
                 executorch_prog_mgr = to_edge_transform_and_lower_to_qnn(
                     module=model,
                     inputs=inputs,
                     compiler_specs=compile_specs,
                 ).to_executorch()
-                # verifier per backend
                 dispatcher = {
                     QnnExecuTorchBackendType.kHtpBackend: callback_htp,
+                    QnnExecuTorchBackendType.kGpuBackend: callback_gpu,
+                    QnnExecuTorchBackendType.kLpaiBackend: callback_lpai,
                 }
                 # remote testing
                 invoke_remote(
                     qnn_config=qnn_config,
                     executorch_prog=executorch_prog_mgr,
-                    callback=partial(dispatcher[qnn_config.backend], voltage=80),
+                    callback=(
+                        partial(dispatcher[qnn_config.backend], voltage=80)
+                        if qnn_config.backend == QnnExecuTorchBackendType.kHtpBackend
+                        else dispatcher[qnn_config.backend]
+                    ),
                 )
 
     @staticmethod
     @unpack_fixtures
     def test(subtests, qnn_config, compile_specs, expected):
-        # extend this for other backends
+        soc_model = getattr(QcomChipset, qnn_config.soc_model)
         backend_compile_specs = {
             QnnExecuTorchBackendType.kHtpBackend: [
-                compile_specs(tuple(d.items()))
-                for d in [
-                    # compile_time option
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "debug": True,
-                        "use_fp16": False,
-                        "htp_performance_mode": QnnExecuTorchHtpPerformanceMode.kHtpHighPowerSaver,
-                    },
-                    # runtime_option (performance mode defaults to kHtpBurst)
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "debug": True,
-                        "use_fp16": False,
-                    },
-                ]
+                # compile_time option
+                {
+                    "soc_model": soc_model,
+                    "debug": True,
+                    "use_fp16": False,
+                    "htp_performance_mode": QnnExecuTorchHtpPerformanceMode.kHtpHighPowerSaver,
+                },
+                # runtime_option (performance mode defaults to kHtpBurst)
+                {"soc_model": soc_model, "debug": True, "use_fp16": False},
+            ],
+            QnnExecuTorchBackendType.kGpuBackend: [
+                # compile_time option: set low perf hint to GPU
+                {
+                    "soc_model": soc_model,
+                    "online_prepare": True,
+                    "performance_mode": QnnExecuTorchGpuPerformanceMode.kGpuPerfHintLow,
+                },
+                # runtime_option: scaffold — GPUruntime perf hint not yet wired in C++
+                # TODO: extend GPU runtime to accept dynamic performance settings
+                {
+                    "soc_model": soc_model,
+                    "debug": True,
+                    "online_prepare": True,
+                },
+            ],
+            QnnExecuTorchBackendType.kLpaiBackend: [
+                {
+                    "soc_model": soc_model,
+                    "fps": 30,
+                    "ftrt_ratio": 10,
+                    "client_perf_type": QnnExecuTorchLpaiClientPerf.kRealTime,
+                },
+                # runtime_option: scaffold — LPAI runtime perf hint not yet wired in C++
+                # TODO: extend LPAI runtime to accept dynamic performance settings
+                {"soc_model": soc_model, "debug": True},
             ],
         }
 
@@ -358,7 +420,9 @@ class Performance:
             with subtests.test(msg=config):
                 __class__._test(
                     qnn_config=qnn_config,
-                    compile_specs=backend_compile_specs[qnn_config.backend][i],
+                    compile_specs=compile_specs(
+                        tuple(backend_compile_specs[qnn_config.backend][i].items())
+                    ),
                     expected=expected,
                     aot=config == "compile_time_option",
                 )
@@ -409,9 +473,7 @@ class Profile:
             model = __class__.Model()
             inputs = model.example_inputs()
             # perform ptq
-            with calibrate(
-                model, [inputs], make_quantizer(soc_model=qnn_config.soc_model)
-            ) as model:
+            with calibrate(model, [inputs], get_quantizer(qnn_config)) as model:
                 # start lowering
                 executorch_prog_mgr = to_edge_transform_and_lower_to_qnn(
                     module=model,
@@ -426,30 +488,43 @@ class Profile:
                     callback=partial(
                         callback,
                         executorch_prog_mgr=executorch_prog_mgr,
-                        expected_profile_events=20,
+                        expected_profile_events=2,
                     ),
                 )
 
     @staticmethod
     @unpack_fixtures
     def test(subtests, qnn_config, compile_specs, expected):
-        # extend this for other backends
+        soc_model = getattr(QcomChipset, qnn_config.soc_model)
         backend_compile_specs = {
             QnnExecuTorchBackendType.kHtpBackend: [
-                compile_specs(tuple(d.items()))
-                for d in [
-                    # compile_time option
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "profile_level": QnnExecuTorchProfileLevel.kProfileDetailed,
-                        "use_fp16": False,
-                    },
-                    # runtime_option
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "use_fp16": False,
-                    },
-                ]
+                # compile_time option
+                {
+                    "soc_model": soc_model,
+                    "profile_level": QnnExecuTorchProfileLevel.kProfileDetailed,
+                    "use_fp16": False,
+                },
+                # runtime_option
+                {"soc_model": soc_model, "use_fp16": False},
+            ],
+            QnnExecuTorchBackendType.kGpuBackend: [
+                # compile_time option
+                {
+                    "soc_model": soc_model,
+                    "profile_level": QnnExecuTorchProfileLevel.kProfileDetailed,
+                    "online_prepare": True,
+                },
+                # runtime_option
+                {"soc_model": soc_model, "online_prepare": True},
+            ],
+            QnnExecuTorchBackendType.kLpaiBackend: [
+                # compile_time option
+                {
+                    "soc_model": soc_model,
+                    "profile_level": QnnExecuTorchProfileLevel.kProfileDetailed,
+                },
+                # runtime_option
+                {"soc_model": soc_model},
             ],
         }
 
@@ -457,7 +532,9 @@ class Profile:
             with subtests.test(msg=config):
                 __class__._test(
                     qnn_config=qnn_config,
-                    compile_specs=backend_compile_specs[qnn_config.backend][i],
+                    compile_specs=compile_specs(
+                        tuple(backend_compile_specs[qnn_config.backend][i].items())
+                    ),
                     expected=expected,
                     aot=config == "compile_time_option",
                 )
@@ -482,17 +559,23 @@ class Saver:
             option_to_flatbuffer,
         )
 
-        # extend this for other backends
+        # saver=True is a top-level QnnExecuTorchOptions field; works across backends
+        soc_model = getattr(QcomChipset, qnn_config.soc_model)
         backend_compile_specs = {
-            QnnExecuTorchBackendType.kHtpBackend: compile_specs(
-                tuple(
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "saver": True,
-                        "use_fp16": False,
-                    }.items()
-                )
-            ),
+            QnnExecuTorchBackendType.kHtpBackend: {
+                "soc_model": soc_model,
+                "saver": True,
+                "use_fp16": False,
+            },
+            QnnExecuTorchBackendType.kGpuBackend: {
+                "soc_model": soc_model,
+                "saver": True,
+                "online_prepare": True,
+            },
+            QnnExecuTorchBackendType.kLpaiBackend: {
+                "soc_model": soc_model,
+                "saver": True,
+            },
         }
 
         with expected:
@@ -500,13 +583,13 @@ class Saver:
             model = __class__.Model()
             inputs = model.example_inputs()
             # perform ptq
-            with calibrate(
-                model, [inputs], make_quantizer(soc_model=qnn_config.soc_model)
-            ) as model:
+            with calibrate(model, [inputs], get_quantizer(qnn_config)) as model:
                 # start lowering
                 with tempfile.TemporaryDirectory() as tmp_dir:
                     # hack saver output folder
-                    cs = backend_compile_specs[qnn_config.backend]
+                    cs = compile_specs(
+                        tuple(backend_compile_specs[qnn_config.backend].items())
+                    )
                     option = flatbuffer_to_option(cs[0].value)
                     option.saver_output_dir = f"{tmp_dir}/saver_output"
                     cs[0].value = option_to_flatbuffer(option)
@@ -539,17 +622,23 @@ class SharedBuffer:
     @staticmethod
     @unpack_fixtures
     def test(qnn_config, compile_specs, expected):
-        # extend this for other backends
+        # shared_buffer=True is a top-level QnnExecuTorchOptions field; works across backends
+        soc_model = getattr(QcomChipset, qnn_config.soc_model)
         backend_compile_specs = {
-            QnnExecuTorchBackendType.kHtpBackend: compile_specs(
-                tuple(
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "shared_buffer": True,
-                        "use_fp16": False,
-                    }.items()
-                )
-            ),
+            QnnExecuTorchBackendType.kHtpBackend: {
+                "soc_model": soc_model,
+                "shared_buffer": True,
+                "use_fp16": False,
+            },
+            QnnExecuTorchBackendType.kGpuBackend: {
+                "soc_model": soc_model,
+                "shared_buffer": True,
+                "online_prepare": True,
+            },
+            QnnExecuTorchBackendType.kLpaiBackend: {
+                "soc_model": soc_model,
+                "shared_buffer": True,
+            },
         }
 
         module = __class__.Model()
@@ -558,8 +647,10 @@ class SharedBuffer:
             module=module,
             inputs=module.example_inputs(),
             qnn_config=qnn_config,
-            quantizer=make_quantizer(soc_model=qnn_config.soc_model),
-            compile_specs=backend_compile_specs[qnn_config.backend],
+            quantizer=get_quantizer(qnn_config),
+            compile_specs=compile_specs(
+                tuple(backend_compile_specs[qnn_config.backend].items())
+            ),
             metrics=expected,
         )
 
@@ -605,9 +696,7 @@ class SpillFill:
             # perform ptq
             model = __class__.Model()
             inputs = model.example_inputs()
-            with calibrate(
-                model, [inputs], make_quantizer(soc_model=qnn_config.soc_model)
-            ) as model:
+            with calibrate(model, [inputs], get_quantizer(qnn_config)) as model:
                 # start lowering
                 edge_prog_mgr = to_edge_transform_and_lower_to_qnn(
                     module=model,
@@ -621,22 +710,23 @@ class SpillFill:
 
 
 class TensorDump:
+    # Simple Conv2d+ReLU model that is supported by all backends
     class Model(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.idx_source = torch.rand(10, 3)
+            self.conv = torch.nn.Conv2d(3, 8, kernel_size=3, padding=1)
+            self.relu = torch.nn.ReLU()
 
         def example_inputs(self):
-            return (torch.randn(3, 10),)
+            return (torch.randn(1, 3, 8, 8),)
 
         def forward(self, x):
-            a, b = torch.topk(x, 3)
-            return a + self.idx_source[b]
+            return self.relu(self.conv(x))
 
     @staticmethod
     @unpack_fixtures
     def test(qnn_config, compile_specs, expected):
-        def callback(adb: SimpleADB, expected_intermediate_events):
+        def callback(adb: SimpleADB, debugger, expected_compared_events):
             with tempfile.TemporaryDirectory() as tmp_dir:
                 etdump_path = f"{tmp_dir}/etdump.etdp"
                 debug_output_path = f"{tmp_dir}/debug_output.bin"
@@ -644,49 +734,82 @@ class TensorDump:
                 adb.pull_debug_output(
                     etdump_path=etdump_path, debug_buffer_path=debug_output_path
                 )
-                inspector = Inspector(
-                    etdump_path=etdump_path, debug_buffer_path=debug_output_path
+                debugger.setup_inspector(
+                    etdump_path=etdump_path,
+                    debug_buffer_path=debug_output_path,
                 )
-                for event_block in inspector.event_blocks:
-                    if event_block.name == "Execute":
-                        assert (
-                            len(event_block.events) == expected_intermediate_events
-                        ), (
-                            f"unexpected number of intermediate events, expecting "
-                            f"{expected_intermediate_events}, but has {len(event_block.events)} events.",
-                        )
+                comparator = debugger.create_comparator(QcomCosineSimilarityComparator)
+                numeric_results = debugger.inspector.calculate_numeric_gap(
+                    distance=comparator,
+                    reference_graph=debugger.reference_graph_name,
+                )
+                numeric_results = numeric_results.set_index("runtime_debug_handle")
+                assert len(numeric_results) == expected_compared_events, (
+                    f"unexpected number of compared events, expecting "
+                    f"{expected_compared_events}, but has {len(numeric_results)} events."
+                )
+                for _, row in numeric_results.iterrows():
+                    assert comparator.is_valid_score(row.gap[0]), (
+                        f"Node {row.aot_ops} is failing "
+                        f"{comparator.metric_name()} test, {row.gap[0]} is lower "
+                        f"than {comparator.threshold}."
+                    )
 
-        # extend this for other backends
+        soc_model = getattr(QcomChipset, qnn_config.soc_model)
+        # dump_intermediate_outputs=True is a top-level QnnExecuTorchOptions field; works across backends
         backend_compile_specs = {
-            QnnExecuTorchBackendType.kHtpBackend: compile_specs(
-                tuple(
-                    {
-                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
-                        "dump_intermediate_outputs": True,
-                        "use_fp16": False,
-                    }.items()
-                )
-            ),
+            QnnExecuTorchBackendType.kHtpBackend: {
+                "soc_model": soc_model,
+                "dump_intermediate_outputs": True,
+                "use_fp16": False,
+            },
+            QnnExecuTorchBackendType.kGpuBackend: {
+                "soc_model": soc_model,
+                "dump_intermediate_outputs": True,
+                "online_prepare": True,
+            },
+            QnnExecuTorchBackendType.kLpaiBackend: {
+                "soc_model": soc_model,
+                "dump_intermediate_outputs": True,
+            },
         }
 
         with expected:
             # perform ptq
             model = __class__.Model()
             inputs = model.example_inputs()
-            with calibrate(
-                model, [inputs], make_quantizer(soc_model=qnn_config.soc_model)
-            ) as model:
+            with calibrate(model, [inputs], get_quantizer(qnn_config)) as model:
                 # start lowering
                 executorch_prog_mgr = to_edge_transform_and_lower_to_qnn(
                     module=model,
                     inputs=inputs,
-                    compiler_specs=backend_compile_specs[qnn_config.backend],
+                    compiler_specs=compile_specs(
+                        tuple(backend_compile_specs[qnn_config.backend].items())
+                    ),
                     generate_etrecord=True,
                 ).to_executorch()
-                # remote testing
-                qnn_config.dump_intermediate_outputs = True
-                invoke_remote(
-                    qnn_config=qnn_config,
-                    executorch_prog=executorch_prog_mgr,
-                    callback=partial(callback, expected_intermediate_events=9),
-                )
+
+                with tempfile.TemporaryDirectory() as etrecord_dir:
+                    etrecord_path = f"{etrecord_dir}/etrecord.bin"
+                    etrecord = executorch_prog_mgr.get_etrecord()
+                    debugger = QNNIntermediateDebugger(inputs)
+                    debugger.set_etrecord_file_path(etrecord_path)
+                    debugger.set_edge_ep(
+                        edge_ep=etrecord.graph_map[debugger.reference_graph_name]
+                    )
+                    etrecord.update_representative_inputs(debugger.sample_input)
+                    etrecord.save(etrecord_path)
+
+                    # remote testing
+                    qnn_config.dump_intermediate_outputs = True
+                    invoke_remote(
+                        qnn_config=qnn_config,
+                        executorch_prog=executorch_prog_mgr,
+                        inputs=inputs,
+                        # conv + relu = 2 intermediate outputs
+                        callback=partial(
+                            callback,
+                            debugger=debugger,
+                            expected_compared_events=2,
+                        ),
+                    )

--- a/backends/qualcomm/tests/rework/src/op.py
+++ b/backends/qualcomm/tests/rework/src/op.py
@@ -3198,7 +3198,7 @@ class LogSoftmax(torch.nn.Module):
     @unpack_fixtures
     def test(subtests, qnn_config, quantizer, compile_spec, expected):
         inputs = (torch.randn(1, 4, 8, 8),)
-        dims = [-1, 1, 2]
+        dims = [-1, 3]
         for dim in dims:
             with subtests.test(msg=f"dim:{dim}"):
                 with expected as metrics:

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -7787,6 +7787,32 @@ class TestQNNQuantizedUtils(TestQNN):
             expected_compared_events=expected_compared_events,
         )
 
+    def test_qnn_backend_dump_intermediate_outputs_conv_relu(self):
+        match get_backend_type(self.backend):
+            case QnnExecuTorchBackendType.kHtpBackend:
+                backend_options = generate_htp_compiler_spec(use_fp16=False)
+            case QnnExecuTorchBackendType.kLpaiBackend:
+                backend_options = generate_lpai_compiler_spec(
+                    target_env=self.get_lpai_target_env()
+                )
+            case _:
+                raise ValueError("Backend is not implemented yet")
+        TestQNN.compiler_specs = generate_qnn_executorch_compiler_spec(
+            soc_model=self.chipset_table[TestQNN.soc_model],
+            backend_options=backend_options,
+            dump_intermediate_outputs=True,
+        )
+        sample_input = (torch.randn(1, 3, 8, 8),)
+        module = ConvRelu()  # noqa: F405
+        module = self.get_qdq_module(module, sample_input)
+
+        self.lower_module_and_test_output(
+            module,
+            sample_input,
+            expected_partitions=1,
+            expected_compared_events=2,
+        )
+
     def test_qnn_backend_dump_intermediate_outputs_topk(self):
         torch.manual_seed(8)
         backend_options = generate_htp_compiler_spec(use_fp16=False)

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -34,6 +34,7 @@ from executorch.backends.qualcomm.serialization.qc_schema import (
     QnnExecuTorchBackendOptions,
     QnnExecuTorchBackendType,
     QnnExecuTorchGpuBackendOptions,
+    QnnExecuTorchGpuPerformanceMode,
     QnnExecuTorchGpuPrecision,
     QnnExecuTorchHtpBackendOptions,
     QnnExecuTorchHtpPerformanceMode,
@@ -1018,6 +1019,7 @@ def draw_graph(title, path, graph_module: torch.fx.GraphModule, format=DrawForma
 
 
 def generate_gpu_compiler_spec(
+    performance_mode: QnnExecuTorchGpuPerformanceMode = QnnExecuTorchGpuPerformanceMode.kGpuPerfHintHigh,
     precision: QnnExecuTorchGpuPrecision = QnnExecuTorchGpuPrecision.kGpuPrecisionUserProvided,
     use_memory_optimizations: bool = True,
     use_node_optimizations: bool = True,
@@ -1028,6 +1030,8 @@ def generate_gpu_compiler_spec(
     Helper function generating backend options for QNN HTP
 
     Args:
+        performance_mode:
+            kGpuPerfHintHigh / kGpuPerfHintNormal / kGpuPerfHintLow
         precision:
             kGpuPrecisionFp32 - Sets the precision mode to floating point 32-bit (FP32).
             kGpuPrecisionFp16 - Sets the precision mode to floating point 16-bit (FP16).
@@ -1046,6 +1050,7 @@ def generate_gpu_compiler_spec(
     """
     # TODO: enable performance hint mechanism in runtime and make this as an option
     gpu_options = QnnExecuTorchGpuBackendOptions()
+    gpu_options.performance_mode = performance_mode
     gpu_options.precision = precision
     gpu_options.use_memory_optimizations = use_memory_optimizations
     gpu_options.use_node_optimizations = use_node_optimizations


### PR DESCRIPTION
Co-author: @winskuo-quic 

### Summary
- extend op / feature test for htp arch (v69~v81)
- extend op / feature test for lpai / gpu backend

### Test plan
```bash
pytest backends/qualcomm/tests/rework/lpai/feature/v6/test.py --device f3c0531 --soc_model SM8850 --build_folder ./build-android/ --backend lpai
pytest backends/qualcomm/tests/rework/lpai/op/v6/test.py
```
```bash
pytest backends/qualcomm/tests/rework/gpu/feature/test.py --device f3c0531 --soc_model SM8650 --build_folder ./build-android/ --backend gpu
ytest backends/qualcomm/tests/rework/gpu/op/test.py --device f3c0531 --soc_model SM8650 --build_folder ./build-android/ --backend gpu
```
