### PR TITLE
Let a serialized fake-tensor state_dict be read back (#22111)

### DIFF
--- a/exir/serde/export_serialize.py
+++ b/exir/serde/export_serialize.py
@@ -17,6 +17,7 @@ import dataclasses
 import heapq
 import inspect
 import io
+import contextlib
 import json
 import logging
 import math
@@ -304,7 +305,16 @@ def _reconstruct_fake_tensor(
     assert len(_CURRENT_DESERIALIZER) != 0, "Need access to current deserializer state"
     fake_tensor = _CURRENT_DESERIALIZER[-1].deserialize_tensor_meta(tensor_meta)
     if is_parameter:
-        fake_tensor = torch.nn.Parameter(fake_tensor)  # type: ignore[assignment]
+        # `nn.Parameter` defaults `requires_grad` to True, which raises on the
+        # integer dtypes quantized weights use. Derived rather than recorded by
+        # the reducer, whose payload is the on-disk format: a float parameter
+        # that had it False therefore comes back True.
+        requires_grad = (
+            fake_tensor.dtype.is_floating_point or fake_tensor.dtype.is_complex
+        )
+        fake_tensor = torch.nn.Parameter(  # type: ignore[assignment]
+            fake_tensor, requires_grad=requires_grad
+        )
     return fake_tensor
 
 
@@ -336,7 +346,19 @@ def deserialize_torch_artifact(
         return {}
     buffer = io.BytesIO(serialized)
     buffer.seek(0)
-    artifact = torch.load(buffer, weights_only=True)
+    # A fake tensor reduces to `_reconstruct_fake_tensor`, which
+    # `weights_only=True` refuses unless it is allowlisted.
+    #
+    # Conditional because `safe_globals` subtracts from one process-global set on
+    # exit, with no refcount: entering it when the caller has already allowed
+    # this global would revoke their registration.
+    allowance = (
+        contextlib.nullcontext()
+        if _reconstruct_fake_tensor in torch.serialization.get_safe_globals()
+        else torch.serialization.safe_globals([_reconstruct_fake_tensor])
+    )
+    with allowance:
+        artifact = torch.load(buffer, weights_only=True)
     assert isinstance(artifact, (tuple, dict))
     return artifact
 

--- a/exir/tests/test_serde.py
+++ b/exir/tests/test_serde.py
@@ -9,7 +9,8 @@
 import io
 import tempfile
 import unittest
-from typing import Tuple
+from contextlib import contextmanager
+from typing import Dict, Iterator, Tuple
 
 import executorch.exir as exir
 
@@ -28,10 +29,19 @@ from executorch.exir.program._program import (
     EdgeProgramManager,
     to_edge_transform_and_lower,
 )
+from executorch.exir.serde.export_serialize import (
+    _CURRENT_DESERIALIZER,
+    _reconstruct_fake_tensor,
+    deserialize_torch_artifact,
+    GraphModuleDeserializer,
+    serialize_torch_artifact,
+)
 from executorch.exir.serde.serialize import deserialize, serialize
 from torch import nn
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.export import export
 from torch.export.exported_program import ExportedProgram as TorchExportedProgram
+from torch.export.graph_signature import InputKind
 from torch.utils import _pytree as pytree
 
 
@@ -350,3 +360,154 @@ class TestSerde(unittest.TestCase):
             torch.randn(10, 10),
         )
         self.check_serde(MemoryOpsModule(), inputs)
+
+
+class TestFakeTensorArtifacts(unittest.TestCase):
+    """`state_dict` / `constants` entries may be FakeTensors.
+
+    `_reduce_fake_tensor` writes one as its `TensorMeta` -- shape and dtype, no
+    storage -- so a caller can record a program's structure without its weight
+    values. The tests above only ever serialize real tensors.
+    """
+
+    @contextmanager
+    def _deserializer_on_the_stack(self) -> Iterator[None]:
+        """Push what `_reconstruct_fake_tensor` reads.
+
+        It rebuilds tensors through the current deserializer's fake mode, which
+        only `deserialize()` puts on this stack. These tests round-trip the
+        artifact alone, so they push it themselves.
+        """
+        deserializer = GraphModuleDeserializer()
+        deserializer.fake_tensor_mode = FakeTensorMode()
+        _CURRENT_DESERIALIZER.append(deserializer)
+        try:
+            yield
+        finally:
+            _CURRENT_DESERIALIZER.pop()
+
+    def _round_trip(self, artifact: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        with self._deserializer_on_the_stack():
+            return deserialize_torch_artifact(serialize_torch_artifact(artifact))
+
+    def test_reading_leaves_a_callers_own_allowlist_entry_alone(self) -> None:
+        """Reading must not revoke an allowance the caller set up itself.
+
+        `safe_globals` subtracts on exit with no refcount, so entering it
+        unconditionally removes a registration made with `add_safe_globals`.
+        """
+        previous = torch.serialization.get_safe_globals()
+        torch.serialization.add_safe_globals([_reconstruct_fake_tensor])
+        try:
+            self._round_trip({"w": FakeTensorMode().from_tensor(torch.randn(2))})
+            self.assertIn(
+                _reconstruct_fake_tensor,
+                torch.serialization.get_safe_globals(),
+                "the caller's own registration must survive the load",
+            )
+        finally:
+            torch.serialization.clear_safe_globals()
+            torch.serialization.add_safe_globals(previous)
+
+    def test_fake_tensor_artifact_round_trips(self) -> None:
+        """The read path must accept what the write path produces.
+
+        `weights_only=True` refuses any global that is not allowlisted,
+        `_reconstruct_fake_tensor` included.
+        """
+        fake_mode = FakeTensorMode()
+        artifact = {"w": fake_mode.from_tensor(torch.randn(4, 8))}
+        self.assertIsInstance(artifact["w"], FakeTensor, "precondition")
+
+        restored = self._round_trip(artifact)
+
+        self.assertEqual({"w"}, set(restored))
+        self.assertIsInstance(restored["w"], FakeTensor)
+        self.assertEqual(torch.Size([4, 8]), restored["w"].shape)
+        self.assertEqual(torch.float32, restored["w"].dtype)
+
+    def test_integer_parameter_survives_deserialization(self) -> None:
+        """A parameter of integer dtype must round-trip.
+
+        Quantized weights are ones. Rebuilding with `nn.Parameter`'s default of
+        `requires_grad=True` raises `only Tensors of floating point dtype can
+        require gradients`.
+        """
+        fake_mode = FakeTensorMode()
+        codes = torch.nn.Parameter(
+            torch.randint(0, 255, (4, 8), dtype=torch.uint8), requires_grad=False
+        )
+        artifact = {"codes": fake_mode.from_tensor(codes)}
+        self.assertIsInstance(artifact["codes"], torch.nn.Parameter, "precondition")
+
+        restored = self._round_trip(artifact)
+
+        self.assertIsInstance(restored["codes"], FakeTensor)
+        self.assertIsInstance(restored["codes"], torch.nn.Parameter)
+        self.assertEqual(torch.uint8, restored["codes"].dtype)
+        self.assertFalse(restored["codes"].requires_grad)
+
+    def test_requires_grad_is_derived_from_the_dtype(self) -> None:
+        """`requires_grad` is rebuilt, not recovered -- pinned so it stays known.
+
+        The reducer records only *that* an entry was a parameter, so a float one
+        that had `requires_grad=False` comes back True.
+        """
+        fake_mode = FakeTensorMode()
+        artifact = {
+            "float_param": fake_mode.from_tensor(
+                torch.nn.Parameter(torch.randn(4), requires_grad=False)
+            ),
+            "int_param": fake_mode.from_tensor(
+                torch.nn.Parameter(
+                    torch.zeros(4, dtype=torch.int64), requires_grad=False
+                )
+            ),
+        }
+
+        restored = self._round_trip(artifact)
+
+        self.assertTrue(restored["float_param"].requires_grad, "derived, not kept")
+        self.assertFalse(restored["int_param"].requires_grad, "cannot be anything else")
+
+    def test_program_with_a_fake_state_dict_round_trips(self) -> None:
+        """The whole program, not just the artifact -- the shape callers use.
+
+        Only this reaches `_verify_exported_program_signature`, which requires
+        every `InputKind.PARAMETER` entry to still be an `nn.Parameter`.
+        """
+
+        class Quantized(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.codes = nn.Parameter(
+                    torch.randint(0, 255, (4, 4), dtype=torch.uint8),
+                    requires_grad=False,
+                )
+                self.scales = nn.Parameter(torch.rand(4, 4), requires_grad=False)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return x + self.codes.to(torch.float32) * self.scales
+
+        program = to_edge(
+            export(Quantized(), (torch.randn(4, 4),), strict=True)
+        ).exported_program()
+        self.assertIn(
+            InputKind.PARAMETER,
+            [spec.kind for spec in program.graph_signature.input_specs],
+            "the model must have parameters for this to test anything",
+        )
+
+        fake_mode = FakeTensorMode()
+        program._state_dict = {
+            name: fake_mode.from_tensor(tensor, static_shapes=True)
+            for name, tensor in program.state_dict.items()
+        }
+
+        restored = deserialize(serialize(program))
+
+        self.assertEqual(set(program.state_dict), set(restored.state_dict))
+        for name, tensor in restored.state_dict.items():
+            self.assertIsInstance(tensor, FakeTensor, f"{name} should stay fake")
+            self.assertIsInstance(tensor, nn.Parameter, f"{name} stays a Parameter")
+        self.assertEqual(torch.uint8, restored.state_dict["codes"].dtype)


### PR DESCRIPTION
Summary:

`serialize_torch_artifact` already supports fake tensors: it installs
`_reduce_fake_tensor`, which writes a FakeTensor as its `TensorMeta` -- shape,
dtype and stride, no storage. Two gaps stopped the matching read path from
working, so an artifact whose `state_dict` holds fake tensors could be written
and then not read back. Both are latent and independent of any caller; they are
split out of the Helios stack that found them so they can be reviewed on their
own.

**1. `weights_only=True` refused ExecuTorch's own reconstructor.**
`deserialize_torch_artifact` loads with `weights_only=True`, which rejects any
global that is not allowlisted:

  WeightsUnpickler error: Unsupported global: GLOBAL
  executorch.exir.serde.export_serialize._reconstruct_fake_tensor
  was not an allowed global by default

Fixed by allowlisting the reconstructor for the load with
`torch.serialization.safe_globals`. That is narrower than `add_safe_globals`,
which registers process-globally and permanently -- but narrower in *time* only,
not per-call: the allowlist is a single process-global set, so a concurrent
`torch.load(weights_only=True)` on another thread during the window accepts this
global too.

**Entering it is conditional, and that is not defensive coding.** `safe_globals`
unions that set on entry and *subtracts* on exit, with no refcount. Entering it
unconditionally therefore revokes the registration of any caller who has already
added this global with `add_safe_globals` -- precisely the workaround people
applied before this function handled it. Measured rather than argued: with the
unconditional form, a probe reading the allowlist around one load reported
`before=True after=False`.

**2. Rebuilding a parameter raised on any integer dtype.**
`_reconstruct_fake_tensor` restored `nn.Parameter` entries as
`torch.nn.Parameter(fake_tensor)`, and that default of `requires_grad=True`
*raises*:

  RuntimeError: only Tensors of floating point dtype can require gradients

`nn.Parameter` accepts an integer tensor as long as `requires_grad` is False,
and quantized weights -- uint8 codes and their zero points -- are exactly that.
So this hit the whole class of quantized models, not an edge case.

`requires_grad` is derived from the dtype. Recording the flag in the reducer
instead was written first, then backed out: the reducer's return value is the
on-disk format, and two other copies of this module in fbsource
(`xplat/spacecraft/sample_apps`, `third-party/mediatek/release-0.7`) still have
the two-argument `_reconstruct_fake_tensor`, so widening the payload would
produce records they cannot read. The cost is fidelity, not correctness: a float
parameter that had `requires_grad=False` comes back True. That was already the
behaviour before integer parameters worked at all, and no reader of a serialized
fake `state_dict` consumes the flag.
`test_requires_grad_is_derived_from_the_dtype` pins it, so it stays a known
trade-off rather than a surprise.

The reasoning behind both choices is left as inline comments on this diff rather
than in the source, which keeps only the two constraints a future reader needs
in order not to undo them.

Scope, so this is not over-read: `torch._export.serde.serialize` carries the
same `requires_grad` defect and is untouched here. It is a different module
path, so it can never be resolved for a record written by this one -- the same
bug in another codebase, not a compatibility hazard for this one.

Differential Revision: D115918112


