### PR TITLE
[executorch][native] Add Scalar value type to the in-memory IR

### DIFF
--- a/backends/native/runtime/graph/Scalar.cpp
+++ b/backends/native/runtime/graph/Scalar.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/graph/Scalar.h>
+
+#include <stdexcept>
+
+#include <executorch/backends/native/runtime/graph/Format.h>
+
+namespace ptn {
+
+int64_t Scalar::to_int() const {
+  const int64_t* v = std::get_if<int64_t>(&value_);
+  if (v == nullptr) {
+    throw std::runtime_error("Scalar::to_int: scalar is not an Int");
+  }
+  return *v;
+}
+
+double Scalar::to_double() const {
+  const double* v = std::get_if<double>(&value_);
+  if (v == nullptr) {
+    throw std::runtime_error("Scalar::to_double: scalar is not a Double");
+  }
+  return *v;
+}
+
+bool Scalar::to_bool() const {
+  const bool* v = std::get_if<bool>(&value_);
+  if (v == nullptr) {
+    throw std::runtime_error("Scalar::to_bool: scalar is not a Bool");
+  }
+  return *v;
+}
+
+const char* Scalar::tag_name() const {
+  switch (tag()) {
+    case Tag::Int:
+      return "Int";
+    case Tag::Double:
+      return "Double";
+    case Tag::Bool:
+      return "Bool";
+  }
+  return "?";
+}
+
+std::string Scalar::to_string() const {
+  if (const bool* b = std::get_if<bool>(&value_)) {
+    return *b ? "true" : "false";
+  }
+  if (is_int()) {
+    return std::to_string(to_int());
+  }
+  return format_double(to_double());
+}
+
+} // namespace ptn

--- a/backends/native/runtime/graph/Scalar.h
+++ b/backends/native/runtime/graph/Scalar.h
@@ -1,0 +1,74 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <variant>
+
+namespace ptn {
+
+// A concrete scalar value: an int / double / bool. Analogous to c10::Scalar.
+// Trivially copyable. There is no "none" state — the graph's Value owns that.
+class Scalar {
+ public:
+  // Which alternative is live. Pinned to the order of the variant below, so a
+  // Tag is exactly an index into it.
+  enum class Tag : int8_t { Int = 0, Double = 1, Bool = 2 };
+
+ private:
+  std::variant<int64_t, double, bool> value_ = int64_t{0};
+
+ public:
+  constexpr Scalar() = default;
+  // Implicit by design (ergonomic: `Scalar s = 5;`). The int overload
+  // disambiguates `Scalar(5)` — without it int -> {int64_t,double,bool} is an
+  // ambiguous conversion. The suppression is scoped to this block so a
+  // genuinely accidental implicit constructor added later is still reported.
+  // cppcheck-suppress-begin noExplicitConstructor
+  /* implicit */ constexpr Scalar(int v) : value_(static_cast<int64_t>(v)) {}
+  /* implicit */ constexpr Scalar(int64_t v) : value_(v) {}
+  /* implicit */ constexpr Scalar(double v) : value_(v) {}
+  /* implicit */ constexpr Scalar(bool v) : value_(v) {}
+  // cppcheck-suppress-end noExplicitConstructor
+  // Every pointer converts to bool, so without this `Scalar s = some_ptr;`
+  // would quietly yield a Bool. Deleted rather than made explicit so the
+  // implicit numeric constructors above keep their ergonomics.
+  template <typename T>
+  Scalar(T*) = delete;
+
+  constexpr Tag tag() const {
+    return static_cast<Tag>(value_.index());
+  }
+  constexpr bool is_int() const {
+    return std::holds_alternative<int64_t>(value_);
+  }
+  constexpr bool is_double() const {
+    return std::holds_alternative<double>(value_);
+  }
+  constexpr bool is_bool() const {
+    return std::holds_alternative<bool>(value_);
+  }
+
+  // Strict accessors: return the live alternative, throw std::runtime_error on
+  // a tag mismatch.
+  int64_t to_int() const;
+  double to_double() const;
+  bool to_bool() const;
+
+  // Promoting read: static_cast the live alternative to T (like
+  // c10::Scalar::to<T>()); works whichever tag is live.
+  template <typename T>
+  constexpr T to() const {
+    return std::visit([](auto v) { return static_cast<T>(v); }, value_);
+  }
+
+  const char* tag_name() const;
+  std::string to_string() const;
+};
+
+} // namespace ptn

--- a/backends/native/runtime/graph/targets.bzl
+++ b/backends/native/runtime/graph/targets.bzl
@@ -19,6 +19,17 @@ def define_common_targets():
         visibility = ["//executorch/backends/native/..."],
     )
 
+    # A concrete scalar value (int / double / bool), tagged. c10::Scalar analog.
+    runtime.cxx_library(
+        name = "scalar",
+        srcs = ["Scalar.cpp"],
+        exported_headers = [
+            "Scalar.h",
+        ],
+        deps = [":format"],
+        visibility = ["//executorch/backends/native/..."],
+    )
+
     # Concrete in-memory IR value types (pure std; no ExecuTorch, no flatbuffers).
     runtime.cxx_library(
         name = "tensor_meta",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22105
* #22104
* #22103
* #22102
* #22101
* #22100
* __->__ #22099
* #22098
* #22097
* #22096

Add `Scalar` (`backends/native/runtime/graph/Scalar.{h,cpp}`), a concrete scalar
value — an int / double / bool tagged over a trivially-copyable union, analogous
to `c10::Scalar` and the scalar slice of the ET-VK ComputeGraph `Value`.

Construct implicitly from `int` / `int64_t` / `double` / `bool`; read via strict
accessors (`to_int` / `to_double` / `to_bool`, which throw on a tag mismatch) or
the promoting `to<T>()` template (a `static_cast` of whichever member is active,
like `c10::Scalar::to<T>()`). Plus `tag()` / `is_*()` predicates and `tag_name()`
/ `to_string()` debug helpers. No "none" state — the graph's Value owns that.

Pure std — no ExecuTorch and no flatbuffers dependency. Mirrored into both the
`fbcode/` and `xplat/` trees to match the native backend layout.

Authored with Claude Code.

Differential Revision: [D114396762](https://our.internmc.facebook.com/intern/diff/D114396762/)