### PR TITLE
[MLX] Add the cell KV-cache layout to the MLX runtime

### DIFF
--- a/.github/workflows/mlx.yml
+++ b/.github/workflows/mlx.yml
@@ -68,7 +68,7 @@ jobs:
         echo "::endgroup::"
 
         echo "::group::Build test runners"
-        ${CONDA_RUN} cmake --build cmake-out --target op_test_runner multi_thread_test_runner mlx_mutable_state_test mlx_sequence_cache_test -j$(( $(sysctl -n hw.ncpu) - 1 ))
+        ${CONDA_RUN} cmake --build cmake-out --target op_test_runner multi_thread_test_runner mlx_mutable_state_test mlx_sequence_cache_test mlx_cell_cache_test -j$(( $(sysctl -n hw.ncpu) - 1 ))
         echo "::endgroup::"
 
         echo "::group::Run mutable-state (multi-session) unit test"
@@ -77,6 +77,7 @@ jobs:
 
         echo "::group::Run off-graph KV-cache op test"
         ./cmake-out/backends/mlx/test/mlx_sequence_cache_test
+        ./cmake-out/backends/mlx/test/mlx_cell_cache_test
         echo "::endgroup::"
 
         echo "::group::Run op unit tests"

--- a/backends/mlx/runtime/MLXBackend.cpp
+++ b/backends/mlx/runtime/MLXBackend.cpp
@@ -7,6 +7,7 @@
 //
 
 #include "MLXCache.h"
+#include "MLXCellCache.h"
 #include "MLXExecutor.h"
 #include "MLXInterpreter.h"
 #include "MLXLoader.h"
@@ -560,6 +561,11 @@ const int cache_builders_registered = [] {
       kMLXBackendId, "seq", [](const cache::CacheConfig& cfg) {
         return std::shared_ptr<cache::CacheBase>(
             std::make_shared<MLXSequenceCache>(cfg));
+      });
+  cache::CacheBuilderRegistry::global().register_builder(
+      kMLXBackendId, "cell", [](const cache::CacheConfig& cfg) {
+        return std::shared_ptr<cache::CacheBase>(
+            std::make_shared<MLXCellCache>(cfg));
       });
   return 0;
 }();

--- a/backends/mlx/runtime/MLXCellCache.h
+++ b/backends/mlx/runtime/MLXCellCache.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <vector>
+
+#include "MLXCache.h" // AttendSpec, MLXCache
+#include "MLXExecutor.h" // resolve_dtype
+#include "MLXPool.h" // Pool
+
+#include <executorch/extension/llm/cache/cache.h>
+#include <executorch/extension/llm/cache/cell_cache.h>
+
+namespace executorch {
+namespace backends {
+namespace mlx {
+
+namespace cache = ::executorch::extension::llm::cache;
+
+// The MLX byte layer behind the neutral CellCache: one Pool per layer for K and
+// one for V, every pool addressed by the same cell index. update_and_fetch
+// places the step, scatters the new K/V into their cells, reads the occupied
+// prefix and hands over the mask the step already built.
+//
+// The mask is never implicit here. A cell's neighbours may belong to another
+// sequence or have been freed, so a single decode token needs one as much as a
+// prefill does, and neither is what MLX's fused "causal" describes.
+class MLXCellCache : public cache::CellCache, public MLXCache {
+ public:
+  explicit MLXCellCache(const cache::CacheConfig& cfg)
+      : cache::CellCache(checked(cfg)) {
+    const ::mlx::core::Dtype dt =
+        resolve_dtype(static_cast<int8_t>(cfg.kv_dtype));
+    kpool_.reserve(static_cast<size_t>(cfg.n_layers));
+    vpool_.reserve(static_cast<size_t>(cfg.n_layers));
+    for (int l = 0; l < cfg.n_layers; ++l) {
+      // layers size 1 = one config broadcast to every layer, else per-layer.
+      const cache::LayerConfig& lc =
+          cfg.layers.size() == 1 ? cfg.layers.front() : cfg.layers[l];
+      // A window bounds what a query attends, not where its token lives, so
+      // every layer spans the whole cell table whatever its policy.
+      kpool_.emplace_back(
+          cfg.initial_capacity, cfg.capacity, lc.n_kv_heads, lc.head_dim, dt);
+      vpool_.emplace_back(
+          cfg.initial_capacity, cfg.capacity, lc.n_kv_heads, lc.head_dim, dt);
+    }
+  }
+
+  AttendSpec update_and_fetch(
+      int layer,
+      const std::vector<int32_t>& positions,
+      const Tensor& k,
+      const Tensor& v,
+      StreamOrDevice s) override {
+    if (layer < 0 || layer >= static_cast<int>(kpool_.size())) {
+      throw std::out_of_range("update_and_fetch: layer out of range");
+    }
+    // Checked before the step is placed, so a miscounted call claims no cell.
+    if (static_cast<int>(positions.size()) !=
+        static_cast<int>(k.shape(2))) { // BHSD: seq axis is 2
+      throw std::runtime_error(
+          "update_and_fetch: one position per key/value token expected");
+    }
+    const cache::CellStep* step = this->place_step(
+        layer, positions.data(), static_cast<int>(positions.size()));
+    if (!step) {
+      throw std::runtime_error(
+          "update_and_fetch: step undeclared, out of cells, or already served");
+    }
+    const size_t l = static_cast<size_t>(layer);
+    kpool_[l].write_cells(step->cells, k, s);
+    vpool_[l].write_cells(step->cells, v, s);
+    return AttendSpec{
+        kpool_[l].read(0, step->read_len, s),
+        vpool_[l].read(0, step->read_len, s),
+        AttendSpec::Mask::Explicit,
+        mask(*step)};
+  }
+
+ private:
+  // The step's bits as SDPA wants them: [1, 1, length, read_len], one row per
+  // query token.
+  static Tensor mask(const cache::CellStep& step) {
+    return ::mlx::core::array(
+        step.mask_bits.data(),
+        ::mlx::core::Shape{1, 1, step.length, step.read_len},
+        ::mlx::core::bool_);
+  }
+
+  // Enforce the neutral contract as an exception, the failure mode this layer
+  // already uses. Runs as the base initializer's argument because CellCache's
+  // own ctor indexes `layers` before this class's body does.
+  static const cache::CacheConfig& checked(const cache::CacheConfig& cfg) {
+    if (!cache::valid(cfg)) {
+      throw std::runtime_error("MLXCellCache: invalid CacheConfig");
+    }
+    return cfg;
+  }
+
+  std::vector<Pool> kpool_;
+  std::vector<Pool> vpool_;
+};
+
+} // namespace mlx
+} // namespace backends
+} // namespace executorch

--- a/backends/mlx/runtime/MLXPool.h
+++ b/backends/mlx/runtime/MLXPool.h
@@ -60,9 +60,9 @@ class Pool {
         s);
   }
 
-  // Place `update` one token per slot, at `cells[i]` for token i. Cells refill
-  // from below as sequences are removed, so a step's slots need not be
-  // contiguous or ordered.
+  // Place `update` one token per slot, at `cells[i]` for token i. The cells
+  // must be distinct. They refill from below as sequences are removed, so
+  // a step's slots need not be contiguous or ordered.
   void write_cells(
       const std::vector<int32_t>& cells,
       const Tensor& update,

--- a/backends/mlx/runtime/MLXPool.h
+++ b/backends/mlx/runtime/MLXPool.h
@@ -86,13 +86,16 @@ class Pool {
       high = std::max(high, cell + 1);
     }
     maybe_grow(high, s);
+    const Tensor u = update.dtype() == dtype_
+        ? update
+        : ::mlx::core::astype(update, dtype_, s);
     // put_along_axis broadcasts the one index per token across heads and
-    // head_dim, and casts the update to the storage dtype.
+    // head_dim.
     buf_ = ::mlx::core::put_along_axis(
         buf_,
         ::mlx::core::array(
             cells.data(), ::mlx::core::Shape{1, 1, T, 1}, ::mlx::core::int32),
-        update,
+        u,
         2,
         s);
   }

--- a/backends/mlx/runtime/MLXPool.h
+++ b/backends/mlx/runtime/MLXPool.h
@@ -19,9 +19,10 @@ namespace backends {
 namespace mlx {
 
 // Per-layer K or V store, SDPA-major [1, H, slots, D] (cells on axis 2). The
-// caller hands down physical slot ranges (it has already applied any ring
-// modulo), so the pool is layout-agnostic: policies differ only in how many
-// slots the layer asks for and how many ranges a step produces.
+// caller hands down physical slots -- a contiguous range, or one index per
+// token -- having already applied any ring modulo, so the pool is
+// layout-agnostic: layouts differ only in how many slots the layer asks for and
+// where in them a step lands.
 class Pool {
  public:
   // initial_slots above max_slots is clamped, not rejected: the config default
@@ -56,6 +57,43 @@ class Pool {
         u,
         ::mlx::core::Shape{0, 0, start, 0},
         ::mlx::core::Shape{1, H, start + len, D},
+        s);
+  }
+
+  // Place `update` one token per slot, at `cells[i]` for token i. Cells refill
+  // from below as sequences are removed, so a step's slots need not be
+  // contiguous or ordered.
+  void write_cells(
+      const std::vector<int32_t>& cells,
+      const Tensor& update,
+      StreamOrDevice s) {
+    const int H = static_cast<int>(buf_.shape(1));
+    const int D = static_cast<int>(buf_.shape(3));
+    const int T = static_cast<int>(cells.size());
+    if (static_cast<int>(update.shape(2)) != T) {
+      throw std::runtime_error(
+          "Pool::write_cells: update length != cell count");
+    }
+    if (static_cast<int>(update.shape(1)) != H ||
+        static_cast<int>(update.shape(3)) != D) {
+      throw std::runtime_error("Pool::write_cells: K/V heads/dim mismatch");
+    }
+    int high = 0;
+    for (int32_t cell : cells) {
+      if (cell < 0 || cell >= max_slots_) {
+        throw std::runtime_error("Pool::write_cells: cell out of bounds");
+      }
+      high = std::max(high, cell + 1);
+    }
+    maybe_grow(high, s);
+    // put_along_axis broadcasts the one index per token across heads and
+    // head_dim, and casts the update to the storage dtype.
+    buf_ = ::mlx::core::put_along_axis(
+        buf_,
+        ::mlx::core::array(
+            cells.data(), ::mlx::core::Shape{1, 1, T, 1}, ::mlx::core::int32),
+        update,
+        2,
         s);
   }
 

--- a/backends/mlx/test/CMakeLists.txt
+++ b/backends/mlx/test/CMakeLists.txt
@@ -112,3 +112,26 @@ if(EXECUTORCH_MLX_ENABLE_SANITIZERS)
     mlx_sequence_cache_test PRIVATE ${_mlx_sanitizer_link_options}
   )
 endif()
+
+et_cxx_test(
+  mlx_cell_cache_test
+  SOURCES
+  ${CMAKE_CURRENT_LIST_DIR}/mlx_cell_cache_test.cpp
+  EXTRA_LIBS
+  mlxdelegate
+  mlx_schema
+  mlx
+  extension_llm_cache
+)
+target_include_directories(
+  mlx_cell_cache_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../runtime
+)
+if(EXECUTORCH_MLX_ENABLE_SANITIZERS)
+  target_compile_options(
+    mlx_cell_cache_test PRIVATE -fsanitize=address,undefined
+                                -fno-omit-frame-pointer
+  )
+  target_link_options(
+    mlx_cell_cache_test PRIVATE ${_mlx_sanitizer_link_options}
+  )
+endif()

--- a/backends/mlx/test/mlx_cell_cache_test.cpp
+++ b/backends/mlx/test/mlx_cell_cache_test.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Op-level test for the cell layout's MLX byte layer (MLXCellCache / Pool).
+//
+// Drives MLXCellCache::update_and_fetch directly (no interpreter / .pte) and
+// checks the AttendSpec against the cells the layout should have claimed: that
+// a token lands in its own cell, that the window is the occupied prefix, and
+// that the mask isolates sequences, hides freed cells and honours a layer's
+// window. The scatter path is covered by refilling a hole below a live cell,
+// which no contiguous write could express.
+//
+// Must run on Apple Silicon: MLX needs the Metal backend.
+
+#include "MLXCellCache.h"
+#include "backend_options.h" // kMLXBackendId
+
+#include <executorch/extension/llm/cache/cache_registry.h>
+#include <mlx/mlx.h>
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <vector>
+
+using namespace ::executorch::backends::mlx;
+namespace cache = ::executorch::extension::llm::cache;
+using ::mlx::core::array;
+
+namespace {
+
+// Max absolute difference within tolerance. Computed in float32: item<float>()
+// reads sizeof(float) bytes, so calling it on an fp16 scalar misreads the
+// buffer.
+bool allclose(const array& a, const array& b, float atol) {
+  using namespace ::mlx::core;
+  array m = max(abs(subtract(astype(a, float32), astype(b, float32))));
+  eval(m);
+  return m.item<float>() <= atol;
+}
+
+// Cell j of a [1, H, S, D] window.
+array cell_of(const array& window, int j) {
+  using namespace ::mlx::core;
+  const int H = static_cast<int>(window.shape(1));
+  const int D = static_cast<int>(window.shape(3));
+  return slice(window, Shape{0, 0, j, 0}, Shape{1, H, j + 1, D});
+}
+
+cache::CacheConfig cell_config(
+    int capacity,
+    int n_layers,
+    int n_kv_heads,
+    int head_dim,
+    int kv_dtype,
+    std::optional<int> initial_capacity = std::nullopt) {
+  cache::CacheConfig cfg;
+  cfg.capacity = capacity;
+  cfg.n_layers = n_layers;
+  cfg.layers = {cache::LayerConfig{
+      cache::LayerPolicy{cache::LayerPolicy::Kind::Flat, 0},
+      n_kv_heads,
+      head_dim}};
+  cfg.kv_dtype = kv_dtype;
+  if (initial_capacity) {
+    cfg.initial_capacity = *initial_capacity;
+  }
+  return cfg;
+}
+
+class MLXCellCacheTest : public ::testing::Test {
+ protected:
+  const int H = 2;
+  const int D = 8;
+  const int kHalf = static_cast<int>(ScalarType::Half);
+  ::mlx::core::StreamOrDevice s = {};
+
+  array randn(int T, ::mlx::core::Dtype dt = ::mlx::core::float16) {
+    return ::mlx::core::random::normal(::mlx::core::Shape{1, H, T, D}, dt);
+  }
+
+  // Declare `seq_ids` and serve layer 0 with K/V of matching length.
+  AttendSpec step(
+      MLXCellCache& c,
+      const std::vector<int32_t>& seq_ids,
+      const std::vector<int32_t>& positions,
+      const array& k,
+      const array& v) {
+    EXPECT_TRUE(c.declare_step(seq_ids));
+    return c.update_and_fetch(0, positions, k, v, s);
+  }
+
+  // The mask as ints, so a row can be compared against an expected pattern.
+  array bits(const AttendSpec& spec) {
+    return ::mlx::core::astype(*spec.mask, ::mlx::core::int32);
+  }
+};
+
+// Prefill of one sequence: tokens take cells 0..3, the window is exactly them,
+// and the mask is lower-triangular.
+TEST_F(MLXCellCacheTest, PrefillClaimsCellsInOrder) {
+  using namespace ::mlx::core;
+  MLXCellCache c(cell_config(/*capacity=*/32, /*n_layers=*/1, H, D, kHalf));
+  const int32_t a = *c.seq_new();
+  array k = randn(4), v = randn(4);
+
+  AttendSpec spec = step(c, {a, a, a, a}, {0, 1, 2, 3}, k, v);
+
+  EXPECT_EQ(spec.kind, AttendSpec::Mask::Explicit);
+  EXPECT_EQ(spec.K.shape(2), 4);
+  EXPECT_TRUE(allclose(spec.K, k, 0.0f));
+  EXPECT_TRUE(allclose(spec.V, v, 0.0f));
+
+  const std::vector<int32_t> causal = {
+      1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1};
+  EXPECT_TRUE(allclose(
+      bits(spec), array(causal.data(), Shape{1, 1, 4, 4}, int32), 0.0f));
+}
+
+// Decode appends one cell and reads the whole prefix back.
+TEST_F(MLXCellCacheTest, DecodeExtendsTheWindow) {
+  using namespace ::mlx::core;
+  MLXCellCache c(cell_config(32, 1, H, D, kHalf));
+  const int32_t a = *c.seq_new();
+  array k0 = randn(2), v0 = randn(2);
+  step(c, {a, a}, {0, 1}, k0, v0);
+
+  array k1 = randn(1), v1 = randn(1);
+  AttendSpec spec = step(c, {a}, {2}, k1, v1);
+
+  EXPECT_EQ(spec.K.shape(2), 3);
+  EXPECT_TRUE(allclose(cell_of(spec.K, 2), k1, 0.0f));
+  EXPECT_TRUE(allclose(cell_of(spec.V, 2), v1, 0.0f));
+  const std::vector<int32_t> all = {1, 1, 1};
+  EXPECT_TRUE(
+      allclose(bits(spec), array(all.data(), Shape{1, 1, 1, 3}, int32), 0.0f));
+}
+
+// Two sequences share the pool: the window spans both, the mask attends only
+// the querying sequence's cells.
+TEST_F(MLXCellCacheTest, MaskIsolatesSequences) {
+  using namespace ::mlx::core;
+  MLXCellCache c(cell_config(32, 1, H, D, kHalf));
+  const int32_t a = *c.seq_new();
+  const int32_t b = *c.seq_new();
+  EXPECT_NE(a, b);
+
+  step(c, {a, a}, {0, 1}, randn(2), randn(2)); // cells 0, 1
+  step(c, {b, b}, {0, 1}, randn(2), randn(2)); // cells 2, 3
+
+  AttendSpec spec = step(c, {b}, {2}, randn(1), randn(1)); // cell 4
+  EXPECT_EQ(spec.K.shape(2), 5);
+  const std::vector<int32_t> only_b = {0, 0, 1, 1, 1};
+  EXPECT_TRUE(allclose(
+      bits(spec), array(only_b.data(), Shape{1, 1, 1, 5}, int32), 0.0f));
+}
+
+// A removed sequence frees its cells; the next token refills the lowest one,
+// landing below a live cell. The scatter must place it there and the mask must
+// skip the cell still free.
+TEST_F(MLXCellCacheTest, FreedCellsRefillBelowLiveOnes) {
+  using namespace ::mlx::core;
+  MLXCellCache c(cell_config(32, 1, H, D, kHalf));
+  const int32_t a = *c.seq_new();
+  const int32_t b = *c.seq_new();
+
+  step(c, {a, a, a}, {0, 1, 2}, randn(3), randn(3)); // cells 0, 1, 2
+  array kb = randn(1), vb = randn(1);
+  step(c, {b}, {0}, kb, vb); // cell 3
+
+  EXPECT_TRUE(c.seq_rm(a, 0, 2)); // frees cells 0 and 1
+  EXPECT_EQ(c.used_end(), 4);
+
+  array kb1 = randn(1), vb1 = randn(1);
+  AttendSpec spec = step(c, {b}, {1}, kb1, vb1); // refills cell 0
+
+  EXPECT_EQ(spec.K.shape(2), 4);
+  EXPECT_TRUE(allclose(cell_of(spec.K, 0), kb1, 0.0f));
+  EXPECT_TRUE(allclose(cell_of(spec.V, 0), vb1, 0.0f));
+  EXPECT_TRUE(allclose(cell_of(spec.K, 3), kb, 0.0f));
+
+  const std::vector<int32_t> b_only = {1, 0, 0, 1};
+  EXPECT_TRUE(allclose(
+      bits(spec), array(b_only.data(), Shape{1, 1, 1, 4}, int32), 0.0f));
+}
+
+// A windowed layer hides cells older than its window; a flat layer keeps them.
+TEST_F(MLXCellCacheTest, WindowHidesOlderCells) {
+  using namespace ::mlx::core;
+  cache::CacheConfig cfg = cell_config(32, /*n_layers=*/2, H, D, kHalf);
+  cfg.layers = {
+      cache::LayerConfig{
+          cache::LayerPolicy{cache::LayerPolicy::Kind::Flat, 0}, H, D},
+      cache::LayerConfig{
+          cache::LayerPolicy{cache::LayerPolicy::Kind::Ring, 2}, H, D}};
+  MLXCellCache c(cfg);
+  const int32_t a = *c.seq_new();
+
+  EXPECT_TRUE(c.declare_step({a, a, a, a}));
+  const std::vector<int32_t> pos = {0, 1, 2, 3};
+  array k = randn(4), v = randn(4);
+  AttendSpec flat = c.update_and_fetch(0, pos, k, v, s);
+  AttendSpec ring = c.update_and_fetch(1, pos, k, v, s);
+
+  // The last query attends every cell on the flat layer, its own window on the
+  // ring one.
+  const std::vector<int32_t> flat_last = {1, 1, 1, 1};
+  const std::vector<int32_t> ring_last = {0, 0, 1, 1};
+  EXPECT_TRUE(allclose(
+      slice(bits(flat), Shape{0, 0, 3, 0}, Shape{1, 1, 4, 4}),
+      array(flat_last.data(), Shape{1, 1, 1, 4}, int32),
+      0.0f));
+  EXPECT_TRUE(allclose(
+      slice(bits(ring), Shape{0, 0, 3, 0}, Shape{1, 1, 4, 4}),
+      array(ring_last.data(), Shape{1, 1, 1, 4}, int32),
+      0.0f));
+}
+
+// The window is shared: both pools grow past the initial allocation and the
+// cells written before growth survive it.
+TEST_F(MLXCellCacheTest, GrowthPreservesExistingCells) {
+  using namespace ::mlx::core;
+  MLXCellCache c(cell_config(32, 1, H, D, kHalf, /*initial_capacity=*/2));
+  const int32_t a = *c.seq_new();
+  array k0 = randn(2), v0 = randn(2);
+  step(c, {a, a}, {0, 1}, k0, v0);
+
+  array k1 = randn(3), v1 = randn(3);
+  AttendSpec spec = step(c, {a, a, a}, {2, 3, 4}, k1, v1);
+
+  EXPECT_EQ(spec.K.shape(2), 5);
+  EXPECT_TRUE(
+      allclose(slice(spec.K, Shape{0, 0, 0, 0}, Shape{1, H, 2, D}), k0, 0.0f));
+  EXPECT_TRUE(
+      allclose(slice(spec.K, Shape{0, 0, 2, 0}, Shape{1, H, 5, D}), k1, 0.0f));
+}
+
+// K/V are cast to the configured storage dtype on the way in.
+TEST_F(MLXCellCacheTest, StorageDtypeDiffersCastsOnWrite) {
+  using namespace ::mlx::core;
+  MLXCellCache c(
+      cell_config(32, 1, H, D, static_cast<int>(ScalarType::BFloat16)));
+  const int32_t a = *c.seq_new();
+  array k = randn(2, float32), v = randn(2, float32);
+
+  AttendSpec spec = step(c, {a, a}, {0, 1}, k, v);
+
+  EXPECT_EQ(spec.K.dtype(), bfloat16);
+  EXPECT_TRUE(allclose(spec.K, k, 1e-2f));
+}
+
+// The step verbs are a contract: no declaration, a miscounted call, a repeated
+// layer and a position a sequence already holds are all refused.
+TEST_F(MLXCellCacheTest, IllFormedStepsThrow) {
+  using namespace ::mlx::core;
+  MLXCellCache c(cell_config(32, 1, H, D, kHalf));
+  const int32_t a = *c.seq_new();
+  array k = randn(2), v = randn(2);
+
+  EXPECT_ANY_THROW(c.update_and_fetch(0, {0, 1}, k, v, s)); // no declare_step
+
+  EXPECT_TRUE(c.declare_step({a, a}));
+  EXPECT_ANY_THROW(c.update_and_fetch(0, {0}, k, v, s)); // positions != tokens
+  EXPECT_ANY_THROW(c.update_and_fetch(1, {0, 1}, k, v, s)); // no such layer
+
+  c.update_and_fetch(0, {0, 1}, k, v, s);
+  EXPECT_ANY_THROW(
+      c.update_and_fetch(0, {0, 1}, k, v, s)); // layer served twice
+
+  EXPECT_TRUE(c.declare_step({a}));
+  array k1 = randn(1), v1 = randn(1);
+  EXPECT_ANY_THROW(c.update_and_fetch(0, {1}, k1, v1, s)); // position not newer
+}
+
+// A step wider than the free cells is refused, and refusing claims nothing.
+TEST_F(MLXCellCacheTest, StepPastCapacityIsRefused) {
+  MLXCellCache c(cell_config(/*capacity=*/2, 1, H, D, kHalf));
+  const int32_t a = *c.seq_new();
+  step(c, {a, a}, {0, 1}, randn(2), randn(2));
+
+  EXPECT_FALSE(c.declare_step({a}));
+  EXPECT_EQ(c.free_cells(), 0);
+}
+
+TEST_F(MLXCellCacheTest, InvalidConfigThrows) {
+  cache::CacheConfig cfg = cell_config(32, /*n_layers=*/2, H, D, kHalf);
+  cfg.layers.resize(1);
+  cfg.layers.push_back(cache::LayerConfig{{}, H, D});
+  cfg.capacity = 0;
+  EXPECT_ANY_THROW(MLXCellCache{cfg});
+}
+
+// A runner reaches a layout by (backend_id, kind), so the builder registration
+// is as much a part of the layout as the class.
+TEST_F(MLXCellCacheTest, RegistryBuildsCellLayout) {
+  auto built = cache::CacheBuilderRegistry::global().build(
+      kMLXBackendId, "cell", cell_config(32, 1, H, D, kHalf));
+  ASSERT_TRUE(built.ok());
+  const std::shared_ptr<cache::CacheBase>& c = *built;
+  EXPECT_NE(c->as_batch_control(), nullptr);
+  EXPECT_EQ(c->as_control(), nullptr);
+}
+
+} // namespace

--- a/backends/mlx/test/mlx_cell_cache_test.cpp
+++ b/backends/mlx/test/mlx_cell_cache_test.cpp
@@ -19,6 +19,7 @@
 
 #include "MLXCellCache.h"
 #include "backend_options.h" // kMLXBackendId
+#include "utils.h" // allclose, flat_config
 
 #include <executorch/extension/llm/cache/cache_registry.h>
 #include <mlx/mlx.h>
@@ -34,43 +35,12 @@ using ::mlx::core::array;
 
 namespace {
 
-// Max absolute difference within tolerance. Computed in float32: item<float>()
-// reads sizeof(float) bytes, so calling it on an fp16 scalar misreads the
-// buffer.
-bool allclose(const array& a, const array& b, float atol) {
-  using namespace ::mlx::core;
-  array m = max(abs(subtract(astype(a, float32), astype(b, float32))));
-  eval(m);
-  return m.item<float>() <= atol;
-}
-
 // Cell j of a [1, H, S, D] window.
 array cell_of(const array& window, int j) {
   using namespace ::mlx::core;
   const int H = static_cast<int>(window.shape(1));
   const int D = static_cast<int>(window.shape(3));
   return slice(window, Shape{0, 0, j, 0}, Shape{1, H, j + 1, D});
-}
-
-cache::CacheConfig cell_config(
-    int capacity,
-    int n_layers,
-    int n_kv_heads,
-    int head_dim,
-    int kv_dtype,
-    std::optional<int> initial_capacity = std::nullopt) {
-  cache::CacheConfig cfg;
-  cfg.capacity = capacity;
-  cfg.n_layers = n_layers;
-  cfg.layers = {cache::LayerConfig{
-      cache::LayerPolicy{cache::LayerPolicy::Kind::Flat, 0},
-      n_kv_heads,
-      head_dim}};
-  cfg.kv_dtype = kv_dtype;
-  if (initial_capacity) {
-    cfg.initial_capacity = *initial_capacity;
-  }
-  return cfg;
 }
 
 class MLXCellCacheTest : public ::testing::Test {
@@ -105,7 +75,7 @@ class MLXCellCacheTest : public ::testing::Test {
 // and the mask is lower-triangular.
 TEST_F(MLXCellCacheTest, PrefillClaimsCellsInOrder) {
   using namespace ::mlx::core;
-  MLXCellCache c(cell_config(/*capacity=*/32, /*n_layers=*/1, H, D, kHalf));
+  MLXCellCache c(flat_config(/*capacity=*/32, /*n_layers=*/1, H, D, kHalf));
   const int32_t a = *c.seq_new();
   array k = randn(4), v = randn(4);
 
@@ -125,7 +95,7 @@ TEST_F(MLXCellCacheTest, PrefillClaimsCellsInOrder) {
 // Decode appends one cell and reads the whole prefix back.
 TEST_F(MLXCellCacheTest, DecodeExtendsTheWindow) {
   using namespace ::mlx::core;
-  MLXCellCache c(cell_config(32, 1, H, D, kHalf));
+  MLXCellCache c(flat_config(32, 1, H, D, kHalf));
   const int32_t a = *c.seq_new();
   array k0 = randn(2), v0 = randn(2);
   step(c, {a, a}, {0, 1}, k0, v0);
@@ -145,7 +115,7 @@ TEST_F(MLXCellCacheTest, DecodeExtendsTheWindow) {
 // the querying sequence's cells.
 TEST_F(MLXCellCacheTest, MaskIsolatesSequences) {
   using namespace ::mlx::core;
-  MLXCellCache c(cell_config(32, 1, H, D, kHalf));
+  MLXCellCache c(flat_config(32, 1, H, D, kHalf));
   const int32_t a = *c.seq_new();
   const int32_t b = *c.seq_new();
   EXPECT_NE(a, b);
@@ -165,7 +135,7 @@ TEST_F(MLXCellCacheTest, MaskIsolatesSequences) {
 // skip the cell still free.
 TEST_F(MLXCellCacheTest, FreedCellsRefillBelowLiveOnes) {
   using namespace ::mlx::core;
-  MLXCellCache c(cell_config(32, 1, H, D, kHalf));
+  MLXCellCache c(flat_config(32, 1, H, D, kHalf));
   const int32_t a = *c.seq_new();
   const int32_t b = *c.seq_new();
 
@@ -192,7 +162,7 @@ TEST_F(MLXCellCacheTest, FreedCellsRefillBelowLiveOnes) {
 // A windowed layer hides cells older than its window; a flat layer keeps them.
 TEST_F(MLXCellCacheTest, WindowHidesOlderCells) {
   using namespace ::mlx::core;
-  cache::CacheConfig cfg = cell_config(32, /*n_layers=*/2, H, D, kHalf);
+  cache::CacheConfig cfg = flat_config(32, /*n_layers=*/2, H, D, kHalf);
   cfg.layers = {
       cache::LayerConfig{
           cache::LayerPolicy{cache::LayerPolicy::Kind::Flat, 0}, H, D},
@@ -225,7 +195,7 @@ TEST_F(MLXCellCacheTest, WindowHidesOlderCells) {
 // cells written before growth survive it.
 TEST_F(MLXCellCacheTest, GrowthPreservesExistingCells) {
   using namespace ::mlx::core;
-  MLXCellCache c(cell_config(32, 1, H, D, kHalf, /*initial_capacity=*/2));
+  MLXCellCache c(flat_config(32, 1, H, D, kHalf, /*initial_capacity=*/2));
   const int32_t a = *c.seq_new();
   array k0 = randn(2), v0 = randn(2);
   step(c, {a, a}, {0, 1}, k0, v0);
@@ -244,7 +214,7 @@ TEST_F(MLXCellCacheTest, GrowthPreservesExistingCells) {
 TEST_F(MLXCellCacheTest, StorageDtypeDiffersCastsOnWrite) {
   using namespace ::mlx::core;
   MLXCellCache c(
-      cell_config(32, 1, H, D, static_cast<int>(ScalarType::BFloat16)));
+      flat_config(32, 1, H, D, static_cast<int>(ScalarType::BFloat16)));
   const int32_t a = *c.seq_new();
   array k = randn(2, float32), v = randn(2, float32);
 
@@ -258,7 +228,7 @@ TEST_F(MLXCellCacheTest, StorageDtypeDiffersCastsOnWrite) {
 // layer and a position a sequence already holds are all refused.
 TEST_F(MLXCellCacheTest, IllFormedStepsThrow) {
   using namespace ::mlx::core;
-  MLXCellCache c(cell_config(32, 1, H, D, kHalf));
+  MLXCellCache c(flat_config(32, 1, H, D, kHalf));
   const int32_t a = *c.seq_new();
   array k = randn(2), v = randn(2);
 
@@ -279,7 +249,7 @@ TEST_F(MLXCellCacheTest, IllFormedStepsThrow) {
 
 // A step wider than the free cells is refused, and refusing claims nothing.
 TEST_F(MLXCellCacheTest, StepPastCapacityIsRefused) {
-  MLXCellCache c(cell_config(/*capacity=*/2, 1, H, D, kHalf));
+  MLXCellCache c(flat_config(/*capacity=*/2, 1, H, D, kHalf));
   const int32_t a = *c.seq_new();
   step(c, {a, a}, {0, 1}, randn(2), randn(2));
 
@@ -288,7 +258,7 @@ TEST_F(MLXCellCacheTest, StepPastCapacityIsRefused) {
 }
 
 TEST_F(MLXCellCacheTest, InvalidConfigThrows) {
-  cache::CacheConfig cfg = cell_config(32, /*n_layers=*/2, H, D, kHalf);
+  cache::CacheConfig cfg = flat_config(32, /*n_layers=*/2, H, D, kHalf);
   cfg.layers.resize(1);
   cfg.layers.push_back(cache::LayerConfig{{}, H, D});
   cfg.capacity = 0;
@@ -299,7 +269,7 @@ TEST_F(MLXCellCacheTest, InvalidConfigThrows) {
 // is as much a part of the layout as the class.
 TEST_F(MLXCellCacheTest, RegistryBuildsCellLayout) {
   auto built = cache::CacheBuilderRegistry::global().build(
-      kMLXBackendId, "cell", cell_config(32, 1, H, D, kHalf));
+      kMLXBackendId, "cell", flat_config(32, 1, H, D, kHalf));
   ASSERT_TRUE(built.ok());
   const std::shared_ptr<cache::CacheBase>& c = *built;
   EXPECT_NE(c->as_batch_control(), nullptr);

--- a/backends/mlx/test/mlx_sequence_cache_test.cpp
+++ b/backends/mlx/test/mlx_sequence_cache_test.cpp
@@ -18,6 +18,7 @@
 // Must run on Apple Silicon: MLX needs the Metal backend.
 
 #include "MLXSequenceCache.h"
+#include "utils.h" // allclose, flat_config, ring_config
 
 #include <mlx/mlx.h>
 
@@ -46,53 +47,6 @@ AttendSpec step(
   std::vector<int32_t> positions(static_cast<size_t>(T));
   std::iota(positions.begin(), positions.end(), start);
   return c.update_and_fetch(layer, positions, k, v, s);
-}
-
-// Max absolute difference within tolerance. Computed in float32: item<float>()
-// reads sizeof(float) bytes, so calling it on an fp16 scalar misreads the
-// buffer.
-bool allclose(const array& a, const array& b, float atol) {
-  using namespace ::mlx::core;
-  array m = max(abs(subtract(astype(a, float32), astype(b, float32))));
-  eval(m);
-  return m.item<float>() <= atol;
-}
-
-cache::CacheConfig flat_config(
-    int capacity,
-    int n_layers,
-    int n_kv_heads,
-    int head_dim,
-    int kv_dtype,
-    std::optional<int> initial_capacity = std::nullopt) {
-  cache::CacheConfig cfg;
-  cfg.capacity = capacity;
-  cfg.n_layers = n_layers;
-  cfg.layers = {cache::LayerConfig{
-      cache::LayerPolicy{cache::LayerPolicy::Kind::Flat, 0},
-      n_kv_heads,
-      head_dim}};
-  cfg.kv_dtype = kv_dtype;
-  if (initial_capacity) {
-    cfg.initial_capacity = *initial_capacity;
-  }
-  return cfg;
-}
-
-// One ring layer of `window` cells; max_write bounds a multi-token step.
-cache::CacheConfig ring_config(
-    int capacity,
-    int window,
-    int max_write,
-    int n_kv_heads,
-    int head_dim,
-    int kv_dtype) {
-  cache::CacheConfig cfg =
-      flat_config(capacity, /*n_layers=*/1, n_kv_heads, head_dim, kv_dtype);
-  cfg.layers[0].policy =
-      cache::LayerPolicy{cache::LayerPolicy::Kind::Ring, window};
-  cfg.max_write = max_write;
-  return cfg;
 }
 
 class MLXSequenceCacheTest : public ::testing::Test {

--- a/backends/mlx/test/utils.h
+++ b/backends/mlx/test/utils.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <executorch/extension/llm/cache/cache.h>
+#include <mlx/mlx.h>
+
+#include <optional>
+
+namespace executorch {
+namespace backends {
+namespace mlx {
+
+// Max absolute difference within tolerance. Computed in float32: item<float>()
+// reads sizeof(float) bytes, so calling it on an fp16 scalar misreads the
+// buffer.
+inline bool
+allclose(const ::mlx::core::array& a, const ::mlx::core::array& b, float atol) {
+  using namespace ::mlx::core;
+  array m = max(abs(subtract(astype(a, float32), astype(b, float32))));
+  eval(m);
+  return m.item<float>() <= atol;
+}
+
+// A single unwindowed layer, so a step's slots are one run over the capacity.
+inline ::executorch::extension::llm::cache::CacheConfig flat_config(
+    int capacity,
+    int n_layers,
+    int n_kv_heads,
+    int head_dim,
+    int kv_dtype,
+    std::optional<int> initial_capacity = std::nullopt) {
+  namespace cache = ::executorch::extension::llm::cache;
+  cache::CacheConfig cfg;
+  cfg.capacity = capacity;
+  cfg.n_layers = n_layers;
+  cfg.layers = {cache::LayerConfig{
+      cache::LayerPolicy{cache::LayerPolicy::Kind::Flat, 0},
+      n_kv_heads,
+      head_dim}};
+  cfg.kv_dtype = kv_dtype;
+  if (initial_capacity) {
+    cfg.initial_capacity = *initial_capacity;
+  }
+  return cfg;
+}
+
+// One ring layer of `window` cells; max_write bounds a multi-token step.
+inline ::executorch::extension::llm::cache::CacheConfig ring_config(
+    int capacity,
+    int window,
+    int max_write,
+    int n_kv_heads,
+    int head_dim,
+    int kv_dtype) {
+  namespace cache = ::executorch::extension::llm::cache;
+  cache::CacheConfig cfg =
+      flat_config(capacity, /*n_layers=*/1, n_kv_heads, head_dim, kv_dtype);
+  cfg.layers[0].policy =
+      cache::LayerPolicy{cache::LayerPolicy::Kind::Ring, window};
+  cfg.max_write = max_write;
+  return cfg;
+}
+
+} // namespace mlx
+} // namespace backends
+} // namespace executorch


### PR DESCRIPTION
## Summary

  `MLXCellCache` turns a `CellStep` into a scatter over the cell axis and materialises the step's mask bits as an explicit SDPA mask, one row per query token. `Pool` grows a matching `write_cells` next to its existing contiguous
  `write`, keeping the pool layout-agnostic: layouts differ only in which slots they ask for. The layout is registered as the `"cell"` builder alongside `"seq"`, which is how a runner selects one.

  ## Files

  - `backends/mlx/runtime/MLXPool.h` — `write_cells`, the scatter primitive
  - `backends/mlx/runtime/MLXCellCache.h` — new; the `CellStepper` face over `Pool`
  - `backends/mlx/runtime/MLXBackend.cpp` — registers the `"cell"` builder
  - `backends/mlx/test/mlx_cell_cache_test.cpp` — new; 11 tests
  - `backends/mlx/test/CMakeLists.txt`, `.github/workflows/mlx.yml` — build and run it

  ## Test

  `mlx_cell_cache_test`, 11 tests. Covers  cell claiming on prefill and decode, the mask isolating sequences, a freed cell
  refilling *below* a live one (the case no contiguous write can express, so the only real exercise of the scatter), a windowed layer hiding older cells, pool growth preserving written cells, storage-dtype casts, the step-verb contract, capacity refusal, and the registry lookup by `(backend_id, kind)`.

  Added to the existing `test-mlx` CI job. 
