### PR TITLE
Android: preserve fbjni internals in minified apps

### DIFF
--- a/extension/android/executorch_android/consumer-proguard-rules.pro
+++ b/extension/android/executorch_android/consumer-proguard-rules.pro
@@ -14,7 +14,7 @@
 # Keep fbjni classes and members according to fbjni's JNI annotations.
 # ExecuTorch's native bindings depend on these internals at runtime.
 -keep @com.facebook.jni.annotations.DoNotStrip class com.facebook.jni.** { *; }
--keepclassmembers class com.facebook.jni.** {
+-keepclasseswithmembers class com.facebook.jni.** {
     @com.facebook.jni.annotations.DoNotStrip *;
 }
 -keep @com.facebook.jni.annotations.DoNotStripAny class com.facebook.jni.** { *; }

--- a/extension/android/executorch_android/consumer-proguard-rules.pro
+++ b/extension/android/executorch_android/consumer-proguard-rules.pro
@@ -11,6 +11,17 @@
     @com.facebook.jni.annotations.DoNotStrip *;
 }
 
+# Keep fbjni classes and members according to fbjni's JNI annotations.
+# ExecuTorch's native bindings depend on these internals at runtime.
+-keep @com.facebook.jni.annotations.DoNotStrip class com.facebook.jni.** { *; }
+-keepclassmembers class com.facebook.jni.** {
+    @com.facebook.jni.annotations.DoNotStrip *;
+}
+-keep @com.facebook.jni.annotations.DoNotStripAny class com.facebook.jni.** { *; }
+
+# javax.annotation is a compile-time-only dependency of fbjni.
+-dontwarn javax.annotation.Nullable
+
 # Keep all native methods across ExecuTorch packages.
 # Use -keepclasseswithmembers (not -keepclasseswithmembernames) to prevent
 # both shrinking and obfuscation of JNI entry points.


### PR DESCRIPTION
### Summary

- preserve fbjni classes and members according to fbjni's own `@DoNotStrip` and `@DoNotStripAny` annotations
- scope the rules to `com.facebook.jni.**` so they do not affect unrelated annotated dependencies
- suppress the warning for fbjni's compile-time-only `javax.annotation.Nullable` reference

This is a follow-up to #19169. That PR protects ExecuTorch's annotated classes, but a minified consumer can still remove fbjni internals that ExecuTorch's native bindings need.

### Motivation

In a standalone release app with R8 enabled, both the 1.4.0 Maven AAR and the 1.4.1 release AAR abort in `Module.initHybrid()` with `SIGABRT` and abort message `ptr`. The R8 mapping contains `com.facebook.jni.HybridData`, but not its annotated `HybridData$Destructor` class.

Keeping all `org.pytorch.executorch.**` classes is not sufficient. Applying the scoped fbjni annotation rules preserves `HybridData$Destructor` and lets the same model execute successfully.

### Test plan

Standalone Android consumer using AGP 9.1.1, Gradle 9.5, `minifyEnabled = true`, and a one-element add-one PTE model on an arm64 Android tablet:

| AAR | Stock consumer rules | With this patch |
| --- | --- | --- |
| 1.4.0 | aborts in `Module.initHybrid()` | `PASS: output=2.0` |
| 1.4.1 | aborts in `Module.initHybrid()` | `PASS: output=2.0` |

The unminified build passes as a control. The fixed R8 mapping retains `com.facebook.jni.HybridData$Destructor`; the stock mapping does not.

The current Android project builds the AAR but does not contain a minified standalone consumer target, so this red/green test was run in a separate minimal consumer app.

- `git diff --check origin/main...HEAD`


cc @kirklandsign @cbilgin