### PR TITLE
Fold the device target into clone_tensor_ptr, split the dtype cast out

### DIFF
--- a/docs/source/backends/cuda/cuda-overview.md
+++ b/docs/source/backends/cuda/cuda-overview.md
@@ -215,12 +215,12 @@ video decoder that writes to the GPU, or an earlier model whose output you kept 
 `from_blob` does not allocate or migrate anything, so the pointer has to be genuinely valid
 on the device you name, and it has to outlive the tensor.
 
-If the data starts on the host, `clone_tensor_ptr_to` allocates on the device and copies it
+If the data starts on the host, `clone_tensor_ptr` with a device target allocates on the device and copies it
 across, which costs one transfer:
 
 ```cpp
 auto host_input = make_tensor_ptr({rows, columns}, std::move(data));
-auto input = clone_tensor_ptr_to(host_input, DeviceType::CUDA);
+auto input = clone_tensor_ptr(host_input, DeviceType::CUDA);
 auto result = module.forward(input);
 ```
 

--- a/docs/source/extension-tensor.md
+++ b/docs/source/extension-tensor.md
@@ -202,19 +202,19 @@ Note that, regardless of whether the original `TensorPtr` owns the data or not, 
 
 #### Cloning To or From a Device
 
-If a tensor lives on CPU and you want a copy on an accelerator, or the other way around, use `clone_tensor_ptr_to` with the device you want. It allocates memory on the target device, copies the data for you, and the returned `TensorPtr` owns that memory.
+If a tensor lives on CPU and you want a copy on an accelerator, or the other way around, pass the device you want to `clone_tensor_ptr`. It allocates memory on the target device, copies the data for you, and the returned `TensorPtr` owns that memory.
 
 ```cpp
 auto cpu_tensor = make_tensor_ptr({2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
 
 // CPU to device:
-auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
+auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
 
 // Device back to CPU:
-auto host_tensor = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+auto host_tensor = clone_tensor_ptr(device_tensor, DeviceType::CPU);
 ```
 
-The direction is chosen from the source and target device. This needs a `DeviceAllocator` registered for the device, so it is available only in the portable (non-`USE_ATEN_LIB`) build. For a plain CPU-to-CPU copy, use `clone_tensor_ptr` instead.
+The direction is chosen from the source and target device. One end has to be CPU: copying from an accelerator to an accelerator is not supported, not even onto the device the tensor already lives on, and asking for it aborts. Leaving the device out clones onto the source tensor's own device, which works for a CPU source; to bring an accelerator tensor back, ask for CPU explicitly as shown above. Copying to or from an accelerator needs a `DeviceAllocator` registered for that device. That transfer path is compiled out of `USE_ATEN_LIB` builds, so there both ends have to be CPU; move the data with `tensor.to(device)` instead.
 
 ### Resizing Tensors
 
@@ -316,7 +316,7 @@ auto tensor = from_blob(
 
 The tensor only records where the memory lives. It does not allocate, copy, or migrate
 anything, so the pointer must really be valid on the device you name. To move data that
-starts on the host, use `clone_tensor_ptr_to(tensor, DeviceType::CUDA)` instead, which
+starts on the host, use `clone_tensor_ptr(tensor, DeviceType::CUDA)` instead, which
 allocates on the device and copies across.
 
 ### Creating Empty Tensors
@@ -418,7 +418,8 @@ Here's a table matching `TensorPtr` creation functions with their corresponding 
 | `at::tensor(data, type)`                    | `make_tensor_ptr(data, type)`               |
 | `at::tensor(data, type).reshape(sizes)`     | `make_tensor_ptr(sizes, data, type)`        |
 | `tensor.clone()`                            | `clone_tensor_ptr(tensor)`                  |
-| `tensor.to(device)`                         | `clone_tensor_ptr_to(tensor, device)`       |
+| `tensor.to(type)`                           | `convert_tensor_ptr(tensor, type)`          |
+| `tensor.to(device)`                         | `clone_tensor_ptr(tensor, device)`          |
 | `tensor.resize_(new_sizes)`                 | `resize_tensor_ptr(tensor, new_sizes)`      |
 | `at::scalar_tensor(value)`                  | `scalar_tensor(value)`                      |
 | `at::from_blob(data, sizes, type)`          | `from_blob(data, sizes, type)`              |
@@ -440,6 +441,8 @@ Here's a table matching `TensorPtr` creation functions with their corresponding 
 | `at::randn_like(tensor)`                    | `randn_like(tensor)`                        |
 | `at::randint(low, high, sizes)`             | `randint(low, high, sizes)`                 |
 | `at::randint_like(tensor, low, high)`       | `randint_like(tensor, low, high)`           |
+
+The `tensor.clone()`, `tensor.to(type)` and `tensor.to(device)` rows are narrower than their ATen counterparts. `convert_tensor_ptr` casts between Bool, the signed and unsigned integer types, Half, BFloat16, Float and Double, and only when `canCast` allows it; asking for the type the tensor already has is a plain clone that skips both limits. `clone_tensor_ptr(tensor, device)` moves data between CPU and an accelerator in the portable build only; in a `USE_ATEN_LIB` build both ends have to be CPU. `clone_tensor_ptr(tensor)` keeps the copy on the source tensor's own device, so it works for a CPU source only. All three abort instead of returning an error; in a `USE_ATEN_LIB` build, call the ATen method on the tensor directly when you need the full behavior.
 
 ## Best Practices
 

--- a/examples/models/gemma4_31b/gemma4_31b_engine.cpp
+++ b/examples/models/gemma4_31b/gemma4_31b_engine.cpp
@@ -33,7 +33,7 @@
 
 namespace executorch::extension::llm {
 
-using ::executorch::extension::clone_tensor_ptr_to;
+using ::executorch::extension::clone_tensor_ptr;
 using ::executorch::extension::from_blob;
 using ::executorch::extension::Module;
 using ::executorch::extension::TensorPtr;
@@ -255,7 +255,7 @@ TensorPtr build_decode_pos_table(
   for (int64_t i = 0; i < ctx_it->second; ++i) {
     pos_data[i] = i;
   }
-  return clone_tensor_ptr_to(
+  return clone_tensor_ptr(
       from_blob(
           pos_data.data(),
           {static_cast<SizesType>(pos_data.size())},
@@ -296,11 +296,11 @@ class Gemma4_31BSession : public LLMSession {
     decode_pos_ =
         from_blob(decode_pos_data_, {1}, executorch::aten::ScalarType::Long);
 #ifdef EXECUTORCH_BUILD_CUDA
-    decode_tokens_dev_ = clone_tensor_ptr_to(decode_tokens_, cuda_device_);
-    decode_pos_dev_ = clone_tensor_ptr_to(decode_pos_, cuda_device_);
+    decode_tokens_dev_ = clone_tensor_ptr(decode_tokens_, cuda_device_);
+    decode_pos_dev_ = clone_tensor_ptr(decode_pos_, cuda_device_);
     auto temp_host =
         from_blob(&temp_val_, {1}, executorch::aten::ScalarType::Float);
-    temp_tensor_dev_ = clone_tensor_ptr_to(temp_host, cuda_device_);
+    temp_tensor_dev_ = clone_tensor_ptr(temp_host, cuda_device_);
 #endif
 #ifdef EXECUTORCH_BUILD_MLX
     if (auto it = metadata_.find(kUseSampling); it != metadata_.end()) {
@@ -581,7 +581,7 @@ class Gemma4_31BSession : public LLMSession {
 
 #ifdef EXECUTORCH_BUILD_CUDA
   TensorPtr to_cuda(TensorPtr tensor, std::vector<TensorPtr>& keep_alive) {
-    keep_alive.push_back(clone_tensor_ptr_to(tensor, cuda_device_));
+    keep_alive.push_back(clone_tensor_ptr(tensor, cuda_device_));
     return keep_alive.back();
   }
 

--- a/examples/models/muse-glimmer/runtime/engine/muse_glimmer_engine.cpp
+++ b/examples/models/muse-glimmer/runtime/engine/muse_glimmer_engine.cpp
@@ -35,7 +35,7 @@
 
 namespace executorch::extension::llm {
 
-using ::executorch::extension::clone_tensor_ptr_to;
+using ::executorch::extension::clone_tensor_ptr;
 using ::executorch::extension::from_blob;
 using ::executorch::extension::Module;
 using ::executorch::extension::TensorPtr;
@@ -462,7 +462,7 @@ TensorPtr build_decode_pos_table(
   for (int64_t i = 0; i < ctx_it->second; ++i) {
     pos_data[i] = i;
   }
-  return clone_tensor_ptr_to(
+  return clone_tensor_ptr(
       from_blob(
           pos_data.data(),
           {static_cast<SizesType>(pos_data.size())},
@@ -507,11 +507,11 @@ class MuseGlimmerSession : public LLMSession,
     decode_pos_ =
         from_blob(decode_pos_data_, {1}, executorch::aten::ScalarType::Long);
 #ifdef EXECUTORCH_BUILD_CUDA
-    decode_tokens_dev_ = clone_tensor_ptr_to(decode_tokens_, cuda_device_);
-    decode_pos_dev_ = clone_tensor_ptr_to(decode_pos_, cuda_device_);
+    decode_tokens_dev_ = clone_tensor_ptr(decode_tokens_, cuda_device_);
+    decode_pos_dev_ = clone_tensor_ptr(decode_pos_, cuda_device_);
     auto temp_host =
         from_blob(&temp_val_, {1}, executorch::aten::ScalarType::Float);
-    temp_tensor_dev_ = clone_tensor_ptr_to(temp_host, cuda_device_);
+    temp_tensor_dev_ = clone_tensor_ptr(temp_host, cuda_device_);
 #endif
 #ifdef EXECUTORCH_BUILD_MLX
     temp_tensor_mlx_ =
@@ -905,7 +905,7 @@ class MuseGlimmerSession : public LLMSession,
 
 #ifdef EXECUTORCH_BUILD_CUDA
   TensorPtr to_cuda(TensorPtr tensor, std::vector<TensorPtr>& keep_alive) {
-    keep_alive.push_back(clone_tensor_ptr_to(tensor, cuda_device_));
+    keep_alive.push_back(clone_tensor_ptr(tensor, cuda_device_));
     return keep_alive.back();
   }
 

--- a/examples/models/muse-glimmer/runtime/engine/muse_glimmer_vision_runtime.cpp
+++ b/examples/models/muse-glimmer/runtime/engine/muse_glimmer_vision_runtime.cpp
@@ -314,7 +314,7 @@ MuseGlimmerVisionRuntime::prepare_decoded_image(
       executorch::aten::DeviceType::CUDA, 0);
   const auto stage_input = [&](const auto& input) {
     device_inputs.push_back(
-        ::executorch::extension::clone_tensor_ptr_to(input, cuda_device));
+        ::executorch::extension::clone_tensor_ptr(input, cuda_device));
     encoder_inputs.emplace_back(device_inputs.back());
   };
   stage_input(inputs.patches);

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchTensor.mm
@@ -169,7 +169,7 @@ NSInteger ExecuTorchElementCountOfShape(NSArray<NSNumber *> *shape) {
 }
 
 - (instancetype)copyToDataType:(ExecuTorchDataType)dataType {
-  auto tensor = clone_tensor_ptr(_tensor, static_cast<ScalarType>(dataType));
+  auto tensor = convert_tensor_ptr(_tensor, static_cast<ScalarType>(dataType));
   return [[ExecuTorchTensor alloc] initWithNativeInstance:&tensor];
 }
 

--- a/extension/tensor/tensor_ptr.cpp
+++ b/extension/tensor/tensor_ptr.cpp
@@ -196,104 +196,26 @@ TensorPtr make_tensor_ptr(
       [data = std::move(data)](void*) {});
 }
 
-TensorPtr clone_tensor_ptr(
-    const executorch::aten::Tensor& tensor,
-    executorch::aten::ScalarType type) {
-#ifndef USE_ATEN_LIB
-  ET_CHECK_MSG(
-      tensor.device_type() == runtime::etensor::DeviceType::CPU,
-      "clone_tensor_ptr only supports CPU tensors; use clone_tensor_ptr_to with a CPU target first.");
-#else // USE_ATEN_LIB
-  ET_CHECK_MSG(
-      tensor.is_cpu(),
-      "clone_tensor_ptr only supports CPU tensors; move it to CPU first (e.g. tensor.to(torch::kCPU)).");
-#endif // USE_ATEN_LIB
-  std::vector<executorch::aten::SizesType> sizes(
-      tensor.sizes().begin(), tensor.sizes().end());
-  std::vector<executorch::aten::DimOrderType> dim_order{
-#ifndef USE_ATEN_LIB
-      tensor.dim_order().begin(), tensor.dim_order().end()
-#endif // USE_ATEN_LIB
-  };
-  std::vector<executorch::aten::StridesType> strides(
-      tensor.strides().begin(), tensor.strides().end());
-  auto dynamism = executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND;
-#ifndef USE_ATEN_LIB
-  dynamism = tensor.shape_dynamism();
-#endif // USE_ATEN_LIB
-  const auto* tensor_data = tensor.const_data_ptr();
-  if (!tensor_data) {
-    return make_tensor_ptr(
-        std::move(sizes),
-        nullptr,
-        std::move(dim_order),
-        std::move(strides),
-        type,
-        executorch::aten::Device(executorch::aten::DeviceType::CPU),
-        dynamism);
-  }
-  const auto tensor_type = tensor.scalar_type();
-  if (tensor_type == type) {
-    return make_tensor_ptr(
-        std::move(sizes),
-        std::vector<uint8_t>(
-            (uint8_t*)tensor_data, (uint8_t*)tensor_data + tensor.nbytes()),
-        std::move(dim_order),
-        std::move(strides),
-        tensor_type,
-        dynamism);
-  }
-  ET_CHECK_MSG(
-      runtime::canCast(tensor_type, type),
-      "Cannot cast tensor type to desired type.");
-  const auto tensor_numel = static_cast<size_t>(tensor.numel());
-  size_t clone_nbytes;
-  ET_CHECK_MSG(
-      !c10::mul_overflows(tensor_numel, aten::elementSize(type), &clone_nbytes),
-      "Overflow computing clone nbytes: numel=%zu element_size=%zu",
-      tensor_numel,
-      aten::elementSize(type));
-  std::vector<uint8_t> data(clone_nbytes);
+namespace {
 
-  // Create a minimal context for error handling in ET_SWITCH
-  struct {
-    [[noreturn]] void fail(torch::executor::Error /* error */) {
-      ET_CHECK_MSG(false, "Unsupported dtype in clone_tensor_ptr");
-    }
-  } ctx;
+struct CopyMetadata final {
+  std::vector<executorch::aten::SizesType> sizes;
+  std::vector<executorch::aten::DimOrderType> dim_order;
+  std::vector<executorch::aten::StridesType> strides;
+  executorch::aten::TensorShapeDynamism dynamism =
+      executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND;
+};
 
-  ET_SWITCH_REALHBBF16_AND_UINT_TYPES(
-      tensor_type, ctx, "clone_tensor_ptr_cast_from", CTYPE_FROM, [&] {
-        const CTYPE_FROM* tensor_data_ptr =
-            static_cast<const CTYPE_FROM*>(tensor_data);
-        ET_SWITCH_REALHBBF16_AND_UINT_TYPES(
-            type, ctx, "clone_tensor_ptr_cast_to", CTYPE_TO, [&] {
-              CTYPE_TO* data_ptr = reinterpret_cast<CTYPE_TO*>(data.data());
-              std::transform(
-                  tensor_data_ptr,
-                  tensor_data_ptr + tensor_numel,
-                  data_ptr,
-                  [](const CTYPE_FROM& val) {
-                    return static_cast<CTYPE_TO>(val);
-                  });
-            });
-      });
-  return make_tensor_ptr(
-      std::move(sizes),
-      std::move(data),
-      std::move(dim_order),
-      std::move(strides),
-      type,
-      dynamism);
-}
-
-runtime::Error resize_tensor_ptr(
-    TensorPtr& tensor,
-    const std::vector<executorch::aten::SizesType>& sizes) {
-  return ET_RUNTIME_NAMESPACE::resize_tensor(
-      *tensor,
-      executorch::aten::ArrayRef<executorch::aten::SizesType>(
-          sizes.data(), sizes.size()));
+CopyMetadata copy_metadata_of(const executorch::aten::Tensor& tensor) {
+  CopyMetadata metadata;
+  metadata.sizes.assign(tensor.sizes().begin(), tensor.sizes().end());
+  metadata.strides.assign(tensor.strides().begin(), tensor.strides().end());
+#ifndef USE_ATEN_LIB
+  metadata.dim_order.assign(
+      tensor.dim_order().begin(), tensor.dim_order().end());
+  metadata.dynamism = tensor.shape_dynamism();
+#endif // USE_ATEN_LIB
+  return metadata;
 }
 
 // ---- Device tensor helper ----
@@ -304,79 +226,200 @@ runtime::Error resize_tensor_ptr(
 
 #ifndef USE_ATEN_LIB
 
-TensorPtr clone_tensor_ptr_to(
-    const TensorPtr& tensor,
-    executorch::aten::Device target) {
-  const auto source = tensor->device();
+TensorPtr copy_across_devices(
+    const executorch::aten::Tensor& tensor,
+    executorch::aten::Device source,
+    executorch::aten::Device destination,
+    CopyMetadata metadata) {
   ET_CHECK_MSG(
-      !(source.is_cpu() && target.is_cpu()),
-      "clone_tensor_ptr_to does not copy CPU-to-CPU; use clone_tensor_ptr.");
-  ET_CHECK_MSG(
-      source.is_cpu() || target.is_cpu(),
-      "Device-to-device copy is not supported; route through CPU.");
+      source.is_cpu() || destination.is_cpu(),
+      "An accelerator tensor can only be copied to CPU, not to an accelerator and not onto the device it already lives on; route the copy through CPU.");
 
-  const auto nbytes = tensor->nbytes();
-  const auto* src_data = tensor->const_data_ptr();
-  ET_CHECK_MSG(src_data != nullptr, "Source tensor has no data.");
+  const auto nbytes = tensor.nbytes();
+  const auto* source_data = tensor.const_data_ptr();
+  ET_CHECK_MSG(source_data != nullptr, "Source tensor has no data.");
 
   // Whichever end is not CPU provides the allocator.
-  const auto device = target.is_cpu() ? source : target;
+  const auto device = destination.is_cpu() ? source : destination;
   auto* allocator = runtime::get_device_allocator(device.type());
   ET_CHECK_MSG(
       allocator != nullptr,
       "No device allocator registered for device type %d",
       static_cast<int>(device.type()));
 
-  std::vector<executorch::aten::SizesType> sizes(
-      tensor->sizes().begin(), tensor->sizes().end());
-  std::vector<executorch::aten::DimOrderType> dim_order(
-      tensor->dim_order().begin(), tensor->dim_order().end());
-  std::vector<executorch::aten::StridesType> strides(
-      tensor->strides().begin(), tensor->strides().end());
-
-  if (target.is_cpu()) {
+  if (destination.is_cpu()) {
     std::vector<uint8_t> cpu_data(nbytes);
-    auto err = allocator->copy_device_to_host(
-        cpu_data.data(), src_data, nbytes, source.index());
+    const auto error = allocator->copy_device_to_host(
+        cpu_data.data(), source_data, nbytes, source.index());
     ET_CHECK_MSG(
-        err == runtime::Error::Ok,
+        error == runtime::Error::Ok,
         "Device-to-host copy failed: error %d",
-        static_cast<int>(err));
+        static_cast<int>(error));
     return make_tensor_ptr(
-        std::move(sizes),
+        std::move(metadata.sizes),
         std::move(cpu_data),
-        std::move(dim_order),
-        std::move(strides),
-        tensor->scalar_type(),
-        tensor->shape_dynamism());
+        std::move(metadata.dim_order),
+        std::move(metadata.strides),
+        tensor.scalar_type(),
+        metadata.dynamism);
   }
 
-  auto result = allocator->allocate(nbytes, target.index());
+  auto allocation = allocator->allocate(nbytes, destination.index());
   ET_CHECK_MSG(
-      result.ok(),
+      allocation.ok(),
       "Failed to allocate device memory: error %d",
-      static_cast<int>(result.error()));
-  void* device_data = result.get();
-  auto err = allocator->copy_host_to_device(
-      device_data, src_data, nbytes, target.index());
+      static_cast<int>(allocation.error()));
+  void* device_data = allocation.get();
+  const auto error = allocator->copy_host_to_device(
+      device_data, source_data, nbytes, destination.index());
   ET_CHECK_MSG(
-      err == runtime::Error::Ok,
+      error == runtime::Error::Ok,
       "Host-to-device copy failed: error %d",
-      static_cast<int>(err));
+      static_cast<int>(error));
   return make_tensor_ptr(
-      std::move(sizes),
+      std::move(metadata.sizes),
       device_data,
-      std::move(dim_order),
-      std::move(strides),
-      tensor->scalar_type(),
-      target,
-      tensor->shape_dynamism(),
-      [allocator, target](void* ptr) {
-        allocator->deallocate(ptr, target.index());
+      std::move(metadata.dim_order),
+      std::move(metadata.strides),
+      tensor.scalar_type(),
+      destination,
+      metadata.dynamism,
+      [allocator, destination](void* ptr) {
+        allocator->deallocate(ptr, destination.index());
       });
 }
 
 #endif // USE_ATEN_LIB
+
+} // namespace
+
+TensorPtr clone_tensor_ptr(
+    const executorch::aten::Tensor& tensor,
+    executorch::aten::Device target) {
+  const auto source = tensor.device();
+  auto metadata = copy_metadata_of(tensor);
+
+#ifdef USE_ATEN_LIB
+  ET_CHECK_MSG(
+      source.is_cpu() && target.is_cpu(),
+      "This build clones CPU tensors only; move data with tensor.to(device) instead.");
+#else // USE_ATEN_LIB
+  if (!source.is_cpu() || !target.is_cpu()) {
+    return copy_across_devices(tensor, source, target, std::move(metadata));
+  }
+#endif // USE_ATEN_LIB
+
+  const auto type = tensor.scalar_type();
+  const auto* source_data = tensor.const_data_ptr();
+  if (!source_data) {
+    return make_tensor_ptr(
+        std::move(metadata.sizes),
+        nullptr,
+        std::move(metadata.dim_order),
+        std::move(metadata.strides),
+        type,
+        executorch::aten::Device(executorch::aten::DeviceType::CPU),
+        metadata.dynamism);
+  }
+  return make_tensor_ptr(
+      std::move(metadata.sizes),
+      std::vector<uint8_t>(
+          static_cast<const uint8_t*>(source_data),
+          static_cast<const uint8_t*>(source_data) + tensor.nbytes()),
+      std::move(metadata.dim_order),
+      std::move(metadata.strides),
+      type,
+      metadata.dynamism);
+}
+
+TensorPtr convert_tensor_ptr(
+    const executorch::aten::Tensor& tensor,
+    executorch::aten::ScalarType type) {
+  ET_CHECK_MSG(
+      tensor.device().is_cpu(),
+      "convert_tensor_ptr only supports CPU tensors; move the data to CPU first.");
+  const auto source_type = tensor.scalar_type();
+  if (source_type == type) {
+    return clone_tensor_ptr(tensor);
+  }
+  auto metadata = copy_metadata_of(tensor);
+  const auto* source_data = tensor.const_data_ptr();
+  if (!source_data) {
+    return make_tensor_ptr(
+        std::move(metadata.sizes),
+        nullptr,
+        std::move(metadata.dim_order),
+        std::move(metadata.strides),
+        type,
+        executorch::aten::Device(executorch::aten::DeviceType::CPU),
+        metadata.dynamism);
+  }
+  ET_CHECK_MSG(
+      runtime::canCast(source_type, type),
+      "Cannot cast tensor type to desired type.");
+  const auto numel = static_cast<size_t>(tensor.numel());
+  size_t nbytes = 0;
+  ET_CHECK_MSG(
+      !c10::mul_overflows(numel, aten::elementSize(type), &nbytes),
+      "Overflow computing converted nbytes: numel=%zu element_size=%zu",
+      numel,
+      aten::elementSize(type));
+  std::vector<uint8_t> data(nbytes);
+
+  // Create a minimal context for error handling in ET_SWITCH
+  struct {
+    [[noreturn]] void fail(torch::executor::Error /* error */) {
+      ET_CHECK_MSG(false, "Unsupported dtype in convert_tensor_ptr");
+    }
+  } ctx;
+
+  ET_SWITCH_REALHBBF16_AND_UINT_TYPES(
+      source_type, ctx, "convert_tensor_ptr_cast_from", CTYPE_FROM, [&] {
+        const CTYPE_FROM* source_data_ptr =
+            static_cast<const CTYPE_FROM*>(source_data);
+        ET_SWITCH_REALHBBF16_AND_UINT_TYPES(
+            type, ctx, "convert_tensor_ptr_cast_to", CTYPE_TO, [&] {
+              CTYPE_TO* data_ptr = reinterpret_cast<CTYPE_TO*>(data.data());
+              std::transform(
+                  source_data_ptr,
+                  source_data_ptr + numel,
+                  data_ptr,
+                  [](const CTYPE_FROM& val) {
+                    return static_cast<CTYPE_TO>(val);
+                  });
+            });
+      });
+  return make_tensor_ptr(
+      std::move(metadata.sizes),
+      std::move(data),
+      std::move(metadata.dim_order),
+      std::move(metadata.strides),
+      type,
+      metadata.dynamism);
+}
+
+TensorPtr clone_tensor_ptr(
+    const executorch::aten::Tensor& tensor,
+    executorch::aten::ScalarType type) {
+  return convert_tensor_ptr(tensor, type);
+}
+
+#ifndef USE_ATEN_LIB
+TensorPtr clone_tensor_ptr_to(
+    const TensorPtr& tensor,
+    executorch::aten::Device target) {
+  return clone_tensor_ptr(*tensor, target);
+}
+#endif // USE_ATEN_LIB
+
+runtime::Error resize_tensor_ptr(
+    TensorPtr& tensor,
+    const std::vector<executorch::aten::SizesType>& sizes) {
+  return ET_RUNTIME_NAMESPACE::resize_tensor(
+      *tensor,
+      executorch::aten::ArrayRef<executorch::aten::SizesType>(
+          sizes.data(), sizes.size()));
+}
 
 } // namespace extension
 } // namespace executorch

--- a/extension/tensor/tensor_ptr.h
+++ b/extension/tensor/tensor_ptr.h
@@ -36,7 +36,8 @@ using TensorPtr = std::shared_ptr<executorch::aten::Tensor>;
  * allocated or copied. The caller is responsible for ensuring `data` already
  * lives on the requested device; construct the `executorch::aten::Device` from
  * the runtime environment and pass it in. To copy CPU data to a device, use
- * `clone_tensor_ptr_to` instead.
+ * `clone_tensor_ptr` with a device target instead, or `tensor.to(device)` in a
+ * USE_ATEN_LIB build.
  *
  * @param sizes A vector specifying the size of each dimension.
  * @param data A pointer to the data buffer (CPU or device, see device).
@@ -110,7 +111,8 @@ inline TensorPtr make_tensor_ptr(
  * vectors of one type and a different scalar type.
  *
  * The result is always a CPU tensor. To move it to a device, use
- * `clone_tensor_ptr_to`.
+ * `clone_tensor_ptr` with a device target, or `tensor.to(device)` in a
+ * USE_ATEN_LIB build.
  *
  * @tparam T The C++ type of the tensor elements, deduced from the vector.
  * @param sizes A vector specifying the size of each dimension.
@@ -206,7 +208,8 @@ inline TensorPtr make_tensor_ptr(
  * vector's data type.
  *
  * The result is always a CPU tensor. To move it to a device, use
- * `clone_tensor_ptr_to`.
+ * `clone_tensor_ptr` with a device target, or `tensor.to(device)` in a
+ * USE_ATEN_LIB build.
  *
  * @tparam T The C++ type of the tensor elements, deduced from the vector.
  * @param data A vector containing the tensor's data.
@@ -238,7 +241,8 @@ inline TensorPtr make_tensor_ptr(
  * from the initializer list's data type.
  *
  * The result is always a CPU tensor. To move it to a device, use
- * `clone_tensor_ptr_to`.
+ * `clone_tensor_ptr` with a device target, or `tensor.to(device)` in a
+ * USE_ATEN_LIB build.
  *
  * @tparam T The C++ type of the tensor elements, deduced from the initializer
  * list.
@@ -280,7 +284,8 @@ inline TensorPtr make_tensor_ptr(
  * initializer list's elements.
  *
  * The result is always a CPU tensor. To move it to a device, use
- * `clone_tensor_ptr_to`.
+ * `clone_tensor_ptr` with a device target, or `tensor.to(device)` in a
+ * USE_ATEN_LIB build.
  *
  * @tparam T The C++ type of the tensor elements, deduced from the initializer
  * list.
@@ -377,7 +382,8 @@ inline TensorPtr make_tensor_ptr(
  * is left empty so the core may infer it from the provided strides.
  *
  * This overload always aliases — it never copies. To copy a tensor's data to
- * a device, use `clone_tensor_ptr_to`.
+ * a device, use `clone_tensor_ptr` with a device target, or
+ * `tensor.to(device)` in a USE_ATEN_LIB build.
  *
  * @param tensor The source tensor to alias.
  * @param sizes Optional sizes override.
@@ -442,7 +448,8 @@ inline TensorPtr make_tensor_ptr(
  * Keeps the original TensorPtr alive until the returned TensorPtr is destroyed.
  *
  * This overload always aliases — it never copies. To copy a tensor's data to
- * a device, use `clone_tensor_ptr_to`.
+ * a device, use `clone_tensor_ptr` with a device target, or
+ * `tensor.to(device)` in a USE_ATEN_LIB build.
  *
  * @param tensor_ptr The source tensor pointer to alias.
  * @param sizes Optional sizes override.
@@ -464,60 +471,135 @@ inline TensorPtr make_tensor_ptr(
 }
 
 /**
- * Creates a TensorPtr that manages a new Tensor with the same properties
- * as the given Tensor, but with a copy of the data owned by the returned
- * TensorPtr, or nullptr if the original data is null.
+ * Creates a TensorPtr that manages a new Tensor with the same properties as the
+ * given Tensor, but with a copy of the data owned by the returned TensorPtr.
+ *
+ * `target` says where the copy lives. The overload without it copies to the
+ * source tensor's own device. One end of every copy has to be CPU: an
+ * accelerator source with an accelerator target is not supported, not even
+ * when both name the same device. So a clone that names no target copies a CPU
+ * source and fails for an accelerator source; route that case through CPU. An
+ * accelerator target keeps its device index, while a CPU result is plain CPU
+ * whatever index was asked for or carried by the source.
+ *
+ * Between CPU and an accelerator the copy goes through the DeviceAllocator
+ * registered for that accelerator, and a device-backed result frees its memory
+ * through the same allocator when destroyed. That path is compiled out of
+ * USE_ATEN_LIB builds, so both ends have to be CPU there; move data with
+ * `tensor.to(device)` instead.
+ *
+ * A CPU-to-CPU clone of a Tensor whose data is null returns a TensorPtr with
+ * null data. A copy that touches an accelerator needs real data and fails
+ * without it.
+ *
+ * The clone keeps the source dtype. To change dtype, use `convert_tensor_ptr`.
  *
  * @param tensor The Tensor to clone.
- * @param type The data type for the cloned tensor. The data will be cast
- * from the source tensor's type.
- * @return A new TensorPtr that manages a Tensor with the specified type
- * and copied/cast data.
+ * @param target The device the copy should live on.
+ * @return A new TensorPtr owning a copy of the data on `target`.
  */
 TensorPtr clone_tensor_ptr(
+    const executorch::aten::Tensor& tensor,
+    executorch::aten::Device target);
+
+/**
+ * Overload that copies to the source tensor's own device.
+ *
+ * @param tensor The Tensor to clone.
+ * @return A new TensorPtr owning a copy of the data.
+ */
+inline TensorPtr clone_tensor_ptr(const executorch::aten::Tensor& tensor) {
+  return clone_tensor_ptr(tensor, tensor.device());
+}
+
+/**
+ * Convenience overload identical to clone_tensor_ptr(*tensor, target).
+ *
+ * @param tensor The TensorPtr to clone.
+ * @param target The device the copy should live on.
+ * @return A new TensorPtr owning a copy of the data on `target`.
+ */
+inline TensorPtr clone_tensor_ptr(
+    const TensorPtr& tensor,
+    executorch::aten::Device target) {
+  return clone_tensor_ptr(*tensor, target);
+}
+
+/**
+ * Convenience overload identical to clone_tensor_ptr(*tensor).
+ *
+ * @param tensor The TensorPtr to clone.
+ * @return A new TensorPtr owning a copy of the data.
+ */
+inline TensorPtr clone_tensor_ptr(const TensorPtr& tensor) {
+  return clone_tensor_ptr(*tensor);
+}
+
+/**
+ * Creates a TensorPtr that manages a new Tensor holding the given Tensor's data
+ * cast to `type`.
+ *
+ * Both the source and the result are CPU tensors: move the data to CPU first if
+ * it lives on an accelerator. The cast covers Bool, the signed and unsigned
+ * integer types, Half, BFloat16, Float and Double; any other type on either
+ * side, complex and quantized among them, aborts. The cast also has to be one
+ * `canCast` allows, so Float to Int and Int to Bool abort as well.
+ * Two requests skip the cast: asking for the type the tensor already has is a
+ * plain clone, and a Tensor whose data is null converts to a TensorPtr with
+ * null data of the requested type.
+ *
+ * @param tensor The Tensor to convert.
+ * @param type The data type for the new tensor. The data is cast from the
+ * source tensor's type.
+ * @return A new TensorPtr that manages a Tensor with the specified type and
+ * cast data.
+ */
+TensorPtr convert_tensor_ptr(
     const executorch::aten::Tensor& tensor,
     executorch::aten::ScalarType type);
 
 /**
- * Creates a TensorPtr that manages a new Tensor with the same properties
- * as the given Tensor, but with a copy of the data owned by the returned
- * TensorPtr, or nullptr if the original data is null.
+ * Convenience overload identical to convert_tensor_ptr(*tensor, type).
  *
- * @param tensor The Tensor to clone.
- * @return A new TensorPtr that manages a Tensor with the same properties as the
- * original but with copied data.
+ * @param tensor The TensorPtr to convert.
+ * @param type The data type for the new tensor. The data is cast from the
+ * source tensor's type.
+ * @return A new TensorPtr that manages a Tensor with the specified type and
+ * cast data.
  */
-inline TensorPtr clone_tensor_ptr(const executorch::aten::Tensor& tensor) {
-  return clone_tensor_ptr(tensor, tensor.scalar_type());
-}
-
-/**
- * Creates a new TensorPtr by cloning the given TensorPtr, copying the
- * underlying data.
- *
- * @param tensor The TensorPtr to clone.
- * @param type The data type for the cloned tensor. The data will be cast
- * from the source tensor's type.
- * @return A new TensorPtr that manages a Tensor with the specified type
- * and copied/cast data.
- */
-inline TensorPtr clone_tensor_ptr(
+inline TensorPtr convert_tensor_ptr(
     const TensorPtr& tensor,
     executorch::aten::ScalarType type) {
-  return clone_tensor_ptr(*tensor, type);
+  return convert_tensor_ptr(*tensor, type);
 }
 
 /**
- * Creates a new TensorPtr by cloning the given TensorPtr, copying the
- * underlying data.
- *
- * @param tensor The TensorPtr to clone.
- * @return A new TensorPtr that manages a Tensor with the same properties as the
- * original but with copied data.
+ * DEPRECATED: a clone keeps the dtype. Use `convert_tensor_ptr(tensor, type)`
+ * to cast instead. May be removed in 1.7.0 or later.
  */
-inline TensorPtr clone_tensor_ptr(const TensorPtr& tensor) {
-  return clone_tensor_ptr(*tensor, tensor->scalar_type());
+ET_DEPRECATED TensorPtr clone_tensor_ptr(
+    const executorch::aten::Tensor& tensor,
+    executorch::aten::ScalarType type);
+
+/**
+ * DEPRECATED: a clone keeps the dtype. Use `convert_tensor_ptr(tensor, type)`
+ * to cast instead. May be removed in 1.7.0 or later.
+ */
+ET_DEPRECATED inline TensorPtr clone_tensor_ptr(
+    const TensorPtr& tensor,
+    executorch::aten::ScalarType type) {
+  return convert_tensor_ptr(*tensor, type);
 }
+
+#ifndef USE_ATEN_LIB
+/**
+ * DEPRECATED: use `clone_tensor_ptr(tensor, target)` instead. The replacement
+ * is also more permissive: a CPU source with a CPU target used to abort here
+ * and is a plain clone there. May be removed in 1.7.0 or later.
+ */
+ET_DEPRECATED TensorPtr
+clone_tensor_ptr_to(const TensorPtr& tensor, executorch::aten::Device target);
+#endif // USE_ATEN_LIB
 
 /**
  * Resizes the Tensor managed by the provided TensorPtr to the new sizes.
@@ -530,32 +612,6 @@ ET_NODISCARD
 runtime::Error resize_tensor_ptr(
     TensorPtr& tensor,
     const std::vector<executorch::aten::SizesType>& sizes);
-
-/**
- * Clones a TensorPtr's data onto the given target device, allocating and
- * copying as needed.
- *
- * The transfer direction is inferred from the source and target device:
- * host-to-device when `target` is an accelerator, and device-to-host when
- * `target` is CPU. Copies use the DeviceAllocator registered for the
- * accelerator side; a device-backed result owns its memory and frees it via
- * that allocator when destroyed.
- *
- * Source and target must differ in device domain: for a CPU-to-CPU copy use
- * clone_tensor_ptr, and device-to-device transfers are not supported.
- *
- * Only available in the ExecuTorch portable build: it relies on the ExecuTorch
- * DeviceAllocator, which has no equivalent in USE_ATEN_LIB builds.
- *
- * @param tensor The source tensor whose data will be copied.
- * @param target The destination device (CPU or an accelerator).
- * @return A TensorPtr backed by `target` memory containing the copied data.
- */
-#ifndef USE_ATEN_LIB
-TensorPtr clone_tensor_ptr_to(
-    const TensorPtr& tensor,
-    executorch::aten::Device target);
-#endif // USE_ATEN_LIB
 
 } // namespace extension
 } // namespace executorch

--- a/extension/tensor/test/tensor_ptr_device_test.cpp
+++ b/extension/tensor/test/tensor_ptr_device_test.cpp
@@ -57,7 +57,7 @@ class TensorPtrDeviceTest : public ::testing::Test {
 TEST_F(TensorPtrDeviceTest, CpuToDeviceTensor) {
   auto cpu_tensor =
       make_tensor_ptr({2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
 
   EXPECT_EQ(device_tensor->dim(), 2);
   EXPECT_EQ(device_tensor->size(0), 2);
@@ -77,7 +77,7 @@ TEST_F(TensorPtrDeviceTest, CpuToDeviceTensor) {
 TEST_F(TensorPtrDeviceTest, CpuToDeviceFromRawData) {
   constexpr std::array<float, 4> data{10.0f, 20.0f, 30.0f, 40.0f};
   auto cpu_tensor = make_tensor_ptr({2, 2}, const_cast<float*>(data.data()));
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
 
   EXPECT_EQ(device_tensor->dim(), 2);
   EXPECT_EQ(device_tensor->size(0), 2);
@@ -99,8 +99,8 @@ TEST_F(TensorPtrDeviceTest, CpuToDeviceFromRawData) {
 TEST_F(TensorPtrDeviceTest, DeviceToCpuTensor) {
   auto cpu_tensor =
       make_tensor_ptr({2, 3}, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
-  auto result_tensor = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  auto result_tensor = clone_tensor_ptr(device_tensor, DeviceType::CPU);
 
   EXPECT_EQ(result_tensor->dim(), 2);
   EXPECT_EQ(result_tensor->size(0), 2);
@@ -124,8 +124,8 @@ TEST_F(TensorPtrDeviceTest, DeviceToCpuPreservesShapeDynamism) {
       {},
       executorch::aten::ScalarType::Float,
       executorch::aten::TensorShapeDynamism::STATIC);
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
-  auto result_tensor = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  auto result_tensor = clone_tensor_ptr(device_tensor, DeviceType::CPU);
 
   EXPECT_EQ(
       result_tensor->shape_dynamism(),
@@ -136,8 +136,8 @@ TEST_F(TensorPtrDeviceTest, RoundtripCpuDeviceCpu) {
   const std::vector<float> original = {1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f};
   auto cpu_tensor = make_tensor_ptr({2, 3}, original);
 
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
-  auto roundtrip_tensor = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  auto roundtrip_tensor = clone_tensor_ptr(device_tensor, DeviceType::CPU);
 
   EXPECT_NE(roundtrip_tensor->const_data_ptr(), cpu_tensor->const_data_ptr());
   EXPECT_NE(
@@ -157,8 +157,8 @@ TEST_F(TensorPtrDeviceTest, RoundtripCpuDeviceCpu) {
 TEST_F(TensorPtrDeviceTest, RoundtripInt32) {
   auto cpu_tensor = make_tensor_ptr({4}, std::vector<int32_t>{10, 20, 30, 40});
 
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
-  auto roundtrip = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
 
   EXPECT_EQ(roundtrip->scalar_type(), executorch::aten::ScalarType::Int);
   const std::vector<int32_t> expected = {10, 20, 30, 40};
@@ -171,33 +171,41 @@ TEST_F(TensorPtrDeviceTest, RoundtripInt32) {
 TEST_F(TensorPtrDeviceTest, DeviceIndexPropagation) {
   auto cpu_tensor = make_tensor_ptr({2}, {1.0f, 2.0f});
   auto device_tensor =
-      clone_tensor_ptr_to(cpu_tensor, Device(DeviceType::CUDA, /*index=*/1));
+      clone_tensor_ptr(cpu_tensor, Device(DeviceType::CUDA, /*index=*/1));
 
   EXPECT_EQ(device_tensor->unsafeGetTensorImpl()->device_index(), 1);
+  EXPECT_EQ(g_mock_cuda.last_allocate_index_, 1);
+  EXPECT_EQ(g_mock_cuda.last_h2d_index_, 1);
 
-  auto roundtrip = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
   EXPECT_FLOAT_EQ(roundtrip->const_data_ptr<float>()[0], 1.0f);
   EXPECT_FLOAT_EQ(roundtrip->const_data_ptr<float>()[1], 2.0f);
+  EXPECT_EQ(g_mock_cuda.last_d2h_index_, 1);
+
+  device_tensor.reset();
+  EXPECT_EQ(g_mock_cuda.last_deallocate_index_, 1);
 }
 
 TEST_F(TensorPtrDeviceTest, DeviceMemoryCleanup) {
   {
     auto cpu_tensor = make_tensor_ptr({2}, {1.0f, 2.0f});
-    auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
+    auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
     EXPECT_EQ(g_mock_cuda.allocate_count_, 1);
     EXPECT_EQ(g_mock_cuda.deallocate_count_, 0);
   }
   EXPECT_EQ(g_mock_cuda.deallocate_count_, 1);
+  EXPECT_NE(g_mock_cuda.last_allocate_ptr_, nullptr);
+  EXPECT_EQ(g_mock_cuda.last_deallocate_ptr_, g_mock_cuda.last_allocate_ptr_);
 }
 
 TEST_F(TensorPtrDeviceTest, ScalarTensorRoundtrip) {
   auto cpu_tensor = make_tensor_ptr({}, {42.0f});
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
 
   EXPECT_EQ(device_tensor->dim(), 0);
   EXPECT_EQ(device_tensor->numel(), 1);
 
-  auto roundtrip = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
   EXPECT_EQ(roundtrip->dim(), 0);
   EXPECT_EQ(roundtrip->numel(), 1);
   EXPECT_FLOAT_EQ(roundtrip->const_data_ptr<float>()[0], 42.0f);
@@ -206,8 +214,8 @@ TEST_F(TensorPtrDeviceTest, ScalarTensorRoundtrip) {
 TEST_F(TensorPtrDeviceTest, RawDataRoundtrip) {
   constexpr std::array<float, 3> raw_data{100.0f, 200.0f, 300.0f};
   auto cpu_tensor = make_tensor_ptr({3}, const_cast<float*>(raw_data.data()));
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
-  auto roundtrip = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
 
   EXPECT_EQ(roundtrip->dim(), 1);
   EXPECT_EQ(roundtrip->size(0), 3);
@@ -217,32 +225,106 @@ TEST_F(TensorPtrDeviceTest, RawDataRoundtrip) {
   EXPECT_FLOAT_EQ(data[2], 300.0f);
 }
 
-TEST_F(TensorPtrDeviceTest, ErrorCpuToCpu) {
+TEST_F(TensorPtrDeviceTest, CpuToCpuCopiesWithoutTheAllocator) {
   auto cpu_tensor = make_tensor_ptr({2}, {1.0f, 2.0f});
-  ET_EXPECT_DEATH(
-      clone_tensor_ptr_to(cpu_tensor, DeviceType::CPU),
-      "does not copy CPU-to-CPU");
+  auto copy = clone_tensor_ptr(cpu_tensor, DeviceType::CPU);
+
+  EXPECT_TRUE(copy->device().is_cpu());
+  EXPECT_NE(copy->const_data_ptr(), cpu_tensor->const_data_ptr());
+  EXPECT_FLOAT_EQ(copy->const_data_ptr<float>()[0], 1.0f);
+  EXPECT_FLOAT_EQ(copy->const_data_ptr<float>()[1], 2.0f);
+  EXPECT_EQ(g_mock_cuda.allocate_count_, 0);
+  EXPECT_EQ(g_mock_cuda.h2d_count_, 0);
+  EXPECT_EQ(g_mock_cuda.d2h_count_, 0);
+}
+
+TEST_F(TensorPtrDeviceTest, CpuCloneReportsOneDeviceWhicheverBranchItTakes) {
+  auto with_data = make_tensor_ptr({2}, {1.0f, 2.0f});
+  auto without_data = make_tensor_ptr({2}, nullptr);
+  const auto target = Device(DeviceType::CPU, /*index=*/3);
+
+  auto copied = clone_tensor_ptr(with_data, target);
+  auto copied_null = clone_tensor_ptr(without_data, target);
+  auto copied_no_target = clone_tensor_ptr(with_data);
+
+  EXPECT_EQ(copied->device(), Device(DeviceType::CPU, /*index=*/0));
+  EXPECT_EQ(copied_null->device(), copied->device());
+  EXPECT_EQ(copied_no_target->device(), copied->device());
+  EXPECT_NE(copied->const_data_ptr(), with_data->const_data_ptr());
+  EXPECT_FLOAT_EQ(copied->const_data_ptr<float>()[1], 2.0f);
+  EXPECT_EQ(copied_null->const_data_ptr(), nullptr);
+  EXPECT_EQ(g_mock_cuda.allocate_count_, 0);
 }
 
 TEST_F(TensorPtrDeviceTest, ErrorNullCpuTensorData) {
   auto null_tensor = make_tensor_ptr({2, 2}, nullptr);
   ET_EXPECT_DEATH(
-      clone_tensor_ptr_to(null_tensor, DeviceType::CUDA),
+      clone_tensor_ptr(null_tensor, DeviceType::CUDA),
       "Source tensor has no data");
 }
 
 TEST_F(TensorPtrDeviceTest, ErrorDeviceToDevice) {
   auto cpu_tensor = make_tensor_ptr({2}, {1.0f, 2.0f});
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
   ET_EXPECT_DEATH(
-      clone_tensor_ptr_to(device_tensor, Device(DeviceType::CUDA, /*index=*/1)),
-      "Device-to-device copy is not supported");
+      clone_tensor_ptr(device_tensor, Device(DeviceType::CUDA, /*index=*/1)),
+      "can only be copied to CPU");
 }
+
+TEST_F(TensorPtrDeviceTest, ErrorNoTargetOnADeviceTensor) {
+  auto cpu_tensor = make_tensor_ptr({2}, {1.0f, 2.0f});
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  ET_EXPECT_DEATH(clone_tensor_ptr(device_tensor), "can only be copied to CPU");
+}
+
+TEST_F(TensorPtrDeviceTest, ErrorConvertingADeviceTensor) {
+  auto cpu_tensor = make_tensor_ptr({2}, {1.0f, 2.0f});
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  ET_EXPECT_DEATH(
+      convert_tensor_ptr(device_tensor, executorch::aten::ScalarType::Double),
+      "only supports CPU tensors");
+}
+
+TEST_F(TensorPtrDeviceTest, ErrorAllocatingDeviceMemory) {
+  auto cpu_tensor = make_tensor_ptr({2}, {1.0f, 2.0f});
+  g_mock_cuda.fail_allocations_ = true;
+  ET_EXPECT_DEATH(
+      clone_tensor_ptr(cpu_tensor, DeviceType::CUDA),
+      "Failed to allocate device memory");
+  g_mock_cuda.fail_allocations_ = false;
+}
+
+#ifdef __GNUC__
+// Disable -Wdeprecated-declarations, as some builds use 'Werror'. This test
+// exists to keep the deprecated spelling working until it is removed.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+TEST_F(TensorPtrDeviceTest, DeprecatedCloneToStillCopiesToTheDevice) {
+  auto cpu_tensor = make_tensor_ptr({2}, {1.0f, 2.0f});
+  auto device_tensor =
+      clone_tensor_ptr_to(cpu_tensor, Device(DeviceType::CUDA, /*index=*/1));
+
+  ASSERT_NE(device_tensor, nullptr);
+  EXPECT_EQ(
+      device_tensor->unsafeGetTensorImpl()->device_type(), DeviceType::CUDA);
+  EXPECT_EQ(device_tensor->unsafeGetTensorImpl()->device_index(), 1);
+  EXPECT_EQ(g_mock_cuda.allocate_count_, 1);
+  EXPECT_EQ(g_mock_cuda.h2d_count_, 1);
+
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
+  EXPECT_FLOAT_EQ(roundtrip->const_data_ptr<float>()[1], 2.0f);
+}
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 TEST_F(TensorPtrDeviceTest, MakeTensorPtrVectorToDevice) {
   auto cpu_tensor =
       make_tensor_ptr({2, 2}, std::vector<float>{1.0f, 2.0f, 3.0f, 4.0f});
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
 
   EXPECT_EQ(device_tensor->dim(), 2);
   EXPECT_EQ(device_tensor->size(0), 2);
@@ -253,7 +335,7 @@ TEST_F(TensorPtrDeviceTest, MakeTensorPtrVectorToDevice) {
   EXPECT_EQ(g_mock_cuda.allocate_count_, 1);
   EXPECT_EQ(g_mock_cuda.h2d_count_, 1);
 
-  auto roundtrip = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
   auto* data = roundtrip->const_data_ptr<float>();
   EXPECT_FLOAT_EQ(data[0], 1.0f);
   EXPECT_FLOAT_EQ(data[1], 2.0f);
@@ -264,7 +346,7 @@ TEST_F(TensorPtrDeviceTest, MakeTensorPtrVectorToDevice) {
 TEST_F(TensorPtrDeviceTest, MakeTensorPtrRawPointerToDevice) {
   constexpr std::array<float, 3> raw{5.0f, 6.0f, 7.0f};
   auto cpu_tensor = make_tensor_ptr({3}, const_cast<float*>(raw.data()));
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
 
   EXPECT_EQ(device_tensor->dim(), 1);
   EXPECT_EQ(device_tensor->size(0), 3);
@@ -275,7 +357,7 @@ TEST_F(TensorPtrDeviceTest, MakeTensorPtrRawPointerToDevice) {
   EXPECT_EQ(g_mock_cuda.allocate_count_, 1);
   EXPECT_EQ(g_mock_cuda.h2d_count_, 1);
 
-  auto roundtrip = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
   auto* data = roundtrip->const_data_ptr<float>();
   EXPECT_FLOAT_EQ(data[0], 5.0f);
   EXPECT_FLOAT_EQ(data[1], 6.0f);
@@ -284,8 +366,8 @@ TEST_F(TensorPtrDeviceTest, MakeTensorPtrRawPointerToDevice) {
 
 TEST_F(TensorPtrDeviceTest, CloneToCpuVerifiesCpuDeviceMetadata) {
   auto cpu_tensor = make_tensor_ptr({3}, {1.0f, 2.0f, 3.0f});
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
-  auto result = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  auto result = clone_tensor_ptr(device_tensor, DeviceType::CPU);
 
   EXPECT_EQ(result->unsafeGetTensorImpl()->device_type(), DeviceType::CPU);
   EXPECT_EQ(result->unsafeGetTensorImpl()->device_index(), 0);
@@ -293,8 +375,8 @@ TEST_F(TensorPtrDeviceTest, CloneToCpuVerifiesCpuDeviceMetadata) {
 
 TEST_F(TensorPtrDeviceTest, MultipleClonesFromSameSource) {
   auto cpu_tensor = make_tensor_ptr({3}, {1.0f, 2.0f, 3.0f});
-  auto device1 = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
-  auto device2 = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
+  auto device1 = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  auto device2 = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
 
   EXPECT_NE(device1->const_data_ptr(), device2->const_data_ptr());
   EXPECT_EQ(g_mock_cuda.allocate_count_, 2);
@@ -307,14 +389,14 @@ TEST_F(TensorPtrDeviceTest, HighDimensionalTensorRoundtrip) {
     data[i] = static_cast<float>(i);
   }
   auto cpu_tensor = make_tensor_ptr({2, 3, 4}, data);
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
 
   EXPECT_EQ(device_tensor->dim(), 3);
   EXPECT_EQ(device_tensor->size(0), 2);
   EXPECT_EQ(device_tensor->size(1), 3);
   EXPECT_EQ(device_tensor->size(2), 4);
 
-  auto roundtrip = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
   auto* result = roundtrip->const_data_ptr<float>();
   for (size_t i = 0; i < 24; ++i) {
     EXPECT_FLOAT_EQ(result[i], static_cast<float>(i));
@@ -323,8 +405,8 @@ TEST_F(TensorPtrDeviceTest, HighDimensionalTensorRoundtrip) {
 
 TEST_F(TensorPtrDeviceTest, RoundtripDouble) {
   auto cpu_tensor = make_tensor_ptr({3}, std::vector<double>{1.1, 2.2, 3.3});
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
-  auto roundtrip = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
 
   EXPECT_EQ(roundtrip->scalar_type(), executorch::aten::ScalarType::Double);
   auto* data = roundtrip->const_data_ptr<double>();
@@ -335,8 +417,8 @@ TEST_F(TensorPtrDeviceTest, RoundtripDouble) {
 
 TEST_F(TensorPtrDeviceTest, RoundtripInt64) {
   auto cpu_tensor = make_tensor_ptr({3}, std::vector<int64_t>{100, 200, 300});
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
-  auto roundtrip = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
 
   EXPECT_EQ(roundtrip->scalar_type(), executorch::aten::ScalarType::Long);
   auto* data = roundtrip->const_data_ptr<int64_t>();
@@ -352,8 +434,8 @@ TEST_F(TensorPtrDeviceTest, LargeTensorRoundtrip) {
     data[i] = static_cast<float>(i) * 0.1f;
   }
   auto cpu_tensor = make_tensor_ptr({static_cast<int32_t>(n)}, data);
-  auto device_tensor = clone_tensor_ptr_to(cpu_tensor, DeviceType::CUDA);
-  auto roundtrip = clone_tensor_ptr_to(device_tensor, DeviceType::CPU);
+  auto device_tensor = clone_tensor_ptr(cpu_tensor, DeviceType::CUDA);
+  auto roundtrip = clone_tensor_ptr(device_tensor, DeviceType::CPU);
 
   auto* result = roundtrip->const_data_ptr<float>();
   for (size_t i = 0; i < n; ++i) {

--- a/extension/tensor/test/tensor_ptr_test.cpp
+++ b/extension/tensor/test/tensor_ptr_test.cpp
@@ -577,11 +577,11 @@ TEST_F(TensorPtrTest, CloneTensorPtrFromExistingTensorInt32) {
   EXPECT_EQ(cloned_tensor->scalar_type(), executorch::aten::ScalarType::Int);
 }
 
-TEST_F(TensorPtrTest, CloneTensorPtrCastInt32ToFloat) {
+TEST_F(TensorPtrTest, ConvertTensorPtrInt32ToFloat) {
   std::vector<int32_t> data = {1, 2, 3, 4};
   auto tensor = make_tensor_ptr({2, 2}, std::move(data));
   auto cloned_tensor =
-      clone_tensor_ptr(*tensor, executorch::aten::ScalarType::Float);
+      convert_tensor_ptr(tensor, executorch::aten::ScalarType::Float);
 
   EXPECT_EQ(cloned_tensor->dim(), 2);
   EXPECT_EQ(cloned_tensor->size(0), 2);
@@ -594,11 +594,11 @@ TEST_F(TensorPtrTest, CloneTensorPtrCastInt32ToFloat) {
   EXPECT_FLOAT_EQ(ptr[3], 4.0f);
 }
 
-TEST_F(TensorPtrTest, CloneTensorPtrCastFloatToBFloat16) {
+TEST_F(TensorPtrTest, ConvertTensorPtrFloatToBFloat16) {
   std::vector<float> data = {1.0f, 2.0f, 3.5f};
   auto tensor = make_tensor_ptr({3}, std::move(data));
   auto cloned_tensor =
-      clone_tensor_ptr(*tensor, executorch::aten::ScalarType::BFloat16);
+      convert_tensor_ptr(*tensor, executorch::aten::ScalarType::BFloat16);
 
   EXPECT_EQ(cloned_tensor->dim(), 1);
   EXPECT_EQ(cloned_tensor->size(0), 3);
@@ -610,22 +610,26 @@ TEST_F(TensorPtrTest, CloneTensorPtrCastFloatToBFloat16) {
   EXPECT_NEAR(static_cast<float>(ptr[2]), 3.5f, 0.01f);
 }
 
-TEST_F(TensorPtrTest, CloneTensorPtrCastKeepsMetadata) {
-  std::vector<uint8_t> data(
-      6 * executorch::aten::elementSize(executorch::aten::ScalarType::Float));
+TEST_F(TensorPtrTest, ConvertTensorPtrKeepsMetadata) {
+  std::vector<float> data = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
   auto tensor = make_tensor_ptr({2, 3}, std::move(data));
   auto cloned_tensor =
-      clone_tensor_ptr(*tensor, executorch::aten::ScalarType::Float);
+      convert_tensor_ptr(*tensor, executorch::aten::ScalarType::Double);
 
   EXPECT_EQ(cloned_tensor->dim(), 2);
   EXPECT_EQ(cloned_tensor->size(0), 2);
   EXPECT_EQ(cloned_tensor->size(1), 3);
   EXPECT_EQ(cloned_tensor->strides()[0], 3);
   EXPECT_EQ(cloned_tensor->strides()[1], 1);
-  EXPECT_EQ(cloned_tensor->scalar_type(), executorch::aten::ScalarType::Float);
+  EXPECT_EQ(cloned_tensor->scalar_type(), executorch::aten::ScalarType::Double);
+  EXPECT_NE(cloned_tensor->const_data_ptr(), tensor->const_data_ptr());
+  auto ptr = cloned_tensor->const_data_ptr<double>();
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_DOUBLE_EQ(ptr[i], static_cast<double>(i + 1));
+  }
 }
 
-TEST_F(TensorPtrTest, CloneTensorPtrCastNullData) {
+TEST_F(TensorPtrTest, ConvertTensorPtrNullData) {
   auto tensor = make_tensor_ptr(
       {2, 2},
       nullptr,
@@ -635,7 +639,7 @@ TEST_F(TensorPtrTest, CloneTensorPtrCastNullData) {
       executorch::aten::DeviceType::CPU,
       executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND);
   auto cloned_tensor =
-      clone_tensor_ptr(*tensor, executorch::aten::ScalarType::Int);
+      convert_tensor_ptr(*tensor, executorch::aten::ScalarType::Int);
 
   EXPECT_EQ(cloned_tensor->dim(), 2);
   EXPECT_EQ(cloned_tensor->size(0), 2);
@@ -644,15 +648,93 @@ TEST_F(TensorPtrTest, CloneTensorPtrCastNullData) {
   EXPECT_EQ(cloned_tensor->scalar_type(), executorch::aten::ScalarType::Int);
 }
 
-TEST_F(TensorPtrTest, CloneTensorPtrCastInvalidExpectDeath) {
+TEST_F(TensorPtrTest, ConvertTensorPtrInvalidExpectDeath) {
   std::vector<float> data = {1.0f, 2.0f};
   auto tensor = make_tensor_ptr({2}, std::move(data));
   ET_EXPECT_DEATH(
       {
-        auto _ = clone_tensor_ptr(*tensor, executorch::aten::ScalarType::Int);
+        auto _ = convert_tensor_ptr(*tensor, executorch::aten::ScalarType::Int);
       },
       "");
 }
+
+TEST_F(TensorPtrTest, ConvertTensorPtrSameTypeCopiesData) {
+  std::vector<float> data = {1.0f, 2.0f, 3.0f};
+  auto tensor = make_tensor_ptr({3}, std::move(data));
+  auto cloned_tensor =
+      convert_tensor_ptr(*tensor, executorch::aten::ScalarType::Float);
+
+  EXPECT_EQ(cloned_tensor->scalar_type(), executorch::aten::ScalarType::Float);
+  ASSERT_NE(cloned_tensor->const_data_ptr(), nullptr);
+  EXPECT_NE(cloned_tensor->const_data_ptr(), tensor->const_data_ptr());
+  auto ptr = cloned_tensor->const_data_ptr<float>();
+  EXPECT_FLOAT_EQ(ptr[0], 1.0f);
+  EXPECT_FLOAT_EQ(ptr[1], 2.0f);
+  EXPECT_FLOAT_EQ(ptr[2], 3.0f);
+
+  // A dtype the cast itself does not handle still copies, because asking for
+  // the type the tensor already has never reaches the cast.
+  std::vector<float> complex_data = {1.0f, 2.0f, 3.0f, 4.0f};
+  auto complex_tensor = make_tensor_ptr(
+      {2},
+      complex_data.data(),
+      {},
+      {},
+      executorch::aten::ScalarType::ComplexFloat);
+  auto complex_clone = convert_tensor_ptr(
+      complex_tensor, executorch::aten::ScalarType::ComplexFloat);
+
+  EXPECT_EQ(
+      complex_clone->scalar_type(), executorch::aten::ScalarType::ComplexFloat);
+  EXPECT_NE(complex_clone->const_data_ptr(), complex_tensor->const_data_ptr());
+}
+
+#ifndef USE_ATEN_LIB
+TEST_F(TensorPtrTest, ConvertTensorPtrKeepsShapeDynamism) {
+  std::vector<float> data = {1.0f, 2.0f, 3.0f};
+  auto tensor = make_tensor_ptr(
+      {3},
+      std::move(data),
+      {},
+      {},
+      executorch::aten::ScalarType::Float,
+      executorch::aten::TensorShapeDynamism::STATIC);
+  auto cloned_tensor =
+      convert_tensor_ptr(*tensor, executorch::aten::ScalarType::Double);
+
+  EXPECT_EQ(
+      cloned_tensor->shape_dynamism(),
+      executorch::aten::TensorShapeDynamism::STATIC);
+}
+#endif // USE_ATEN_LIB
+
+#ifdef __GNUC__
+// Disable -Wdeprecated-declarations, as some builds use 'Werror'. These two
+// tests exist to keep the deprecated spellings working until they are removed.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+TEST_F(TensorPtrTest, DeprecatedCloneWithScalarTypeStillConverts) {
+  std::vector<float> data = {1.0f, 2.0f};
+  auto tensor = make_tensor_ptr({2}, std::move(data));
+
+  for (const auto& cloned_tensor :
+       {clone_tensor_ptr(*tensor, executorch::aten::ScalarType::Double),
+        clone_tensor_ptr(tensor, executorch::aten::ScalarType::Double)}) {
+    ASSERT_NE(cloned_tensor, nullptr);
+    EXPECT_EQ(
+        cloned_tensor->scalar_type(), executorch::aten::ScalarType::Double);
+    ASSERT_NE(cloned_tensor->const_data_ptr(), nullptr);
+    auto ptr = cloned_tensor->const_data_ptr<double>();
+    EXPECT_DOUBLE_EQ(ptr[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptr[1], 2.0);
+  }
+}
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 TEST_F(TensorPtrTest, MakeTensorPtrFromTensorPtrInt32) {
   std::vector<int32_t> data = {1, 2, 3, 4};


### PR DESCRIPTION
extension/tensor had five entry points for copying a tensor: four
clone_tensor_ptr overloads (Tensor or TensorPtr, with or without a
ScalarType) and a separate clone_tensor_ptr_to for moving data between
CPU and an accelerator. Two cast the dtype, one moved the data, and the
names did not say which was which.

Now there is one clone and one convert:

  auto same_place = clone_tensor_ptr(tensor);
  auto on_device  = clone_tensor_ptr(tensor, DeviceType::CUDA);
  auto back_home  = clone_tensor_ptr(on_device, DeviceType::CPU);
  auto as_float   = convert_tensor_ptr(tensor, ScalarType::Float);

A clone copies the data and keeps the dtype. Where the copy lives is the
second argument; the overload without it copies to the source tensor's
own device. convert_tensor_ptr is the old cast path renamed, with the
same-type case delegated to the clone instead of repeated inline.

One end of every copy still has to be CPU, because DeviceAllocator has
no device-to-device copy. So a clone with no target keeps a CPU tensor
where it is but does not let an accelerator tensor clone in place. The
header, the docs page and the error message all say that now.

Every call shape that compiled at the merge base still compiles,
including the address of the one-argument clone and a braced device.
Three behaviours change. CPU to CPU with an explicit CPU
target used to abort; it is a plain clone now. USE_ATEN_LIB builds still
take CPU only, but a device target there moved from a compile error to a
runtime one. An accelerator target keeps its device index, a CPU target
keeps only the device type, which is what the old code produced.

The three old spellings stay as ET_DEPRECATED forwarders, so old code
still compiles and links; api-life-cycle.md allows deleting them in
1.7.0 or later. clone_tensor_ptr(tensor, {}) still means Byte, and still
warns, because Device is not default constructible.

Test Plan:
extension_tensor_test: 173 pass here, 165 at the merge base. Fifteen
mutations, each rebuilt, rerun and caught by a named test, covering the
device index at all four allocator calls, the freed pointer, the
allocation error check, the CPU-only guard and the cast loop in
convert_tensor_ptr, shape dynamism, the same-type delegation, the
one-argument clone's default target, and all three deprecated
forwarders. Compiled the changed sources with and without USE_ATEN_LIB,
on gcc and clang; clang-format clean; nm shows exported symbols a
superset of the merge base.

Authored with AI assistance (Claude Code).
