### PR TITLE
[cuda backend] support multi-SM AOTI PTEs

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -294,6 +294,7 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Release \
             -DEXECUTORCH_BUILD_CUDA=ON \
             -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
+            -DEXECUTORCH_ENABLE_LOGGING=ON \
             -DPYTHON_EXECUTABLE=python \
             -Bcmake-out .
         cmake --build cmake-out --target executor_runner -j4
@@ -359,6 +360,7 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Release \
             -DEXECUTORCH_BUILD_CUDA=ON \
             -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
+            -DEXECUTORCH_ENABLE_LOGGING=ON \
             -DPYTHON_EXECUTABLE=python \
             -Bcmake-out .
         cmake --build cmake-out --target executor_runner -j4

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -160,7 +160,7 @@ jobs:
         done
 
   export-cuda-target-smem-cross-arch:
-    name: export-cuda-target-smem-cross-arch-a100
+    name: export-cuda-multi-arch-a100
     needs: [changed-files, run-decision]
     if: |
       contains(needs.changed-files.outputs.changed-files, 'backends/cuda') ||
@@ -178,15 +178,13 @@ jobs:
       gpu-arch-version: "13.0"
       use-custom-docker-registry: false
       submodules: recursive
-      upload-artifact: cuda-target-smem-cross-arch
+      upload-artifact: cuda-multi-arch-a100
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         set -eux
 
         PYTHON_EXECUTABLE=python ./install_executorch.sh
         export LD_LIBRARY_PATH="/opt/conda/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-        # A10G (sm_86) supports 99 KiB of opt-in shared memory per block.
-        export ET_CUDA_TARGET_SMEM_BYTES=101376
         # The A100 exporter has an AVX-512 host CPU while the A10G runner has
         # AVX2. Keep the generated AOTI host wrapper compatible with both.
         export ATEN_CPU_CAPABILITY=avx2
@@ -199,16 +197,33 @@ jobs:
         assert capability == (8, 0), f"Expected A100 sm_80 exporter, got {capability}"
         PY
 
-        for model in linear sdpa; do
-          model_dir="${RUNNER_ARTIFACT_DIR}/${model}"
-          mkdir -p "${model_dir}"
+        # Export an sm80 native PTE with no PTX. This artifact must fail on the
+        # A10G because its metadata has neither an sm86 native variant nor PTX.
+        model_dir="${RUNNER_ARTIFACT_DIR}/native-sm80/linear"
+        mkdir -p "${model_dir}"
+        TORCHINDUCTOR_CACHE_DIR="${RUNNER_TEMP}/inductor-native-sm80" \
           python -m examples.cuda.scripts.export \
+            --model_name=linear \
+            --output_dir="${model_dir}" \
+            --cuda_include_ptx=OFF \
+            --seed=0
+
+        # Export the explicit PTX fallback separately. A10G supports 99 KiB of
+        # opt-in shared memory per block, so constrain the A100 export to it.
+        for model in linear sdpa; do
+          model_dir="${RUNNER_ARTIFACT_DIR}/fallback-sm80/${model}"
+          mkdir -p "${model_dir}"
+          ET_CUDA_TARGET_SMEM_BYTES=101376 \
+          TORCHINDUCTOR_CACHE_DIR="${RUNNER_TEMP}/inductor-fallback-sm80-${model}" \
+            python -m examples.cuda.scripts.export \
             --model_name="${model}" \
-            --output_dir "${model_dir}"
+            --output_dir="${model_dir}" \
+            --cuda_include_ptx=ON \
+            --seed=0
         done
 
   test-cuda-target-smem-cross-arch:
-    name: test-cuda-target-smem-cross-arch-a10g
+    name: merge-and-test-cuda-multi-arch-a10g
     needs: [export-cuda-target-smem-cross-arch]
     if: needs.export-cuda-target-smem-cross-arch.result == 'success'
     uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
@@ -222,7 +237,8 @@ jobs:
       gpu-arch-version: "13.0"
       use-custom-docker-registry: false
       submodules: recursive
-      download-artifact: cuda-target-smem-cross-arch
+      download-artifact: cuda-multi-arch-a100
+      upload-artifact: cuda-multi-arch-merged
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       script: |
         set -eux
@@ -243,6 +259,38 @@ jobs:
         )
         PY
 
+        # Independently export an sm86 native PTE with no PTX. A fixed seed
+        # makes its external weights byte-identical to both A100 exports.
+        model_dir="${RUNNER_ARTIFACT_DIR}/native-sm86/linear"
+        mkdir -p "${model_dir}"
+        TORCHINDUCTOR_CACHE_DIR="${RUNNER_TEMP}/inductor-native-sm86" \
+          python -m examples.cuda.scripts.export \
+            --model_name=linear \
+            --output_dir="${model_dir}" \
+            --cuda_include_ptx=OFF \
+            --seed=0
+
+        sm80_ptd="${RUNNER_ARTIFACT_DIR}/native-sm80/linear/aoti_cuda_blob.ptd"
+        sm86_ptd="${RUNNER_ARTIFACT_DIR}/native-sm86/linear/aoti_cuda_blob.ptd"
+        fallback_ptd="${RUNNER_ARTIFACT_DIR}/fallback-sm80/linear/aoti_cuda_blob.ptd"
+        cmp "${sm80_ptd}" "${sm86_ptd}"
+        cmp "${sm80_ptd}" "${fallback_ptd}"
+        sha256sum "${sm80_ptd}" "${sm86_ptd}" "${fallback_ptd}"
+
+        merged_dir="${RUNNER_ARTIFACT_DIR}/merged"
+        mkdir -p "${merged_dir}"
+        python -m executorch.backends.cuda.merge_ptes \
+          --input-pte "${RUNNER_ARTIFACT_DIR}/native-sm80/linear/linear.pte" \
+          --input-pte "${RUNNER_ARTIFACT_DIR}/native-sm86/linear/linear.pte" \
+          --input-ptd "${sm80_ptd}" \
+          --input-ptd "${sm86_ptd}" \
+          --fallback-pte "${RUNNER_ARTIFACT_DIR}/fallback-sm80/linear/linear.pte" \
+          --fallback-ptd "${fallback_ptd}" \
+          --output-pte "${merged_dir}/linear.pte" \
+          --output-ptd "${merged_dir}/aoti_cuda_blob.ptd" \
+          | tee "${merged_dir}/provenance.txt"
+        cmp "${sm80_ptd}" "${merged_dir}/aoti_cuda_blob.ptd"
+
         cmake -DCMAKE_BUILD_TYPE=Release \
             -DEXECUTORCH_BUILD_CUDA=ON \
             -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
@@ -251,11 +299,98 @@ jobs:
         cmake --build cmake-out --target executor_runner -j4
 
         for model in linear sdpa; do
-          model_dir="${RUNNER_ARTIFACT_DIR}/${model}"
+          model_dir="${RUNNER_ARTIFACT_DIR}/fallback-sm80/${model}"
           ./cmake-out/executor_runner \
             --model_path "${model_dir}/${model}.pte" \
             --data_path "${model_dir}/aoti_cuda_blob.ptd"
         done
+
+        # The local native PTE and merged PTE must run on sm86.
+        ./cmake-out/executor_runner \
+          --model_path "${RUNNER_ARTIFACT_DIR}/native-sm86/linear/linear.pte" \
+          --data_path "${sm86_ptd}"
+        ./cmake-out/executor_runner \
+          --model_path "${merged_dir}/linear.pte" \
+          --data_path "${merged_dir}/aoti_cuda_blob.ptd"
+
+        # The sm80 native-only PTE must be rejected on sm86.
+        set +e
+        ./cmake-out/executor_runner \
+          --model_path "${RUNNER_ARTIFACT_DIR}/native-sm80/linear/linear.pte" \
+          --data_path "${sm80_ptd}" \
+          >"${RUNNER_ARTIFACT_DIR}/native-sm80-on-sm86.log" 2>&1
+        native_status=$?
+        set -e
+        cat "${RUNNER_ARTIFACT_DIR}/native-sm80-on-sm86.log"
+        test "${native_status}" -ne 0
+        grep -q "no native or PTX variant compatible with sm86" \
+          "${RUNNER_ARTIFACT_DIR}/native-sm80-on-sm86.log"
+
+  test-cuda-merged-pte-a100:
+    name: test-cuda-merged-pte-a100
+    needs: [test-cuda-target-smem-cross-arch]
+    if: needs.test-cuda-target-smem-cross-arch.result == 'success'
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      timeout: 90
+      runner: mt-l-x86iavx512-11-125-a100
+      gpu-arch-type: cuda
+      gpu-arch-version: "13.0"
+      use-custom-docker-registry: false
+      submodules: recursive
+      download-artifact: cuda-multi-arch-merged
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      script: |
+        set -eux
+
+        PYTHON_EXECUTABLE=python ./install_executorch.sh
+        export LD_LIBRARY_PATH="/opt/conda/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+        python - <<'PY'
+        import torch
+
+        capability = torch.cuda.get_device_capability()
+        assert capability == (8, 0), f"Expected A100 sm_80 runner, got {capability}"
+        PY
+
+        cmake -DCMAKE_BUILD_TYPE=Release \
+            -DEXECUTORCH_BUILD_CUDA=ON \
+            -DEXECUTORCH_BUILD_EXTENSION_TENSOR=ON \
+            -DPYTHON_EXECUTABLE=python \
+            -Bcmake-out .
+        cmake --build cmake-out --target executor_runner -j4
+
+        sm80_ptd="${RUNNER_ARTIFACT_DIR}/native-sm80/linear/aoti_cuda_blob.ptd"
+        sm86_ptd="${RUNNER_ARTIFACT_DIR}/native-sm86/linear/aoti_cuda_blob.ptd"
+        fallback_ptd="${RUNNER_ARTIFACT_DIR}/fallback-sm80/linear/aoti_cuda_blob.ptd"
+        merged_ptd="${RUNNER_ARTIFACT_DIR}/merged/aoti_cuda_blob.ptd"
+        cmp "${sm80_ptd}" "${sm86_ptd}"
+        cmp "${sm80_ptd}" "${fallback_ptd}"
+        cmp "${sm80_ptd}" "${merged_ptd}"
+
+        # The local native PTE and merged PTE must run on sm80.
+        ./cmake-out/executor_runner \
+          --model_path "${RUNNER_ARTIFACT_DIR}/native-sm80/linear/linear.pte" \
+          --data_path "${sm80_ptd}"
+        ./cmake-out/executor_runner \
+          --model_path "${RUNNER_ARTIFACT_DIR}/merged/linear.pte" \
+          --data_path "${merged_ptd}"
+
+        # The sm86 native-only PTE must be rejected on sm80.
+        set +e
+        ./cmake-out/executor_runner \
+          --model_path "${RUNNER_ARTIFACT_DIR}/native-sm86/linear/linear.pte" \
+          --data_path "${sm86_ptd}" \
+          >"${RUNNER_ARTIFACT_DIR}/native-sm86-on-sm80.log" 2>&1
+        native_status=$?
+        set -e
+        cat "${RUNNER_ARTIFACT_DIR}/native-sm86-on-sm80.log"
+        test "${native_status}" -ne 0
+        grep -q "no native or PTX variant compatible with sm80" \
+          "${RUNNER_ARTIFACT_DIR}/native-sm86-on-sm80.log"
 
   unittest-cuda:
     name: unittest-cuda

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -370,6 +370,11 @@ jobs:
         conda install -y -c conda-forge 'libstdcxx-ng>=12'
         export LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
 
+        python -m pytest \
+          backends/cuda/tests/test_cuda_weight_metadata.py \
+          backends/cuda/tests/test_merge_ptes.py \
+          -v -o "addopts="
+
         cmake --preset llm-release-cuda -DEXECUTORCH_BUILD_TESTS=ON
         cmake --build cmake-out --target test_cuda_allocator test_cuda_mutable_state test_cuda_weight_cache -j$(nproc)
         ctest --test-dir cmake-out -R test_cuda_allocator --output-on-failure -V

--- a/backends/cuda/BUCK
+++ b/backends/cuda/BUCK
@@ -118,6 +118,7 @@ fbcode_target(
     visibility = ["PUBLIC"],
     deps = [
         ":cuda_backend",
+        "//caffe2:torch",
         "//executorch/exir/_serialize:lib",
         "//executorch/exir:schema",
         "//executorch/extension/flat_tensor/serialize:serialize",

--- a/backends/cuda/BUCK
+++ b/backends/cuda/BUCK
@@ -111,6 +111,21 @@ fbcode_target(
 
 fbcode_target(
     _kind = runtime.python_library,
+    name = "merge_ptes",
+    srcs = [
+        "merge_ptes.py",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        ":cuda_backend",
+        "//executorch/exir/_serialize:lib",
+        "//executorch/exir:schema",
+        "//executorch/extension/flat_tensor/serialize:serialize",
+    ],
+)
+
+fbcode_target(
+    _kind = runtime.python_library,
     name = "cuda_partitioner",
     srcs = [
         "cuda_partitioner.py",

--- a/backends/cuda/cuda_backend.py
+++ b/backends/cuda/cuda_backend.py
@@ -520,6 +520,14 @@ class CudaBackend(AotiBackend, BackendDetails):
             return False
 
     @classmethod
+    def _should_include_ptx(cls, compile_specs: List[CompileSpec]) -> bool:
+        include_ptx = True
+        for spec in compile_specs:
+            if spec.key == "cuda_include_ptx":
+                include_ptx = _on_off_compile_spec_value(spec)
+        return include_ptx and cls._setup_cuda_environment_for_fatbin()
+
+    @classmethod
     def save_data_externally(cls) -> bool:
         """
         CUDA backend saves weight storages (and, when configured, SO blobs) in
@@ -539,7 +547,29 @@ class CudaBackend(AotiBackend, BackendDetails):
             result = super().preprocess(edge_program, compile_specs)
         if capture.artifact is None:
             raise RuntimeError("CUDA AOTI did not return a structured Weights output")
-        collector.add_preprocess_result(result, capture.artifact, cls.get_device_name())
+        target_sm = None
+        ptx_compute = 0
+        if torch.version.hip is None:
+            from torch._inductor.codegen.cuda.compile_utils import (
+                _nvcc_arch_as_compile_option,
+            )
+
+            compiled_arch = _nvcc_arch_as_compile_option()
+            target_arch = compiled_arch.removesuffix("a")
+            if not target_arch.isdigit():
+                raise RuntimeError(f"Unsupported CUDA architecture: {compiled_arch}")
+            target_sm = int(target_arch)
+            # Architecture-accelerated PTX targets such as compute_90a and
+            # compute_120a are not forward-compatible fallback images.
+            if cls._should_include_ptx(compile_specs) and compiled_arch.isdigit():
+                ptx_compute = int(compiled_arch)
+        collector.add_preprocess_result(
+            result,
+            capture.artifact,
+            cls.get_device_name(),
+            target_sm=target_sm,
+            ptx_compute=ptx_compute,
+        )
         return result
 
     @classmethod
@@ -759,7 +789,7 @@ class CudaBackend(AotiBackend, BackendDetails):
 
         # Configure CUDA environment variables based on detected version
 
-        emit_multi_arch_kernel = CudaBackend._setup_cuda_environment_for_fatbin()
+        emit_multi_arch_kernel = cls._should_include_ptx(compile_specs)
         # Base options for all platforms
 
         options: Dict[str, typing.Any] = {

--- a/backends/cuda/cuda_weight_collector.py
+++ b/backends/cuda/cuda_weight_collector.py
@@ -24,6 +24,7 @@ from executorch.exir.tensor import scalar_type_enum
 
 CUDA_WEIGHT_CACHE_MAGIC = b"ETCUDAFQN3"
 CUDA_MULTI_ARCH_MAGIC = b"ETCUDAFQN4"
+CUDA_MULTI_ARCH_FALLBACK_MAGIC = b"ETCUDAFQN5"
 
 AOTI_DEVICE_TYPE_CPU = 0
 AOTI_DEVICE_TYPE_CUDA = 1
@@ -49,16 +50,17 @@ class CudaWeightArtifact:
 
 @dataclass(frozen=True)
 class CudaAotiVariant:
-    """One native AOTI shared library and its CUDA compatibility metadata."""
+    """One AOTI shared library and its CUDA runtime-selection metadata."""
 
     target_sm: int
     ptx_compute: int
     so_blob_key: str
+    fallback_only: bool = False
 
 
 @dataclass(frozen=True)
 class CudaAotiMetadata:
-    """CUDA AOTI code variants sharing one FQN weight manifest."""
+    """CUDA AOTI native and fallback variants sharing one weight manifest."""
 
     variants: List[CudaAotiVariant]
     entries: List[CudaWeightEntry]
@@ -170,7 +172,10 @@ def encode_cuda_multi_arch_metadata(
     if not variants:
         raise ValueError("CUDA AOTI metadata requires at least one variant")
 
-    output = bytearray(CUDA_MULTI_ARCH_MAGIC)
+    has_fallback = any(variant.fallback_only for variant in variants)
+    output = bytearray(
+        CUDA_MULTI_ARCH_FALLBACK_MAGIC if has_fallback else CUDA_MULTI_ARCH_MAGIC
+    )
 
     def write_string(value: str) -> None:
         encoded = value.encode("utf-8")
@@ -178,11 +183,12 @@ def encode_cuda_multi_arch_metadata(
         output.extend(encoded)
 
     target_sms = set()
+    fallback_count = 0
     output.extend(struct.pack("<I", len(variants)))
     for variant in variants:
         if variant.target_sm <= 0:
             raise ValueError(f"Invalid CUDA target SM: {variant.target_sm}")
-        if variant.target_sm in target_sms:
+        if not variant.fallback_only and variant.target_sm in target_sms:
             raise ValueError(f"Duplicate CUDA target SM: {variant.target_sm}")
         if variant.ptx_compute < 0 or variant.ptx_compute > variant.target_sm:
             raise ValueError(
@@ -190,9 +196,20 @@ def encode_cuda_multi_arch_metadata(
             )
         if not variant.so_blob_key:
             raise ValueError("CUDA AOTI variant is missing its shared-object key")
-        target_sms.add(variant.target_sm)
+        if variant.fallback_only:
+            fallback_count += 1
+            if variant.ptx_compute == 0:
+                raise ValueError("CUDA fallback variant must contain PTX")
+        else:
+            target_sms.add(variant.target_sm)
+            if has_fallback and variant.ptx_compute != 0:
+                raise ValueError("Regular CUDA variants cannot advertise PTX fallback")
         output.extend(struct.pack("<II", variant.target_sm, variant.ptx_compute))
+        if has_fallback:
+            output.extend(struct.pack("<I", int(variant.fallback_only)))
         write_string(variant.so_blob_key)
+    if fallback_count > 1:
+        raise ValueError("CUDA AOTI metadata supports only one fallback variant")
 
     output.extend(struct.pack("<I", len(entries)))
     for entry in entries:
@@ -285,31 +302,49 @@ def decode_cuda_aoti_metadata(data: bytes) -> CudaAotiMetadata:
         if not so_blob_key:
             raise ValueError("CUDA AOTI metadata is missing its shared-object key")
         variants.append(CudaAotiVariant(0, 0, so_blob_key))
-    elif magic == CUDA_MULTI_ARCH_MAGIC:
+    elif magic in (CUDA_MULTI_ARCH_MAGIC, CUDA_MULTI_ARCH_FALLBACK_MAGIC):
+        has_fallback = magic == CUDA_MULTI_ARCH_FALLBACK_MAGIC
         (num_variants,) = reader.unpack("<I")
         if num_variants == 0 or num_variants > 256:
             raise ValueError(
                 f"CUDA AOTI metadata has invalid variant count: {num_variants}"
             )
         target_sms = set()
+        fallback_count = 0
         for _ in range(num_variants):
             target_sm, ptx_compute = reader.unpack("<II")
+            (flags,) = reader.unpack("<I") if has_fallback else (0,)
+            fallback_only = bool(flags & 1)
             so_blob_key = reader.read_string()
             if (
                 target_sm == 0
-                or target_sm in target_sms
                 or ptx_compute > target_sm
+                or flags & ~1
                 or not so_blob_key
             ):
                 raise ValueError("CUDA AOTI metadata contains an invalid variant")
-            target_sms.add(target_sm)
+            if fallback_only:
+                fallback_count += 1
+                if ptx_compute == 0:
+                    raise ValueError(
+                        "CUDA AOTI metadata contains an invalid fallback variant"
+                    )
+            else:
+                if target_sm in target_sms or (has_fallback and ptx_compute != 0):
+                    raise ValueError(
+                        "CUDA AOTI metadata contains an invalid regular variant"
+                    )
+                target_sms.add(target_sm)
             variants.append(
                 CudaAotiVariant(
                     target_sm=target_sm,
                     ptx_compute=ptx_compute,
                     so_blob_key=so_blob_key,
+                    fallback_only=fallback_only,
                 )
             )
+        if fallback_count > 1:
+            raise ValueError("CUDA AOTI metadata contains multiple fallback variants")
     else:
         raise ValueError("Unrecognized CUDA AOTI metadata")
 

--- a/backends/cuda/cuda_weight_collector.py
+++ b/backends/cuda/cuda_weight_collector.py
@@ -165,6 +165,38 @@ def encode_cuda_weight_metadata(
     return bytes(output)
 
 
+def _validate_cuda_aoti_variant(
+    variant: CudaAotiVariant, has_fallback: bool, regular_sms: set[int]
+) -> None:
+    if variant.target_sm <= 0:
+        raise ValueError(f"Invalid CUDA target SM: {variant.target_sm}")
+    if variant.ptx_compute < 0 or variant.ptx_compute > variant.target_sm:
+        raise ValueError(
+            f"Invalid PTX compute target {variant.ptx_compute} for sm{variant.target_sm}"
+        )
+    if not variant.so_blob_key:
+        raise ValueError("CUDA AOTI variant is missing its shared-object key")
+    if variant.fallback_only:
+        if variant.ptx_compute == 0:
+            raise ValueError("CUDA fallback variant must contain PTX")
+        return
+    if variant.target_sm in regular_sms:
+        raise ValueError(f"Duplicate CUDA target SM: {variant.target_sm}")
+    regular_sms.add(variant.target_sm)
+    if has_fallback and variant.ptx_compute != 0:
+        raise ValueError("Regular CUDA variants cannot advertise PTX fallback")
+
+
+def _validate_cuda_aoti_variants(
+    variants: List[CudaAotiVariant], has_fallback: bool
+) -> None:
+    if sum(variant.fallback_only for variant in variants) > 1:
+        raise ValueError("CUDA AOTI metadata supports only one fallback variant")
+    regular_sms: set[int] = set()
+    for variant in variants:
+        _validate_cuda_aoti_variant(variant, has_fallback, regular_sms)
+
+
 def encode_cuda_multi_arch_metadata(
     variants: List[CudaAotiVariant], entries: List[CudaWeightEntry]
 ) -> bytes:
@@ -173,6 +205,7 @@ def encode_cuda_multi_arch_metadata(
         raise ValueError("CUDA AOTI metadata requires at least one variant")
 
     has_fallback = any(variant.fallback_only for variant in variants)
+    _validate_cuda_aoti_variants(variants, has_fallback)
     output = bytearray(
         CUDA_MULTI_ARCH_FALLBACK_MAGIC if has_fallback else CUDA_MULTI_ARCH_MAGIC
     )
@@ -182,34 +215,12 @@ def encode_cuda_multi_arch_metadata(
         output.extend(struct.pack("<I", len(encoded)))
         output.extend(encoded)
 
-    target_sms = set()
-    fallback_count = 0
     output.extend(struct.pack("<I", len(variants)))
     for variant in variants:
-        if variant.target_sm <= 0:
-            raise ValueError(f"Invalid CUDA target SM: {variant.target_sm}")
-        if not variant.fallback_only and variant.target_sm in target_sms:
-            raise ValueError(f"Duplicate CUDA target SM: {variant.target_sm}")
-        if variant.ptx_compute < 0 or variant.ptx_compute > variant.target_sm:
-            raise ValueError(
-                f"Invalid PTX compute target {variant.ptx_compute} for sm{variant.target_sm}"
-            )
-        if not variant.so_blob_key:
-            raise ValueError("CUDA AOTI variant is missing its shared-object key")
-        if variant.fallback_only:
-            fallback_count += 1
-            if variant.ptx_compute == 0:
-                raise ValueError("CUDA fallback variant must contain PTX")
-        else:
-            target_sms.add(variant.target_sm)
-            if has_fallback and variant.ptx_compute != 0:
-                raise ValueError("Regular CUDA variants cannot advertise PTX fallback")
         output.extend(struct.pack("<II", variant.target_sm, variant.ptx_compute))
         if has_fallback:
             output.extend(struct.pack("<I", int(variant.fallback_only)))
         write_string(variant.so_blob_key)
-    if fallback_count > 1:
-        raise ValueError("CUDA AOTI metadata supports only one fallback variant")
 
     output.extend(struct.pack("<I", len(entries)))
     for entry in entries:

--- a/backends/cuda/cuda_weight_collector.py
+++ b/backends/cuda/cuda_weight_collector.py
@@ -22,9 +22,7 @@ from executorch.exir.backend.backend_details import PreprocessResult
 from executorch.exir.tensor import scalar_type_enum
 
 
-CUDA_WEIGHT_CACHE_MAGIC = b"ETCUDAFQN3"
-CUDA_MULTI_ARCH_MAGIC = b"ETCUDAFQN4"
-CUDA_MULTI_ARCH_FALLBACK_MAGIC = b"ETCUDAFQN5"
+CUDA_AOTI_METADATA_MAGIC = b"ETCUDAFQN0"
 
 AOTI_DEVICE_TYPE_CPU = 0
 AOTI_DEVICE_TYPE_CUDA = 1
@@ -134,41 +132,10 @@ def _is_aoti_library_local_fqn(fqn: str) -> bool:
     return fqn.startswith("_tensor_constant")
 
 
-def encode_cuda_weight_metadata(
-    so_blob_key: str, entries: List[CudaWeightEntry]
-) -> bytes:
-    """Encode the per-method FQN-to-tensor metadata consumed by CUDA runtime."""
-    output = bytearray(CUDA_WEIGHT_CACHE_MAGIC)
-
-    def write_string(value: str) -> None:
-        encoded = value.encode("utf-8")
-        output.extend(struct.pack("<I", len(encoded)))
-        output.extend(encoded)
-
-    write_string(so_blob_key)
-    output.extend(struct.pack("<I", len(entries)))
-    for entry in entries:
-        write_string(entry.fqn)
-        write_string(entry.storage_key)
-        output.extend(
-            struct.pack(
-                "<QiiqI",
-                entry.storage_nbytes,
-                entry.dtype,
-                entry.device_type,
-                entry.storage_offset,
-                len(entry.sizes),
-            )
-        )
-        output.extend(struct.pack(f"<{len(entry.sizes)}q", *entry.sizes))
-        output.extend(struct.pack(f"<{len(entry.strides)}q", *entry.strides))
-    return bytes(output)
-
-
 def _validate_cuda_aoti_variant(
     variant: CudaAotiVariant, has_fallback: bool, regular_sms: set[int]
 ) -> None:
-    if variant.target_sm <= 0:
+    if variant.target_sm < 0:
         raise ValueError(f"Invalid CUDA target SM: {variant.target_sm}")
     if variant.ptx_compute < 0 or variant.ptx_compute > variant.target_sm:
         raise ValueError(
@@ -190,14 +157,29 @@ def _validate_cuda_aoti_variant(
 def _validate_cuda_aoti_variants(
     variants: List[CudaAotiVariant], has_fallback: bool
 ) -> None:
+    untargeted = [variant for variant in variants if variant.target_sm == 0]
+    if untargeted:
+        if len(variants) != 1 or untargeted[0].ptx_compute or has_fallback:
+            raise ValueError(
+                "Untargeted CUDA AOTI metadata requires one non-fallback variant"
+            )
+        if not untargeted[0].so_blob_key:
+            raise ValueError("CUDA AOTI variant is missing its shared-object key")
+        return
     if sum(variant.fallback_only for variant in variants) > 1:
         raise ValueError("CUDA AOTI metadata supports only one fallback variant")
+    if len(variants) > 1 and any(
+        variant.ptx_compute and not variant.fallback_only for variant in variants
+    ):
+        raise ValueError(
+            "Multi-variant CUDA AOTI metadata requires an explicit PTX fallback"
+        )
     regular_sms: set[int] = set()
     for variant in variants:
         _validate_cuda_aoti_variant(variant, has_fallback, regular_sms)
 
 
-def encode_cuda_multi_arch_metadata(
+def encode_cuda_aoti_metadata(
     variants: List[CudaAotiVariant], entries: List[CudaWeightEntry]
 ) -> bytes:
     """Encode CUDA AOTI variants followed by one shared weight manifest."""
@@ -206,9 +188,7 @@ def encode_cuda_multi_arch_metadata(
 
     has_fallback = any(variant.fallback_only for variant in variants)
     _validate_cuda_aoti_variants(variants, has_fallback)
-    output = bytearray(
-        CUDA_MULTI_ARCH_FALLBACK_MAGIC if has_fallback else CUDA_MULTI_ARCH_MAGIC
-    )
+    output = bytearray(CUDA_AOTI_METADATA_MAGIC)
 
     def write_string(value: str) -> None:
         encoded = value.encode("utf-8")
@@ -218,8 +198,7 @@ def encode_cuda_multi_arch_metadata(
     output.extend(struct.pack("<I", len(variants)))
     for variant in variants:
         output.extend(struct.pack("<II", variant.target_sm, variant.ptx_compute))
-        if has_fallback:
-            output.extend(struct.pack("<I", int(variant.fallback_only)))
+        output.extend(struct.pack("<I", int(variant.fallback_only)))
         write_string(variant.so_blob_key)
 
     output.extend(struct.pack("<I", len(entries)))
@@ -304,60 +283,33 @@ def _decode_weight_entries(reader: _MetadataReader) -> List[CudaWeightEntry]:
 
 
 def decode_cuda_aoti_metadata(data: bytes) -> CudaAotiMetadata:
-    """Decode legacy single-SO or multi-SM CUDA AOTI metadata."""
+    """Decode CUDA AOTI variant and shared-weight metadata."""
     reader = _MetadataReader(data)
-    magic = bytes(reader.read(len(CUDA_WEIGHT_CACHE_MAGIC)))
-    variants = []
-    if magic == CUDA_WEIGHT_CACHE_MAGIC:
-        so_blob_key = reader.read_string()
-        if not so_blob_key:
-            raise ValueError("CUDA AOTI metadata is missing its shared-object key")
-        variants.append(CudaAotiVariant(0, 0, so_blob_key))
-    elif magic in (CUDA_MULTI_ARCH_MAGIC, CUDA_MULTI_ARCH_FALLBACK_MAGIC):
-        has_fallback = magic == CUDA_MULTI_ARCH_FALLBACK_MAGIC
-        (num_variants,) = reader.unpack("<I")
-        if num_variants == 0 or num_variants > 256:
-            raise ValueError(
-                f"CUDA AOTI metadata has invalid variant count: {num_variants}"
-            )
-        target_sms = set()
-        fallback_count = 0
-        for _ in range(num_variants):
-            target_sm, ptx_compute = reader.unpack("<II")
-            (flags,) = reader.unpack("<I") if has_fallback else (0,)
-            fallback_only = bool(flags & 1)
-            so_blob_key = reader.read_string()
-            if (
-                target_sm == 0
-                or ptx_compute > target_sm
-                or flags & ~1
-                or not so_blob_key
-            ):
-                raise ValueError("CUDA AOTI metadata contains an invalid variant")
-            if fallback_only:
-                fallback_count += 1
-                if ptx_compute == 0:
-                    raise ValueError(
-                        "CUDA AOTI metadata contains an invalid fallback variant"
-                    )
-            else:
-                if target_sm in target_sms or (has_fallback and ptx_compute != 0):
-                    raise ValueError(
-                        "CUDA AOTI metadata contains an invalid regular variant"
-                    )
-                target_sms.add(target_sm)
-            variants.append(
-                CudaAotiVariant(
-                    target_sm=target_sm,
-                    ptx_compute=ptx_compute,
-                    so_blob_key=so_blob_key,
-                    fallback_only=fallback_only,
-                )
-            )
-        if fallback_count > 1:
-            raise ValueError("CUDA AOTI metadata contains multiple fallback variants")
-    else:
+    magic = bytes(reader.read(len(CUDA_AOTI_METADATA_MAGIC)))
+    if magic != CUDA_AOTI_METADATA_MAGIC:
         raise ValueError("Unrecognized CUDA AOTI metadata")
+
+    variants = []
+    (num_variants,) = reader.unpack("<I")
+    if num_variants == 0 or num_variants > 256:
+        raise ValueError(
+            f"CUDA AOTI metadata has invalid variant count: {num_variants}"
+        )
+    for _ in range(num_variants):
+        target_sm, ptx_compute, flags = reader.unpack("<III")
+        if flags & ~1:
+            raise ValueError("CUDA AOTI metadata contains invalid variant flags")
+        variants.append(
+            CudaAotiVariant(
+                target_sm=target_sm,
+                ptx_compute=ptx_compute,
+                so_blob_key=reader.read_string(),
+                fallback_only=bool(flags & 1),
+            )
+        )
+    _validate_cuda_aoti_variants(
+        variants, any(variant.fallback_only for variant in variants)
+    )
 
     entries = _decode_weight_entries(reader)
     reader.finish()
@@ -565,15 +517,10 @@ class CudaWeightCollector:
             self._add_weight(entry, data, external_tag)
             serialized_entries.append(entry)
 
-        if target_sm is None:
-            result.processed_bytes = encode_cuda_weight_metadata(
-                so_blob_key, serialized_entries
-            )
-        else:
-            result.processed_bytes = encode_cuda_multi_arch_metadata(
-                [CudaAotiVariant(target_sm, ptx_compute, so_blob_key)],
-                serialized_entries,
-            )
+        result.processed_bytes = encode_cuda_aoti_metadata(
+            [CudaAotiVariant(target_sm or 0, ptx_compute, so_blob_key)],
+            serialized_entries,
+        )
         self._results.append(result)
 
     def finish(self) -> None:

--- a/backends/cuda/cuda_weight_collector.py
+++ b/backends/cuda/cuda_weight_collector.py
@@ -23,6 +23,7 @@ from executorch.exir.tensor import scalar_type_enum
 
 
 CUDA_WEIGHT_CACHE_MAGIC = b"ETCUDAFQN3"
+CUDA_MULTI_ARCH_MAGIC = b"ETCUDAFQN4"
 
 AOTI_DEVICE_TYPE_CPU = 0
 AOTI_DEVICE_TYPE_CUDA = 1
@@ -44,6 +45,23 @@ class CudaWeightEntry:
 class CudaWeightArtifact:
     entries: List[CudaWeightEntry]
     storages: Dict[str, FileBackedData]
+
+
+@dataclass(frozen=True)
+class CudaAotiVariant:
+    """One native AOTI shared library and its CUDA compatibility metadata."""
+
+    target_sm: int
+    ptx_compute: int
+    so_blob_key: str
+
+
+@dataclass(frozen=True)
+class CudaAotiMetadata:
+    """CUDA AOTI code variants sharing one FQN weight manifest."""
+
+    variants: List[CudaAotiVariant]
+    entries: List[CudaWeightEntry]
 
 
 @dataclass
@@ -143,6 +161,161 @@ def encode_cuda_weight_metadata(
         output.extend(struct.pack(f"<{len(entry.sizes)}q", *entry.sizes))
         output.extend(struct.pack(f"<{len(entry.strides)}q", *entry.strides))
     return bytes(output)
+
+
+def encode_cuda_multi_arch_metadata(
+    variants: List[CudaAotiVariant], entries: List[CudaWeightEntry]
+) -> bytes:
+    """Encode CUDA AOTI variants followed by one shared weight manifest."""
+    if not variants:
+        raise ValueError("CUDA AOTI metadata requires at least one variant")
+
+    output = bytearray(CUDA_MULTI_ARCH_MAGIC)
+
+    def write_string(value: str) -> None:
+        encoded = value.encode("utf-8")
+        output.extend(struct.pack("<I", len(encoded)))
+        output.extend(encoded)
+
+    target_sms = set()
+    output.extend(struct.pack("<I", len(variants)))
+    for variant in variants:
+        if variant.target_sm <= 0:
+            raise ValueError(f"Invalid CUDA target SM: {variant.target_sm}")
+        if variant.target_sm in target_sms:
+            raise ValueError(f"Duplicate CUDA target SM: {variant.target_sm}")
+        if variant.ptx_compute < 0 or variant.ptx_compute > variant.target_sm:
+            raise ValueError(
+                f"Invalid PTX compute target {variant.ptx_compute} for sm{variant.target_sm}"
+            )
+        if not variant.so_blob_key:
+            raise ValueError("CUDA AOTI variant is missing its shared-object key")
+        target_sms.add(variant.target_sm)
+        output.extend(struct.pack("<II", variant.target_sm, variant.ptx_compute))
+        write_string(variant.so_blob_key)
+
+    output.extend(struct.pack("<I", len(entries)))
+    for entry in entries:
+        write_string(entry.fqn)
+        write_string(entry.storage_key)
+        output.extend(
+            struct.pack(
+                "<QiiqI",
+                entry.storage_nbytes,
+                entry.dtype,
+                entry.device_type,
+                entry.storage_offset,
+                len(entry.sizes),
+            )
+        )
+        output.extend(struct.pack(f"<{len(entry.sizes)}q", *entry.sizes))
+        output.extend(struct.pack(f"<{len(entry.strides)}q", *entry.strides))
+    return bytes(output)
+
+
+class _MetadataReader:
+    def __init__(self, data: bytes) -> None:
+        self._data = memoryview(data)
+        self._offset = 0
+
+    def read(self, size: int) -> memoryview:
+        end = self._offset + size
+        if size < 0 or end > len(self._data):
+            raise ValueError("Truncated CUDA AOTI metadata")
+        value = self._data[self._offset : end]
+        self._offset = end
+        return value
+
+    def unpack(self, format: str) -> Tuple[Any, ...]:
+        size = struct.calcsize(format)
+        return struct.unpack(format, self.read(size))
+
+    def read_string(self) -> str:
+        (size,) = self.unpack("<I")
+        try:
+            return bytes(self.read(size)).decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError("CUDA AOTI metadata contains invalid UTF-8") from error
+
+    def finish(self) -> None:
+        if self._offset != len(self._data):
+            raise ValueError("CUDA AOTI metadata contains trailing bytes")
+
+
+def _decode_weight_entries(reader: _MetadataReader) -> List[CudaWeightEntry]:
+    (num_entries,) = reader.unpack("<I")
+    if num_entries > 1 << 20:
+        raise ValueError(f"CUDA AOTI metadata has too many weights: {num_entries}")
+
+    entries = []
+    for _ in range(num_entries):
+        fqn = reader.read_string()
+        storage_key = reader.read_string()
+        storage_nbytes, dtype, device_type, storage_offset, ndim = reader.unpack(
+            "<QiiqI"
+        )
+        if not fqn or not storage_key or ndim > 64:
+            raise ValueError("CUDA AOTI metadata contains an invalid weight entry")
+        sizes = reader.unpack(f"<{ndim}q") if ndim else ()
+        strides = reader.unpack(f"<{ndim}q") if ndim else ()
+        if storage_offset < 0 or any(value < 0 for value in sizes + strides):
+            raise ValueError("CUDA AOTI metadata contains invalid tensor metadata")
+        entries.append(
+            CudaWeightEntry(
+                fqn=fqn,
+                storage_key=storage_key,
+                storage_nbytes=storage_nbytes,
+                dtype=dtype,
+                device_type=device_type,
+                storage_offset=storage_offset,
+                sizes=tuple(sizes),
+                strides=tuple(strides),
+            )
+        )
+    return entries
+
+
+def decode_cuda_aoti_metadata(data: bytes) -> CudaAotiMetadata:
+    """Decode legacy single-SO or multi-SM CUDA AOTI metadata."""
+    reader = _MetadataReader(data)
+    magic = bytes(reader.read(len(CUDA_WEIGHT_CACHE_MAGIC)))
+    variants = []
+    if magic == CUDA_WEIGHT_CACHE_MAGIC:
+        so_blob_key = reader.read_string()
+        if not so_blob_key:
+            raise ValueError("CUDA AOTI metadata is missing its shared-object key")
+        variants.append(CudaAotiVariant(0, 0, so_blob_key))
+    elif magic == CUDA_MULTI_ARCH_MAGIC:
+        (num_variants,) = reader.unpack("<I")
+        if num_variants == 0 or num_variants > 256:
+            raise ValueError(
+                f"CUDA AOTI metadata has invalid variant count: {num_variants}"
+            )
+        target_sms = set()
+        for _ in range(num_variants):
+            target_sm, ptx_compute = reader.unpack("<II")
+            so_blob_key = reader.read_string()
+            if (
+                target_sm == 0
+                or target_sm in target_sms
+                or ptx_compute > target_sm
+                or not so_blob_key
+            ):
+                raise ValueError("CUDA AOTI metadata contains an invalid variant")
+            target_sms.add(target_sm)
+            variants.append(
+                CudaAotiVariant(
+                    target_sm=target_sm,
+                    ptx_compute=ptx_compute,
+                    so_blob_key=so_blob_key,
+                )
+            )
+    else:
+        raise ValueError("Unrecognized CUDA AOTI metadata")
+
+    entries = _decode_weight_entries(reader)
+    reader.finish()
+    return CudaAotiMetadata(variants=variants, entries=entries)
 
 
 class CudaWeightCollector:
@@ -311,6 +484,8 @@ class CudaWeightCollector:
         result: PreprocessResult,
         artifact: CudaWeightArtifact,
         device_name: str,
+        target_sm: Optional[int] = None,
+        ptx_compute: int = 0,
     ) -> None:
         if result.data_store_output is None:
             raise RuntimeError("CUDA AOTI preprocess returned no named data")
@@ -344,9 +519,15 @@ class CudaWeightCollector:
             self._add_weight(entry, data, external_tag)
             serialized_entries.append(entry)
 
-        result.processed_bytes = encode_cuda_weight_metadata(
-            so_blob_key, serialized_entries
-        )
+        if target_sm is None:
+            result.processed_bytes = encode_cuda_weight_metadata(
+                so_blob_key, serialized_entries
+            )
+        else:
+            result.processed_bytes = encode_cuda_multi_arch_metadata(
+                [CudaAotiVariant(target_sm, ptx_compute, so_blob_key)],
+                serialized_entries,
+            )
         self._results.append(result)
 
     def finish(self) -> None:

--- a/backends/cuda/merge_ptes.py
+++ b/backends/cuda/merge_ptes.py
@@ -58,6 +58,21 @@ class CudaPteInput:
 
 
 @dataclass(frozen=True)
+class CudaPteProvenance:
+    delegate: Tuple[str, int]
+    kind: str
+    target_sm: int
+    ptx_compute: int
+    source_pte: Path
+
+
+@dataclass(frozen=True)
+class CudaPteMergeResult:
+    pte: Cord
+    provenance: Tuple[CudaPteProvenance, ...]
+
+
+@dataclass(frozen=True)
 class _PtdBlob:
     offset: int
     size: int
@@ -376,16 +391,19 @@ def _compact_delegate_data(program: Program) -> None:
 
 
 def _merge_delegate_variants(
-    artifacts: Sequence[_Artifact],
-    artifact_delegates: Sequence[Dict[Tuple[str, int], CudaAotiMetadata]],
+    regular_artifacts: Sequence[_Artifact],
+    regular_delegates: Sequence[Dict[Tuple[str, int], CudaAotiMetadata]],
+    fallback_artifact: Optional[_Artifact],
+    fallback_delegates: Optional[Dict[Tuple[str, int], CudaAotiMetadata]],
     reference_metadata: CudaAotiMetadata,
     identity: Tuple[str, int],
     merged_store: NamedDataStore,
+    provenance: List[CudaPteProvenance],
 ) -> List[CudaAotiVariant]:
     variants = []
     target_sms = set()
-    reference = artifacts[0]
-    for artifact, delegates in zip(artifacts, artifact_delegates):
+    reference = regular_artifacts[0]
+    for artifact, delegates in zip(regular_artifacts, regular_delegates):
         metadata = delegates[identity]
         _validate_shared_weights(
             reference, reference_metadata, artifact, metadata, identity
@@ -402,28 +420,72 @@ def _merge_delegate_variants(
                     f"{variant.so_blob_key!r}"
                 ) from error
             merged_store.add_named_data(variant.so_blob_key, so_data)
-            variants.append(variant)
+            variants.append(replace(variant, ptx_compute=0, fallback_only=False))
+            provenance.append(
+                CudaPteProvenance(
+                    delegate=identity,
+                    kind="cubin",
+                    target_sm=variant.target_sm,
+                    ptx_compute=0,
+                    source_pte=artifact.source.pte_path,
+                )
+            )
 
     variants.sort(key=lambda variant: variant.target_sm)
-    fallback = next((variant for variant in variants if variant.ptx_compute), None)
-    if fallback is not None:
-        variants = [
-            variant if variant is fallback else replace(variant, ptx_compute=0)
-            for variant in variants
+    if fallback_artifact is not None:
+        assert fallback_delegates is not None
+        metadata = fallback_delegates[identity]
+        _validate_shared_weights(
+            reference, reference_metadata, fallback_artifact, metadata, identity
+        )
+        fallback_variants = [
+            variant for variant in metadata.variants if variant.ptx_compute
         ]
+        if len(fallback_variants) != 1:
+            raise ValueError(
+                f"Fallback PTE {fallback_artifact.source.pte_path} must contain "
+                f"exactly one PTX-capable variant for delegate {identity}"
+            )
+        fallback = replace(fallback_variants[0], fallback_only=True)
+        try:
+            so_data = fallback_artifact.pte_named_data[fallback.so_blob_key]
+        except KeyError as error:
+            raise ValueError(
+                f"{fallback_artifact.source.pte_path} does not contain CUDA SO "
+                f"{fallback.so_blob_key!r}"
+            ) from error
+        merged_store.add_named_data(fallback.so_blob_key, so_data)
+        variants.append(fallback)
+        provenance.append(
+            CudaPteProvenance(
+                delegate=identity,
+                kind="ptx-fallback",
+                target_sm=fallback.target_sm,
+                ptx_compute=fallback.ptx_compute,
+                source_pte=fallback_artifact.source.pte_path,
+            )
+        )
     return variants
 
 
-def merge_cuda_pte_files(inputs: Sequence[CudaPteInput]) -> Cord:
-    """Merge native CUDA exports into a PTE containing one SO per target SM."""
+def merge_cuda_pte_files_with_provenance(
+    inputs: Sequence[CudaPteInput], fallback: Optional[CudaPteInput] = None
+) -> CudaPteMergeResult:
+    """Merge exact-SM CUDA exports and an optional PTX-only fallback source."""
     if torch.version.hip is not None:
         raise RuntimeError(
             "CUDA PTE merging supports only NVIDIA CUDA and is not supported on ROCm"
         )
-    if len(inputs) < 2:
+    if not inputs:
+        raise ValueError("At least one regular CUDA PTE input is required")
+    if len(inputs) + int(fallback is not None) < 2:
         raise ValueError("At least two CUDA PTE inputs are required")
-    artifacts = [_load_artifact(source) for source in inputs]
-    reference = artifacts[0]
+    regular_artifacts = [_load_artifact(source) for source in inputs]
+    fallback_artifact = _load_artifact(fallback) if fallback is not None else None
+    artifacts = [*regular_artifacts]
+    if fallback_artifact is not None:
+        artifacts.append(fallback_artifact)
+    reference = regular_artifacts[0]
     reference_identities = [delegate.identity for delegate in reference.delegates]
 
     for candidate in artifacts[1:]:
@@ -449,24 +511,39 @@ def merge_cuda_pte_files(inputs: Sequence[CudaPteInput]) -> Cord:
     if reference.pte.named_data is not None:
         merged_store.merge_named_data_store(reference.pte.named_data)
 
-    artifact_delegates = [
+    regular_delegates = [
         {delegate.identity: delegate.metadata for delegate in artifact.delegates}
-        for artifact in artifacts
+        for artifact in regular_artifacts
     ]
-    expected_target_sms = None
+    fallback_delegates = (
+        {
+            delegate.identity: delegate.metadata
+            for delegate in fallback_artifact.delegates
+        }
+        if fallback_artifact is not None
+        else None
+    )
+    expected_variants = None
+    provenance: List[CudaPteProvenance] = []
     for identity_index, identity in enumerate(reference_identities):
         reference_metadata = reference.delegates[identity_index].metadata
         variants = _merge_delegate_variants(
-            artifacts,
-            artifact_delegates,
+            regular_artifacts,
+            regular_delegates,
+            fallback_artifact,
+            fallback_delegates,
             reference_metadata,
             identity,
             merged_store,
+            provenance,
         )
-        current_target_sms = tuple(variant.target_sm for variant in variants)
-        if expected_target_sms is None:
-            expected_target_sms = current_target_sms
-        elif current_target_sms != expected_target_sms:
+        current_variants = tuple(
+            (variant.target_sm, variant.ptx_compute, variant.fallback_only)
+            for variant in variants
+        )
+        if expected_variants is None:
+            expected_variants = current_variants
+        elif current_variants != expected_variants:
             raise ValueError(
                 f"CUDA target variants differ across delegates at {identity}"
             )
@@ -487,26 +564,40 @@ def merge_cuda_pte_files(inputs: Sequence[CudaPteInput]) -> Cord:
         )
 
     _compact_delegate_data(merged_program)
-    return serialize_pte_binary(
-        PTEFile(
-            program=merged_program,
-            mutable_data=reference.pte.mutable_data,
-            named_data=merged_store.get_named_data_store_output(),
+    return CudaPteMergeResult(
+        pte=serialize_pte_binary(
+            PTEFile(
+                program=merged_program,
+                mutable_data=reference.pte.mutable_data,
+                named_data=merged_store.get_named_data_store_output(),
+            ),
+            extract_delegate_segments=True,
         ),
-        extract_delegate_segments=True,
+        provenance=tuple(provenance),
     )
+
+
+def merge_cuda_pte_files(
+    inputs: Sequence[CudaPteInput], fallback: Optional[CudaPteInput] = None
+) -> Cord:
+    return merge_cuda_pte_files_with_provenance(inputs, fallback).pte
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Merge native CUDA PTE exports into one multi-SM PTE"
+        description=(
+            "Merge exact-SM CUDA PTEs with an optional explicit PTX fallback"
+        )
     )
     parser.add_argument(
         "--input-pte",
         action="append",
         required=True,
         type=Path,
-        help="Native CUDA PTE to merge; the first input supplies common data",
+        help=(
+            "Regular CUDA PTE contributing exact-SM native cubins; the first "
+            "input supplies common data"
+        ),
     )
     parser.add_argument(
         "--input-ptd",
@@ -520,7 +611,22 @@ def _parse_args() -> argparse.Namespace:
         action="append",
         type=int,
         default=[],
-        help="Target SM for an FQN3 input; assumes that input carries PTX",
+        help="Target SM for a legacy FQN3 regular input",
+    )
+    parser.add_argument(
+        "--fallback-pte",
+        type=Path,
+        help="Single CUDA PTE contributing only the PTX runtime fallback",
+    )
+    parser.add_argument(
+        "--fallback-ptd",
+        type=Path,
+        help="PTD paired with --fallback-pte",
+    )
+    parser.add_argument(
+        "--fallback-legacy-target-sm",
+        type=int,
+        help="Target SM for a legacy FQN3 --fallback-pte",
     )
     parser.add_argument("--output-pte", required=True, type=Path)
     parser.add_argument("--output-ptd", type=Path)
@@ -536,6 +642,10 @@ def main() -> None:
         raise ValueError("--legacy-target-sm must be provided once per --input-pte")
     if args.input_ptd and args.output_ptd is None:
         raise ValueError("--output-ptd is required when --input-ptd is provided")
+    if args.fallback_ptd is not None and args.fallback_pte is None:
+        raise ValueError("--fallback-ptd requires --fallback-pte")
+    if args.fallback_legacy_target_sm is not None and args.fallback_pte is None:
+        raise ValueError("--fallback-legacy-target-sm requires --fallback-pte")
 
     sources = [
         CudaPteInput(
@@ -547,13 +657,22 @@ def main() -> None:
         )
         for index, pte_path in enumerate(args.input_pte)
     ]
-    output = merge_cuda_pte_files(sources)
+    fallback = (
+        CudaPteInput(
+            pte_path=args.fallback_pte,
+            ptd_path=args.fallback_ptd,
+            legacy_target_sm=args.fallback_legacy_target_sm,
+        )
+        if args.fallback_pte is not None
+        else None
+    )
+    result = merge_cuda_pte_files_with_provenance(sources, fallback)
     args.output_pte.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile(
         dir=args.output_pte.parent, prefix=f".{args.output_pte.name}.", delete=False
     ) as temporary:
         temporary_path = Path(temporary.name)
-        output.write_to_file(temporary)
+        result.pte.write_to_file(temporary)
     os.replace(temporary_path, args.output_pte)
 
     if args.output_ptd is not None:
@@ -562,6 +681,18 @@ def main() -> None:
         args.output_ptd.parent.mkdir(parents=True, exist_ok=True)
         if args.input_ptd[0].resolve() != args.output_ptd.resolve():
             shutil.copyfile(args.input_ptd[0], args.output_ptd)
+
+    print("Merged CUDA code provenance:")
+    print("delegate\tkind\ttarget\tsource PTE")
+    for entry in result.provenance:
+        delegate = f"{entry.delegate[0]}[{entry.delegate[1]}]"
+        if entry.kind == "cubin":
+            target = f"sm{entry.target_sm}"
+            source = str(entry.source_pte)
+        else:
+            target = f"compute_{entry.ptx_compute} (source sm{entry.target_sm})"
+            source = f"{entry.source_pte} [fallback]"
+        print(f"{delegate}\t{entry.kind}\t{target}\t{source}")
 
 
 if __name__ == "__main__":

--- a/backends/cuda/merge_ptes.py
+++ b/backends/cuda/merge_ptes.py
@@ -21,7 +21,7 @@ from executorch.backends.cuda.cuda_weight_collector import (
     CudaAotiVariant,
     CudaWeightEntry,
     decode_cuda_aoti_metadata,
-    encode_cuda_multi_arch_metadata,
+    encode_cuda_aoti_metadata,
 )
 from executorch.exir._serialize._cord import Cord
 from executorch.exir._serialize._named_data_store import (
@@ -54,7 +54,6 @@ class CudaPteInput:
 
     pte_path: Path
     ptd_path: Optional[Path]
-    legacy_target_sm: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -199,20 +198,8 @@ def _load_artifact(source: CudaPteInput) -> _Artifact:
                 _delegate_payload(pte.program, delegate)
             )
             if metadata.variants[0].target_sm == 0:
-                if source.legacy_target_sm is None:
-                    raise ValueError(
-                        f"Legacy CUDA metadata in {source.pte_path} requires "
-                        "--legacy-target-sm"
-                    )
-                metadata = CudaAotiMetadata(
-                    variants=[
-                        CudaAotiVariant(
-                            target_sm=source.legacy_target_sm,
-                            ptx_compute=source.legacy_target_sm,
-                            so_blob_key=metadata.variants[0].so_blob_key,
-                        )
-                    ],
-                    entries=metadata.entries,
+                raise ValueError(
+                    f"Untargeted CUDA metadata in {source.pte_path} cannot be merged"
                 )
             delegates.append(_CudaDelegate((plan.name, delegate_index), metadata))
     if not delegates:
@@ -561,9 +548,7 @@ def merge_cuda_pte_files_with_provenance(
             raise ValueError(
                 f"CUDA target variants differ across delegates at {identity}"
             )
-        merged_payload = encode_cuda_multi_arch_metadata(
-            variants, reference_metadata.entries
-        )
+        merged_payload = encode_cuda_aoti_metadata(variants, reference_metadata.entries)
         plan_name, delegate_index = identity
         plan = next(
             plan for plan in merged_program.execution_plan if plan.name == plan_name
@@ -619,13 +604,6 @@ def _parse_args() -> argparse.Namespace:
         help="PTD paired by position with --input-pte",
     )
     parser.add_argument(
-        "--legacy-target-sm",
-        action="append",
-        type=int,
-        default=[],
-        help="Target SM for a legacy FQN3 regular input",
-    )
-    parser.add_argument(
         "--fallback-pte",
         type=Path,
         help="Single CUDA PTE contributing only the PTX runtime fallback",
@@ -634,11 +612,6 @@ def _parse_args() -> argparse.Namespace:
         "--fallback-ptd",
         type=Path,
         help="PTD paired with --fallback-pte",
-    )
-    parser.add_argument(
-        "--fallback-legacy-target-sm",
-        type=int,
-        help="Target SM for a legacy FQN3 --fallback-pte",
     )
     parser.add_argument("--output-pte", required=True, type=Path)
     parser.add_argument("--output-ptd", type=Path)
@@ -650,22 +623,14 @@ def main() -> None:
     args = _parse_args()
     if args.input_ptd and len(args.input_ptd) != len(args.input_pte):
         raise ValueError("--input-ptd must be provided once per --input-pte")
-    if args.legacy_target_sm and len(args.legacy_target_sm) != len(args.input_pte):
-        raise ValueError("--legacy-target-sm must be provided once per --input-pte")
     if args.input_ptd and args.output_ptd is None:
         raise ValueError("--output-ptd is required when --input-ptd is provided")
     if args.fallback_ptd is not None and args.fallback_pte is None:
         raise ValueError("--fallback-ptd requires --fallback-pte")
-    if args.fallback_legacy_target_sm is not None and args.fallback_pte is None:
-        raise ValueError("--fallback-legacy-target-sm requires --fallback-pte")
-
     sources = [
         CudaPteInput(
             pte_path=pte_path,
             ptd_path=args.input_ptd[index] if args.input_ptd else None,
-            legacy_target_sm=(
-                args.legacy_target_sm[index] if args.legacy_target_sm else None
-            ),
         )
         for index, pte_path in enumerate(args.input_pte)
     ]
@@ -673,7 +638,6 @@ def main() -> None:
         CudaPteInput(
             pte_path=args.fallback_pte,
             ptd_path=args.fallback_ptd,
-            legacy_target_sm=args.fallback_legacy_target_sm,
         )
         if args.fallback_pte is not None
         else None

--- a/backends/cuda/merge_ptes.py
+++ b/backends/cuda/merge_ptes.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+import torch
+
 from executorch.backends.cuda.cuda_weight_collector import (
     CudaAotiMetadata,
     CudaAotiVariant,
@@ -414,6 +416,10 @@ def _merge_delegate_variants(
 
 def merge_cuda_pte_files(inputs: Sequence[CudaPteInput]) -> Cord:
     """Merge native CUDA exports into a PTE containing one SO per target SM."""
+    if torch.version.hip is not None:
+        raise RuntimeError(
+            "CUDA PTE merging supports only NVIDIA CUDA and is not supported on ROCm"
+        )
     if len(inputs) < 2:
         raise ValueError("At least two CUDA PTE inputs are required")
     artifacts = [_load_artifact(source) for source in inputs]

--- a/backends/cuda/merge_ptes.py
+++ b/backends/cuda/merge_ptes.py
@@ -468,6 +468,45 @@ def _merge_delegate_variants(
     return variants
 
 
+def _load_merge_artifacts(
+    inputs: Sequence[CudaPteInput], fallback: Optional[CudaPteInput]
+) -> Tuple[List[_Artifact], Optional[_Artifact], List[Tuple[str, int]]]:
+    regular_artifacts = [_load_artifact(source) for source in inputs]
+    fallback_artifact = _load_artifact(fallback) if fallback is not None else None
+    artifacts = [*regular_artifacts]
+    if fallback_artifact is not None:
+        artifacts.append(fallback_artifact)
+
+    reference = regular_artifacts[0]
+    reference_identities = [delegate.identity for delegate in reference.delegates]
+    for candidate in artifacts[1:]:
+        _validate_programs(reference, candidate)
+        candidate_identities = [delegate.identity for delegate in candidate.delegates]
+        if candidate_identities != reference_identities:
+            raise ValueError(
+                f"CUDA delegate layout differs between {reference.source.pte_path} "
+                f"and {candidate.source.pte_path}"
+            )
+    return regular_artifacts, fallback_artifact, reference_identities
+
+
+def _prepare_merged_output(reference: _Artifact) -> Tuple[Program, NamedDataStore]:
+    merged_program = copy.deepcopy(reference.pte.program)
+    for plan in merged_program.execution_plan:
+        for delegate in plan.delegates:
+            if delegate.id == CUDA_BACKEND_ID:
+                delegate.compile_specs = [
+                    spec
+                    for spec in delegate.compile_specs
+                    if spec.key != "cuda_include_ptx"
+                ]
+
+    merged_store = NamedDataStore()
+    if reference.pte.named_data is not None:
+        merged_store.merge_named_data_store(reference.pte.named_data)
+    return merged_program, merged_store
+
+
 def merge_cuda_pte_files_with_provenance(
     inputs: Sequence[CudaPteInput], fallback: Optional[CudaPteInput] = None
 ) -> CudaPteMergeResult:
@@ -480,36 +519,11 @@ def merge_cuda_pte_files_with_provenance(
         raise ValueError("At least one regular CUDA PTE input is required")
     if len(inputs) + int(fallback is not None) < 2:
         raise ValueError("At least two CUDA PTE inputs are required")
-    regular_artifacts = [_load_artifact(source) for source in inputs]
-    fallback_artifact = _load_artifact(fallback) if fallback is not None else None
-    artifacts = [*regular_artifacts]
-    if fallback_artifact is not None:
-        artifacts.append(fallback_artifact)
+    regular_artifacts, fallback_artifact, reference_identities = _load_merge_artifacts(
+        inputs, fallback
+    )
     reference = regular_artifacts[0]
-    reference_identities = [delegate.identity for delegate in reference.delegates]
-
-    for candidate in artifacts[1:]:
-        _validate_programs(reference, candidate)
-        if [
-            delegate.identity for delegate in candidate.delegates
-        ] != reference_identities:
-            raise ValueError(
-                f"CUDA delegate layout differs between {reference.source.pte_path} "
-                f"and {candidate.source.pte_path}"
-            )
-
-    merged_program = copy.deepcopy(reference.pte.program)
-    for plan in merged_program.execution_plan:
-        for delegate in plan.delegates:
-            if delegate.id == CUDA_BACKEND_ID:
-                delegate.compile_specs = [
-                    spec
-                    for spec in delegate.compile_specs
-                    if spec.key != "cuda_include_ptx"
-                ]
-    merged_store = NamedDataStore()
-    if reference.pte.named_data is not None:
-        merged_store.merge_named_data_store(reference.pte.named_data)
+    merged_program, merged_store = _prepare_merged_output(reference)
 
     regular_delegates = [
         {delegate.identity: delegate.metadata for delegate in artifact.delegates}
@@ -585,9 +599,7 @@ def merge_cuda_pte_files(
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description=(
-            "Merge exact-SM CUDA PTEs with an optional explicit PTX fallback"
-        )
+        description=("Merge exact-SM CUDA PTEs with an optional explicit PTX fallback")
     )
     parser.add_argument(
         "--input-pte",

--- a/backends/cuda/merge_ptes.py
+++ b/backends/cuda/merge_ptes.py
@@ -1,0 +1,546 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import copy
+import hashlib
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+from executorch.backends.cuda.cuda_weight_collector import (
+    CudaAotiMetadata,
+    CudaAotiVariant,
+    CudaWeightEntry,
+    decode_cuda_aoti_metadata,
+    encode_cuda_multi_arch_metadata,
+)
+from executorch.exir._serialize._cord import Cord
+from executorch.exir._serialize._named_data_store import (
+    NamedDataStore,
+    NamedDataStoreOutput,
+)
+from executorch.exir._serialize._program import (
+    deserialize_pte_binary,
+    PTEFile,
+    serialize_pte_binary,
+)
+from executorch.exir.schema import (
+    BackendDelegateDataReference,
+    BackendDelegateInlineData,
+    DataLocation,
+    Program,
+)
+from executorch.extension.flat_tensor.serialize.serialize import (
+    _deserialize_to_flat_tensor,
+    FlatTensorHeader,
+)
+
+
+CUDA_BACKEND_ID = "CudaBackend"
+
+
+@dataclass(frozen=True)
+class CudaPteInput:
+    """One native CUDA export and its optional external tensor data."""
+
+    pte_path: Path
+    ptd_path: Optional[Path]
+    legacy_target_sm: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class _PtdBlob:
+    offset: int
+    size: int
+
+
+class _PtdIndex:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        with path.open("rb") as source:
+            prefix = source.read(8 + FlatTensorHeader.EXPECTED_LENGTH)
+            header = FlatTensorHeader.from_bytes(prefix[8:])
+            if not header.is_valid():
+                raise ValueError(f"Invalid PTD header in {path}")
+            source.seek(0)
+            flatbuffer_size = header.flatbuffer_offset + header.flatbuffer_size
+            flat_tensor = _deserialize_to_flat_tensor(source.read(flatbuffer_size))
+
+        file_size = path.stat().st_size
+        self._blobs: Dict[str, _PtdBlob] = {}
+        for named_data in flat_tensor.named_data:
+            if named_data.key in self._blobs:
+                raise ValueError(f"PTD contains duplicate key {named_data.key!r}")
+            if named_data.segment_index >= len(flat_tensor.segments):
+                raise ValueError(
+                    f"PTD key {named_data.key!r} has an invalid segment index"
+                )
+            segment = flat_tensor.segments[named_data.segment_index]
+            offset = header.segment_base_offset + segment.offset
+            if offset + segment.size > file_size:
+                raise ValueError(f"PTD key {named_data.key!r} extends past end of file")
+            self._blobs[named_data.key] = _PtdBlob(offset, segment.size)
+        self._digests: Dict[str, bytes] = {}
+
+    def keys(self) -> set[str]:
+        return set(self._blobs)
+
+    def size(self, key: str) -> int:
+        try:
+            return self._blobs[key].size
+        except KeyError as error:
+            raise ValueError(f"PTD {self.path} does not contain key {key!r}") from error
+
+    def sha256(self, key: str) -> bytes:
+        digest = self._digests.get(key)
+        if digest is not None:
+            return digest
+        try:
+            blob = self._blobs[key]
+        except KeyError as error:
+            raise ValueError(f"PTD {self.path} does not contain key {key!r}") from error
+
+        hasher = hashlib.sha256()
+        remaining = blob.size
+        with self.path.open("rb") as source:
+            source.seek(blob.offset)
+            while remaining:
+                chunk = source.read(min(8 * 1024 * 1024, remaining))
+                if not chunk:
+                    raise ValueError(f"PTD {self.path} is truncated at key {key!r}")
+                hasher.update(chunk)
+                remaining -= len(chunk)
+        digest = hasher.digest()
+        self._digests[key] = digest
+        return digest
+
+
+@dataclass
+class _CudaDelegate:
+    identity: Tuple[str, int]
+    metadata: CudaAotiMetadata
+
+
+@dataclass
+class _Artifact:
+    source: CudaPteInput
+    pte: PTEFile
+    pte_named_data: Dict[str, bytes]
+    ptd: Optional[_PtdIndex]
+    delegates: List[_CudaDelegate]
+
+    def blob_size(self, key: str) -> int:
+        data = self.pte_named_data.get(key)
+        if data is not None:
+            return len(data)
+        if self.ptd is not None:
+            return self.ptd.size(key)
+        raise ValueError(f"{self.source.pte_path} does not contain named data {key!r}")
+
+    def blob_sha256(self, key: str) -> bytes:
+        data = self.pte_named_data.get(key)
+        if data is not None:
+            return hashlib.sha256(data).digest()
+        if self.ptd is not None:
+            return self.ptd.sha256(key)
+        raise ValueError(f"{self.source.pte_path} does not contain named data {key!r}")
+
+
+def _named_data_bytes(output: Optional[NamedDataStoreOutput]) -> Dict[str, bytes]:
+    if output is None:
+        return {}
+    return {
+        key: bytes(output.buffers[entry.buffer_index])
+        for key, entry in output.pte_data.items()
+    }
+
+
+def _delegate_payload(program: Program, delegate) -> bytes:
+    if delegate.processed.location != DataLocation.INLINE:
+        raise ValueError("PTE deserialization did not restore delegate data inline")
+    try:
+        return bytes(program.backend_delegate_data[delegate.processed.index].data)
+    except IndexError as error:
+        raise ValueError("CUDA delegate references invalid processed data") from error
+
+
+def _load_artifact(source: CudaPteInput) -> _Artifact:
+    pte = deserialize_pte_binary(source.pte_path.read_bytes())
+    delegates = []
+    for plan in pte.program.execution_plan:
+        for delegate_index, delegate in enumerate(plan.delegates):
+            if delegate.id != CUDA_BACKEND_ID:
+                continue
+            metadata = decode_cuda_aoti_metadata(
+                _delegate_payload(pte.program, delegate)
+            )
+            if metadata.variants[0].target_sm == 0:
+                if source.legacy_target_sm is None:
+                    raise ValueError(
+                        f"Legacy CUDA metadata in {source.pte_path} requires "
+                        "--legacy-target-sm"
+                    )
+                metadata = CudaAotiMetadata(
+                    variants=[
+                        CudaAotiVariant(
+                            target_sm=source.legacy_target_sm,
+                            ptx_compute=source.legacy_target_sm,
+                            so_blob_key=metadata.variants[0].so_blob_key,
+                        )
+                    ],
+                    entries=metadata.entries,
+                )
+            delegates.append(_CudaDelegate((plan.name, delegate_index), metadata))
+    if not delegates:
+        raise ValueError(f"{source.pte_path} contains no CUDA delegates")
+    ptd = _PtdIndex(source.ptd_path) if source.ptd_path is not None else None
+    return _Artifact(source, pte, _named_data_bytes(pte.named_data), ptd, delegates)
+
+
+def _normalized_program(program: Program) -> Program:
+    normalized = copy.deepcopy(program)
+    payloads = []
+    for plan in normalized.execution_plan:
+        for delegate in plan.delegates:
+            payload = _delegate_payload(normalized, delegate)
+            if delegate.id == CUDA_BACKEND_ID:
+                payload = b"CUDA_AOTI_VARIANTS"
+                delegate.compile_specs = [
+                    spec
+                    for spec in delegate.compile_specs
+                    if spec.key != "cuda_include_ptx"
+                ]
+            delegate.processed = BackendDelegateDataReference(
+                location=DataLocation.INLINE, index=len(payloads)
+            )
+            payloads.append(BackendDelegateInlineData(data=payload))
+    normalized.backend_delegate_data = payloads
+    return normalized
+
+
+def _entry_map(entries: Iterable[CudaWeightEntry]) -> Dict[str, CudaWeightEntry]:
+    result = {}
+    for entry in entries:
+        if entry.fqn in result:
+            raise ValueError(f"Duplicate CUDA weight FQN {entry.fqn!r}")
+        result[entry.fqn] = entry
+    return result
+
+
+def _entry_without_storage_key(entry: CudaWeightEntry) -> Tuple[object, ...]:
+    return (
+        entry.fqn,
+        entry.storage_nbytes,
+        entry.dtype,
+        entry.device_type,
+        entry.storage_offset,
+        entry.sizes,
+        entry.strides,
+    )
+
+
+def _validate_shared_weights(
+    reference: _Artifact,
+    reference_metadata: CudaAotiMetadata,
+    candidate: _Artifact,
+    candidate_metadata: CudaAotiMetadata,
+    identity: Tuple[str, int],
+) -> None:
+    reference_entries = _entry_map(reference_metadata.entries)
+    candidate_entries = _entry_map(candidate_metadata.entries)
+    if reference_entries.keys() != candidate_entries.keys():
+        raise ValueError(f"CUDA weights differ for delegate {identity}: FQN mismatch")
+
+    for fqn, reference_entry in reference_entries.items():
+        candidate_entry = candidate_entries[fqn]
+        if _entry_without_storage_key(reference_entry) != _entry_without_storage_key(
+            candidate_entry
+        ):
+            raise ValueError(
+                f"CUDA weight metadata differs for delegate {identity}, FQN {fqn!r}"
+            )
+        if (
+            reference.blob_size(reference_entry.storage_key)
+            != reference_entry.storage_nbytes
+        ):
+            raise ValueError(
+                f"CUDA weight {fqn!r} has an invalid size in {reference.source.pte_path}"
+            )
+        if (
+            candidate.blob_size(candidate_entry.storage_key)
+            != candidate_entry.storage_nbytes
+        ):
+            raise ValueError(
+                f"CUDA weight {fqn!r} has an invalid size in {candidate.source.pte_path}"
+            )
+        if reference.blob_sha256(reference_entry.storage_key) != candidate.blob_sha256(
+            candidate_entry.storage_key
+        ):
+            raise ValueError(
+                f"CUDA weight content differs for delegate {identity}, FQN {fqn!r}"
+            )
+
+
+def _cuda_so_keys(artifact: _Artifact) -> set[str]:
+    return {
+        variant.so_blob_key
+        for delegate in artifact.delegates
+        for variant in delegate.metadata.variants
+    }
+
+
+def _cuda_weight_keys(artifact: _Artifact) -> set[str]:
+    return {
+        entry.storage_key
+        for delegate in artifact.delegates
+        for entry in delegate.metadata.entries
+    }
+
+
+def _validate_programs(reference: _Artifact, candidate: _Artifact) -> None:
+    if _normalized_program(reference.pte.program) != _normalized_program(
+        candidate.pte.program
+    ):
+        raise ValueError(
+            f"ExecuTorch programs differ between {reference.source.pte_path} and "
+            f"{candidate.source.pte_path}"
+        )
+    if reference.pte.mutable_data != candidate.pte.mutable_data:
+        raise ValueError(
+            f"Mutable program data differs between {reference.source.pte_path} and "
+            f"{candidate.source.pte_path}"
+        )
+
+    reference_non_cuda = {
+        key: value
+        for key, value in reference.pte_named_data.items()
+        if key not in _cuda_so_keys(reference)
+        and key not in _cuda_weight_keys(reference)
+    }
+    candidate_non_cuda = {
+        key: value
+        for key, value in candidate.pte_named_data.items()
+        if key not in _cuda_so_keys(candidate)
+        and key not in _cuda_weight_keys(candidate)
+    }
+    if reference_non_cuda != candidate_non_cuda:
+        raise ValueError(
+            f"Non-CUDA named data differs between {reference.source.pte_path} and "
+            f"{candidate.source.pte_path}"
+        )
+
+    reference_external = (
+        reference.ptd.keys() - _cuda_weight_keys(reference)
+        if reference.ptd is not None
+        else set()
+    )
+    candidate_external = (
+        candidate.ptd.keys() - _cuda_weight_keys(candidate)
+        if candidate.ptd is not None
+        else set()
+    )
+    if reference_external != candidate_external:
+        raise ValueError(
+            f"Non-CUDA external data differs between {reference.source.pte_path} and "
+            f"{candidate.source.pte_path}"
+        )
+    for key in reference_external:
+        if reference.blob_size(key) != candidate.blob_size(
+            key
+        ) or reference.blob_sha256(key) != candidate.blob_sha256(key):
+            raise ValueError(
+                f"External data {key!r} differs between "
+                f"{reference.source.pte_path} and {candidate.source.pte_path}"
+            )
+
+
+def _compact_delegate_data(program: Program) -> None:
+    payloads = []
+    for plan in program.execution_plan:
+        for delegate in plan.delegates:
+            payload = _delegate_payload(program, delegate)
+            delegate.processed = BackendDelegateDataReference(
+                location=DataLocation.INLINE, index=len(payloads)
+            )
+            payloads.append(BackendDelegateInlineData(data=payload))
+    program.backend_delegate_data = payloads
+
+
+def merge_cuda_pte_files(inputs: Sequence[CudaPteInput]) -> Cord:
+    """Merge native CUDA exports into a PTE containing one SO per target SM."""
+    if len(inputs) < 2:
+        raise ValueError("At least two CUDA PTE inputs are required")
+    artifacts = [_load_artifact(source) for source in inputs]
+    reference = artifacts[0]
+    reference_identities = [delegate.identity for delegate in reference.delegates]
+
+    for candidate in artifacts[1:]:
+        _validate_programs(reference, candidate)
+        if [
+            delegate.identity for delegate in candidate.delegates
+        ] != reference_identities:
+            raise ValueError(
+                f"CUDA delegate layout differs between {reference.source.pte_path} "
+                f"and {candidate.source.pte_path}"
+            )
+
+    merged_program = copy.deepcopy(reference.pte.program)
+    for plan in merged_program.execution_plan:
+        for delegate in plan.delegates:
+            if delegate.id == CUDA_BACKEND_ID:
+                delegate.compile_specs = [
+                    spec
+                    for spec in delegate.compile_specs
+                    if spec.key != "cuda_include_ptx"
+                ]
+    merged_store = NamedDataStore()
+    if reference.pte.named_data is not None:
+        merged_store.merge_named_data_store(reference.pte.named_data)
+
+    artifact_delegates = [
+        {delegate.identity: delegate.metadata for delegate in artifact.delegates}
+        for artifact in artifacts
+    ]
+    expected_target_sms = None
+    for identity_index, identity in enumerate(reference_identities):
+        reference_metadata = reference.delegates[identity_index].metadata
+        variants = []
+        target_sms = set()
+        for artifact, delegates in zip(artifacts, artifact_delegates):
+            metadata = delegates[identity]
+            _validate_shared_weights(
+                reference, reference_metadata, artifact, metadata, identity
+            )
+            for variant in metadata.variants:
+                if variant.target_sm in target_sms:
+                    raise ValueError(f"Duplicate CUDA target sm{variant.target_sm}")
+                target_sms.add(variant.target_sm)
+                try:
+                    so_data = artifact.pte_named_data[variant.so_blob_key]
+                except KeyError as error:
+                    raise ValueError(
+                        f"{artifact.source.pte_path} does not contain CUDA SO "
+                        f"{variant.so_blob_key!r}"
+                    ) from error
+                merged_store.add_named_data(variant.so_blob_key, so_data)
+                variants.append(variant)
+
+        variants.sort(key=lambda variant: variant.target_sm)
+        fallback = next(
+            (variant for variant in variants if variant.ptx_compute != 0), None
+        )
+        if fallback is not None:
+            variants = [
+                variant if variant is fallback else replace(variant, ptx_compute=0)
+                for variant in variants
+            ]
+        current_target_sms = tuple(variant.target_sm for variant in variants)
+        if expected_target_sms is None:
+            expected_target_sms = current_target_sms
+        elif current_target_sms != expected_target_sms:
+            raise ValueError(
+                f"CUDA target variants differ across delegates at {identity}"
+            )
+        merged_payload = encode_cuda_multi_arch_metadata(
+            variants, reference_metadata.entries
+        )
+        plan_name, delegate_index = identity
+        plan = next(
+            plan for plan in merged_program.execution_plan if plan.name == plan_name
+        )
+        delegate = plan.delegates[delegate_index]
+        delegate.processed = BackendDelegateDataReference(
+            location=DataLocation.INLINE,
+            index=len(merged_program.backend_delegate_data),
+        )
+        merged_program.backend_delegate_data.append(
+            BackendDelegateInlineData(data=merged_payload)
+        )
+
+    _compact_delegate_data(merged_program)
+    return serialize_pte_binary(
+        PTEFile(
+            program=merged_program,
+            mutable_data=reference.pte.mutable_data,
+            named_data=merged_store.get_named_data_store_output(),
+        ),
+        extract_delegate_segments=True,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Merge native CUDA PTE exports into one multi-SM PTE"
+    )
+    parser.add_argument(
+        "--input-pte",
+        action="append",
+        required=True,
+        type=Path,
+        help="Native CUDA PTE to merge; the first input supplies common data",
+    )
+    parser.add_argument(
+        "--input-ptd",
+        action="append",
+        type=Path,
+        default=[],
+        help="PTD paired by position with --input-pte",
+    )
+    parser.add_argument(
+        "--legacy-target-sm",
+        action="append",
+        type=int,
+        default=[],
+        help="Target SM for an FQN3 input; assumes that input carries PTX",
+    )
+    parser.add_argument("--output-pte", required=True, type=Path)
+    parser.add_argument("--output-ptd", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Command-line entry point for CUDA PTE merging."""
+    args = _parse_args()
+    if args.input_ptd and len(args.input_ptd) != len(args.input_pte):
+        raise ValueError("--input-ptd must be provided once per --input-pte")
+    if args.legacy_target_sm and len(args.legacy_target_sm) != len(args.input_pte):
+        raise ValueError("--legacy-target-sm must be provided once per --input-pte")
+    if args.input_ptd and args.output_ptd is None:
+        raise ValueError("--output-ptd is required when --input-ptd is provided")
+
+    sources = [
+        CudaPteInput(
+            pte_path=pte_path,
+            ptd_path=args.input_ptd[index] if args.input_ptd else None,
+            legacy_target_sm=(
+                args.legacy_target_sm[index] if args.legacy_target_sm else None
+            ),
+        )
+        for index, pte_path in enumerate(args.input_pte)
+    ]
+    output = merge_cuda_pte_files(sources)
+    args.output_pte.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=args.output_pte.parent, prefix=f".{args.output_pte.name}.", delete=False
+    ) as temporary:
+        temporary_path = Path(temporary.name)
+        output.write_to_file(temporary)
+    os.replace(temporary_path, args.output_pte)
+
+    if args.output_ptd is not None:
+        if not args.input_ptd:
+            raise ValueError("--output-ptd requires --input-ptd")
+        args.output_ptd.parent.mkdir(parents=True, exist_ok=True)
+        if args.input_ptd[0].resolve() != args.output_ptd.resolve():
+            shutil.copyfile(args.input_ptd[0], args.output_ptd)
+
+
+if __name__ == "__main__":
+    main()

--- a/backends/cuda/merge_ptes.py
+++ b/backends/cuda/merge_ptes.py
@@ -373,6 +373,45 @@ def _compact_delegate_data(program: Program) -> None:
     program.backend_delegate_data = payloads
 
 
+def _merge_delegate_variants(
+    artifacts: Sequence[_Artifact],
+    artifact_delegates: Sequence[Dict[Tuple[str, int], CudaAotiMetadata]],
+    reference_metadata: CudaAotiMetadata,
+    identity: Tuple[str, int],
+    merged_store: NamedDataStore,
+) -> List[CudaAotiVariant]:
+    variants = []
+    target_sms = set()
+    reference = artifacts[0]
+    for artifact, delegates in zip(artifacts, artifact_delegates):
+        metadata = delegates[identity]
+        _validate_shared_weights(
+            reference, reference_metadata, artifact, metadata, identity
+        )
+        for variant in metadata.variants:
+            if variant.target_sm in target_sms:
+                raise ValueError(f"Duplicate CUDA target sm{variant.target_sm}")
+            target_sms.add(variant.target_sm)
+            try:
+                so_data = artifact.pte_named_data[variant.so_blob_key]
+            except KeyError as error:
+                raise ValueError(
+                    f"{artifact.source.pte_path} does not contain CUDA SO "
+                    f"{variant.so_blob_key!r}"
+                ) from error
+            merged_store.add_named_data(variant.so_blob_key, so_data)
+            variants.append(variant)
+
+    variants.sort(key=lambda variant: variant.target_sm)
+    fallback = next((variant for variant in variants if variant.ptx_compute), None)
+    if fallback is not None:
+        variants = [
+            variant if variant is fallback else replace(variant, ptx_compute=0)
+            for variant in variants
+        ]
+    return variants
+
+
 def merge_cuda_pte_files(inputs: Sequence[CudaPteInput]) -> Cord:
     """Merge native CUDA exports into a PTE containing one SO per target SM."""
     if len(inputs) < 2:
@@ -411,36 +450,13 @@ def merge_cuda_pte_files(inputs: Sequence[CudaPteInput]) -> Cord:
     expected_target_sms = None
     for identity_index, identity in enumerate(reference_identities):
         reference_metadata = reference.delegates[identity_index].metadata
-        variants = []
-        target_sms = set()
-        for artifact, delegates in zip(artifacts, artifact_delegates):
-            metadata = delegates[identity]
-            _validate_shared_weights(
-                reference, reference_metadata, artifact, metadata, identity
-            )
-            for variant in metadata.variants:
-                if variant.target_sm in target_sms:
-                    raise ValueError(f"Duplicate CUDA target sm{variant.target_sm}")
-                target_sms.add(variant.target_sm)
-                try:
-                    so_data = artifact.pte_named_data[variant.so_blob_key]
-                except KeyError as error:
-                    raise ValueError(
-                        f"{artifact.source.pte_path} does not contain CUDA SO "
-                        f"{variant.so_blob_key!r}"
-                    ) from error
-                merged_store.add_named_data(variant.so_blob_key, so_data)
-                variants.append(variant)
-
-        variants.sort(key=lambda variant: variant.target_sm)
-        fallback = next(
-            (variant for variant in variants if variant.ptx_compute != 0), None
+        variants = _merge_delegate_variants(
+            artifacts,
+            artifact_delegates,
+            reference_metadata,
+            identity,
+            merged_store,
         )
-        if fallback is not None:
-            variants = [
-                variant if variant is fallback else replace(variant, ptx_compute=0)
-                for variant in variants
-            ]
         current_target_sms = tuple(variant.target_sm for variant in variants)
         if expected_target_sms is None:
             expected_target_sms = current_target_sms

--- a/backends/cuda/runtime/cuda_backend.cpp
+++ b/backends/cuda/runtime/cuda_backend.cpp
@@ -343,6 +343,12 @@ class ET_EXPERIMENTAL CudaBackend final
       uint32_t current_sm = 0;
       if (!(fqn_weights.variants.size() == 1 &&
             fqn_weights.variants[0].target_sm == 0)) {
+#if defined(EXECUTORCH_USE_HIP)
+        ET_LOG(
+            Error,
+            "Multi-SM CUDA AOTI metadata is not supported by the ROCm runtime");
+        return Error::NotSupported;
+#else
         int device_index = 0;
         cudaDeviceProp device_properties{};
         ET_CUDA_CHECK_OR_RETURN_ERROR(cudaGetDevice(&device_index));
@@ -355,6 +361,7 @@ class ET_EXPERIMENTAL CudaBackend final
                 fqn_weights, current_sm, variant_index, uses_ptx_fallback),
             "Failed to select a CUDA AOTI variant for sm%u",
             current_sm);
+#endif
       }
       const auto& variant = fqn_weights.variants[variant_index];
       so_blob_key = variant.so_blob_key;

--- a/backends/cuda/runtime/cuda_backend.cpp
+++ b/backends/cuda/runtime/cuda_backend.cpp
@@ -366,7 +366,7 @@ class ET_EXPERIMENTAL CudaBackend final
       const auto& variant = fqn_weights.variants[variant_index];
       so_blob_key = variant.so_blob_key;
       if (variant.target_sm == 0) {
-        ET_LOG(Info, "Selected legacy CUDA AOTI variant");
+        ET_LOG(Info, "Selected untargeted CUDA AOTI variant");
       } else if (uses_ptx_fallback) {
         ET_LOG(
             Info,

--- a/backends/cuda/runtime/cuda_backend.cpp
+++ b/backends/cuda/runtime/cuda_backend.cpp
@@ -338,7 +338,39 @@ class ET_EXPERIMENTAL CudaBackend final
           CudaWeightCache::parse(
               processed->data(), processed->size(), fqn_weights),
           "Malformed CUDA FQN weight metadata");
-      so_blob_key = fqn_weights.so_blob_key;
+      size_t variant_index = 0;
+      bool uses_ptx_fallback = false;
+      uint32_t current_sm = 0;
+      if (!(fqn_weights.variants.size() == 1 &&
+            fqn_weights.variants[0].target_sm == 0)) {
+        int device_index = 0;
+        cudaDeviceProp device_properties{};
+        ET_CUDA_CHECK_OR_RETURN_ERROR(cudaGetDevice(&device_index));
+        ET_CUDA_CHECK_OR_RETURN_ERROR(
+            cudaGetDeviceProperties(&device_properties, device_index));
+        current_sm = static_cast<uint32_t>(
+            device_properties.major * 10 + device_properties.minor);
+        ET_CHECK_OK_OR_RETURN_ERROR(
+            CudaWeightCache::select_variant(
+                fqn_weights, current_sm, variant_index, uses_ptx_fallback),
+            "Failed to select a CUDA AOTI variant for sm%u",
+            current_sm);
+      }
+      const auto& variant = fqn_weights.variants[variant_index];
+      so_blob_key = variant.so_blob_key;
+      if (variant.target_sm == 0) {
+        ET_LOG(Info, "Selected legacy CUDA AOTI variant");
+      } else if (uses_ptx_fallback) {
+        ET_LOG(
+            Info,
+            "Selected sm%u CUDA AOTI PTX fallback (compute_%u) for sm%u",
+            variant.target_sm,
+            variant.ptx_compute,
+            current_sm);
+      } else {
+        ET_LOG(
+            Info, "Selected native sm%u CUDA AOTI variant", variant.target_sm);
+      }
     } else {
       ET_CHECK_OK_OR_RETURN_ERROR(
           executorch::backends::aoti::resolve_blob_keys(

--- a/backends/cuda/runtime/cuda_weight_cache.cpp
+++ b/backends/cuda/runtime/cuda_weight_cache.cpp
@@ -140,7 +140,8 @@ bool is_supported_device_type(int32_t device_type) {
 
 bool CudaWeightCache::is_serialized(const void* data, size_t size) {
   return data != nullptr && size >= kFormatMagicSize &&
-      std::memcmp(data, kFormatMagic, kFormatMagicSize) == 0;
+      (std::memcmp(data, kFormatMagic, kFormatMagicSize) == 0 ||
+       std::memcmp(data, kMultiArchFormatMagic, kFormatMagicSize) == 0);
 }
 
 Error CudaWeightCache::parse(
@@ -152,10 +153,41 @@ Error CudaWeightCache::parse(
   }
 
   MetadataReader reader(data, size);
-  if (!reader.skip(kFormatMagicSize) ||
-      !reader.read_string(metadata.so_blob_key) ||
-      metadata.so_blob_key.empty()) {
+  const bool is_multi_arch =
+      std::memcmp(data, kMultiArchFormatMagic, kFormatMagicSize) == 0;
+  if (!reader.skip(kFormatMagicSize)) {
     return Error::InvalidProgram;
+  }
+
+  metadata.variants.clear();
+  if (is_multi_arch) {
+    uint32_t num_variants = 0;
+    constexpr uint32_t kMaxVariants = 256;
+    if (!reader.read_u32(num_variants) || num_variants == 0 ||
+        num_variants > kMaxVariants) {
+      return Error::InvalidProgram;
+    }
+    metadata.variants.reserve(num_variants);
+    std::unordered_set<uint32_t> target_sms;
+    for (uint32_t index = 0; index < num_variants; ++index) {
+      Variant variant;
+      if (!reader.read_u32(variant.target_sm) || variant.target_sm == 0 ||
+          !reader.read_u32(variant.ptx_compute) ||
+          variant.ptx_compute > variant.target_sm ||
+          !reader.read_string(variant.so_blob_key) ||
+          variant.so_blob_key.empty() ||
+          !target_sms.emplace(variant.target_sm).second) {
+        return Error::InvalidProgram;
+      }
+      metadata.variants.push_back(std::move(variant));
+    }
+  } else {
+    Variant variant;
+    if (!reader.read_string(variant.so_blob_key) ||
+        variant.so_blob_key.empty()) {
+      return Error::InvalidProgram;
+    }
+    metadata.variants.push_back(std::move(variant));
   }
 
   uint32_t num_entries = 0;
@@ -200,6 +232,49 @@ Error CudaWeightCache::parse(
   }
 
   return reader.empty() ? Error::Ok : Error::InvalidProgram;
+}
+
+Error CudaWeightCache::select_variant(
+    const Metadata& metadata,
+    uint32_t current_sm,
+    size_t& variant_index,
+    bool& uses_ptx_fallback) {
+  ET_CHECK_OR_RETURN_ERROR(
+      !metadata.variants.empty(), InvalidProgram, "CUDA AOTI has no variants");
+
+  if (metadata.variants.size() == 1 && metadata.variants[0].target_sm == 0) {
+    variant_index = 0;
+    uses_ptx_fallback = false;
+    return Error::Ok;
+  }
+
+  for (size_t index = 0; index < metadata.variants.size(); ++index) {
+    if (metadata.variants[index].target_sm == current_sm) {
+      variant_index = index;
+      uses_ptx_fallback = false;
+      return Error::Ok;
+    }
+  }
+
+  std::optional<size_t> fallback;
+  for (size_t index = 0; index < metadata.variants.size(); ++index) {
+    const Variant& variant = metadata.variants[index];
+    if (variant.ptx_compute == 0 || variant.ptx_compute > current_sm) {
+      continue;
+    }
+    if (!fallback.has_value() ||
+        variant.target_sm < metadata.variants[*fallback].target_sm) {
+      fallback = index;
+    }
+  }
+  ET_CHECK_OR_RETURN_ERROR(
+      fallback.has_value(),
+      NotSupported,
+      "CUDA AOTI has no native or PTX variant compatible with sm%u",
+      current_sm);
+  variant_index = *fallback;
+  uses_ptx_fallback = true;
+  return Error::Ok;
 }
 
 Error CudaWeightCache::validate_view(const Entry& entry) {

--- a/backends/cuda/runtime/cuda_weight_cache.cpp
+++ b/backends/cuda/runtime/cuda_weight_cache.cpp
@@ -140,9 +140,7 @@ bool is_supported_device_type(int32_t device_type) {
 
 bool CudaWeightCache::is_serialized(const void* data, size_t size) {
   return data != nullptr && size >= kFormatMagicSize &&
-      (std::memcmp(data, kFormatMagic, kFormatMagicSize) == 0 ||
-       std::memcmp(data, kMultiArchFormatMagic, kFormatMagicSize) == 0 ||
-       std::memcmp(data, kMultiArchFallbackFormatMagic, kFormatMagicSize) == 0);
+      std::memcmp(data, kFormatMagic, kFormatMagicSize) == 0;
 }
 
 Error CudaWeightCache::parse(
@@ -154,56 +152,52 @@ Error CudaWeightCache::parse(
   }
 
   MetadataReader reader(data, size);
-  const bool has_fallback =
-      std::memcmp(data, kMultiArchFallbackFormatMagic, kFormatMagicSize) == 0;
-  const bool is_multi_arch = has_fallback ||
-      std::memcmp(data, kMultiArchFormatMagic, kFormatMagicSize) == 0;
   if (!reader.skip(kFormatMagicSize)) {
     return Error::InvalidProgram;
   }
 
   metadata.variants.clear();
-  if (is_multi_arch) {
-    uint32_t num_variants = 0;
-    constexpr uint32_t kMaxVariants = 256;
-    if (!reader.read_u32(num_variants) || num_variants == 0 ||
-        num_variants > kMaxVariants) {
-      return Error::InvalidProgram;
-    }
-    metadata.variants.reserve(num_variants);
-    std::unordered_set<uint32_t> target_sms;
-    bool found_fallback = false;
-    for (uint32_t index = 0; index < num_variants; ++index) {
-      Variant variant;
-      uint32_t flags = 0;
-      if (!reader.read_u32(variant.target_sm) || variant.target_sm == 0 ||
-          !reader.read_u32(variant.ptx_compute) ||
-          variant.ptx_compute > variant.target_sm ||
-          (has_fallback && !reader.read_u32(flags)) || (flags & ~1U) != 0 ||
-          !reader.read_string(variant.so_blob_key) ||
-          variant.so_blob_key.empty()) {
-        return Error::InvalidProgram;
-      }
-      variant.fallback_only = (flags & 1U) != 0;
-      if (variant.fallback_only) {
-        if (variant.ptx_compute == 0 || found_fallback) {
-          return Error::InvalidProgram;
-        }
-        found_fallback = true;
-      } else if (
-          (has_fallback && variant.ptx_compute != 0) ||
-          !target_sms.emplace(variant.target_sm).second) {
-        return Error::InvalidProgram;
-      }
-      metadata.variants.push_back(std::move(variant));
-    }
-  } else {
+  uint32_t num_variants = 0;
+  constexpr uint32_t kMaxVariants = 256;
+  if (!reader.read_u32(num_variants) || num_variants == 0 ||
+      num_variants > kMaxVariants) {
+    return Error::InvalidProgram;
+  }
+  metadata.variants.reserve(num_variants);
+  std::unordered_set<uint32_t> target_sms;
+  bool found_fallback = false;
+  bool regular_has_ptx = false;
+  for (uint32_t index = 0; index < num_variants; ++index) {
     Variant variant;
-    if (!reader.read_string(variant.so_blob_key) ||
+    uint32_t flags = 0;
+    if (!reader.read_u32(variant.target_sm) ||
+        !reader.read_u32(variant.ptx_compute) ||
+        variant.ptx_compute > variant.target_sm || !reader.read_u32(flags) ||
+        (flags & ~1U) != 0 || !reader.read_string(variant.so_blob_key) ||
         variant.so_blob_key.empty()) {
       return Error::InvalidProgram;
     }
+    variant.fallback_only = (flags & 1U) != 0;
+    if (variant.target_sm == 0) {
+      if (num_variants != 1 || variant.ptx_compute != 0 ||
+          variant.fallback_only) {
+        return Error::InvalidProgram;
+      }
+    } else if (variant.fallback_only) {
+      if (variant.ptx_compute == 0 || found_fallback) {
+        return Error::InvalidProgram;
+      }
+      found_fallback = true;
+    } else {
+      if (!target_sms.emplace(variant.target_sm).second) {
+        return Error::InvalidProgram;
+      }
+      regular_has_ptx |= variant.ptx_compute != 0;
+    }
     metadata.variants.push_back(std::move(variant));
+  }
+  if (num_variants > 1 && regular_has_ptx) {
+    return Error::InvalidProgram;
   }
 
   uint32_t num_entries = 0;
@@ -273,25 +267,20 @@ Error CudaWeightCache::select_variant(
     }
   }
 
-  std::optional<size_t> fallback;
   for (size_t index = 0; index < metadata.variants.size(); ++index) {
     const Variant& variant = metadata.variants[index];
-    if (variant.ptx_compute == 0 || variant.ptx_compute > current_sm) {
-      continue;
-    }
-    if (!fallback.has_value() ||
-        variant.target_sm < metadata.variants[*fallback].target_sm) {
-      fallback = index;
+    if (variant.ptx_compute != 0 && variant.ptx_compute <= current_sm &&
+        (variant.fallback_only || metadata.variants.size() == 1)) {
+      variant_index = index;
+      uses_ptx_fallback = true;
+      return Error::Ok;
     }
   }
   ET_CHECK_OR_RETURN_ERROR(
-      fallback.has_value(),
+      false,
       NotSupported,
       "CUDA AOTI has no native or PTX variant compatible with sm%u",
       current_sm);
-  variant_index = *fallback;
-  uses_ptx_fallback = true;
-  return Error::Ok;
 }
 
 Error CudaWeightCache::validate_view(const Entry& entry) {

--- a/backends/cuda/runtime/cuda_weight_cache.cpp
+++ b/backends/cuda/runtime/cuda_weight_cache.cpp
@@ -141,7 +141,8 @@ bool is_supported_device_type(int32_t device_type) {
 bool CudaWeightCache::is_serialized(const void* data, size_t size) {
   return data != nullptr && size >= kFormatMagicSize &&
       (std::memcmp(data, kFormatMagic, kFormatMagicSize) == 0 ||
-       std::memcmp(data, kMultiArchFormatMagic, kFormatMagicSize) == 0);
+       std::memcmp(data, kMultiArchFormatMagic, kFormatMagicSize) == 0 ||
+       std::memcmp(data, kMultiArchFallbackFormatMagic, kFormatMagicSize) == 0);
 }
 
 Error CudaWeightCache::parse(
@@ -153,7 +154,9 @@ Error CudaWeightCache::parse(
   }
 
   MetadataReader reader(data, size);
-  const bool is_multi_arch =
+  const bool has_fallback =
+      std::memcmp(data, kMultiArchFallbackFormatMagic, kFormatMagicSize) == 0;
+  const bool is_multi_arch = has_fallback ||
       std::memcmp(data, kMultiArchFormatMagic, kFormatMagicSize) == 0;
   if (!reader.skip(kFormatMagicSize)) {
     return Error::InvalidProgram;
@@ -169,13 +172,26 @@ Error CudaWeightCache::parse(
     }
     metadata.variants.reserve(num_variants);
     std::unordered_set<uint32_t> target_sms;
+    bool found_fallback = false;
     for (uint32_t index = 0; index < num_variants; ++index) {
       Variant variant;
+      uint32_t flags = 0;
       if (!reader.read_u32(variant.target_sm) || variant.target_sm == 0 ||
           !reader.read_u32(variant.ptx_compute) ||
           variant.ptx_compute > variant.target_sm ||
+          (has_fallback && !reader.read_u32(flags)) || (flags & ~1U) != 0 ||
           !reader.read_string(variant.so_blob_key) ||
-          variant.so_blob_key.empty() ||
+          variant.so_blob_key.empty()) {
+        return Error::InvalidProgram;
+      }
+      variant.fallback_only = (flags & 1U) != 0;
+      if (variant.fallback_only) {
+        if (variant.ptx_compute == 0 || found_fallback) {
+          return Error::InvalidProgram;
+        }
+        found_fallback = true;
+      } else if (
+          (has_fallback && variant.ptx_compute != 0) ||
           !target_sms.emplace(variant.target_sm).second) {
         return Error::InvalidProgram;
       }
@@ -249,7 +265,8 @@ Error CudaWeightCache::select_variant(
   }
 
   for (size_t index = 0; index < metadata.variants.size(); ++index) {
-    if (metadata.variants[index].target_sm == current_sm) {
+    if (!metadata.variants[index].fallback_only &&
+        metadata.variants[index].target_sm == current_sm) {
       variant_index = index;
       uses_ptx_fallback = false;
       return Error::Ok;

--- a/backends/cuda/runtime/cuda_weight_cache.h
+++ b/backends/cuda/runtime/cuda_weight_cache.h
@@ -24,9 +24,7 @@ namespace executorch::backends::cuda {
 
 class CudaWeightCache final {
  public:
-  static constexpr char kFormatMagic[] = "ETCUDAFQN3";
-  static constexpr char kMultiArchFormatMagic[] = "ETCUDAFQN4";
-  static constexpr char kMultiArchFallbackFormatMagic[] = "ETCUDAFQN5";
+  static constexpr char kFormatMagic[] = "ETCUDAFQN0";
   static constexpr size_t kFormatMagicSize = sizeof(kFormatMagic) - 1;
 
   struct Variant {

--- a/backends/cuda/runtime/cuda_weight_cache.h
+++ b/backends/cuda/runtime/cuda_weight_cache.h
@@ -25,7 +25,14 @@ namespace executorch::backends::cuda {
 class CudaWeightCache final {
  public:
   static constexpr char kFormatMagic[] = "ETCUDAFQN3";
+  static constexpr char kMultiArchFormatMagic[] = "ETCUDAFQN4";
   static constexpr size_t kFormatMagicSize = sizeof(kFormatMagic) - 1;
+
+  struct Variant {
+    uint32_t target_sm{0};
+    uint32_t ptx_compute{0};
+    std::string so_blob_key;
+  };
 
   struct Entry {
     std::string fqn;
@@ -39,7 +46,7 @@ class CudaWeightCache final {
   };
 
   struct Metadata {
-    std::string so_blob_key;
+    std::vector<Variant> variants;
     std::vector<Entry> entries;
   };
 
@@ -47,6 +54,12 @@ class CudaWeightCache final {
 
   static runtime::Error
   parse(const void* data, size_t size, Metadata& metadata);
+
+  static runtime::Error select_variant(
+      const Metadata& metadata,
+      uint32_t current_sm,
+      size_t& variant_index,
+      bool& uses_ptx_fallback);
 
   runtime::Error load(
       CudaDelegateHandle* handle,

--- a/backends/cuda/runtime/cuda_weight_cache.h
+++ b/backends/cuda/runtime/cuda_weight_cache.h
@@ -26,12 +26,14 @@ class CudaWeightCache final {
  public:
   static constexpr char kFormatMagic[] = "ETCUDAFQN3";
   static constexpr char kMultiArchFormatMagic[] = "ETCUDAFQN4";
+  static constexpr char kMultiArchFallbackFormatMagic[] = "ETCUDAFQN5";
   static constexpr size_t kFormatMagicSize = sizeof(kFormatMagic) - 1;
 
   struct Variant {
     uint32_t target_sm{0};
     uint32_t ptx_compute{0};
     std::string so_blob_key;
+    bool fallback_only{false};
   };
 
   struct Entry {

--- a/backends/cuda/runtime/test/test_cuda_weight_cache.cpp
+++ b/backends/cuda/runtime/test/test_cuda_weight_cache.cpp
@@ -59,6 +59,36 @@ std::vector<uint8_t> serialized_metadata(
   return output;
 }
 
+std::vector<uint8_t> serialized_multi_arch_metadata() {
+  std::vector<uint8_t> output(
+      cuda::CudaWeightCache::kMultiArchFormatMagic,
+      cuda::CudaWeightCache::kMultiArchFormatMagic +
+          cuda::CudaWeightCache::kFormatMagicSize);
+  append_u32(output, 3); // variants
+  append_u32(output, 80);
+  append_u32(output, 80);
+  append_string(output, "sm80-so");
+  append_u32(output, 90);
+  append_u32(output, 90);
+  append_string(output, "sm90-so");
+  append_u32(output, 120);
+  append_u32(output, 120);
+  append_string(output, "sm120-so");
+  append_u32(output, 1); // entries
+  append_string(output, "model.weight");
+  append_string(output, "storage-key");
+  append_u64(output, 24);
+  append_u32(output, 6);
+  append_u32(output, 1);
+  append_u64(output, 0);
+  append_u32(output, 2);
+  append_u64(output, 2);
+  append_u64(output, 3);
+  append_u64(output, 3);
+  append_u64(output, 1);
+  return output;
+}
+
 } // namespace
 
 TEST(CudaWeightCacheTest, LegacyPayloadIsNotMisdetected) {
@@ -73,7 +103,9 @@ TEST(CudaWeightCacheTest, ParsesSerializedMetadata) {
   ASSERT_EQ(
       cuda::CudaWeightCache::parse(bytes.data(), bytes.size(), metadata),
       Error::Ok);
-  ASSERT_EQ(metadata.so_blob_key, "so-key");
+  ASSERT_EQ(metadata.variants.size(), 1u);
+  EXPECT_EQ(metadata.variants[0].target_sm, 0u);
+  EXPECT_EQ(metadata.variants[0].so_blob_key, "so-key");
   ASSERT_EQ(metadata.entries.size(), 1u);
   const auto& entry = metadata.entries[0];
   EXPECT_EQ(entry.fqn, "model.weight");
@@ -83,6 +115,88 @@ TEST(CudaWeightCacheTest, ParsesSerializedMetadata) {
   EXPECT_EQ(entry.device_type, 1);
   EXPECT_EQ(entry.sizes, (std::vector<int64_t>{2, 3}));
   EXPECT_EQ(entry.strides, (std::vector<int64_t>{3, 1}));
+}
+
+TEST(CudaWeightCacheTest, ParsesAndSelectsMultiArchMetadata) {
+  const std::vector<uint8_t> bytes = serialized_multi_arch_metadata();
+  cuda::CudaWeightCache::Metadata metadata;
+  ASSERT_EQ(
+      cuda::CudaWeightCache::parse(bytes.data(), bytes.size(), metadata),
+      Error::Ok);
+  ASSERT_EQ(metadata.variants.size(), 3u);
+  EXPECT_EQ(metadata.variants[0].target_sm, 80u);
+  EXPECT_EQ(metadata.variants[2].so_blob_key, "sm120-so");
+
+  size_t variant_index = 0;
+  bool uses_ptx_fallback = false;
+  EXPECT_EQ(
+      cuda::CudaWeightCache::select_variant(
+          metadata, 120, variant_index, uses_ptx_fallback),
+      Error::Ok);
+  EXPECT_EQ(variant_index, 2u);
+  EXPECT_FALSE(uses_ptx_fallback);
+
+  EXPECT_EQ(
+      cuda::CudaWeightCache::select_variant(
+          metadata, 100, variant_index, uses_ptx_fallback),
+      Error::Ok);
+  EXPECT_EQ(variant_index, 0u);
+  EXPECT_TRUE(uses_ptx_fallback);
+}
+
+TEST(CudaWeightCacheTest, SelectsLowestCompatiblePtxFallback) {
+  cuda::CudaWeightCache::Metadata metadata;
+  metadata.variants = {
+      {90, 90, "sm90-so"},
+      {80, 80, "sm80-so"},
+      {120, 0, "sm120-so"},
+  };
+  size_t variant_index = 0;
+  bool uses_ptx_fallback = false;
+  ASSERT_EQ(
+      cuda::CudaWeightCache::select_variant(
+          metadata, 120, variant_index, uses_ptx_fallback),
+      Error::Ok);
+  EXPECT_EQ(metadata.variants[variant_index].target_sm, 120u);
+  EXPECT_FALSE(uses_ptx_fallback);
+
+  ASSERT_EQ(
+      cuda::CudaWeightCache::select_variant(
+          metadata, 100, variant_index, uses_ptx_fallback),
+      Error::Ok);
+  EXPECT_EQ(metadata.variants[variant_index].target_sm, 80u);
+  EXPECT_TRUE(uses_ptx_fallback);
+}
+
+TEST(CudaWeightCacheTest, RejectsWhenNoVariantIsCompatible) {
+  cuda::CudaWeightCache::Metadata metadata;
+  metadata.variants = {{120, 0, "sm120-so"}};
+  size_t variant_index = 0;
+  bool uses_ptx_fallback = false;
+  EXPECT_EQ(
+      cuda::CudaWeightCache::select_variant(
+          metadata, 90, variant_index, uses_ptx_fallback),
+      Error::NotSupported);
+}
+
+TEST(CudaWeightCacheTest, RejectsDuplicateMultiArchTarget) {
+  std::vector<uint8_t> bytes(
+      cuda::CudaWeightCache::kMultiArchFormatMagic,
+      cuda::CudaWeightCache::kMultiArchFormatMagic +
+          cuda::CudaWeightCache::kFormatMagicSize);
+  append_u32(bytes, 2);
+  append_u32(bytes, 80);
+  append_u32(bytes, 80);
+  append_string(bytes, "first-so");
+  append_u32(bytes, 80);
+  append_u32(bytes, 0);
+  append_string(bytes, "second-so");
+  append_u32(bytes, 0);
+
+  cuda::CudaWeightCache::Metadata metadata;
+  EXPECT_EQ(
+      cuda::CudaWeightCache::parse(bytes.data(), bytes.size(), metadata),
+      Error::InvalidProgram);
 }
 
 TEST(CudaWeightCacheTest, RejectsTruncationAndTrailingData) {

--- a/backends/cuda/runtime/test/test_cuda_weight_cache.cpp
+++ b/backends/cuda/runtime/test/test_cuda_weight_cache.cpp
@@ -89,6 +89,24 @@ std::vector<uint8_t> serialized_multi_arch_metadata() {
   return output;
 }
 
+std::vector<uint8_t> serialized_fallback_metadata() {
+  std::vector<uint8_t> output(
+      cuda::CudaWeightCache::kMultiArchFallbackFormatMagic,
+      cuda::CudaWeightCache::kMultiArchFallbackFormatMagic +
+          cuda::CudaWeightCache::kFormatMagicSize);
+  append_u32(output, 2); // variants
+  append_u32(output, 80);
+  append_u32(output, 0);
+  append_u32(output, 0); // regular
+  append_string(output, "sm80-so");
+  append_u32(output, 80);
+  append_u32(output, 80);
+  append_u32(output, 1); // fallback only
+  append_string(output, "fallback-so");
+  append_u32(output, 0); // entries
+  return output;
+}
+
 } // namespace
 
 TEST(CudaWeightCacheTest, LegacyPayloadIsNotMisdetected) {
@@ -165,6 +183,33 @@ TEST(CudaWeightCacheTest, SelectsLowestCompatiblePtxFallback) {
           metadata, 100, variant_index, uses_ptx_fallback),
       Error::Ok);
   EXPECT_EQ(metadata.variants[variant_index].target_sm, 80u);
+  EXPECT_TRUE(uses_ptx_fallback);
+}
+
+TEST(CudaWeightCacheTest, FallbackOnlyVariantNeverWinsNativeMatch) {
+  const std::vector<uint8_t> bytes = serialized_fallback_metadata();
+  cuda::CudaWeightCache::Metadata metadata;
+  ASSERT_EQ(
+      cuda::CudaWeightCache::parse(bytes.data(), bytes.size(), metadata),
+      Error::Ok);
+  ASSERT_EQ(metadata.variants.size(), 2u);
+  EXPECT_FALSE(metadata.variants[0].fallback_only);
+  EXPECT_TRUE(metadata.variants[1].fallback_only);
+
+  size_t variant_index = 0;
+  bool uses_ptx_fallback = false;
+  ASSERT_EQ(
+      cuda::CudaWeightCache::select_variant(
+          metadata, 80, variant_index, uses_ptx_fallback),
+      Error::Ok);
+  EXPECT_EQ(variant_index, 0u);
+  EXPECT_FALSE(uses_ptx_fallback);
+
+  ASSERT_EQ(
+      cuda::CudaWeightCache::select_variant(
+          metadata, 90, variant_index, uses_ptx_fallback),
+      Error::Ok);
+  EXPECT_EQ(variant_index, 1u);
   EXPECT_TRUE(uses_ptx_fallback);
 }
 

--- a/backends/cuda/runtime/test/test_cuda_weight_cache.cpp
+++ b/backends/cuda/runtime/test/test_cuda_weight_cache.cpp
@@ -43,6 +43,10 @@ std::vector<uint8_t> serialized_metadata(
       cuda::CudaWeightCache::kFormatMagic,
       cuda::CudaWeightCache::kFormatMagic +
           cuda::CudaWeightCache::kFormatMagicSize);
+  append_u32(output, 1); // variants
+  append_u32(output, 0); // untargeted (ROCm)
+  append_u32(output, 0); // no PTX
+  append_u32(output, 0); // regular
   append_string(output, "so-key");
   append_u32(output, 1); // entries
   append_string(output, "model.weight");
@@ -61,18 +65,21 @@ std::vector<uint8_t> serialized_metadata(
 
 std::vector<uint8_t> serialized_multi_arch_metadata() {
   std::vector<uint8_t> output(
-      cuda::CudaWeightCache::kMultiArchFormatMagic,
-      cuda::CudaWeightCache::kMultiArchFormatMagic +
+      cuda::CudaWeightCache::kFormatMagic,
+      cuda::CudaWeightCache::kFormatMagic +
           cuda::CudaWeightCache::kFormatMagicSize);
   append_u32(output, 3); // variants
   append_u32(output, 80);
-  append_u32(output, 80);
+  append_u32(output, 0);
+  append_u32(output, 0); // regular
   append_string(output, "sm80-so");
   append_u32(output, 90);
-  append_u32(output, 90);
+  append_u32(output, 0);
+  append_u32(output, 0); // regular
   append_string(output, "sm90-so");
   append_u32(output, 120);
-  append_u32(output, 120);
+  append_u32(output, 0);
+  append_u32(output, 0); // regular
   append_string(output, "sm120-so");
   append_u32(output, 1); // entries
   append_string(output, "model.weight");
@@ -91,8 +98,8 @@ std::vector<uint8_t> serialized_multi_arch_metadata() {
 
 std::vector<uint8_t> serialized_fallback_metadata() {
   std::vector<uint8_t> output(
-      cuda::CudaWeightCache::kMultiArchFallbackFormatMagic,
-      cuda::CudaWeightCache::kMultiArchFallbackFormatMagic +
+      cuda::CudaWeightCache::kFormatMagic,
+      cuda::CudaWeightCache::kFormatMagic +
           cuda::CudaWeightCache::kFormatMagicSize);
   append_u32(output, 2); // variants
   append_u32(output, 80);
@@ -109,7 +116,7 @@ std::vector<uint8_t> serialized_fallback_metadata() {
 
 } // namespace
 
-TEST(CudaWeightCacheTest, LegacyPayloadIsNotMisdetected) {
+TEST(CudaWeightCacheTest, RawAotiPayloadIsNotMisdetected) {
   const std::string legacy = "so-key\nweights-key";
   EXPECT_FALSE(
       cuda::CudaWeightCache::is_serialized(legacy.data(), legacy.size()));
@@ -157,32 +164,19 @@ TEST(CudaWeightCacheTest, ParsesAndSelectsMultiArchMetadata) {
   EXPECT_EQ(
       cuda::CudaWeightCache::select_variant(
           metadata, 100, variant_index, uses_ptx_fallback),
-      Error::Ok);
-  EXPECT_EQ(variant_index, 0u);
-  EXPECT_TRUE(uses_ptx_fallback);
+      Error::NotSupported);
 }
 
-TEST(CudaWeightCacheTest, SelectsLowestCompatiblePtxFallback) {
+TEST(CudaWeightCacheTest, SelectsPtxFromPortableSingleVariant) {
   cuda::CudaWeightCache::Metadata metadata;
-  metadata.variants = {
-      {90, 90, "sm90-so"},
-      {80, 80, "sm80-so"},
-      {120, 0, "sm120-so"},
-  };
+  metadata.variants = {{80, 80, "sm80-so"}};
   size_t variant_index = 0;
   bool uses_ptx_fallback = false;
   ASSERT_EQ(
       cuda::CudaWeightCache::select_variant(
-          metadata, 120, variant_index, uses_ptx_fallback),
-      Error::Ok);
-  EXPECT_EQ(metadata.variants[variant_index].target_sm, 120u);
-  EXPECT_FALSE(uses_ptx_fallback);
-
-  ASSERT_EQ(
-      cuda::CudaWeightCache::select_variant(
           metadata, 100, variant_index, uses_ptx_fallback),
       Error::Ok);
-  EXPECT_EQ(metadata.variants[variant_index].target_sm, 80u);
+  EXPECT_EQ(variant_index, 0u);
   EXPECT_TRUE(uses_ptx_fallback);
 }
 
@@ -226,16 +220,40 @@ TEST(CudaWeightCacheTest, RejectsWhenNoVariantIsCompatible) {
 
 TEST(CudaWeightCacheTest, RejectsDuplicateMultiArchTarget) {
   std::vector<uint8_t> bytes(
-      cuda::CudaWeightCache::kMultiArchFormatMagic,
-      cuda::CudaWeightCache::kMultiArchFormatMagic +
+      cuda::CudaWeightCache::kFormatMagic,
+      cuda::CudaWeightCache::kFormatMagic +
+          cuda::CudaWeightCache::kFormatMagicSize);
+  append_u32(bytes, 2);
+  append_u32(bytes, 80);
+  append_u32(bytes, 0);
+  append_u32(bytes, 0);
+  append_string(bytes, "first-so");
+  append_u32(bytes, 80);
+  append_u32(bytes, 0);
+  append_u32(bytes, 0);
+  append_string(bytes, "second-so");
+  append_u32(bytes, 0);
+
+  cuda::CudaWeightCache::Metadata metadata;
+  EXPECT_EQ(
+      cuda::CudaWeightCache::parse(bytes.data(), bytes.size(), metadata),
+      Error::InvalidProgram);
+}
+
+TEST(CudaWeightCacheTest, RejectsImplicitPtxFallbackInMultiVariantMetadata) {
+  std::vector<uint8_t> bytes(
+      cuda::CudaWeightCache::kFormatMagic,
+      cuda::CudaWeightCache::kFormatMagic +
           cuda::CudaWeightCache::kFormatMagicSize);
   append_u32(bytes, 2);
   append_u32(bytes, 80);
   append_u32(bytes, 80);
-  append_string(bytes, "first-so");
-  append_u32(bytes, 80);
   append_u32(bytes, 0);
-  append_string(bytes, "second-so");
+  append_string(bytes, "sm80-so");
+  append_u32(bytes, 120);
+  append_u32(bytes, 0);
+  append_u32(bytes, 0);
+  append_string(bytes, "sm120-so");
   append_u32(bytes, 0);
 
   cuda::CudaWeightCache::Metadata metadata;

--- a/backends/cuda/tests/test_cuda_export.py
+++ b/backends/cuda/tests/test_cuda_export.py
@@ -133,6 +133,33 @@ class TestCudaBackendCompileOptions(unittest.TestCase):
 
                 self.assertIs(triton_compiler.max_shared_mem, local_max_shared_mem)
 
+    def test_cuda_include_ptx_compile_spec(self):
+        with mock.patch.object(
+            CudaBackend, "_setup_cuda_environment_for_fatbin", return_value=True
+        ):
+            options = CudaBackend.get_aoti_compile_options(
+                [CompileSpec(key="cuda_include_ptx", value=b"ON")]
+            )
+
+        self.assertTrue(options["aot_inductor.emit_multi_arch_kernel"])
+
+    def test_cuda_include_ptx_off_disables_multi_arch_kernel(self):
+        with mock.patch.object(
+            CudaBackend, "_setup_cuda_environment_for_fatbin"
+        ) as setup_fatbin:
+            options = CudaBackend.get_aoti_compile_options(
+                [CompileSpec(key="cuda_include_ptx", value=b"OFF")]
+            )
+
+        setup_fatbin.assert_not_called()
+        self.assertFalse(options["aot_inductor.emit_multi_arch_kernel"])
+
+    def test_invalid_cuda_include_ptx_compile_spec(self):
+        with self.assertRaisesRegex(ValueError, "Invalid cuda_include_ptx"):
+            CudaBackend.get_aoti_compile_options(
+                [CompileSpec(key="cuda_include_ptx", value=b"MAYBE")]
+            )
+
 
 class TestCudaExport(unittest.TestCase):
     """Test CUDA export functionality for various operations using to_edge_transform_and_lower."""

--- a/backends/cuda/tests/test_cuda_partitioner.py
+++ b/backends/cuda/tests/test_cuda_partitioner.py
@@ -21,9 +21,10 @@ from executorch.backends.cuda.cuda_partitioner import CudaPartitioner
 from executorch.backends.cuda.cuda_weight_collector import (
     AOTI_DEVICE_TYPE_CPU,
     AOTI_DEVICE_TYPE_CUDA,
-    CUDA_WEIGHT_CACHE_MAGIC,
+    CUDA_AOTI_METADATA_MAGIC,
+    CudaAotiVariant,
     CudaWeightCollector,
-    encode_cuda_weight_metadata,
+    encode_cuda_aoti_metadata,
 )
 from executorch.exir._serialize._cord import FileBackedData
 from executorch.exir._serialize._named_data_store import NamedDataStore
@@ -95,8 +96,10 @@ class TestCudaLowMemoryExport(unittest.TestCase):
                 artifact.storages[artifact.entries[1].storage_key].to_bytes(),
             )
 
-            metadata = encode_cuda_weight_metadata("so-key", artifact.entries)
-            self.assertTrue(metadata.startswith(CUDA_WEIGHT_CACHE_MAGIC))
+            metadata = encode_cuda_aoti_metadata(
+                [CudaAotiVariant(0, 0, "so-key")], artifact.entries
+            )
+            self.assertTrue(metadata.startswith(CUDA_AOTI_METADATA_MAGIC))
             self.assertIn(b"first", metadata)
             self.assertIn(b"second", metadata)
             for storage in artifact.storages.values():

--- a/backends/cuda/tests/test_cuda_weight_metadata.py
+++ b/backends/cuda/tests/test_cuda_weight_metadata.py
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from executorch.backends.cuda.cuda_weight_collector import (
+    AOTI_DEVICE_TYPE_CUDA,
+    CUDA_MULTI_ARCH_MAGIC,
+    CudaAotiVariant,
+    CudaWeightEntry,
+    decode_cuda_aoti_metadata,
+    encode_cuda_multi_arch_metadata,
+    encode_cuda_weight_metadata,
+)
+
+
+class TestCudaWeightMetadata(unittest.TestCase):
+    @staticmethod
+    def _entry() -> CudaWeightEntry:
+        return CudaWeightEntry(
+            fqn="model.weight",
+            storage_key="cuda_fqn_weight:cuda:model.weight",
+            storage_nbytes=24,
+            dtype=6,
+            device_type=AOTI_DEVICE_TYPE_CUDA,
+            storage_offset=0,
+            sizes=(2, 3),
+            strides=(3, 1),
+        )
+
+    def test_multi_arch_metadata_has_shared_weights(self) -> None:
+        entry = self._entry()
+        encoded = encode_cuda_multi_arch_metadata(
+            [
+                CudaAotiVariant(80, 80, "sm80-so"),
+                CudaAotiVariant(120, 120, "sm120-so"),
+            ],
+            [entry],
+        )
+        self.assertTrue(encoded.startswith(CUDA_MULTI_ARCH_MAGIC))
+        decoded = decode_cuda_aoti_metadata(encoded)
+        self.assertEqual(
+            decoded.variants,
+            [
+                CudaAotiVariant(80, 80, "sm80-so"),
+                CudaAotiVariant(120, 120, "sm120-so"),
+            ],
+        )
+        self.assertEqual(decoded.entries, [entry])
+
+    def test_multi_arch_metadata_rejects_duplicate_target(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Duplicate CUDA target SM"):
+            encode_cuda_multi_arch_metadata(
+                [
+                    CudaAotiVariant(80, 80, "first"),
+                    CudaAotiVariant(80, 0, "second"),
+                ],
+                [self._entry()],
+            )
+
+    def test_legacy_metadata_decodes_as_unspecified_target(self) -> None:
+        decoded = decode_cuda_aoti_metadata(
+            encode_cuda_weight_metadata("legacy-so", [self._entry()])
+        )
+        self.assertEqual(decoded.variants, [CudaAotiVariant(0, 0, "legacy-so")])
+        self.assertEqual(decoded.entries, [self._entry()])
+
+    def test_metadata_rejects_trailing_data(self) -> None:
+        encoded = encode_cuda_multi_arch_metadata(
+            [CudaAotiVariant(80, 80, "sm80-so")], [self._entry()]
+        )
+        with self.assertRaisesRegex(ValueError, "trailing bytes"):
+            decode_cuda_aoti_metadata(encoded + b"\0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/cuda/tests/test_cuda_weight_metadata.py
+++ b/backends/cuda/tests/test_cuda_weight_metadata.py
@@ -8,13 +8,11 @@ import unittest
 
 from executorch.backends.cuda.cuda_weight_collector import (
     AOTI_DEVICE_TYPE_CUDA,
-    CUDA_MULTI_ARCH_FALLBACK_MAGIC,
-    CUDA_MULTI_ARCH_MAGIC,
+    CUDA_AOTI_METADATA_MAGIC,
     CudaAotiVariant,
     CudaWeightEntry,
     decode_cuda_aoti_metadata,
-    encode_cuda_multi_arch_metadata,
-    encode_cuda_weight_metadata,
+    encode_cuda_aoti_metadata,
 )
 
 
@@ -32,31 +30,31 @@ class TestCudaWeightMetadata(unittest.TestCase):
             strides=(3, 1),
         )
 
-    def test_multi_arch_metadata_has_shared_weights(self) -> None:
+    def test_targeted_metadata_has_shared_weights(self) -> None:
         entry = self._entry()
-        encoded = encode_cuda_multi_arch_metadata(
+        encoded = encode_cuda_aoti_metadata(
             [
-                CudaAotiVariant(80, 80, "sm80-so"),
-                CudaAotiVariant(120, 120, "sm120-so"),
+                CudaAotiVariant(80, 0, "sm80-so"),
+                CudaAotiVariant(120, 0, "sm120-so"),
             ],
             [entry],
         )
-        self.assertTrue(encoded.startswith(CUDA_MULTI_ARCH_MAGIC))
+        self.assertTrue(encoded.startswith(CUDA_AOTI_METADATA_MAGIC))
         decoded = decode_cuda_aoti_metadata(encoded)
         self.assertEqual(
             decoded.variants,
             [
-                CudaAotiVariant(80, 80, "sm80-so"),
-                CudaAotiVariant(120, 120, "sm120-so"),
+                CudaAotiVariant(80, 0, "sm80-so"),
+                CudaAotiVariant(120, 0, "sm120-so"),
             ],
         )
         self.assertEqual(decoded.entries, [entry])
 
-    def test_multi_arch_metadata_rejects_duplicate_target(self) -> None:
+    def test_metadata_rejects_duplicate_target(self) -> None:
         with self.assertRaisesRegex(ValueError, "Duplicate CUDA target SM"):
-            encode_cuda_multi_arch_metadata(
+            encode_cuda_aoti_metadata(
                 [
-                    CudaAotiVariant(80, 80, "first"),
+                    CudaAotiVariant(80, 0, "first"),
                     CudaAotiVariant(80, 0, "second"),
                 ],
                 [self._entry()],
@@ -64,14 +62,14 @@ class TestCudaWeightMetadata(unittest.TestCase):
 
     def test_fallback_metadata_allows_matching_regular_target(self) -> None:
         entry = self._entry()
-        encoded = encode_cuda_multi_arch_metadata(
+        encoded = encode_cuda_aoti_metadata(
             [
                 CudaAotiVariant(80, 0, "sm80-so"),
                 CudaAotiVariant(80, 80, "fallback-so", fallback_only=True),
             ],
             [entry],
         )
-        self.assertTrue(encoded.startswith(CUDA_MULTI_ARCH_FALLBACK_MAGIC))
+        self.assertTrue(encoded.startswith(CUDA_AOTI_METADATA_MAGIC))
         decoded = decode_cuda_aoti_metadata(encoded)
         self.assertEqual(
             decoded.variants,
@@ -83,7 +81,7 @@ class TestCudaWeightMetadata(unittest.TestCase):
 
     def test_fallback_metadata_rejects_multiple_fallbacks(self) -> None:
         with self.assertRaisesRegex(ValueError, "only one fallback"):
-            encode_cuda_multi_arch_metadata(
+            encode_cuda_aoti_metadata(
                 [
                     CudaAotiVariant(80, 80, "first", fallback_only=True),
                     CudaAotiVariant(75, 75, "second", fallback_only=True),
@@ -91,15 +89,37 @@ class TestCudaWeightMetadata(unittest.TestCase):
                 [self._entry()],
             )
 
-    def test_legacy_metadata_decodes_as_unspecified_target(self) -> None:
-        decoded = decode_cuda_aoti_metadata(
-            encode_cuda_weight_metadata("legacy-so", [self._entry()])
+    def test_multi_variant_metadata_rejects_implicit_ptx_fallback(self) -> None:
+        with self.assertRaisesRegex(ValueError, "explicit PTX fallback"):
+            encode_cuda_aoti_metadata(
+                [
+                    CudaAotiVariant(80, 80, "sm80-so"),
+                    CudaAotiVariant(120, 0, "sm120-so"),
+                ],
+                [self._entry()],
+            )
+
+    def test_untargeted_metadata_for_rocm(self) -> None:
+        encoded = encode_cuda_aoti_metadata(
+            [CudaAotiVariant(0, 0, "rocm-so")], [self._entry()]
         )
-        self.assertEqual(decoded.variants, [CudaAotiVariant(0, 0, "legacy-so")])
+        self.assertTrue(encoded.startswith(CUDA_AOTI_METADATA_MAGIC))
+        decoded = decode_cuda_aoti_metadata(encoded)
+        self.assertEqual(decoded.variants, [CudaAotiVariant(0, 0, "rocm-so")])
         self.assertEqual(decoded.entries, [self._entry()])
 
+    def test_untargeted_metadata_cannot_mix_with_targeted_variants(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires one non-fallback variant"):
+            encode_cuda_aoti_metadata(
+                [
+                    CudaAotiVariant(0, 0, "rocm-so"),
+                    CudaAotiVariant(80, 0, "sm80-so"),
+                ],
+                [self._entry()],
+            )
+
     def test_metadata_rejects_trailing_data(self) -> None:
-        encoded = encode_cuda_multi_arch_metadata(
+        encoded = encode_cuda_aoti_metadata(
             [CudaAotiVariant(80, 80, "sm80-so")], [self._entry()]
         )
         with self.assertRaisesRegex(ValueError, "trailing bytes"):

--- a/backends/cuda/tests/test_cuda_weight_metadata.py
+++ b/backends/cuda/tests/test_cuda_weight_metadata.py
@@ -8,6 +8,7 @@ import unittest
 
 from executorch.backends.cuda.cuda_weight_collector import (
     AOTI_DEVICE_TYPE_CUDA,
+    CUDA_MULTI_ARCH_FALLBACK_MAGIC,
     CUDA_MULTI_ARCH_MAGIC,
     CudaAotiVariant,
     CudaWeightEntry,
@@ -57,6 +58,35 @@ class TestCudaWeightMetadata(unittest.TestCase):
                 [
                     CudaAotiVariant(80, 80, "first"),
                     CudaAotiVariant(80, 0, "second"),
+                ],
+                [self._entry()],
+            )
+
+    def test_fallback_metadata_allows_matching_regular_target(self) -> None:
+        entry = self._entry()
+        encoded = encode_cuda_multi_arch_metadata(
+            [
+                CudaAotiVariant(80, 0, "sm80-so"),
+                CudaAotiVariant(80, 80, "fallback-so", fallback_only=True),
+            ],
+            [entry],
+        )
+        self.assertTrue(encoded.startswith(CUDA_MULTI_ARCH_FALLBACK_MAGIC))
+        decoded = decode_cuda_aoti_metadata(encoded)
+        self.assertEqual(
+            decoded.variants,
+            [
+                CudaAotiVariant(80, 0, "sm80-so"),
+                CudaAotiVariant(80, 80, "fallback-so", fallback_only=True),
+            ],
+        )
+
+    def test_fallback_metadata_rejects_multiple_fallbacks(self) -> None:
+        with self.assertRaisesRegex(ValueError, "only one fallback"):
+            encode_cuda_multi_arch_metadata(
+                [
+                    CudaAotiVariant(80, 80, "first", fallback_only=True),
+                    CudaAotiVariant(75, 75, "second", fallback_only=True),
                 ],
                 [self._entry()],
             )

--- a/backends/cuda/tests/test_merge_ptes.py
+++ b/backends/cuda/tests/test_merge_ptes.py
@@ -1,0 +1,360 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from executorch.backends.cuda.cuda_weight_collector import (
+    AOTI_DEVICE_TYPE_CUDA,
+    CudaAotiVariant,
+    CudaWeightEntry,
+    decode_cuda_aoti_metadata,
+    encode_cuda_multi_arch_metadata,
+    encode_cuda_weight_metadata,
+)
+from executorch.backends.cuda.merge_ptes import (
+    CudaPteInput,
+    main as merge_main,
+    merge_cuda_pte_files,
+)
+from executorch.exir._serialize._named_data_store import NamedDataStore
+from executorch.exir._serialize._program import (
+    deserialize_pte_binary,
+    PTEFile,
+    serialize_pte_binary,
+)
+from executorch.exir._serialize.data_serializer import DataEntry, DataPayload
+from executorch.exir.backend.compile_spec_schema import CompileSpec
+from executorch.exir.schema import (
+    BackendDelegate,
+    BackendDelegateDataReference,
+    BackendDelegateInlineData,
+    ContainerMetadata,
+    DataLocation,
+    ExecutionPlan,
+    Program,
+    SubsegmentOffsets,
+)
+from executorch.extension.flat_tensor.serialize.serialize import FlatTensorSerializer
+
+
+class TestMergeCudaPtes(unittest.TestCase):
+    def _write_artifact(
+        self,
+        directory: Path,
+        target_sm: int,
+        so_data: bytes,
+        weight_data: bytes,
+        *,
+        fqn: str = "model.weight",
+        weight_key: str = "cuda_fqn_weight:cuda:model.weight",
+        ptx_compute: int | None = None,
+        legacy: bool = False,
+    ) -> CudaPteInput:
+        if ptx_compute is None:
+            ptx_compute = target_sm
+        so_key = hashlib.sha256(so_data).hexdigest() + "_so_blob"
+        entry = CudaWeightEntry(
+            fqn=fqn,
+            storage_key=weight_key,
+            storage_nbytes=len(weight_data),
+            dtype=1,
+            device_type=AOTI_DEVICE_TYPE_CUDA,
+            storage_offset=0,
+            sizes=(len(weight_data),),
+            strides=(1,),
+        )
+        metadata = (
+            encode_cuda_weight_metadata(so_key, [entry])
+            if legacy
+            else encode_cuda_multi_arch_metadata(
+                [CudaAotiVariant(target_sm, ptx_compute, so_key)], [entry]
+            )
+        )
+        compile_specs = [CompileSpec("method_name", b"forward")]
+        compile_specs.append(
+            CompileSpec("cuda_include_ptx", b"ON" if ptx_compute else b"OFF")
+        )
+        delegate = BackendDelegate(
+            id="CudaBackend",
+            processed=BackendDelegateDataReference(DataLocation.INLINE, 0),
+            compile_specs=compile_specs,
+        )
+        program = Program(
+            version=0,
+            execution_plan=[
+                ExecutionPlan(
+                    name="forward",
+                    container_meta_type=ContainerMetadata("", ""),
+                    values=[],
+                    inputs=[],
+                    outputs=[],
+                    chains=[],
+                    operators=[],
+                    delegates=[delegate],
+                    non_const_buffer_sizes=[],
+                )
+            ],
+            constant_buffer=[],
+            backend_delegate_data=[BackendDelegateInlineData(metadata)],
+            segments=[],
+            constant_segment=SubsegmentOffsets(0, []),
+        )
+        store = NamedDataStore()
+        store.add_named_data(so_key, so_data)
+        pte_path = directory / "model.pte"
+        with pte_path.open("wb") as output:
+            serialize_pte_binary(
+                PTEFile(
+                    program=program, named_data=store.get_named_data_store_output()
+                ),
+                extract_delegate_segments=True,
+            ).write_to_file(output)
+
+        ptd_path = directory / "aoti_cuda_blob.ptd"
+        serializer = FlatTensorSerializer()
+        with ptd_path.open("wb") as output:
+            serializer.serialize(
+                DataPayload(
+                    buffers=[weight_data],
+                    named_data={weight_key: DataEntry(0, 1, None)},
+                )
+            ).write_to_file(output)
+        return CudaPteInput(
+            pte_path=pte_path,
+            ptd_path=ptd_path,
+            legacy_target_sm=target_sm if legacy else None,
+        )
+
+    def test_merges_variants_and_keeps_one_weight_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sm80 = root / "sm80"
+            sm120 = root / "sm120"
+            sm80.mkdir()
+            sm120.mkdir()
+            inputs = [
+                self._write_artifact(sm80, 80, b"sm80-so", b"shared-weight"),
+                self._write_artifact(sm120, 120, b"sm120-so", b"shared-weight"),
+            ]
+
+            merged = deserialize_pte_binary(bytes(merge_cuda_pte_files(inputs)))
+            delegate = merged.program.execution_plan[0].delegates[0]
+            payload = merged.program.backend_delegate_data[
+                delegate.processed.index
+            ].data
+            metadata = decode_cuda_aoti_metadata(payload)
+            self.assertEqual(
+                [variant.target_sm for variant in metadata.variants], [80, 120]
+            )
+            self.assertEqual(
+                [variant.ptx_compute for variant in metadata.variants], [80, 0]
+            )
+            self.assertEqual(len(metadata.entries), 1)
+            self.assertEqual(metadata.entries[0].fqn, "model.weight")
+            self.assertEqual(
+                set(merged.named_data.pte_data),
+                {
+                    hashlib.sha256(b"sm80-so").hexdigest() + "_so_blob",
+                    hashlib.sha256(b"sm120-so").hexdigest() + "_so_blob",
+                },
+            )
+            self.assertNotIn(
+                "cuda_include_ptx",
+                {
+                    spec.key
+                    for spec in merged.program.execution_plan[0]
+                    .delegates[0]
+                    .compile_specs
+                },
+            )
+
+    def test_allows_only_lowest_source_to_contain_ptx(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sm80 = root / "sm80"
+            sm120 = root / "sm120"
+            sm80.mkdir()
+            sm120.mkdir()
+            inputs = [
+                self._write_artifact(sm80, 80, b"sm80-so", b"weight"),
+                self._write_artifact(
+                    sm120,
+                    120,
+                    b"sm120-so",
+                    b"weight",
+                    ptx_compute=0,
+                ),
+            ]
+
+            merged = deserialize_pte_binary(bytes(merge_cuda_pte_files(inputs)))
+            delegate = merged.program.execution_plan[0].delegates[0]
+            metadata = decode_cuda_aoti_metadata(
+                merged.program.backend_delegate_data[delegate.processed.index].data
+            )
+            self.assertEqual(
+                [variant.ptx_compute for variant in metadata.variants], [80, 0]
+            )
+
+    def test_preserves_no_ptx_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sm80 = root / "sm80"
+            sm120 = root / "sm120"
+            sm80.mkdir()
+            sm120.mkdir()
+            inputs = [
+                self._write_artifact(sm80, 80, b"sm80-so", b"weight", ptx_compute=0),
+                self._write_artifact(
+                    sm120,
+                    120,
+                    b"sm120-so",
+                    b"weight",
+                    ptx_compute=0,
+                ),
+            ]
+
+            merged = deserialize_pte_binary(bytes(merge_cuda_pte_files(inputs)))
+            delegate = merged.program.execution_plan[0].delegates[0]
+            metadata = decode_cuda_aoti_metadata(
+                merged.program.backend_delegate_data[delegate.processed.index].data
+            )
+            self.assertEqual(
+                [variant.ptx_compute for variant in metadata.variants], [0, 0]
+            )
+
+    def test_merges_legacy_fqn3_source_with_explicit_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sm80 = root / "sm80"
+            sm120 = root / "sm120"
+            sm80.mkdir()
+            sm120.mkdir()
+            inputs = [
+                self._write_artifact(sm80, 80, b"sm80-so", b"weight", legacy=True),
+                self._write_artifact(sm120, 120, b"sm120-so", b"weight"),
+            ]
+
+            merged = deserialize_pte_binary(bytes(merge_cuda_pte_files(inputs)))
+            delegate = merged.program.execution_plan[0].delegates[0]
+            metadata = decode_cuda_aoti_metadata(
+                merged.program.backend_delegate_data[delegate.processed.index].data
+            )
+            self.assertEqual(
+                [variant.target_sm for variant in metadata.variants], [80, 120]
+            )
+            self.assertEqual(
+                [variant.ptx_compute for variant in metadata.variants], [80, 0]
+            )
+
+    def test_rejects_different_weight_content(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sm80 = root / "sm80"
+            sm120 = root / "sm120"
+            sm80.mkdir()
+            sm120.mkdir()
+            inputs = [
+                self._write_artifact(sm80, 80, b"sm80-so", b"first-weight"),
+                self._write_artifact(sm120, 120, b"sm120-so", b"other-weight"),
+            ]
+            with self.assertRaisesRegex(ValueError, "weight content differs"):
+                merge_cuda_pte_files(inputs)
+
+    def test_library_local_weight_keys_are_normalized_to_base(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sm80 = root / "sm80"
+            sm120 = root / "sm120"
+            sm80.mkdir()
+            sm120.mkdir()
+            inputs = [
+                self._write_artifact(
+                    sm80,
+                    80,
+                    b"sm80-so",
+                    b"constant",
+                    fqn="_tensor_constant0",
+                    weight_key="cuda_fqn_weight:cuda:sm80-so:_tensor_constant0",
+                ),
+                self._write_artifact(
+                    sm120,
+                    120,
+                    b"sm120-so",
+                    b"constant",
+                    fqn="_tensor_constant0",
+                    weight_key="cuda_fqn_weight:cuda:sm120-so:_tensor_constant0",
+                ),
+            ]
+
+            merged = deserialize_pte_binary(bytes(merge_cuda_pte_files(inputs)))
+            delegate = merged.program.execution_plan[0].delegates[0]
+            metadata = decode_cuda_aoti_metadata(
+                merged.program.backend_delegate_data[delegate.processed.index].data
+            )
+            self.assertEqual(
+                metadata.entries[0].storage_key,
+                "cuda_fqn_weight:cuda:sm80-so:_tensor_constant0",
+            )
+
+    def test_rejects_duplicate_target_sm(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            first = root / "first"
+            second = root / "second"
+            first.mkdir()
+            second.mkdir()
+            inputs = [
+                self._write_artifact(first, 80, b"first-so", b"weight"),
+                self._write_artifact(second, 80, b"second-so", b"weight"),
+            ]
+            with self.assertRaisesRegex(ValueError, "Duplicate CUDA target sm80"):
+                merge_cuda_pte_files(inputs)
+
+    def test_cli_writes_merged_pte_and_reuses_base_ptd(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            sm80 = root / "sm80"
+            sm120 = root / "sm120"
+            output = root / "output"
+            sm80.mkdir()
+            sm120.mkdir()
+            first = self._write_artifact(sm80, 80, b"sm80-so", b"weight")
+            second = self._write_artifact(sm120, 120, b"sm120-so", b"weight")
+            self.assertIsNotNone(first.ptd_path)
+            output_pte = output / "model.pte"
+            output_ptd = output / "aoti_cuda_blob.ptd"
+
+            with patch(
+                "sys.argv",
+                [
+                    "merge_ptes",
+                    "--input-pte",
+                    str(first.pte_path),
+                    "--input-pte",
+                    str(second.pte_path),
+                    "--input-ptd",
+                    str(first.ptd_path),
+                    "--input-ptd",
+                    str(second.ptd_path),
+                    "--output-pte",
+                    str(output_pte),
+                    "--output-ptd",
+                    str(output_ptd),
+                ],
+            ):
+                merge_main()
+
+            self.assertTrue(output_pte.is_file())
+            assert first.ptd_path is not None
+            self.assertEqual(output_ptd.read_bytes(), first.ptd_path.read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/cuda/tests/test_merge_ptes.py
+++ b/backends/cuda/tests/test_merge_ptes.py
@@ -17,8 +17,7 @@ from executorch.backends.cuda.cuda_weight_collector import (
     CudaAotiVariant,
     CudaWeightEntry,
     decode_cuda_aoti_metadata,
-    encode_cuda_multi_arch_metadata,
-    encode_cuda_weight_metadata,
+    encode_cuda_aoti_metadata,
 )
 from executorch.backends.cuda.merge_ptes import (
     CudaPteInput,
@@ -58,7 +57,6 @@ class TestMergeCudaPtes(unittest.TestCase):
         fqn: str = "model.weight",
         weight_key: str = "cuda_fqn_weight:cuda:model.weight",
         ptx_compute: int | None = None,
-        legacy: bool = False,
     ) -> CudaPteInput:
         if ptx_compute is None:
             ptx_compute = target_sm
@@ -73,12 +71,8 @@ class TestMergeCudaPtes(unittest.TestCase):
             sizes=(len(weight_data),),
             strides=(1,),
         )
-        metadata = (
-            encode_cuda_weight_metadata(so_key, [entry])
-            if legacy
-            else encode_cuda_multi_arch_metadata(
-                [CudaAotiVariant(target_sm, ptx_compute, so_key)], [entry]
-            )
+        metadata = encode_cuda_aoti_metadata(
+            [CudaAotiVariant(target_sm, ptx_compute, so_key)], [entry]
         )
         compile_specs = [CompileSpec("method_name", b"forward")]
         compile_specs.append(
@@ -132,7 +126,6 @@ class TestMergeCudaPtes(unittest.TestCase):
         return CudaPteInput(
             pte_path=pte_path,
             ptd_path=ptd_path,
-            legacy_target_sm=target_sm if legacy else None,
         )
 
     def test_merges_variants_and_keeps_one_weight_manifest(self) -> None:
@@ -242,30 +235,6 @@ class TestMergeCudaPtes(unittest.TestCase):
             delegate = merged.program.execution_plan[0].delegates[0]
             metadata = decode_cuda_aoti_metadata(
                 merged.program.backend_delegate_data[delegate.processed.index].data
-            )
-            self.assertEqual(
-                [variant.ptx_compute for variant in metadata.variants], [0, 0]
-            )
-
-    def test_merges_legacy_fqn3_source_with_explicit_target(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            sm80 = root / "sm80"
-            sm120 = root / "sm120"
-            sm80.mkdir()
-            sm120.mkdir()
-            inputs = [
-                self._write_artifact(sm80, 80, b"sm80-so", b"weight", legacy=True),
-                self._write_artifact(sm120, 120, b"sm120-so", b"weight"),
-            ]
-
-            merged = deserialize_pte_binary(bytes(merge_cuda_pte_files(inputs)))
-            delegate = merged.program.execution_plan[0].delegates[0]
-            metadata = decode_cuda_aoti_metadata(
-                merged.program.backend_delegate_data[delegate.processed.index].data
-            )
-            self.assertEqual(
-                [variant.target_sm for variant in metadata.variants], [80, 120]
             )
             self.assertEqual(
                 [variant.ptx_compute for variant in metadata.variants], [0, 0]

--- a/backends/cuda/tests/test_merge_ptes.py
+++ b/backends/cuda/tests/test_merge_ptes.py
@@ -5,8 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import hashlib
+import io
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
@@ -155,7 +157,10 @@ class TestMergeCudaPtes(unittest.TestCase):
                 [variant.target_sm for variant in metadata.variants], [80, 120]
             )
             self.assertEqual(
-                [variant.ptx_compute for variant in metadata.variants], [80, 0]
+                [variant.ptx_compute for variant in metadata.variants], [0, 0]
+            )
+            self.assertFalse(
+                any(variant.fallback_only for variant in metadata.variants)
             )
             self.assertEqual(len(metadata.entries), 1)
             self.assertEqual(metadata.entries[0].fqn, "model.weight")
@@ -176,13 +181,15 @@ class TestMergeCudaPtes(unittest.TestCase):
                 },
             )
 
-    def test_allows_only_lowest_source_to_contain_ptx(self) -> None:
+    def test_uses_ptx_only_from_explicit_fallback(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             sm80 = root / "sm80"
             sm120 = root / "sm120"
+            fallback_dir = root / "fallback"
             sm80.mkdir()
             sm120.mkdir()
+            fallback_dir.mkdir()
             inputs = [
                 self._write_artifact(sm80, 80, b"sm80-so", b"weight"),
                 self._write_artifact(
@@ -193,14 +200,24 @@ class TestMergeCudaPtes(unittest.TestCase):
                     ptx_compute=0,
                 ),
             ]
+            fallback = self._write_artifact(fallback_dir, 75, b"fallback-so", b"weight")
 
-            merged = deserialize_pte_binary(bytes(merge_cuda_pte_files(inputs)))
+            merged = deserialize_pte_binary(
+                bytes(merge_cuda_pte_files(inputs, fallback))
+            )
             delegate = merged.program.execution_plan[0].delegates[0]
             metadata = decode_cuda_aoti_metadata(
                 merged.program.backend_delegate_data[delegate.processed.index].data
             )
             self.assertEqual(
-                [variant.ptx_compute for variant in metadata.variants], [80, 0]
+                [variant.target_sm for variant in metadata.variants], [80, 120, 75]
+            )
+            self.assertEqual(
+                [variant.ptx_compute for variant in metadata.variants], [0, 0, 75]
+            )
+            self.assertEqual(
+                [variant.fallback_only for variant in metadata.variants],
+                [False, False, True],
             )
 
     def test_preserves_no_ptx_fallback(self) -> None:
@@ -251,7 +268,7 @@ class TestMergeCudaPtes(unittest.TestCase):
                 [variant.target_sm for variant in metadata.variants], [80, 120]
             )
             self.assertEqual(
-                [variant.ptx_compute for variant in metadata.variants], [80, 0]
+                [variant.ptx_compute for variant in metadata.variants], [0, 0]
             )
 
     def test_rejects_different_weight_content(self) -> None:
@@ -318,6 +335,25 @@ class TestMergeCudaPtes(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "Duplicate CUDA target sm80"):
                 merge_cuda_pte_files(inputs)
 
+    def test_rejects_fallback_without_ptx(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            regular_dir = root / "regular"
+            fallback_dir = root / "fallback"
+            regular_dir.mkdir()
+            fallback_dir.mkdir()
+            regular = self._write_artifact(regular_dir, 80, b"sm80-so", b"weight")
+            fallback = self._write_artifact(
+                fallback_dir,
+                75,
+                b"fallback-so",
+                b"weight",
+                ptx_compute=0,
+            )
+
+            with self.assertRaisesRegex(ValueError, "exactly one PTX-capable"):
+                merge_cuda_pte_files([regular], fallback)
+
     def test_rejects_rocm(self) -> None:
         with patch(
             "executorch.backends.cuda.merge_ptes.torch.version.hip", "6.3"
@@ -329,11 +365,14 @@ class TestMergeCudaPtes(unittest.TestCase):
             root = Path(temporary)
             sm80 = root / "sm80"
             sm120 = root / "sm120"
+            fallback_dir = root / "fallback"
             output = root / "output"
             sm80.mkdir()
             sm120.mkdir()
+            fallback_dir.mkdir()
             first = self._write_artifact(sm80, 80, b"sm80-so", b"weight")
             second = self._write_artifact(sm120, 120, b"sm120-so", b"weight")
+            fallback = self._write_artifact(fallback_dir, 75, b"fallback-so", b"weight")
             self.assertIsNotNone(first.ptd_path)
             output_pte = output / "model.pte"
             output_ptd = output / "aoti_cuda_blob.ptd"
@@ -350,17 +389,29 @@ class TestMergeCudaPtes(unittest.TestCase):
                     str(first.ptd_path),
                     "--input-ptd",
                     str(second.ptd_path),
+                    "--fallback-pte",
+                    str(fallback.pte_path),
+                    "--fallback-ptd",
+                    str(fallback.ptd_path),
                     "--output-pte",
                     str(output_pte),
                     "--output-ptd",
                     str(output_ptd),
                 ],
-            ):
+            ), redirect_stdout(io.StringIO()) as stdout:
                 merge_main()
 
             self.assertTrue(output_pte.is_file())
             assert first.ptd_path is not None
             self.assertEqual(output_ptd.read_bytes(), first.ptd_path.read_bytes())
+            report = stdout.getvalue()
+            self.assertIn(f"cubin\tsm80\t{first.pte_path}", report)
+            self.assertIn(f"cubin\tsm120\t{second.pte_path}", report)
+            self.assertIn(
+                f"ptx-fallback\tcompute_75 (source sm75)\t"
+                f"{fallback.pte_path} [fallback]",
+                report,
+            )
 
 
 if __name__ == "__main__":

--- a/backends/cuda/tests/test_merge_ptes.py
+++ b/backends/cuda/tests/test_merge_ptes.py
@@ -44,6 +44,7 @@ from executorch.exir.schema import (
 from executorch.extension.flat_tensor.serialize.serialize import FlatTensorSerializer
 
 
+@patch("executorch.backends.cuda.merge_ptes.torch.version.hip", None)
 class TestMergeCudaPtes(unittest.TestCase):
     def _write_artifact(
         self,
@@ -316,6 +317,12 @@ class TestMergeCudaPtes(unittest.TestCase):
             ]
             with self.assertRaisesRegex(ValueError, "Duplicate CUDA target sm80"):
                 merge_cuda_pte_files(inputs)
+
+    def test_rejects_rocm(self) -> None:
+        with patch(
+            "executorch.backends.cuda.merge_ptes.torch.version.hip", "6.3"
+        ), self.assertRaisesRegex(RuntimeError, "only NVIDIA CUDA"):
+            merge_cuda_pte_files([])
 
     def test_cli_writes_merged_pte_and_reuses_base_ptd(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/examples/cuda/README.md
+++ b/examples/cuda/README.md
@@ -40,7 +40,7 @@ checks that the `.pte` embeds a code object for the architecture it compiled for
 
 CUDA AOTI exports record their compiled target SM. Exports of the same program
 and weights can be combined so the runtime selects an exactly matching native
-AOTI library, or falls back to the PTX carried by the lowest compatible target.
+AOTI library, or uses one explicitly designated PTX fallback.
 
 ```bash
 python -m executorch.backends.cuda.merge_ptes \
@@ -48,24 +48,29 @@ python -m executorch.backends.cuda.merge_ptes \
   --input-pte rtx5090/model.pte \
   --input-ptd a100/aoti_cuda_blob.ptd \
   --input-ptd rtx5090/aoti_cuda_blob.ptd \
+  --fallback-pte portable/model.pte \
+  --fallback-ptd portable/aoti_cuda_blob.ptd \
   --output-pte merged/model.pte \
   --output-ptd merged/aoti_cuda_blob.ptd
 ```
 
 The inputs must come from the same ExecuTorch program and contain identical
-weights. The merged PTE stores every architecture-specific shared library. The
-output PTD reuses one validated copy of the weights. Each source may contain or
-omit PTX. If several sources contain forward-compatible PTX, only the lowest
-target SM is advertised as the runtime fallback. If none contains PTX, the
-merged PTE supports exact native-SM matches only.
+weights. Each regular `--input-pte` contributes only exact-SM native cubins;
+any PTX capability in a regular input is ignored. At most one
+`--fallback-pte` may be provided, and it must contain exactly one PTX-capable
+variant. The runtime uses it only when no regular input provides a native cubin
+for the current SM. The output PTD reuses one validated copy of the weights.
+After merging, the tool prints every native SM and PTX fallback together with
+its source PTE.
 
-To avoid carrying redundant PTX bytes in higher-SM shared libraries, export the
-lowest-SM source with the default behavior and add this compile spec to each
-higher-SM `CudaPartitioner`:
+Export every regular input with PTX disabled:
 
 ```python
 CompileSpec("cuda_include_ptx", b"OFF")
 ```
 
-The merge step cannot safely remove PTX from an already-linked shared library,
-so this option must be set while exporting the higher-SM source PTEs.
+Export the fallback with PTX enabled and with any portability constraints, such
+as a shared-memory limit, required by its target GPU set. AOTI host code and its
+CUDA fatbin are linked into one shared library, so the merge step does not
+rewrite ELF sections. Instead, the merged metadata makes regular libraries
+native-only and marks the fallback library as PTX-only for runtime selection.

--- a/examples/cuda/README.md
+++ b/examples/cuda/README.md
@@ -35,3 +35,37 @@ installed PyTorch build does not list in `torch.cuda.get_arch_list()`.
 The example emits `amd_triton.pte` and `aoti_cuda_blob.ptd`. It uses a fresh
 Inductor cache and fails unless it finds generated Triton source there, and it
 checks that the `.pte` embeds a code object for the architecture it compiled for.
+
+## Merge native NVIDIA GPU exports
+
+CUDA AOTI exports record their compiled target SM. Exports of the same program
+and weights can be combined so the runtime selects an exactly matching native
+AOTI library, or falls back to the PTX carried by the lowest compatible target.
+
+```bash
+python -m executorch.backends.cuda.merge_ptes \
+  --input-pte a100/model.pte \
+  --input-pte rtx5090/model.pte \
+  --input-ptd a100/aoti_cuda_blob.ptd \
+  --input-ptd rtx5090/aoti_cuda_blob.ptd \
+  --output-pte merged/model.pte \
+  --output-ptd merged/aoti_cuda_blob.ptd
+```
+
+The inputs must come from the same ExecuTorch program and contain identical
+weights. The merged PTE stores every architecture-specific shared library. The
+output PTD reuses one validated copy of the weights. Each source may contain or
+omit PTX. If several sources contain forward-compatible PTX, only the lowest
+target SM is advertised as the runtime fallback. If none contains PTX, the
+merged PTE supports exact native-SM matches only.
+
+To avoid carrying redundant PTX bytes in higher-SM shared libraries, export the
+lowest-SM source with the default behavior and add this compile spec to each
+higher-SM `CudaPartitioner`:
+
+```python
+CompileSpec("cuda_include_ptx", b"OFF")
+```
+
+The merge step cannot safely remove PTX from an already-linked shared library,
+so this option must be set while exporting the higher-SM source PTEs.

--- a/examples/cuda/scripts/export.py
+++ b/examples/cuda/scripts/export.py
@@ -19,6 +19,7 @@ from executorch.examples.models import MODEL_NAME_TO_MODEL
 from executorch.examples.models.model_factory import EagerModelFactory
 
 from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
+from executorch.exir.backend.compile_spec_schema import CompileSpec
 
 from executorch.extension.export_util.utils import save_pte_program
 
@@ -51,6 +52,16 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--generate_etrecord", action=argparse.BooleanOptionalAction)
     parser.add_argument("--save_processed_bytes", action=argparse.BooleanOptionalAction)
+    parser.add_argument(
+        "--cuda_include_ptx",
+        choices=("ON", "OFF"),
+        help="Explicitly enable or disable PTX in the exported CUDA AOTI library",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Seed model initialization and example input generation",
+    )
 
     args = parser.parse_args()
     return args
@@ -73,6 +84,9 @@ def main():
             f"Available models are {list(MODEL_NAME_TO_MODEL.keys())}."
         )
 
+    if args.seed is not None:
+        torch.manual_seed(args.seed)
+
     (
         model,
         example_args,
@@ -87,9 +101,12 @@ def main():
         dynamic_shapes=dynamic_shapes,
     )
 
-    partitioner = CudaPartitioner(
-        [CudaBackend.generate_method_name_compile_spec(args.model_name)]
-    )
+    compile_specs = [CudaBackend.generate_method_name_compile_spec(args.model_name)]
+    if args.cuda_include_ptx is not None:
+        compile_specs.append(
+            CompileSpec("cuda_include_ptx", args.cuda_include_ptx.encode())
+        )
+    partitioner = CudaPartitioner(compile_specs)
 
     et_prog = to_edge_transform_and_lower(
         exported_programs,


### PR DESCRIPTION
### Summary

Add one current `ETCUDAFQN0` metadata format that stores target-specific CUDA AOTI shared libraries with one shared FQN weight manifest. At runtime, CUDA first selects an exact-SM regular variant. If no exact regular variant exists, it may use the PTX from one explicitly designated fallback PTE when that PTX is compatible with the current GPU. The fallback is no longer inferred from the lowest regular target SM.

Add a PTE/PTD merge tool with two input classes:

- One or more regular PTEs provide exact-SM native variants. Their merged metadata sets `ptx_compute=0`, so they are never considered as PTX fallbacks. Regular exports should use `CompileSpec("cuda_include_ptx", b"OFF")` to avoid embedding redundant PTX.
- At most one fallback PTE provides the PTX-capable variant. It is marked `fallback_only`, is never selected as an exact native variant, and is considered only when the merged PTE has no regular variant for the current SM.

The merge validates the ExecuTorch program, CUDA delegate layout, non-CUDA named data, weight metadata, and streamed PTD weight hashes. CUDA PTE merging is NVIDIA-only and explicitly rejects ROCm.

### Merged artifact layout

For an A100 (`sm80`) regular export, an RTX 5090 (`sm120`) regular export, and one PTX fallback export, the merged artifact is structured as follows:

```text
merged.pte
├── program and CUDA delegates
│   └── `ETCUDAFQN0` CUDA variant metadata (per delegate)
│       ├── regular: target_sm=80,  ptx_compute=0 -> sm80 source SO key
│       ├── regular: target_sm=120, ptx_compute=0 -> sm120 source SO key
│       └── fallback_only: target_sm=<source SM>,
│           ptx_compute=<fallback compute capability> -> fallback source SO key
├── named data
│   ├── sm80 source SO key -> actual AOTI SO containing the prebuilt sm80 cubin
│   ├── sm120 source SO key -> actual AOTI SO containing the prebuilt sm120 cubin
│   └── fallback source SO key -> actual PTX-bearing fallback AOTI SO
└── one shared FQN weight manifest

merged.ptd
└── shared external tensor data reused from the regular base export
```

The tool copies each AOTI SO atomically rather than rewriting its ELF/fatbin. The regular/fallback distinction is encoded in the merged metadata: only regular variants participate in exact-SM native selection, while the fallback SO contributes PTX only to fallback selection. After merging, the CLI prints a provenance table mapping every stored SM cubin and the fallback PTX entry to its source PTE.

This PR was authored with OpenAI Codex.

### Test plan

The primary validation is a real cross-hardware CUDA CI pipeline spanning A100 (`sm80`) and A10G (`sm86`):

1. Export an A100 native PTE and an A10G native PTE independently on their respective GPUs, both with PTX disabled and isolated Inductor caches.
2. Export a separate PTX fallback PTE on A100 with the A10G shared-memory constraint.
3. Verify byte-for-byte that the A100 native PTD, A10G native PTD, fallback PTD, and final merged PTD are identical.
4. On A10G, verify the A10G native PTE succeeds, the A100 native-only PTE is rejected with no compatible native/PTX variant, and the merged PTE succeeds.
5. On A100, verify the A100 native PTE succeeds, the A10G native-only PTE is rejected with no compatible native/PTX variant, and the same merged PTE succeeds.

Additional Python coverage exercises the single `ETCUDAFQN0` metadata format, untargeted ROCm metadata, explicit fallback-only encoding, PTE/PTD merging, shared-weight validation, duplicate regular SM rejection, provenance reporting, and ROCm merge rejection. C++ coverage exercises metadata parsing, exact regular selection, PTX fallback selection, incompatibility, and duplicate targets.

Locally ran the 17 targeted CUDA metadata/merge tests, Python lint/format checks, workflow YAML parsing, and `git diff --check`.
