### PR TITLE
arm: extend CMSIS-Pack smoke test to Cortex-M

### DIFF
--- a/backends/arm/cmsis_pack/test/smoke/run.sh
+++ b/backends/arm/cmsis_pack/test/smoke/run.sh
@@ -50,12 +50,14 @@ python3 "${TEST_DIR}/../validate_pack.py" "${PACK_FILE}"
 echo
 echo "=== Consumer build (${DOCKER_IMAGE}) ==="
 docker run --rm \
-    -v "${TEST_DIR}:/workspace" \
+    -v "${TEST_DIR}:/workspace-src:ro" \
     -v "${OUTPUT_DIR}:/pack-output:ro" \
     "${DOCKER_IMAGE}" \
     bash -lc '
 set -euo pipefail
-cd /workspace
+rm -rf /tmp/executorch-smoke
+cp -a /workspace-src /tmp/executorch-smoke
+cd /tmp/executorch-smoke
 
 # Acquire the toolchain set declared in vcpkg-configuration.json
 # (cmsis-toolbox + arm-none-eabi-gcc + cmake + ninja).

--- a/backends/arm/cmsis_pack/test/smoke/smoke.cproject.yml
+++ b/backends/arm/cmsis_pack/test/smoke/smoke.cproject.yml
@@ -14,6 +14,7 @@ project:
     - component: Machine Learning:ExecuTorch:Runtime
     - component: Machine Learning:ExecuTorch:Kernel Utils
     - component: Machine Learning:ExecuTorch:Kernel Registration
+    - component: Machine Learning:ExecuTorch Operators:Portable add
     - component: Machine Learning:ExecuTorch Operators:Cortex-M quantized_add
 
   groups:

--- a/backends/arm/cmsis_pack/test/smoke/smoke.cproject.yml
+++ b/backends/arm/cmsis_pack/test/smoke/smoke.cproject.yml
@@ -9,11 +9,12 @@ project:
 
   components:
     - component: ARM::CMSIS:CORE
+    - component: ARM::CMSIS:NN Lib
     - component: ARM::Device:Startup&C Startup
     - component: Machine Learning:ExecuTorch:Runtime
     - component: Machine Learning:ExecuTorch:Kernel Utils
     - component: Machine Learning:ExecuTorch:Kernel Registration
-    - component: Machine Learning:ExecuTorch Operators:Portable add
+    - component: Machine Learning:ExecuTorch Operators:Cortex-M quantized_add
 
   groups:
     - group: App

--- a/backends/arm/cmsis_pack/test/smoke/smoke.csolution.yml
+++ b/backends/arm/cmsis_pack/test/smoke/smoke.csolution.yml
@@ -10,6 +10,7 @@ solution:
 
   packs:
     - pack: ARM::CMSIS@>=6.0.0
+    - pack: ARM::CMSIS-NN@7.0.0
     - pack: ARM::Cortex_DFP@>=1.1.0
     - pack: PyTorch::ExecuTorch
 


### PR DESCRIPTION
## Summary

Extend the CMSIS-Pack smoke consumer to exercise a Cortex-M operator instead of only a Portable operator.

This change:

- adds the CMSIS-NN component to the smoke project;
- selects `Cortex-M quantized_add`;
uses `ARM::CMSIS-NN@7.0.0` to keep the smoke test on the currently supported CMSIS-NN major version;
- copies the smoke project into a writable container-local directory so the test does not depend on host bind-mount ownership.

This directly exercises the Cortex-M / CMSIS-NN path on the ARMCM55 target.

## Testing

```text
python -m pytest \
  backends/arm/cmsis_pack/test/test_generate_register_all_kernels.py \
  backends/arm/cmsis_pack/test/all_ops/test_gen_cproject.py -q

21 passed
```

```text
DOCKER_IMAGE=ghcr.io/arm-software/avh-mlops/arm-mlops-docker-licensed-community:latest-amd64 \
bash backends/arm/cmsis_pack/test/smoke/run.sh

Build summary: 1 succeeded, 0 failed
=== PASS ===
```

Related to #14880.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani