### PR TITLE
Move _unittest.yml to linux_job_v3

### DIFF
--- a/.ci/scripts/tests/test_gather_benchmark_configs.py
+++ b/.ci/scripts/tests/test_gather_benchmark_configs.py
@@ -24,6 +24,11 @@ class TestGatehrBenchmarkConfigs(unittest.TestCase):
         cls.gather_benchmark_configs = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(cls.gather_benchmark_configs)
 
+        # The script writes its matrix to $GITHUB_OUTPUT when that is set and
+        # only prints it when it is not, so the CLI tests below assert against a
+        # stdout that a real CI environment would leave empty.
+        cls.cli_env = {k: v for k, v in os.environ.items() if k != "GITHUB_OUTPUT"}
+
     def test_extract_all_configs_android(self):
         android_configs = self.gather_benchmark_configs.extract_all_configs(
             self.gather_benchmark_configs.BENCHMARK_CONFIGS, "android"
@@ -222,7 +227,7 @@ class TestGatehrBenchmarkConfigs(unittest.TestCase):
                 cmd.append(f"--{key}")
                 cmd.append(value)
 
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, env=self.cli_env)
         self.assertEqual(result.returncode, 0, f"Error: {result.stderr}")
         self.assertIn('"model": "mv2"', result.stdout)
         self.assertIn('"model": "dl3"', result.stdout)
@@ -243,7 +248,7 @@ class TestGatehrBenchmarkConfigs(unittest.TestCase):
                 cmd.append(f"--{key}")
                 cmd.append(value)
 
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, env=self.cli_env)
         self.assertEqual(result.returncode, 0, f"Error: {result.stderr}")
         self.assertIn('{"include": []}', result.stdout)
 
@@ -261,7 +266,7 @@ class TestGatehrBenchmarkConfigs(unittest.TestCase):
                 cmd.append(f"--{key}")
                 cmd.append(value)
 
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, env=self.cli_env)
         self.assertEqual(result.returncode, 0, f"Error: {result.stderr}")
         self.assertIn('"model": "mv2"', result.stdout)
         self.assertIn('"model": "dl3"', result.stdout)
@@ -282,7 +287,7 @@ class TestGatehrBenchmarkConfigs(unittest.TestCase):
                 cmd.append(f"--{key}")
                 cmd.append(value)
 
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, env=self.cli_env)
         self.assertEqual(result.returncode, 1, f"Error: {result.stderr}")
         self.assertIn("Unsupported config 'qnn_q8'", result.stderr)
 

--- a/.github/workflows/_docker-image.yml
+++ b/.github/workflows/_docker-image.yml
@@ -3,7 +3,7 @@ name: Resolve CI docker image
 # linux_job_v3 passes `docker-image` straight to the runner pod's container, which
 # is pulled before any step runs, so nothing inside the job can derive it. Callers
 # depend on this workflow and name the image as
-# 308535385114.dkr.ecr.us-east-1.amazonaws.com/executorch/ci-image:<name>-<hash>.
+# ${docker-registry}/ci-image:<name>-${ci-docker-hash}.
 #
 # Nothing here waits for docker-builds. A commit that changes .ci/docker needs the
 # ciflow/docker label to build the images it asks for; without them the pod fails
@@ -15,6 +15,12 @@ on:
       ci-docker-hash:
         description: Tag suffix shared by every executorch CI image for this commit.
         value: ${{ jobs.resolve.outputs.ci-docker-hash }}
+      docker-registry:
+        description: |
+          Registry and namespace the CI images live in. An output rather than a
+          literal at each call site, and not an `env`, which GitHub does not
+          allow in a reusable workflow's `with`.
+        value: 308535385114.dkr.ecr.us-east-1.amazonaws.com/executorch
 
 permissions:
   contents: read

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -30,14 +30,19 @@ on:
         default: 90
 
 jobs:
+  docker-image:
+    name: Resolve CI docker image
+    uses: ./.github/workflows/_docker-image.yml
+
   linux:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    needs: docker-image
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
     permissions:
       id-token: write
       contents: read
     with:
-      runner: linux.2xlarge.memory
-      docker-image: ${{ inputs.docker-image }}
+      runner: mt-l-x86iavx512-8-64
+      docker-image: ${{ needs.docker-image.outputs.docker-registry }}/${{ inputs.docker-image }}-${{ needs.docker-image.outputs.ci-docker-hash }}
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: ${{ inputs.linux-timeout }}


### PR DESCRIPTION
First of six splitting up #22107, which was too large to review in one piece. Each PR stacks on the previous one.

`_docker-image.yml`, which this depends on, now lands in #22106 instead.

`_unittest.yml` is its first caller, so pull.yml and trunk.yml exercise the resolution on every PR. The `docker-image` input still takes `ci-image:<name>`, so its own callers are unchanged; this workflow expands that into the full ECR reference.

Authored with Claude Code.