### PR TITLE
[executorch] Arm backend: Preserve Arm pass behavior for Conv1d conversion

### DIFF
--- a/backends/arm/_passes/conv1d_unsqueeze_pass.py
+++ b/backends/arm/_passes/conv1d_unsqueeze_pass.py
@@ -7,6 +7,7 @@
 
 from typing import Set, Type
 
+from executorch.backends.arm._passes import ArmOpTargetedPass
 from executorch.backends.arm._passes.convert_squeezes_to_view import (
     ConvertSqueezesToViewPass,
 )
@@ -15,10 +16,11 @@ from executorch.backends.arm._passes.size_adjust_input_pass import SizeAdjustInp
 from executorch.backends.transforms.convert_conv1d_to_conv2d_pass import (
     ConvertConv1dToConv2dPass,
 )
+from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
 
-class Conv1dUnsqueezePass(ConvertConv1dToConv2dPass):
+class Conv1dUnsqueezePass(ConvertConv1dToConv2dPass, ArmOpTargetedPass):
     """Arm wrapper for the shared Conv1d-to-Conv2d transform."""
 
     _passes_required_after: Set[Type[ExportPass]] = {
@@ -26,3 +28,4 @@ class Conv1dUnsqueezePass(ConvertConv1dToConv2dPass):
         RewriteConvPass,
         SizeAdjustInputPass,
     }
+    target_ops = (exir_ops.edge.aten.convolution.default,)

--- a/backends/arm/test/ops/test_conv1d.py
+++ b/backends/arm/test/ops/test_conv1d.py
@@ -118,6 +118,11 @@ class Conv1d(torch.nn.Module):
         return x
 
 
+class Conv1dWithLeakyReLU(Conv1d):
+    def forward(self, x):
+        return torch.nn.functional.leaky_relu(super().forward(x), negative_slope=0.0)
+
+
 conv1d_2_3x2x40_nobias = Conv1d(
     in_channels=2,
     out_channels=3,
@@ -322,6 +327,18 @@ def test_convolution_1d_tosa_INT(test_data):
         aten_op,
         exir_op,
         per_channel_quantization=per_channel_quantization,
+        qtol=1,
+    )
+    pipeline.run()
+
+
+def test_convolution_1d_with_leaky_relu_tosa_INT():
+    model = Conv1dWithLeakyReLU()
+    pipeline = TosaPipelineINT[input_t](
+        model,
+        model.get_inputs(),
+        [aten_op, "torch.ops.aten.leaky_relu.default"],
+        [exir_op, "executorch_exir_dialects_edge__ops_aten_leaky_relu_default"],
         qtol=1,
     )
     pipeline.run()


### PR DESCRIPTION
Keep the shared Conv1d-to-Conv2d transform on the Arm pass hierarchy so whole-graph retracing retains Arm handling for quantized operators without fake kernels. Restore targeted-pass filtering for convolution graphs.

Add a quantized Conv1d-plus-LeakyReLU regression that exercises the failure reported on D116841181.

Test plan:
- `buck test @fbcode//mode/dev-nosan fbcode//executorch/backends/arm/test:conv1d -- --exact "fbcode//executorch/backends/arm/test:conv1d - test_conv1d.py::test_convolution_1d_with_leaky_relu_tosa_INT"`
- `arc lint -a` and `arc lint` on changed files
- Attempted the exact `test_ceres_u55_handwriting` CI repro; the Buck daemon was killed by host OOM before completion.
- `python -m py_compile backends/arm/_passes/conv1d_unsqueeze_pass.py backends/arm/test/ops/test_conv1d.py`

This PR was authored with Codex.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani