### PR TITLE
Re-pin the Android golden artifact, which S3 has expired

### DIFF
--- a/extension/android/executorch_android/android_test_setup.sh
+++ b/extension/android/executorch_android/android_test_setup.sh
@@ -29,8 +29,10 @@ prepare_tinyllama() {
 }
 
 prepare_golden() {
-  local url="https://gha-artifacts.s3.amazonaws.com/pytorch/executorch/test-backend-artifacts/golden-artifacts-xnnpack/golden_artifacts_26052718.zip"
-  curl -sL -o /tmp/golden.zip "$url"
+  # _test_backend.yml uploads these with retention-days: 90, so this pin has to
+  # be refreshed from a newer hourly key before it ages out.
+  local url="https://gha-artifacts.s3.amazonaws.com/pytorch/executorch/test-backend-artifacts/golden-artifacts-xnnpack/golden_artifacts_26082700.zip"
+  curl -fsSL -o /tmp/golden.zip "$url"
   unzip -o /tmp/golden.zip -d /tmp/golden/
   for model in mobilenet_v2 vit_b_16; do
     cp "/tmp/golden/xnnpack/${model}.pte" "${BASEDIR}/src/androidTest/resources/"


### PR DESCRIPTION
_test_backend.yml uploads the golden-artifact zips with retention-days: 90. The key android_test_setup.sh pinned was written on 2026-05-27, so S3's lifecycle sweep deleted it mid-afternoon on 2026-08-26 and build-android has failed on every run since. This pins the 2026-08-27 00:00 UTC key, which carries the same six files the script copies out.

curl ran without -f, so it wrote the 387-byte NoSuchKey error document to /tmp/golden.zip and the job failed several lines later as "not a zipfile" rather than as a 404. Adding -f moves the failure to the download, and the comment says out loud that the new pin is on the same 90-day fuse.

Authored with Claude Code.