### PR TITLE
Cortex-M: convert suite inputs on the comparison path as well

### DIFF
--- a/backends/test/suite/flows/cortex_m.py
+++ b/backends/test/suite/flows/cortex_m.py
@@ -27,11 +27,11 @@ from executorch.backends.cortex_m.test.tester import CortexMQuantize, CortexMTes
 from executorch.backends.test.suite.flow import TestFlow
 
 
-def _create_cortex_m_tester(model, inputs, **kwargs) -> CortexMTester:
+def _to_channels_last(inputs):
     # The CMSIS-NN kernels are NHWC, and CortexMConv2DCheck rejects any pattern
     # whose tensors are not channels_last. The suite hands over contiguous
     # tensors, which silently costs every convolution in the model.
-    inputs = tuple(
+    return tuple(
         (
             t.to(memory_format=torch.channels_last)
             if isinstance(t, torch.Tensor) and t.dim() == 4
@@ -39,12 +39,31 @@ def _create_cortex_m_tester(model, inputs, **kwargs) -> CortexMTester:
         )
         for t in inputs
     )
+
+
+class _ChannelsLastTester(CortexMTester):
+    """Converts on the comparison path as well as the build path.
+
+    The suite runs the program against the inputs it built the case with rather
+    than the ones handed to the tester, and the operator suite does so by
+    default, so converting only in the factory leaves the runtime reading a
+    contiguous tensor as NHWC.
+    """
+
+    def run_method_and_compare_outputs(self, *args, **kwargs):
+        if kwargs.get("inputs") is not None:
+            kwargs["inputs"] = _to_channels_last(kwargs["inputs"])
+        return super().run_method_and_compare_outputs(*args, **kwargs)
+
+
+def _create_cortex_m_tester(model, inputs, **kwargs) -> CortexMTester:
+    inputs = _to_channels_last(inputs)
     # The Serialize stage is also the stage that invokes the ELF, so its timeout
     # is the FVP's --timelimit rather than a serialization budget, and 120s is
     # not enough for an ImageNet-sized model on an M55 with no NPU. Kept under
     # the suite conftest's 1200s pytest timeout so the FVP reports the overrun
     # instead of pytest killing the process.
-    return CortexMTester(model, inputs, timeout=900, **kwargs)
+    return _ChannelsLastTester(model, inputs, timeout=900, **kwargs)
 
 
 # Models that cannot run on the FVP runner at all, so there is nothing for the


### PR DESCRIPTION
The flow converts a 4-D input to channels_last before handing it to the tester,
because the CMSIS-NN kernels are NHWC and CortexMConv2DCheck rejects anything
else. The suite then runs the program against the inputs it built the case with
rather than the ones the tester holds, and the operator suite does so by
default -- _test_op passes generate_random_test_inputs=False. So every 4-D
operator case was handing a contiguous tensor to a program compiled for NHWC.

    conv2d, contiguous inputs, compared on them     SNR = -3.06 dB
    conv2d, channels_last inputs, compared on them  SNR = 61.13 dB

Nothing about that is visible from the outside: it reads as a backend accuracy
problem rather than a harness one, and it accounted for fifty of the operator
suite's failures, including every conv2d, avg_pool2d, max_pool2d and
conv_transpose2d case.

Converting in a tester subclass covers both paths. The models suite is
unaffected -- it takes the generate_random_test_inputs default of True, so the
harness generates its own inputs from the tester's -- and its results are
unchanged at 7 passed, 25 skipped, 10 xfailed.

Authored with Claude Code.