### PR TITLE
Resolve c10 directly for aten_device

### DIFF
--- a/extension/aten_util/targets.bzl
+++ b/extension/aten_util/targets.bzl
@@ -23,9 +23,17 @@ def define_common_targets():
         # build environments where those live in a separate library from c10,
         # they collide at link time with the copies the application already
         # links.
-        exported_external_deps = [
-            "c10",
-        ],
+        exported_external_deps = ["c10"] if runtime.is_oss else [],
+        fbcode_exported_deps = [
+            "fbcode//caffe2/c10:c10",
+        ] if not runtime.is_oss else [],
+        xplat_exported_deps = select({
+            "DEFAULT": ["fbsource//xplat/caffe2/c10:c10"],
+            "ovr_config//build_mode:arvr_mode[enabled]": select({
+                "DEFAULT": ["fbsource//xplat/caffe2/c10:c10_ovrsource"],
+                "ovr_config//os:android": ["fbsource//xplat/caffe2/c10:c10"],
+            }),
+        }) if not runtime.is_oss else [],
     )
 
     runtime.cxx_library(


### PR DESCRIPTION
### Summary

Keep the OSS `c10` external dependency, but use explicit fbcode and xplat c10 targets for internal builds. This prevents imported stacks from falling through to the removed `third-party-buck/projects/c10` package.

The ARVR dependency split remains unchanged:
- Android uses the xplat c10 flavor.
- Native ARVR uses `c10_ovrsource`.

Internal diff: D117426475, stacked on D117410892.

### Test plan

- `buck build --flagfile fbcode//mode/dev fbcode//executorch/backends/qualcomm/tests:test_qnn_delegate fbcode//executorch/backends/qualcomm/tests:test_qnn_delegate_x86 fbcode//executorch/backends/qualcomm/tests:tester`
- Verified c10 dependency resolution for fbcode, xplat, ARVR Android, and native ARVR configurations.

Authored with Codex.