### PR TITLE
Add view_copy-collapse pass (#22186)

### DIFF
--- a/backends/mlx/passes.py
+++ b/backends/mlx/passes.py
@@ -19,6 +19,7 @@ from executorch.backends.mlx.pattern_utils import (
     PatternMatch,
     walk_back,
 )
+from executorch.backends.transforms.collapse_view_copy import CollapseViewCopyPass
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import (
     ExportedProgramPassBase,
@@ -318,68 +319,6 @@ class CanonicalizePermutePass(ExportPass):
             modified = True
 
         if modified:
-            graph.lint()
-
-        return PassResult(graph_module, modified)
-
-
-class CollapseViewCopyPass(ExportPass):
-    """
-    Collapses consecutive view_copy nodes into a single view_copy.
-
-    view_copy(view_copy(x, shape1), shape2) → view_copy(x, shape2)
-
-    Only the final shape matters, so intermediate view_copys can be removed.
-    """
-
-    def call(self, graph_module: GraphModule) -> PassResult:
-        graph = graph_module.graph
-        modified = False
-        view_copy_target = exir_ops.edge.aten.view_copy.default
-
-        for node in list(graph.nodes):
-            if node.op != "call_function" or node.target != view_copy_target:
-                continue
-
-            parent = node.args[0]
-            if (
-                isinstance(parent, Node)
-                and parent.op == "call_function"
-                and parent.target == view_copy_target
-                and len(parent.users) == 1
-            ):
-                original_input = parent.args[0]
-                target_shape = node.args[1]
-
-                # Check if final shape matches original input shape (identity).
-                # Compare meta shapes (not args) so SymInt dims are handled.
-                # Use try/except because shapes may contain unbacked SymInts
-                # (e.g. from .item() calls) that can't be guarded on.
-                original_val = (
-                    original_input.meta.get("val")
-                    if isinstance(original_input, Node)
-                    else None
-                )
-                output_val = node.meta.get("val")
-                is_identity = False
-                if original_val is not None and output_val is not None:
-                    try:
-                        is_identity = original_val.shape == output_val.shape
-                    except Exception:
-                        is_identity = False
-                if is_identity:
-                    # Identity — remove both view_copys
-                    node.replace_all_uses_with(original_input)
-                    graph.erase_node(node)
-                    graph.erase_node(parent)
-                else:
-                    # Collapse: view_copy(view_copy(x, s1), s2) → view_copy(x, s2)
-                    node.args = (original_input, target_shape)
-                    graph.erase_node(parent)
-                modified = True
-
-        if modified:
-            graph.eliminate_dead_code()
             graph.lint()
 
         return PassResult(graph_module, modified)

--- a/backends/native/BUCK
+++ b/backends/native/BUCK
@@ -29,6 +29,7 @@ fbcode_target(
     deps = [
         "fbsource//third-party/pypi/flatbuffers:flatbuffers",
         "//caffe2:torch",
+        "//executorch/backends/transforms:collapse_view_copy",
         "//executorch/exir:lib",
         "//executorch/exir/_serialize:lib",
         "//executorch/exir/backend:backend_details",

--- a/backends/native/passes/__init__.py
+++ b/backends/native/passes/__init__.py
@@ -14,16 +14,23 @@ in its own module; this package aggregates them and exposes the default pass lis
 
 from typing import List, Union
 
+from executorch.backends.transforms.collapse_view_copy import CollapseViewCopyPass
+
 from executorch.exir.pass_base import ExportedProgramPassBase, ExportPass
 from executorch.exir.passes.cse_pass import CSEPass
 
 __all__ = [
+    "CollapseViewCopyPass",
     "get_default_passes",
 ]
 
 
 def get_default_passes() -> List[Union[ExportPass, ExportedProgramPassBase]]:
-    """Passes enabled by default for the native backend."""
+    """Passes enabled by default for the native backend.
+
+    CSE runs after view_copy collapsing to dedupe the settled graph.
+    """
     return [
+        CollapseViewCopyPass(),
         CSEPass(),
     ]

--- a/backends/transforms/collapse_view_copy.py
+++ b/backends/transforms/collapse_view_copy.py
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+from torch.fx import GraphModule, Node
+
+
+class CollapseViewCopyPass(ExportPass):
+    """Collapse consecutive view_copy nodes into a single view_copy.
+
+    view_copy(view_copy(x, shape1), shape2) -> view_copy(x, shape2)
+
+    Only the final shape matters, so intermediate view_copys can be dropped. If
+    the collapsed chain reproduces the original input's shape it is an identity
+    and removed entirely.
+    """
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        graph = graph_module.graph
+        modified = False
+        view_copy_target = exir_ops.edge.aten.view_copy.default
+
+        for node in list(graph.nodes):
+            if node.op != "call_function" or node.target != view_copy_target:
+                continue
+
+            parent = node.args[0]
+            if not (
+                isinstance(parent, Node)
+                and parent.op == "call_function"
+                and parent.target == view_copy_target
+                and len(parent.users) == 1
+            ):
+                continue
+
+            original_input = parent.args[0]
+            target_shape = node.args[1]
+
+            # Compare meta shapes (not args) so SymInt dims are handled. Guard
+            # with try/except because shapes may hold unbacked SymInts (e.g.
+            # from .item()) that cannot be compared.
+            original_val = (
+                original_input.meta.get("val")
+                if isinstance(original_input, Node)
+                else None
+            )
+            output_val = node.meta.get("val")
+            is_identity = False
+            if original_val is not None and output_val is not None:
+                try:
+                    is_identity = original_val.shape == output_val.shape
+                except Exception:
+                    is_identity = False
+
+            if is_identity:
+                node.replace_all_uses_with(original_input)
+                graph.erase_node(node)
+                graph.erase_node(parent)
+            else:
+                node.args = (original_input, target_shape)
+                graph.erase_node(parent)
+            modified = True
+
+        if modified:
+            graph.eliminate_dead_code()
+            graph.lint()
+
+        return PassResult(graph_module, modified)

--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -89,6 +89,19 @@ def define_common_targets():
     )
 
     runtime.python_library(
+        name = "collapse_view_copy",
+        srcs = ["collapse_view_copy.py"],
+        visibility = [
+            "//executorch/backends/...",
+        ],
+        deps = [
+            "//caffe2:torch",
+            "//executorch/exir:pass_base",
+            "//executorch/exir/dialects:lib",
+        ],
+    )
+
+    runtime.python_library(
         name = "fuse_view_copy",
         srcs = ["fuse_view_copy.py"],
         visibility = [
@@ -400,6 +413,18 @@ def define_common_targets():
             "//executorch/exir:lib",
             "//executorch/extension/pybindings:portable_lib",
             "fbsource//third-party/pypi/pytest:pytest",
+        ],
+    )
+
+    runtime.python_test(
+        name = "test_collapse_view_copy",
+        srcs = [
+            "test/test_collapse_view_copy.py",
+        ],
+        deps = [
+            "//caffe2:torch",
+            "//executorch/exir:lib",
+            ":collapse_view_copy",
         ],
     )
 

--- a/backends/transforms/test/test_collapse_view_copy.py
+++ b/backends/transforms/test/test_collapse_view_copy.py
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+import torch.nn as nn
+
+from executorch.backends.transforms.collapse_view_copy import CollapseViewCopyPass
+from executorch.exir.dialects._ops import ops as _edge_ops
+
+
+class CollapseViewCopyPassTest(unittest.TestCase):
+    def test_collapses_chain(self):
+        # view_copy(view_copy(x)) collapses to a single view_copy on x.
+        vc = _edge_ops.edge.aten.view_copy.default
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        x.meta["val"] = torch.zeros(6)
+        v1 = g.call_function(vc, (x, [2, 3]))
+        v1.meta["val"] = torch.zeros(2, 3)
+        v2 = g.call_function(vc, (v1, [3, 2]))
+        v2.meta["val"] = torch.zeros(3, 2)
+        g.output((v2,))
+        gm = torch.fx.GraphModule(nn.Module(), g)
+
+        result = CollapseViewCopyPass().call(gm)
+        self.assertTrue(result.modified)
+        view_copies = [
+            n for n in gm.graph.nodes if n.op == "call_function" and n.target is vc
+        ]
+        self.assertEqual(len(view_copies), 1)
+        self.assertIs(view_copies[0].args[0], x)


### PR DESCRIPTION
Summary:

CollapseViewCopyPass folds consecutive edge view_copy nodes into a single
view_copy, dropping the chain entirely when it reproduces the input shape
(an identity). It is added to get_default_passes() ahead of CSE.

Reviewed By: digantdesai

Differential Revision: D113936302


