### PR TITLE
[MLX]: Add trunc op handler for mlx backend

### DIFF
--- a/backends/mlx/ops.py
+++ b/backends/mlx/ops.py
@@ -159,6 +159,7 @@ from executorch.backends.mlx.serialization.mlx_graph_schema import (
     TransposeNode,
     TrilNode,
     TriuNode,
+    TruncNode,
     UpdateAndAttendNode,
     VarNode,
     VidOrTid,
@@ -384,6 +385,7 @@ _UNARY_OPS: List[Tuple[Any, Any, str]] = [
     # Rounding
     (torch.ops.aten.floor.default, FloorNode, "aten.floor"),
     (torch.ops.aten.ceil.default, CeilNode, "aten.ceil"),
+    (torch.ops.aten.trunc.default, TruncNode, "aten.trunc"),
     # Powers / roots
     (torch.ops.aten.square.default, SquareNode, "aten.square"),
     (torch.ops.aten.exp.default, ExpNode, "aten.exp"),
@@ -836,7 +838,6 @@ for _targets, _node_cls, _op_name, _lift_b in _BINARY_OPS:
         _make_binary_handler(_node_cls, _op_name, _lift_b)
     )
 
-
 _SCALAR_INT_OPS: List[Tuple[Any, Any, str]] = [
     (operator.add, AddIntNode, "operator.add"),
     (operator.sub, SubtractIntNode, "operator.sub"),
@@ -937,7 +938,6 @@ for _targets, _node_cls, _op_name, _max_args in _REDUCTION_OPS:
         _make_reduction_handler(_node_cls, _op_name, _max_args)
     )
 
-
 _FULL_OPS: List[Tuple[List[Any], str, Optional[float]]] = [
     ([torch.ops.aten.full.default], "aten.full", None),
     ([torch.ops.aten.zeros.default], "aten.zeros", 0.0),
@@ -987,7 +987,6 @@ def _make_full_handler(op_name: str, fixed_fill: Optional[float]):
 
 for _targets, _op_name, _fixed_fill in _FULL_OPS:
     REGISTRY.register(target=_targets)(_make_full_handler(_op_name, _fixed_fill))
-
 
 _FULL_LIKE_OPS: List[Tuple[List[Any], str, Optional[float]]] = [
     ([torch.ops.aten.full_like.default], "aten.full_like", None),

--- a/backends/mlx/ops.py
+++ b/backends/mlx/ops.py
@@ -838,6 +838,7 @@ for _targets, _node_cls, _op_name, _lift_b in _BINARY_OPS:
         _make_binary_handler(_node_cls, _op_name, _lift_b)
     )
 
+
 _SCALAR_INT_OPS: List[Tuple[Any, Any, str]] = [
     (operator.add, AddIntNode, "operator.add"),
     (operator.sub, SubtractIntNode, "operator.sub"),
@@ -938,6 +939,7 @@ for _targets, _node_cls, _op_name, _max_args in _REDUCTION_OPS:
         _make_reduction_handler(_node_cls, _op_name, _max_args)
     )
 
+
 _FULL_OPS: List[Tuple[List[Any], str, Optional[float]]] = [
     ([torch.ops.aten.full.default], "aten.full", None),
     ([torch.ops.aten.zeros.default], "aten.zeros", 0.0),
@@ -987,6 +989,7 @@ def _make_full_handler(op_name: str, fixed_fill: Optional[float]):
 
 for _targets, _op_name, _fixed_fill in _FULL_OPS:
     REGISTRY.register(target=_targets)(_make_full_handler(_op_name, _fixed_fill))
+
 
 _FULL_LIKE_OPS: List[Tuple[List[Any], str, Optional[float]]] = [
     ([torch.ops.aten.full_like.default], "aten.full_like", None),

--- a/backends/mlx/runtime/MLXInterpreter.h
+++ b/backends/mlx/runtime/MLXInterpreter.h
@@ -1546,6 +1546,11 @@ inline void exec_ceil(const CeilNode& n, ExecutionState& st, StreamOrDevice s) {
 }
 
 inline void
+exec_trunc(const TruncNode& n, ExecutionState& st, StreamOrDevice s) {
+  st.set_tensor(n.out, trunc(st.const_tensor_ref(n.x), s));
+}
+
+inline void
 exec_square(const SquareNode& n, ExecutionState& st, StreamOrDevice s) {
   st.set_tensor(n.out, square(st.const_tensor_ref(n.x), s));
 }
@@ -2235,6 +2240,9 @@ class Interpreter {
         break;
       case OpCode::CEIL:
         ops::exec_ceil(std::get<CeilNode>(instr.node), st, s);
+        break;
+      case OpCode::TRUNC:
+        ops::exec_trunc(std::get<TruncNode>(instr.node), st, s);
         break;
       case OpCode::SQUARE:
         ops::exec_square(std::get<SquareNode>(instr.node), st, s);

--- a/backends/mlx/serialization/schema.fbs
+++ b/backends/mlx/serialization/schema.fbs
@@ -845,6 +845,11 @@ table NegNode {
     out: Tid (required);
 }
 
+table TruncNode {
+    x: Tid (required);
+    out: Tid (required);
+}
+
 // =============================================================================
 // Math ops - Binary element-wise
 // =============================================================================
@@ -1191,7 +1196,8 @@ union OpNode {
     BitwiseXorNode,
     IfNode,
     RandomBitsNode,
-    UpdateAndAttendNode
+    UpdateAndAttendNode,
+    TruncNode,
     // BC: Add new op nodes here (append only)
 }
 

--- a/backends/mlx/test/test_ops.py
+++ b/backends/mlx/test/test_ops.py
@@ -4819,6 +4819,7 @@ def _make_unary_op_test(
 _UNARY_OP_TESTS = [
     {"op_name": "floor",      "op_fn": torch.floor,      "shapes": _SHAPES_3, "input_fn": _input_fn(scale=10)},
     {"op_name": "ceil",       "op_fn": torch.ceil,       "shapes": _SHAPES_3, "input_fn": _input_fn(scale=10)},
+    {"op_name": "trunc",      "op_fn": torch.trunc,      "shapes": _SHAPES_3, "input_fn": _input_fn(scale=10)},
     {"op_name": "square",     "op_fn": torch.square,     "shapes": _SHAPES_3},
     {"op_name": "exp",        "op_fn": torch.exp,        "shapes": _SHAPES_3},
     {"op_name": "sin",        "op_fn": torch.sin,        "shapes": _SHAPES_3, "input_fn": _input_fn(scale=3.14159)},


### PR DESCRIPTION
### Summary

Add trunc op handler for the mlx backend. The issue suggested to implement the handler by decomposing it with a floor and ceil op. But I instead chose to implement it via the trunc backend method already available in [MLX C++ ops](https://ml-explore.github.io/mlx/build/html/cpp/ops.html#_CPPv45truncRK5array14StreamOrDevice).

Fixes https://github.com/pytorch/executorch/issues/18923

### Test plan

I added a Unary op test and ran the test with:
```
python3 -m executorch.backends.mlx.test.run_all_tests --rebuild trunc
```

I have an M3 pro Mac so the MLX backend tests ran with my installed MLX libraries.

cc @metascroy