### PR TITLE
Ship the MLX metallib bundle in the template

### DIFF
--- a/Package.swift.template
+++ b/Package.swift.template
@@ -8,7 +8,6 @@
  */
 
 import PackageDescription
-import Foundation
 
 let version = "__VERSION__"
 let url = "https://ossci-ios.s3.amazonaws.com/executorch/"
@@ -148,19 +147,15 @@ for (key, value) in products {
 // resource bundle both MLX products share. Kept out of the generic loop above so
 // there is one bundle (executorch_backend_mlx_resources.bundle) rather than a
 // separate debug copy, and so the release and debug delegates resolve the same
-// name. Each slice's MLX binary asks for its own mlx-<slice>.metallib. The files
-// are committed to this branch by the release job and gitignored elsewhere, so
-// each is included only when present.
+// name. Each slice's MLX binary asks for its own mlx-<slice>.metallib. The
+// release job commits all three files to this branch beside the manifest, so they
+// are always present in the published package and copied unconditionally.
 let mlxMetallibSlices = ["mlx-ios", "mlx-ios-simulator", "mlx-macos"]
-let mlxResourcesDir = ".Package.swift/backend_mlx_resources"
 if products.keys.contains("backend_mlx") {
   packageTargets.append(.target(
     name: "backend_mlx_resources",
-    path: mlxResourcesDir,
-    resources: mlxMetallibSlices.compactMap { slice in
-      FileManager.default.fileExists(atPath: "\(mlxResourcesDir)/\(slice).metallib")
-        ? .copy("\(slice).metallib") : nil
-    }
+    path: ".Package.swift/backend_mlx_resources",
+    resources: mlxMetallibSlices.map { .copy("\($0).metallib") }
   ))
   for suffix in ["", debug_suffix] {
     if let index = packageTargets.firstIndex(where: {

--- a/Package.swift.template
+++ b/Package.swift.template
@@ -143,13 +143,11 @@ for (key, value) in products {
   packageTargets.append(target)
 }
 
-// The MLX Metal kernel libraries, one per platform slice, shipped as a single
-// resource bundle both MLX products share. Kept out of the generic loop above so
-// there is one bundle (executorch_backend_mlx_resources.bundle) rather than a
-// separate debug copy, and so the release and debug delegates resolve the same
-// name. Each slice's MLX binary asks for its own mlx-<slice>.metallib. The
-// release job commits all three files to this branch beside the manifest, so they
-// are always present in the published package and copied unconditionally.
+// One resource bundle shared by both MLX products (release and debug) so they
+// resolve the same bundle name, with a per-slice metallib since one slice's does
+// not load on another. Kept out of the loop above to avoid a per-debug copy. The
+// release job commits all three files beside the manifest, so copy them
+// unconditionally.
 let mlxMetallibSlices = ["mlx-ios", "mlx-ios-simulator", "mlx-macos"]
 if products.keys.contains("backend_mlx") {
   packageTargets.append(.target(


### PR DESCRIPTION
## Summary

Fix the MLX resource bundle in the SwiftPM package template so it is not empty for consumers.

The metallib bundle used a relative-path existence guard, and SwiftPM evaluates a dependency's manifest with the consumer's working directory, so the guard was always false and the published bundle shipped with zero Metal kernel files. MLX then faults at first device use. Ship all three per-slice metallibs unconditionally, which the release job always commits beside the manifest, so the guard is unnecessary. Also trim the resource-bundle comment to match the main manifest.

The `Foundation` linked framework is kept: the MLX delegate's Objective-C++ Metal code calls into it, and a static archive in an xcframework carries no autolink hint.

## Test plan

Materialized the template and confirmed it parses, and that all three metallib slices are declared as resources.
