### PR TITLE
Arm backend: Fix VGF neural statistics test PAL init and dangling test target

### DIFF
--- a/backends/arm/test/vgf_neural_statistics_test.cpp
+++ b/backends/arm/test/vgf_neural_statistics_test.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <executorch/backends/arm/runtime/VGFNeuralStatistics.h>
+#include <executorch/runtime/platform/runtime.h>
 
 namespace vgf = executorch::backends::vgf;
 
@@ -32,6 +33,9 @@ void set_env(const char* name, const char* value) {
 class ScopedNeuralStatisticsEnv {
  public:
   ScopedNeuralStatisticsEnv() {
+    // Reading the runtime config can ET_LOG, which aborts unless the PAL is up.
+    executorch::runtime::runtime_init();
+
     const char* enable = std::getenv(vgf::kVgfNeuralStatisticsEnableEnv);
     const char* mode = std::getenv(vgf::kVgfNeuralStatisticsModeEnv);
     if (enable != nullptr) {

--- a/devtools/inspector/tests/targets.bzl
+++ b/devtools/inspector/tests/targets.bzl
@@ -28,14 +28,6 @@ def define_common_targets(is_fbcode = False):
     )
 
     python_unittest(
-        name = "vgf_neural_statistics_test",
-        srcs = ["vgf_neural_statistics_test.py"],
-        deps = [
-            "//executorch/devtools/inspector:vgf_neural_statistics",
-        ],
-    )
-
-    python_unittest(
         name = "event_blocks_test",
         srcs = ["event_blocks_test.py"],
         deps = [


### PR DESCRIPTION
Two fixes for the VGF neural statistics tests added in #22074.

1. `VgfNeuralStatisticsTest.RuntimeConfigFallsBackToMode1` aborted.

The invalid-mode fallback path in `get_vgf_neural_statistics_runtime_config()` calls `ET_LOG`, which aborts with `ExecuTorch PAL must be initialized before call to et_pal_current_ticks()` when the runtime has not been initialized. Initialize the PAL in the test env fixture, the same way `backends/arm/test/vela_external_blocks_test.cpp` does.

2. `//executorch/devtools/inspector/tests:vgf_neural_statistics_test` failed to build.

The `python_unittest` target points at `vgf_neural_statistics_test.py`, which was never added to the tree, so the target fails to build with `File not found: devtools/inspector/tests/vgf_neural_statistics_test.py`. Remove the dangling target.



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani