### PR TITLE
Skip the ROCm unit test job on pull requests from a fork

### DIFF
--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -158,7 +158,14 @@ jobs:
   unittest-rocm-gfx950:
     name: unittest-rocm-gfx950-rocm${{ matrix.rocm-version }}
     needs: [aoti-run-decision]
-    if: needs.aoti-run-decision.outputs.run-aoti == 'true'
+    # Skipped on pull requests from a fork: the job requests an OIDC token to
+    # reach the ROCm runners, which a fork cannot be issued, so it fails while
+    # starting rather than running anything. The ROCm jobs below already carry
+    # this condition.
+    if: |
+      needs.aoti-run-decision.outputs.run-aoti == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION

Every pull request from a fork that touches one of this job's trigger paths
fails, before running any repository code:

    ##[error]Credentials could not be loaded, please check your action inputs:
             Could not load credentials from any providers
    ##[error]An error occurred trying to start process '/usr/bin/bash' with
             working directory '.../pytorch/executorch'. No such file or directory

The job requests an OIDC token to reach the ROCm runners, and a fork cannot be
issued one, so it stops while setting up. The two ROCm jobs directly below it
already carry a condition for exactly this, and they skip cleanly instead.

Add the same condition here. The job still runs on pushes to main and on pull
requests from a branch in this repository, so nothing that currently works is
lost. Only the case that cannot succeed is skipped.

Its trigger list includes `install_requirements.py`, `CMakeLists.txt`,
`CMakePresets.json` and `torch_pin.py`, so an outside contributor editing any of
those sees a red check they have no way to fix or interpret.

Test Plan:
Confirmed the job genuinely works when it is allowed to run: it succeeded on
main at 3bc76d0080, and is skipped on main commits where its trigger paths were
untouched. So this is specifically the fork case, not a broken job.

Verified the workflow still parses, that the new condition is character for
character the one the sibling ROCm jobs use, and that no ROCm job in this file is
now left without it.

Evaluated the condition for each event: a push to main runs, a pull request from
this repository runs, and a pull request from a fork skips.

