### PR TITLE
Qualcomm: skip higher-order ops in LiftConstantScalarOperands

### DIFF
--- a/backends/qualcomm/_passes/lift_constant_scalar_operands.py
+++ b/backends/qualcomm/_passes/lift_constant_scalar_operands.py
@@ -184,6 +184,10 @@ class LiftConstantScalarOperands(ExportPass):
             if (
                 n.op != "call_function"
                 or isinstance(n.target, (BuiltinMethodType, BuiltinFunctionType))
+                # higher-order ops (e.g. wrap_with_set_grad_enabled) have no
+                # OpOverload schema; lifting inspects node.target._schema, so skip
+                # them instead of crashing on the missing attribute.
+                or not isinstance(n.target, torch._ops.OpOverload)
                 or n.target in SKIP_LIFT_OPS
             ):
                 continue

--- a/backends/qualcomm/tests/test_passes.py
+++ b/backends/qualcomm/tests/test_passes.py
@@ -10,6 +10,7 @@ from executorch.backends.qualcomm._passes import (
     FoldQDQ,
     InsertIOQDQ,
     InsertReshapeForReduceOps,
+    LiftConstantScalarOperands,
     RemoveRedundancy,
 )
 from executorch.backends.qualcomm._passes.qnn_pass_manager import (
@@ -97,6 +98,29 @@ class TestPasses(unittest.TestCase):
         self.assertTrue(
             QnnOperatorSupport.is_node_supported(support, None, context_loader_nodes[0])
         )
+
+    def test_lift_constant_scalar_operands_skips_higher_order_ops(self):
+        # A `with torch.no_grad()` block is captured as a higher-order op
+        # (wrap_with_set_grad_enabled) whose target has no OpOverload schema.
+        # LiftConstantScalarOperands inspects node.target._schema, so it must skip
+        # such nodes instead of crashing with AttributeError.
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                with torch.no_grad():
+                    y = x + 1
+                return y * 2
+
+        gm = torch.export.export(Model(), (torch.randn(3),), strict=True).graph_module
+        higher_order_ops = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            and not isinstance(node.target, torch._ops.OpOverload)
+        ]
+        self.assertTrue(higher_order_ops, "expected a higher-order op in the graph")
+
+        # Must not raise.
+        LiftConstantScalarOperands().call(gm)
 
     def test_build_op_wrappers_returns_context_binary(self):
         op_name = "ctx_loader_build"


### PR DESCRIPTION
The pass inspects node.target._schema to lift scalar operands, but higher-order ops (e.g. wrap_with_set_grad_enabled from a torch.no_grad block) have no OpOverload schema, so the pass crashed with AttributeError on a valid exported program (surfaced exporting Mamba2 / Mixtral MoE via the QNN backend). Skip non-OpOverload targets.

