### PR TITLE
Transforms: let the shared driver decline a reduction it cannot cross

### DIFF
--- a/backends/arm/_passes/propagate_view_copy_permute_pass.py
+++ b/backends/arm/_passes/propagate_view_copy_permute_pass.py
@@ -90,6 +90,24 @@ class TosaPropagationOverrides(_BasePass):
             or node.target == exir_ops.backend.tosa.RESCALE.default
         )
 
+    def is_swappable(self, next_node: torch.fx.Node) -> bool:
+        # Arm normalizes reductions to keepdim=True before this pass runs, so a
+        # non-keepdim reduction here means the pipeline is misordered. The
+        # shared pass merely declines; Arm wants to hear about it.
+        if next_node.target in self._REDUCTION_TARGETS:
+            keep_dim = (
+                next_node.args[2]
+                if len(next_node.args) > 2
+                else next_node.kwargs.get("keepdim")
+            )
+            if keep_dim is not True:
+                raise RuntimeError(
+                    f"{self.__class__.__name__} expects keep_dim=True for "
+                    f"reduction ops to simplify propagation logic, got "
+                    f"{keep_dim} for node {next_node.name}."
+                )
+        return super().is_swappable(next_node)
+
     def is_multi_input_elementwise(self, node: torch.fx.Node) -> bool:
         return node.target == exir_ops.backend.tosa.TABLE.default
 

--- a/backends/transforms/propagate_view_copy_permute_pass.py
+++ b/backends/transforms/propagate_view_copy_permute_pass.py
@@ -369,9 +369,9 @@ class PropagateViewCopyPermutePass(ExportPass, ABC):
                 else next_node.kwargs.get("keepdim")
             )
             if keep_dim is not True:
-                raise RuntimeError(
-                    f"{self.__class__.__name__} expects keep_dim=True for reduction ops to simplify propagation logic, got {keep_dim} for node {next_node.name}."
-                )
+                # A reduction that drops the dimension changes rank, so the
+                # permutation cannot simply be remapped across it.
+                return False
         return True
 
     def _can_move_through_elementwise(

--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -246,6 +246,19 @@ def define_common_targets():
         ],
     )
 
+    runtime.python_test(
+        name = "test_propagate_view_copy_permute_pass",
+        srcs = [
+            "test/test_propagate_view_copy_permute_pass.py",
+        ],
+        deps = [
+            "//caffe2:torch",
+            ":propagate_view_copy_permute_pass",
+            "//executorch/exir/dialects:lib",
+            "fbsource//third-party/pypi/pytest:pytest",
+        ],
+    )
+
     runtime.python_library(
         name = "canonicalize_view_copy_permute_pass",
         srcs = [

--- a/backends/transforms/test/test_propagate_view_copy_permute_pass.py
+++ b/backends/transforms/test/test_propagate_view_copy_permute_pass.py
@@ -1,0 +1,105 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from executorch.backends.transforms.propagate_view_copy_permute_pass import (
+    PropagateViewCopyPermuteDownPass,
+    PropagateViewCopyPermuteUpPass,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+
+PERMUTE = exir_ops.edge.aten.permute_copy.default
+ABS = exir_ops.edge.aten.abs.default
+NEG = exir_ops.edge.aten.neg.default
+SIGMOID = exir_ops.edge.aten.sigmoid.default
+ADD = exir_ops.edge.aten.add.Tensor
+SUM = exir_ops.edge.aten.sum.dim_IntList
+
+SOURCE_SHAPE = (1, 2, 3, 4)
+PERMUTED_SHAPE = (1, 3, 4, 2)
+PERMUTATION = [0, 2, 3, 1]
+
+
+def _forked_permute(graph: torch.fx.Graph, branches: int) -> list[torch.fx.Node]:
+    """A permute feeding `branches` pointwise users."""
+    x = graph.placeholder("x")
+    x.meta["val"] = torch.empty(SOURCE_SHAPE)
+    permute = graph.call_function(PERMUTE, args=(x, PERMUTATION))
+    permute.meta["val"] = torch.empty(PERMUTED_SHAPE)
+
+    users = []
+    for target in (ABS, NEG, SIGMOID)[:branches]:
+        user = graph.call_function(target, args=(permute,))
+        user.meta["val"] = torch.empty(PERMUTED_SHAPE)
+        users.append(user)
+    return users
+
+
+def _permute_counts(graph: torch.fx.Graph) -> tuple[int, int, int]:
+    """Permute counts before propagation, after the down pass, and after the up pass."""
+    graph.lint()
+    graph_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    def count() -> int:
+        return [
+            node.target
+            for node in graph_module.graph.nodes
+            if node.op == "call_function"
+        ].count(PERMUTE)
+
+    before = count()
+    graph_module = PropagateViewCopyPermuteDownPass().call(graph_module).graph_module
+    after_down = count()
+    graph_module = PropagateViewCopyPermuteUpPass().call(graph_module).graph_module
+    return before, after_down, count()
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Splitting a fork where some branches rejoin and others do not leaves "
+    "one copy below the meeting node and one at the source, and the up pass has "
+    "no fork split of its own to hoist the first above the rejoin. No model in a "
+    "15-model sweep produces this shape, so the driver does not special-case it; "
+    "the general fix is to stop propagation increasing the copy count at all.",
+)
+def test_mixed_reconvergence_fork_does_not_strand_a_permute() -> None:
+    graph = torch.fx.Graph()
+    left, right, diverging = _forked_permute(graph, branches=3)
+    rejoin = graph.call_function(ADD, args=(left, right))
+    rejoin.meta["val"] = torch.empty(PERMUTED_SHAPE)
+    graph.output((rejoin, diverging))
+
+    assert _permute_counts(graph) == (1, 1, 1)
+
+
+def test_fork_split_still_applies_when_every_branch_rejoins() -> None:
+    graph = torch.fx.Graph()
+    left, right = _forked_permute(graph, branches=2)
+    rejoin = graph.call_function(ADD, args=(left, right))
+    rejoin.meta["val"] = torch.empty(PERMUTED_SHAPE)
+    graph.output(rejoin)
+
+    assert _permute_counts(graph) == (1, 1, 1)
+
+
+def test_fork_split_still_applies_when_every_branch_diverges() -> None:
+    graph = torch.fx.Graph()
+    left, right = _forked_permute(graph, branches=2)
+    graph.output((left, right))
+
+    # The down pass gives each branch its own copy; the up pass merges them
+    # back onto the shared producer.
+    assert _permute_counts(graph) == (1, 2, 1)
+
+
+def test_is_swappable_declines_reduction_that_drops_the_dimension() -> None:
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    pass_ = PropagateViewCopyPermuteUpPass()
+
+    assert pass_.is_swappable(graph.call_function(SUM, args=(x, [1], True)))
+    assert not pass_.is_swappable(graph.call_function(SUM, args=(x, [1], False)))


### PR DESCRIPTION
is_swappable raised when it met a reduction that drops the dimension, so a
graph containing one could not go through the pass at all. A conv backbone with
a global-average-pool head is enough: conv -> permute -> mean(dim=(1,2)) ->
linear crashes the pass rather than being left alone.

Answer the question instead. The permutation cannot be remapped across a
rank-changing reduction, so the shared pass declines and the copy stops there,
which is what "not swappable" means.

Arm keeps the raise, in an override. Its pipeline normalizes reductions to
keepdim=True before this pass runs, so meeting one here means the ordering is
wrong rather than that the graph is unusual, and it wants to hear about that.
The split is the point: the shared pass states what it can do, the backend
states what it expects.

The pass suite produces a failure set identical to merge base, name for name.

Also add a regression file for the fork-split paths the driver already has,
covering both uniform shapes. The mixed shape -- some branches rejoining, some
not -- is recorded as a strict xfail rather than special-cased: the split
strands a copy there, but a sweep of fifteen models (mv2, mv3_small, resnet18,
efficientnet_b0, squeezenet, shufflenet, mnasnet, regnet, lraspp, deeplabv3,
swin_t, MultiheadAttention, TransformerEncoderLayer and two synthetic
multi-output heads) never produces it. Naming the shape in the driver buys
nothing measurable and the general fix is to stop propagation increasing the
copy count at all.

Authored with Claude Code.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell