### PR TITLE
[CUDA] Elide dense causal masks in long-context prefill

### DIFF
--- a/backends/cuda/tests/test_triton_sdpa.py
+++ b/backends/cuda/tests/test_triton_sdpa.py
@@ -517,6 +517,175 @@ class TestTritonSdpa(unittest.TestCase):
         self.assertFalse(torch.isnan(out).any())
         self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
 
+    # ------------------------------------------------------------------
+    # is_causal + kv_len: in-kernel bottom-right causal reconstruction
+    #
+    # This mirrors the global-attention path: instead of passing a
+    # dense [B, 1, L_q, L_kv] causal bool mask, the caller passes
+    # attn_mask=None, is_causal=True, kv_len=<filled positions>. The kernel
+    # reconstructs a standard causal mask with BOTTOM-RIGHT alignment (query row
+    # i sits at absolute position (kv_len - L_q) + i and attends to keys
+    # [0, (kv_len - L_q) + i]) — the correct semantics for chunked prefill /
+    # decode over a KV cache. These tests assert numerically equivalent output
+    # to the explicit dense bottom-right causal mask.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _dense_bottom_right_causal_mask(B, Lq, kv_len, Lk, device):
+        """Dense [B, 1, Lq, Lk] causal mask, bottom-right aligned + kv_len bound.
+
+        Row i (absolute position (kv_len - Lq) + i) attends to keys
+        [0, (kv_len - Lq) + i]; positions >= kv_len are never attended (matches
+        the FlatKVCache empty-tail semantics the kv_len bound enforces).
+        """
+        q_abs = (kv_len - Lq) + torch.arange(Lq, device=device).view(Lq, 1)
+        cache_pos = torch.arange(Lk, device=device).view(1, Lk)
+        keep = (cache_pos <= q_abs) & (cache_pos < kv_len)
+        return keep.view(1, 1, Lq, Lk).expand(B, 1, Lq, Lk).contiguous()
+
+    def test_mask_is_causal_matches_dense_prefill(self):
+        """is_causal + kv_len reconstruction == explicit dense causal, prefill shapes.
+
+        Sweeps GQA ratios and chunked-prefill shapes (L_q < L_kv, the global
+        layer case: a prefill chunk of L_q new queries over a kv_len-long
+        context in a large flat buffer).
+        """
+        D = 128  # head_dim (pow2)
+        B = 1
+        # (H_q, H_kv, L_q, kv_len, L_kv_buffer)
+        shapes = [
+            (16, 2, 128, 128, 256),  # first chunk: kv_len == L_q
+            (16, 2, 64, 200, 256),  # later chunk: L_q < kv_len < buffer
+            (8, 2, 32, 96, 512),  # smaller chunk, larger buffer
+            (4, 4, 64, 64, 128),  # MHA square
+        ]
+        for H_q, H_kv, Lq, kv_len, Lk in shapes:
+            with self.subTest(H_q=H_q, H_kv=H_kv, Lq=Lq, kv_len=kv_len, Lk=Lk):
+                torch.manual_seed(0)
+                q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+                k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                kv_len_t = torch.tensor([kv_len], dtype=torch.int32, device="cuda")
+
+                dense = self._dense_bottom_right_causal_mask(B, Lq, kv_len, Lk, "cuda")
+                out_dense = self.sdpa(
+                    q, k, v, attn_mask=dense, enable_gqa=True, kv_len=kv_len_t
+                )
+                out_inkernel = self.sdpa(
+                    q,
+                    k,
+                    v,
+                    attn_mask=None,
+                    enable_gqa=True,
+                    kv_len=kv_len_t,
+                    is_causal=True,
+                )
+                # Same masking semantics; the two paths may autotune to different
+                # tiles (different bf16 reduction order), so compare with a tight
+                # tolerance rather than bit-exact.
+                self.assertLess(
+                    _max_abs_error(out_inkernel, out_dense),
+                    MAX_ABS_TOL,
+                    "is_causal + kv_len != dense causal",
+                )
+                # And both must match the fp32 reference within tolerance.
+                ref = _reference_sdpa(q, k, v, attn_mask=dense)
+                self.assertLess(_max_abs_error(out_inkernel, ref), MAX_ABS_TOL)
+                self.assertLess(_max_abs_error(out_dense, ref), MAX_ABS_TOL)
+
+    def test_mask_is_causal_small_query_splitk(self):
+        """Verifier-sized query blocks retain bottom-right causal masking."""
+        B, H_q, H_kv, D = 1, 8, 2, 128
+        kv_len, Lk = 131, 256
+        for Lq in (2, 3, 4):
+            with self.subTest(Lq=Lq):
+                torch.manual_seed(Lq)
+                q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+                k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                kv_len_t = torch.tensor([kv_len], dtype=torch.int32, device="cuda")
+                dense = self._dense_bottom_right_causal_mask(B, Lq, kv_len, Lk, "cuda")
+
+                out = self.sdpa(
+                    q,
+                    k,
+                    v,
+                    enable_gqa=True,
+                    kv_len=kv_len_t,
+                    is_causal=True,
+                )
+                ref = _reference_sdpa(q, k, v, attn_mask=dense)
+
+                self.assertFalse(torch.isnan(out).any())
+                self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
+
+    def test_explicit_mask_composes_with_causal_kv_len(self):
+        """An explicit mask is intersected with the reconstructed causal mask."""
+        B, H_q, H_kv, Lq, Lk, D = 1, 8, 2, 4, 256, 128
+        kv_len = 131
+        torch.manual_seed(5)
+        q = torch.randn(B, H_q, Lq, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+        kv_len_t = torch.tensor([kv_len], dtype=torch.int32, device="cuda")
+        extra = torch.ones(B, 1, Lq, Lk, dtype=torch.bool, device="cuda")
+        extra[:, :, :, 1::3] = False
+        causal = self._dense_bottom_right_causal_mask(B, Lq, kv_len, Lk, "cuda")
+
+        out = self.sdpa(
+            q,
+            k,
+            v,
+            attn_mask=extra,
+            enable_gqa=True,
+            kv_len=kv_len_t,
+            is_causal=True,
+        )
+        ref = _reference_sdpa(q, k, v, attn_mask=extra & causal)
+
+        self.assertFalse(torch.isnan(out).any())
+        self.assertLess(_max_abs_error(out, ref), MAX_ABS_TOL)
+
+    def test_mask_is_causal_matches_dense_decode(self):
+        """is_causal + kv_len is a no-op vs dense for L_q==1 decode over a KV cache."""
+        D, B, H_q, H_kv = 128, 1, 16, 2
+        for kv_len, Lk in [(64, 512), (300, 512), (511, 512)]:
+            with self.subTest(kv_len=kv_len, Lk=Lk):
+                torch.manual_seed(1)
+                q = torch.randn(B, H_q, 1, D, dtype=torch.bfloat16, device="cuda")
+                k = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                v = torch.randn(B, H_kv, Lk, D, dtype=torch.bfloat16, device="cuda")
+                kv_len_t = torch.tensor([kv_len], dtype=torch.int32, device="cuda")
+
+                dense = self._dense_bottom_right_causal_mask(B, 1, kv_len, Lk, "cuda")
+                out_dense = self.sdpa(
+                    q, k, v, attn_mask=dense, enable_gqa=True, kv_len=kv_len_t
+                )
+                out_inkernel = self.sdpa(
+                    q,
+                    k,
+                    v,
+                    attn_mask=None,
+                    enable_gqa=True,
+                    kv_len=kv_len_t,
+                    is_causal=True,
+                )
+                self.assertLess(
+                    _max_abs_error(out_inkernel, out_dense),
+                    MAX_ABS_TOL,
+                    "decode is_causal + kv_len != dense",
+                )
+
+    def test_mask_is_causal_requires_kv_len(self):
+        """is_causal=True with L_q != L_kv and no kv_len should raise."""
+        B, H, Lq, Lk, D = 1, 4, 32, 64, 128
+        torch.manual_seed(0)
+        q = torch.randn(B, H, Lq, D, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn(B, H, Lk, D, dtype=torch.bfloat16, device="cuda")
+        v = torch.randn(B, H, Lk, D, dtype=torch.bfloat16, device="cuda")
+        with self.assertRaises(RuntimeError):
+            self.sdpa(q, k, v, is_causal=True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backends/cuda/triton/kernels/sdpa.py
+++ b/backends/cuda/triton/kernels/sdpa.py
@@ -206,6 +206,7 @@ def _sdpa_fwd_kernel_non_pow2(
     HAS_KV_LEN: tl.constexpr,
     NUM_GROUPS: tl.constexpr,
     PACK_GQA: tl.constexpr,
+    MASK_IS_CAUSAL: tl.constexpr = False,
 ):
     """
     SDPA forward kernel for non-power-of-2 HEAD_DIM.
@@ -287,6 +288,10 @@ def _sdpa_fwd_kernel_non_pow2(
             causal_mask = offs_n[None, :] > seq_pos[:, None]
             qk = tl.where(causal_mask, tl.full(qk.shape, NEG_INF, dtype=tl.float32), qk)
 
+        if MASK_IS_CAUSAL:
+            causal_mask = offs_n[None, :] > (kv_len - LQ) + seq_pos[:, None]
+            qk = tl.where(causal_mask, tl.full(qk.shape, NEG_INF, dtype=tl.float32), qk)
+
         if HAS_MASK:
             m_ptrs = (
                 mask_b_base
@@ -345,7 +350,7 @@ def _sdpa_fwd_kernel_non_pow2(
 # Power-of-2 HEAD_DIM kernels
 # ==============================================================================
 @triton.jit
-def _sdpa_fwd_kernel_body(
+def _sdpa_fwd_kernel_body(  # noqa: C901
     Q_ptr,
     K_ptr,
     V_ptr,
@@ -384,6 +389,7 @@ def _sdpa_fwd_kernel_body(
     HEAD_DIM: tl.constexpr,
     NUM_GROUPS: tl.constexpr,
     PACK_GQA: tl.constexpr,
+    MASK_IS_CAUSAL: tl.constexpr = False,
 ):
     """
     Shared kernel body for SDPA forward pass.
@@ -466,6 +472,8 @@ def _sdpa_fwd_kernel_body(
     # the branch is uniform and turns into a real skip (not predication).
     if IS_CAUSAL:
         max_seq_pos = tl.max(seq_pos)
+    if MASK_IS_CAUSAL:
+        max_kv_pos = (kv_len - Lq) + tl.max(seq_pos)
 
     for start_n in tl.range(0, kv_len, BLOCK_N):
         offs_n = start_n + offs_n_init
@@ -483,6 +491,8 @@ def _sdpa_fwd_kernel_body(
         elif IS_CAUSAL:
             # Block is entirely in the future for every row -> skip.
             block_active = start_n <= max_seq_pos
+        elif MASK_IS_CAUSAL:
+            block_active = start_n <= max_kv_pos
         else:
             block_active = True
 
@@ -506,6 +516,12 @@ def _sdpa_fwd_kernel_body(
 
             if IS_CAUSAL:
                 causal = offs_n[None, :] > seq_pos[:, None]
+                qk = tl.where(
+                    causal, tl.full(qk.shape, -float("inf"), dtype=tl.float32), qk
+                )
+
+            if MASK_IS_CAUSAL:
+                causal = offs_n[None, :] > (kv_len - Lq) + seq_pos[:, None]
                 qk = tl.where(
                     causal, tl.full(qk.shape, -float("inf"), dtype=tl.float32), qk
                 )
@@ -603,7 +619,16 @@ def _sdpa_prefill_prune(configs, nargs, **kwargs):
 
 @triton.autotune(
     configs=_SDPA_PREFILL_CONFIGS,
-    key=["Lq", "Lk", "HEAD_DIM", "HAS_MASK", "IS_CAUSAL", "NUM_GROUPS", "PACK_GQA"],
+    key=[
+        "Lq",
+        "Lk",
+        "HEAD_DIM",
+        "HAS_MASK",
+        "IS_CAUSAL",
+        "MASK_IS_CAUSAL",
+        "NUM_GROUPS",
+        "PACK_GQA",
+    ],
     prune_configs_by={"early_config_prune": _sdpa_prefill_prune},
 )
 @triton.jit
@@ -646,6 +671,7 @@ def _sdpa_fwd_kernel(
     PACK_GQA: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    MASK_IS_CAUSAL: tl.constexpr = False,
 ):
     _sdpa_fwd_kernel_body(
         Q_ptr,
@@ -686,6 +712,7 @@ def _sdpa_fwd_kernel(
         HEAD_DIM=HEAD_DIM,
         NUM_GROUPS=NUM_GROUPS,
         PACK_GQA=PACK_GQA,
+        MASK_IS_CAUSAL=MASK_IS_CAUSAL,
     )
 
 
@@ -776,6 +803,7 @@ def _launch_pow2_kernel(
     pack_gqa: bool,
     kv_len_ptr: Optional[torch.Tensor] = None,
     HAS_KV_LEN: bool = False,
+    mask_is_causal: bool = False,
 ) -> None:
     """Launch power-of-2 optimized SDPA kernel."""
     stride_qb, stride_qh, stride_qm, stride_qd = query.stride()
@@ -835,6 +863,7 @@ def _launch_pow2_kernel(
         HEAD_DIM=D,
         NUM_GROUPS=num_groups,
         PACK_GQA=pack_gqa,
+        MASK_IS_CAUSAL=mask_is_causal,
     )
 
 
@@ -857,6 +886,7 @@ def _launch_non_pow2_kernel(
     pack_gqa: bool,
     kv_len_ptr: Optional[torch.Tensor] = None,
     HAS_KV_LEN: bool = False,
+    mask_is_causal: bool = False,
 ) -> None:
     """Launch non-power-of-2 SDPA kernel with dynamic HEAD_DIM masking."""
     stride_qb, stride_qh, stride_qm, stride_qd = query.stride()
@@ -931,6 +961,7 @@ def _launch_non_pow2_kernel(
         HAS_KV_LEN=HAS_KV_LEN,
         NUM_GROUPS=num_groups,
         PACK_GQA=pack_gqa,
+        MASK_IS_CAUSAL=mask_is_causal,
         num_warps=num_warps,
         num_stages=num_stages,
     )
@@ -961,7 +992,8 @@ def sdpa(
         value: Value tensor [B, H_kv, L_kv, D], dtype torch.bfloat16
         attn_mask: Optional bool mask [B, 1, L_q, L_kv] (broadcast over heads)
         dropout_p: must be 0.0
-        is_causal: apply causal masking
+        is_causal: apply causal masking. With ``kv_len``, non-square inputs use
+            bottom-right causal alignment without materializing a dense mask.
         scale: attention scale (default: 1/sqrt(D))
         enable_gqa: allow H_q != H_kv (GQA/MQA)
         kv_len: Optional GPU int scalar = number of valid (filled) KV positions.
@@ -984,10 +1016,10 @@ def sdpa(
     D = D_q
     num_groups = H_q // H_kv
 
-    if is_causal and L_q != L_kv:
+    if is_causal and L_q != L_kv and kv_len is None:
         raise RuntimeError(
             f"Causal masking requires L_q == L_kv; got L_q={L_q}, L_kv={L_kv}. "
-            "For decode (L_q < L_kv), use an explicit bool mask instead."
+            "For non-square causal attention, pass kv_len."
         )
 
     out = torch.empty((B, H_q, L_q, D), device=query.device, dtype=query.dtype)
@@ -1006,6 +1038,12 @@ def sdpa(
         ).contiguous()
     else:
         kv_len_t = None
+
+    # A device-resident KV bound provides the absolute query offset needed for
+    # bottom-right causal masking. Keep an explicit mask, if present: the
+    # kernels compose it with the causal bound rather than silently dropping it.
+    mask_is_causal = is_causal and HAS_KV_LEN
+    kernel_is_causal = is_causal and not mask_is_causal
 
     # Split-K dispatch with a kv_len bound, power-of-2 head dimension, and a
     # large KV buffer. The legacy decode launcher remains isolated at L_q == 1;
@@ -1054,6 +1092,7 @@ def sdpa(
                 num_groups,
                 kv_len_t,
                 HAS_KV_LEN,
+                mask_is_causal,
             )
             return out
 
@@ -1086,11 +1125,12 @@ def sdpa(
             stride_mb,
             stride_mq,
             stride_mk,
-            is_causal,
+            kernel_is_causal,
             num_groups,
             pack_gqa,
             kv_len_t,
             HAS_KV_LEN,
+            mask_is_causal,
         )
     else:
         _launch_non_pow2_kernel(
@@ -1107,11 +1147,12 @@ def sdpa(
             D,
             sm_scale,
             HAS_MASK,
-            is_causal,
+            kernel_is_causal,
             num_groups,
             pack_gqa,
             kv_len_t,
             HAS_KV_LEN,
+            mask_is_causal,
         )
 
     return out
@@ -1621,7 +1662,7 @@ def _sdpa_decode_splitk_abstract(
         triton.Config({"BLOCK_N": 256}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_N": 256}, num_warps=8, num_stages=2),
     ],
-    key=["Lk", "HEAD_DIM", "NUM_GROUPS", "LQ", "HAS_MASK"],
+    key=["Lk", "HEAD_DIM", "NUM_GROUPS", "LQ", "HAS_MASK", "MASK_IS_CAUSAL"],
 )
 @triton.jit
 def _sdpa_small_query_splitk_kernel(
@@ -1668,6 +1709,7 @@ def _sdpa_small_query_splitk_kernel(
     chunk_size,
     HAS_MASK: tl.constexpr,
     HAS_KV_LEN: tl.constexpr,
+    MASK_IS_CAUSAL: tl.constexpr,
     BLOCK_N: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     NUM_GROUPS: tl.constexpr,
@@ -1748,6 +1790,13 @@ def _sdpa_small_query_splitk_kernel(
             )
             qk = tl.where(
                 mask_block, qk, tl.full(qk.shape, -float("inf"), dtype=tl.float32)
+            )
+
+        if MASK_IS_CAUSAL:
+            absolute_q = (kv_len - LQ) + query_rows
+            causal = offs_n[None, :] > absolute_q[:, None]
+            qk = tl.where(
+                causal, tl.full(qk.shape, -float("inf"), dtype=tl.float32), qk
             )
 
         m_ij = tl.maximum(m_i, tl.max(qk, axis=1).to(tl.float32))
@@ -1904,6 +1953,7 @@ def _launch_small_query_splitk(
     num_groups: int,
     kv_len_ptr: Optional[torch.Tensor] = None,
     HAS_KV_LEN: bool = False,
+    mask_is_causal: bool = False,
 ) -> None:
     num_splits, chunk_size = _decode_splitk_config(L_kv)
 
@@ -1973,6 +2023,7 @@ def _launch_small_query_splitk(
         chunk_size,
         HAS_MASK=HAS_MASK,
         HAS_KV_LEN=HAS_KV_LEN,
+        MASK_IS_CAUSAL=mask_is_causal,
         HEAD_DIM=D,
         NUM_GROUPS=num_groups,
         LQ=L_q,

--- a/examples/models/gemma4_31b/cuda_source_transformations.py
+++ b/examples/models/gemma4_31b/cuda_source_transformations.py
@@ -133,6 +133,10 @@ def _lenaware_attention_forward(
     O(context) instead of O(max_seq_len) — and routes L_q==1 decode through the
     length-aware split-K flash-decoding kernel. Sliding-window layers are not
     patched (they already use a bounded ring buffer).
+
+    NOTE: ``attn_mask`` is unused — the full-attention mask is standard causal,
+    so it is reconstructed in the kernel (``is_causal=True`` with ``kv_len``) to
+    save data transfer, exactly as on the TurboQuant path.
     """
     B, T, _ = x.shape
 
@@ -172,14 +176,18 @@ def _lenaware_attention_forward(
 
     # ``scale=self.scaling`` (= 1.0 for Gemma 4) — Gemma's QK-norm has absorbed
     # the 1/sqrt(d) factor into trained weights. ``enable_gqa=True`` lets the
-    # kernel handle the head ratio without materializing expanded K/V.
+    # kernel handle the head ratio without materializing expanded K/V. In-kernel
+    # causal: pass no dense mask; the kernel reconstructs the standard causal
+    # mask analytically (bottom-right aligned via kv_len), so the dense
+    # [1, 1, T, max_seq_len] bool mask is dead code and dropped by DCE -- exactly
+    # as on the TurboQuant path.
     y = torch.ops.triton.sdpa(
         q,
         k,
         v,
-        attn_mask,
+        None,  # attn_mask: reconstruct the causal mask in-kernel
         0.0,  # dropout_p
-        False,  # is_causal: attn_mask already encodes causal masking
+        True,  # is_causal: with kv_len, uses bottom-right aligned causal
         self.scaling,
         True,  # enable_gqa
         kv_len,

--- a/examples/models/muse-glimmer/source_transformations/cuda.py
+++ b/examples/models/muse-glimmer/source_transformations/cuda.py
@@ -504,6 +504,9 @@ def _lenaware_attention_forward(
     routes L_q==1 decode through the length-aware split-K flash-decoding kernel.
     Sliding-window layers are not patched (they already use a bounded ring
     buffer).
+
+    The global mask is standard causal, so reconstruct it analytically inside
+    SDPA from ``kv_len`` and avoid materializing/reading the dense mask.
     """
     B, T, _ = x.shape
 
@@ -536,14 +539,15 @@ def _lenaware_attention_forward(
 
     # scale=self.attn_scale absorbs the muP query scaling and 1/sqrt(D).
     # enable_gqa=True lets the kernel handle the 16:1 head ratio without
-    # materializing expanded K/V.
+    # materializing expanded K/V. With kv_len, is_causal uses bottom-right
+    # alignment for chunked prefill and decode.
     y = torch.ops.triton.sdpa(
         xq,
         k,
         v,
-        attn_mask,
+        None,
         0.0,  # dropout_p
-        False,  # is_causal: attn_mask already encodes causal masking
+        True,
         self.attn_scale,
         True,  # enable_gqa
         kv_len,
@@ -595,7 +599,8 @@ def cuda_source_transformations(
             n_bounded += 1
         print(
             f"[muse_glimmer cuda] length-aware SDPA: bounded {n_bounded} global-attention "
-            f"layers to runtime kv_len (O(context) attention)"
+            "layers to runtime kv_len (O(context) attention); "
+            "in-kernel causal mask (dense mask dropped)"
         )
         return
 


### PR DESCRIPTION
## Summary

Elide causal-mask-elision work on top of `split_k_nan`.

- Generate bottom-right causal bounds inside Triton SDPA instead of materializing dense masks.
- Cover standard SDPA plus the Gemma4 and Muse-Glimmer source transformations; TQ4 SDPA and its operator schema remain unchanged.
- Preserve explicit arbitrary masks by composing them with the reconstructed causal bound.
- Apply bottom-right causal masking in the verifier-sized (`L_q=2..4`) split-K path.
- Preserve the numerically stable online-softmax implementation from `split_k_nan`; this does not restore the previous `phi=5` approximation.

## Operator-level performance

RTX 5090, BF16 GQA (`B=1, Hq=32, Hkv=2, D=128`), explicit dense causal mask versus in-kernel causal reconstruction:

| Lq | Lkv | Dense mask | In-kernel causal | Speedup |
|---:|---:|---:|---:|---:|
| 128 | 16,384 | 0.643 ms | 0.505 ms | 1.27x |
| 512 | 16,384 | 1.190 ms | 1.008 ms | 1.18x |
| 512 | 32,768 | 2.397 ms | 2.004 ms | 1.20x |

## Test plan

- `lintrunner init && lintrunner -a` (clean).
- Standard Triton SDPA: 27 passed.
- TQ4 SDPA schema and implementation match `split_k_nan`; focused long-context checks: 2 passed.
- Full TQ4 kernel suite: 35 passed, 2 skipped; the export-only case requires the generated `program.fbs` resource unavailable in the ad-hoc GPU worktree.
- `git diff --check`.
