### PR TITLE
Fix broken fbsource//xplat/executorch/backends/vulkan/test:vulkan_compute_api_testAndroid-32bit caus (#22109)

### DIFF
--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -113,7 +113,7 @@ TEST_F(VulkanComputeAPITest, device_to_host_staging_prefers_cached_memory) {
       context()->adapter_ptr()->vma().create_staging_buffer(
           4096, vkapi::CopyDirection::DEVICE_TO_HOST);
   const VmaAllocator allocator = staging_buffer.vma_allocator();
-  ASSERT_NE(allocator, VK_NULL_HANDLE);
+  ASSERT_NE(allocator, nullptr);
 
   const VkPhysicalDeviceMemoryProperties* memory_properties = nullptr;
   vmaGetMemoryProperties(allocator, &memory_properties);
@@ -132,7 +132,7 @@ TEST_F(VulkanComputeAPITest, device_to_host_staging_prefers_cached_memory) {
   }
 
   const VmaAllocation allocation = staging_buffer.allocation();
-  ASSERT_NE(allocation, VK_NULL_HANDLE);
+  ASSERT_NE(allocation, nullptr);
 
   VkMemoryPropertyFlags selected_flags = 0;
   vmaGetAllocationMemoryProperties(allocator, allocation, &selected_flags);


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/pytorch/executorch/pull/22109

Reviewed By: SS-JIA

Differential Revision: D117231906


