### PR TITLE
Qualcomm AI Engine Direct - Fix windows build script changing directory

### DIFF
--- a/backends/qualcomm/scripts/build.ps1
+++ b/backends/qualcomm/scripts/build.ps1
@@ -188,7 +188,7 @@ if (-not $SkipArm64Windows) {
 
     # Activate the VS environment for ARM64 MSVC toolchain
     $VsGenerator = Get-InstalledVsGenerator
-    & $VsGenerator.DevShell -Arch arm64
+    & $VsGenerator.DevShell -Arch arm64 -SkipAutomaticLocation
     Assert-GeneratorSupported $VsGenerator.Generator
 
     Prepare-BuildDir $BuildRoot
@@ -335,7 +335,7 @@ if (-not $SkipX86Windows) {
 
     # Activate the VS environment for AMD64 MSVC toolchain
     $VsGenerator = Get-InstalledVsGenerator
-    & $VsGenerator.DevShell -Arch amd64
+    & $VsGenerator.DevShell -Arch amd64 -SkipAutomaticLocation
     Assert-GeneratorSupported $VsGenerator.Generator
 
     Prepare-BuildDir $BuildRoot


### PR DESCRIPTION
### Summary
- build.ps1 which launches Launch-VsDevShell.ps1 (the script Visual Studio ships) changes the current directory
to VS's configured default projects location — which for most installs is %USERPROFILE%\source\repos.
- Add -SkipAutomaticLocation to avoid this behavior.