### PR TITLE
Ship the TorchAO kernels in the wheel

### DIFF
--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -156,6 +156,10 @@ _BUNDLED_XNNPACK_SYMBOLS = ("xnn_create_runtime_v4",)
 _MLX_SYMBOLS = ("executorch::backends::mlx::mutable_state_note_handle",)
 _BUNDLED_MLX_SYMBOLS = ("mlx::core::allocator::free",)
 
+# A representative symbol from the TorchAO kernels. These are Apple Silicon only, so
+# most wheels ship no such library and the row below is not required.
+_TORCHAO_KERNEL_SYMBOLS = ("torchao::quantization::get_qvals_range",)
+
 # A representative symbol from the profiler. A second definer means two event
 # tracers, so a trace records only part of what ran.
 _ETDUMP_SYMBOLS = ("executorch::etdump::ETDumpGen::ETDumpGen",)
@@ -962,6 +966,12 @@ _OWNED_COMPONENTS = (
         _QUANTIZED_KERNEL_SYMBOLS,
         _library_file_name("libexecutorch_kernels_quantized"),
         True,
+    ),
+    (
+        "set of TorchAO kernels",
+        _TORCHAO_KERNEL_SYMBOLS,
+        _library_file_name("libexecutorch_kernels_torchao"),
+        False,
     ),
     # The CUDA components. Required exactly when the wheel says it is a CUDA wheel,
     # which is decided at check time rather than here: a fixed False meant a wheel
@@ -2195,7 +2205,9 @@ def test_extension_contains_no_component() -> None:
     # Not every shipped library serves Python. The quantized kernels exist for a C++
     # application, since Python registers those operators through the torch-linked
     # ahead-of-time library at export time, and requiring a dependency would demand the
-    # extension link code it has no use for.
+    # extension link code it has no use for. The TorchAO kernels are in that same
+    # category: torchao registers its operators itself at export time, so the extension
+    # has no reason to link them either.
     #
     # The CUDA delegate is NOT in that category. The build deliberately links it into the
     # extension with a retention option, so it does carry a dependency, and excluding it
@@ -2205,7 +2217,10 @@ def test_extension_contains_no_component() -> None:
     expected = {
         name
         for name in shipped
-        if not any(marker in name for marker in ("kernels_quantized", "extension_cuda"))
+        if not any(
+            marker in name
+            for marker in ("kernels_quantized", "kernels_torchao", "extension_cuda")
+        )
     }
     unused = sorted(expected - needed)
     assert not unused, (
@@ -2313,6 +2328,7 @@ def test_shipped_library_names_are_expected() -> None:
         "libexecutorch",
         "libexecutorch_kernels_optimized",
         "libexecutorch_kernels_quantized",
+        "libexecutorch_kernels_torchao",
         "libexecutorch_backend_cuda",
         "libexecutorch_extension_cuda",
         # The same library under the name a non-shared build gives it. The shared

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1130,6 +1130,25 @@ if(EXECUTORCH_BUILD_KERNELS_TORCHAO)
   executorch_target_link_options_shared_lib(torchao_ops_executorch)
   list(APPEND _executorch_kernels torchao_ops_executorch)
 
+  # The wheel ships one shared library per component so a process holds a single
+  # copy of each. These kernels are static archives declared in the TorchAO
+  # submodule, so wrap them the way the quantized kernels are wrapped rather
+  # than changing a third-party target. extension_threadpool is named explicitly
+  # because the kernels call into it and the wheel ships it as its own library,
+  # so this resolves against that one copy instead of bundling a second.
+  if(EXECUTORCH_BUILD_SHARED)
+    executorch_add_shared_library(
+      executorch_kernels_torchao torchao_ops_executorch extension_threadpool
+      executorch_shared
+    )
+    # Holds registration constructors and no symbol a consumer names, so a link
+    # with --as-needed would drop it and register nothing.
+    executorch_target_link_options_shared_lib(executorch_kernels_torchao)
+    # Ships beside the runtime in the wheel's lib/ directory, and links it, so
+    # it has to be able to find it from wherever the package is installed.
+    executorch_target_shipped_runtime_path(executorch_kernels_torchao)
+  endif()
+
   install(
     TARGETS torchao_ops_executorch torchao_kernels_aarch64
     EXPORT ExecuTorchTargets

--- a/docs/source/using-executorch-cpp.md
+++ b/docs/source/using-executorch-cpp.md
@@ -178,6 +178,7 @@ These are the components the package provides:
 | `threadpool` | Multi-threaded execution. | Linux, macOS |
 | `etdump` | Profiling, to record what ran and how long it took. | Linux, macOS |
 | `kernels_quantized` | The quantized operator kernels | Linux, macOS |
+| `kernels_torchao` | The TorchAO low-bit quantized kernels | macOS, Apple Silicon |
 | `backend_cuda` | The CUDA delegate | Linux |
 | `extension_cuda` | The CUDA stream extension | Linux |
 | `backend_openvino` | The OpenVINO delegate | Linux |
@@ -188,8 +189,9 @@ To see what your own install offers, ask CMake:
 ```cmake
 find_package(executorch REQUIRED)
 foreach(_component
-        runtime kernels_optimized kernels_quantized backend_xnnpack
-        backend_mlx backend_cuda extension_cuda backend_openvino threadpool etdump)
+        runtime kernels_optimized kernels_quantized kernels_torchao
+        backend_xnnpack backend_mlx backend_cuda extension_cuda
+        backend_openvino threadpool etdump)
   if(TARGET executorch::${_component})
     message(STATUS "have ${_component}")
   endif()

--- a/setup.py
+++ b/setup.py
@@ -2178,6 +2178,8 @@ class CustomBuild(build):
                     cmake_build_args += ["--target", "optimized_native_cpu_ops_lib"]
                 if cmake_cache.is_enabled("EXECUTORCH_BUILD_KERNELS_QUANTIZED"):
                     cmake_build_args += ["--target", "executorch_quantized_ops"]
+                if cmake_cache.is_enabled("EXECUTORCH_BUILD_KERNELS_TORCHAO"):
+                    cmake_build_args += ["--target", "executorch_kernels_torchao"]
                 if cmake_cache.is_enabled("EXECUTORCH_BUILD_XNNPACK"):
                     cmake_build_args += ["--target", "xnnpack_backend"]
 
@@ -2348,6 +2350,20 @@ setup(
                     dependent_cmake_flags=[
                         "EXECUTORCH_BUILD_SHARED",
                         "EXECUTORCH_BUILD_KERNELS_QUANTIZED",
+                    ],
+                ),
+                # The TorchAO kernels, so a C++ application running a model that
+                # uses them can link them from the wheel. The Apple framework build
+                # already ships these; this is the wheel's equivalent. Written to
+                # the cache root because the wrapper target is declared there.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/",
+                    src_name=get_dynamic_lib_name("executorch_kernels_torchao"),
+                    dst="executorch/lib/"
+                    + get_dynamic_lib_name("executorch_kernels_torchao"),
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_KERNELS_TORCHAO",
                     ],
                 ),
                 # The OpenVINO delegate, so a C++ application can link it from the

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -74,6 +74,7 @@
 # executorch::backend_mlx        The MLX delegate. macOS on Apple Silicon only.
 #                                Its Metal kernel archive is published as
 #                                MLX_METALLIB_PATH, see below.
+# executorch::kernels_torchao    The TorchAO kernels. macOS on Apple Silicon only.
 # executorch::backend_cuda       The CUDA delegate. Linux only.
 # executorch::extension_cuda     The CUDA stream extension. Linux only.
 # executorch::backend_openvino   The OpenVINO delegate. Linux only. Opens the
@@ -333,6 +334,7 @@ if(_executorch_runtime_library AND NOT _executorch_targets_supported)
   foreach(
     _executorch_component IN
     ITEMS libexecutorch_kernels_optimized
+          libexecutorch_kernels_torchao
           libexecutorch_backend_xnnpack
           libexecutorch_backend_mlx
           libexecutorch_backend_cuda
@@ -590,6 +592,9 @@ _executorch_define_component(threadpool executorch_threadpool)
 # checks, so it has to be defined here or a consumer following the documentation
 # gets a bare name that CMake hands to the linker as a literal flag.
 _executorch_define_component(kernels_optimized executorch_kernels_optimized)
+# The TorchAO kernels, present only in a wheel built for Apple Silicon, which is
+# the only architecture they build for.
+_executorch_define_component(kernels_torchao executorch_kernels_torchao)
 # The quantized kernels, optional in the same way: a wheel built without them
 # simply has no such library and the component is not defined.
 #

--- a/tools/cmake/preset/pybind.cmake
+++ b/tools/cmake/preset/pybind.cmake
@@ -59,9 +59,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set_overridable_option(EXECUTORCH_BUILD_EXTENSION_TRAINING ON)
   set_overridable_option(EXECUTORCH_BUILD_EXTENSION_LLM_RUNNER ON)
   set_overridable_option(EXECUTORCH_BUILD_EXTENSION_LLM ON)
-  # MLX requires Apple Silicon (ARM64) and the Metal compiler (xcrun -sdk macosx
-  # metal) which is only available with Xcode, not Command Line Tools
+  # Both of these are Apple Silicon only. The TorchAO kernels build only for
+  # aarch64, which is what TORCHAO_BUILD_CPU_AARCH64 selects; the Apple
+  # framework build already ships them and this brings the wheel in line. MLX
+  # additionally needs the Metal compiler (xcrun -sdk macosx metal), which comes
+  # with Xcode and not with the Command Line Tools.
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+    set_overridable_option(EXECUTORCH_BUILD_KERNELS_TORCHAO ON)
     execute_process(
       COMMAND xcrun -sdk macosx --find metal
       RESULT_VARIABLE _metal_compiler_result


### PR DESCRIPTION

The Apple framework build ships the TorchAO low-bit quantized kernels for every
slice it produces, and the wheel never builds them at all. So a model quantized
with those kernels runs from a Swift application and not from the wheel, on the
same machine.

Turn them on for the wheel on Apple Silicon, which is the only architecture they
build for, and ship them as a linkable component the way the other kernel sets
already are.

The kernels are declared as a static archive in the TorchAO submodule, so rather
than change a third-party target they are wrapped into a shared library the same
way the quantized kernels are. That wrapper names the thread pool explicitly,
because the kernels call into it and the wheel ships it as its own library, so this
resolves against that one copy instead of bundling a second, and it carries the same
runtime search path the other shipped libraries do so it can find them from wherever
the package is installed.

Nothing changes off Apple Silicon, and nothing changes for a build that is not
producing a wheel: without the shared option the kernels stay a static archive as
before.

Also add the component to the release checks and to the C++ documentation, so the new
library has an expected name, has its single owner asserted, and appears in the
component table a consumer reads. The checks also assert the Python extension depends
on every shipped library, and these kernels are excluded from that the same way the
quantized ones are: torchao registers its operators itself at export time, so the
extension has no reason to link them.

Test Plan:
Configured the wheel preset on macOS arm64 and confirmed the option is on and the
wrapper target exists, then built it.

The first attempt failed to link, which is what led to naming the thread pool: the
kernels reference it for their parallel loops, and the archive alone does not carry
it. With that dependency the library builds and records a dependency on the shipped
thread pool rather than absorbing a copy of it.

Verified the built library is a shared library with the unversioned name the
packaging entry looks for, and that the symbol the new ownership row uses is real,
visible to the tool that check runs, and defined by exactly one shipped library.

Corrected after CI: the first version failed the release check asserting the Python
extension depends on every shipped library, because it does not link these kernels and
has no reason to. Excluded them alongside the quantized kernels, which are excluded for
the same reason.

Also corrected after review: the library was missing the runtime search path every
other shipped library carries, so it could not have loaded from an installed wheel at
all. Verified by rebuilding and loading it from a layout with only that path present,
and by confirming it fails without it.

