### PR TITLE
Declare torchao as a wheel dependency

### DIFF
--- a/install_requirements.py
+++ b/install_requirements.py
@@ -49,8 +49,9 @@ def install_requirements(use_pytorch_nightly):
     # torchao's CUDA channel publishes x86_64 only, so asking for a CUDA build makes the pin
     # unsatisfiable on aarch64. Only that case is special-cased: falling back everywhere would
     # change which torchao a CPU x86_64 install resolves, and the CUDA build is genuinely wanted
-    # where it exists. Nothing in the wheel links or bundles torchao; it is a quantization
-    # workflow dependency of the examples and tests.
+    # where it exists. This nightly is what a development checkout is tested against, and the
+    # wheel's own torchao lower bound is this same version so that installing the package
+    # afterwards leaves this pin in place rather than replacing it.
     if platform.machine().lower() in ("aarch64", "arm64"):
         # The cpu channel specifically, not the index root. The root carries every variant, and a
         # pin without a local segment admits all of them while ordering a local segment highest,

--- a/setup.py
+++ b/setup.py
@@ -614,6 +614,32 @@ def _package_relative_depth(library: Path) -> int:
     return max(len(parts) - index - 2, 0)
 
 
+def _torchao_requirement() -> str:
+    """The torchao dependency, pinned to the series install_requirements.py installs.
+
+    Derived from that module rather than written out, so a nightly bump cannot move the
+    pin without moving this bound with it. A bump into the next series would otherwise
+    silently stop satisfying the lower bound, and installing this package over a
+    development checkout would replace the torchao that was just installed.
+
+    Loaded by path, the way install_utils is above, because setuptools executes this
+    file without the project directory on sys.path, so a plain import does not resolve.
+    """
+    path = Path(__file__).parent / "install_requirements.py"
+    spec = importlib.util.spec_from_file_location("install_requirements", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    # The module imports install_utils by name at import time, which only resolves
+    # because that name is registered below.
+    sys.modules.setdefault("install_utils", install_utils)
+    spec.loader.exec_module(module)
+
+    version = module.TORCHAO_NIGHTLY_VERSION
+    major, minor = (int(part) for part in version.split(".")[:2])
+    return f"torchao>={version},<{major}.{minor + 1}"
+
+
 def _base_dependencies() -> List[str]:
     """Runtime dependencies for the full wheel.
 
@@ -639,6 +665,21 @@ def _base_dependencies() -> List[str]:
         "py-cpuinfo",
         "requests",
         "pytorch-tokenizers",
+        # Shipped code imports torchao at module scope in many places, so a plain install cannot
+        # lower a model without it. Among others: the XNNPACK utilities the partitioner uses
+        # (backends/xnnpack/utils/utils.py), the Core ML quantizer, and executorch.export itself.
+        # The MLX backend needs it too, though indirectly: it registers a torchao operator that
+        # only exists once torchao has been imported.
+        #
+        # The lower bound is the nightly install_requirements.py pins, so that installing this
+        # package over a development checkout leaves that pin in place. A bound at the stable
+        # release instead would evict it, because a dev release sorts below its own final.
+        #
+        # The upper bound is what makes naming a pre-release safe. A specifier that names one
+        # accepts pre-releases for this requirement, so without the bound pip would resolve a
+        # pre-release of the next series wherever one is published, such as an index carrying
+        # nightlies. Keep both bounds in the same series.
+        _torchao_requirement(),
         "pyyaml",
         "ruamel.yaml",
         "sympy",


### PR DESCRIPTION

A wheel built from main cannot lower a model without a dependency it does not
declare. On a clean environment, with the nightly wheel installed:

    >>> import executorch.export
    ModuleNotFoundError: No module named 'torchao'

    >>> import executorch.backends.xnnpack.partition.xnnpack_partitioner
    ModuleNotFoundError: No module named 'torchao'

    >>> import executorch.backends.apple.coreml.quantizer
    ModuleNotFoundError: No module named 'torchao'

    >>> import executorch.backends.mlx
    AttributeError: '_OpNamespace' 'torchao' object has no attribute 'dequantize_affine'

`executorch.export` is the top-level export API and XNNPACK is the default
backend, so this is the common path, not a corner case.

The cause is that shipped code imports torchao at module scope while main
declares nothing. `install_requirements.py` installs torchao, so a development
checkout always has it and the gap is invisible there. The MLX failure reads
differently because that backend registers a torchao operator rather than
importing the package, so the missing dependency surfaces as a missing
attribute.

This affects wheels built from main. The 1.4 release does not have the problem:
its release-only dependency patch already adds a torchao requirement, which is
what the published 1.4.1 wheel carries.

Declared as a plain dependency rather than an optional extra because the
affected paths are the default ones, and because extras here are reserved for
whole opt-in backends.

Both bounds of the requirement are deliberate:

The lower bound is the nightly `install_requirements.py` pins. That matters
because `install_executorch.py` installs requirements first and then installs
this package, so a bound at the stable release would evict the pin it had just
set, leaving a development checkout on a torchao the repository does not test
against. A dev release sorts below its own final, so `0.18.0.dev...` does not
satisfy `>=0.18.0`.

The upper bound is what makes naming a pre-release safe. A specifier that names
a pre-release accepts pre-releases for that requirement, so unbounded it would
resolve a pre-release of the next series wherever one is published, which
includes the nightly index a developer is told to configure.

Also correct the comment in `install_requirements.py` claiming nothing in the
wheel uses torchao, which is what this change disproves.

The minimal (export only) wheel is unaffected: torchao is not in its dependency
subset, so its declared set is unchanged.

Test Plan:
Built wheels differing only in this dependency line and installed each into a
fresh virtual environment where torch was the only package installed by hand.

With the dependency declared, pip resolves torchao 0.18.0 and all four imports
above succeed. Without it, torchao is absent and all four fail with the errors
shown, so the check can actually fail.

Checked the resolution with pip itself rather than by reasoning, in the two cases
that motivate the bounds:

- Installing over an environment already holding the pinned nightly, this
  requirement reports it as already satisfied, where a bound at the stable
  release replaces it.
- With a nightly index configured, this requirement still resolves the stable
  0.18.0, where the same lower bound without an upper bound resolves a
  pre-release of the next series.

Imports were run from an unrelated directory and confirmed to resolve to the
installed package rather than a source checkout. Also confirmed
`executorch.exir` imports without torchao, which is why the minimal wheel
correctly does not declare it.

The bound is derived from the constant install_requirements.py pins rather than written
out beside a comment asking for the two to be kept in sync. A bump within the series is
already safe; a bump into the next series would have stopped satisfying the lower bound
and silently restored the failure above, which a comment cannot prevent.

That module is loaded by path, the way install_utils already is in this file, because
setuptools executes setup.py without the project directory on sys.path and a plain
import does not resolve there.

