### PR TITLE
Bump PyTorch pin to nightly dev20260823

### DIFF
--- a/.ci/docker/ci_commit_pins/pytorch.txt
+++ b/.ci/docker/ci_commit_pins/pytorch.txt
@@ -1,1 +1,1 @@
-release/2.13
+b1c1cc8ee4018ca065df249a03b586662fd0329a

--- a/runtime/core/portable_type/c10/c10/util/complex.h
+++ b/runtime/core/portable_type/c10/c10/util/complex.h
@@ -31,18 +31,10 @@ C10_HOST_DEVICE T abs(const c10::complex<T>& z) {
 #endif
 }
 
-#if defined(USE_ROCM)
-#define ROCm_Bug(x)
-#else
-#define ROCm_Bug(x) x
-#endif
-
 template <typename T>
 C10_HOST_DEVICE T arg(const c10::complex<T>& z) {
-  return ROCm_Bug(std)::atan2(std::imag(z), std::real(z));
+  return std::atan2(std::imag(z), std::real(z));
 }
-
-#undef ROCm_Bug
 
 template <typename T>
 constexpr T norm(const c10::complex<T>& z) {
@@ -73,6 +65,9 @@ constexpr c10::complex<T> conj(const c10::complex<T>& z) {
 #define C10_INTERNAL_INCLUDE_COMPLEX_REMAINING_H
 // math functions are included in a separate file
 #include <c10/util/complex_math.h> // IWYU pragma: keep
-// utilities for complex types
-#include <c10/util/complex_utils.h> // IWYU pragma: keep
 #undef C10_INTERNAL_INCLUDE_COMPLEX_REMAINING_H
+
+namespace c10 {
+using torch::headeronly::is_complex;
+using torch::headeronly::scalar_value_type;
+} // namespace c10

--- a/runtime/core/portable_type/c10/c10/util/llvmMathExtras.h
+++ b/runtime/core/portable_type/c10/c10/util/llvmMathExtras.h
@@ -400,6 +400,7 @@ constexpr inline bool isShiftedUInt(uint64_t x) {
       N + S <= 64, "isShiftedUInt<N, S> with N + S > 64 is too wide.");
   // Per the two static_asserts above, S must be strictly less than 64.  So
   // 1 << S is not undefined behavior.
+  // NOLINTNEXTLINE(bugprone-chained-comparison)
   return isUInt<N + S>(x) && (x % (UINT64_C(1) << S) == 0);
 }
 

--- a/runtime/core/portable_type/c10/c10/util/overflows.h
+++ b/runtime/core/portable_type/c10/c10/util/overflows.h
@@ -61,12 +61,27 @@ template <typename To, typename From>
 std::enable_if_t<std::is_floating_point_v<From>, bool> overflows(
     From f,
     bool strict_unsigned [[maybe_unused]] = false) {
-  using limit = std::numeric_limits<typename scalar_value_type<To>::type>;
+  using ToScalar = typename scalar_value_type<To>::type;
+  using limit = std::numeric_limits<ToScalar>;
   if (limit::has_infinity && std::isinf(static_cast<double>(f))) {
     return false;
   }
   if (!limit::has_quiet_NaN && (f != f)) {
     return true;
+  }
+  if constexpr (std::is_integral_v<ToScalar>) {
+    // limit::max() for wide integer types is NOT exactly representable in
+    // floating point (e.g. int64 max = 2^63-1 rounds up to 2^63), so `f >
+    // limit::max()` lets a just-out-of-range value like 2^63 slip through and
+    // then become INT64_MIN via static_cast. Compare against the
+    // exactly-representable upper bound max()+1 == 2^digits instead. lowest()
+    // is 0 or a negated power of two, so it stays exact. (digits-1 keeps the
+    // shift < 64 for the uint64 case; the *2 recovers 2^digits without a 1<<64
+    // overflow.)
+    constexpr int digits = limit::digits;
+    constexpr From upper =
+        static_cast<From>(uint64_t{1} << (digits - 1)) * From{2};
+    return f < static_cast<From>(limit::lowest()) || f >= upper;
   }
   return f < limit::lowest() || f > limit::max();
 }

--- a/runtime/core/portable_type/c10/torch/headeronly/macros/Macros.h
+++ b/runtime/core/portable_type/c10/torch/headeronly/macros/Macros.h
@@ -123,6 +123,15 @@
 #define C10_HAS_CPP_ATTRIBUTE(x) (0)
 #endif
 
+/// Bind a returned reference/pointer's lifetime to a parameter (or *this) so
+/// Clang can warn when it would dangle. Expands to nothing on compilers that
+/// lack the attribute (e.g. non-clang, older nvcc).
+#if C10_HAS_CPP_ATTRIBUTE(clang::lifetimebound)
+#define C10_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define C10_LIFETIMEBOUND
+#endif
+
 #ifndef FBCODE_CAFFE2
 /// DEPRECATED: Warn if a type or return value is discarded.
 #define C10_NODISCARD [[nodiscard]]

--- a/runtime/core/portable_type/c10/torch/headeronly/util/Half.h
+++ b/runtime/core/portable_type/c10/torch/headeronly/util/Half.h
@@ -213,7 +213,7 @@ C10_HOST_DEVICE inline float fp16_ieee_to_fp32_value(uint16_t h) {
    * Now, remember that denormalized half-precision numbers are represented as:
    *    FP16 = mantissa * 2**(-24).
    * The trick is to construct a normalized single-precision number with the
-   * same mantissa and thehalf-precision input and with an exponent which would
+   * same mantissa and the half-precision input and with an exponent which would
    * scale the corresponding mantissa bits to 2**(-24). A normalized
    * single-precision floating-point number is represented as: FP32 = (1 +
    * mantissa * 2**(-23)) * 2**(exponent - 127) Therefore, when the biased

--- a/runtime/core/portable_type/c10/torch/headeronly/util/TypeSafeSignMath.h
+++ b/runtime/core/portable_type/c10/torch/headeronly/util/TypeSafeSignMath.h
@@ -14,20 +14,6 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-int-float-conversion")
 
 namespace c10 {
 
-/// Returns false since we cannot have x < 0 if x is unsigned.
-template <typename T>
-inline constexpr bool is_negative(
-    const T& /*x*/,
-    std::true_type /*is_unsigned*/) {
-  return false;
-}
-
-/// Returns true if a signed variable x < 0
-template <typename T>
-inline constexpr bool is_negative(const T& x, std::false_type /*is_unsigned*/) {
-  return x < T(0);
-}
-
 /// Returns true if x < 0
 /// NOTE: Will fail on an unsigned custom type
 ///       For the most part it's possible to fix this if
@@ -35,19 +21,12 @@ inline constexpr bool is_negative(const T& x, std::false_type /*is_unsigned*/) {
 ///       However, notably, c10::Half does not :-(
 template <typename T>
 inline constexpr bool is_negative(const T& x) {
-  return is_negative(x, std::is_unsigned<T>());
-}
-
-/// Returns the sign of an unsigned variable x as 0, 1
-template <typename T>
-inline constexpr int signum(const T& x, std::true_type /*is_unsigned*/) {
-  return T(0) < x;
-}
-
-/// Returns the sign of a signed variable x as -1, 0, 1
-template <typename T>
-inline constexpr int signum(const T& x, std::false_type /*is_unsigned*/) {
-  return (T(0) < x) - (x < T(0));
+  if constexpr (std::is_unsigned_v<T>) {
+    // An unsigned value can never be less than zero.
+    return false;
+  } else {
+    return x < T(0);
+  }
 }
 
 /// Returns the sign of x as -1, 0, 1
@@ -57,7 +36,11 @@ inline constexpr int signum(const T& x, std::false_type /*is_unsigned*/) {
 ///       However, notably, c10::Half does not :-(
 template <typename T>
 inline constexpr int signum(const T& x) {
-  return signum(x, std::is_unsigned<T>());
+  if constexpr (std::is_unsigned_v<T>) {
+    return T(0) < x;
+  } else {
+    return (T(0) < x) - (x < T(0));
+  }
 }
 
 /// Returns true if a and b are not both negative
@@ -86,53 +69,22 @@ inline constexpr bool greater_than_max(const T& x) {
 #pragma GCC diagnostic pop
 #endif
 
-/// Returns true if x < lowest(Limit). Standard comparison
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& x,
-    std::false_type /*limit_is_unsigned*/,
-    std::false_type /*x_is_unsigned*/) {
-  return x < std::numeric_limits<Limit>::lowest();
-}
-
-/// Returns false since all the limit is signed and therefore includes
-/// negative values but x cannot be negative because it is unsigned
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& /*x*/,
-    std::false_type /*limit_is_unsigned*/,
-    std::true_type /*x_is_unsigned*/) {
-  return false;
-}
-
-/// Returns true if x < 0, where 0 is constructed from T.
-/// Limit is not signed, so its lower value is zero
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& x,
-    std::true_type /*limit_is_unsigned*/,
-    std::false_type /*x_is_unsigned*/) {
-  return x < T(0);
-}
-
-/// Returns false sign both types are unsigned
-template <typename Limit, typename T>
-inline constexpr bool less_than_lowest(
-    const T& /*x*/,
-    std::true_type /*limit_is_unsigned*/,
-    std::true_type /*x_is_unsigned*/) {
-  return false;
-}
-
-/// Returns true if x is less than the lowest value of type T
+/// Returns true if x is less than the lowest value of type Limit
 /// NOTE: Will fail on an unsigned custom type
 ///       For the most part it's possible to fix this if
 ///       the custom type has a constexpr constructor.
 ///       However, notably, c10::Half does not :
 template <typename Limit, typename T>
 inline constexpr bool less_than_lowest(const T& x) {
-  return less_than_lowest<Limit>(
-      x, std::is_unsigned<Limit>(), std::is_unsigned<T>());
+  if constexpr (std::is_unsigned_v<T>) {
+    // x is unsigned, so it can never be below the lowest value of any type.
+    return false;
+  } else if constexpr (std::is_unsigned_v<Limit>) {
+    // Limit is unsigned, so its lowest value is zero.
+    return x < T(0);
+  } else {
+    return x < std::numeric_limits<Limit>::lowest();
+  }
 }
 
 } // namespace c10

--- a/runtime/core/portable_type/c10/torch/headeronly/util/complex.h
+++ b/runtime/core/portable_type/c10/torch/headeronly/util/complex.h
@@ -3,6 +3,7 @@
 #include <complex>
 
 #include <torch/headeronly/macros/Macros.h>
+#include <torch/headeronly/util/BFloat16.h>
 #include <torch/headeronly/util/Half.h>
 
 #if defined(__CUDACC__) || defined(__HIPCC__)
@@ -588,6 +589,60 @@ struct alignas(4) complex<Half> {
   }
 };
 
+template <>
+struct alignas(4) complex<BFloat16> {
+  BFloat16 real_;
+  BFloat16 imag_;
+
+  // Constructors
+  complex() = default;
+  // BFloat16 constructor is not constexpr so the following constructor can't
+  // be constexpr
+  C10_HOST_DEVICE explicit inline complex(
+      const BFloat16& real,
+      const BFloat16& imag)
+      : real_(real), imag_(imag) {}
+  C10_HOST_DEVICE inline complex(const c10::complex<float>& value)
+      : real_(value.real()), imag_(value.imag()) {}
+
+  // Conversion operator
+  inline C10_HOST_DEVICE operator c10::complex<float>() const {
+    return {real_, imag_};
+  }
+
+  constexpr C10_HOST_DEVICE BFloat16 real() const {
+    return real_;
+  }
+  constexpr C10_HOST_DEVICE BFloat16 imag() const {
+    return imag_;
+  }
+
+  C10_HOST_DEVICE complex<BFloat16>& operator+=(
+      const complex<BFloat16>& other) {
+    real_ = static_cast<float>(real_) + static_cast<float>(other.real_);
+    imag_ = static_cast<float>(imag_) + static_cast<float>(other.imag_);
+    return *this;
+  }
+
+  C10_HOST_DEVICE complex<BFloat16>& operator-=(
+      const complex<BFloat16>& other) {
+    real_ = static_cast<float>(real_) - static_cast<float>(other.real_);
+    imag_ = static_cast<float>(imag_) - static_cast<float>(other.imag_);
+    return *this;
+  }
+
+  C10_HOST_DEVICE complex<BFloat16>& operator*=(
+      const complex<BFloat16>& other) {
+    auto a = static_cast<float>(real_);
+    auto b = static_cast<float>(imag_);
+    auto c = static_cast<float>(other.real());
+    auto d = static_cast<float>(other.imag());
+    real_ = a * c - b * d;
+    imag_ = a * d + b * c;
+    return *this;
+  }
+};
+
 } // namespace c10
 
 HIDDEN_NAMESPACE_BEGIN(torch, headeronly)
@@ -614,3 +669,8 @@ using c10::complex_literals::operator""_id;
 HIDDEN_NAMESPACE_END(torch, headeronly)
 
 C10_CLANG_DIAGNOSTIC_POP()
+
+#define C10_INTERNAL_INCLUDE_COMPLEX_REMAINING_H
+// utilities for complex types
+#include <torch/headeronly/util/complex_utils.h> // IWYU pragma: keep
+#undef C10_INTERNAL_INCLUDE_COMPLEX_REMAINING_H

--- a/torch_pin.py
+++ b/torch_pin.py
@@ -1,2 +1,2 @@
 TORCH_VERSION = "2.13.0"
-# NIGHTLY_VERSION = "dev20260318" Temporarily pinning to stable release candidate. Revert https://github.com/pytorch/executorch/pull/18287
+NIGHTLY_VERSION = "dev20260823"


### PR DESCRIPTION
## Summary

Automated weekly PyTorch pin bump.

- Updates `NIGHTLY_VERSION` in `torch_pin.py` to `dev20260823`
- Updates `.ci/docker/ci_commit_pins/pytorch.txt` to the corresponding nightly commit hash
- Syncs c10 headers from PyTorch into `runtime/core/portable_type/c10/`

This PR was created automatically. If CI fails, Claude will attempt to fix issues (up to 3 attempts). If CI still fails, human review will be requested.

cc @jakeszwe