### PR TITLE
NXP backend: Upgrade the eIQ Neutron SDK to v3.2.1

### DIFF
--- a/backends/nxp/requirements-eiq.txt
+++ b/backends/nxp/requirements-eiq.txt
@@ -1,3 +1,3 @@
 --index-url https://eiq.nxp.com/repository
-eiq-neutron-sdk==3.2.0
+eiq-neutron-sdk==3.2.1
 eiq_nsys

--- a/docs/source/backends/nxp/nxp-overview.md
+++ b/docs/source/backends/nxp/nxp-overview.md
@@ -24,10 +24,10 @@ Among currently supported machine learning models are:
 
 - [MCUXpresso IDE](https://www.nxp.com/design/design-center/software/development-software/mcuxpresso-software-and-tools-/mcuxpresso-integrated-development-environment-ide:MCUXpresso-IDE) or [MCUXpresso Visual Studio Code extension](https://www.nxp.com/design/design-center/software/development-software/mcuxpresso-software-and-tools-/mcuxpresso-for-visual-studio-code:MCUXPRESSO-VSC)
 - [MCUXpresso SDK 26.06](https://mcuxpresso.nxp.com/mcuxsdk/26.06.00/html/index.html)
-- eIQ Neutron SDK version 3.2.0, what you can download from eIQ PyPI:
+- eIQ Neutron SDK version 3.2.1, what you can download from eIQ PyPI:
 
 ```commandline
-$ pip install --index-url https://eiq.nxp.com/repository eiq-neutron-sdk==3.2.0
+$ pip install --index-url https://eiq.nxp.com/repository eiq-neutron-sdk==3.2.1
 ```
 
 Instead of manually installing requirements, except MCUXpresso IDE and SDK, you can use the setup script: 

--- a/examples/nxp/setup.sh
+++ b/examples/nxp/setup.sh
@@ -8,7 +8,7 @@ set -u
 EIQ_PYPI_URL="${EIQ_PYPI_URL:-https://eiq.nxp.com/repository}"
 
 # Install eIQ Neutron dependencies - SDK and simulator
-pip install --index-url ${EIQ_PYPI_URL} eiq-neutron-sdk==3.2.0 eiq_nsys
+pip install --index-url ${EIQ_PYPI_URL} eiq-neutron-sdk==3.2.1 eiq_nsys
 
 # Get the directory of the current script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
### Summary
NXP backend: Upgrade the eIQ Neutron SDK to v3.2.1

### Test plan
Tested by unit tests