### PR TITLE
Drop redundant recompiles before ARM pass retracing (#22162)

### DIFF
--- a/backends/arm/_passes/canonicalize_view_copy_permute_pass.py
+++ b/backends/arm/_passes/canonicalize_view_copy_permute_pass.py
@@ -18,3 +18,5 @@ class CanonicalizeViewCopyPermutePass(_CanonicalizeViewCopyPermutePass, ArmPass)
     mismatch.
 
     """
+
+    _recompile_before_retrace = False

--- a/backends/arm/_passes/fuse_duplicate_users_pass.py
+++ b/backends/arm/_passes/fuse_duplicate_users_pass.py
@@ -21,5 +21,7 @@ TOSA_EXCLUDED_TARGETS = frozenset({exir_ops.backend.tosa.RESCALE.default})
 class FuseDuplicateUsersPass(_FuseDuplicateUsersPass, ArmPass):
     """TOSA-aware configuration of the shared duplicate-user fusion."""
 
+    _recompile_before_retrace = False
+
     def __init__(self, excluded_targets: frozenset | None = None) -> None:
         super().__init__(excluded_targets or TOSA_EXCLUDED_TARGETS)

--- a/backends/transforms/canonicalize_view_copy_permute_pass.py
+++ b/backends/transforms/canonicalize_view_copy_permute_pass.py
@@ -35,6 +35,7 @@ class CanonicalizeViewCopyPermutePass(ExportPass):
     """
 
     _passes_required_after: Set[Type[ExportPass]] = set()
+    _recompile_before_retrace = True
 
     _VIEW_TARGET = exir_ops.edge.aten.view_copy.default
     _PERMUTE_TARGET = exir_ops.edge.aten.permute_copy.default
@@ -81,7 +82,10 @@ class CanonicalizeViewCopyPermutePass(ExportPass):
 
         if modified:
             graph_module.graph.eliminate_dead_code()
-            graph_module.recompile()
+            if self._recompile_before_retrace:
+                graph_module.recompile()
+            else:
+                graph_module.graph.lint()
             graph_module = super().call(graph_module).graph_module
 
         return PassResult(graph_module, modified)

--- a/backends/transforms/fuse_duplicate_users_pass.py
+++ b/backends/transforms/fuse_duplicate_users_pass.py
@@ -28,6 +28,7 @@ class FuseDuplicateUsersPass(ExportPass):
     """
 
     _passes_required_after: Set[Type[ExportPass]] = set()
+    _recompile_before_retrace = True
 
     def __init__(self, excluded_targets: frozenset | None = None) -> None:
         super().__init__()
@@ -85,7 +86,8 @@ class FuseDuplicateUsersPass(ExportPass):
                     producers.append(representative)
 
         if modified:
-            graph_module.recompile()
+            if self._recompile_before_retrace:
+                graph_module.recompile()
             graph_module.graph.lint()
             graph_module = super().call(graph_module).graph_module
 


### PR DESCRIPTION
Summary:

Drop redundant recompile() before ARM pass retracing.

Remove redundant GraphModule.recompile() calls immediately before super().call(graph_module) in CanonicalizeViewCopyPermutePass and FuseDuplicateUsersPass. The following ExportPass retrace/interpreter does not consume compiled Python code object, so recompile adds wall time without changing graph.

Keep graph.lint() in modified paths for invariant checking. Behavior-preserving lowering speedup.

On an ensemble network of ~1M parameters, lowering produced identical output while running 17.9 seconds faster (4.7%).

Differential Revision: D114790155


