### PR TITLE
Arm backend: Fix uninitialized struct in VGFSetup

### DIFF
--- a/backends/arm/runtime/VGFSetup.cpp
+++ b/backends/arm/runtime/VGFSetup.cpp
@@ -3211,9 +3211,15 @@ bool VgfRepr::process_vgf(
           return false;
         }
 
+        const VkDataGraphPipelineSessionBindPointRequirementARM
+            bind_point_requirement_template{
+                .sType =
+                    VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM,
+                .pNext = nullptr,
+            };
         vector<VkDataGraphPipelineSessionBindPointRequirementARM>
-            bind_point_requirements;
-        bind_point_requirements.resize(bind_point_count);
+            bind_point_requirements(
+                bind_point_count, bind_point_requirement_template);
         {
           VGF_PROFILE_SCOPE(
               event_tracer, "VGF_INIT_QUERY_DATA_GRAPH_BIND_POINTS");


### PR DESCRIPTION
For the VkDataGraphPipelineSessionBindPointRequirementARM struct, documentation at
https://docs.vulkan.org/refpages/latest/refpages/source/VkDataGraphPipelineSessionBindPointRequirementARM.html
mentions "sType must be [VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SESSION_BIND_POINT_REQUIREMENT_ARM](https://docs.vulkan.org/refpages/latest/refpages/source/VkStructureType.html)".

The struct was uninitialized, so set this value. Certain VGF backends can assert on the uninitialized struct.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani