### PR TITLE
Persist seed-mismatch re-packs so the packed cache converges after an XNNPACK upgrade (#22183)

### DIFF
--- a/backends/xnnpack/runtime/XNNWeightsCache.cpp
+++ b/backends/xnnpack/runtime/XNNWeightsCache.cpp
@@ -338,6 +338,7 @@ size_t XNNWeightsCache::look_up(
     const xnn_weights_cache_look_up_key* cache_key) {
   const void* unpacked_weights_ptr = cache_key->kernel;
   const void* unpacked_bias_ptr = cache_key->bias;
+  context->last_lookup_seed_mismatch_ = false;
   auto entry = context->unpacked_data_to_name_.find(unpacked_weights_ptr);
   if (entry == context->unpacked_data_to_name_.end()) {
     context->last_lookup_unnamed_ = true;
@@ -369,6 +370,7 @@ size_t XNNWeightsCache::look_up(
         weight_bias_name.c_str(),
         packed_weight_entry->second.seed,
         cache_key->seed);
+    context->last_lookup_seed_mismatch_ = true;
     return SIZE_MAX;
   }
   packed_weight_entry->second.in_current_runtime = true;
@@ -377,7 +379,21 @@ size_t XNNWeightsCache::look_up(
 
 void* XNNWeightsCache::reserve_space(XNNWeightsCache* context, size_t n) {
 #ifndef _WIN32
-  if (context->last_lookup_unnamed_ || context->loaded_from_disk_) {
+  // XNNPACK also re-packs for a different runtime context by calling
+  // reserve_space with no preceding look_up, so consume the flag here:
+  // only the re-pack directly following a seed-mismatch look_up may take
+  // the file-backed path.
+  const bool seed_mismatch_repack = context->last_lookup_seed_mismatch_;
+  context->last_lookup_seed_mismatch_ = false;
+
+  // Unnamed constants never reload by name, and an incidental re-pack of an
+  // already-valid loaded cache needn't persist — both go to heap. A
+  // seed-mismatch re-pack is different: the loaded entry is stale (XNNPACK
+  // upgrade), so it must take the file-backed path below, letting
+  // save_packed_index persist the refreshed seed so the next launch hits
+  // instead of re-packing into heap (dirty memory) every time.
+  if (context->last_lookup_unnamed_ ||
+      (context->loaded_from_disk_ && !seed_mismatch_repack)) {
     return context->reserve_space_heap(n);
   }
   if (context->packed_file_fd_ >= 0) {
@@ -670,6 +686,13 @@ bool XNNWeightsCache::load_packed_cache() {
   const size_t index_region_end = file_size - 20;
 
   void* map = mmap(nullptr, file_size, PROT_READ, MAP_SHARED, fd, 0);
+  // The live MAP_SHARED mapping keeps this open file description — and with
+  // it the flock — alive for as long as the mapping exists, so close() alone
+  // does NOT drop the lock. Without the explicit LOCK_UN the O_RDWR reopen in
+  // initialize_for_runtime always fails with EWOULDBLOCK, leaving
+  // packed_file_fd_ == -1, which silently disables every write path (new
+  // packs, seed-mismatch re-packs, save_packed_index) after a warm load.
+  flock(fd, LOCK_UN);
   close(fd);
   if (map == MAP_FAILED) {
     return false;

--- a/backends/xnnpack/runtime/XNNWeightsCache.h
+++ b/backends/xnnpack/runtime/XNNWeightsCache.h
@@ -236,6 +236,16 @@ class XNNWeightsCache {
   // different runtime context) that doesn't need to persist.
   bool loaded_from_disk_{false};
 
+  // Set by look_up when a named entry is present but its cached seed does not
+  // match the current ukernel's seed (i.e. an XNNPACK upgrade invalidated the
+  // loaded packing). Unlike an incidental re-pack of an already-valid loaded
+  // cache, this stale entry MUST be re-packed to the file and persisted;
+  // otherwise every launch re-packs it into heap (anonymous dirty memory that
+  // can OOM/jetsam the app in the background) and the cache never converges.
+  // Consumed (and cleared) by reserve_space so the file-backed path is taken
+  // only by the re-pack that directly follows the seed-mismatch look_up.
+  bool last_lookup_seed_mismatch_{false};
+
   // See mutex() for the locking contract — caller-owned, no internal
   // use within this class.
   std::mutex instance_mutex_;

--- a/backends/xnnpack/test/runtime/test_xnn_weights_cache.cpp
+++ b/backends/xnnpack/test/runtime/test_xnn_weights_cache.cpp
@@ -226,6 +226,36 @@ class XNNWeightsCacheTest : public ::testing::Test {
     ASSERT_EQ(status, xnn_status_success);
   }
 
+  // One "app launch": a fresh cache instance bound to cache_path loads the
+  // file if it exists, packs-and-runs the graph, and persists the index.
+  void RunLaunchWithCacheFile(
+      const std::string& cache_path,
+      std::vector<float>& output) {
+    const std::vector<size_t> batches{1, 2, 3};
+    const size_t num_batches = 1 * 2 * 3;
+    const size_t padding = 32;
+    std::vector<float> input(
+        num_batches * kLaunchInputChannels + padding, 1.0f);
+    output.assign(num_batches * kLaunchOutputChannels, 0.0f);
+
+    XNNWeightsCache cache;
+    cache.set_packed_cache_path(cache_path);
+    ASSERT_EQ(
+        cache.initialize_for_runtime(memory_allocator_.get(), data_map_.get()),
+        Error::Ok);
+    BuildAndRunGraphWithWeightsCache(
+        cache,
+        batches,
+        kLaunchInputChannels,
+        kLaunchOutputChannels,
+        input.data(),
+        output.data());
+    ASSERT_EQ(cache.save_packed_index(), Error::Ok);
+  }
+
+  static constexpr size_t kLaunchInputChannels = 3;
+  static constexpr size_t kLaunchOutputChannels = 4;
+
   // Program builder constants.
   static constexpr int kSegmentAlignment = 16;
   static constexpr std::array<int, 2> kSegmentSizes{384, 128};
@@ -736,6 +766,57 @@ void write_le_u64(std::ostream& f, uint64_t v) {
   }
 }
 
+// Locate the 4-byte seed field of the first index entry by walking the
+// footer [index_start:u64][entry_count:u32][magic:u32][version:u32] at the
+// end of the file, then the entry record
+// [name_len:u32][name][file_offset:u64][data_size:u64][seed:u32].
+// Returns 0 when the file is too small or carries no entries.
+size_t find_first_entry_seed_offset(std::istream& f) {
+  f.seekg(0, std::ios::end);
+  const size_t file_size = f.tellg();
+  if (file_size < 24) {
+    return 0;
+  }
+  uint8_t footer[20];
+  f.seekg(file_size - 20);
+  f.read(reinterpret_cast<char*>(footer), 20);
+  if (read_le_u32(footer + 8) == 0) {
+    return 0;
+  }
+  const uint64_t index_start = read_le_u64(footer);
+  f.seekg(index_start);
+  uint8_t name_len_buf[4];
+  f.read(reinterpret_cast<char*>(name_len_buf), 4);
+  return index_start + 4 + read_le_u32(name_len_buf) + 8 + 8;
+}
+
+uint32_t read_first_entry_seed(const std::string& path) {
+  std::ifstream f(path, std::ios::binary);
+  const size_t seed_offset = find_first_entry_seed_offset(f);
+  if (seed_offset == 0) {
+    return 0;
+  }
+  uint8_t seed_buf[4];
+  f.seekg(seed_offset);
+  f.read(reinterpret_cast<char*>(seed_buf), 4);
+  return read_le_u32(seed_buf);
+}
+
+void write_first_entry_seed(const std::string& path, uint32_t seed) {
+  std::fstream f(path, std::ios::binary | std::ios::in | std::ios::out);
+  const size_t seed_offset = find_first_entry_seed_offset(f);
+  if (seed_offset == 0) {
+    return;
+  }
+  f.seekp(seed_offset);
+  write_le_u32(f, seed);
+}
+
+off_t file_size_of(const std::string& path) {
+  struct stat st {};
+  return ::stat(path.c_str(), &st) == 0 ? st.st_size : -1;
+}
+
 } // namespace
 
 // A cache file written by older code (kCacheVersion=1) carries no per-entry
@@ -889,31 +970,8 @@ TEST_F(
 
   // Corrupt the seed field of the first entry to a value no real ukernel
   // would emit (0xDEADBEEF).
-  {
-    std::fstream f(cache_path, std::ios::binary | std::ios::in | std::ios::out);
-    ASSERT_TRUE(f.is_open());
-    f.seekg(0, std::ios::end);
-    size_t file_size = f.tellg();
-    ASSERT_GE(file_size, 24u);
-
-    uint8_t footer_buf[20];
-    f.seekg(file_size - 20);
-    f.read(reinterpret_cast<char*>(footer_buf), 20);
-    uint64_t index_start = read_le_u64(footer_buf);
-    uint32_t entry_count = read_le_u32(footer_buf + 8);
-    ASSERT_GT(entry_count, 0u);
-
-    f.seekg(index_start);
-    uint8_t name_len_buf[4];
-    f.read(reinterpret_cast<char*>(name_len_buf), 4);
-    uint32_t name_len = read_le_u32(name_len_buf);
-
-    size_t seed_offset = index_start + 4 + name_len + 8 + 8;
-    f.seekp(seed_offset);
-    uint32_t corrupted = 0xDEADBEEFu;
-    f.write(reinterpret_cast<const char*>(&corrupted), 4);
-    f.close();
-  }
+  write_first_entry_seed(cache_path, 0xDEADBEEFu);
+  ASSERT_EQ(read_first_entry_seed(cache_path), 0xDEADBEEFu);
 
   // Reload and run. Output must still match baseline.
   std::vector<float> after_corruption(num_batches * output_channels, 0.0f);
@@ -932,6 +990,76 @@ TEST_F(
   }
 
   EXPECT_EQ(after_corruption, baseline);
+
+  ::unlink(cache_path.c_str());
+}
+
+// An XNNPACK upgrade changes the per-ukernel seed, so every loaded entry
+// misses look_up and is re-packed. That re-pack must land in the cache file,
+// not on the heap: only the file-backed path lets save_packed_index write
+// back the refreshed seed. On the heap path the file keeps the stale seed
+// and the same re-pack repeats into anonymous dirty memory every launch.
+TEST_F(XNNWeightsCacheTest, SeedMismatch_RepackIsPersistedToFile) {
+  const std::string cache_path = std::string("/tmp/xnn_weights_cache_reseed_") +
+      std::to_string(::getpid()) + ".packed_cache";
+  ::unlink(cache_path.c_str());
+
+  std::vector<float> output;
+  RunLaunchWithCacheFile(cache_path, output);
+  const off_t size_after_first_launch = file_size_of(cache_path);
+  ASSERT_GT(size_after_first_launch, 0);
+
+  const uint32_t real_seed = read_first_entry_seed(cache_path);
+  ASSERT_NE(real_seed, 0u);
+
+  // Simulate the upgrade: the persisted seed no longer matches what the
+  // current ukernel reports for the same weights.
+  write_first_entry_seed(cache_path, 0xDEADBEEFu);
+  ASSERT_EQ(read_first_entry_seed(cache_path), 0xDEADBEEFu);
+
+  std::vector<float> output_after_upgrade;
+  RunLaunchWithCacheFile(cache_path, output_after_upgrade);
+
+  EXPECT_EQ(read_first_entry_seed(cache_path), real_seed)
+      << "seed-mismatch re-pack must be written back to the cache file";
+  EXPECT_GT(file_size_of(cache_path), size_after_first_launch)
+      << "the re-packed weights must be appended to the file, not left on heap";
+  EXPECT_EQ(output_after_upgrade, output);
+
+  ::unlink(cache_path.c_str());
+}
+
+// The point of persisting the re-pack is convergence: exactly one launch
+// pays for the rebuild, and every launch after it is a plain cache hit —
+// no new packing, no file growth. Before the fix each launch re-packed into
+// heap and the file never stopped being stale.
+TEST_F(XNNWeightsCacheTest, SeedMismatch_CacheConvergesAfterOneRebuild) {
+  const std::string cache_path =
+      std::string("/tmp/xnn_weights_cache_converge_") +
+      std::to_string(::getpid()) + ".packed_cache";
+  ::unlink(cache_path.c_str());
+
+  std::vector<float> baseline;
+  RunLaunchWithCacheFile(cache_path, baseline);
+  const uint32_t real_seed = read_first_entry_seed(cache_path);
+  ASSERT_NE(real_seed, 0u);
+
+  write_first_entry_seed(cache_path, 0xDEADBEEFu);
+
+  // Rebuild launch: absorbs the one-time re-pack.
+  std::vector<float> output;
+  RunLaunchWithCacheFile(cache_path, output);
+  const off_t size_after_rebuild = file_size_of(cache_path);
+  ASSERT_GT(size_after_rebuild, 0);
+
+  // Steady state: three more launches must be pure hits.
+  for (int launch = 0; launch < 3; ++launch) {
+    RunLaunchWithCacheFile(cache_path, output);
+    EXPECT_EQ(file_size_of(cache_path), size_after_rebuild)
+        << "cache did not converge; launch " << launch << " re-packed";
+    EXPECT_EQ(read_first_entry_seed(cache_path), real_seed);
+    EXPECT_EQ(output, baseline);
+  }
 
   ::unlink(cache_path.c_str());
 }


### PR DESCRIPTION
Summary:

After an XNNPACK upgrade the per-ukernel seed changes, so every entry loaded
from the packed weight cache misses `look_up` (seed mismatch) and XNNPACK
re-packs it. `reserve_space` routes all re-packs to heap whenever
`loaded_from_disk_` is set, and `save_packed_index` only persists when new mmap
regions were added — so the refreshed packing is never written back. Every
launch then reloads the same stale file, re-packs all weights into anonymous
(dirty) heap, and, when backgrounded, can be OOM/jetsam-killed. The cache
never converges.

Fix: track a per-`look_up` `last_lookup_seed_mismatch_` flag, set when a named
entry is present but its cached seed differs from the current ukernel's seed.
`reserve_space` keeps unnamed constants and incidental warm re-packs on heap as
before, but routes a seed-mismatch re-pack to the file-backed path. This lets
`save_packed_index` persist the refreshed seed, so the next launch hits and the
cache converges after a single rebuild, with the re-pack landing in
reclaimable file-backed pages instead of anonymous dirty memory.

Note: the old packed bytes of re-packed entries remain as orphans, so the
file grows ~once per XNNPACK upgrade (see the `file_bytes` logging in
`save_packed_index`); orphan GC/compaction is a follow-up.

---

**V2 — addressing review comments**

**1. "For this 'miss' — can you ever get here with `loaded_from_disk_ == true`?"**

Yes, and that is exactly why the `loaded_from_disk_` clause has to stay. Two
ways in:

- A named entry that is simply absent from the loaded index (a weight the
  cached PTE never had) misses `look_up` with both flags false.
- More importantly, per D111354375 cause #3, XNNPACK re-packs some weights for
  a different runtime context by calling `reserve_space` with **no preceding
  `look_up` at all**.

That second case exposed a bug in V1: with no `look_up` to reset it,
`last_lookup_seed_mismatch_` stayed `true` from an earlier lookup and would
route such a re-pack to the file, re-growing the cache on every load — the very
regression D111354375 fixed. `reserve_space` now **consumes** the flag
(reads it, then clears it), so only the re-pack that directly follows a
seed-mismatch `look_up` takes the file-backed path.

**2. Writing the tests surfaced a pre-existing bug that made V1 a no-op**

`load_packed_cache` takes `flock(LOCK_SH)`, `mmap`s the file `MAP_SHARED`, then
`close(fd)`. The live mapping keeps the open file description — and therefore
the `flock` — alive, so `close()` never drops the lock. The `open_locked(...,
O_RDWR)` that follows in `initialize_for_runtime` then always fails with
`EWOULDBLOCK`, leaving `packed_file_fd_ == -1`. Confirmed:

```
LOCK_SH -> mmap -> close -> LOCK_EX  =>  EWOULDBLOCK
LOCK_SH ->         close -> LOCK_EX  =>  OK
```

With `packed_file_fd_ == -1`, `reserve_space`'s file-backed branch is
unreachable and `save_packed_index` early-returns, so **every write path after
a warm load was dead** — including the seed-mismatch re-pack this diff adds.
The `flock(...) failed (errno=11)` line is present in the logs of every
existing cache test, right after "Loaded packed weight cache"; nothing asserted
on it.

Fixed with an explicit `flock(fd, LOCK_UN)` before the `close(fd)`, which
preserves exactly the lock scope the original `close()` placement intended.

**3. Tests**

Two new tests in `test_xnn_weights_cache.cpp`:

- `SeedMismatch_RepackIsPersistedToFile` — tamper the persisted seed to
  simulate the upgrade, then assert the next launch writes the refreshed seed
  back and appends the re-packed bytes to the file (i.e. it did not land on
  heap), with unchanged inference output.
- `SeedMismatch_CacheConvergesAfterOneRebuild` — assert exactly one launch pays
  for the rebuild and the three launches after it are pure hits: no file
  growth, seed stable, output stable.

Both fail on V1's routing logic and pass with the fix. Also factored the
duplicated footer/seed-field walking in the existing tests into
`read_first_entry_seed` / `write_first_entry_seed` helpers (the old inline
corruption write was host-endian; the helper is little-endian like the format).

Reviewed By: JakeStevens

Differential Revision: D117550758


