### PR TITLE
Arm backend: Show real pass names in Arm crash reports

### DIFF
--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -219,6 +219,7 @@ def _graph_pass_name(graph_pass: Callable[[GraphModule], PassResult | None]) -> 
 class _ExportedProgramGraphPassAdapter(ExportedProgramPassBase):
     def __init__(self, graph_pass: Callable[[GraphModule], PassResult | None]) -> None:
         self.graph_pass = graph_pass
+        self.__name__ = _graph_pass_name(graph_pass)
 
     def call(self, exported_program: ExportedProgram) -> ExportedProgramPassResult:
         graph_pass = cast(Any, self.graph_pass)

--- a/backends/arm/test/passes/test_arm_pass_manager_errors.py
+++ b/backends/arm/test/passes/test_arm_pass_manager_errors.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+import torch
+
+from executorch.backends.arm._passes.arm_pass_manager import (
+    _ExportedProgramGraphPassAdapter,
+)
+from executorch.exir.pass_manager import ExportedProgramPassManager, PassType
+from torch.fx import GraphModule
+from torch.fx.passes.infra.pass_base import PassResult
+
+
+def test_exported_program_adapter_preserves_pass_names_in_errors() -> None:
+    """Report wrapped pass names instead of the adapter class name."""
+
+    def successful_pass(graph_module: GraphModule) -> PassResult:
+        return PassResult(graph_module, False)
+
+    def failing_pass(graph_module: GraphModule) -> PassResult:
+        raise RuntimeError("test failure")
+
+    exported_program = torch.export.export(torch.nn.ReLU(), (torch.randn(2, 3),))
+    passes: list[PassType] = [
+        _ExportedProgramGraphPassAdapter(successful_pass),
+        _ExportedProgramGraphPassAdapter(failing_pass),
+    ]
+
+    with pytest.raises(Exception) as error:
+        ExportedProgramPassManager(passes)(exported_program)
+
+    assert "running the 'failing_pass' pass" in str(error.value)
+    assert "following passes: ['successful_pass']" in str(error.value)

--- a/exir/pass_manager.py
+++ b/exir/pass_manager.py
@@ -1,12 +1,12 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 import copy
-import inspect
 import logging
 import operator
 from typing import Callable, List, Optional, Type, TypeAlias, Union
@@ -36,7 +36,9 @@ PassType: TypeAlias = Union[
 
 def _get_pass_name(fn: PassType) -> str:
     """Returns a human-readable name for a pass."""
-    return fn.__name__ if inspect.isfunction(fn) else type(fn).__name__
+    if hasattr(fn, "__name__"):
+        return fn.__name__
+    return type(fn).__name__
 
 
 def _can_eliminate_common_getitems(gm: torch.fx.GraphModule) -> bool:


### PR DESCRIPTION
When an Arm pass failed, crash reports named
_ExportedProgramGraphPassAdapter instead of the pass that actually failed. The list of passes that ran successfully had the same problem. This made the report useless for finding the broken pass.

Copy the wrapped pass name onto each adapter and make the pass manager use that name in error messages. Add a regression test for the failed pass and the passes that ran before it.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell @rascani