### PR TITLE
Ship the Core ML delegate as a linkable library in the macOS wheel

### DIFF
--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -878,6 +878,11 @@ _REQUIRED_ON_A_CUDA_WHEEL = "cuda-wheel-only"
 
 # Marker for a row whose owner every Linux wheel carries and no macOS wheel does.
 _REQUIRED_ON_LINUX = "linux-only"
+# Marker for a row whose owner every macOS wheel carries and no other wheel does.
+# The Core ML delegate is built on every macOS wheel, so its presence is decidable
+# from the installed wheel and a macOS wheel that dropped it should fail rather than
+# quietly regress to folding it into the Python extension.
+_REQUIRED_ON_MACOS = "macos-only"
 # Narrower than the marker above on purpose. The Qualcomm SDK the delegate builds
 # against is published for Linux x86_64 only, so the aarch64 Linux wheels ship no such
 # library and demanding it there would fail a wheel that is correct. Reusing the
@@ -891,6 +896,8 @@ def _resolve_required(required):
         return bool(_wheel_cuda_train())
     if required == _REQUIRED_ON_LINUX:
         return sys.platform == "linux"
+    if required == _REQUIRED_ON_MACOS:
+        return sys.platform == "darwin"
     if required == _REQUIRED_ON_LINUX_X86:
         return sys.platform == "linux" and platform.machine() in ("x86_64", "amd64")
     return required
@@ -952,13 +959,14 @@ _OWNED_COMPONENTS = (
         _library_file_name("libexecutorch_backend_xnnpack"),
         True,
     ),
-    # Not required: the delegate is built only on a macOS wheel, so every other
-    # wheel legitimately ships no Core ML library and the row skips.
+    # Required on macOS, where the delegate is built for every wheel, so a macOS
+    # wheel that folds it back into the Python extension fails here. Not built on
+    # any other platform, where the row resolves to not-required and skips.
     (
         "Core ML delegate",
         _COREML_SYMBOLS,
         _library_file_name("libexecutorch_backend_coreml"),
-        False,
+        _REQUIRED_ON_MACOS,
     ),
     # Not required: the delegate is built only on an Apple Silicon macOS wheel whose
     # build found the Metal compiler, so every other wheel legitimately ships no MLX

--- a/.ci/scripts/wheel/test_shared_libraries.py
+++ b/.ci/scripts/wheel/test_shared_libraries.py
@@ -155,6 +155,12 @@ _BUNDLED_XNNPACK_SYMBOLS = ("xnn_create_runtime_v4",)
 # does: a second copy means two MLX runtimes in one process.
 _MLX_SYMBOLS = ("executorch::backends::mlx::mutable_state_note_handle",)
 _BUNDLED_MLX_SYMBOLS = ("mlx::core::allocator::free",)
+# A representative symbol from the Core ML delegate, exported from the shipped
+# library. get_registered_delegate() rather than the constructor, which demangles
+# to two entries (complete and base object), while this is a single definition.
+_COREML_SYMBOLS = (
+    "executorch::backends::coreml::CoreMLBackendDelegate::get_registered_delegate()",
+)
 
 # A representative symbol from the TorchAO kernels. These are Apple Silicon only, so
 # most wheels ship no such library and the row below is not required.
@@ -945,6 +951,14 @@ _OWNED_COMPONENTS = (
         _XNNPACK_SYMBOLS,
         _library_file_name("libexecutorch_backend_xnnpack"),
         True,
+    ),
+    # Not required: the delegate is built only on a macOS wheel, so every other
+    # wheel legitimately ships no Core ML library and the row skips.
+    (
+        "Core ML delegate",
+        _COREML_SYMBOLS,
+        _library_file_name("libexecutorch_backend_coreml"),
+        False,
     ),
     # Not required: the delegate is built only on an Apple Silicon macOS wheel whose
     # build found the Metal compiler, so every other wheel legitimately ships no MLX
@@ -2337,6 +2351,7 @@ def test_shipped_library_names_are_expected() -> None:
         # dependency, so both have to ship and both are expected here.
         "libextension_cuda",
         "libexecutorch_backend_xnnpack",
+        "libexecutorch_backend_coreml",
         "libexecutorch_backend_mlx",
         "libexecutorch_backend_openvino",
         "libexecutorch_backend_qnn",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1419,7 +1419,11 @@ if(EXECUTORCH_BUILD_PYBIND)
   # Only the libraries that do not already retain themselves are named. A
   # delegate that calls executorch_target_link_options_shared_lib exports
   # --no-as-needed around its own file to every consumer, so the CUDA and
-  # OpenVINO backends are covered by that and are deliberately absent here.
+  # OpenVINO backends are covered by that and are deliberately absent here. That
+  # export is emitted only for NOT APPLE, so it does nothing for an Apple-only
+  # delegate like Core ML; those are covered instead by Mach-O, which keeps a
+  # named dylib's namespace-scope initializers without an --as-needed
+  # equivalent.
   foreach(_retained_component optimized_native_cpu_ops_lib xnnpack_backend
                               extension_threadpool etdump
   )

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -12,6 +12,15 @@ if(APPLE)
   find_library(SQLITE_LIBRARY sqlite3 REQUIRED)
 endif()
 
+# Signals to packaging whether the standalone shared delegate library was built.
+# Reset to OFF on every configure so a reused build directory that switches
+# platform or library type does not carry a stale value; the shared branch below
+# turns it on only when it actually produces the library.
+set(EXECUTORCH_COREML_DELEGATE_LIBRARY_BUILT
+    OFF
+    CACHE INTERNAL "The standalone Core ML delegate library was built"
+)
+
 if(EXECUTORCH_BUILD_DEVTOOLS)
   # protobuf requires frtti
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -frtti")
@@ -281,13 +290,6 @@ if(APPLE)
       coremldelegate
       PUBLIC coreml_util coreml_inmemoryfs
       PRIVATE executorch_core
-    )
-    # Clear the packaging signal too, so an in-place reconfigure that turns the
-    # shared build off does not leave a stale ON in the cache and make packaging
-    # look for a library this build no longer produces.
-    set(EXECUTORCH_COREML_DELEGATE_LIBRARY_BUILT
-        OFF
-        CACHE INTERNAL "The standalone Core ML delegate library was built"
     )
   endif()
 

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -266,6 +266,15 @@ if(APPLE)
     )
     # Ships beside the runtime in the wheel's lib/ directory.
     executorch_target_shipped_runtime_path(coremldelegate)
+    # A signal for packaging that the standalone delegate library exists. The
+    # EXECUTORCH_BUILD_COREML flag alone is not enough because it is also on for
+    # the Python extension on non-Apple platforms, where this shared library is
+    # not built, so keying the wheel's install on it would look for a file that
+    # was never produced.
+    set(EXECUTORCH_COREML_DELEGATE_LIBRARY_BUILT
+        ON
+        CACHE INTERNAL "The standalone Core ML delegate library was built"
+    )
   else()
     target_link_libraries(
       coremldelegate

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -186,7 +186,16 @@ endif()
 # coremldelegate
 
 if(APPLE)
-  add_library(coremldelegate)
+  # Build the delegate as a shared library for the wheel so a C++ consumer can
+  # link it, and so the Python extension links it dynamically instead of
+  # absorbing its code. Keep it static everywhere else so no other build
+  # changes.
+  if(EXECUTORCH_BUILD_SHARED)
+    set(_coreml_backend_library_type SHARED)
+  else()
+    set(_coreml_backend_library_type STATIC)
+  endif()
+  add_library(coremldelegate ${_coreml_backend_library_type})
   target_sources(coremldelegate PRIVATE ${KVSTORE_SOURCES} ${DELEGATE_SOURCES})
 
   target_include_directories(
@@ -237,11 +246,33 @@ if(APPLE)
   endif()
 
   target_link_libraries(
-    coremldelegate
-    PUBLIC coreml_util coreml_inmemoryfs
-    PRIVATE executorch_core ${ACCELERATE_FRAMEWORK} ${COREML_FRAMEWORK}
-            ${FOUNDATION_FRAMEWORK} ${SQLITE_LIBRARY}
+    coremldelegate PRIVATE ${ACCELERATE_FRAMEWORK} ${COREML_FRAMEWORK}
+                           ${FOUNDATION_FRAMEWORK} ${SQLITE_LIBRARY}
   )
+  if(EXECUTORCH_BUILD_SHARED)
+    set_target_properties(
+      coremldelegate PROPERTIES OUTPUT_NAME executorch_backend_coreml
+    )
+    executorch_target_soname_policy(coremldelegate)
+    # coreml_util and coreml_inmemoryfs are static archives this delegate owns,
+    # so bundle them inside this one shipped library instead of making every
+    # consumer supply them. A plain private link is enough, not whole-archive:
+    # the delegate references the helpers it uses, so ordinary resolution pulls
+    # exactly those objects. They carry no self-registering constructors that an
+    # unreferenced link would drop, which is the only thing force_load would add
+    # here.
+    target_link_libraries(
+      coremldelegate PRIVATE coreml_util coreml_inmemoryfs executorch_shared
+    )
+    # Ships beside the runtime in the wheel's lib/ directory.
+    executorch_target_shipped_runtime_path(coremldelegate)
+  else()
+    target_link_libraries(
+      coremldelegate
+      PUBLIC coreml_util coreml_inmemoryfs
+      PRIVATE executorch_core
+    )
+  endif()
 
   executorch_target_link_options_shared_lib(coremldelegate)
 

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -188,8 +188,9 @@ endif()
 if(APPLE)
   # Build the delegate as a shared library for the wheel so a C++ consumer can
   # link it, and so the Python extension links it dynamically instead of
-  # absorbing its code. Keep it static everywhere else so no other build
-  # changes.
+  # absorbing its code. Keyed on EXECUTORCH_BUILD_SHARED rather than
+  # BUILD_SHARED_LIBS, the same way the other shipped delegates decide this, so
+  # the wheel controls it independently of the generic CMake switch.
   if(EXECUTORCH_BUILD_SHARED)
     set(_coreml_backend_library_type SHARED)
   else()

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -282,6 +282,13 @@ if(APPLE)
       PUBLIC coreml_util coreml_inmemoryfs
       PRIVATE executorch_core
     )
+    # Clear the packaging signal too, so an in-place reconfigure that turns the
+    # shared build off does not leave a stale ON in the cache and make packaging
+    # look for a library this build no longer produces.
+    set(EXECUTORCH_COREML_DELEGATE_LIBRARY_BUILT
+        OFF
+        CACHE INTERNAL "The standalone Core ML delegate library was built"
+    )
   endif()
 
   executorch_target_link_options_shared_lib(coremldelegate)

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -259,9 +259,9 @@ if(APPLE)
     # so bundle them inside this one shipped library instead of making every
     # consumer supply them. A plain private link is enough, not whole-archive:
     # the delegate references the helpers it uses, so ordinary resolution pulls
-    # exactly those objects. They carry no self-registering constructors that an
-    # unreferenced link would drop, which is the only thing force_load would add
-    # here.
+    # exactly those objects. Neither helper registers anything from an
+    # unreferenced namespace-scope initializer, which is the only thing
+    # force_load would add here.
     target_link_libraries(
       coremldelegate PRIVATE coreml_util coreml_inmemoryfs executorch_shared
     )

--- a/docs/source/using-executorch-cpp.md
+++ b/docs/source/using-executorch-cpp.md
@@ -182,6 +182,7 @@ These are the components the package provides:
 | `backend_cuda` | The CUDA delegate | Linux |
 | `extension_cuda` | The CUDA stream extension | Linux |
 | `backend_openvino` | The OpenVINO delegate | Linux |
+| `backend_coreml` | The Core ML delegate, for Apple GPU and Neural Engine execution | macOS |
 | `backend_mlx` | The MLX delegate, for Apple GPU execution | macOS, Apple Silicon |
 
 To see what your own install offers, ask CMake:
@@ -190,17 +191,13 @@ To see what your own install offers, ask CMake:
 find_package(executorch REQUIRED)
 foreach(_component
         runtime kernels_optimized kernels_quantized kernels_torchao
-        backend_xnnpack backend_mlx backend_cuda extension_cuda
+        backend_xnnpack backend_coreml backend_mlx backend_cuda extension_cuda
         backend_openvino threadpool etdump)
   if(TARGET executorch::${_component})
     message(STATUS "have ${_component}")
   endif()
 endforeach()
 ```
-
-On macOS the Core ML delegate is registered inside the Python extension rather than shipped as a
-separate C++ library, so a C++ application there cannot link it as a component; use it from
-Python, or build from source if you need it in C++.
 
 Profiling a Core ML model records `DELEGATE_CALL`, which tells you how long the delegate ran in
 total. It does not record the individual operators inside the delegate, because that detail comes

--- a/setup.py
+++ b/setup.py
@@ -2170,6 +2170,8 @@ class CustomBuild(build):
             if cmake_cache.is_enabled("EXECUTORCH_BUILD_SHARED"):
                 cmake_build_args += ["--target", "executorch_shared"]
                 cmake_build_args += ["--target", "etdump"]
+                if cmake_cache.is_enabled("EXECUTORCH_COREML_DELEGATE_LIBRARY_BUILT"):
+                    cmake_build_args += ["--target", "coremldelegate"]
                 if cmake_cache.is_enabled(
                     "EXECUTORCH_BUILD_PTHREADPOOL"
                 ) and cmake_cache.is_enabled("EXECUTORCH_BUILD_CPUINFO"):

--- a/setup.py
+++ b/setup.py
@@ -2410,8 +2410,10 @@ setup(
                     dst="executorch/lib/"
                     + get_dynamic_lib_name("executorch_backend_coreml"),
                     dependent_cmake_flags=[
-                        "EXECUTORCH_BUILD_SHARED",
-                        "EXECUTORCH_BUILD_COREML",
+                        # Not EXECUTORCH_BUILD_COREML: that is also on for the Python
+                        # extension on non-Apple platforms, where this shared library
+                        # is not built. This flag is set only when it actually is.
+                        "EXECUTORCH_COREML_DELEGATE_LIBRARY_BUILT",
                     ],
                 ),
                 # Install the prebuilt pybindings extension wrapper for the runtime,

--- a/setup.py
+++ b/setup.py
@@ -2402,6 +2402,18 @@ setup(
                         "EXECUTORCH_BUILD_MLX",
                     ],
                 ),
+                # Install the Core ML delegate beside them, so a C++ consumer can
+                # link it out of the wheel rather than only reaching it from Python.
+                BuiltFile(
+                    src_dir="%CMAKE_CACHE_DIR%/backends/apple/coreml/",
+                    src_name=get_dynamic_lib_name("executorch_backend_coreml"),
+                    dst="executorch/lib/"
+                    + get_dynamic_lib_name("executorch_backend_coreml"),
+                    dependent_cmake_flags=[
+                        "EXECUTORCH_BUILD_SHARED",
+                        "EXECUTORCH_BUILD_COREML",
+                    ],
+                ),
                 # Install the prebuilt pybindings extension wrapper for the runtime,
                 # portable kernels, and a selection of backends. This lets users
                 # load and execute .pte files from python.

--- a/tools/cmake/executorch-wheel-config.cmake
+++ b/tools/cmake/executorch-wheel-config.cmake
@@ -71,6 +71,7 @@
 #                                model. Not part of EXECUTORCH_LIBRARIES, see
 #                                below.
 # executorch::backend_xnnpack    The XNNPACK delegate.
+# executorch::backend_coreml     The Core ML delegate. macOS only.
 # executorch::backend_mlx        The MLX delegate. macOS on Apple Silicon only.
 #                                Its Metal kernel archive is published as
 #                                MLX_METALLIB_PATH, see below.
@@ -336,6 +337,7 @@ if(_executorch_runtime_library AND NOT _executorch_targets_supported)
     ITEMS libexecutorch_kernels_optimized
           libexecutorch_kernels_torchao
           libexecutorch_backend_xnnpack
+          libexecutorch_backend_coreml
           libexecutorch_backend_mlx
           libexecutorch_backend_cuda
           libexecutorch_extension_cuda
@@ -658,6 +660,8 @@ if(TARGET executorch::runtime AND TARGET executorch::threadpool)
 endif()
 
 _executorch_define_component(backend_xnnpack executorch_backend_xnnpack)
+# The Core ML delegate, present only in a wheel built on macOS.
+_executorch_define_component(backend_coreml executorch_backend_coreml)
 # The MLX delegate, present only in a wheel built on Apple Silicon with the
 # Metal compiler available.
 _executorch_define_component(backend_mlx executorch_backend_mlx)


### PR DESCRIPTION
## Summary

On macOS, the ExecuTorch pip wheel builds the Core ML delegate as a static library and folds it into the Python extension `_C`. That has two downsides:

1. A C++ application that installs the wheel **cannot link the Core ML delegate**, because there is no standalone library to link against (XNNPACK and MLX already ship one; Core ML is the odd one out).
2. `_C` carries the delegate's code even though `_C` is otherwise just the Python bindings.

This change makes Core ML match how XNNPACK and MLX already ship: when the wheel is built (`EXECUTORCH_BUILD_SHARED`), the delegate is built as a shared library named `executorch_backend_coreml` and installed into the wheel's `lib/`. `_C` then links it dynamically instead of absorbing it, and a C++ app can link it through `find_package(executorch)` with the new `backend_coreml` component.

Nothing changes for a source build: off the wheel path the delegate stays static and links exactly as before.

## What changed

- `backends/apple/coreml/CMakeLists.txt`: the delegate builds `SHARED` under `EXECUTORCH_BUILD_SHARED`, named `executorch_backend_coreml`, with the shared-object soname policy and an `@loader_path` runtime path, and bundles its `coreml_util` / `coreml_inmemoryfs` helper archives. The static (source-build) path is unchanged.
- `setup.py`: ships `lib/libexecutorch_backend_coreml.dylib`.
- `tools/cmake/executorch-wheel-config.cmake`: adds the `backend_coreml` `find_package` component.
- `.ci/scripts/wheel/test_shared_libraries.py`: adds the library to the name allowlist and a one-owner row for the delegate.

## Test plan

Built with `EXECUTORCH_BUILD_SHARED=ON EXECUTORCH_BUILD_COREML=ON` on macOS and confirmed with `nm`/`otool`:

- `libexecutorch_backend_coreml.dylib` is produced with install name `@rpath/libexecutorch_backend_coreml.1.dylib` and an `@loader_path` rpath;
- it exports the delegate entry point exactly once;
- it links the shared runtime `@rpath/libexecutorch.1.dylib` (not a static copy), plus the CoreML/Accelerate/Foundation frameworks and sqlite3;
- the referenced `coreml_util` / `coreml_inmemoryfs` helpers are bundled in.

The wheel release check that asserts one owner per component passes, with the delegate's `get_registered_delegate()` symbol defined only by this library.
