### PR TITLE
Ship the MLX delegate as a linkable library in the wheel

### DIFF
--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -149,6 +149,13 @@ _OPENVINO_BACKEND_SYMBOLS = ("executorch::backends::openvino::OpenvinoBackend",)
 
 _BUNDLED_XNNPACK_SYMBOLS = ("xnn_create_runtime_v4",)
 
+# A representative symbol from the MLX delegate, and one from the MLX runtime the
+# delegate bundles. The runtime is third-party code compiled into the delegate
+# rather than depended on, so it gets its own row for the same reason XNNPACK's
+# does: a second copy means two MLX runtimes in one process.
+_MLX_SYMBOLS = ("executorch::backends::mlx::mutable_state_note_handle",)
+_BUNDLED_MLX_SYMBOLS = ("mlx::core::allocator::free",)
+
 # A representative symbol from the profiler. A second definer means two event
 # tracers, so a trace records only part of what ran.
 _ETDUMP_SYMBOLS = ("executorch::etdump::ETDumpGen::ETDumpGen",)
@@ -935,6 +942,15 @@ _OWNED_COMPONENTS = (
         _library_file_name("libexecutorch_backend_xnnpack"),
         True,
     ),
+    # Not required: the delegate is built only on an Apple Silicon macOS wheel whose
+    # build found the Metal compiler, so every other wheel legitimately ships no MLX
+    # library and the row skips.
+    (
+        "MLX delegate",
+        _MLX_SYMBOLS,
+        _library_file_name("libexecutorch_backend_mlx"),
+        False,
+    ),
     (
         "set of CPU kernels",
         _KERNEL_SYMBOLS,
@@ -992,6 +1008,13 @@ _OWNED_COMPONENTS = (
         _BUNDLED_XNNPACK_SYMBOLS,
         _library_file_name("libexecutorch_backend_xnnpack"),
         True,
+    ),
+    # Not required, for the same reason as the delegate row above.
+    (
+        "bundled MLX runtime",
+        _BUNDLED_MLX_SYMBOLS,
+        _library_file_name("libexecutorch_backend_mlx"),
+        False,
     ),
     # Required on Linux, where packaging turns the backend on for every non-minimal
     # build. A fixed False passed a wheel that had compiled the delegate back into the
@@ -2298,6 +2321,7 @@ def test_shipped_library_names_are_expected() -> None:
         # dependency, so both have to ship and both are expected here.
         "libextension_cuda",
         "libexecutorch_backend_xnnpack",
+        "libexecutorch_backend_mlx",
         "libexecutorch_backend_openvino",
         "libexecutorch_backend_qnn",
         "libexecutorch_threadpool",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1490,8 +1490,10 @@ if(EXECUTORCH_BUILD_PYBIND)
 
   # Copy the MLX metallib next to the Python extension for editable installs.
   # MLX uses dladdr() to find the directory containing the library with MLX
-  # code, then looks for mlx.metallib in that directory. When MLX is statically
-  # linked into the Python extension, we need the metallib colocated with it.
+  # code, then looks for mlx.metallib in that directory. This covers the case
+  # where the delegate is static and therefore absorbed into the extension; a
+  # shared delegate carries MLX itself and is served by the copy installed
+  # beside it instead.
   executorch_target_copy_mlx_metallib(portable_lib)
 endif()
 

--- a/backends/mlx/CMakeLists.txt
+++ b/backends/mlx/CMakeLists.txt
@@ -267,7 +267,14 @@ set(_mlx_backend__srcs
     ${CMAKE_CURRENT_SOURCE_DIR}/runtime/mlx_mutable_state.cpp
 )
 
-add_library(mlxdelegate ${_mlx_backend__srcs})
+# Build the delegate as a shared library for the wheel so a C++ consumer can
+# link it, and keep it static everywhere else so no other build changes.
+if(EXECUTORCH_BUILD_SHARED)
+  set(_mlx_backend_library_type SHARED)
+else()
+  set(_mlx_backend_library_type STATIC)
+endif()
+add_library(mlxdelegate ${_mlx_backend_library_type} ${_mlx_backend__srcs})
 
 # Ensure schema is generated before compiling
 add_dependencies(mlxdelegate mlx_schema)
@@ -294,15 +301,35 @@ target_include_directories(
 )
 
 # Link against MLX and executorch. mlx is an imported static lib (built by
-# mlx_external); it is only consumed at build time here, not re-exported, so
-# downstream consumers must link to mlx separately via the package config.
-# extension_llm_cache carries the off-graph KV-cache registry the backend binds
-# to in init(); it is defined under EXECUTORCH_BUILD_EXTENSION_LLM, which the
-# mlx preset enables.
+# mlx_external) and is not re-exported, so a consumer of the static build must
+# link mlx separately via the package config. The shared build bundles it
+# instead, see below. extension_llm_cache carries the off-graph KV-cache
+# registry the backend binds to in init(); it is defined under
+# EXECUTORCH_BUILD_EXTENSION_LLM, which the mlx preset enables.
 target_link_libraries(
-  mlxdelegate PRIVATE mlx_schema executorch_core extension_llm_cache
-                      $<BUILD_INTERFACE:mlx>
+  mlxdelegate PRIVATE mlx_schema extension_llm_cache $<BUILD_INTERFACE:mlx>
 )
+if(EXECUTORCH_BUILD_SHARED)
+  set_target_properties(
+    mlxdelegate PROPERTIES OUTPUT_NAME executorch_backend_mlx
+  )
+  executorch_target_soname_policy(mlxdelegate)
+  # mlx is built as a static archive, so bundle it inside this library instead
+  # of making every consumer supply it. Written out rather than routed through
+  # executorch_target_whole_archive() so the archive stays out of this target's
+  # link interface: the imported target exists only while building, and naming
+  # it anywhere a consumer can see would leave the installed export set
+  # referring to a target that is not there. The BUILD_INTERFACE link above
+  # already makes the archive a build prerequisite.
+  target_link_options(
+    mlxdelegate PRIVATE "SHELL:LINKER:-force_load,$<TARGET_FILE:mlx>"
+  )
+  target_link_libraries(mlxdelegate PRIVATE executorch_shared)
+  # Ships beside the runtime in the wheel's lib/ directory.
+  executorch_target_shipped_runtime_path(mlxdelegate)
+else()
+  target_link_libraries(mlxdelegate PRIVATE executorch_core)
+endif()
 
 executorch_target_link_options_shared_lib(mlxdelegate)
 target_compile_options(mlxdelegate PRIVATE ${_common_compile_options})
@@ -353,6 +380,23 @@ set(MLX_METALLIB_PATH
     "${_mlx_metallib}"
     CACHE INTERNAL "Path to mlx.metallib for pybindings"
 )
+
+# Whether the Python extension is the image carrying MLX code, which is true
+# only when the delegate is static and therefore absorbed into it. Packaging
+# reads this to decide whether the metallib has to ship beside the extension: a
+# shared delegate carries MLX itself and is served by the copy beside it
+# instead.
+if(EXECUTORCH_BUILD_SHARED)
+  set(EXECUTORCH_MLX_METALLIB_IN_PYBINDINGS
+      OFF
+      CACHE INTERNAL "Ship mlx.metallib beside the Python extension"
+  )
+else()
+  set(EXECUTORCH_MLX_METALLIB_IN_PYBINDINGS
+      ON
+      CACHE INTERNAL "Ship mlx.metallib beside the Python extension"
+  )
+endif()
 
 # -----------------------------------------------------------------------------
 # Tests (off by default; CI passes -DEXECUTORCH_BUILD_TESTS=ON)

--- a/docs/source/using-executorch-cpp.md
+++ b/docs/source/using-executorch-cpp.md
@@ -181,6 +181,7 @@ These are the components the package provides:
 | `backend_cuda` | The CUDA delegate | Linux |
 | `extension_cuda` | The CUDA stream extension | Linux |
 | `backend_openvino` | The OpenVINO delegate | Linux |
+| `backend_mlx` | The MLX delegate, for Apple GPU execution | macOS, Apple Silicon |
 
 To see what your own install offers, ask CMake:
 
@@ -188,16 +189,16 @@ To see what your own install offers, ask CMake:
 find_package(executorch REQUIRED)
 foreach(_component
         runtime kernels_optimized kernels_quantized backend_xnnpack
-        backend_cuda extension_cuda backend_openvino threadpool etdump)
+        backend_mlx backend_cuda extension_cuda backend_openvino threadpool etdump)
   if(TARGET executorch::${_component})
     message(STATUS "have ${_component}")
   endif()
 endforeach()
 ```
 
-On macOS the Core ML and MLX delegates are registered inside the Python extension rather than
-shipped as separate C++ libraries, so a C++ application there cannot link them as components; use
-them from Python, or build from source if you need them in C++.
+On macOS the Core ML delegate is registered inside the Python extension rather than shipped as a
+separate C++ library, so a C++ application there cannot link it as a component; use it from
+Python, or build from source if you need it in C++.
 
 Profiling a Core ML model records `DELEGATE_CALL`, which tells you how long the delegate ran in
 total. It does not record the individual operators inside the delegate, because that detail comes
@@ -231,6 +232,17 @@ export OPENVINO_LIB_PATH="$(python -c 'import glob, openvino, os; print(sorted(g
 
 Without it the delegate still registers and the program still links, and the failure arrives later,
 when the model is loaded.
+
+The MLX delegate has a similar requirement. Its Metal kernels live in a separate `mlx.metallib`
+file, which MLX looks for next to whichever library holds MLX code. The wheel ships it beside the
+delegate, so a program that links the delegate where it sits needs nothing extra. A program that
+copies the delegate next to its own binary has to copy that file too, and `find_package` reports
+where it is:
+
+```cmake
+find_package(executorch REQUIRED COMPONENTS backend_mlx)
+message(STATUS "Metal kernels: ${MLX_METALLIB_PATH}")
+```
 
 #### When something does not work
 

--- a/setup.py
+++ b/setup.py
@@ -2333,6 +2333,18 @@ setup(
                         "EXECUTORCH_BUILD_XNNPACK",
                     ],
                 ),
+                # Install the MLX delegate beside them, so a C++ consumer can link
+                # it out of the wheel rather than only reaching it from Python.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/backends/mlx/",
+                    src_name=get_dynamic_lib_name("executorch_backend_mlx"),
+                    dst="executorch/lib/"
+                    + get_dynamic_lib_name("executorch_backend_mlx"),
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_MLX",
+                    ],
+                ),
                 # Install the prebuilt pybindings extension wrapper for the runtime,
                 # portable kernels, and a selection of backends. This lets users
                 # load and execute .pte files from python.
@@ -2348,15 +2360,28 @@ setup(
                     modpath="executorch.extension.pybindings.data_loader",
                     dependent_cmake_flags=["EXECUTORCH_BUILD_PYBIND"],
                 ),
-                # MLX metallib (Metal GPU kernels) must be colocated with _C.so
-                # because MLX uses dladdr() to find the directory containing the library,
-                # then looks for mlx.metallib in that directory at runtime.
+                # MLX metallib (Metal GPU kernels) must be colocated with the image
+                # that carries MLX code, because MLX resolves its own address with
+                # dladdr() and looks for mlx.metallib in that directory at runtime.
+                # Which image that is depends on how the delegate was built: a shared
+                # delegate carries MLX itself, while a static one is absorbed into the
+                # Python extension. The build decides which of these two entries
+                # applies, so exactly one copy ships.
                 # After submodule migration, the path is backends/mlx/mlx/...
                 BuiltFile(
                     src_dir="%CMAKE_CACHE_DIR%/backends/mlx/mlx/mlx/backend/metal/kernels/",
                     src_name="mlx.metallib",
+                    dst="executorch/lib/",
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_MLX",
+                    ],
+                ),
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/backends/mlx/mlx/mlx/backend/metal/kernels/",
+                    src_name="mlx.metallib",
                     dst="executorch/extension/pybindings/",
-                    dependent_cmake_flags=["EXECUTORCH_BUILD_MLX"],
+                    dependent_cmake_flags=["EXECUTORCH_MLX_METALLIB_IN_PYBINDINGS"],
                 ),
                 BuiltExtension(
                     src="extension/training/_training_lib.*",  # @lint-ignore https://github.com/pytorch/executorch/blob/cb3eba0d7f630bc8cec0a9cc1df8ae2f17af3f7a/scripts/lint_xrefs.sh

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -71,6 +71,9 @@
 #                                model. Not part of EXECUTORCH_LIBRARIES, see
 #                                below.
 # executorch::backend_xnnpack    The XNNPACK delegate.
+# executorch::backend_mlx        The MLX delegate. macOS on Apple Silicon only.
+#                                Its Metal kernel archive is published as
+#                                MLX_METALLIB_PATH, see below.
 # executorch::backend_cuda       The CUDA delegate. Linux only.
 # executorch::extension_cuda     The CUDA stream extension. Linux only.
 # executorch::backend_openvino   The OpenVINO delegate. Linux only. Opens the
@@ -85,6 +88,11 @@
 # executorch.kernels.quantized loads carries its own copy of those kernels, so a
 # process holding both stops on a repeated operator registration, and a consumer
 # linking the aggregate would inherit that without asking for it.
+#
+# MLX_METALLIB_PATH is set when the wheel ships the MLX delegate's Metal kernel
+# archive. MLX locates that archive next to whichever library holds MLX code, so
+# an application that copies the delegate somewhere else has to bring the
+# archive along, and this is where it finds it.
 #
 # Check with if(TARGET executorch::<name>) rather than assuming one exists. A
 # namespaced name that was never defined is a configure-time error that names
@@ -326,6 +334,7 @@ if(_executorch_runtime_library AND NOT _executorch_targets_supported)
     _executorch_component IN
     ITEMS libexecutorch_kernels_optimized
           libexecutorch_backend_xnnpack
+          libexecutorch_backend_mlx
           libexecutorch_backend_cuda
           libexecutorch_extension_cuda
           libexecutorch_backend_openvino
@@ -644,6 +653,23 @@ if(TARGET executorch::runtime AND TARGET executorch::threadpool)
 endif()
 
 _executorch_define_component(backend_xnnpack executorch_backend_xnnpack)
+# The MLX delegate, present only in a wheel built on Apple Silicon with the
+# Metal compiler available.
+_executorch_define_component(backend_mlx executorch_backend_mlx)
+# MLX locates its Metal kernel archive relative to the library holding MLX code,
+# so an application that copies the delegate next to its own binary has to bring
+# the archive along. Publish its path so a consumer does not have to guess the
+# layout inside the wheel.
+#
+# Tested directly rather than with find_file, for the reason given above the
+# package root search: the path is a fixed offset from this file, so a search
+# adds nothing, and it would apply the consumer's find-root rules. Not cached
+# either, so a second install in the same build tree does not inherit the first
+# one's path.
+set(_executorch_mlx_metallib "${_executorch_package_root}/lib/mlx.metallib")
+if(EXISTS "${_executorch_mlx_metallib}")
+  set(MLX_METALLIB_PATH "${_executorch_mlx_metallib}")
+endif()
 _executorch_define_component(backend_openvino executorch_backend_openvino)
 # The CUDA delegate and its stream helper, present only in a wheel built from a
 # CUDA index. A CPU wheel defines neither, so a consumer asking for one is told


### PR DESCRIPTION

MLX is reachable from Python but not from C++. The macOS wheel carries no MLX
library at all: the delegate is statically fused into the Python extension, so a
C++ application that links the wheel cannot use it.

`find_package(executorch)` offers no MLX component, and running an MLX program
fails at load:

    Backend MLXBackend is not registered.

Build the delegate as a shared library in the wheel, the same way the XNNPACK
delegate already is, and package it beside the runtime. A C++ consumer can then
link `executorch::backend_mlx`.

The static MLX archive is bundled into the shared library rather than left for
the consumer to supply, since it carries the delegate's kernels. The archive is
kept out of the target's interface deliberately, so an imported target that only
exists while building cannot reach the installed export set.

The Metal kernel archive moves from beside the Python extension to beside the
shared library. MLX finds that archive by resolving the address of its own code
with `dladdr()` and looking in the resulting directory, so it has to sit next to
whichever image carries MLX. Building the delegate shared moves that code out of
the Python extension entirely, so both the Python path and a C++ consumer now
resolve to the library directory and one copy serves both. The extension shrinks
from 5.7 MB to 0.9 MB as a result.

The copy placed beside the Python extension during a build is kept, because
without the shared option the delegate is static and is absorbed into the
extension, which is then the image that carries MLX.

Nothing changes for a build that is not producing a wheel: without the shared
option the delegate stays a static library linking the static runtime.

Test Plan:
Built the wheel on macOS arm64 with MLX enabled, installed it into a new virtual
environment holding only torch and the wheel, and exercised both paths. The
build-tree copy of the Metal archive was hidden for every run, because MLX falls
back to a compile-time path that still exists on a build machine and would
otherwise mask a failure.

`find_package(executorch)` now reports `executorch::backend_mlx` alongside the
other components, where the list previously ended at `backend_xnnpack`. A C++
program linking it loads an MLX program and produces the expected output, where
the same program previously failed with the error above. The same program on an
XNNPACK model still passes, so the harness is sound.

The Python path still exports, runs and matches eager exactly.

Which directory the Metal archive has to live in was measured rather than
reasoned about, by removing each copy in turn. Only the copy beside the shared
library works; the one beside the Python extension is not reachable from either
path once the delegate is shared. That is why a single copy ships.

Also add the delegate to the wheel's own release checks, which assert both that
every shipped library has an expected name and that each component has exactly
one owning library. The second one matters here because this library bundles a
third-party runtime, which is the case those checks exist to police.

The Metal kernel archive ships beside whichever image carries MLX code, which is the
delegate when it is built shared and the Python extension when it is not. The build
records which case applies, so exactly one copy ships either way.

Document the new component: the C++ page previously said a C++ application on
macOS cannot link MLX at all, which is what this change makes false, and its
component table and probe loop omitted it. The wheel's package config now also
publishes the archive's path, the way the source package already does, so an
application that relocates the delegate can bring the archive with it.

Ran the wheel's own two release checks against that install. Both pass, and the
new ownership rows are doing work rather than skipping: each reports a single
owner for the delegate and for the bundled runtime. Confirmed they can fail by
planting a second copy of the library, which makes them report two definers.

Confirmed a consumer is handed the Metal archive's path by configuring a project
against the installed package, and that the archive is selected for every build
that produces the delegate, shared or static.

Corrected after review, all three verified rather than reasoned about:

The archive was shipping twice in a shared build, because the entry covering the
static case was gated on MLX alone. The build now records which image carries MLX and
exactly one copy ships in every configuration.

The package config located the archive with find_file, which is the pattern the file's
own comment explains it avoids: it applies the consumer's find-root rules, so a
cross-compiling toolchain reroots an absolute path into its sysroot and reports a
complete package as missing. It also cached the result, which goes stale across two
installs in one build tree. Now a plain existence test and an uncached set, which is
what the rest of the file does.

Documented the new component and the published path in the config's own header block,
and gave the delegate the same runtime-file caveat the OpenVINO one already has.

