### PR TITLE
Move the shared reusable workflows to linux_job_v3

### DIFF
--- a/.ci/scripts/pytest-parallelism.sh
+++ b/.ci/scripts/pytest-parallelism.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Pin pytest-xdist's worker count, but only when the container is allowed less
+# CPU than the machine it landed on. `auto` asks psutil for the machine's
+# physical cores, which inside an OSDC pod is the whole node, so the workers
+# exhaust the pod's memory. nproc honours the pod's cpuset, which is what
+# pytorch relies on for OMP_NUM_THREADS on the same fleet.
+#
+# Left alone when unconstrained. `auto` already discounts hyperthreads there,
+# while nproc counts them, so overriding it would double the workers and halve
+# the memory each one gets.
+
+if [[ -z "${PYTEST_XDIST_AUTO_NUM_WORKERS:-}" ]] && command -v nproc >/dev/null 2>&1; then
+  cpus_allowed="$(nproc)"
+  cpus_installed="$(nproc --all)"
+  echo "pytest-xdist: ${cpus_allowed} of ${cpus_installed} CPUs available"
+  if [[ "${cpus_allowed}" -lt "${cpus_installed}" ]]; then
+    export PYTEST_XDIST_AUTO_NUM_WORKERS="${cpus_allowed}"
+    echo "PYTEST_XDIST_AUTO_NUM_WORKERS=${PYTEST_XDIST_AUTO_NUM_WORKERS}"
+  fi
+fi

--- a/.ci/scripts/test_backend.sh
+++ b/.ci/scripts/test_backend.sh
@@ -7,6 +7,9 @@
 # LICENSE file in the root directory of this source tree.
 set -eux
 
+# Cap pytest-xdist's `auto` workers to the container's CPU quota.
+source .ci/scripts/pytest-parallelism.sh
+
 SUITE=$1
 FLOW=$2
 ARTIFACT_DIR=$3

--- a/.ci/scripts/unittest-linux-cmake.sh
+++ b/.ci/scripts/unittest-linux-cmake.sh
@@ -7,6 +7,9 @@
 # LICENSE file in the root directory of this source tree.
 set -eux
 
+# Cap pytest-xdist's `auto` workers to the container's CPU quota.
+source .ci/scripts/pytest-parallelism.sh
+
 # Some ARM/TOSA-adjacent tests import modules that require tosa_serializer.
 # Install from a local tosa-tools checkout when available. If absent in this
 # checkout layout, clone the pinned upstream tag and install from there.

--- a/.github/workflows/_docker-image.yml
+++ b/.github/workflows/_docker-image.yml
@@ -37,10 +37,22 @@ jobs:
       - name: Checkout ExecuTorch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          # build-cadence-runner.yml reaches this workflow on pull_request_target,
+          # where github.sha is the base branch tip. Resolving the tag from there
+          # while the test jobs check out the fork head would test a docker change
+          # against the old image.
+          ref: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.sha || github.sha }}
+          # Nothing here runs the checked-out code, only `git rev-parse` over it,
+          # but on pull_request_target that code is the fork's and the token is
+          # the base repository's, so do not leave one next to the other.
+          persist-credentials: false
 
       - name: Compute the docker tag
         id: hash
         run: |
           set -eu
-          echo "ci-docker-hash=$(git rev-parse HEAD:.ci/docker)" >> "$GITHUB_OUTPUT"
+          # Assigned on its own line: set -e does not catch a failure inside a
+          # command substitution, so `echo "x=$(git rev-parse ...)"` would write
+          # git's error text as the tag and exit 0.
+          CI_DOCKER_HASH="$(git rev-parse HEAD:.ci/docker)"
+          echo "ci-docker-hash=${CI_DOCKER_HASH}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_llm_server.yml
+++ b/.github/workflows/_llm_server.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       docker-image:
-        description: Docker image to use for Linux tests.
+        description: Name of the docker image to use, without registry or tag suffix.
         required: false
         type: string
         default: ci-image:executorch-ubuntu-22.04-clang12

--- a/.github/workflows/_llm_server.yml
+++ b/.github/workflows/_llm_server.yml
@@ -10,14 +10,19 @@ on:
         default: ci-image:executorch-ubuntu-22.04-clang12
 
 jobs:
+  docker-image:
+    name: Resolve CI docker image
+    uses: ./.github/workflows/_docker-image.yml
+
   linux:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    needs: docker-image
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
     permissions:
       id-token: write
       contents: read
     with:
-      runner: linux.2xlarge
-      docker-image: ${{ inputs.docker-image }}
+      runner: mt-l-x86iavx512-8-64
+      docker-image: ${{ needs.docker-image.outputs.docker-registry }}/${{ inputs.docker-image }}-${{ needs.docker-image.outputs.ci-docker-hash }}
       submodules: recursive
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 60

--- a/.github/workflows/_test_arduino_library.yml
+++ b/.github/workflows/_test_arduino_library.yml
@@ -14,15 +14,20 @@ on:
         default: 90
 
 jobs:
+  docker-image:
+    name: Resolve CI docker image
+    uses: ./.github/workflows/_docker-image.yml
+
   run:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    needs: docker-image
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
     permissions:
       id-token: write
       contents: read
     with:
       job-name: arduino-library
-      runner: linux.2xlarge
-      docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
+      runner: mt-l-x86iavx512-8-64
+      docker-image: ${{ needs.docker-image.outputs.docker-registry }}/ci-image:executorch-ubuntu-22.04-arm-sdk-${{ needs.docker-image.outputs.ci-docker-hash }}
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: ${{ inputs.timeout }}

--- a/.github/workflows/_test_arduino_library.yml
+++ b/.github/workflows/_test_arduino_library.yml
@@ -58,9 +58,9 @@ jobs:
         # moving branch: reproducible, and one less thing to fail transiently.
         ARDUINO_CLI_VERSION=1.5.1
         ARDUINO_LINT_VERSION=1.3.0
-        # RUNNER_TEMP and GITHUB_WORKSPACE both point at host paths this
-        # container cannot write to, and HOME may too, so keep the toolchain
-        # and every arduino-cli directory somewhere local to the container.
+        # HOME is /github/home, which arduino-cli's directories should not share
+        # with the runner's own state, so keep the toolchain and every
+        # arduino-cli directory somewhere local to the container.
         ARDUINO_CI_DIR=/tmp/.arduino-ci
         export ARDUINO_DIRECTORIES_USER="${ARDUINO_CI_DIR}/user"
         export ARDUINO_DIRECTORIES_DATA="${ARDUINO_CI_DIR}/data"

--- a/.github/workflows/_test_backend.yml
+++ b/.github/workflows/_test_backend.yml
@@ -42,7 +42,7 @@ on:
         type: string
         default: mt-l-x86iavx512-16-128
       docker-image:
-        description: 'Docker image for Linux jobs'
+        description: 'Name of the docker image to use, without registry or tag suffix'
         required: false
         type: string
         default: ci-image:executorch-ubuntu-22.04-clang12
@@ -50,6 +50,7 @@ on:
 jobs:
   docker-image:
     name: Resolve CI docker image
+    if: ${{ inputs.run-linux }}
     uses: ./.github/workflows/_docker-image.yml
 
   test-backend-linux:

--- a/.github/workflows/_test_backend.yml
+++ b/.github/workflows/_test_backend.yml
@@ -40,7 +40,7 @@ on:
         description: 'Runner type for Linux jobs'
         required: false
         type: string
-        default: linux.4xlarge.memory
+        default: mt-l-x86iavx512-16-128
       docker-image:
         description: 'Docker image for Linux jobs'
         required: false
@@ -48,7 +48,12 @@ on:
         default: ci-image:executorch-ubuntu-22.04-clang12
 
 jobs:
+  docker-image:
+    name: Resolve CI docker image
+    uses: ./.github/workflows/_docker-image.yml
+
   test-backend-linux:
+    needs: docker-image
     if: ${{ inputs.run-linux }}
     strategy:
       fail-fast: false
@@ -57,11 +62,14 @@ jobs:
         suite: [models, operators]
         exclude: ${{ fromJSON(inputs.exclude) }}
 
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    permissions:
+      id-token: write
+      contents: read
     with:
       ref: ${{ inputs.ref }}
       runner: ${{ inputs.runner-linux }}
-      docker-image: ${{ inputs.docker-image }}
+      docker-image: ${{ needs.docker-image.outputs.docker-registry }}/${{ inputs.docker-image }}-${{ needs.docker-image.outputs.ci-docker-hash }}
       submodules: recursive
       timeout: ${{ inputs.timeout }}
       upload-artifact: test-report-${{ inputs.backend }}-${{ matrix.flow }}-${{ matrix.suite }}

--- a/.github/workflows/_test_cadence.yml
+++ b/.github/workflows/_test_cadence.yml
@@ -16,7 +16,7 @@ on:
         description: 'Runner type'
         required: false
         type: string
-        default: linux.8xlarge.memory
+        default: mt-l-x86iavx512-32-256
       ref:
         description: 'Git ref to checkout'
         required: false
@@ -29,12 +29,20 @@ on:
         default: 90
 
 jobs:
+  docker-image:
+    name: Resolve CI docker image
+    uses: ./.github/workflows/_docker-image.yml
+
   test-aot:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    needs: docker-image
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    permissions:
+      id-token: write
+      contents: read
     with:
       job-name: test-aot
       runner: ${{ inputs.runner }}
-      docker-image: ${{ inputs.docker-image }}
+      docker-image: ${{ needs.docker-image.outputs.docker-registry }}/${{ inputs.docker-image }}-${{ needs.docker-image.outputs.ci-docker-hash }}
       submodules: recursive
       ref: ${{ inputs.ref }}
       timeout: ${{ inputs.timeout }}
@@ -50,11 +58,15 @@ jobs:
         python -m pytest backends/cadence/aot/tests/ -v -n auto --reruns 2 --reruns-delay 1
 
   test-ops:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    needs: docker-image
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    permissions:
+      id-token: write
+      contents: read
     with:
       job-name: test-ops
       runner: ${{ inputs.runner }}
-      docker-image: ${{ inputs.docker-image }}
+      docker-image: ${{ needs.docker-image.outputs.docker-registry }}/${{ inputs.docker-image }}-${{ needs.docker-image.outputs.ci-docker-hash }}
       submodules: recursive
       ref: ${{ inputs.ref }}
       timeout: ${{ inputs.timeout }}

--- a/.github/workflows/_test_cadence.yml
+++ b/.github/workflows/_test_cadence.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
     inputs:
       docker-image:
-        description: 'Docker image to use'
+        description: 'Name of the docker image to use, without registry or tag suffix'
         required: false
         type: string
         default: ci-image:executorch-ubuntu-22.04-clang12

--- a/.github/workflows/_test_cortex_m_e2e.yml
+++ b/.github/workflows/_test_cortex_m_e2e.yml
@@ -23,8 +23,16 @@ on:
         default: 120
 
 jobs:
+  docker-image:
+    name: Resolve CI docker image
+    uses: ./.github/workflows/_docker-image.yml
+
   run:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    needs: docker-image
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         model: ${{ fromJSON(inputs.models) }}
@@ -32,8 +40,8 @@ jobs:
       fail-fast: false
     with:
       job-name: ${{ matrix.model }}-${{ matrix.target }}
-      runner: linux.2xlarge.memory
-      docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
+      runner: mt-l-x86iavx512-8-64
+      docker-image: ${{ needs.docker-image.outputs.docker-registry }}/ci-image:executorch-ubuntu-22.04-arm-sdk-${{ needs.docker-image.outputs.ci-docker-hash }}
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: ${{ inputs.timeout }}

--- a/.github/workflows/_test_cortex_m_ops.yml
+++ b/.github/workflows/_test_cortex_m_ops.yml
@@ -18,16 +18,24 @@ on:
         default: 120
 
 jobs:
+  docker-image:
+    name: Resolve CI docker image
+    uses: ./.github/workflows/_docker-image.yml
+
   run:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    needs: docker-image
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         target: ${{ fromJSON(inputs.targets) }}
       fail-fast: false
     with:
       job-name: cortex-m-ops-${{ matrix.target }}
-      runner: linux.2xlarge.memory
-      docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
+      runner: mt-l-x86iavx512-8-64
+      docker-image: ${{ needs.docker-image.outputs.docker-registry }}/ci-image:executorch-ubuntu-22.04-arm-sdk-${{ needs.docker-image.outputs.ci-docker-hash }}
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: ${{ inputs.timeout }}

--- a/.github/workflows/_test_riscv.yml
+++ b/.github/workflows/_test_riscv.yml
@@ -37,11 +37,19 @@ on:
         type: string
 
 jobs:
+  docker-image:
+    name: Resolve CI docker image
+    uses: ./.github/workflows/_docker-image.yml
+
   run:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    needs: docker-image
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    permissions:
+      id-token: write
+      contents: read
     with:
-      runner: linux.2xlarge
-      docker-image: ci-image:executorch-ubuntu-24.04-gcc14
+      runner: mt-l-x86iavx512-8-64
+      docker-image: ${{ needs.docker-image.outputs.docker-registry }}/ci-image:executorch-ubuntu-24.04-gcc14-${{ needs.docker-image.outputs.ci-docker-hash }}
       submodules: 'recursive'
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: ${{ inputs.timeout }}

--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/riscv64.yml
+      - .github/workflows/_test_riscv.yml
       - .ci/scripts/test_riscv_qemu.sh
       - tools/cmake/preset/riscv64_linux.cmake
       - examples/riscv/**

--- a/.github/workflows/test-backend-arm.yml
+++ b/.github/workflows/test-backend-arm.yml
@@ -19,6 +19,9 @@ concurrency:
 jobs:
   test-arm:
     uses: ./.github/workflows/_test_backend.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       backend: arm
       flows: >-
@@ -35,6 +38,9 @@ jobs:
 
   test-arm-vgf:
     uses: ./.github/workflows/_test_backend.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       backend: arm-vgf
       flows: >-

--- a/.github/workflows/test-backend-coreml.yml
+++ b/.github/workflows/test-backend-coreml.yml
@@ -36,6 +36,9 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/test-backend-coreml.yml') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/_test_backend.yml')
     uses: ./.github/workflows/_test_backend.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       backend: coreml
       # The heavier coreml_static_int8 macOS matrix saturates the shared

--- a/.github/workflows/test-backend-cortex-m.yml
+++ b/.github/workflows/test-backend-cortex-m.yml
@@ -49,6 +49,9 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/test-backend-cortex-m.yml') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/_test_backend.yml')
     uses: ./.github/workflows/_test_backend.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       backend: cortex_m
       flows: '["cortex_m"]'

--- a/.github/workflows/test-backend-nxp.yml
+++ b/.github/workflows/test-backend-nxp.yml
@@ -39,6 +39,9 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/test-backend-nxp.yml') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/_test_backend.yml')
     uses: ./.github/workflows/_test_backend.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       backend: nxp
       flows: '["nxp_neutron_imxrt700_int8_ptq"]'

--- a/.github/workflows/test-backend-openvino.yml
+++ b/.github/workflows/test-backend-openvino.yml
@@ -21,6 +21,9 @@ concurrency:
 jobs:
   test-openvino:
     uses: ./.github/workflows/_test_backend.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       backend: openvino
       flows: '["openvino"]'

--- a/.github/workflows/test-backend-qnn.yml
+++ b/.github/workflows/test-backend-qnn.yml
@@ -19,6 +19,9 @@ concurrency:
 jobs:
   test-qnn:
     uses: ./.github/workflows/_test_backend.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       backend: qnn
       flows: >-
@@ -28,4 +31,4 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-linux: true
-      runner-linux: linux.8xlarge.memory
+      runner-linux: mt-l-x86iavx512-32-256

--- a/.github/workflows/test-backend-vulkan.yml
+++ b/.github/workflows/test-backend-vulkan.yml
@@ -21,6 +21,9 @@ jobs:
   # runners. Runs on every PR and nightly.
   test-vulkan:
     uses: ./.github/workflows/_test_backend.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       backend: vulkan
       flows: >-

--- a/.github/workflows/test-backend-webgpu.yml
+++ b/.github/workflows/test-backend-webgpu.yml
@@ -19,6 +19,9 @@ concurrency:
 jobs:
   test-webgpu:
     uses: ./.github/workflows/_test_backend.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       backend: webgpu
       flows: '["webgpu"]'

--- a/.github/workflows/test-backend-xnnpack.yml
+++ b/.github/workflows/test-backend-xnnpack.yml
@@ -19,6 +19,9 @@ concurrency:
 jobs:
   test-xnnpack:
     uses: ./.github/workflows/_test_backend.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       backend: xnnpack
       flows: >-

--- a/backends/arm/test/test_arm_backend.sh
+++ b/backends/arm/test/test_arm_backend.sh
@@ -12,6 +12,9 @@ script_dir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 et_root_dir=$(cd ${script_dir}/../../.. && pwd)
 cd "${et_root_dir}"
 pwd
+
+# Cap pytest-xdist's `auto` workers to the container's CPU quota.
+source .ci/scripts/pytest-parallelism.sh
 scratch_dir=${et_root_dir}/examples/arm/arm-scratch
 setup_path_script=${scratch_dir}/setup_path.sh
 _setup_msg="please refer to ${et_root_dir}/examples/arm/setup.sh to properly install necessary tools."

--- a/backends/nxp/run_unittests.sh
+++ b/backends/nxp/run_unittests.sh
@@ -10,6 +10,10 @@ EXECUTORCH_DIR=$(dirname $(dirname $SCRIPT_DIR))
 
 cd $EXECUTORCH_DIR
 
+# Cap pytest-xdist's workers to the container's CPU quota. Applies to
+# `-n logical` as well, despite the variable's name.
+source .ci/scripts/pytest-parallelism.sh
+
 # '-c /dev/null' is used to ignore root level pytest.ini.
 pytest -c /dev/null -n "logical" backends/nxp/tests/
 

--- a/examples/riscv/README.md
+++ b/examples/riscv/README.md
@@ -35,7 +35,7 @@ The driver does three steps:
 
 ## CI
 
-`.github/workflows/_test_riscv_qemu.yml` is a reusable `workflow_call`
-job (mirroring `_test_cortex_m_e2e.yml`) invoked from `pull.yml` to run on
-every PR. It runs on the standard `linux.2xlarge` x86_64 runner using the
-`executorch-ubuntu-22.04-gcc11` docker image.
+`.github/workflows/_test_riscv.yml` is a reusable `workflow_call`
+job (mirroring `_test_cortex_m_e2e.yml`) invoked from `riscv64.yml`. It runs on
+the `mt-l-x86iavx512-8-64` x86_64 runner using the
+`executorch-ubuntu-24.04-gcc14` docker image.


### PR DESCRIPTION
Second of six splitting up #22107. Stacked on the landed #22106.

Moves the shared reusable workflows to `linux_job_v3`: `_test_backend.yml`, `_test_cadence.yml`, `_test_cortex_m_e2e.yml`, `_test_cortex_m_ops.yml`, `_test_riscv.yml`, `_test_arduino_library.yml`, `_llm_server.yml`, plus the nine `test-backend-*.yml` callers. Every job also changes runner fleet, from EC2 to OSDC:

| EC2 | OSDC |
|---|---|
| `linux.2xlarge` | `mt-l-x86iavx512-8-64` |
| `linux.4xlarge.memory` (`_test_backend` default) | `mt-l-x86iavx512-16-128` |
| `linux.8xlarge.memory` (`_test_cadence` default, `test-backend-qnn`) | `mt-l-x86iavx512-32-256` |

Also caps pytest-xdist's worker count. `-n auto` and `-n logical` size themselves from `psutil.cpu_count()`, which reports the node rather than the pod's cpuset, so on `mt-l-x86iavx512-16-128` the backend suite started 48 export workers on 116Gi instead of 8 on 128Gi. `PYTEST_XDIST_AUTO_NUM_WORKERS` from `nproc` pins it to what the pod actually has.

**Test plan.** `test-backend-*` and arduino run on this pull request and are green. `_test_riscv`, `_llm_server` and the two cortex-m workflows are only reachable from `riscv64.yml`, trunk and nightly, none of which this change's paths match, so they were dispatched by hand. Fork pull requests are a known gap, see below.

**Known gap, not introduced here.** A fork pull request gets no OIDC token, so v3's role assume fails and sccache dies against a bogus `the C compiler is not able to compile a simple test program`. This is already live on main from the unit test migration, and pytorch/test-infra#8735 fixes it for every repo on v3.

Authored with Claude Code.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani
