### PR TITLE
Document nightly wheels and linking macOS backends from C++

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -23,6 +23,14 @@ This package includes the dependencies needed to export a PyTorch model, as well
 pip install executorch
 ```
 
+To get the latest features before they reach a stable release, install a nightly
+build instead. Nightly wheels are built from the `main` branch every day, so a
+change that has landed but is not yet in a stable release is available there first.
+
+```
+pip install executorch --pre --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+```
+
 To build the framework from source, see [Building From Source](using-executorch-building-from-source.md). Backend delegates may require additional dependencies. See the appropriate backend documentation for more information.
 
 > **_NOTE:_** On Windows, ExecuTorch requires a [Visual Studio Developer Powershell](https://learn.microsoft.com/en-us/visualstudio/ide/reference/command-prompt-powershell?view=vs-2022). Running from outside of a developer prompt will manifest as errors related to CL.exe.

--- a/docs/source/using-executorch-cpp.md
+++ b/docs/source/using-executorch-cpp.md
@@ -199,6 +199,21 @@ foreach(_component
 endforeach()
 ```
 
+On macOS the Core ML and MLX delegates link the same way, by naming their
+component. Registration is handled for you: each backend registers itself through
+a static initializer, and the imported target carries the link options that keep
+that initializer from being dropped, so you do not need `-force_load` or any
+whole-archive flag of your own.
+
+```cmake
+find_package(executorch REQUIRED COMPONENTS kernels_optimized backend_coreml backend_mlx)
+
+target_link_libraries(app PRIVATE executorch::runtime
+                                  executorch::kernels_optimized
+                                  executorch::backend_coreml
+                                  executorch::backend_mlx)
+```
+
 Profiling a Core ML model records `DELEGATE_CALL`, which tells you how long the delegate ran in
 total. It does not record the individual operators inside the delegate, because that detail comes
 from the Core ML developer tools sources, and the wheel does not build them. An XNNPACK model


### PR DESCRIPTION
## Summary

Two small documentation gaps for the pip wheel.

**Nightly install.** New features land on the `main` branch and reach users through a nightly build before the next stable release. The getting-started guide only showed the stable install, so add the nightly command:

```
pip install executorch --pre --extra-index-url https://download.pytorch.org/whl/nightly/cpu
```

**Linking macOS backends from C++.** The C++ guide showed how to link a backend using XNNPACK as the example, but never showed the macOS Core ML and MLX delegates. Add a short example that links both, and state that registration is automatic: each backend registers itself through a static initializer, and its CMake target already carries the link options that keep that initializer from being dropped, so a consumer does not need any force-load flag.

## Test plan

Documentation only. Reviewed the rendered Markdown and confirmed the install command and the CMake snippet match the wheel's CMake package.
