### PR TITLE
Cortex-M: run the operator suite on the schedule

### DIFF
--- a/.github/workflows/test-backend-cortex-m.yml
+++ b/.github/workflows/test-backend-cortex-m.yml
@@ -52,12 +52,17 @@ jobs:
     with:
       backend: cortex_m
       flows: '["cortex_m"]'
-      # Most of the operator suite still fails on a kernel the runner does not
-      # carry. Growing ops_list in backends/cortex_m/test/build_test_runner.sh
-      # is the wrong fix -- portable kernels bloat the binary, and most of these
-      # operators should be lowered, folded or decomposed instead of reaching
-      # one. Excluded until enough of them lower to be worth the runtime.
-      exclude: '[{"flow": "cortex_m", "suite": "operators"}]'
+      # The operator suite is a scoreboard for how much of the operator set the
+      # backend lowers, not a gate: most of its cases reach an operator cortex_m
+      # does not implement and abort on a kernel the runner does not carry. It
+      # earns a scheduled run, not a place on every PR and every merge to main.
+      # Growing ops_list to make those cases run is not the fix -- a case that
+      # only passes on a portable fallback says nothing about coverage.
+      exclude: >-
+        ${{ (github.event_name == 'schedule'
+             || github.event_name == 'workflow_dispatch')
+            && '[]'
+            || '[{"flow": "cortex_m", "suite": "operators"}]' }}
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-linux: true

--- a/backends/test/suite/flows/cortex_m.py
+++ b/backends/test/suite/flows/cortex_m.py
@@ -27,11 +27,11 @@ from executorch.backends.cortex_m.test.tester import CortexMQuantize, CortexMTes
 from executorch.backends.test.suite.flow import TestFlow
 
 
-def _create_cortex_m_tester(model, inputs, **kwargs) -> CortexMTester:
+def _to_channels_last(inputs):
     # The CMSIS-NN kernels are NHWC, and CortexMConv2DCheck rejects any pattern
     # whose tensors are not channels_last. The suite hands over contiguous
     # tensors, which silently costs every convolution in the model.
-    inputs = tuple(
+    return tuple(
         (
             t.to(memory_format=torch.channels_last)
             if isinstance(t, torch.Tensor) and t.dim() == 4
@@ -39,12 +39,31 @@ def _create_cortex_m_tester(model, inputs, **kwargs) -> CortexMTester:
         )
         for t in inputs
     )
+
+
+class _ChannelsLastTester(CortexMTester):
+    """Converts on the comparison path as well as the build path.
+
+    The suite runs the program against the inputs it built the case with rather
+    than the ones handed to the tester, and the operator suite does so by
+    default, so converting only in the factory leaves the runtime reading a
+    contiguous tensor as NHWC.
+    """
+
+    def run_method_and_compare_outputs(self, *args, **kwargs):
+        if kwargs.get("inputs") is not None:
+            kwargs["inputs"] = _to_channels_last(kwargs["inputs"])
+        return super().run_method_and_compare_outputs(*args, **kwargs)
+
+
+def _create_cortex_m_tester(model, inputs, **kwargs) -> CortexMTester:
+    inputs = _to_channels_last(inputs)
     # The Serialize stage is also the stage that invokes the ELF, so its timeout
     # is the FVP's --timelimit rather than a serialization budget, and 120s is
-    # not enough for an ImageNet-sized model on an M55 with no NPU. Kept under
-    # the suite conftest's 1200s pytest timeout so the FVP reports the overrun
-    # instead of pytest killing the process.
-    return CortexMTester(model, inputs, timeout=900, **kwargs)
+    # not enough for an ImageNet-sized model on an M55 with no NPU. The suite
+    # conftest wraps each case in a pytest timeout of its own -- 1200s for
+    # models, 120s for operators -- so this only bounds a single FVP run.
+    return _ChannelsLastTester(model, inputs, timeout=900, **kwargs)
 
 
 # Models that cannot run on the FVP runner at all, so there is nothing for the


### PR DESCRIPTION
### Summary
The operator suite has been excluded from the Cortex-M backend job since the flow
landed. Run it nightly and on workflow_dispatch, leaving pull requests and merges
to main with the models suite only, the way the Arm workflow holds its FVP-backed
Ethos-U flows back from per-PR runs.

It is a scoreboard rather than a gate: of 540 cases 237 pass, and most of the
rest reach an operator the backend does not lower and abort on a kernel the test
runner does not carry. The job cannot go red either way -- test_backend.sh
captures pytest's status and the summary generator never re-raises it.

Enabling it needs a harness fix first. The flow converts a 4-D input to
channels_last before handing it to the tester, because the CMSIS-NN kernels are
NHWC and CortexMConv2DCheck rejects anything else, but the suite runs the program
against the inputs it built the case with rather than the ones the tester holds --
and the operator suite does so by default, since _test_op passes
generate_random_test_inputs=False. Every 4-D operator case was therefore handing
a contiguous tensor to a program compiled for NHWC:

    conv2d, contiguous inputs, compared on them     SNR = -3.06 dB
    conv2d, channels_last inputs, compared on them  SNR = 61.13 dB

That accounted for fifty of the suite's failures, including every conv2d,
avg_pool2d, max_pool2d and conv_transpose2d case. Converting in a tester subclass
covers both paths. The models suite is unaffected: it takes the default of True,
and the harness then derives its inputs from the tester's.

Not growing ops_list to make the remaining cases run. A case that only passes
because the runner carries a portable fallback says nothing about what the
backend lowers -- conv1d passes fourteen of fifteen cases while lowering none of
them -- and .rodata runs from the Corstone-300's 512 KiB DTCM, which the full set
of missing portable kernels overflows.

Authored with Claude Code.
