### PR TITLE
[executorch][native] Add Value + index-arena ids to the in-memory IR

### DIFF
--- a/backends/native/runtime/graph/Ids.h
+++ b/backends/native/runtime/graph/Ids.h
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+namespace ptn {
+
+// Index-arena handles: a NodeRef indexes the graph's node arena, a ValueRef
+// its value arena. Plain int32_t aliases — they index, compare, and hash
+// directly, at the cost of no NodeRef/ValueRef type distinction. kInvalid marks
+// "no ref".
+using NodeRef = int32_t;
+using ValueRef = int32_t;
+constexpr int32_t kInvalid = -1;
+
+inline bool valid(int32_t ref) {
+  return ref >= 0;
+}
+
+// std::cmp_less compares the signed ref against the unsigned size without
+// casting either side.
+inline bool in_bounds(int32_t ref, size_t size) {
+  return valid(ref) && std::cmp_less(ref, size);
+}
+
+} // namespace ptn

--- a/backends/native/runtime/graph/Value.cpp
+++ b/backends/native/runtime/graph/Value.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/graph/Value.h>
+
+#include <stdexcept>
+
+namespace ptn {
+
+const TensorMeta& Value::tensor_meta() const {
+  const TensorMeta* m = std::get_if<TensorMeta>(&value_);
+  if (m == nullptr) {
+    throw std::runtime_error("Value::tensor_meta: value is not a Tensor");
+  }
+  return *m;
+}
+
+const Scalar& Value::scalar() const {
+  const Scalar* s = std::get_if<Scalar>(&value_);
+  if (s == nullptr) {
+    throw std::runtime_error("Value::scalar: value is not a Scalar");
+  }
+  return *s;
+}
+
+const std::vector<ValueRef>& Value::content_refs() const {
+  const std::vector<ValueRef>* refs =
+      std::get_if<std::vector<ValueRef>>(&value_);
+  if (refs == nullptr) {
+    throw std::runtime_error("Value::content_refs: value is not a List");
+  }
+  return *refs;
+}
+
+} // namespace ptn

--- a/backends/native/runtime/graph/Value.h
+++ b/backends/native/runtime/graph/Value.h
@@ -1,0 +1,97 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <any>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <executorch/backends/native/runtime/graph/Ids.h>
+#include <executorch/backends/native/runtime/graph/Scalar.h>
+#include <executorch/backends/native/runtime/graph/TensorMeta.h>
+
+namespace ptn {
+
+enum class ValueKind : int8_t {
+  None = 0,
+  Tensor = 1,
+  Scalar = 2,
+  List = 3,
+};
+
+// A single SSA value (dataflow edge) in a Graph: its contents plus def-use
+// wiring, a storage alias and an open annotation map. The ref fields are plain
+// handles; whether one is in range is a property of the owning arena, so
+// nothing here validates them.
+//
+// The variant's alternatives are listed in ValueKind order, so kind() is its
+// index. A List holds ValueRefs to its elements rather than nested Values, so
+// nesting goes through the arena; nothing deserialized is a List, it exists for
+// in-memory rewrites such as grouping a tuple.
+class Value {
+ private:
+  std::variant<std::monostate, TensorMeta, Scalar, std::vector<ValueRef>>
+      value_;
+
+ public:
+  // SSA name, scoped to the enclosing Graph.
+  std::string name;
+  // Defining node; invalid => graph input.
+  NodeRef producer_ref = kInvalid;
+  // Def-use, built by inverting node inputs.
+  std::vector<NodeRef> consumer_refs;
+  // Shares storage with this value (a view); fresh if invalid.
+  ValueRef alias_ref = kInvalid;
+  // Open annotations for graph passes and engines, like node.meta in FX.
+  std::unordered_map<std::string, std::any> attrs;
+
+  Value() = default; // a None value with an empty name
+
+  explicit Value(std::string name) // a named None value
+      : name(std::move(name)) {}
+
+  Value(std::string name, TensorMeta meta)
+      : value_(std::move(meta)), name(std::move(name)) {}
+
+  // The empty dim_order_hint is what makes the tensor contiguous.
+  Value(std::string name, ScalarType dtype, std::vector<Dim> sizes)
+      : value_(TensorMeta{dtype, std::move(sizes), {}}),
+        name(std::move(name)) {}
+
+  Value(std::string name, Scalar value)
+      : value_(value), name(std::move(name)) {}
+
+  Value(std::string name, std::vector<ValueRef> elem_refs)
+      : value_(std::move(elem_refs)), name(std::move(name)) {}
+
+  ValueKind kind() const {
+    return static_cast<ValueKind>(value_.index());
+  }
+  bool is_tensor() const {
+    return std::holds_alternative<TensorMeta>(value_);
+  }
+  bool is_scalar() const {
+    return std::holds_alternative<Scalar>(value_);
+  }
+  bool is_list() const {
+    return std::holds_alternative<std::vector<ValueRef>>(value_);
+  }
+  bool is_none() const {
+    return std::holds_alternative<std::monostate>(value_);
+  }
+
+  // Typed payload accessors: throw std::runtime_error unless the kind matches.
+  const TensorMeta& tensor_meta() const;
+  const Scalar& scalar() const;
+  const std::vector<ValueRef>& content_refs() const;
+};
+
+} // namespace ptn

--- a/backends/native/runtime/graph/targets.bzl
+++ b/backends/native/runtime/graph/targets.bzl
@@ -38,3 +38,25 @@ def define_common_targets():
         ],
         visibility = ["//executorch/backends/native/..."],
     )
+
+    runtime.cxx_library(
+        name = "ids",
+        exported_headers = [
+            "Ids.h",
+        ],
+        visibility = ["//executorch/backends/native/..."],
+    )
+
+    runtime.cxx_library(
+        name = "value",
+        srcs = ["Value.cpp"],
+        exported_headers = [
+            "Value.h",
+        ],
+        exported_deps = [
+            ":ids",
+            ":scalar",
+            ":tensor_meta",
+        ],
+        visibility = ["//executorch/backends/native/..."],
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22105
* #22104
* #22103
* #22102
* #22101
* #22100
* #22099
* #22098
* __->__ #22216
* #22215
* #22214
* #22097
* #22096

Next in-memory IR types for the native runtime, under
`backends/native/runtime/graph/`:

- `Ids.h` — `NodeRef` / `ValueRef`, plain `int32_t` index-arena aliases plus
  `kInvalid`, a `valid()` helper, and an
  `in_bounds(ref, size)` helper that pairs the validity check with a range check
  via `std::cmp_less`, so neither side has to be cast to the other's signedness.
  `NodeRef` indexes `Graph.nodes`; `ValueRef` indexes `Graph.values`.
- `Value` (`Value.{h,cpp}`) — one SSA value (dataflow edge): a `std::variant`
  over `std::monostate` / `TensorMeta` / `Scalar` / `std::vector<ValueRef>`, with
  the alternatives declared in `ValueKind` order so `kind()` is the variant's
  index. Plus def-use wiring (`producer_ref` / `consumer_refs`), a storage
  `alias_ref`, and an open `attrs` (`std::any`) scratch map. Construct via the
  per-kind constructors; read via typed accessors that throw on a kind mismatch.
  A `List` holds `ValueRef`s to its element values (an arena grouping), so
  nesting is via the arena and there is no recursive value type; the AOT
  deserializer builds only Tensor / Scalar / None.

Pure std — no ExecuTorch and no flatbuffers dependency. Mirrored into both the
`fbcode/` and `xplat/` trees to match the native backend layout.

Authored with Claude Code.

Differential Revision: [D114396769](https://our.internmc.facebook.com/intern/diff/D114396769/)