### PR TITLE
Qualcomm: reject a delegate whose QNN graph I/O does not match its si…

### DIFF
--- a/backends/qualcomm/qnn_preprocess.py
+++ b/backends/qualcomm/qnn_preprocess.py
@@ -8,6 +8,7 @@ import logging
 from collections import defaultdict
 from typing import Dict, final, List
 
+import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManager
 import torch  # noqa: F401
 from executorch.backends.qualcomm._passes.qnn_pass_manager import (
     get_qnn_pass_manager_cls,
@@ -44,6 +45,49 @@ DEFAULT_GRAPH_NAME = "forward"
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
+
+
+def _check_io_binding(edge_program: ExportedProgram, nodes_to_wrappers) -> None:
+    """Fail here if QNN's graph I/O will not line up with the delegate signature.
+
+    At runtime the delegate binds its arguments positionally: it walks the tensor
+    lists recovered from the context binary and consumes one argument per tensor
+    the name prefixes mark as bindable (QnnExecuTorchBackend::execute). Nothing
+    reconciles that walk with the number of arguments ExecuTorch actually passes,
+    so a graph that publishes extra I/O reads past the end of the argument list on
+    device. Catching it here costs one pass over the wrappers and reports the
+    offending tensor names instead of a register dump.
+    """
+    qnn_inputs, qnn_outputs = set(), set()
+    for wrappers in nodes_to_wrappers.values():
+        for wrapper in wrappers.values():
+            name = PyQnnManager.PyQnnTensorWrapper(wrapper).GetName()
+            # Mutable buffers are threaded through separately and never consume a
+            # delegate argument; the runtime skips them by the same marker.
+            if "mutbuf_" in name:
+                continue
+            if name.startswith("input_"):
+                qnn_inputs.add(name)
+            elif name.startswith("output_"):
+                qnn_outputs.add(name)
+
+    signature = edge_program.graph_signature
+    num_inputs = len(signature.user_inputs)
+    num_outputs = len(signature.user_outputs)
+    if len(qnn_inputs) == num_inputs and len(qnn_outputs) == num_outputs:
+        return
+
+    raise RuntimeError(
+        "QNN graph I/O does not match the delegated program signature. QNN "
+        f"declares {len(qnn_inputs)} graph inputs and {len(qnn_outputs)} graph "
+        f"outputs; the signature declares {num_inputs} user inputs and "
+        f"{num_outputs} user outputs. The runtime binds delegate arguments "
+        "positionally, so this reads past the end of the argument list on device."
+        f"\n  qnn inputs        : {sorted(qnn_inputs)}"
+        f"\n  qnn outputs       : {sorted(qnn_outputs)}"
+        f"\n  signature inputs  : {list(signature.user_inputs)}"
+        f"\n  signature outputs : {list(signature.user_outputs)}"
+    )
 
 
 @final
@@ -111,6 +155,7 @@ class QnnBackend(BackendDetails):
             else:
                 raise RuntimeError(f"{node.op} is not supported in Qnn")
 
+        _check_io_binding(edge_program, nodes_to_wrappers)
         return py_op_wrapper_list
 
     @staticmethod

--- a/backends/qualcomm/tests/test_passes.py
+++ b/backends/qualcomm/tests/test_passes.py
@@ -848,5 +848,79 @@ class TestPasses(unittest.TestCase):
         self.assertGreaterEqual(reused, 1, "third manager must reuse the live bundle")
 
 
+class TestIoBindingCheck(unittest.TestCase):
+    """_check_io_binding must fire when QNN publishes I/O the signature lacks.
+
+    The runtime binds delegate arguments positionally against the tensor list in
+    the context binary, so a graph that declares more bindable tensors than the
+    program passes reads past the end of args. That has to be caught at lowering.
+    """
+
+    @staticmethod
+    def _edge_program(num_inputs, num_outputs):
+        signature = MagicMock()
+        signature.user_inputs = [f"arg_{i}" for i in range(num_inputs)]
+        signature.user_outputs = [f"out_{i}" for i in range(num_outputs)]
+        edge_program = MagicMock()
+        edge_program.graph_signature = signature
+        return edge_program
+
+    def _run(self, names, num_inputs, num_outputs):
+        from executorch.backends.qualcomm import qnn_preprocess
+
+        wrappers = {f"n{i}": {0: object()} for i in range(len(names))}
+        by_id = {
+            id(next(iter(v.values()))): name
+            for v, name in zip(wrappers.values(), names)
+        }
+
+        class _StubWrapper:
+            def __init__(self, wrapper):
+                self._name = by_id[id(wrapper)]
+
+            def GetName(self):
+                return self._name
+
+        with unittest.mock.patch.object(
+            qnn_preprocess.PyQnnManager, "PyQnnTensorWrapper", _StubWrapper
+        ):
+            qnn_preprocess._check_io_binding(
+                self._edge_program(num_inputs, num_outputs), wrappers
+            )
+
+    def test_matching_io_passes(self):
+        self._run(
+            ["input_0_x", "output_y", "conv2d_3", "_frozen_param0"],
+            num_inputs=1,
+            num_outputs=1,
+        )
+
+    def test_mutable_buffers_do_not_consume_arguments(self):
+        # A mutable buffer is threaded through separately and is not a user input.
+        self._run(
+            ["input_0_x", "input_1_mutbuf_0_cache", "output_y"],
+            num_inputs=1,
+            num_outputs=1,
+        )
+
+    def test_extra_published_inputs_are_rejected(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self._run(
+                ["input_0_x", "input_1_stray", "input_2_stray", "output_y"],
+                num_inputs=1,
+                num_outputs=1,
+            )
+        message = str(ctx.exception)
+        self.assertIn("QNN declares 3 graph inputs", message)
+        self.assertIn("input_1_stray", message)
+
+    def test_extra_published_outputs_are_rejected(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self._run(
+                ["input_0_x", "output_y", "output_stray"], num_inputs=1, num_outputs=1
+            )
+        self.assertIn("2 graph outputs", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…gnature

At runtime the delegate binds its arguments positionally, walking the tensor lists recovered from the context binary and consuming one argument per tensor the name prefixes mark as bindable. A graph that publishes more bindable I/O than the program passes therefore reads past the end of the argument list on device, where all it leaves behind is a fault address and two counts.

Everything needed to catch that is already in hand at the end of _build_op_wrappers: nodes_to_wrappers holds every tensor that will be serialized into the binary, under the names the runtime will read, and the delegated program carries the signature those names have to agree with. Compare them there and report the offending names, rather than letting the disagreement reach a device.

The comparison uses the runtime's own rules so the two cannot drift: an "input_"-prefixed tensor binds an input, an "output_"-prefixed tensor binds an output, and anything carrying "mutbuf_" is skipped, since mutable buffers are threaded through separately and never consume an argument. Prebuilt context binaries return earlier in the same function and never reach the check; preprocess_multimethod runs it once per program against that program's own signature; tensor-dump mode promotes native tensors to APP_READ without giving them an output_ prefix, so they are excluded too.

Checked against ten real lowerings -- single input/output, multi-input, multi-output, partially-consumed multi-output and a mutable buffer, each in fp16 and quantized -- with no false positives. The unit tests drive the comparison directly with stub wrapper names, covering the matching case, a mutable buffer that must not consume an argument, and a surplus on either side.

One case is worth knowing about: a model returning the same tensor twice has two user_outputs but one output_-prefixed wrapper, so this fires. That is a real defect today, since the runtime's output loop never fills the second argument, and the fix belongs on the runtime side rather than in weakening the check.
