### PR TITLE
Cortex-M: lower a spatial mean.dim to the average-pool kernel

### DIFF
--- a/backends/cortex_m/passes/decompose_mean_pass.py
+++ b/backends/cortex_m/passes/decompose_mean_pass.py
@@ -14,7 +14,8 @@ from torch.fx.node import Argument
 
 class DecomposeMeanPass(ExportPass):
     """
-    Decomposes AdaptiveAvgPool2d into AvgPool2d operation.
+    Rewrites AdaptiveAvgPool2d and spatial mean.dim into AvgPool2d, which
+    CMSIS-NN has a kernel for. Both are spellings of the same classifier head.
     """
 
     def call_operator(
@@ -42,4 +43,62 @@ class DecomposeMeanPass(ExportPass):
             if adaptive_output.shape == avg_pool_output.shape:
                 new_op = torch.ops.aten.avg_pool2d.default
                 return super().call_operator(new_op, new_args, kwargs, meta)
+
+        if op == torch.ops.aten.mean.dim:
+            decomposed = self._mean_dim_to_avg_pool2d(args, kwargs, meta)
+            if decomposed is not None:
+                return decomposed
+
         return super().call_operator(op, args, kwargs, meta)
+
+    def _mean_dim_to_avg_pool2d(
+        self,
+        args: tuple[Argument, ...],
+        kwargs: Dict[str, Argument],
+        meta: NodeMetadata,
+    ) -> ProxyValue | None:
+        """A mean over both spatial dimensions of NCHW is an average pool
+        covering the whole plane. Any other reduction is left alone."""
+        # A mean over a constant arrives as a bare tensor rather than a proxy.
+        if not isinstance(args[0], ProxyValue):
+            return None
+
+        input_tensor = args[0].to_tensor()
+        # The rank matters as well as the dims: a 3-D mean([-2, -1]) normalizes
+        # to the same pair and is not a spatial reduction.
+        if input_tensor.dim() != 4:
+            return None
+
+        # The kernel size and the view both take the shape as literals, which a
+        # symbolic dimension cannot supply.
+        if any(not isinstance(d, int) for d in input_tensor.shape):
+            return None
+
+        dims = args[1]
+        if not isinstance(dims, (list, tuple)) or not all(
+            isinstance(d, int) for d in dims
+        ):
+            return None
+        if sorted(cast(int, d) % 4 for d in dims) != [2, 3]:
+            return None
+
+        # dtype= would change the accumulation type, which avg_pool2d cannot do.
+        if kwargs.get("dtype") is not None:
+            return None
+
+        n, c, h, w = input_tensor.shape
+        pooled = super().call_operator(
+            torch.ops.aten.avg_pool2d.default,
+            (args[0], [h, w], [1, 1], [0, 0], False, False),
+            {},
+            meta,
+        )
+
+        keepdim = args[2] if len(args) > 2 else kwargs.get("keepdim", False)
+        if keepdim:
+            return pooled
+        # avg_pool2d keeps the spatial dimensions; a mean without keepdim drops
+        # them.
+        return super().call_operator(
+            torch.ops.aten.view.default, (pooled, [n, c]), {}, meta
+        )

--- a/backends/cortex_m/test/ops/test_mean.py
+++ b/backends/cortex_m/test/ops/test_mean.py
@@ -1,0 +1,227 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+from executorch.backends.arm.test.common import parametrize
+from executorch.backends.cortex_m.passes.decompose_mean_pass import DecomposeMeanPass
+from executorch.backends.cortex_m.test.tester import (
+    CortexMTester,
+    McuTestCase,
+    ramp_tensor,
+)
+
+
+# DecomposeMeanPass rewrites the mean before annotation, so the edge graph
+# already holds an average pool; what these pin down is that it then quantizes
+# like any other pool, that no zero padding is inserted around it, and that the
+# reduced dimensions are dropped by a view exactly when keepdim is false.
+class CortexMSpatialMean(torch.nn.Module):
+    ops_before_transforms = {
+        "executorch_exir_dialects_edge__ops_aten_avg_pool2d_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_mean_dim": 0,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 3,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 3,
+    }
+    ops_after_transforms = {
+        "executorch_exir_dialects_edge__ops_cortex_m_quantized_avg_pool2d_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_cortex_m_pad_default": 0,
+        "executorch_exir_dialects_edge__ops_aten_mean_dim": 0,
+    }
+
+    def forward(self, x):
+        return x.mean([2, 3])
+
+
+class CortexMSpatialMeanKeepdim(CortexMSpatialMean):
+    ops_before_transforms = {
+        **CortexMSpatialMean.ops_before_transforms,
+        "executorch_exir_dialects_edge__ops_aten_view_copy_default": 0,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 2,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 2,
+    }
+    ops_after_transforms = {
+        **CortexMSpatialMean.ops_after_transforms,
+        "executorch_exir_dialects_edge__ops_aten_view_copy_default": 0,
+    }
+
+    def forward(self, x):
+        return x.mean([2, 3], keepdim=True)
+
+
+class CortexMNegativeDimMean(CortexMSpatialMean):
+    def forward(self, x):
+        return x.mean([-2, -1])
+
+
+# The declining cases share one pair of counts, which pins only the decline
+# itself: their boundary quant/dequant counts differ from each other.
+fallback_ops_before_transforms: dict[str, int] = {
+    "executorch_exir_dialects_edge__ops_aten_mean_dim": 1,
+}
+fallback_ops_after_transforms: dict[str, int] = {
+    "executorch_exir_dialects_edge__ops_aten_mean_dim": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_quantized_avg_pool2d_default": 0,
+}
+
+
+class CortexMChannelMean(torch.nn.Module):
+    def forward(self, x):
+        return x.mean([1])
+
+
+class CortexMAllButBatchMean(torch.nn.Module):
+    def forward(self, x):
+        return x.mean([1, 2, 3])
+
+
+class CortexMOneSpatialDimMean(torch.nn.Module):
+    def forward(self, x):
+        return x.mean([2])
+
+
+class CortexMDtypeMean(torch.nn.Module):
+    def forward(self, x):
+        return x.mean([2, 3], dtype=torch.float32)
+
+
+class CortexMConstantMean(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("stats", ramp_tensor(-1, 1, (4, 8)))
+
+    def forward(self, x):
+        return x + self.stats.mean([0])
+
+
+def nhwc(shape):
+    """The pool kernel requires channels_last, and nothing before the runtime
+    rejects a contiguous tensor, so the layout has to arrive with the program
+    input -- which is how the model tests and the suite flow drive it."""
+    return ramp_tensor(-5, 5, shape).to(memory_format=torch.channels_last)
+
+
+test_cases = {
+    "spatial": McuTestCase(
+        model=CortexMSpatialMean(),
+        example_inputs=(nhwc((1, 8, 4, 4)),),
+    ),
+    "spatial_keepdim": McuTestCase(
+        model=CortexMSpatialMeanKeepdim(),
+        example_inputs=(nhwc((1, 8, 4, 4)),),
+    ),
+    "spatial_negative_dims": McuTestCase(
+        model=CortexMNegativeDimMean(),
+        example_inputs=(nhwc((1, 8, 4, 4)),),
+    ),
+    "spatial_non_square": McuTestCase(
+        model=CortexMSpatialMean(),
+        example_inputs=(nhwc((1, 8, 3, 5)),),
+    ),
+    # The only case that reaches the kernel's batch loop, and the only one
+    # whose view moves more than one row.
+    "spatial_batched": McuTestCase(
+        model=CortexMSpatialMean(),
+        example_inputs=(nhwc((3, 8, 4, 4)),),
+    ),
+}
+
+# Reductions with no average-pool equivalent. They stay in fp32, which the test
+# runner carries no kernel for, so these only go as far as the dialect.
+fallback_test_cases = {
+    "channel": McuTestCase(
+        model=CortexMChannelMean(),
+        example_inputs=(nhwc((1, 8, 4, 4)),),
+    ),
+    "all_but_batch": McuTestCase(
+        model=CortexMAllButBatchMean(),
+        example_inputs=(nhwc((1, 8, 4, 4)),),
+    ),
+    "one_spatial_dim": McuTestCase(
+        model=CortexMOneSpatialDimMean(),
+        example_inputs=(nhwc((1, 8, 4, 4)),),
+    ),
+    # The trailing dims of a 3-D tensor normalize to the same [2, 3] a spatial
+    # reduction does, and pooling them would be wrong.
+    "rank_3_trailing_dims": McuTestCase(
+        model=CortexMNegativeDimMean(),
+        example_inputs=(ramp_tensor(-5, 5, (2, 8, 4)),),
+    ),
+    # dtype= changes the accumulation type, which avg_pool2d has no argument
+    # for.
+    "accumulate_dtype": McuTestCase(
+        model=CortexMDtypeMean(),
+        example_inputs=(nhwc((1, 8, 4, 4)),),
+    ),
+    # A mean over a buffer reaches the pass as a bare tensor rather than a
+    # proxy, so the guard for it has to come before anything reads a shape.
+    "constant_operand": McuTestCase(
+        model=CortexMConstantMean(),
+        example_inputs=(ramp_tensor(-5, 5, (2, 8)),),
+    ),
+}
+
+
+def test_dynamic_batch_is_refused():
+    """A symbolic dimension has no literal to put in the kernel size or the
+    view, and the suite's flow does not exercise dynamic shapes."""
+    exported = torch.export.export(
+        CortexMSpatialMean(),
+        (torch.randn(2, 8, 4, 4),),
+        dynamic_shapes=({0: torch.export.Dim("batch", min=1, max=8)},),
+    )
+    rewritten = DecomposeMeanPass()(exported.module()).graph_module
+    assert any(node.target is torch.ops.aten.mean.dim for node in rewritten.graph.nodes)
+
+
+@parametrize("test_case", test_cases)
+def test_lowered_shape_matches_eager(test_case, cortex_m_target):
+    """The harness takes its reference from a program exported after the pass
+    has run, so it compares the rewrite against itself. The reduced shape is
+    the one thing that comparison cannot see."""
+    tester = CortexMTester(
+        test_case.model, test_case.example_inputs, target_config=cortex_m_target
+    )
+    tester.quantize().export().to_edge().run_passes()
+    graph = tester.get_artifact().exported_program().graph
+    (output,) = graph.output_node().args[0]
+    assert (
+        output.meta["val"].shape == test_case.model(*test_case.example_inputs).shape
+    ), output.meta["val"].shape
+
+
+@parametrize("test_case", test_cases)
+def test_dialect_mean(test_case, cortex_m_target):
+    tester = CortexMTester(
+        test_case.model, test_case.example_inputs, target_config=cortex_m_target
+    )
+    tester.test_dialect(
+        test_case.model.ops_before_transforms,
+        test_case.model.ops_after_transforms,
+        qtol=1,
+    )
+
+
+@parametrize("test_case", test_cases)
+def test_implementation_mean(test_case, cortex_m_target):
+    tester = CortexMTester(
+        test_case.model, test_case.example_inputs, target_config=cortex_m_target
+    )
+    tester.test_implementation(qtol=1)
+
+
+@parametrize("test_case", fallback_test_cases)
+def test_dialect_mean_fallback(test_case, cortex_m_target):
+    tester = CortexMTester(
+        test_case.model, test_case.example_inputs, target_config=cortex_m_target
+    )
+    tester.test_dialect(
+        fallback_ops_before_transforms, fallback_ops_after_transforms, qtol=1
+    )

--- a/backends/test/suite/flows/cortex_m.py
+++ b/backends/test/suite/flows/cortex_m.py
@@ -72,7 +72,6 @@ CORTEX_M_XFAILS = [
     "test_convnext_small",
     "test_densenet161",
     "test_maxvit_t",
-    "test_mnasnet1_0",
     "test_shufflenet_v2_x1_0",
     # 4.00 bytes per parameter: none of the convolutions lower, so the weights
     # stay fp32 and the 100 MiB program overruns the pool. Lowering conv1d


### PR DESCRIPTION
### Summary
DecomposeMeanPass rewrote nn.AdaptiveAvgPool2d(1) into avg_pool2d but not the other spelling of the same classifier head, a bare x.mean([2, 3]). MNASNet uses that one, which left an fp32 reduction mid-graph and a program needing aten::mean.out and dim_order_ops::_to_dim_order_copy.out, neither of which the test runner carries.

A mean over both spatial dimensions is an average pool over the whole plane: a [H, W] kernel with no padding, plus a view when keepdim is false. Everything else declines -- the rank has to be four, since a 3-D mean([-2, -1]) normalizes to the same dims, and dtype= changes the accumulation type. A mean over a constant arrives as a bare tensor rather than a proxy and is declined before anything reads its shape. So is a symbolic dimension, which has no literal to put in the kernel size or the view.

count_include_pad is false because the lowering inserts a cortex_m::pad node whenever it is set, without checking whether there is any padding to apply.

A mean over a contiguous tensor becomes a pool the kernel rejects at runtime, which is what a contiguous nn.AvgPool2d already does.

test_mnasnet1_0 comes off the flow's xfail list.

Authored with Claude Code.