### PR TITLE
Arm backend: Update VGF test for fused ReLU qparams

### DIFF
--- a/backends/arm/test/passes/test_rewrite_conv_pass.py
+++ b/backends/arm/test/passes/test_rewrite_conv_pass.py
@@ -534,9 +534,7 @@ def test_rewrite_conv_a16w8_preserves_int32_after_permute() -> None:
 
 
 @pytest.mark.skipif(not _VGF_ENABLED, reason="VGF not enabled")
-def test_fold_and_annotate_q_params_vgf_quant_tracks_fused_relu_qparams() -> (
-    None
-):
+def test_fold_and_annotate_q_params_vgf_quant_tracks_fused_relu_qparams() -> None:
     exported_program = _export_quantized(TinyConvReluCat())
     gm = _run_pre_rewrite_passes(to_edge(exported_program).exported_program())
 

--- a/backends/arm/test/passes/test_rewrite_conv_pass.py
+++ b/backends/arm/test/passes/test_rewrite_conv_pass.py
@@ -534,22 +534,24 @@ def test_rewrite_conv_a16w8_preserves_int32_after_permute() -> None:
 
 
 @pytest.mark.skipif(not _VGF_ENABLED, reason="VGF not enabled")
-def test_fold_and_annotate_q_params_vgf_quant_preserves_output_qparams_on_non_fuseable_clamp() -> (
+def test_fold_and_annotate_q_params_vgf_quant_tracks_fused_relu_qparams() -> (
     None
 ):
     exported_program = _export_quantized(TinyConvReluCat())
     gm = _run_pre_rewrite_passes(to_edge(exported_program).exported_program())
 
     conv = _get_call_function_node(gm, exir_ops.edge.aten.convolution.default)
-    clamp = _get_call_function_node(gm, exir_ops.edge.aten.clamp.default)
+    output_qparams = conv.meta["output_qparams"][0]
 
     assert conv.meta["input_qparams"]
-    assert not conv.meta["output_qparams"]
-    assert clamp.meta["output_qparams"]
+    assert output_qparams.qmin == output_qparams.zp
+    assert not any(
+        node.target == exir_ops.edge.aten.clamp.default for node in gm.graph.nodes
+    )
 
 
 @pytest.mark.skipif(not _VGF_ENABLED, reason="VGF not enabled")
-def test_rewrite_conv_vgf_quant_handles_non_fuseable_conv_clamp_cat_branch() -> None:
+def test_rewrite_conv_vgf_quant_handles_fused_conv_relu_cat_branch() -> None:
     exported_program = _export_quantized(TinyConvReluCat())
     compile_spec = _compile_spec()
 


### PR DESCRIPTION
Update the VGF rewrite-convolution regression for the ReLU fusion behavior introduced by D116922192.

The ReLU is fused into the convolution before ConvertToClampPass runs, so the clamp is fused away and no clamp node remains. Verify that the fused convolution owns the output quantization parameters with qmin rewritten to the zero point.

Rename the adjacent lowering test to describe the fused Conv-ReLU-Cat path.

Test plan:
- `buck test @fbcode//mode/dev fbcode//executorch/backends/arm/test:rewrite_conv_pass -- --exact "fbcode//executorch/backends/arm/test:rewrite_conv_pass - test_rewrite_conv_pass.py::test_fold_and_annotate_q_params_vgf_quant_tracks_fused_relu_qparams"`
- `buck test @fbcode//mode/dev fbcode//executorch/backends/arm/test:rewrite_conv_pass -- --exact "fbcode//executorch/backends/arm/test:rewrite_conv_pass - test_rewrite_conv_pass.py::test_rewrite_conv_vgf_quant_handles_fused_conv_relu_cat_branch" "fbcode//executorch/backends/arm/test:rewrite_conv_pass - test_rewrite_conv_pass.py::test_rewrite_conv_vgf_quant_infers_quantized_bias_dtype_from_inputs"`
- `arc lint -a` and `arc lint` on changed files
- `python -m py_compile backends/arm/test/passes/test_rewrite_conv_pass.py`

This PR was authored with Codex.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani