### PR TITLE
Implement no_rope_layer_interval for Llama

### DIFF
--- a/examples/models/llama/attention.py
+++ b/examples/models/llama/attention.py
@@ -539,7 +539,8 @@ class AttentionMHA(Attention):
                 q = q * self.scale_query_by
 
         # Apply RoPE to Q only (K already has RoPE from donor layer)
-        q, _ = self.rope.forward(q, q, freqs_cos, freqs_sin)
+        if self.use_rope:
+            q, _ = self.rope.forward(q, q, freqs_cos, freqs_sin)
         q = q.transpose(1, 2)
 
         if self.use_qk_norm and not self.qk_norm_before_rope:

--- a/examples/models/llama/attention.py
+++ b/examples/models/llama/attention.py
@@ -438,10 +438,14 @@ class AttentionMHA(Attention):
 
         self.layer_id = layer_id
         self.rope = rope
-        self.use_rope = (
-            args.no_rope_layer_interval is None
-            or (layer_id + 1) % args.no_rope_layer_interval != 0
+
+        interval = args.no_rope_layer_interval
+        rope_layer_id = (
+            args.n_layers - args.num_kv_shared_layers - 1
+            if self.is_kv_shared_layer
+            else layer_id
         )
+        self.use_rope = interval is None or (rope_layer_id + 1) % interval != 0
 
         causal_mask = torch.tril(
             torch.ones(

--- a/examples/models/llama/attention.py
+++ b/examples/models/llama/attention.py
@@ -438,6 +438,10 @@ class AttentionMHA(Attention):
 
         self.layer_id = layer_id
         self.rope = rope
+        self.use_rope = (
+            args.no_rope_layer_interval is None
+            or (layer_id + 1) % args.no_rope_layer_interval != 0
+        )
 
         causal_mask = torch.tril(
             torch.ones(
@@ -569,7 +573,8 @@ class AttentionMHA(Attention):
                 q = q * self.scale_query_by
             k = self.k_norm_fn(k)
 
-        q, k = self.rope.forward(q, k, freqs_cos, freqs_sin)
+        if self.use_rope:
+            q, k = self.rope.forward(q, k, freqs_cos, freqs_sin)
 
         q = q.transpose(1, 2)  # (bs, n_local_heads, seqlen, head_dim)
         k = k.transpose(1, 2)

--- a/examples/models/llama/model_args.py
+++ b/examples/models/llama/model_args.py
@@ -194,6 +194,12 @@ class ModelArgs:
         if self.n_kv_heads is None:
             self.n_kv_heads = self.n_heads
 
+        if self.no_rope_layer_interval is not None and self.no_rope_layer_interval <= 0:
+            raise ValueError(
+                "no_rope_layer_interval must be a positive integer, "
+                f"got {self.no_rope_layer_interval}"
+            )
+
         # rope_theta overrides rope_freq_base since it's the official name.
         if self.rope_theta is not None:
             self.rope_freq_base = self.rope_theta

--- a/examples/models/llama/static_attention.py
+++ b/examples/models/llama/static_attention.py
@@ -936,10 +936,15 @@ class StaticAttention(Attention):
         self._init_wo(config)
         self.rope = _Rope(rope.params)
         self.layer_id = layer_id
-        self.use_rope = (
-            config.no_rope_layer_interval is None
-            or (layer_id + 1) % config.no_rope_layer_interval != 0
+
+        interval = config.no_rope_layer_interval
+        rope_layer_id = (
+            config.n_layers - config.num_kv_shared_layers - 1
+            if self.is_kv_shared_layer
+            else layer_id
         )
+        self.use_rope = interval is None or (rope_layer_id + 1) % interval != 0
+
         self._init_qk_norms(config, is_kv_shared_layer)
 
     def _init_wo(self, config: ModelArgs) -> None:

--- a/examples/models/llama/static_attention.py
+++ b/examples/models/llama/static_attention.py
@@ -936,6 +936,10 @@ class StaticAttention(Attention):
         self._init_wo(config)
         self.rope = _Rope(rope.params)
         self.layer_id = layer_id
+        self.use_rope = (
+            config.no_rope_layer_interval is None
+            or (layer_id + 1) % config.no_rope_layer_interval != 0
+        )
         self._init_qk_norms(config, is_kv_shared_layer)
 
     def _init_wo(self, config: ModelArgs) -> None:
@@ -1036,6 +1040,8 @@ class StaticAttention(Attention):
             is_kv_shared_layer=is_kv_shared,
             **kwargs,
         )
+
+        instance.use_rope = other.use_rope
 
         # Replace nn.Linear with LoRALinear where the source uses LoRA.
         if has_lora:
@@ -1185,6 +1191,9 @@ class StaticAttention(Attention):
             freqs_cos (list): List of cosine frequencies.
             freqs_sin (list): List of sine frequencies.
         """
+        if not self.use_rope:
+            return qs, ks
+
         qs = [self.rope(q, freqs_cos, freqs_sin) for q in qs]
         if ks is not None:
             ks = [self.rope(k, freqs_cos, freqs_sin) for k in ks]
@@ -1401,7 +1410,8 @@ class StaticAttention(Attention):
             if self.use_qk_norm and self.qk_norm_before_rope:
                 q = self.q_norm(q) * self.scale_query_by
 
-            q = self.rope(q, freqs_cos, freqs_sin)
+            if self.use_rope:
+                q = self.rope(q, freqs_cos, freqs_sin)
 
             if self.use_qk_norm and not self.qk_norm_before_rope:
                 q = self.q_norm(q) * self.scale_query_by
@@ -1416,8 +1426,9 @@ class StaticAttention(Attention):
                 q = self.q_norm(q) * self.scale_query_by
                 k = self.k_norm(k)
 
-            q = self.rope(q, freqs_cos, freqs_sin)
-            k = self.rope(k, freqs_cos, freqs_sin)
+            if self.use_rope:
+                q = self.rope(q, freqs_cos, freqs_sin)
+                k = self.rope(k, freqs_cos, freqs_sin)
 
             if self.use_qk_norm and not self.qk_norm_before_rope:
                 q = self.q_norm(q) * self.scale_query_by

--- a/examples/models/llama/tests/test_static_attention.py
+++ b/examples/models/llama/tests/test_static_attention.py
@@ -569,6 +569,17 @@ class StaticAttentionTest(unittest.TestCase):
                 f"Unexpected RoPE setting for layer {layer_id}",
             )
 
+    def test_invalid_no_rope_layer_interval(self):
+        with self.assertRaisesRegex(
+            ValueError, "no_rope_layer_interval must be a positive integer"
+        ):
+            ModelArgs(no_rope_layer_interval=0)
+
+        with self.assertRaisesRegex(
+            ValueError, "no_rope_layer_interval must be a positive integer"
+        ):
+            ModelArgs(no_rope_layer_interval=-1)
+
     def test_no_rope_layer_interval_preserved_in_static_attention(self):
         config = ModelArgs(
             dim=64,
@@ -722,6 +733,42 @@ class StaticAttentionTest(unittest.TestCase):
 
         self.assertEqual(y.shape, (1, config.max_seq_len, config.dim))
         self.assertIsNone(update["out_cache_state"])
+
+    def test_yoco_shared_layer_skips_rope(self):
+        config = self._make_yoco_args(n_layers=4, num_kv_shared_layers=2)
+        config.no_rope_layer_interval = 3
+        rope = Rope(config)
+
+        attn_mha = AttentionMHA(config, layer_id=2, rope=rope).eval()
+
+        x = torch.rand(1, config.max_seq_len, config.dim)
+        q = attn_mha.wq(x).view(1, config.max_seq_len, config.n_heads, config.head_dim)
+        freqs_cos, freqs_sin = rope.get_freqs(None, config.max_seq_len)
+
+        shared_kv = (
+            torch.randn(
+                1,
+                config.n_kv_heads,
+                config.max_seq_len,
+                config.head_dim,
+            ),
+            torch.randn(
+                1,
+                config.n_kv_heads,
+                config.max_seq_len,
+                config.head_dim,
+            ),
+        )
+
+        prepared_q, prepared_k, prepared_v = attn_mha._prepare_qkv_shared(
+            q, shared_kv, freqs_cos, freqs_sin
+        )
+
+        expected_q = q.transpose(1, 2)
+
+        self.assertTrue(torch.equal(prepared_q, expected_q))
+        self.assertTrue(torch.equal(prepared_k, shared_kv[0]))
+        self.assertTrue(torch.equal(prepared_v, shared_kv[1]))
 
     def test_yoco_lora_with_shared_layer(self):
         config = self._make_yoco_args(n_layers=4, num_kv_shared_layers=2)

--- a/examples/models/llama/tests/test_static_attention.py
+++ b/examples/models/llama/tests/test_static_attention.py
@@ -736,10 +736,12 @@ class StaticAttentionTest(unittest.TestCase):
 
     def test_yoco_shared_layer_skips_rope(self):
         config = self._make_yoco_args(n_layers=4, num_kv_shared_layers=2)
-        config.no_rope_layer_interval = 3
+        config.no_rope_layer_interval = 2
         rope = Rope(config)
 
         attn_mha = AttentionMHA(config, layer_id=2, rope=rope).eval()
+        self.assertFalse(AttentionMHA(config, layer_id=1, rope=rope).use_rope)
+        self.assertFalse(attn_mha.use_rope)
 
         x = torch.rand(1, config.max_seq_len, config.dim)
         q = attn_mha.wq(x).view(1, config.max_seq_len, config.n_heads, config.head_dim)

--- a/examples/models/llama/tests/test_static_attention.py
+++ b/examples/models/llama/tests/test_static_attention.py
@@ -545,6 +545,116 @@ class StaticAttentionTest(unittest.TestCase):
         y, _ = static_attn(x, freqs_cos, freqs_sin, masks={0: mask})
         self.assertTrue(torch.isclose(y, expected, rtol=1e-3).all())
 
+    def test_no_rope_layer_interval(self):
+        config = ModelArgs(
+            dim=64,
+            n_heads=4,
+            n_kv_heads=2,
+            head_dim=16,
+            max_batch_size=1,
+            max_context_len=32,
+            max_seq_len=8,
+            n_layers=8,
+            no_rope_layer_interval=4,
+        )
+        rope = Rope(config)
+
+        expected = [True, True, True, False, True, True, True, False]
+
+        for layer_id, expected_use_rope in enumerate(expected):
+            attn_mha = AttentionMHA(config, layer_id=layer_id, rope=rope)
+            self.assertEqual(
+                attn_mha.use_rope,
+                expected_use_rope,
+                f"Unexpected RoPE setting for layer {layer_id}",
+            )
+
+    def test_no_rope_layer_interval_preserved_in_static_attention(self):
+        config = ModelArgs(
+            dim=64,
+            n_heads=4,
+            n_kv_heads=2,
+            head_dim=16,
+            max_batch_size=1,
+            max_context_len=32,
+            max_seq_len=8,
+            n_layers=8,
+            no_rope_layer_interval=4,
+        )
+        rope = Rope(config)
+
+        for layer_id, expected_use_rope in enumerate(
+            [True, True, True, False, True, True, True, False]
+        ):
+            attn_mha = AttentionMHA(config, layer_id=layer_id, rope=rope)
+            static_attn = StaticAttention.from_attention_mha(attn_mha)
+
+            self.assertEqual(attn_mha.use_rope, expected_use_rope)
+            self.assertEqual(static_attn.use_rope, expected_use_rope)
+
+    def test_no_rope_layer_interval_direct_static_attention(self):
+        config = ModelArgs(
+            dim=64,
+            n_heads=4,
+            n_kv_heads=2,
+            head_dim=16,
+            max_batch_size=1,
+            max_context_len=32,
+            max_seq_len=8,
+            n_layers=8,
+            no_rope_layer_interval=4,
+        )
+        rope = Rope(config)
+
+        for layer_id, expected_use_rope in enumerate(
+            [True, True, True, False, True, True, True, False]
+        ):
+            static_attn = StaticAttention(config, layer_id=layer_id, rope=rope)
+
+            self.assertEqual(
+                static_attn.use_rope,
+                expected_use_rope,
+                f"Unexpected RoPE setting for layer {layer_id}",
+            )
+
+    def test_no_rope_layer_interval_skips_rope(self):
+        config = ModelArgs(
+            dim=64,
+            n_heads=4,
+            n_kv_heads=2,
+            head_dim=16,
+            max_batch_size=1,
+            max_context_len=32,
+            max_seq_len=8,
+            n_layers=8,
+            no_rope_layer_interval=4,
+        )
+        rope = Rope(config)
+        attn_mha = AttentionMHA(config, layer_id=3, rope=rope).eval()
+
+        x = torch.rand(1, config.max_seq_len, config.dim)
+        freqs_cos, freqs_sin = rope.get_freqs(None, config.max_seq_len)
+
+        q = attn_mha.wq(x).view(1, config.max_seq_len, config.n_heads, config.head_dim)
+        k = attn_mha.wk(x).view(
+            1, config.max_seq_len, config.n_kv_heads, config.head_dim
+        )
+
+        prepared_q, prepared_k, _ = attn_mha._prepare_qkv(
+            q,
+            x,
+            1,
+            config.max_seq_len,
+            freqs_cos,
+            freqs_sin,
+        )
+
+        expected_q = q.transpose(1, 2)
+        expected_k = k.transpose(1, 2)
+
+        self.assertTrue(torch.equal(prepared_q, expected_q))
+        self.assertTrue(torch.equal(prepared_k, expected_k))
+
     # --- YOCO tests ---
 
     def _make_yoco_args(self, n_layers=4, num_kv_shared_layers=2):

--- a/examples/models/llama/tests/test_static_attention.py
+++ b/examples/models/llama/tests/test_static_attention.py
@@ -743,6 +743,9 @@ class StaticAttentionTest(unittest.TestCase):
         self.assertFalse(AttentionMHA(config, layer_id=1, rope=rope).use_rope)
         self.assertFalse(attn_mha.use_rope)
 
+        rope_attn_mha = AttentionMHA(config, layer_id=0, rope=rope).eval()
+        self.assertTrue(rope_attn_mha.use_rope)
+
         x = torch.rand(1, config.max_seq_len, config.dim)
         q = attn_mha.wq(x).view(1, config.max_seq_len, config.n_heads, config.head_dim)
         freqs_cos, freqs_sin = rope.get_freqs(None, config.max_seq_len)


### PR DESCRIPTION
### Summary

Fix `no_rope_layer_interval` handling in the Llama export path.

`ModelArgs` already supports `no_rope_layer_interval`, and SmolLM3-3B sets it to `4`, but the Llama attention implementation previously applied RoPE to every layer.

This change:
- Applies `no_rope_layer_interval` in `AttentionMHA`.
- Skips RoPE on the configured layers.
- Preserves the setting when converting `AttentionMHA` to `StaticAttention`.
- Applies the same behavior to the static attention paths.
- Adds regression tests covering the interval, propagation, and actual RoPE skipping.

Fixes #22043

### Test plan

- `lintrunner`
- `git diff --check`
- `python -m pytest examples/models/llama/tests/test_static_attention.py -k "no_rope_layer_interval" -v`
  - 4 passed
- `python -m pytest examples/models/llama/tests/test_static_attention.py -v`
  - 21 passed, 1 failed
  - `test_within_transformer` also fails on the clean baseline and is unrelated to this change.

The full SmolLM3-3B export/reproduction was not rerun locally. If possible, please rerun the SmolLM3-3B export and the two reported prompts against this PR to confirm that the issue is resolved.

cc @larryliu0820 @mergennachin @cccclai @helunwencser @jackzhxng @digantdesai