### PR TITLE
[executorch][native] Add Value + index-arena ids to the in-memory IR

### DIFF
--- a/backends/native/runtime/graph/Ids.h
+++ b/backends/native/runtime/graph/Ids.h
@@ -1,0 +1,35 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+namespace ptn {
+
+// Index-arena handles. A NodeRef indexes Graph.nodes; a ValueRef indexes
+// Graph.values. Plain int32_t aliases — they index, compare, and hash
+// directly, at the cost of no NodeRef/ValueRef type distinction. kInvalid
+// marks "no ref" (e.g. a graph input has no producer node; a fresh value has
+// no alias).
+using NodeRef = int32_t;
+using ValueRef = int32_t;
+constexpr int32_t kInvalid = -1;
+
+inline bool valid(int32_t ref) {
+  return ref >= 0;
+}
+
+// True when `ref` addresses one of `size` elements: valid and in range. The
+// signed/unsigned comparison goes through std::cmp_less so neither side has to
+// be cast to the other's signedness.
+inline bool in_bounds(int32_t ref, size_t size) {
+  return valid(ref) && std::cmp_less(ref, size);
+}
+
+} // namespace ptn

--- a/backends/native/runtime/graph/Value.cpp
+++ b/backends/native/runtime/graph/Value.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/graph/Value.h>
+
+#include <stdexcept>
+
+namespace ptn {
+
+const TensorMeta& Value::tensor_meta() const {
+  const TensorMeta* m = std::get_if<TensorMeta>(&value_);
+  if (m == nullptr) {
+    throw std::runtime_error("Value::tensor_meta: value is not a Tensor");
+  }
+  return *m;
+}
+
+const Scalar& Value::scalar() const {
+  const Scalar* s = std::get_if<Scalar>(&value_);
+  if (s == nullptr) {
+    throw std::runtime_error("Value::scalar: value is not a Scalar");
+  }
+  return *s;
+}
+
+const std::vector<ValueRef>& Value::content_refs() const {
+  const std::vector<ValueRef>* refs =
+      std::get_if<std::vector<ValueRef>>(&value_);
+  if (refs == nullptr) {
+    throw std::runtime_error("Value::content_refs: value is not a List");
+  }
+  return *refs;
+}
+
+} // namespace ptn

--- a/backends/native/runtime/graph/Value.h
+++ b/backends/native/runtime/graph/Value.h
@@ -1,0 +1,102 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <any>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <executorch/backends/native/runtime/graph/Ids.h>
+#include <executorch/backends/native/runtime/graph/Scalar.h>
+#include <executorch/backends/native/runtime/graph/TensorMeta.h>
+
+namespace ptn {
+
+// What a Value holds.
+enum class ValueKind : int8_t {
+  None = 0,
+  Tensor = 1,
+  Scalar = 2,
+  List = 3,
+};
+
+// A single SSA value (dataflow edge) in a Graph: its contents plus def-use
+// wiring, a storage-alias fact, and an open attrs map.
+//
+// The contents are a std::variant whose alternatives are listed in ValueKind
+// order, so kind() is the variant's index. Construct via the constructors (one
+// per kind); read the payload via the typed accessors after checking kind()
+// (each accessor throws std::runtime_error on a kind mismatch). A List holds
+// ValueRefs to its element values (a grouping over arena values, e.g. a tuple
+// produced by an in-memory rewrite) — nesting is via the arena, so there is no
+// recursive value type. The AOT deserializer builds only Tensor / Scalar /
+// None; List is reserved for in-memory construction.
+class Value {
+ private:
+  std::variant<std::monostate, TensorMeta, Scalar, std::vector<ValueRef>>
+      value_;
+
+ public:
+  // SSA name, scoped to the enclosing Graph.
+  std::string name;
+  // Defining node; invalid => graph input.
+  NodeRef producer_ref = kInvalid;
+  // Def-use, built by inverting node inputs.
+  std::vector<NodeRef> consumer_refs;
+  // Shares storage with this value (a view); fresh if invalid.
+  ValueRef alias_ref = kInvalid;
+  // Scratch + planner annotations.
+  std::unordered_map<std::string, std::any> attrs;
+
+  Value() = default; // a None value with an empty name
+
+  explicit Value(std::string name) // a named None value
+      : name(std::move(name)) {}
+
+  Value(std::string name, TensorMeta meta) // Tensor
+      : value_(std::move(meta)), name(std::move(name)) {}
+
+  // Tensor from dtype + sizes: a contiguous, unquantized TensorMeta. The empty
+  // dim_order_hint is what makes it contiguous, so it is spelled out.
+  Value(std::string name, ScalarType dtype, std::vector<Dim> sizes)
+      : value_(TensorMeta{dtype, std::move(sizes), {}}),
+        name(std::move(name)) {}
+
+  Value(std::string name, Scalar value) // Scalar
+      : value_(value), name(std::move(name)) {}
+
+  Value(std::string name, std::vector<ValueRef> elem_refs) // List
+      : value_(std::move(elem_refs)), name(std::move(name)) {}
+
+  ValueKind kind() const {
+    return static_cast<ValueKind>(value_.index());
+  }
+  bool is_tensor() const {
+    return std::holds_alternative<TensorMeta>(value_);
+  }
+  bool is_scalar() const {
+    return std::holds_alternative<Scalar>(value_);
+  }
+  bool is_list() const {
+    return std::holds_alternative<std::vector<ValueRef>>(value_);
+  }
+  bool is_none() const {
+    return std::holds_alternative<std::monostate>(value_);
+  }
+
+  // Typed payload accessors. Each throws std::runtime_error unless kind()
+  // matches; guard with the is_*() / kind() predicates.
+  const TensorMeta& tensor_meta() const;
+  const Scalar& scalar() const;
+  const std::vector<ValueRef>& content_refs() const;
+};
+
+} // namespace ptn

--- a/backends/native/runtime/graph/targets.bzl
+++ b/backends/native/runtime/graph/targets.bzl
@@ -42,3 +42,28 @@ def define_common_targets():
         ],
         visibility = ["//executorch/backends/native/..."],
     )
+
+    # Index-arena handles (NodeRef / ValueRef); header-only.
+    runtime.cxx_library(
+        name = "ids",
+        exported_headers = [
+            "Ids.h",
+        ],
+        visibility = ["//executorch/backends/native/..."],
+    )
+
+    # A single SSA value: a std::variant (tensor / scalar / list / none) plus
+    # def-use wiring, storage alias, and an attrs scratch map.
+    runtime.cxx_library(
+        name = "value",
+        srcs = ["Value.cpp"],
+        exported_headers = [
+            "Value.h",
+        ],
+        exported_deps = [
+            ":ids",
+            ":scalar",
+            ":tensor_meta",
+        ],
+        visibility = ["//executorch/backends/native/..."],
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22105
* #22104
* #22103
* #22102
* #22101
* __->__ #22100
* #22099
* #22098
* #22097
* #22096

Next in-memory IR types for the native runtime, under
`backends/native/runtime/graph/`:

- `Ids.h` — `NodeRef` / `ValueRef`, plain `int32_t` index-arena aliases (ET-VK
  `vkapi` style) plus `kInvalid` and a `valid()` helper. `NodeRef` indexes
  `Graph.nodes`; `ValueRef` indexes `Graph.values`.
- `Value` (`Value.{h,cpp}`) — one SSA value (dataflow edge): a tagged union
  (`ValueKind` = None / Tensor / Scalar / List) over per-kind members, plus
  def-use wiring (`producer` / `consumers`), a storage `alias_of`, and an open
  `attrs` (`std::any`) scratch map. Construct via the `tensor` / `scalar` /
  `list` / `none` factories; read via typed accessors that throw on a kind
  mismatch. A `List` holds `ValueRef`s to its element values (an arena
  grouping), so nesting is via the arena and there is no recursive value type;
  the AOT deserializer builds only Tensor / Scalar / None.

Pure std — no ExecuTorch and no flatbuffers dependency. Mirrored into both the
`fbcode/` and `xplat/` trees to match the native backend layout.

Authored with Claude Code.

Differential Revision: [D114396769](https://our.internmc.facebook.com/intern/diff/D114396769/)