### PR TITLE
Transforms: stop fork splitting from stranding a permute

### DIFF
--- a/backends/arm/_passes/propagate_view_copy_permute_pass.py
+++ b/backends/arm/_passes/propagate_view_copy_permute_pass.py
@@ -54,6 +54,24 @@ class TosaPropagationOverrides:
             or node.target == exir_ops.backend.tosa.RESCALE.default
         )
 
+    def is_swappable(self, next_node: torch.fx.Node) -> bool:
+        # Arm normalizes reductions to keepdim=True before this pass runs, so a
+        # non-keepdim reduction here means the pipeline is misordered. The
+        # shared pass merely declines; Arm wants to hear about it.
+        if next_node.target in self._REDUCTION_TARGETS:
+            keep_dim = (
+                next_node.args[2]
+                if len(next_node.args) > 2
+                else next_node.kwargs.get("keepdim")
+            )
+            if keep_dim is not True:
+                raise RuntimeError(
+                    f"{self.__class__.__name__} expects keep_dim=True for "
+                    f"reduction ops to simplify propagation logic, got "
+                    f"{keep_dim} for node {next_node.name}."
+                )
+        return super().is_swappable(next_node)
+
     def is_multi_input_elementwise(self, node: torch.fx.Node) -> bool:
         return node.target == exir_ops.backend.tosa.TABLE.default
 

--- a/backends/transforms/propagate_view_copy_permute_pass.py
+++ b/backends/transforms/propagate_view_copy_permute_pass.py
@@ -28,6 +28,7 @@ from executorch.exir import ExportedProgram
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 
+
 @dataclass(frozen=True)
 class _ForkBranchSplit:
     next_node: torch.fx.Node
@@ -346,9 +347,9 @@ class PropagateViewCopyPermutePass(ExportPass, ABC):
                 else next_node.kwargs.get("keepdim")
             )
             if keep_dim is not True:
-                raise RuntimeError(
-                    f"{self.__class__.__name__} expects keep_dim=True for reduction ops to simplify propagation logic, got {keep_dim} for node {next_node.name}."
-                )
+                # A reduction that drops the dimension changes rank, so the
+                # permutation cannot simply be remapped across it.
+                return False
         return True
 
     def _can_move_through_elementwise(
@@ -408,9 +409,9 @@ class PropagateViewCopyPermuteUpPass(PropagateViewCopyPermutePass):
 
     def fuse_horizontal(self, graph_module):
         modified = False
-        result = FuseDuplicateUsersPass(
-            self.duplicate_user_fusion_exclusions()
-        ).call(graph_module)
+        result = FuseDuplicateUsersPass(self.duplicate_user_fusion_exclusions()).call(
+            graph_module
+        )
         graph_module = result.graph_module
         modified |= result.modified
         return PassResult(graph_module, modified)
@@ -746,12 +747,67 @@ class PropagateViewCopyPermuteDownPass(PropagateViewCopyPermutePass):
     ) -> bool:
         if frontier is not node and previous_frontier is None:
             return False
+        if self._fork_split_strands_a_copy(next_nodes):
+            return False
         plan = self._plan_fork_split(node, frontier, next_nodes)
         if plan is None:
             return False
         producer, branch_splits = plan
         self._apply_fork_split(node, frontier, producer, branch_splits)
         return True
+
+    @staticmethod
+    def _fork_split_strands_a_copy(
+        next_nodes: Sequence[torch.fx.Node], search_limit: int = 64
+    ) -> bool:
+        """Whether splitting this fork would leave a copy that cannot be merged.
+
+        After a split, each branch carries its own copy. Two things can merge
+        them again: branches that rejoin have their copies fused at the meeting
+        node, and branches that stay separate have their copies hoisted back to
+        the shared producer on the way up.
+
+        Both work when every branch does the same thing. A fork where some
+        branches rejoin and others do not ends with copies at two different
+        producers -- one below the rejoin, one at the source -- and neither
+        mechanism can bring those together. Upward propagation has no fork
+        split of its own, so it cannot hoist a copy above a rejoin.
+
+        The graph output is not a meeting point; returned values carry
+        independent copies.
+        """
+        if len(next_nodes) < 2:
+            return False
+
+        owner: dict[torch.fx.Node, int] = {}
+        group = list(range(len(next_nodes)))
+
+        def root(i: int) -> int:
+            while group[i] != i:
+                group[i] = group[group[i]]
+                i = group[i]
+            return i
+
+        for index, start in enumerate(next_nodes):
+            frontier = [start]
+            visited = 0
+            while frontier and visited < search_limit:
+                current = frontier.pop()
+                if current.op == "output":
+                    continue
+                visited += 1
+                previous = owner.get(current)
+                if previous is None:
+                    owner[current] = index
+                    frontier.extend(current.users)
+                elif root(previous) != root(index):
+                    group[root(previous)] = root(index)
+
+        sizes: dict[int, int] = {}
+        for index in range(len(next_nodes)):
+            sizes[root(index)] = sizes.get(root(index), 0) + 1
+        # Uniform is fine: one group (all rejoin) or all singletons (all diverge).
+        return len(sizes) > 1 and any(size > 1 for size in sizes.values())
 
     def _plan_fork_split(
         self,


### PR DESCRIPTION
Splitting a permute over a fork is meant to be free: each branch takes its own
copy on the way down, and the copies merge again on the way up. That holds when
every branch behaves the same way -- branches that rejoin have their copies
fused at the meeting node, branches that stay separate have theirs hoisted back
to the shared producer.

It does not hold for a fork where some branches rejoin and others do not. The
rejoining side ends with a copy below the meeting node, the diverging side with
one at the source, and neither mechanism can bring those together: upward
propagation has no fork split of its own, so it cannot hoist a copy above a
rejoin. Five ops are enough to see it, with no views and no quantization:

    p = x.permute(0, 2, 3, 1)
    return torch.abs(p) + torch.neg(p), torch.sigmoid(p)

    before: 1   after Down: 2   after Up: 2

Decline the split in exactly that shape. Uniform forks are unaffected, which is
what keeps the existing behaviour: all-rejoin still splits and fuses at the
meeting node, all-diverge still splits and merges at the producer. A sweep of 75
fan-out shapes now regresses none, and the wins on real graphs are unchanged --
MultiheadAttention 10 to 9, TransformerEncoderLayer 14 to 11.

Also stop is_swappable raising on a non-keepdim reduction. The shared pass
answers the question it was asked and declines; Arm overrides it to keep raising,
since its pipeline normalizes reductions earlier and a violation there means the
ordering is wrong rather than that the graph is unusual.

No behaviour change for Arm: the pass suite produces a failure set identical to
merge base, name for name.

Authored with Claude Code.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell