### PR TITLE
Qualcomm: fall back over-rank ops to CPU instead of aborting the build

### DIFF
--- a/backends/qualcomm/partition/qnn_partitioner.py
+++ b/backends/qualcomm/partition/qnn_partitioner.py
@@ -48,6 +48,25 @@ from .utils import filter_fn, generate_qnn_executorch_option, get_skip_decomp_ta
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+# Highest tensor rank the QNN HTP backend accepts; ranks above this are rejected
+# at graph-prepare, so such nodes must not be delegated.
+QNN_TENSOR_RANK_LIMIT = 5
+
+
+def _max_io_tensor_rank(node: torch.fx.Node) -> int:
+    """Largest tensor rank among a node's output and tensor-valued inputs."""
+
+    def _ranks(val):
+        if isinstance(val, (list, tuple)):
+            return [len(v.shape) for v in val if hasattr(v, "shape")]
+        return [len(val.shape)] if hasattr(val, "shape") else []
+
+    ranks = _ranks(node.meta.get("val"))
+    for arg in node.args:
+        if isinstance(arg, torch.fx.Node):
+            ranks += _ranks(arg.meta.get("val"))
+    return max(ranks, default=0)
+
 
 class QnnOperatorSupport(OperatorSupportBase):
     def __init__(
@@ -107,6 +126,17 @@ class QnnOperatorSupport(OperatorSupportBase):
             or node.target.__name__ in self.skip_node_op_set
         ):
             logger.info(f"[{self.phase}] {node.target.__name__} | Skipped")
+            return False
+
+        # The HTP backend rejects tensors with rank > QNN_TENSOR_RANK_LIMIT at
+        # graph-prepare (QnnBackend_validateOpConfig 3110, "incorrect Rank"). Left
+        # in a partition, one such op aborts the whole context binary. Detect it
+        # here so the op falls back to CPU instead of failing the entire build.
+        if _max_io_tensor_rank(node) > QNN_TENSOR_RANK_LIMIT:
+            logger.info(
+                f"[{self.phase}] {node.target.__name__} | "
+                f"Unsupported: tensor rank exceeds {QNN_TENSOR_RANK_LIMIT}"
+            )
             return False
 
         supported = False

--- a/backends/qualcomm/tests/test_passes.py
+++ b/backends/qualcomm/tests/test_passes.py
@@ -98,6 +98,44 @@ class TestPasses(unittest.TestCase):
             QnnOperatorSupport.is_node_supported(support, None, context_loader_nodes[0])
         )
 
+    def test_partitioner_falls_back_on_rank_above_htp_limit(self):
+        # The HTP backend rejects tensors with rank > 5 at graph-prepare; the
+        # partitioner must report such ops as unsupported so they fall back to CPU
+        # instead of aborting the whole context binary.
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x.unsqueeze(0) + 1  # rank-5 input -> rank-6 output
+
+        exported_program = torch.export.export(
+            Model(), (torch.randn(1, 1, 1, 1, 4),), strict=True
+        )
+        edge_program = to_edge(
+            {"forward": exported_program},
+            compile_config=EdgeCompileConfig(_check_ir_validity=False),
+        )._edge_programs["forward"]
+        rank6_nodes = [
+            node
+            for node in edge_program.graph.nodes
+            if node.op == "call_function"
+            and getattr(node.meta.get("val", None), "ndim", 0) == 6
+        ]
+        self.assertTrue(rank6_nodes, "expected a rank-6 node in the graph")
+
+        # Drive is_node_supported with a mock self. node_visitors is populated so
+        # the over-rank node passes the visitor-existence checks and reaches the
+        # rank guard; without the guard it would fall through to the (mocked) live
+        # backend and be reported supported.
+        support = MagicMock()
+        support.phase = "QnnPartitioner"
+        support.skip_node_id_set = set()
+        support.skip_node_op_set = set()
+        support.nodes_to_wrappers = {}
+        support.node_visitors = {
+            node.target.__name__: MagicMock() for node in rank6_nodes
+        }
+        for node in rank6_nodes:
+            self.assertFalse(QnnOperatorSupport.is_node_supported(support, None, node))
+
     def test_build_op_wrappers_returns_context_binary(self):
         op_name = "ctx_loader_build"
         ctx_bin = b"qnn_context_binary"


### PR DESCRIPTION
The HTP backend rejects tensors with rank > 5 at graph-prepare (QnnBackend_validateOpConfig 3110, 'incorrect Rank'). When such an op is left in a partition it aborts the entire context binary rather than falling back to CPU (surfaced exporting quantized Mamba2's rank-6 chunked-scan intermediates). Report rank > 5 as unsupported in is_node_supported so the op degrades to CPU.
