### PR TITLE
Restore the banked memory planner after the storage_base rename

### DIFF
--- a/exir/banked_memory_planning.py
+++ b/exir/banked_memory_planning.py
@@ -34,7 +34,7 @@ from executorch.exir.memory_planning import (
     _compute_total_sizes,
     _does_not_overlap,
     _find_max_overlapping_allocations_offset,
-    _resolve_inplace_specs,
+    _resolve_storage_base_specs,
     AllocationSpec,
     get_node_tensor_specs,
     MemoryAlgoResult,
@@ -181,11 +181,13 @@ class BankedGreedy:
         self._check_bank_alignments(alignment)
         all_specs = list(specs)
 
-        # In-place outputs share their base's storage, so they inherit its bank
-        # rather than being placed or counted against capacity.
-        planned = [spec for spec in all_specs if spec.inplace_base is None]
-        deferred_inplace = [spec for spec in all_specs if spec.inplace_base is not None]
-        for spec in deferred_inplace:
+        # Storage-backed specs live inside another spec's allocation, so they
+        # inherit its bank rather than being placed or counted against capacity.
+        planned = [spec for spec in all_specs if spec.storage_base is None]
+        deferred_storage_base = [
+            spec for spec in all_specs if spec.storage_base is not None
+        ]
+        for spec in deferred_storage_base:
             spec.realign(alignment)
 
         self._reject_non_cpu(all_specs)
@@ -236,9 +238,9 @@ class BankedGreedy:
             result.spec_dict[spec] = SpecAllocResult(mem_id, 0, 0)
             spec2obj[spec] = sobj
 
-        for spec in deferred_inplace:
+        for spec in deferred_storage_base:
             result.spec_dict[spec] = SpecAllocResult(0, 0, 0)
-        _resolve_inplace_specs(deferred_inplace, spec2obj, result)
+        _resolve_storage_base_specs(deferred_storage_base, spec2obj, result)
 
         result.bufsizes = _compute_total_sizes(
             objects, graph_module, 0, result, len(spec2obj)

--- a/exir/tests/test_banked_memory_planning.py
+++ b/exir/tests/test_banked_memory_planning.py
@@ -22,7 +22,6 @@ from executorch.exir.banked_memory_planning import (
 from executorch.exir.memory_planning import (
     collect_specs_from_nodes,
     greedy,
-    materialize_buffer,
     MemoryPlanningAlgorithmSuite,
     pick_shared_obj,
     update_all_tensors_lifetime,
@@ -118,7 +117,7 @@ def packed_size(specs: Sequence[TensorSpec]) -> int:
     ordered = sorted(specs, key=lambda s: s.allocated_memory, reverse=True)
     for spec in ordered:
         pick_shared_obj(objects, spec, True)
-    return materialize_buffer(objects)
+    return sum(sobj.size for sobj in objects)
 
 
 def assert_no_free_readmission(
@@ -658,6 +657,20 @@ class TestInPlaceSpecs(unittest.TestCase):
         aliased = make_spec(1024, (0, 10))
         aliased.inplace_base = base
         bufsizes, _ = plan(BankedGreedy(two_banks(1 * KiB, 64 * KiB)), [base, aliased])
+        self.assertEqual(bufsizes[1], 1024)
+        self.assertEqual(bufsizes[2], 0)
+
+    def test_storage_backed_spec_sits_at_its_offset_inside_the_base(self) -> None:
+        base = make_spec(1024, (0, 10))
+        aliased = make_spec(256, (0, 10))
+        aliased.storage_base = base
+        aliased.storage_base_offset = 512
+
+        bufsizes, alloc = plan(
+            BankedGreedy(two_banks(1 * KiB, 64 * KiB)), [base, aliased]
+        )
+        self.assertEqual(alloc[id(aliased)][0], alloc[id(base)][0])
+        self.assertEqual(alloc[id(aliased)][1], alloc[id(base)][1] + 512)
         self.assertEqual(bufsizes[1], 1024)
         self.assertEqual(bufsizes[2], 0)
 


### PR DESCRIPTION
### Summary
#21840 renamed _resolve_inplace_specs to _resolve_storage_base_specs and TensorSpec.inplace_base to storage_base, and deleted materialize_buffer. exir/banked_memory_planning.py imported the first of those, so the module stopped importing and exir/tests/test_banked_memory_planning.py failed at collection. That single collection error red-lighted every unittest, unittest-editable and unittest-release job on main.

Moving the banked planner onto the new names is the whole fix. _resolve_storage_base_specs already applies storage_base_offset when it places a deferred spec inside its base's shared object, so the planner gains offset support without further change. The banked planner had no coverage of a non-zero offset, so a test pins down that a storage-backed spec lands at its offset inside the base, in the base's bank, without costing the bank anything.

The packed_size test helper wanted only the total, so it sums the shared object sizes instead of reviving materialize_buffer.

Authored with Claude Code.