### PR TITLE
Implement load_into for SharedPtrDataLoader

### DIFF
--- a/extension/data_loader/shared_ptr_data_loader.h
+++ b/extension/data_loader/shared_ptr_data_loader.h
@@ -13,6 +13,7 @@
 #include <executorch/runtime/core/error.h>
 #include <executorch/runtime/core/result.h>
 #include <executorch/runtime/platform/log.h>
+#include <cstring>
 #include <memory>
 
 namespace executorch {
@@ -45,6 +46,24 @@ class SharedPtrDataLoader final : public executorch::runtime::DataLoader {
         size_);
     return executorch::runtime::FreeableBuffer(
         static_cast<uint8_t*>(data_.get()) + offset, size, /*free_fn=*/nullptr);
+  }
+
+  ET_NODISCARD executorch::runtime::Error load_into(
+      size_t offset,
+      size_t size,
+      ET_UNUSED const SegmentInfo& segment_info,
+      void* buffer) const override {
+    ET_CHECK_OR_RETURN_ERROR(
+        buffer != nullptr,
+        InvalidArgument,
+        "Destination buffer cannot be null");
+
+    auto result = load(offset, size, segment_info);
+    if (!result.ok()) {
+      return result.error();
+    }
+    std::memcpy(buffer, result->data(), size);
+    return executorch::runtime::Error::Ok;
   }
 
   ET_NODISCARD executorch::runtime::Result<size_t> size() const override {

--- a/extension/data_loader/test/shared_ptr_data_loader_test.cpp
+++ b/extension/data_loader/test/shared_ptr_data_loader_test.cpp
@@ -140,3 +140,61 @@ TEST_F(SharedPtrDataLoaderTest, OutOfBoundsLoadFails) {
     EXPECT_NE(fb.error(), Error::Ok);
   }
 }
+
+TEST_F(SharedPtrDataLoaderTest, InBoundsLoadIntoSucceeds) {
+  // Create some heterogeneous data.
+  const size_t SIZE = 256;
+  std::shared_ptr<uint8_t[]> data(
+      new uint8_t[SIZE], std::default_delete<uint8_t[]>());
+  for (int i = 0; i < SIZE; ++i) {
+    data[i] = i;
+  }
+
+  // Wrap it in a loader.
+  SharedPtrDataLoader sbdl(data, SIZE);
+
+  uint8_t dst[3] = {};
+  Error err = sbdl.load_into(
+      /*offset=*/2,
+      /*size=*/sizeof(dst),
+      /*segment_info=*/
+      DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program),
+      dst);
+  EXPECT_EQ(err, Error::Ok);
+  EXPECT_EQ(0, std::memcmp(dst, "\x02\x03\x04", sizeof(dst)));
+
+  // Data is unaltered.
+  EXPECT_EQ(data[2], 2);
+}
+
+TEST_F(SharedPtrDataLoaderTest, LoadIntoNullDstFails) {
+  // Wrap some data in a loader.
+  const size_t SIZE = 256;
+  std::shared_ptr<uint8_t[]> data(
+      new uint8_t[SIZE], std::default_delete<uint8_t[]>());
+
+  // Wrap it in a loader.
+  SharedPtrDataLoader sbdl(data, SIZE);
+
+  // Loading into a null destination should fail.
+  {
+    Error err = sbdl.load_into(
+        /*offset=*/0,
+        /*size=*/1,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program),
+        nullptr);
+    EXPECT_NE(err, Error::Ok);
+  }
+
+  // Loading zero bytes still fails if dst is null.
+  {
+    Error err = sbdl.load_into(
+        /*offset=*/0,
+        /*size=*/0,
+        /*segment_info=*/
+        DataLoader::SegmentInfo(DataLoader::SegmentInfo::Type::Program),
+        nullptr);
+    EXPECT_NE(err, Error::Ok);
+  }
+}


### PR DESCRIPTION
### Summary

`SharedPtrDataLoader` never overrode `load_into`, so it fell back to the stub in `runtime/core/data_loader.h` that logs an error and returns `NotImplemented`. Anything loading through it fails as a result — `Program::load_mutable_subsegment_into` and the training `state_dict_util` being the ones that matter, so a mutable buffer with a serialized initial value can't be read out of a shared buffer at all. The other loaders all implement this; this one looks like it was just missed.

Mirrors `BufferDataLoader::load_into`.

Fixes #11562

### Test plan

Added `InBoundsLoadIntoSucceeds` and `LoadIntoNullDstFails` to `extension/data_loader/test/shared_ptr_data_loader_test.cpp`, matching the `BufferDataLoader` equivalents. Ran the `SharedPtrDataLoaderTest` suite locally, all 4 pass.

Authored with AI assistance (Claude Code).
