### PR TITLE
Correct comments on the Core ML wheel library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1421,9 +1421,10 @@ if(EXECUTORCH_BUILD_PYBIND)
   # --no-as-needed around its own file to every consumer, so the CUDA and
   # OpenVINO backends are covered by that and are deliberately absent here. That
   # export is emitted only for NOT APPLE, so it does nothing for an Apple-only
-  # delegate like Core ML; those are covered instead by Mach-O, which keeps a
-  # named dylib's namespace-scope initializers without an --as-needed
-  # equivalent.
+  # delegate like Core ML; that dylib is instead kept because it is named
+  # directly on the link line, which retains its namespace-scope initializers
+  # without an --as-needed equivalent. Only -dead_strip_dylibs would drop it,
+  # and nothing here passes that.
   foreach(_retained_component optimized_native_cpu_ops_lib xnnpack_backend
                               extension_threadpool etdump
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1421,10 +1421,11 @@ if(EXECUTORCH_BUILD_PYBIND)
   # --no-as-needed around its own file to every consumer, so the CUDA and
   # OpenVINO backends are covered by that and are deliberately absent here. That
   # export is emitted only for NOT APPLE, so it does nothing for an Apple-only
-  # delegate like Core ML; that dylib is instead kept because it is named
-  # directly on the link line, which retains its namespace-scope initializers
-  # without an --as-needed equivalent. Only -dead_strip_dylibs would drop it,
-  # and nothing here passes that.
+  # delegate like Core ML. In the wheel's shared build that dylib is instead
+  # kept because it is named directly on the link line, which retains its
+  # namespace-scope initializers without an --as-needed equivalent; only
+  # -dead_strip_dylibs would drop it, and nothing here passes that. In a static
+  # build the delegate is an archive kept by force_load instead.
   foreach(_retained_component optimized_native_cpu_ops_lib xnnpack_backend
                               extension_threadpool etdump
   )

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -199,10 +199,9 @@ if(APPLE)
   # link it, and so the Python extension links it dynamically instead of
   # absorbing its code. Keyed on EXECUTORCH_BUILD_SHARED rather than
   # BUILD_SHARED_LIBS, the same way the other shipped delegates decide this, so
-  # the wheel controls it independently of the generic CMake switch. Shipping it
-  # shared means a duplicate-symbol conflict would surface at load time rather
-  # than at static-link time; the process must hold exactly one copy of the
-  # delegate, which the single shipped library and the dynamic link preserve.
+  # the wheel controls it independently of the generic CMake switch. The wheel
+  # ships this one delegate library and _C links that copy rather than embedding
+  # another.
   if(EXECUTORCH_BUILD_SHARED)
     set(_coreml_backend_library_type SHARED)
   else()
@@ -273,9 +272,7 @@ if(APPLE)
     # the delegate references the helpers it uses, so ordinary resolution pulls
     # exactly those objects. Neither helper registers anything from an
     # unreferenced namespace-scope initializer, which is the only thing
-    # force_load would add here. Private also keeps the helpers' include
-    # directories out of this library's export interface, which is intended: a
-    # wheel consumer links the bundled delegate and never names the helpers.
+    # force_load would add here.
     target_link_libraries(
       coremldelegate PRIVATE coreml_util coreml_inmemoryfs executorch_shared
     )

--- a/backends/apple/coreml/CMakeLists.txt
+++ b/backends/apple/coreml/CMakeLists.txt
@@ -199,7 +199,10 @@ if(APPLE)
   # link it, and so the Python extension links it dynamically instead of
   # absorbing its code. Keyed on EXECUTORCH_BUILD_SHARED rather than
   # BUILD_SHARED_LIBS, the same way the other shipped delegates decide this, so
-  # the wheel controls it independently of the generic CMake switch.
+  # the wheel controls it independently of the generic CMake switch. Shipping it
+  # shared means a duplicate-symbol conflict would surface at load time rather
+  # than at static-link time; the process must hold exactly one copy of the
+  # delegate, which the single shipped library and the dynamic link preserve.
   if(EXECUTORCH_BUILD_SHARED)
     set(_coreml_backend_library_type SHARED)
   else()
@@ -270,7 +273,9 @@ if(APPLE)
     # the delegate references the helpers it uses, so ordinary resolution pulls
     # exactly those objects. Neither helper registers anything from an
     # unreferenced namespace-scope initializer, which is the only thing
-    # force_load would add here.
+    # force_load would add here. Private also keeps the helpers' include
+    # directories out of this library's export interface, which is intended: a
+    # wheel consumer links the bundled delegate and never names the helpers.
     target_link_libraries(
       coremldelegate PRIVATE coreml_util coreml_inmemoryfs executorch_shared
     )


### PR DESCRIPTION
## Summary

Fix three comments on the standalone Core ML delegate library in the macOS wheel. Comment changes only, no behavior change.

- The shipped dylib is retained because it is named directly on the link line, not by anything specific to the Mach-O format, and only `-dead_strip_dylibs` would drop it (nothing passes that).
- Linking the helper archives privately also keeps their include directories out of the library's export interface, which is intended, since a wheel consumer links the bundled delegate and never names the helpers.
- Shipping the delegate as a shared library moves a duplicate-symbol conflict from static-link time to load time; the single shipped library and the dynamic link keep exactly one copy in the process.

## Test plan

Comment-only. Confirmed both CMake files still pass cmake-format.
