### PR TITLE
Fix Windows MSVC Debug build of XNNPACK and clang-cl kernel gating

### DIFF
--- a/backends/xnnpack/cmake/Dependencies.cmake
+++ b/backends/xnnpack/cmake/Dependencies.cmake
@@ -76,6 +76,15 @@ set(XNNPACK_BUILD_ALL_MICROKERNELS
     OFF
     CACHE BOOL ""
 )
+
+# XNNPACK nests variadic macros (XNN_RETURN_IF_ERROR expands to xnn_log_error),
+# which MSVC's default legacy preprocessor mis-expands. Only observable where
+# XNN_LOG_LEVEL is non-zero, i.e. Debug configurations. Not applied to clang-cl,
+# which sets MSVC but already has a conforming preprocessor.
+if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+  add_compile_options(/Zc:preprocessor)
+endif()
+
 add_subdirectory("${XNNPACK_SOURCE_DIR}")
 include_directories(SYSTEM ${XNNPACK_INCLUDE_DIR})
 list(APPEND xnnpack_third_party XNNPACK)

--- a/tools/cmake/preset/llm.cmake
+++ b/tools/cmake/preset/llm.cmake
@@ -20,9 +20,11 @@ set_overridable_option(EXECUTORCH_BUILD_KERNELS_OPTIMIZED ON)
 set_overridable_option(EXECUTORCH_BUILD_XNNPACK ON)
 
 # Turn on the quantized and LLM kernels unless on Windows with MSVC build since
-# they don't currently compile.
+# they don't currently compile. MSVC is also set for clang-cl, which does
+# compile them, so key off the compiler ID instead.
 if(NOT ((CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL
-                                                 "WIN32") AND MSVC)
+                                                 "WIN32")
+        AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 )
   set_overridable_option(EXECUTORCH_BUILD_KERNELS_QUANTIZED ON)
   set_overridable_option(EXECUTORCH_BUILD_KERNELS_LLM ON)


### PR DESCRIPTION
Fixes #22084.

### The bug

Any Debug preset with XNNPACK enabled fails to compile `XNNPACK/src/subgraph.c` under the MSVC toolset:

```
subgraph.c(2663,3): error C2143: syntax error: missing ')' before 'string'
subgraph.c(2663,3): error C2059: syntax error: ')'
subgraph.c(2918,5): error C2143: syntax error: missing ')' before 'string'
subgraph.c(3500,5): error C2143: syntax error: missing ')' before 'string'
```

XNNPACK nests two variadic macros. `XNN_RETURN_IF_ERROR` (`src/xnnpack/internal.h`) expands to `xnn_log_error("" __VA_ARGS__)`, and `xnn_log_error` (`src/xnnpack/log.h`) is itself variadic and concatenates a location suffix onto its first parameter:

```c
#define xnn_log_error(format, ...) \
  xnn_log_error_(format " (%s, %s:%i)", ##__VA_ARGS__, __FUNCTION__, __FILE__, __LINE__)
```

MSVC's default legacy preprocessor forwards the outer `__VA_ARGS__` into the inner macro as a single un-split argument. `format` therefore binds to the whole blob and the suffix is glued onto the last *argument* instead of the format string, yielding `node_id " (%s, %s:%i)"`. Only the three call sites in `subgraph.c` that pass a format string **plus** format arguments are affected, which is exactly lines 2663, 2918 and 3500 at the currently pinned XNNPACK revision.

`/Zc:preprocessor` selects MSVC's conformant preprocessor and resolves it. The guard keys off `CMAKE_C_COMPILER_ID` rather than the `MSVC` variable because `MSVC` is also true under clang-cl, which already conforms.

### Why CI is green today

`XNN_LOG_LEVEL` is `5` only for `$<CONFIG:Debug>` and `0` otherwise, so in Release `xnn_log_error` expands to nothing and the broken expansion never happens. The existing `windows-msvc` job builds Release only, leaving Debug uncovered. A cheap regression guard would be adding `-DEXECUTORCH_XNNPACK_LOG_LEVEL=5` to `.ci/scripts/setup-windows-msvc.ps1`, which exercises the path without a second full build; I left that out of this PR to keep it reviewable, happy to add it if wanted.

### Second, related fix

`tools/cmake/preset/llm.cmake` disabled the quantized and LLM kernels on Windows whenever the `MSVC` variable was set. CMake also sets `MSVC` for clang-cl, so those kernels were silently dropped from every Windows clang-cl build while the accompanying warning advised the user to switch to `-T ClangCL` in order to get them. That contradicts the stated intent of #15719 ("Only block when building with MSVC"), so the check now uses `CMAKE_CXX_COMPILER_ID`. The `pybind` preset already enables the same kernels and is built with `-T ClangCL` in Windows CI, so this path is covered.

### Testing

On Windows with VS 2022 (MSVC 19.43):

- `xnnpack-subgraph` in Debug under the default MSVC toolset fails with the errors above before the change and builds cleanly after it.
- All 96 XNNPACK logic-layer sources compiled with `XNN_LOG_LEVEL=5`, with and without `/Zc:preprocessor`, confirming the flag introduces no new diagnostics.
- `cmake --preset llm-debug` still disables the kernels and warns under MSVC, and now enables them under `-T ClangCL`, where `custom_ops`, `quantized_kernels` and `quantized_ops_lib` all build clean.

`cmake-format` and `cmakelint` pass on both files.

### Follow-up, not in this PR

`make parakeet-vulkan` builds the ExecuTorch core with `llm-debug-vulkan` but the runner with a preset pinned to `Release`. On MSVC that is a `/MDd` vs `/MD` CRT mismatch, so the reporter is likely to hit `LNK2038` next. Every other backend pairs like with like (`parakeet-cuda` uses `llm-release-cuda`). The fix is presumably an `llm-release-vulkan` preset mirroring `llm-release-cuda`, but that changes behaviour for existing Linux users of the target so it belongs on its own.

This PR was authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
