### PR TITLE
Load an older PTD file in the Python reader instead of rejecting it

### DIFF
--- a/extension/flat_tensor/serialize/serialize.py
+++ b/extension/flat_tensor/serialize/serialize.py
@@ -401,10 +401,12 @@ class FlatTensorSerializer(DataSerializer):
         flat_tensor_bytes = data[0 : header.flatbuffer_offset + header.flatbuffer_size]
         flat_tensor = _deserialize_to_flat_tensor(flat_tensor_bytes)
 
-        # Verify that this is a supported version.
-        if flat_tensor.version != _FLAT_TENSOR_VERSION:
+        # Verify that this is a supported version. Older files still load; only
+        # a file newer than this reader understands is refused, matching the
+        # runtime readers and the append-only schema policy in schema/README.md.
+        if flat_tensor.version > _FLAT_TENSOR_VERSION:
             raise NotImplementedError(
-                f"Flat tensor files reports unsupported version {flat_tensor.version}. Expected {_FLAT_TENSOR_VERSION}."
+                f"Flat tensor file reports version {flat_tensor.version}, which is newer than this reader supports (max {_FLAT_TENSOR_VERSION})."
             )
 
         # Extract the buffers.

--- a/extension/flat_tensor/test/test_serialize.py
+++ b/extension/flat_tensor/test/test_serialize.py
@@ -13,6 +13,7 @@ import tempfile
 import unittest
 
 from typing import Dict, List, Optional
+from unittest import mock
 
 import torch
 
@@ -31,6 +32,7 @@ from executorch.exir.tensor_layout import TensorLayout
 
 from executorch.extension.flat_tensor.serialize.serialize import (
     _deserialize_to_flat_tensor,
+    _FLAT_TENSOR_VERSION,
     _FLATBUFFER_ALIGNMENT,
     FlatTensorConfig,
     FlatTensorHeader,
@@ -278,6 +280,50 @@ class TestSerialize(unittest.TestCase):
                 f"Buffer at index {i} does not match.",
             )
 
+        self._check_named_data_entries(
+            TEST_DATA_PAYLOAD.named_data, deserialized_payload.named_data
+        )
+
+    def test_deserialize_refuses_newer_version(self) -> None:
+        # A file whose version is newer than this reader understands must be
+        # refused, rather than silently misread. Serialize with a bumped
+        # version, then deserialize with the real (lower) reader version.
+        config = FlatTensorConfig()
+        serializer: DataSerializer = FlatTensorSerializer(config)
+
+        with mock.patch(
+            "executorch.extension.flat_tensor.serialize.serialize._FLAT_TENSOR_VERSION",
+            _FLAT_TENSOR_VERSION + 1,
+        ):
+            serialized_data = bytes(serializer.serialize(TEST_DATA_PAYLOAD))
+
+        with self.assertRaises(NotImplementedError):
+            serializer.deserialize(Cord(serialized_data))
+
+    def test_deserialize_accepts_older_version(self) -> None:
+        # Back-compat: a file older than the reader must still load, and load
+        # correctly. Serialize at the current version, then deserialize with the
+        # reader's version bumped higher, so the file looks older than the
+        # reader. This is what `>` buys over the previous `!=`, which rejected
+        # any mismatch including older.
+        config = FlatTensorConfig()
+        serializer: DataSerializer = FlatTensorSerializer(config)
+        serialized_data = bytes(serializer.serialize(TEST_DATA_PAYLOAD))
+
+        with mock.patch(
+            "executorch.extension.flat_tensor.serialize.serialize._FLAT_TENSOR_VERSION",
+            _FLAT_TENSOR_VERSION + 1,
+        ):
+            deserialized_payload = serializer.deserialize(Cord(serialized_data))
+
+        # The older file must not just load without raising; it must round-trip
+        # intact, so a regression that loads but drops data can't pass silently.
+        for i in range(len(deserialized_payload.buffers)):
+            self.assertEqual(
+                TEST_DATA_PAYLOAD.buffers[i],
+                deserialized_payload.buffers[i],
+                f"Buffer at index {i} does not match.",
+            )
         self._check_named_data_entries(
             TEST_DATA_PAYLOAD.named_data, deserialized_payload.named_data
         )


### PR DESCRIPTION
### Summary

The Python `FlatTensorSerializer.deserialize` refused any PTD file whose `version` did not **exactly** equal `_FLAT_TENSOR_VERSION`:

```python
if flat_tensor.version != _FLAT_TENSOR_VERSION:
    raise NotImplementedError(...)
```

That rejects an **older** file too, which contradicts:
- the append-only schema policy in `schema/README.md` (older files stay loadable), and
- the C++ runtime readers, which accept anything `<=` their supported version and only refuse a file **newer** than they understand (`Program::load`, `FlatTensorDataMap::load`).

This aligns the Python PTD reader with that policy: compare with `>` instead of `!=`, so an older or equal file loads and only a newer one is refused. The error message now says the file is newer than this reader supports.

### Context

This was called out as a follow-up during review of #22114 (which adds the `<=` gate on the C++ side). It keeps the Python export/tooling path consistent so a future non-zero PTD version won't regress it.

### Test plan

Two tests in `extension/flat_tensor/test/test_serialize.py`:
- `test_deserialize_refuses_newer_version` — a bumped-version file is refused.
- `test_deserialize_accepts_older_version` — a file older than the reader still loads (the case the old `!=` wrongly rejected).

Both are behavior-only; no schema or format change. Version constants are unchanged (still `0`), so this is inert for existing files and only changes behavior once a non-zero version is ever stamped.
