### PR TITLE
Arm backend: Handle Conv1d conversion across control flow

### DIFF
--- a/backends/arm/_passes/rewrite_conv_pass.py
+++ b/backends/arm/_passes/rewrite_conv_pass.py
@@ -33,7 +33,10 @@ from executorch.backends.arm.constants import (
     ODHWI_ORDER,
     OHWI_ORDER,
 )
-from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
+from executorch.backends.arm.tosa.mapping import (
+    TOSA_CONTROL_FLOW_SOURCE_NODE_META,
+    TosaSpecialDtype,
+)
 from executorch.backends.arm.tosa.specification import get_context_shape_env
 from executorch.backends.transforms.utils import create_constant_placeholder
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -208,6 +211,111 @@ class RewriteConvPass(ArmPass):
                 persistent_buffer=persistent_buffer,
             )
 
+    def _resolve_control_flow_constant(
+        self, node: torch.fx.Node
+    ) -> tuple[torch.fx.Node, torch.Tensor, list[torch.fx.Node]]:
+        """Resolve a child input back to a constant in an enclosing graph."""
+        source = node
+        visited = set()
+        rescales = []
+        while source not in visited:
+            visited.add(source)
+            # A captured constant can be requantized at every control-flow
+            # boundary. Save those operations so the rewritten constant can
+            # later be put through the same chain in its new layout.
+            if source.target == exir_ops.backend.tosa.RESCALE.default:
+                if not isinstance(source.args[0], torch.fx.Node):
+                    raise RuntimeError(
+                        f"Rescale node {source.name} has no tensor input"
+                    )
+                rescales.append(source)
+                source = source.args[0]
+                continue
+            try:
+                tensor = get_param_tensor(self.exported_program, source)
+            except RuntimeError:
+                # Branch placeholders are not constants themselves. The TOSA
+                # backend records the corresponding operand in the parent
+                # graph, which may itself be a placeholder in another branch.
+                parent_source = source.meta.get(TOSA_CONTROL_FLOW_SOURCE_NODE_META)
+                if not isinstance(parent_source, torch.fx.Node):
+                    raise
+                source = parent_source
+                continue
+            # get_param_tensor returns None only for a None input. Keep this
+            # guard for its Optional return type; source is always an FX node.
+            if tensor is None:
+                raise RuntimeError(
+                    f"Node {source.name} is not a parameter, buffer, or constant"
+                )
+            return source, tensor, rescales
+        raise RuntimeError(f"Cycle while resolving control-flow input {node.name}")
+
+    def _rewrite_control_flow_bias(
+        self,
+        graph_module: torch.fx.GraphModule,
+        conv_node: torch.fx.Node,
+        bias_node: torch.fx.Node,
+        input_node: torch.fx.Node,
+        weight_node: torch.fx.Node,
+    ) -> torch.fx.Node:
+        """Create an INT32 bias from a rescaled constant control-flow input."""
+        if bias_node.target != exir_ops.backend.tosa.RESCALE.default or not isinstance(
+            bias_node.args[0], torch.fx.Node
+        ):
+            return bias_node
+
+        constant_source, quantized_bias, parent_rescales = (
+            self._resolve_control_flow_constant(bias_node.args[0])
+        )
+        conv_qparams = get_input_qparams(conv_node)
+        input_qparams = conv_qparams[0]
+        weight_qparams = conv_qparams[1]
+        bias_qparams = conv_qparams[2]
+
+        # Recover the scale at which the captured bias was originally stored.
+        # The rescales are discovered from the innermost graph outwards, hence
+        # the reversal before composing their scale ratios.
+        rescale_chain = [*reversed(parent_rescales), bias_node]
+        boundary_scale = 1.0
+        for rescale in rescale_chain:
+            boundary_scales = cast(list[float], rescale.args[2])
+            boundary_scale *= boundary_scales[0]
+        boundary_zp = cast(int, rescale_chain[0].args[3])
+        source_scale = boundary_scale * bias_qparams.get_scale_per_tensor()
+        float_bias = (quantized_bias.to(torch.float32) - boundary_zp) * source_scale
+
+        # TOSA convolution accumulates into INT32. Its bias therefore uses the
+        # product of the activation and weight scales, rather than the scale
+        # assigned to a captured control-flow operand by the quantizer.
+        activation_scale = input_qparams.get_scale_per_tensor()
+        weight_scales = (
+            torch.tensor(weight_qparams.get_scale_per_channel())
+            if weight_qparams.per_channel
+            else torch.tensor(weight_qparams.get_scale_per_tensor())
+        )
+        bias_scales = activation_scale * weight_scales
+        rewritten_bias = torch.round(float_bias / bias_scales).to(torch.int64)
+        rewritten_bias = rewritten_bias.clamp(
+            torch.iinfo(torch.int32).min, torch.iinfo(torch.int32).max
+        ).to(torch.int32)
+
+        kind = get_constant_placeholder_kind(self.exported_program, constant_source)
+        persistent_buffer = is_persistent_buffer(self.exported_program, constant_source)
+        with graph_module.graph.inserting_after(bias_node):
+            rewritten_bias_node = create_constant_placeholder(
+                self.exported_program,
+                graph=graph_module.graph,
+                name=f"{conv_node.name}_bias_int32",
+                kind=kind,
+                data=rewritten_bias,
+                persistent_buffer=persistent_buffer,
+            )
+        # A16W8 stores the bias in an INT32 tensor but TOSA interprets it as
+        # the INT48 accumulator type.
+        self._mark_bias_as_int48_if_needed(conv_node, rewritten_bias_node)
+        return rewritten_bias_node
+
     def _rewrite_weight(
         self,
         graph_module: torch.fx.GraphModule,
@@ -217,19 +325,36 @@ class RewriteConvPass(ArmPass):
         name_suffix: str,
         reshape_dims: tuple[int, ...] | None = None,
     ) -> torch.fx.Node:
-        """Create a convolution-local rewritten weight placeholder."""
-        weight_tensor = get_param_tensor(self.exported_program, weight_node)  # type: ignore[arg-type]
-        if weight_tensor is None:
-            raise RuntimeError(
-                f"Weight node {weight_node.name} is not a parameter or buffer"
-            )
+        """Create a convolution-local weight in the layout required by TOSA."""
+        source_node = weight_node
+        rescale_node = None
+        if (
+            weight_node.target == exir_ops.edge.aten.view_copy.default
+            and isinstance(weight_node.args[0], torch.fx.Node)
+            and weight_node.args[0].target == exir_ops.backend.tosa.RESCALE.default
+        ):
+            rescale_node = weight_node.args[0]
+            if not isinstance(rescale_node.args[0], torch.fx.Node):
+                raise RuntimeError(
+                    f"Rescaled weight node {rescale_node.name} has no tensor input"
+                )
+            source_node = rescale_node.args[0]
 
-        rewritten_weight = weight_tensor.permute(permute_dims)
+        constant_source, weight_tensor, parent_rescales = (
+            self._resolve_control_flow_constant(source_node)
+        )
+
+        if rescale_node is not None:
+            # RESCALE is elementwise, so reshape the constant before it instead
+            # of trying to evaluate the quantized rescale during compilation.
+            weight_shape = cast(list[int], weight_node.args[1])
+            weight_tensor = weight_tensor.reshape(weight_shape)
+        rewritten_weight_value = weight_tensor.permute(permute_dims)
         if reshape_dims is not None:
-            rewritten_weight = rewritten_weight.reshape(*reshape_dims)
-        rewritten_weight = rewritten_weight.contiguous()
-        kind = get_constant_placeholder_kind(self.exported_program, weight_node)
-        persistent_buffer = is_persistent_buffer(self.exported_program, weight_node)
+            rewritten_weight_value = rewritten_weight_value.reshape(*reshape_dims)
+        rewritten_weight_value = rewritten_weight_value.contiguous()
+        kind = get_constant_placeholder_kind(self.exported_program, constant_source)
+        persistent_buffer = is_persistent_buffer(self.exported_program, constant_source)
 
         with graph_module.graph.inserting_after(weight_node):
             rewritten_weight_node = create_constant_placeholder(
@@ -237,12 +362,36 @@ class RewriteConvPass(ArmPass):
                 graph=graph_module.graph,
                 name=f"{conv_node.name}_weight_{name_suffix}",
                 kind=kind,
-                data=rewritten_weight,
+                data=rewritten_weight_value,
                 persistent_buffer=persistent_buffer,
             )
-        if special_dtype := weight_node.meta.get(TosaSpecialDtype.meta_key()):
+        if special_dtype := source_node.meta.get(TosaSpecialDtype.meta_key()):
             rewritten_weight_node.meta[TosaSpecialDtype.meta_key()] = special_dtype
-        return rewritten_weight_node
+
+        # Layout changes commute with elementwise RESCALE operations. Rebuild
+        # the saved outer-to-inner chain after the permuted constant so nested
+        # branches retain exactly the quantization boundaries they started with.
+        rescale_chain = [*reversed(parent_rescales)]
+        if rescale_node is not None:
+            rescale_chain.append(rescale_node)
+        rewritten_weight: torch.fx.Node = rewritten_weight_node
+        for original_rescale in rescale_chain:
+            with graph_module.graph.inserting_after(rewritten_weight):
+                rewritten_rescale = create_node(
+                    graph=graph_module.graph,
+                    op_target=exir_ops.backend.tosa.RESCALE.default,
+                    args=(rewritten_weight, *original_rescale.args[1:]),
+                    kwargs=original_rescale.kwargs,
+                    from_node=original_rescale,
+                )
+            rewritten_rescale.meta["val"] = exir_ops.backend.tosa.RESCALE.default(
+                get_first_fake_tensor(rewritten_weight),
+                *original_rescale.args[1:],
+                **original_rescale.kwargs,
+            )
+            rewritten_weight = rewritten_rescale
+
+        return rewritten_weight
 
     def _is_quantized_conv(self, node: torch.fx.Node) -> bool:
         return bool(node.meta.get("input_qparams", {}))
@@ -280,12 +429,28 @@ class RewriteConvPass(ArmPass):
             )
 
         activation = users[0]
+        if activation.target == exir_ops.edge.aten.view_copy.default:
+            view_output_qparams = activation.meta.get("output_qparams", {})
+            if view_output_qparams:
+                return view_output_qparams
         if activation.target == exir_ops.edge.aten.clamp.default:
             activation_output_qparams = activation.meta.get("output_qparams", {})
             if activation_output_qparams:
                 return activation_output_qparams
 
         return get_output_qparams(node)
+
+    def _get_effective_conv_input_qparams(self, node: torch.fx.Node):
+        """Return conv qparams, including those attached to input views."""
+        input_qparams = dict(node.meta.get("input_qparams", {}))
+        for index in (0, 1):
+            arg = node.args[index]
+            if index in input_qparams or not isinstance(arg, torch.fx.Node):
+                continue
+            arg_qparams = arg.meta.get("input_qparams", {})
+            if 0 in arg_qparams:
+                input_qparams[index] = arg_qparams[0]
+        return input_qparams
 
     def insert_output_rescale(
         self,
@@ -294,7 +459,7 @@ class RewriteConvPass(ArmPass):
         conv_node,
         conv_fake_tensor: torch.Tensor,
     ):
-        input_qparams = get_input_qparams(source_node)
+        input_qparams = self._get_effective_conv_input_qparams(source_node)
         output_qparams = self._get_effective_output_qparams(source_node)[0]
         weight_qparams = input_qparams[1]
         input_qparams = input_qparams[0]
@@ -643,6 +808,11 @@ class RewriteConvPass(ArmPass):
                 group,
             ) = node.args
 
+            if self._is_quantized_conv(node):
+                node.meta["input_qparams"] = self._get_effective_conv_input_qparams(
+                    node
+                )
+
             input_fake_tensor = get_first_fake_tensor(x)
             weight_fake_tensor = get_first_fake_tensor(weight)
             input_shape = input_fake_tensor.shape
@@ -660,6 +830,13 @@ class RewriteConvPass(ArmPass):
             elif isinstance(bias, torch.fx.Node):
                 if input_fake_tensor.dtype in self._FP8_DTYPES:
                     bias = self._rewrite_fp8_bias(graph_module, node, bias)
+                elif (
+                    self._is_quantized_conv(node)
+                    and get_first_fake_tensor(bias).dtype != torch.int32
+                ):
+                    bias = self._rewrite_control_flow_bias(
+                        graph_module, node, bias, x, weight
+                    )
                 else:
                     self._mark_bias_as_int48_if_needed(node, bias)
 

--- a/backends/arm/test/ops/test_cond.py
+++ b/backends/arm/test/ops/test_cond.py
@@ -159,6 +159,50 @@ class CondTwoArgsTwoOutputs(torch.nn.Module):
         return torch.cond(predicate, true_branch, false_branch, [lhs, rhs])
 
 
+class CondConv1d(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.true_conv = torch.nn.Conv1d(2, 4, 3, padding=1)
+        self.false_conv = torch.nn.Conv1d(2, 4, 3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        def true_branch(arg: torch.Tensor) -> torch.Tensor:
+            return self.true_conv(arg)
+
+        def false_branch(arg: torch.Tensor) -> torch.Tensor:
+            return self.false_conv(arg)
+
+        return torch.cond(x.sum() > 0, true_branch, false_branch, [x])
+
+
+class NestedCondConv1d(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.inner_true_conv = torch.nn.Conv1d(2, 4, 3, padding=1)
+        self.inner_false_conv = torch.nn.Conv1d(2, 4, 3, padding=1)
+        self.outer_false_conv = torch.nn.Conv1d(2, 4, 3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        def outer_true(arg: torch.Tensor) -> torch.Tensor:
+            def inner_true(inner_arg: torch.Tensor) -> torch.Tensor:
+                return self.inner_true_conv(inner_arg)
+
+            def inner_false(inner_arg: torch.Tensor) -> torch.Tensor:
+                return self.inner_false_conv(inner_arg)
+
+            return torch.cond(
+                arg.mean() > 0.5,
+                inner_true,
+                inner_false,
+                [arg],
+            )
+
+        def outer_false(arg: torch.Tensor) -> torch.Tensor:
+            return self.outer_false_conv(arg)
+
+        return torch.cond(x.sum() > 0, outer_true, outer_false, [x])
+
+
 def _single_input_case(
     module_factory: Callable[[], torch.nn.Module]
 ) -> Callable[[], tuple[torch.nn.Module, input_t1]]:
@@ -240,6 +284,70 @@ def test_cond_tosa_FP(case: Callable[[], tuple[torch.nn.Module, tuple]]):
         ["torch.ops.higher_order.cond"],
     )
     pipeline.run()
+
+
+def test_cond_conv1d_tosa_FP():
+    TosaPipelineFP[tuple](
+        CondConv1d(),
+        (torch.randn(1, 2, 8),),
+        aten_op,
+        tosa_extensions=["cf"],
+    ).run()
+
+
+def test_cond_conv1d_tosa_INT():
+    # Regression test for a quantized Conv1d whose weight and bias are captured
+    # by a branch. RewriteConvPass must resolve them in the enclosing graph.
+    module = CondConv1d()
+    example_inputs = (torch.randn(1, 2, 8),)
+    pipeline = TosaPipelineINT[tuple](
+        module,
+        example_inputs,
+        aten_op,
+        tosa_extensions=["cf"],
+    )
+    _set_branch_calibration_samples(pipeline, module, example_inputs)
+    pipeline.run()
+
+
+def test_cond_conv1d_tosa_INT_branches():
+    # Exercise both branch graphs explicitly. A single random input only checks
+    # the selected branch at runtime even though both branches are lowered.
+    for example_input in (torch.rand(1, 2, 8), -torch.rand(1, 2, 8)):
+        module = CondConv1d()
+        example_inputs = (example_input,)
+        pipeline = TosaPipelineINT[tuple](
+            module,
+            example_inputs,
+            aten_op,
+            tosa_extensions=["cf"],
+        )
+        _set_branch_calibration_samples(pipeline, module, example_inputs)
+        pipeline.run()
+
+
+def test_nested_cond_conv1d_tosa_INT():
+    # These samples select inner-true, inner-false, and outer-false respectively.
+    # They prove that constant provenance and rescale chains survive more than
+    # one control-flow boundary, not only a single torch.cond.
+    calibration_samples = (
+        (torch.ones(1, 2, 8),),
+        (torch.full((1, 2, 8), 0.1),),
+        (-torch.ones(1, 2, 8),),
+    )
+    for example_inputs in calibration_samples:
+        pipeline = TosaPipelineINT[tuple](
+            NestedCondConv1d(),
+            example_inputs,
+            aten_op,
+            tosa_extensions=["cf"],
+        )
+        quant_stage_pos = pipeline.find_pos("quantize")
+        quant_stage = pipeline._stages[quant_stage_pos].args[0]
+        # Calibrate all paths for every runtime case; otherwise the result could
+        # fail because an unselected branch lacks quantization observations.
+        quant_stage.calibration_samples = calibration_samples
+        pipeline.run()
 
 
 @common.parametrize("case", test_cases)

--- a/backends/arm/test/passes/test_fuse_constant_ops_pass.py
+++ b/backends/arm/test/passes/test_fuse_constant_ops_pass.py
@@ -17,7 +17,10 @@ from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from executorch.backends.arm.test.tester.test_pipeline import PassPipeline
 from executorch.backends.arm.tosa.backend import TOSABackend
-from executorch.backends.arm.tosa.mapping import TosaSpecialDtype
+from executorch.backends.arm.tosa.mapping import (
+    TOSA_CONTROL_FLOW_SOURCE_NODE_META,
+    TosaSpecialDtype,
+)
 from executorch.backends.arm.tosa.specification import (
     TosaLoweringContext,
     TosaSpecification,
@@ -386,6 +389,10 @@ def test_fuse_constant_args_preserves_unused_control_flow_inputs() -> None:
         "x",
     ]
     assert placeholders[1].meta["is_input"] is True
+    cond_inputs = cast(list[torch.fx.Node], cond_node.args[-1])
+    # Regularization must retain the exact parent operand, including when this
+    # unused branch input is preserved for control-flow signature consistency.
+    assert placeholders[1].meta[TOSA_CONTROL_FLOW_SOURCE_NODE_META] is cond_inputs[0]
     assert len(placeholders[1].users) == 0
 
 

--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -33,6 +33,7 @@ from executorch.backends.arm.process_node import (
 from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
 from executorch.backends.arm.tosa.mapping import (
     TOSA_CONTROL_FLOW_REGION_NAME_META,
+    TOSA_CONTROL_FLOW_SOURCE_NODE_META,
     TOSA_TENSOR_NAME_META,
 )
 from executorch.exir.backend.backend_details import BackendDetails, PreprocessResult
@@ -230,6 +231,10 @@ class TOSABackend(BackendDetails):
 
         for submodule_input, submodule_arg in zip(submodule_inputs, args, strict=True):
             submodule_input.meta["val"] = _get_matching_fake_tensor(submodule_arg)
+            # Keep the parent operand reachable from the branch placeholder.
+            # Passes that must rewrite constants can then follow parameters and
+            # buffers across one or more nested control-flow boundaries.
+            submodule_input.meta[TOSA_CONTROL_FLOW_SOURCE_NODE_META] = submodule_arg
 
         output_node = submodule.graph.output_node()
         if isinstance(output_node.args[0], Node):

--- a/backends/arm/tosa/mapping.py
+++ b/backends/arm/tosa/mapping.py
@@ -18,6 +18,7 @@ import tosa_serializer as ts
 from executorch.backends.arm.tosa.specification import TosaSpecification
 
 TOSA_CONTROL_FLOW_REGION_NAME_META = "tosa_control_flow_region_name"
+TOSA_CONTROL_FLOW_SOURCE_NODE_META = "tosa_control_flow_source_node"
 TOSA_TENSOR_NAME_META = "tosa_tensor_name"
 
 UNSUPPORTED_DTYPES = (

--- a/backends/transforms/convert_conv1d_to_conv2d_pass.py
+++ b/backends/transforms/convert_conv1d_to_conv2d_pass.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
+# Copyright 2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -19,8 +20,11 @@ from executorch.exir.pass_base import ExportPass, PassResult
 class ConvertConv1dToConv2dPass(ExportPass):
     """Express Conv1d as Conv2d with a unit-height spatial dimension.
 
-    Only convolutions with lifted parameter, buffer, or constant weights are
-    converted. Dynamic weights and unfolded QDQ weights are left unchanged.
+    At the top level, only convolutions with lifted parameter, buffer, or
+    constant weights are converted. Dynamic weights and unfolded QDQ weights
+    are left unchanged.
+    Weights passed across control-flow boundaries are unsqueezed inside the
+    nested graph so its input signature remains unchanged.
     The pass emits squeeze and unsqueeze boundaries for each converted
     convolution; downstream view cleanup can fold adjacent boundaries.
     """
@@ -66,14 +70,137 @@ class ConvertConv1dToConv2dPass(ExportPass):
             return None
         return weight_node
 
-    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+    @staticmethod
+    def _is_conv1d(node: torch.fx.Node) -> bool:
+        return (
+            node.op == "call_function"
+            and node.target == exir_ops.edge.aten.convolution.default
+            and len(node.args) == 9
+            and len(node.args[3]) == 1
+        )
+
+    @staticmethod
+    def _convert_node(
+        graph: torch.fx.Graph,
+        node: torch.fx.Node,
+        input_node: torch.fx.Node,
+        weight_node: torch.fx.Node,
+        unsqueeze_weight: bool,
+    ) -> None:
+        """Rewrite one Conv1d node as an equivalent Conv2d operation.
+
+        The rewrite adds a unit-height dimension to the input, expands the
+        convolution attributes to two spatial dimensions, and removes the
+        unit-height dimension from the output. When requested, it also inserts
+        an unsqueeze that produces a weight with shape ``[O, I, 1, K]`` from
+        the original ``[O, I, K]`` weight.
+
+        Args:
+            graph (torch.fx.Graph): Graph containing the convolution.
+            node (torch.fx.Node): Conv1d node to rewrite.
+            input_node (torch.fx.Node): Convolution input node.
+            weight_node (torch.fx.Node): Convolution weight node.
+            unsqueeze_weight (bool): Whether to add a graph-local weight
+                unsqueeze. Nested control-flow graphs require this to preserve
+                their input signatures.
+        """
+        with graph.inserting_before(node):
+            input_2d = graph.call_function(
+                exir_ops.edge.aten.unsqueeze_copy.default,
+                args=(input_node, 2),
+            )
+            weight_2d = (
+                graph.call_function(
+                    exir_ops.edge.aten.unsqueeze_copy.default,
+                    args=(weight_node, 2),
+                )
+                if unsqueeze_weight
+                else weight_node
+            )
+
+        args = list(node.args)
+        args[0] = input_2d
+        args[1] = weight_2d
+        args[3] = [1, *list(args[3])]  # stride
+        args[4] = [0, *list(args[4])]  # padding
+        args[5] = [1, *list(args[5])]  # dilation
+        args[7] = [0, *list(args[7])]  # output padding
+        node.args = tuple(args)
+
+        with graph.inserting_after(node):
+            output_1d = graph.call_function(
+                exir_ops.edge.aten.squeeze_copy.dim,
+                args=(node, 2),
+            )
+        for user in list(node.users):
+            if user is not output_1d:
+                user.replace_input_with(node, output_1d)
+
+    def _convert_nested_graph(self, graph_module: torch.fx.GraphModule) -> bool:
+        """Convert Conv1d nodes in a control-flow subgraph and its children.
+
+        Each conversion unsqueezes the weight inside the subgraph, preserving
+        the 3D weight expected at the control-flow boundary.
+
+        Args:
+            graph_module (torch.fx.GraphModule): Subgraph to convert.
+
+        Returns:
+            bool: True if this subgraph or one of its children was modified.
+        """
         graph = graph_module.graph
         modified = False
-        candidates = {
-            node: weight_node
-            for node in graph.nodes
-            if (weight_node := self._conv1d_weight_node(node)) is not None
-        }
+        for node in list(graph.nodes):
+            if not self._is_conv1d(node):
+                continue
+            input_node, weight_node = node.args[:2]
+            if not isinstance(input_node, torch.fx.Node) or not isinstance(
+                weight_node, torch.fx.Node
+            ):
+                continue
+            weight_meta = weight_node.meta.get("val")
+            if not isinstance(weight_meta, torch.Tensor) or weight_meta.dim() != 3:
+                continue
+            # A nested graph receives its weight through the control-flow
+            # interface. Keep that interface 3D and create the 4D Conv2d
+            # weight locally instead of changing the value supplied by its
+            # parent graph.
+            self._convert_node(
+                graph,
+                node,
+                input_node,
+                weight_node,
+                unsqueeze_weight=True,
+            )
+            modified = True
+
+        for child in graph_module.children():
+            if isinstance(child, torch.fx.GraphModule):
+                modified = self._convert_nested_graph(child) or modified
+
+        if modified:
+            graph_module.recompile()
+        return modified
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        graph = graph_module.graph
+        is_root = graph_module is self.exported_program.graph_module
+
+        # Preserve the signature through which a parent supplies parameters to
+        # a nested graph by using graph-local weight unsqueezes.
+        modified = not is_root and self._convert_nested_graph(graph_module)
+
+        # At the root, lifted weights belong to the exported program and can be
+        # changed to 4D once instead of being unsqueezed while the model runs.
+        candidates = (
+            {
+                node: weight_node
+                for node in graph.nodes
+                if (weight_node := self._conv1d_weight_node(node)) is not None
+            }
+            if is_root
+            else {}
+        )
 
         for node, weight_node in candidates.items():
             if any(
@@ -93,30 +220,21 @@ class ConvertConv1dToConv2dPass(ExportPass):
                 continue
             if not self._unsqueeze_weight(weight_node):
                 continue
-            with graph.inserting_before(node):
-                input_2d = graph.call_function(
-                    exir_ops.edge.aten.unsqueeze_copy.default,
-                    args=(input_node, 2),
-                )
-
-            args = list(node.args)
-            args[0] = input_2d
-            args[3] = [1, *list(args[3])]  # stride
-            args[4] = [0, *list(args[4])]  # padding
-            args[5] = [1, *list(args[5])]  # dilation
-            args[7] = [0, *list(args[7])]  # output padding
-            node.args = tuple(args)
-
-            with graph.inserting_after(node):
-                output_1d = graph.call_function(
-                    exir_ops.edge.aten.squeeze_copy.dim,
-                    args=(node, 2),
-                )
-            for user in list(node.users):
-                if user is not output_1d:
-                    user.replace_input_with(node, output_1d)
-
+            self._convert_node(
+                graph,
+                node,
+                input_node,
+                weight_node,
+                unsqueeze_weight=False,
+            )
             modified = True
+
+        # The normal entry point invokes this call method for the root graph.
+        # Explicitly apply the rewrite to its child control-flow GraphModules.
+        if is_root:
+            for child in graph_module.children():
+                if isinstance(child, torch.fx.GraphModule):
+                    modified = self._convert_nested_graph(child) or modified
 
         if not modified:
             return PassResult(graph_module, False)

--- a/backends/transforms/test/test_convert_conv1d_to_conv2d_pass.py
+++ b/backends/transforms/test/test_convert_conv1d_to_conv2d_pass.py
@@ -107,6 +107,22 @@ class WeightUsedAsConvInput(torch.nn.Module):
         )
 
 
+class CondConv1d(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.true_conv = torch.nn.Conv1d(2, 4, 3, padding=1)
+        self.false_conv = torch.nn.Conv1d(2, 4, 3, padding=1)
+
+    def forward(self, x):
+        def true_branch(arg):
+            return self.true_conv(arg)
+
+        def false_branch(arg):
+            return self.false_conv(arg)
+
+        return torch.cond(x.sum() > 0, true_branch, false_branch, [x])
+
+
 def _edge(model: torch.nn.Module, inputs: tuple[torch.Tensor, ...]):
     return to_edge(torch.export.export(model.eval(), inputs)).exported_program()
 
@@ -166,6 +182,22 @@ def test_convert_dynamic_activation_shapes():
     runtime_input = torch.randn(3, 2, 17)
 
     torch.testing.assert_close(converted.module()(runtime_input), model(runtime_input))
+
+
+def test_convert_control_flow_subgraphs():
+    model = CondConv1d().eval()
+    example_input = torch.randn(1, 2, 8)
+    edge = _edge(model, (example_input,))
+
+    converted = _transform(edge, ConvertConv1dToConv2dPass(edge))
+
+    for runtime_input in (example_input.abs(), -example_input.abs()):
+        torch.testing.assert_close(
+            converted.module()(runtime_input), model(runtime_input)
+        )
+
+    assert edge.state_dict["true_conv.weight"].dim() == 3
+    assert edge.state_dict["false_conv.weight"].dim() == 3
 
 
 def test_convert_transposed_conv1d():


### PR DESCRIPTION
### Summary
Convert Conv1d nodes inside nested graph modules without changing branch signatures. Insert branch-local weight views while retaining parameter mutation for ordinary top-level graphs.

Track captured constants across control-flow boundaries so convolution rewriting can recover weights and biases from enclosing graphs. Preserve nested TOSA rescale chains and convert quantized biases to the scale required by convolution.

Mark rewritten A16W8 biases as the TOSA INT48 accumulator type while retaining their physical INT32 storage.

### Test plan
Add regression coverage for both conditional branches and nested quantized Conv1d paths.



cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani