### PR TITLE
Add persistent Supertonic JSONL mode

### DIFF
--- a/examples/models/supertonic/CMakeLists.txt
+++ b/examples/models/supertonic/CMakeLists.txt
@@ -141,3 +141,18 @@ set_tests_properties(
   PROPERTIES TIMEOUT 1800 SKIP_REGULAR_EXPRESSION
              "SKIP: Supertonic integration assets are unavailable"
 )
+add_test(
+  NAME supertonic_jsonl_integration
+  COMMAND
+    ${CMAKE_COMMAND} -DRUNNER=$<TARGET_FILE:supertonic_runner>
+    -DPTE=${SUPERTONIC_INTEGRATION_PTE}
+    -DASSET_DIR=${SUPERTONIC_INTEGRATION_ASSET_DIR}
+    -DSTYLE=${SUPERTONIC_INTEGRATION_STYLE}
+    -DWORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/jsonl-integration -P
+    ${CMAKE_CURRENT_SOURCE_DIR}/runtime/tests/run_jsonl_server_integration.cmake
+)
+set_tests_properties(
+  supertonic_jsonl_integration
+  PROPERTIES TIMEOUT 1800 SKIP_REGULAR_EXPRESSION
+             "SKIP: Supertonic JSONL server assets are unavailable"
+)

--- a/examples/models/supertonic/README.md
+++ b/examples/models/supertonic/README.md
@@ -1,8 +1,8 @@
 # Supertonic on ExecuTorch MLX
 
 This example exports [Supertonic 3](https://huggingface.co/Supertone/supertonic-3)
-to one dynamic FP16 ExecuTorch program and performs one-shot text-to-speech
-synthesis with the MLX delegate.
+to one dynamic FP16 ExecuTorch program and performs one-shot or persistent
+text-to-speech synthesis with the MLX delegate.
 
 Run all commands from the ExecuTorch repository root. Keep downloaded assets
 and generated programs outside the source tree:
@@ -69,6 +69,43 @@ The runner is written to
 
 The runner writes a mono PCM16 WAV at the sample rate recorded in the model
 metadata (44.1 kHz for the pinned assets).
+
+## 5. Keep the runner warm
+
+Use `--server_jsonl` to load the PTE once, perform one discarded warmup, and
+process synthesis requests sequentially from stdin:
+
+```bash
+./cmake-out/examples/models/supertonic/supertonic_runner \
+  --pte="${SUPERTONIC_PTE}" \
+  --asset_dir="${SUPERTONIC_ASSETS}" \
+  --voice_style="${SUPERTONIC_ASSETS}/voice_styles/F1.json" \
+  --language=en \
+  --speed=1.05 \
+  --seed=42 \
+  --server_jsonl
+```
+
+After loading and warmup, the runner emits this protocol-v1 `ready` schema;
+`sample_rate` is always `44100` for the supported model:
+
+```json
+{"type":"ready","protocol_version":1,"sample_rate":44100,"load_seconds":0.03,"warmup_seconds":0.04}
+```
+
+Each request writes one complete WAV before returning its timing and RTF:
+
+```json
+{"type":"synthesize","id":1,"text":"Hello.","output":"/tmp/supertonic/1.wav"}
+{"type":"result","id":1,"output":"/tmp/supertonic/1.wav","samples":82810,"audio_seconds":1.8778,"synthesis_seconds":0.0524,"rtf":0.0279}
+```
+
+Stdout is reserved for JSONL responses and flushed after every record;
+diagnostics go to stderr. Request lines are limited to 64 KiB, and IDs must be
+positive and strictly increasing. Output files are created atomically and must
+not already exist. Malformed requests return an `error` record without stopping
+the runner. Send `{"type":"shutdown"}` to receive `{"type":"stopped"}` and
+exit cleanly; closing stdin also exits with status zero.
 
 ## Platform and model limits
 

--- a/examples/models/supertonic/runtime/main.cpp
+++ b/examples/models/supertonic/runtime/main.cpp
@@ -10,11 +10,19 @@
 #include "wav_writer.h"
 
 #include <gflags/gflags.h>
+#include <nlohmann/json.hpp>
 
+#include <unistd.h>
+#include <cerrno>
+#include <chrono>
 #include <cmath>
+#include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 #include <limits>
+#include <optional>
+#include <set>
 #include <stdexcept>
 #include <string>
 
@@ -32,13 +40,251 @@ DEFINE_string(language, "en", "Published Supertonic language tag.");
 DEFINE_double(speed, 1.05, "Positive duration speed divisor.");
 DEFINE_uint64(seed, 42, "Portable xorshift64/Box-Muller latent seed.");
 DEFINE_string(output, "supertonic.wav", "Output mono PCM16 WAV path.");
+DEFINE_bool(
+    server_jsonl,
+    false,
+    "Keep the model resident and serve JSONL requests on stdin.");
+DEFINE_string(
+    warmup_text,
+    "Warmup.",
+    "Text synthesized and discarded before the JSONL ready event.");
 
 namespace {
+
+using Json = nlohmann::ordered_json;
+
+constexpr size_t kMaxJsonLineBytes = 64 * 1024;
 
 void require_file(const std::filesystem::path& path, const char* flag) {
   if (!std::filesystem::is_regular_file(path)) {
     throw std::invalid_argument(
         std::string(flag) + " does not name a readable file: " + path.string());
+  }
+}
+
+void write_json_line(const Json& value) {
+  std::cout << value.dump() << '\n';
+  std::cout.flush();
+  if (!std::cout) {
+    throw std::runtime_error("failed to write JSONL response");
+  }
+}
+
+void write_error(std::optional<uint64_t> id, const std::string& message) {
+  write_json_line({
+      {"type", "error"},
+      {"id", id.has_value() ? Json(*id) : Json(nullptr)},
+      {"message", message},
+  });
+}
+
+double elapsed_seconds(std::chrono::steady_clock::time_point started) {
+  const double elapsed =
+      std::chrono::duration<double>(std::chrono::steady_clock::now() - started)
+          .count();
+  if (!std::isfinite(elapsed) || elapsed < 0.0) {
+    throw std::runtime_error("elapsed time is not finite and nonnegative");
+  }
+  return elapsed;
+}
+
+std::optional<std::string> validate_output_path(
+    const std::filesystem::path& output) {
+  std::error_code error;
+  if (std::filesystem::exists(output, error)) {
+    return "output already exists: " + output.string();
+  }
+  if (error) {
+    return "failed to inspect output path: " + output.string();
+  }
+  const std::filesystem::path parent = output.parent_path().empty()
+      ? std::filesystem::path(".")
+      : output.parent_path();
+  if (!std::filesystem::is_directory(parent, error)) {
+    return "output parent is not an existing directory: " + parent.string();
+  }
+  if (error) {
+    return "failed to inspect output parent: " + parent.string();
+  }
+  return std::nullopt;
+}
+
+enum class LineReadResult {
+  Line,
+  End,
+  TooLong,
+};
+
+LineReadResult read_json_line(std::istream& input, std::string& line) {
+  line.clear();
+  char character;
+  while (input.get(character)) {
+    if (character == '\n') {
+      return LineReadResult::Line;
+    }
+    if (line.size() == kMaxJsonLineBytes) {
+      while (input.get(character) && character != '\n') {
+      }
+      return LineReadResult::TooLong;
+    }
+    line.push_back(character);
+  }
+  return line.empty() ? LineReadResult::End : LineReadResult::Line;
+}
+
+void write_wav_without_overwrite(
+    const std::filesystem::path& output,
+    const std::vector<float>& waveform,
+    int sample_rate) {
+  const std::filesystem::path parent = output.parent_path().empty()
+      ? std::filesystem::path(".")
+      : output.parent_path();
+  std::string temporary_template =
+      (parent / ("." + output.filename().string() + ".XXXXXX")).string();
+  int temporary_fd = mkstemp(temporary_template.data());
+  if (temporary_fd < 0) {
+    throw std::runtime_error(
+        "failed to create temporary WAV: " + output.string() + ": " +
+        std::strerror(errno));
+  }
+  const std::filesystem::path temporary(temporary_template);
+  std::error_code cleanup_error;
+  try {
+    const std::string fd_path = "/dev/fd/" + std::to_string(temporary_fd);
+    if (!supertonic::write_pcm16_wav(fd_path, waveform, sample_rate)) {
+      throw std::runtime_error(
+          "failed to write output WAV: " + output.string());
+    }
+    if (close(temporary_fd) != 0) {
+      const int close_error = errno;
+      temporary_fd = -1;
+      throw std::runtime_error(
+          "failed to close output WAV: " + output.string() + ": " +
+          std::strerror(close_error));
+    }
+    temporary_fd = -1;
+    if (renamex_np(temporary.c_str(), output.c_str(), RENAME_EXCL) != 0) {
+      const int rename_error = errno;
+      if (rename_error == EEXIST) {
+        throw std::invalid_argument(
+            "output already exists: " + output.string());
+      }
+      throw std::runtime_error(
+          "failed to finalize output WAV: " + output.string() + ": " +
+          std::strerror(rename_error));
+    }
+  } catch (...) {
+    if (temporary_fd >= 0) {
+      close(temporary_fd);
+    }
+    std::filesystem::remove(temporary, cleanup_error);
+    throw;
+  }
+}
+
+int run_jsonl_server(
+    supertonic::SupertonicRunner& runner,
+    const supertonic::SynthesisOptions& defaults,
+    double load_seconds) {
+  supertonic::SynthesisOptions warmup = defaults;
+  warmup.text = FLAGS_warmup_text;
+  const auto warmup_started = std::chrono::steady_clock::now();
+  (void)runner.synthesize(warmup);
+  write_json_line({
+      {"type", "ready"},
+      {"protocol_version", 1},
+      {"sample_rate", runner.metadata().sample_rate},
+      {"load_seconds", load_seconds},
+      {"warmup_seconds", elapsed_seconds(warmup_started)},
+  });
+
+  uint64_t last_request_id = 0;
+  std::string line;
+  while (true) {
+    const LineReadResult line_result = read_json_line(std::cin, line);
+    if (line_result == LineReadResult::End) {
+      return 0;
+    }
+    if (line_result == LineReadResult::TooLong) {
+      write_error(std::nullopt, "JSON request exceeds 65536 bytes");
+      continue;
+    }
+    std::optional<uint64_t> id;
+    try {
+      const Json request = Json::parse(line);
+      if (!request.is_object() || !request.contains("type") ||
+          !request["type"].is_string()) {
+        throw std::invalid_argument("request must be an object with type");
+      }
+      const std::string type = request["type"].get<std::string>();
+      if (type == "shutdown") {
+        if (request.size() != 1) {
+          throw std::invalid_argument("shutdown request has unexpected fields");
+        }
+        write_json_line({{"type", "stopped"}});
+        return 0;
+      }
+      if (type != "synthesize") {
+        throw std::invalid_argument("unknown request type: " + type);
+      }
+      if (!request.contains("id") || !request["id"].is_number_unsigned() ||
+          request["id"].get<uint64_t>() == 0) {
+        throw std::invalid_argument("id must be a positive integer");
+      }
+      id = request["id"].get<uint64_t>();
+      static const std::set<std::string> expected{
+          "type", "id", "text", "output"};
+      std::set<std::string> actual;
+      for (auto item = request.begin(); item != request.end(); ++item) {
+        actual.insert(item.key());
+      }
+      if (actual != expected) {
+        throw std::invalid_argument("synthesize request has unexpected fields");
+      }
+      if (!request["text"].is_string() ||
+          request["text"].get_ref<const std::string&>().empty()) {
+        throw std::invalid_argument("text must be a nonempty string");
+      }
+      if (!request["output"].is_string() ||
+          request["output"].get_ref<const std::string&>().empty()) {
+        throw std::invalid_argument("output must be a nonempty string");
+      }
+      if (*id <= last_request_id) {
+        throw std::invalid_argument(
+            "id must increase monotonically above " +
+            std::to_string(last_request_id));
+      }
+      last_request_id = *id;
+
+      const std::filesystem::path output = request["output"].get<std::string>();
+      if (const auto error = validate_output_path(output)) {
+        throw std::invalid_argument(*error);
+      }
+      supertonic::SynthesisOptions options = defaults;
+      options.text = request["text"].get<std::string>();
+      const auto result = runner.synthesize(options);
+      write_wav_without_overwrite(
+          output,
+          result.waveform,
+          static_cast<int>(runner.metadata().sample_rate));
+      const double audio_seconds = static_cast<double>(result.waveform.size()) /
+          runner.metadata().sample_rate;
+      write_json_line({
+          {"type", "result"},
+          {"id", *id},
+          {"output", output.string()},
+          {"samples", result.waveform.size()},
+          {"audio_seconds", audio_seconds},
+          {"synthesis_seconds", result.elapsed_seconds},
+          {"rtf",
+           audio_seconds > 0.0 ? result.elapsed_seconds / audio_seconds : 0.0},
+      });
+    } catch (const Json::parse_error&) {
+      write_error(std::nullopt, "malformed JSON request");
+    } catch (const std::exception& error) {
+      std::cerr << "Supertonic JSONL request failed: " << error.what() << '\n';
+      write_error(id, error.what());
+    }
   }
 }
 
@@ -50,9 +296,14 @@ int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   try {
     if (FLAGS_pte.empty() || FLAGS_asset_dir.empty() ||
-        FLAGS_voice_style.empty() || FLAGS_text.empty()) {
+        FLAGS_voice_style.empty() ||
+        (!FLAGS_server_jsonl && FLAGS_text.empty())) {
       throw std::invalid_argument(
-          "--pte, --asset_dir, --voice_style, and --text are required");
+          "--pte, --asset_dir, and --voice_style are required; --text is "
+          "required unless --server_jsonl is set");
+    }
+    if (FLAGS_server_jsonl && FLAGS_warmup_text.empty()) {
+      throw std::invalid_argument("--warmup_text must not be empty");
     }
     const std::filesystem::path pte(FLAGS_pte);
     const std::filesystem::path indexer =
@@ -70,7 +321,9 @@ int main(int argc, char** argv) {
     }
     require_file(style, "--voice_style");
 
+    const auto load_started = std::chrono::steady_clock::now();
     supertonic::SupertonicRunner runner(pte.string(), indexer.string());
+    const double load_seconds = elapsed_seconds(load_started);
 
     supertonic::SynthesisOptions options;
     options.text = FLAGS_text;
@@ -78,6 +331,10 @@ int main(int argc, char** argv) {
     options.voice_style_paths = {style};
     options.speed = static_cast<float>(FLAGS_speed);
     options.seed = FLAGS_seed;
+    if (FLAGS_server_jsonl) {
+      return run_jsonl_server(runner, options, load_seconds);
+    }
+
     auto result = runner.synthesize(options);
     if (!supertonic::write_pcm16_wav(
             FLAGS_output,

--- a/examples/models/supertonic/runtime/tests/run_jsonl_server_integration.cmake
+++ b/examples/models/supertonic/runtime/tests/run_jsonl_server_integration.cmake
@@ -1,0 +1,229 @@
+foreach(required RUNNER PTE ASSET_DIR STYLE WORK_DIR)
+  if(NOT DEFINED ${required})
+    message(FATAL_ERROR "Missing JSONL runner variable: ${required}")
+  endif()
+endforeach()
+
+if(NOT EXISTS "${PTE}"
+   OR NOT EXISTS "${ASSET_DIR}/onnx/unicode_indexer.json"
+   OR NOT EXISTS "${STYLE}"
+)
+  message("SKIP: Supertonic JSONL server assets are unavailable")
+  return()
+endif()
+
+file(MAKE_DIRECTORY "${WORK_DIR}")
+set(output_one "${WORK_DIR}/000001.wav")
+set(output_two "${WORK_DIR}/000002.wav")
+file(REMOVE "${output_one}" "${output_two}")
+set(requests "${WORK_DIR}/requests.jsonl")
+file(
+  WRITE "${requests}"
+  "{\"type\":\"synthesize\",\"id\":1,\"text\":\"First warm request.\",\"output\":\"${output_one}\"}\n"
+  "{bad json\n"
+  "{\"type\":\"synthesize\",\"id\":1,\"text\":\"Duplicate request.\",\"output\":\"${WORK_DIR}/duplicate.wav\"}\n"
+  "{\"type\":\"synthesize\",\"id\":2,\"text\":\"Existing output.\",\"output\":\"${output_one}\"}\n"
+  "{\"type\":\"synthesize\",\"id\":3,\"text\":\"Second warm request.\",\"output\":\"${output_two}\"}\n"
+  "{\"type\":\"shutdown\"}\n"
+)
+
+execute_process(
+  COMMAND
+    "${RUNNER}" "--pte=${PTE}" "--asset_dir=${ASSET_DIR}"
+    "--voice_style=${STYLE}" "--server_jsonl=true" "--warmup_text=Warmup."
+    "--language=en" "--speed=1.05" "--seed=42"
+  INPUT_FILE "${requests}"
+  RESULT_VARIABLE server_result
+  OUTPUT_VARIABLE server_output
+  ERROR_VARIABLE server_error
+)
+if(NOT server_result EQUAL 0)
+  message(
+    FATAL_ERROR
+      "Supertonic JSONL runner failed (${server_result})\n${server_output}${server_error}"
+  )
+endif()
+
+string(REPLACE "\n" ";" response_lines "${server_output}")
+list(FILTER response_lines EXCLUDE REGEX "^$")
+list(LENGTH response_lines response_count)
+if(NOT response_count EQUAL 7)
+  message(
+    FATAL_ERROR
+      "Expected seven JSONL responses, got ${response_count}: ${server_output}"
+  )
+endif()
+
+set(expected_types
+    ready
+    result
+    error
+    error
+    error
+    result
+    stopped
+)
+foreach(index RANGE 0 6)
+  list(GET response_lines ${index} response)
+  list(GET expected_types ${index} expected_type)
+  string(
+    JSON
+    response_type
+    ERROR_VARIABLE
+    json_error
+    GET
+    "${response}"
+    type
+  )
+  if(json_error OR NOT response_type STREQUAL expected_type)
+    message(
+      FATAL_ERROR
+        "Response ${index} has type '${response_type}', expected '${expected_type}': ${json_error}"
+    )
+  endif()
+endforeach()
+
+list(GET response_lines 0 ready)
+string(JSON ready_member_count LENGTH "${ready}")
+set(ready_members)
+if(ready_member_count GREATER 0)
+  math(EXPR ready_last_member "${ready_member_count} - 1")
+  foreach(index RANGE 0 ${ready_last_member})
+    string(JSON ready_member MEMBER "${ready}" ${index})
+    list(APPEND ready_members "${ready_member}")
+  endforeach()
+endif()
+list(SORT ready_members)
+set(expected_ready_members load_seconds protocol_version sample_rate type
+                           warmup_seconds
+)
+list(SORT expected_ready_members)
+string(JSON protocol_version GET "${ready}" protocol_version)
+string(JSON sample_rate GET "${ready}" sample_rate)
+string(JSON load_seconds GET "${ready}" load_seconds)
+string(JSON warmup_seconds GET "${ready}" warmup_seconds)
+if(NOT ready_members STREQUAL expected_ready_members
+   OR NOT protocol_version EQUAL 1
+   OR NOT sample_rate EQUAL 44100
+   OR load_seconds LESS 0
+   OR warmup_seconds LESS 0
+)
+  message(FATAL_ERROR "Malformed JSONL server ready event: ${ready}")
+endif()
+
+list(GET response_lines 1 first_result)
+list(GET response_lines 2 malformed_error)
+list(GET response_lines 3 duplicate_error)
+list(GET response_lines 4 existing_error)
+list(GET response_lines 5 second_result)
+string(JSON first_id GET "${first_result}" id)
+string(JSON first_output GET "${first_result}" output)
+string(JSON first_samples GET "${first_result}" samples)
+string(JSON first_audio_seconds GET "${first_result}" audio_seconds)
+string(JSON first_synthesis_seconds GET "${first_result}" synthesis_seconds)
+string(JSON first_rtf GET "${first_result}" rtf)
+string(JSON second_id GET "${second_result}" id)
+string(JSON second_output GET "${second_result}" output)
+string(JSON second_samples GET "${second_result}" samples)
+string(JSON second_audio_seconds GET "${second_result}" audio_seconds)
+string(JSON second_synthesis_seconds GET "${second_result}" synthesis_seconds)
+string(JSON second_rtf GET "${second_result}" rtf)
+string(JSON malformed_id_type TYPE "${malformed_error}" id)
+string(JSON duplicate_id GET "${duplicate_error}" id)
+string(JSON duplicate_message GET "${duplicate_error}" message)
+string(JSON existing_id GET "${existing_error}" id)
+string(JSON existing_message GET "${existing_error}" message)
+if(NOT malformed_id_type STREQUAL "NULL"
+   OR NOT duplicate_id EQUAL 1
+   OR NOT duplicate_message MATCHES "monotonically"
+   OR NOT existing_id EQUAL 2
+   OR NOT existing_message MATCHES "already exists"
+   OR NOT first_id EQUAL 1
+   OR NOT second_id EQUAL 3
+   OR NOT first_output STREQUAL output_one
+   OR NOT second_output STREQUAL output_two
+   OR first_samples LESS_EQUAL 0
+   OR second_samples LESS_EQUAL 0
+   OR first_audio_seconds LESS_EQUAL 0
+   OR second_audio_seconds LESS_EQUAL 0
+   OR first_synthesis_seconds LESS 0
+   OR second_synthesis_seconds LESS 0
+   OR first_rtf LESS 0
+   OR second_rtf LESS 0
+)
+  message(FATAL_ERROR "JSONL server result fields are invalid")
+endif()
+
+function(validate_wav path)
+  if(NOT EXISTS "${path}")
+    message(FATAL_ERROR "JSONL server WAV does not exist: ${path}")
+  endif()
+  file(SIZE "${path}" output_size)
+  if(output_size LESS 46)
+    message(FATAL_ERROR "JSONL server WAV is too small: ${output_size} bytes")
+  endif()
+  file(READ "${path}" wav_hex HEX)
+  string(TOLOWER "${wav_hex}" wav_hex)
+  string(SUBSTRING "${wav_hex}" 0 8 riff_header)
+  string(SUBSTRING "${wav_hex}" 16 8 wave_header)
+  string(SUBSTRING "${wav_hex}" 44 4 channel_hex)
+  string(SUBSTRING "${wav_hex}" 48 8 sample_rate_hex)
+  string(SUBSTRING "${wav_hex}" 68 4 bits_hex)
+  if(NOT riff_header STREQUAL "52494646"
+     OR NOT wave_header STREQUAL "57415645"
+     OR NOT channel_hex STREQUAL "0100"
+     OR NOT sample_rate_hex STREQUAL "44ac0000"
+     OR NOT bits_hex STREQUAL "1000"
+  )
+    message(FATAL_ERROR "JSONL server WAV format is invalid: ${path}")
+  endif()
+  string(SUBSTRING "${wav_hex}" 88 -1 pcm_hex)
+  if(pcm_hex MATCHES "^0*$")
+    message(
+      FATAL_ERROR "JSONL server WAV PCM payload is entirely zero: ${path}"
+    )
+  endif()
+endfunction()
+
+validate_wav("${output_one}")
+validate_wav("${output_two}")
+
+set(empty_requests "${WORK_DIR}/empty.jsonl")
+file(WRITE "${empty_requests}" "")
+execute_process(
+  COMMAND
+    "${RUNNER}" "--pte=${PTE}" "--asset_dir=${ASSET_DIR}"
+    "--voice_style=${STYLE}" "--server_jsonl=true" "--warmup_text=Warmup."
+    "--language=en" "--speed=1.05" "--seed=42"
+  INPUT_FILE "${empty_requests}"
+  RESULT_VARIABLE eof_result
+  OUTPUT_VARIABLE eof_output
+  ERROR_VARIABLE eof_error
+)
+if(NOT eof_result EQUAL 0)
+  message(
+    FATAL_ERROR
+      "Supertonic JSONL EOF exit failed (${eof_result})\n${eof_output}${eof_error}"
+  )
+endif()
+string(REPLACE "\n" ";" eof_lines "${eof_output}")
+list(FILTER eof_lines EXCLUDE REGEX "^$")
+list(LENGTH eof_lines eof_count)
+if(NOT eof_count EQUAL 1)
+  message(FATAL_ERROR "EOF run must emit only ready: ${eof_output}")
+endif()
+list(GET eof_lines 0 eof_ready)
+string(
+  JSON
+  eof_type
+  ERROR_VARIABLE
+  eof_json_error
+  GET
+  "${eof_ready}"
+  type
+)
+if(eof_json_error OR NOT eof_type STREQUAL "ready")
+  message(FATAL_ERROR "EOF run did not emit a valid ready record")
+endif()
+
+message("${server_output}")

--- a/examples/models/supertonic/runtime/tests/run_jsonl_server_integration.cmake
+++ b/examples/models/supertonic/runtime/tests/run_jsonl_server_integration.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.24)
+
 foreach(required RUNNER PTE ASSET_DIR STYLE WORK_DIR)
   if(NOT DEFINED ${required})
     message(FATAL_ERROR "Missing JSONL runner variable: ${required}")


### PR DESCRIPTION
### Summary

Add persistent JSONL mode to the Supertonic MLX runner so applications can load and warm the model once, then synthesize multiple utterances sequentially without restarting the process.

The protocol-v1 ready record is intentionally strict and includes the model sample rate:

```json
{"type":"ready","protocol_version":1,"sample_rate":44100,"load_seconds":0.03,"warmup_seconds":0.04}
```

Synthesis requests use positive, strictly increasing IDs and produce one complete mono PCM16 WAV before returning timing and RTF metadata. Malformed or request-local failures return an error record without terminating the resident runner. A shutdown request exits cleanly; EOF is also a clean exit.

This follows the one-shot Supertonic runtime landed in #22063. It does not add model assets, generated PTEs, a Python client, benchmarks, or application-specific code.

### What to review

- `examples/models/supertonic/runtime/main.cpp`: bounded JSONL parsing, warmup/readiness, strict request validation, sequential synthesis, error recovery, and atomic no-overwrite WAV installation.
- `examples/models/supertonic/runtime/tests/run_jsonl_server_integration.cmake`: exact five-field ready schema with `sample_rate == 44100`, success/error sequencing, shutdown/EOF behavior, and WAV validation.
- `examples/models/supertonic/CMakeLists.txt`: asset-gated native integration registration.
- `examples/models/supertonic/README.md`: persistent-mode usage and protocol contract.

### Test plan

- `lintrunner examples/models/supertonic/CMakeLists.txt examples/models/supertonic/README.md examples/models/supertonic/runtime/main.cpp examples/models/supertonic/runtime/tests/run_jsonl_server_integration.cmake`
- `clang-format --dry-run --Werror examples/models/supertonic/runtime/main.cpp`
- Built `supertonic_runner` from this clean worktree on macOS arm64 against the installed ExecuTorch MLX dependency set.
- Built and ran `supertonic_runtime_test`: all helper tests passed.
- Ran focused CTest registration: `supertonic_runtime_helpers` passed and `supertonic_jsonl_integration` skipped as designed because the real PTE/model assets are not present locally.
- Ran `run_jsonl_server_integration.cmake` end to end with a protocol-faithful fake runner: exact ready schema/sample rate, successful requests, malformed JSON, nonmonotonic ID, existing-output rejection, shutdown, EOF, and WAV checks passed.
- Ran the downstream Muse Glimmer strict protocol adapter suite: 19 tests passed.
- GitHub `test-mlx-supertonic` passed on the fixed head with pinned public assets, including export, native build, one-shot synthesis, and the real-PTE JSONL integration.
