### PR TITLE
Add bf16 x fp32 gemv decode (#22255)

### DIFF
--- a/extension/llm/custom_ops/op_sdpa.cpp
+++ b/extension/llm/custom_ops/op_sdpa.cpp
@@ -46,6 +46,7 @@ bool validate_flash_attention_args(
     const Tensor& query,
     const Tensor& key,
     const Tensor& value,
+    const Tensor& output,
     const optional<Tensor>& attn_mask) {
   ET_CHECK_OR_RETURN_FALSE(query.dim() == 4, "query must be a 4D tensor");
   ET_CHECK_OR_RETURN_FALSE(key.dim() == 4, "key must be a 4D tensor");
@@ -67,6 +68,11 @@ bool validate_flash_attention_args(
       (query.scalar_type() == key.scalar_type()) &&
           (query.scalar_type() == value.scalar_type()),
       "Key and Value must have the same data type as Query");
+
+  ET_CHECK_OR_RETURN_FALSE(
+      value.scalar_type() == ScalarType::Char ||
+          output.scalar_type() == value.scalar_type(),
+      "Output must have the same data type as Value for non-quantized SDPA");
 
   ET_CHECK_OR_RETURN_FALSE(
       !attn_mask.has_value() || attn_mask.value().dim() == 2,
@@ -348,7 +354,7 @@ Tensor& flash_attention_kernel_out(
   (void)ctx;
   ET_KERNEL_CHECK(
       ctx,
-      validate_flash_attention_args(query, key, value, attn_mask),
+      validate_flash_attention_args(query, key, value, output, attn_mask),
       InvalidArgument,
       output);
 
@@ -449,7 +455,7 @@ Tensor& custom_sdpa_out_impl(
 
   ET_KERNEL_CHECK_MSG(
       ctx,
-      validate_flash_attention_args(q, k, v, attn_mask),
+      validate_flash_attention_args(q, k, v, output, attn_mask),
       InvalidArgument,
       output,
       "Invalid arguments");

--- a/extension/llm/custom_ops/op_sdpa_impl.h
+++ b/extension/llm/custom_ops/op_sdpa_impl.h
@@ -330,7 +330,8 @@ void _qk_at_v_gemm(
     const int64_t o_stride_m,
     const accum_t beta,
     accum_t* buf_qdq_ptr,
-    const bool widen_v) {
+    const bool widen_v,
+    const bool use_fp32_qk_weights) {
   if (v_data.dtype == ScalarType::Char) {
     if constexpr (std::is_same<accum_t, float>::value) {
       const float* qk = static_cast<const float*>(qk_data);
@@ -380,6 +381,18 @@ void _qk_at_v_gemm(
     // qk has been cast to the activation dtype (see qk_reduced_data); both
     // operands are reduced precision and accumulate into the float output.
     if constexpr (std::is_same<accum_t, float>::value) {
+      if (use_fp32_qk_weights) {
+        ::executorch::cpublas::gemv(
+            n,
+            k,
+            1.0f,
+            static_cast<const ::executorch::aten::BFloat16*>(v_data.data),
+            v_stride_n,
+            static_cast<const float*>(qk_data),
+            beta,
+            o_data);
+        return;
+      }
       if (widen_v) {
         ET_CHECK_MSG(
             v_data.dtype == ScalarType::BFloat16,
@@ -1251,9 +1264,13 @@ void cpu_flash_attention(
         const bool widen_v = is_reduced_type && !is_quantized_sdpa &&
             std::is_same<scalar_t, ::executorch::aten::BFloat16>::value &&
             qBlockSize >= kMinQBlockForWidenedAV;
+        const bool use_fp32_qk_weights = is_reduced_type &&
+            !is_quantized_sdpa &&
+            std::is_same<scalar_t, ::executorch::aten::BFloat16>::value &&
+            qBlockSize == 1;
         const void* qk_gemm_data = qk_data;
         if constexpr (is_reduced_type) {
-          if (!is_quantized_sdpa && !widen_v) {
+          if (!is_quantized_sdpa && !widen_v && !use_fp32_qk_weights) {
             vec::convert<accum_t, scalar_t>(
                 qk_data, qk_reduced_data, qBlockSize * kvBlockSize);
             qk_gemm_data = qk_reduced_data;
@@ -1272,7 +1289,8 @@ void cpu_flash_attention(
             headSize,
             n == 0 ? static_cast<accum_t>(0) : static_cast<accum_t>(1),
             buf_qdq_ptr,
-            widen_v);
+            widen_v,
+            use_fp32_qk_weights);
       }
       // dst <- dst / sum[row]
       // reorder MHA output with strides

--- a/extension/llm/custom_ops/op_sdpa_test.cpp
+++ b/extension/llm/custom_ops/op_sdpa_test.cpp
@@ -790,6 +790,32 @@ TEST(OpScaledDotProductAttentionTest, HalfMatchesFloat) {
       1e-2, 1e-2);
 }
 
+class CustomSdpaTest : public OperatorTest {};
+
+TEST_F(CustomSdpaTest, RejectsOutputValueDtypeMismatch) {
+  TensorFactory<executorch::aten::ScalarType::Half> tf_half;
+  TensorFactory<executorch::aten::ScalarType::BFloat16> tf_bfloat16;
+
+  auto query = tf_half.ones({1, 1, 1, 4});
+  auto key = tf_half.ones({1, 1, 1, 4});
+  auto value = tf_half.ones({1, 1, 1, 4});
+  auto output = tf_bfloat16.zeros({1, 1, 1, 4});
+
+  ET_EXPECT_KERNEL_FAILURE(
+      context_,
+      torch::executor::native::custom_sdpa_out(
+          context_,
+          query,
+          key,
+          value,
+          /*start_pos=*/0,
+          std::nullopt,
+          /*dropout_p=*/0.0,
+          /*is_causal=*/false,
+          std::nullopt,
+          output));
+}
+
 TEST(OpScaledDotProductAttentionTest, CorrectnessTest_51) {
   TensorFactory<executorch::aten::ScalarType::Float> tfFloat;
 

--- a/kernels/optimized/blas/BlasKernel.cpp
+++ b/kernels/optimized/blas/BlasKernel.cpp
@@ -387,14 +387,14 @@ TARGET_ARM_BF16_ATTRIBUTE static void dot4_with_fp32_arith_bfdot(
 #endif // COMPILER_SUPPORTS_ARM_BF16_TARGET
 
 #if defined(__aarch64__)
-template <int64_t kRegisterPairs>
+template <int64_t kRegisterPairs, typename b_t>
 C10_ALWAYS_INLINE void gemv_notrans_block_neon(
     int64_t output_offset,
     int64_t k,
     float alpha,
     const BFloat16* a,
     int64_t lda,
-    const BFloat16* b,
+    const b_t* b,
     float beta,
     float* c) {
   float32x4_t acc[kRegisterPairs * 2];
@@ -432,13 +432,14 @@ C10_ALWAYS_INLINE void gemv_notrans_block_neon(
   }
 }
 
-static void gemv_notrans_neon(
+template <typename b_t>
+void gemv_notrans_neon(
     int64_t m,
     int64_t k,
     float alpha,
     const BFloat16* a,
     int64_t lda,
-    const BFloat16* b,
+    const b_t* b,
     float beta,
     float* c) {
   int64_t i = 0;
@@ -849,6 +850,35 @@ void bf16_gemv_notrans_with_fp32_arith(
       c[i] += static_cast<float>(a_col[i]) * b_val;
     }
   }
+}
+
+void bf16_fp32_gemv_notrans_with_fp32_arith(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const float* b,
+    float beta,
+    float* c) {
+#if defined(__aarch64__)
+  gemv_notrans_neon(m, k, alpha, a, lda, b, beta, c);
+#else
+  if (beta == 0.0f) {
+    std::fill(c, c + m, 0.0f);
+  } else if (beta != 1.0f) {
+    for (int64_t i = 0; i < m; ++i) {
+      c[i] *= beta;
+    }
+  }
+  for (int64_t l = 0; l < k; ++l) {
+    const BFloat16* a_col = a + l * lda;
+    const float b_val = b[l] * alpha;
+    for (int64_t i = 0; i < m; ++i) {
+      c[i] += static_cast<float>(a_col[i]) * b_val;
+    }
+  }
+#endif
 }
 
 void bf16_gemv_transa_with_fp32_arith(

--- a/kernels/optimized/blas/BlasKernel.h
+++ b/kernels/optimized/blas/BlasKernel.h
@@ -155,6 +155,15 @@ void bf16_gemv_notrans_with_fp32_arith(
     const torch::executor::BFloat16* b,
     float beta,
     float* c);
+void bf16_fp32_gemv_notrans_with_fp32_arith(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const torch::executor::BFloat16* a,
+    int64_t lda,
+    const float* b,
+    float beta,
+    float* c);
 void bf16_gemv_transa_with_fp32_arith(
     int64_t m,
     int64_t k,

--- a/kernels/optimized/blas/CPUBlas.cpp
+++ b/kernels/optimized/blas/CPUBlas.cpp
@@ -55,6 +55,19 @@ bool gemm_uses_blas() {
 #endif
 }
 
+void gemv(
+    int64_t m,
+    int64_t k,
+    const float alpha,
+    const BFloat16* a,
+    int64_t lda,
+    const float* b,
+    const float beta,
+    float* c) {
+  internal::bf16_fp32_gemv_notrans_with_fp32_arith(
+      m, k, alpha, a, lda, b, beta, c);
+}
+
 // clang-format off
 void normalize_last_dims(
     TransposeType transa, TransposeType transb,

--- a/kernels/optimized/blas/CPUBlas.h
+++ b/kernels/optimized/blas/CPUBlas.h
@@ -50,6 +50,18 @@ inline char to_blas(TransposeType trans) {
 // this library.
 bool gemm_uses_blas();
 
+// Column-major c = beta * c + alpha * (a @ b), where a is BFloat16 and b and
+// c are float.
+void gemv(
+    int64_t m,
+    int64_t k,
+    const float alpha,
+    const executorch::aten::BFloat16* a,
+    int64_t lda,
+    const float* b,
+    const float beta,
+    float* c);
+
 // clang-format off
 template <typename scalar_t, typename opmath_t, typename out_t = scalar_t>
 void gemm_impl(

--- a/kernels/optimized/test/libblas_test.cpp
+++ b/kernels/optimized/test/libblas_test.cpp
@@ -72,6 +72,24 @@ float reference_dot(const T* a, const T* b, int64_t len) {
   return sum;
 }
 
+void reference_bf16_fp32_gemv_notrans(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const executorch::aten::BFloat16* a,
+    int64_t lda,
+    const float* b,
+    float beta,
+    std::vector<float>& c) {
+  for (int64_t i = 0; i < m; ++i) {
+    float dot = 0.0f;
+    for (int64_t l = 0; l < k; ++l) {
+      dot += static_cast<float>(a[l * lda + i]) * b[l];
+    }
+    c[i] = beta == 0.0f ? alpha * dot : beta * c[i] + alpha * dot;
+  }
+}
+
 // Column-major c = beta * c + alpha * (op(a) @ b), accumulated in fp32, mirror-
 // ing the generic gemm_{transa,notrans}_ templates the bf16 specializations
 // replace.
@@ -309,6 +327,35 @@ TEST(BlasTest, BF16FloatGemmDecodeShapesMatchScalarAccumulation) {
           " m=" + std::to_string(shape.m) + " k=" + std::to_string(shape.k) +
           " alpha=" + std::to_string(alpha) + " beta=" + std::to_string(beta);
       for (int64_t i = 0; i < shape.m; ++i) {
+        expect_near_relative(c[i], expected[i], context.c_str());
+      }
+    }
+  }
+}
+
+TEST(BlasTest, BF16FP32GemvDecodeShapesMatchScalarAccumulation) {
+  using executorch::aten::BFloat16;
+
+  for (const auto [m, k] :
+       {std::pair{64, 511}, std::pair{128, 512}, std::pair{130, 513}}) {
+    const int64_t lda = m + 3;
+    const auto a = make_values<BFloat16>(lda * k, 11);
+    const auto b = make_values<float>(k, 12);
+
+    for (const auto [alpha, beta] :
+         {std::pair{1.0f, 0.0f}, std::pair{-0.5f, 0.25f}}) {
+      auto c = make_values<float>(m, 13);
+      auto expected = c;
+
+      reference_bf16_fp32_gemv_notrans(
+          m, k, alpha, a.data(), lda, b.data(), beta, expected);
+      executorch::cpublas::gemv(
+          m, k, alpha, a.data(), lda, b.data(), beta, c.data());
+
+      const std::string context = "m=" + std::to_string(m) +
+          " k=" + std::to_string(k) + " alpha=" + std::to_string(alpha) +
+          " beta=" + std::to_string(beta);
+      for (int64_t i = 0; i < m; ++i) {
         expect_near_relative(c[i], expected[i], context.c_str());
       }
     }


### PR DESCRIPTION
Summary:

Add a mixed BF16 × FP32 GEMV path for single-token SDPA decoding. This keeps attention weights in FP32, avoiding conversion to BF16 and preserving softmax precision, while using an optimized NEON implementation on ARM and a portable fallback elsewhere. Add coverage for representative decode shapes and alpha/beta behavior.

Reviewed By: digantdesai

Differential Revision: D117224614


