### PR TITLE
Add reinplace pass (#22258)

### DIFF
--- a/backends/native/BUCK
+++ b/backends/native/BUCK
@@ -17,6 +17,7 @@ fbcode_target(
         "__init__.py",
         "partitioner.py",
         "passes/__init__.py",
+        "passes/reinplace.py",
         "preprocess.py",
         "serialization/__init__.py",
         "serialization/graph_serialize.py",

--- a/backends/native/partitioner.py
+++ b/backends/native/partitioner.py
@@ -9,15 +9,17 @@ Native backend partitioner.
 
 Claims core ATen ops (torch.Tag.core) plus an explicit opt-in set, and delegates
 whole torch.cond control-flow ops whose branches are fully supported. Graph
-cleanup (CSE) runs before lowering via transform_passes, since ExecuTorch forbids
-a partitioner from mutating the graph module.
+cleanup (CSE, reinplace) runs before lowering via transform_passes, since
+ExecuTorch forbids a partitioner from mutating the graph module.
 """
 
 from typing import Callable, final, List, Mapping, Optional, Tuple
 
 import torch
+from executorch.backends.native.passes import backend_inplace_aten_variants
 
 from executorch.exir.backend.compile_spec_schema import CompileSpec
+
 from executorch.exir.backend.partitioner import (
     DelegationSpec,
     Partitioner,
@@ -52,7 +54,7 @@ PTN_SERIALIZATION_KEY = "serialize_as_ptn"
 
 
 class NativeSupportedOperators(OperatorSupportBase):
-    _NON_CORE = set(_SUPPORTED_NON_CORE_OPS)
+    _NON_CORE = set(_SUPPORTED_NON_CORE_OPS) | backend_inplace_aten_variants()
 
     def is_node_supported(
         self, submodules: Mapping[str, torch.nn.Module], node: Node

--- a/backends/native/passes/__init__.py
+++ b/backends/native/passes/__init__.py
@@ -7,12 +7,33 @@
 """
 Graph transformation passes for the native backend.
 
-Passed to ``to_edge_transform_and_lower`` via its ``transform_passes`` argument so
-they run on the edge-dialect graph before partitioning/delegation. Each pass lives
-in its own module; this package aggregates them and exposes the default pass list.
+These are intended to be passed to ``to_edge_transform_and_lower`` via its
+``transform_passes`` argument, so they run on the edge-dialect graph before
+partitioning/delegation:
+
+    to_edge_transform_and_lower(
+        ep,
+        transform_passes=get_default_passes(),
+        partitioner=[NativePartitioner()],
+        compile_config=EdgeCompileConfig(_check_ir_validity=False),
+    )
+
+reinplace rewrites functional ops into their in-place forms (e.g. relu -> relu_),
+which are not in the core-ATen opset, so callers must disable IR validity
+checking via ``EdgeCompileConfig(_check_ir_validity=False)`` (the same config the
+MLX backend requires).
+
+Each pass lives in its own module; this package aggregates them and exposes the
+default pass list.
 """
 
 from typing import List, Union
+
+from executorch.backends.native.passes.reinplace import (
+    backend_inplace_aten_variants,
+    BACKEND_INPLACE_OPS,
+    NativeReinplacePass,
+)
 
 from executorch.backends.transforms.collapse_view_copy import CollapseViewCopyPass
 
@@ -20,17 +41,22 @@ from executorch.exir.pass_base import ExportedProgramPassBase, ExportPass
 from executorch.exir.passes.cse_pass import CSEPass
 
 __all__ = [
+    "backend_inplace_aten_variants",
+    "BACKEND_INPLACE_OPS",
     "CollapseViewCopyPass",
     "get_default_passes",
+    "NativeReinplacePass",
 ]
 
 
 def get_default_passes() -> List[Union[ExportPass, ExportedProgramPassBase]]:
     """Passes enabled by default for the native backend.
 
-    CSE runs after view_copy collapsing to dedupe the settled graph.
+    view_copy collapsing and CSE run first to settle the graph; reinplace runs
+    last, rewriting functional ops into their in-place edge forms.
     """
     return [
         CollapseViewCopyPass(),
         CSEPass(),
+        NativeReinplacePass(),
     ]

--- a/backends/native/passes/reinplace.py
+++ b/backends/native/passes/reinplace.py
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+reinplace pass for the native backend.
+
+reinplace rewrites functional ops into their in-place forms (e.g. relu -> relu_),
+which are not in the core-ATen opset, so callers must disable IR validity
+checking via ``EdgeCompileConfig(_check_ir_validity=False)`` (the same config the
+MLX backend requires).
+"""
+
+from typing import Tuple
+
+import torch
+
+from executorch.exir.dialects._ops import ops as _edge_ops
+from executorch.exir.pass_base import ExportedProgramPassBase, ExportedProgramPassResult
+
+_edge = _edge_ops.edge.aten
+
+# Single source of truth: base names of the ops the backend can execute in-place.
+# reinplace rewrites the functional edge op to its mutating variant (e.g.
+# relu -> relu_), and the partitioner must claim that variant to keep it in the
+# delegate (see backend_inplace_aten_variants).
+_INPLACE_OP_NAMES: Tuple[str, ...] = (
+    "relu",
+    "gelu",
+    "sigmoid",
+    "index_put",
+    "index_copy",
+)
+
+# Edge ops the backend can execute in-place, consumed as reinplace's op set.
+BACKEND_INPLACE_OPS: frozenset = frozenset(
+    getattr(_edge, name).default for name in _INPLACE_OP_NAMES
+)
+
+
+def backend_inplace_aten_variants() -> set:
+    """Mutating aten variants that reinplace introduces for BACKEND_INPLACE_OPS.
+
+    reinplace rewrites e.g. relu -> aten.relu_.default; those in-place ops are
+    not core-tagged, so the partitioner must claim them explicitly to keep them
+    inside the delegate.
+    """
+    ops = set()
+    for name in _INPLACE_OP_NAMES:
+        packet = getattr(torch.ops.aten, f"{name}_", None)
+        overload = getattr(packet, "default", None) if packet is not None else None
+        if overload is not None:
+            ops.add(overload)
+    return ops
+
+
+class NativeReinplacePass(ExportedProgramPassBase):
+    """Rewrite backend-supported elementwise ops into their in-place edge forms.
+
+    Runs as an EP-aware pass because ``reinplace_pass`` needs ``graph_signature``
+    to protect mutable inputs/buffers. A fresh op set is passed each call so
+    ``reinplace_pass`` cannot mutate shared state, and passing an explicit
+    ``ops_to_inplace`` fully replaces reinplace's default set.
+    """
+
+    def call(self, exported_program) -> ExportedProgramPassResult:
+        from executorch.exir.passes.reinplace import reinplace_pass
+
+        exported_program = reinplace_pass(
+            exported_program, ops_to_inplace=set(BACKEND_INPLACE_OPS)
+        )
+        return ExportedProgramPassResult(exported_program, True)

--- a/backends/native/test/test_partitioner.py
+++ b/backends/native/test/test_partitioner.py
@@ -18,7 +18,10 @@ from executorch.backends.native.partitioner import (
     NativeSupportedOperators,
     PTN_SERIALIZATION_KEY,
 )
-from executorch.backends.native.passes import get_default_passes
+from executorch.backends.native.passes import (
+    backend_inplace_aten_variants,
+    get_default_passes,
+)
 from executorch.backends.native.serialization import deserialize_graph
 from executorch.backends.native.serialization.schema import GraphArg
 from executorch.exir import to_edge_transform_and_lower
@@ -64,6 +67,18 @@ class NativeSupportedOperatorsTest(unittest.TestCase):
         # Every op in the explicit opt-in set is claimed.
         for op in _SUPPORTED_NON_CORE_OPS:
             with self.subTest(op=str(op)):
+                self.assertTrue(
+                    self.sup.is_node_supported({}, _make_node("call_function", op))
+                )
+
+    def test_accepts_inplace_aten_variants(self):
+        # reinplace rewrites e.g. relu -> relu_; the mutating variants are not
+        # core-tagged, so the partitioner must claim them explicitly.
+        variants = backend_inplace_aten_variants()
+        self.assertTrue(variants)
+        for op in variants:
+            with self.subTest(op=str(op)):
+                self.assertNotIn(torch.Tag.core, op.tags)
                 self.assertTrue(
                     self.sup.is_node_supported({}, _make_node("call_function", op))
                 )

--- a/backends/native/test/test_passes.py
+++ b/backends/native/test/test_passes.py
@@ -8,8 +8,9 @@ import unittest
 
 import torch
 import torch.nn as nn
-
 from executorch.backends.native import get_default_compile_config
+
+from executorch.backends.native.passes.reinplace import NativeReinplacePass
 from executorch.exir import to_edge
 from executorch.exir.passes.cse_pass import CSEPass
 
@@ -37,3 +38,23 @@ class CSEPassTest(unittest.TestCase):
             if n.op == "call_function" and "add" in str(n.target)
         ]
         self.assertEqual(len(adds), 1, f"expected CSE to leave one add, got {adds}")
+
+
+class NativeReinplacePassTest(unittest.TestCase):
+    def test_rewrites_relu_in_place(self):
+        class ReluModel(nn.Module):
+            def forward(self, x):
+                # relu on an intermediate (x + 1) can be rewritten in place;
+                # relu directly on the immutable user input x cannot.
+                return torch.relu(x + 1)
+
+        ep = _transformed(ReluModel(), (torch.randn(4, 4),), [NativeReinplacePass()])
+        targets = [
+            str(n.target)
+            for n in ep.graph_module.graph.nodes
+            if n.op == "call_function"
+        ]
+        self.assertTrue(
+            any("relu_" in t for t in targets),
+            f"expected in-place relu_, got {targets}",
+        )

--- a/backends/native/test/test_preprocess.py
+++ b/backends/native/test/test_preprocess.py
@@ -164,6 +164,23 @@ class PreprocessSerializationTest(unittest.TestCase):
             )
         )
 
+    def test_reinplace_produces_inplace_relu(self):
+        class ReluModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = nn.Linear(8, 8)
+
+            def forward(self, x):
+                return torch.relu(self.linear(x))
+
+        blob = _get_delegate_blob(_lower(ReluModel(), (torch.randn(1, 8),)))
+        graph = deserialize_graph(blob)
+        targets = _call_function_targets(graph)
+        self.assertTrue(
+            any(t is not None and "relu_" in t for t in targets),
+            f"expected in-place relu_, got {targets}",
+        )
+
     def test_constants_shipped_via_named_data(self):
         edge = _lower(nn.Linear(4, 4), (torch.randn(1, 4),))
         blob = _get_delegate_blob(edge)


### PR DESCRIPTION
Summary:

NativeReinplacePass rewrites backend-supported functional edge ops into their
in-place forms (e.g. relu -> relu_) and is appended to get_default_passes().
The partitioner claims the resulting in-place aten variants (via
backend_inplace_aten_variants) so they stay inside the delegate.

Reviewed By: digantdesai

Differential Revision: D113936371


