### PR TITLE
Put `device` right after `type` in the raw-pointer tensor factories

### DIFF
--- a/docs/source/backends/cuda/cuda-overview.md
+++ b/docs/source/backends/cuda/cuda-overview.md
@@ -224,9 +224,10 @@ auto input = clone_tensor_ptr_to(host_input, DeviceType::CUDA);
 auto result = module.forward(input);
 ```
 
-The device argument defaults to `DeviceType::CPU`, so existing code that wraps host memory
-keeps working unchanged. Leaving it at the default while handing over a device pointer
-produces a CPU-tagged tensor that the delegate rejects.
+The device argument defaults to `DeviceType::CPU` in the overloads that do not take a custom
+deleter, so a plain `from_blob(host_ptr, sizes, type)` still means host memory. The deleter
+overloads require the device to be named. Leaving the device at CPU while handing over a
+device pointer produces a CPU-tagged tensor that the delegate rejects.
 
 **How the delegate decides a tensor is device resident.** Two checks, in this order. First
 the tensor's own `device_type` has to be `CUDA`, which is metadata set by whoever built the

--- a/docs/source/backends/cuda/cuda-overview.md
+++ b/docs/source/backends/cuda/cuda-overview.md
@@ -199,8 +199,24 @@ exported without them expects device tensors. Passing the wrong kind is a caller
 something the runtime corrects, so the two are not interchangeable at run time.
 
 **From C++ it is the same contract.** With the copies skipped, the input has to be a tensor
-the delegate will accept as device resident. `clone_tensor_ptr_to` allocates on the device
-and copies the data across:
+the delegate will accept as device resident. There are two ways to build one, and which is
+right depends on where the data already is.
+
+If the data is already in device memory, wrap the pointer with `from_blob` and name the
+device right after the scalar type. Nothing is copied:
+
+```cpp
+auto input = from_blob(device_data, {rows, columns}, ScalarType::Float, DeviceType::CUDA);
+auto result = module.forward(input);
+```
+
+This is the path to use when the producer of the data is another GPU kernel, a camera or
+video decoder that writes to the GPU, or an earlier model whose output you kept on device.
+`from_blob` does not allocate or migrate anything, so the pointer has to be genuinely valid
+on the device you name, and it has to outlive the tensor.
+
+If the data starts on the host, `clone_tensor_ptr_to` allocates on the device and copies it
+across, which costs one transfer:
 
 ```cpp
 auto host_input = make_tensor_ptr({rows, columns}, std::move(data));
@@ -208,8 +224,9 @@ auto input = clone_tensor_ptr_to(host_input, DeviceType::CUDA);
 auto result = module.forward(input);
 ```
 
-`from_blob` is not enough on its own. It has no device parameter, so the tensor it returns
-is tagged CPU whatever the pointer points at, and the delegate rejects it.
+The device argument defaults to `DeviceType::CPU`, so existing code that wraps host memory
+keeps working unchanged. Leaving it at the default while handing over a device pointer
+produces a CPU-tagged tensor that the delegate rejects.
 
 **How the delegate decides a tensor is device resident.** Two checks, in this order. First
 the tensor's own `device_type` has to be `CUDA`, which is metadata set by whoever built the

--- a/docs/source/extension-tensor.md
+++ b/docs/source/extension-tensor.md
@@ -148,6 +148,7 @@ auto tensor = make_tensor_ptr(
     {2, 3},                               // sizes
     data,                                 // data pointer
     ScalarType::Double,                   // double scalar type
+    DeviceType::CPU,                      // the data lives in host memory
     TensorShapeDynamism::DYNAMIC_BOUND,   // default dynamism
     [](void* ptr) { delete[] static_cast<double*>(ptr); });
 ```
@@ -287,10 +288,31 @@ auto tensor = from_blob(
     data,             // data pointer
     {3},              // sizes
     ScalarType::Int,  // int scalar type
+    DeviceType::CPU,  // the data lives in host memory
     [](void* ptr) { delete[] static_cast<int*>(ptr); });
 ```
 
 The `TensorPtr` will call the custom deleter when it is destroyed.
+
+*Wrapping Data That Already Lives on an Accelerator*
+
+`from_blob()` and `make_tensor_ptr()` take the device right after the scalar type. It
+defaults to `DeviceType::CPU`, so host pointers need nothing extra. Pass a different device
+when the pointer you hand over is already accelerator memory, and no copy is made.
+
+```cpp
+void* device_data = /* allocated with cudaMalloc, or returned by another kernel */;
+auto tensor = from_blob(
+    device_data,        // pointer into device memory
+    {2, 3},             // sizes
+    ScalarType::Float,  // float scalar type
+    DeviceType::CUDA);  // the data lives on the GPU
+```
+
+The tensor only records where the memory lives. It does not allocate, copy, or migrate
+anything, so the pointer must really be valid on the device you name. To move data that
+starts on the host, use `clone_tensor_ptr_to(tensor, DeviceType::CUDA)` instead, which
+allocates on the device and copies across.
 
 ### Creating Empty Tensors
 

--- a/docs/source/extension-tensor.md
+++ b/docs/source/extension-tensor.md
@@ -296,9 +296,14 @@ The `TensorPtr` will call the custom deleter when it is destroyed.
 
 *Wrapping Data That Already Lives on an Accelerator*
 
-`from_blob()` and `make_tensor_ptr()` take the device right after the scalar type. It
-defaults to `DeviceType::CPU`, so host pointers need nothing extra. Pass a different device
-when the pointer you hand over is already accelerator memory, and no copy is made.
+`from_blob()` and `make_tensor_ptr()` take the device right after the scalar type. Pass a
+different device when the pointer you hand over is already accelerator memory, and no copy
+is made.
+
+The device defaults to `DeviceType::CPU` in the overloads that do not take a custom deleter,
+so a plain `from_blob(host_ptr, sizes, type)` keeps meaning host memory. In the deleter
+overloads the device has to be named, as shown in the example above, because a parameter
+with a default cannot come before one without.
 
 ```cpp
 void* device_data = /* allocated with cudaMalloc, or returned by another kernel */;

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.mm
@@ -347,6 +347,7 @@ NSInteger ExecuTorchElementCountOfShape(NSArray<NSNumber *> *shape) {
     utils::toVector<DimOrderType>(dimensionOrder),
     utils::toVector<StridesType>(strides),
     static_cast<ScalarType>(dataType),
+    executorch::aten::DeviceType::CPU,
     static_cast<TensorShapeDynamism>(shapeDynamism)
   );
   return [self initWithNativeInstance:&tensor];

--- a/extension/image/image_processor_apple.cpp
+++ b/extension/image/image_processor_apple.cpp
@@ -1022,6 +1022,7 @@ Result<TensorPtr> ImageProcessor::process(
       std::move(tensor_shape),
       static_cast<void*>(output.release()),
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
       [](void* p) { delete[] static_cast<float*>(p); });
 
@@ -1063,6 +1064,7 @@ Result<TensorPtr> ImageProcessor::process_yuv(
       std::move(tensor_shape),
       static_cast<void*>(output.release()),
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
       [](void* p) { delete[] static_cast<float*>(p); });
 
@@ -1330,6 +1332,7 @@ Result<TensorPtr> process_pixelbuffer(
       std::move(tensor_shape),
       static_cast<void*>(output.release()),
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
       [](void* p) { delete[] static_cast<float*>(p); });
 

--- a/extension/tensor/tensor_ptr.cpp
+++ b/extension/tensor/tensor_ptr.cpp
@@ -73,9 +73,9 @@ TensorPtr make_tensor_ptr(
     std::vector<executorch::aten::DimOrderType> dim_order,
     std::vector<executorch::aten::StridesType> strides,
     executorch::aten::ScalarType type,
+    executorch::aten::Device device,
     executorch::aten::TensorShapeDynamism dynamism,
-    std::function<void(void*)> deleter,
-    executorch::aten::Device device) {
+    std::function<void(void*)> deleter) {
   const auto dim = sizes.size();
   ET_CHECK_MSG(
       dim_order.empty() || dim_order.size() == dim,
@@ -190,6 +190,7 @@ TensorPtr make_tensor_ptr(
       std::move(dim_order),
       std::move(strides),
       type,
+      executorch::aten::Device(executorch::aten::DeviceType::CPU),
       dynamism,
       // Data is moved into the deleter and is destroyed together with Storage.
       [data = std::move(data)](void*) {});
@@ -228,6 +229,7 @@ TensorPtr clone_tensor_ptr(
         std::move(dim_order),
         std::move(strides),
         type,
+        executorch::aten::Device(executorch::aten::DeviceType::CPU),
         dynamism);
   }
   const auto tensor_type = tensor.scalar_type();
@@ -367,11 +369,11 @@ TensorPtr clone_tensor_ptr_to(
       std::move(dim_order),
       std::move(strides),
       tensor->scalar_type(),
+      target,
       tensor->shape_dynamism(),
       [allocator, target](void* ptr) {
         allocator->deallocate(ptr, target.index());
-      },
-      target);
+      });
 }
 
 #endif // USE_ATEN_LIB

--- a/extension/tensor/tensor_ptr.h
+++ b/extension/tensor/tensor_ptr.h
@@ -43,11 +43,11 @@ using TensorPtr = std::shared_ptr<executorch::aten::Tensor>;
  * @param dim_order A vector specifying the order of dimensions.
  * @param strides A vector specifying the strides of the tensor.
  * @param type The scalar type of the tensor elements.
+ * @param device The device on which `data` resides (default CPU).
  * @param dynamism Specifies the mutability of the tensor's shape.
  * @param deleter A custom deleter function for managing the lifetime of the
  * data buffer. If provided, this deleter will be called when the managed Tensor
  * object is destroyed.
- * @param device The device on which `data` resides (default CPU).
  * @return A TensorPtr that manages the newly created Tensor.
  */
 TensorPtr make_tensor_ptr(
@@ -57,11 +57,11 @@ TensorPtr make_tensor_ptr(
     std::vector<executorch::aten::StridesType> strides,
     const executorch::aten::ScalarType type =
         executorch::aten::ScalarType::Float,
+    executorch::aten::Device device =
+        executorch::aten::Device(executorch::aten::DeviceType::CPU),
     const executorch::aten::TensorShapeDynamism dynamism =
         executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
-    std::function<void(void*)> deleter = nullptr,
-    executorch::aten::Device device =
-        executorch::aten::Device(executorch::aten::DeviceType::CPU));
+    std::function<void(void*)> deleter = nullptr);
 
 /**
  * Creates a TensorPtr that manages a Tensor with the specified properties.
@@ -70,12 +70,12 @@ TensorPtr make_tensor_ptr(
  * device semantics.
  *
  * @param sizes A vector specifying the size of each dimension.
- * @param data A pointer to the data buffer (CPU or device, see device_type).
+ * @param data A pointer to the data buffer (CPU or device, see device).
  * @param type The scalar type of the tensor elements.
+ * @param device The device on which `data` resides (default CPU).
  * @param dynamism Specifies the mutability of the tensor's shape.
  * @param deleter A custom deleter function for managing the lifetime of the
  * data buffer.
- * @param device The device on which `data` resides (default CPU).
  * @return A TensorPtr that manages the newly created Tensor.
  */
 inline TensorPtr make_tensor_ptr(
@@ -83,20 +83,20 @@ inline TensorPtr make_tensor_ptr(
     void* data,
     const executorch::aten::ScalarType type =
         executorch::aten::ScalarType::Float,
+    executorch::aten::Device device =
+        executorch::aten::Device(executorch::aten::DeviceType::CPU),
     const executorch::aten::TensorShapeDynamism dynamism =
         executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
-    std::function<void(void*)> deleter = nullptr,
-    executorch::aten::Device device =
-        executorch::aten::Device(executorch::aten::DeviceType::CPU)) {
+    std::function<void(void*)> deleter = nullptr) {
   return make_tensor_ptr(
       std::move(sizes),
       data,
       {},
       {},
       type,
+      device,
       dynamism,
-      std::move(deleter),
-      device);
+      std::move(deleter));
 }
 
 /**
@@ -181,6 +181,7 @@ inline TensorPtr make_tensor_ptr(
         std::move(dim_order),
         std::move(strides),
         type,
+        executorch::aten::Device(executorch::aten::DeviceType::CPU),
         dynamism,
         [data_ptr = std::move(data_ptr)](void*) {});
   }
@@ -192,6 +193,7 @@ inline TensorPtr make_tensor_ptr(
       std::move(dim_order),
       std::move(strides),
       type,
+      executorch::aten::Device(executorch::aten::DeviceType::CPU),
       dynamism,
       [data_ptr = std::move(data_ptr)](void*) {});
 }
@@ -425,13 +427,13 @@ inline TensorPtr make_tensor_ptr(
       std::move(strides),
       tensor.scalar_type(),
 #ifndef USE_ATEN_LIB
+      executorch::aten::Device(tensor.device_type(), tensor.device_index()),
       tensor.shape_dynamism(),
-      std::move(deleter),
-      executorch::aten::Device(tensor.device_type(), tensor.device_index()));
+      std::move(deleter));
 #else // USE_ATEN_LIB
+      tensor.device(),
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
-      std::move(deleter),
-      tensor.device());
+      std::move(deleter));
 #endif // USE_ATEN_LIB
 }
 

--- a/extension/tensor/tensor_ptr_maker.h
+++ b/extension/tensor/tensor_ptr_maker.h
@@ -121,9 +121,9 @@ class TensorPtrMaker final {
         std::move(dim_order_),
         std::move(strides_),
         type_,
+        device_,
         dynamism_,
-        std::move(deleter_),
-        device_);
+        std::move(deleter_));
   }
 
   /**
@@ -195,6 +195,7 @@ inline TensorPtrMaker for_blob(
  * outlive the TensorPtr created by this function.
  * @param sizes A vector specifying the size of each dimension.
  * @param type The scalar type of the tensor elements.
+ * @param device The device on which `data` resides (default CPU).
  * @param dynamism Specifies whether the tensor's shape is static or dynamic.
  * @return A TensorPtr instance managing the newly created Tensor.
  */
@@ -202,9 +203,12 @@ inline TensorPtr from_blob(
     void* data,
     std::vector<executorch::aten::SizesType> sizes,
     executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::Device device =
+        executorch::aten::Device(executorch::aten::DeviceType::CPU),
     executorch::aten::TensorShapeDynamism dynamism =
         executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return for_blob(data, std::move(sizes), type)
+      .device(device)
       .dynamism(dynamism)
       .make_tensor_ptr();
 }
@@ -222,6 +226,7 @@ inline TensorPtr from_blob(
  * @param sizes A vector specifying the size of each dimension.
  * @param strides A vector specifying the stride for each dimension.
  * @param type The scalar type of the tensor elements.
+ * @param device The device on which `data` resides (default CPU).
  * @param dynamism Specifies whether the tensor's shape is static, dynamic, or
  * bounded.
  * @return A TensorPtr instance managing the newly created Tensor.
@@ -231,10 +236,13 @@ inline TensorPtr from_blob(
     std::vector<executorch::aten::SizesType> sizes,
     std::vector<executorch::aten::StridesType> strides,
     executorch::aten::ScalarType type = executorch::aten::ScalarType::Float,
+    executorch::aten::Device device =
+        executorch::aten::Device(executorch::aten::DeviceType::CPU),
     executorch::aten::TensorShapeDynamism dynamism =
         executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return for_blob(data, std::move(sizes), type)
       .strides(std::move(strides))
+      .device(device)
       .dynamism(dynamism)
       .make_tensor_ptr();
 }
@@ -251,6 +259,7 @@ inline TensorPtr from_blob(
  * outlive the TensorPtr created by this function.
  * @param sizes A vector specifying the size of each dimension.
  * @param type The scalar type of the tensor elements.
+ * @param device The device on which `data` resides.
  * @param deleter A function to delete the data when it's no longer needed.
  * @param dynamism Specifies whether the tensor's shape is static or dynamic.
  * @return A TensorPtr instance that manages the newly created Tensor.
@@ -259,10 +268,12 @@ inline TensorPtr from_blob(
     void* data,
     std::vector<executorch::aten::SizesType> sizes,
     executorch::aten::ScalarType type,
+    executorch::aten::Device device,
     std::function<void(void*)>&& deleter,
     executorch::aten::TensorShapeDynamism dynamism =
         executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return for_blob(data, std::move(sizes), type)
+      .device(device)
       .deleter(std::move(deleter))
       .dynamism(dynamism)
       .make_tensor_ptr();
@@ -281,6 +292,7 @@ inline TensorPtr from_blob(
  * @param sizes A vector specifying the size of each dimension.
  * @param strides A vector specifying the stride for each dimension.
  * @param type The scalar type of the tensor elements.
+ * @param device The device on which `data` resides.
  * @param deleter A function to delete the data when it's no longer needed.
  * @param dynamism Specifies whether the tensor's shape is static or dynamic.
  * @return A TensorPtr instance that manages the newly created Tensor.
@@ -290,11 +302,13 @@ inline TensorPtr from_blob(
     std::vector<executorch::aten::SizesType> sizes,
     std::vector<executorch::aten::StridesType> strides,
     executorch::aten::ScalarType type,
+    executorch::aten::Device device,
     std::function<void(void*)>&& deleter,
     executorch::aten::TensorShapeDynamism dynamism =
         executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND) {
   return for_blob(data, std::move(sizes), type)
       .strides(std::move(strides))
+      .device(device)
       .deleter(std::move(deleter))
       .dynamism(dynamism)
       .make_tensor_ptr();

--- a/extension/tensor/test/targets.bzl
+++ b/extension/tensor/test/targets.bzl
@@ -22,14 +22,18 @@ def define_common_targets():
             ],
         )
 
-        runtime.cxx_test(
-            name = "tensor_ptr_device_test" + aten_suffix,
-            srcs = [
-                "tensor_ptr_device_test.cpp",
-            ],
-            deps = [
-                "//executorch/extension/tensor:tensor",
-                "//executorch/runtime/core:device_allocator",
-                "//executorch/runtime/core/test:mock_cuda_allocator",
-            ],
-        )
+    # tensor_ptr_device_test.cpp is guarded by `#ifndef USE_ATEN_LIB` from top to bottom, so
+    # it only has tests to run in portable mode. Defining it once, outside the aten_mode
+    # loop, keeps its `tensor` dependency honest: the `_aten` variant used to link the
+    # portable library and then compile zero tests.
+    runtime.cxx_test(
+        name = "tensor_ptr_device_test",
+        srcs = [
+            "tensor_ptr_device_test.cpp",
+        ],
+        deps = [
+            "//executorch/extension/tensor:tensor",
+            "//executorch/runtime/core:device_allocator",
+            "//executorch/runtime/core/test:mock_cuda_allocator",
+        ],
+    )

--- a/extension/tensor/test/tensor_ptr_device_test.cpp
+++ b/extension/tensor/test/tensor_ptr_device_test.cpp
@@ -361,10 +361,12 @@ TEST_F(TensorPtrDeviceTest, LargeTensorRoundtrip) {
   }
 }
 
-// The `device` argument sits immediately after `type` in every factory that
-// takes a raw pointer, so tagging a buffer that already lives on an accelerator
-// never needs the trailing arguments spelled out. Tagging is metadata only: it
-// must not allocate or copy.
+// The `device` argument sits immediately after `type` in the `make_tensor_ptr`
+// and `from_blob` overloads that take a raw pointer, so tagging a buffer that
+// already lives on an accelerator never needs the trailing arguments spelled
+// out. `for_blob` is the exception: it carries no `device` parameter and takes
+// the device through its `.device()` builder method instead. Tagging is
+// metadata only: it must not allocate or copy.
 
 TEST_F(TensorPtrDeviceTest, MakeTensorPtrTagsDeviceAfterType) {
   std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
@@ -519,10 +521,89 @@ TEST_F(TensorPtrDeviceTest, ForBlobBuilderMatchesFromBlob) {
       executorch::aten::ScalarType::Float,
       DeviceType::CUDA);
 
+  // Assert the device absolutely, not just that the two agree. Comparing them
+  // to each other alone would still pass if both paths dropped the device.
+  EXPECT_EQ(built->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+  EXPECT_EQ(direct->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
   EXPECT_EQ(
       built->unsafeGetTensorImpl()->device_type(),
       direct->unsafeGetTensorImpl()->device_type());
   EXPECT_EQ(built->const_data_ptr(), direct->const_data_ptr());
+}
+
+// A tensor built as a view of another tensor has to inherit where that data
+// lives. Aliasing device memory and reporting it as CPU would hand the delegate
+// a pointer it refuses, or worse, one a host memcpy would try to touch.
+TEST_F(TensorPtrDeviceTest, ViewOfDeviceTensorInheritsDeviceAndIndex) {
+  std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
+  auto source = make_tensor_ptr(
+      {2, 2},
+      raw.data(),
+      executorch::aten::ScalarType::Float,
+      Device(DeviceType::CUDA, 1));
+
+  auto view = make_tensor_ptr(*source);
+  auto reshaped = make_tensor_ptr(*source, {4});
+
+  EXPECT_EQ(view->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+  EXPECT_EQ(view->unsafeGetTensorImpl()->device_index(), 1);
+  EXPECT_EQ(reshaped->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+  EXPECT_EQ(reshaped->unsafeGetTensorImpl()->device_index(), 1);
+  EXPECT_EQ(view->const_data_ptr(), raw.data());
+  EXPECT_EQ(reshaped->const_data_ptr(), raw.data());
+  EXPECT_EQ(g_mock_cuda.allocate_count_, 0);
+  EXPECT_EQ(g_mock_cuda.h2d_count_, 0);
+}
+
+// Every `from_blob` overload has to carry the device index through, not just
+// the device type. A delegate picks its stream from the index.
+TEST_F(TensorPtrDeviceTest, FromBlobPreservesNonZeroDeviceIndex) {
+  std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
+  const auto device = Device(DeviceType::CUDA, 3);
+
+  auto plain = from_blob(
+      raw.data(), {2, 2}, executorch::aten::ScalarType::Float, device);
+  auto strided = from_blob(
+      raw.data(), {2, 2}, {2, 1}, executorch::aten::ScalarType::Float, device);
+
+  EXPECT_EQ(plain->unsafeGetTensorImpl()->device_index(), 3);
+  EXPECT_EQ(strided->unsafeGetTensorImpl()->device_index(), 3);
+
+  bool plain_deleted = false;
+  bool strided_deleted = false;
+  {
+    auto with_deleter = from_blob(
+        raw.data(),
+        {2, 2},
+        executorch::aten::ScalarType::Float,
+        device,
+        [&plain_deleted](void*) { plain_deleted = true; });
+    auto strided_with_deleter = from_blob(
+        raw.data(),
+        {2, 2},
+        {2, 1},
+        executorch::aten::ScalarType::Float,
+        device,
+        [&strided_deleted](void*) { strided_deleted = true; });
+
+    EXPECT_EQ(with_deleter->unsafeGetTensorImpl()->device_index(), 3);
+    EXPECT_EQ(strided_with_deleter->unsafeGetTensorImpl()->device_index(), 3);
+    EXPECT_FALSE(plain_deleted);
+    EXPECT_FALSE(strided_deleted);
+  }
+  EXPECT_TRUE(plain_deleted);
+  EXPECT_TRUE(strided_deleted);
+}
+
+// `FromBlobDefaultsToCpu` above covers the bare overload. The strided overload
+// has its own defaulted `device` parameter, and nothing else exercises it
+// without naming a device explicitly.
+TEST_F(TensorPtrDeviceTest, FromBlobWithStridesDefaultsToCpu) {
+  std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
+  auto strided = from_blob(
+      raw.data(), {2, 2}, {2, 1}, executorch::aten::ScalarType::Float);
+
+  EXPECT_EQ(strided->unsafeGetTensorImpl()->device_type(), DeviceType::CPU);
 }
 
 #endif // USE_ATEN_LIB

--- a/extension/tensor/test/tensor_ptr_device_test.cpp
+++ b/extension/tensor/test/tensor_ptr_device_test.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/extension/tensor/tensor_ptr.h>
+#include <executorch/extension/tensor/tensor_ptr_maker.h>
 
 #include <gtest/gtest.h>
 
@@ -358,6 +359,170 @@ TEST_F(TensorPtrDeviceTest, LargeTensorRoundtrip) {
   for (size_t i = 0; i < n; ++i) {
     EXPECT_FLOAT_EQ(result[i], data[i]);
   }
+}
+
+// The `device` argument sits immediately after `type` in every factory that
+// takes a raw pointer, so tagging a buffer that already lives on an accelerator
+// never needs the trailing arguments spelled out. Tagging is metadata only: it
+// must not allocate or copy.
+
+TEST_F(TensorPtrDeviceTest, MakeTensorPtrTagsDeviceAfterType) {
+  std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
+  auto tensor = make_tensor_ptr(
+      {2, 2},
+      raw.data(),
+      executorch::aten::ScalarType::Float,
+      DeviceType::CUDA);
+
+  EXPECT_EQ(tensor->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+  EXPECT_EQ(tensor->unsafeGetTensorImpl()->device_index(), 0);
+  EXPECT_EQ(tensor->const_data_ptr(), raw.data());
+  EXPECT_EQ(g_mock_cuda.allocate_count_, 0);
+  EXPECT_EQ(g_mock_cuda.h2d_count_, 0);
+}
+
+TEST_F(TensorPtrDeviceTest, MakeTensorPtrDefaultsToCpu) {
+  std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
+  auto bare = make_tensor_ptr({2, 2}, raw.data());
+  auto typed =
+      make_tensor_ptr({2, 2}, raw.data(), executorch::aten::ScalarType::Float);
+
+  EXPECT_EQ(bare->unsafeGetTensorImpl()->device_type(), DeviceType::CPU);
+  EXPECT_EQ(typed->unsafeGetTensorImpl()->device_type(), DeviceType::CPU);
+}
+
+TEST_F(TensorPtrDeviceTest, MakeTensorPtrKeepsDynamismAndDeleterAfterDevice) {
+  auto* raw = new float[4]{1.0f, 2.0f, 3.0f, 4.0f};
+  bool deleted = false;
+  {
+    auto tensor = make_tensor_ptr(
+        {2, 2},
+        raw,
+        executorch::aten::ScalarType::Float,
+        Device(DeviceType::CUDA, 1),
+        executorch::aten::TensorShapeDynamism::STATIC,
+        [&deleted](void* p) {
+          deleted = true;
+          delete[] static_cast<float*>(p);
+        });
+
+    EXPECT_EQ(tensor->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+    EXPECT_EQ(tensor->unsafeGetTensorImpl()->device_index(), 1);
+    EXPECT_EQ(
+        tensor->shape_dynamism(),
+        executorch::aten::TensorShapeDynamism::STATIC);
+    EXPECT_FALSE(deleted);
+  }
+  EXPECT_TRUE(deleted);
+}
+
+TEST_F(TensorPtrDeviceTest, MakeTensorPtrPrimaryTagsDeviceAfterType) {
+  std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
+  auto tensor = make_tensor_ptr(
+      {2, 2},
+      raw.data(),
+      {0, 1},
+      {2, 1},
+      executorch::aten::ScalarType::Float,
+      DeviceType::CUDA);
+
+  EXPECT_EQ(tensor->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+  EXPECT_EQ(tensor->const_data_ptr(), raw.data());
+  EXPECT_EQ(g_mock_cuda.allocate_count_, 0);
+}
+
+TEST_F(TensorPtrDeviceTest, FromBlobTagsDeviceAfterType) {
+  std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
+  auto tensor = from_blob(
+      raw.data(),
+      {2, 2},
+      executorch::aten::ScalarType::Float,
+      DeviceType::CUDA);
+
+  EXPECT_EQ(tensor->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+  EXPECT_EQ(tensor->const_data_ptr(), raw.data());
+  EXPECT_EQ(g_mock_cuda.allocate_count_, 0);
+}
+
+TEST_F(TensorPtrDeviceTest, FromBlobDefaultsToCpu) {
+  std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
+  auto tensor = from_blob(raw.data(), {2, 2});
+
+  EXPECT_EQ(tensor->unsafeGetTensorImpl()->device_type(), DeviceType::CPU);
+}
+
+TEST_F(TensorPtrDeviceTest, FromBlobWithStridesTagsDevice) {
+  std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
+  auto tensor = from_blob(
+      raw.data(),
+      {2, 2},
+      {2, 1},
+      executorch::aten::ScalarType::Float,
+      DeviceType::CUDA);
+
+  EXPECT_EQ(tensor->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+  EXPECT_EQ(tensor->strides()[0], 2);
+  EXPECT_EQ(tensor->strides()[1], 1);
+}
+
+TEST_F(TensorPtrDeviceTest, FromBlobRunsDeleterAfterDevice) {
+  auto* raw = new float[4]{1.0f, 2.0f, 3.0f, 4.0f};
+  bool deleted = false;
+  {
+    auto tensor = from_blob(
+        raw,
+        {2, 2},
+        executorch::aten::ScalarType::Float,
+        DeviceType::CUDA,
+        [&deleted](void* p) {
+          deleted = true;
+          delete[] static_cast<float*>(p);
+        });
+
+    EXPECT_EQ(tensor->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+    EXPECT_FALSE(deleted);
+  }
+  EXPECT_TRUE(deleted);
+}
+
+TEST_F(TensorPtrDeviceTest, FromBlobWithStridesRunsDeleterAfterDevice) {
+  auto* raw = new float[4]{1.0f, 2.0f, 3.0f, 4.0f};
+  bool deleted = false;
+  {
+    auto tensor = from_blob(
+        raw,
+        {2, 2},
+        {2, 1},
+        executorch::aten::ScalarType::Float,
+        DeviceType::CUDA,
+        [&deleted](void* p) {
+          deleted = true;
+          delete[] static_cast<float*>(p);
+        },
+        executorch::aten::TensorShapeDynamism::STATIC);
+
+    EXPECT_EQ(tensor->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+    EXPECT_EQ(
+        tensor->shape_dynamism(),
+        executorch::aten::TensorShapeDynamism::STATIC);
+  }
+  EXPECT_TRUE(deleted);
+}
+
+TEST_F(TensorPtrDeviceTest, ForBlobBuilderMatchesFromBlob) {
+  std::array<float, 4> raw{1.0f, 2.0f, 3.0f, 4.0f};
+  auto built =
+      for_blob(raw.data(), {2, 2}).device(DeviceType::CUDA).make_tensor_ptr();
+  auto direct = from_blob(
+      raw.data(),
+      {2, 2},
+      executorch::aten::ScalarType::Float,
+      DeviceType::CUDA);
+
+  EXPECT_EQ(
+      built->unsafeGetTensorImpl()->device_type(),
+      direct->unsafeGetTensorImpl()->device_type());
+  EXPECT_EQ(built->const_data_ptr(), direct->const_data_ptr());
 }
 
 #endif // USE_ATEN_LIB

--- a/extension/tensor/test/tensor_ptr_maker_test.cpp
+++ b/extension/tensor/test/tensor_ptr_maker_test.cpp
@@ -195,6 +195,7 @@ TEST_F(TensorPtrMakerTest, TensorDeleterReleasesCapturedSharedPtr) {
       data_ptr.get(),
       {4, 5},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       [data_ptr, &deleter_called](void*) mutable { deleter_called = true; });
 
   EXPECT_EQ(data_ptr.use_count(), 2);

--- a/extension/tensor/test/tensor_ptr_test.cpp
+++ b/extension/tensor/test/tensor_ptr_test.cpp
@@ -129,6 +129,7 @@ TEST_F(TensorPtrTest, TensorResize) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_UNBOUND);
   EXPECT_EQ(resize_tensor_ptr(tensor, {5, 4}), Error::Ok);
   EXPECT_EQ(tensor->size(0), 5);
@@ -153,6 +154,7 @@ TEST_F(TensorPtrTest, TensorWithCustomDataDeleter) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
       [&deleter_called](void* ptr) {
         deleter_called = true;
@@ -173,6 +175,7 @@ TEST_F(TensorPtrTest, TensorManagesMovedVector) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
       [moved_data = std::move(data), &deleter_called](void*) mutable {
         deleter_called = true;
@@ -195,6 +198,7 @@ TEST_F(TensorPtrTest, TensorDeleterReleasesCapturedSharedPtr) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
       [data_ptr, &deleter_called](void*) mutable { deleter_called = true; });
 
@@ -458,6 +462,7 @@ TEST_F(TensorPtrTest, MakeViewRankDecreaseFlatten) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_UNBOUND);
   auto view = make_tensor_ptr(tensor, {6});
   EXPECT_EQ(view->dim(), 1);
@@ -532,6 +537,7 @@ TEST_F(TensorPtrTest, MakeViewDynamismPropagationResizeAlias) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_UNBOUND);
   auto alias = make_tensor_ptr(tensor);
   EXPECT_EQ(resize_tensor_ptr(alias, {2, 6}), Error::Ok);
@@ -626,6 +632,7 @@ TEST_F(TensorPtrTest, CloneTensorPtrCastNullData) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND);
   auto cloned_tensor =
       clone_tensor_ptr(*tensor, executorch::aten::ScalarType::Int);
@@ -1012,6 +1019,7 @@ TEST_F(TensorPtrTest, TensorDataDeleterReleasesCapturedSharedPtr) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
       [data_ptr, &deleter_called](void*) mutable { deleter_called = true; });
 
@@ -1051,6 +1059,7 @@ TEST_F(TensorPtrTest, CustomDeleterWithSharedData) {
         {},
         {},
         executorch::aten::ScalarType::Float,
+        executorch::aten::DeviceType::CPU,
         executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
         [data, &deleter_called](void*) mutable {
           deleter_called = true;
@@ -1123,6 +1132,7 @@ TEST_F(TensorPtrTest, MakeViewFromTensorPtrKeepsSourceAlive) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
       [&freed](void* p) {
         freed = true;
@@ -1147,6 +1157,7 @@ TEST_F(TensorPtrTest, MakeViewFromTensorDoesNotKeepAliveByDefault) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
       [&freed](void* p) {
         freed = true;
@@ -1169,6 +1180,7 @@ TEST_F(TensorPtrTest, MakeViewFromTensorWithDeleterKeepsAlive) {
       {},
       {},
       executorch::aten::ScalarType::Float,
+      executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND,
       [&freed](void* p) {
         freed = true;

--- a/extension/training/module/state_dict_util.cpp
+++ b/extension/training/module/state_dict_util.cpp
@@ -89,6 +89,7 @@ load_state_dict(const runtime::NamedDataMap& data_map) {
         dim_order,
         strides,
         metadata_res->scalar_type(),
+        exec_aten::DeviceType::CPU,
         exec_aten::TensorShapeDynamism::STATIC,
         [](void* ptr) {
           free(ptr);


### PR DESCRIPTION
### Summary

One parameter order for every tensor factory that takes a raw data pointer: `device` sits immediately after `type`, so `deleter` stays last.

```cpp
auto t = make_tensor_ptr({2, 2}, p, ScalarType::Half, DeviceType::CUDA);
auto u = from_blob(p, {2, 2}, ScalarType::Half, DeviceType::CUDA, free_cuda);
```

`Device` is implicitly constructible from `DeviceType`, so no wrapper is needed at the call site. `for_blob(...).device(...)` already worked and still does; the tests check that the builder and the free function agree.

Before this change `device` was the trailing parameter, after `deleter`, so tagging a buffer that already lives on an accelerator meant spelling out every intermediate argument.

Reordered:
- `make_tensor_ptr(sizes, data, dim_order, strides, type, device, dynamism, deleter)`
- `make_tensor_ptr(sizes, data, type, device, dynamism, deleter)`
- all four `from_blob` overloads

The two `from_blob` overloads that take a deleter make `device` required, because a defaulted parameter cannot come before a non-defaulted one. The overloads that own their data (they take a `std::vector`) are unchanged: that data is always host memory.

This adds no new overload, so there is still exactly one way to write each call.

### Compatibility

Callers that passed `dynamism` or `deleter` positionally now have to name the CPU device. `Device` and `TensorShapeDynamism` are unrelated types, so any missed caller is a compile error, never a silent change of meaning. All in-tree callers are updated (16 sites).

This also matches the Objective-C and Swift bindings, where `dataType:` already sits immediately before `shapeDynamism:` in `initWithBytesNoCopy:shape:strides:dimensionOrder:dataType:shapeDynamism:`. Those bindings do not expose device yet; when they do, `device:` slots between the two and the ordering rule stays the same across all three languages.

### Test plan

Ten new tests in `extension/tensor/test/tensor_ptr_device_test.cpp` cover both `make_tensor_ptr` forms and all four `from_blob` forms. They check that the device type and index are recorded, that the data pointer is unchanged and nothing is allocated or copied, that `dynamism` and `deleter` still work when they follow `device`, and that the CPU default is still CPU.

Verified locally: 162 of 162 tests pass across the three tensor extension suites. Removing the device wiring makes 7 of the 10 new tests fail; the other 3 assert CPU behavior, which that particular break preserves.
