### PR TITLE
[executorch] Remove obsolete VGF slice xfail

### DIFF
--- a/backends/arm/test/ops/test_slice.py
+++ b/backends/arm/test/ops/test_slice.py
@@ -386,12 +386,6 @@ def test_slice_tensor_u85_INT_step(test_data: Tuple):
 @common.parametrize(
     "test_data",
     test_data_step_int | test_data_step_fp,
-    xfails={
-        "arange_fp32_2d_step4": (
-            "MLCE-1969: Emlayer 0.10 Interval memory planner corrupts "
-            "multi-input CONCAT output"
-        ),
-    },
 )
 @common.SkipIfNoModelConverter
 def test_slice_tensor_vgf_no_quant_step(test_data: Tuple):


### PR DESCRIPTION
The VGF converter 0.10 upgrade makes the arange_fp32_2d_step4 slice case pass. Remove its stale strict xfail so the successful result is not reported as an XPASS failure.

Test plan: `buck test @fbcode//mode/dev fbcode//executorch/backends/arm/test:slice -- --exact "fbcode//executorch/backends/arm/test:slice - test_slice.py::test_slice_tensor_vgf_no_quant_step[arange_fp32_2d_step4]"`

Local OSS test was not run because pytest is not installed in this checkout environment.

This PR was authored with Codex.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani