### PR TITLE
Stabilize random model tests (#22262)

### DIFF
--- a/backends/xnnpack/test/models/llama2_et_example.py
+++ b/backends/xnnpack/test/models/llama2_et_example.py
@@ -17,9 +17,11 @@ class TestLlama2ETExample(unittest.TestCase):
         torch._dynamo.reset()
 
     def test_f32(self):
+        torch.manual_seed(0)
         self._test()
 
     def test_f16(self):
+        torch.manual_seed(0)
         self._test(torch.float16)
 
     # TODO - dynamic shape
@@ -31,7 +33,17 @@ class TestLlama2ETExample(unittest.TestCase):
         ], f"Only fp32 and fp16 are supported, but got dtype: {dtype}"
 
         llama2 = Llama2Model()
-        model = llama2.get_eager_model().to(dtype)
+        model = llama2.get_eager_model()
+        # This example uses random weights. Keep them and the floating-point
+        # buffers in a small range so fp16 intermediates do not overflow to
+        # inf/nan and make the backend comparison depend on random state.
+        with torch.no_grad():
+            for parameter in model.parameters():
+                parameter.uniform_(-0.02, 0.02)
+            for buffer in model.buffers():
+                if buffer.is_floating_point():
+                    buffer.uniform_(-0.02, 0.02)
+        model = model.to(dtype)
 
         # Only convert fp32 inputs to dtype
         example_inputs = tuple(

--- a/backends/xnnpack/test/ops/test_linear.py
+++ b/backends/xnnpack/test/ops/test_linear.py
@@ -559,6 +559,7 @@ class TestLinear(unittest.TestCase):
                 # )
 
     def test_qd8_f32_per_channel_shared_dq_chain(self):
+        torch.manual_seed(42)
         for use_bias in (False, True):
             module = SharedDQChain(
                 input_size=13,
@@ -573,6 +574,7 @@ class TestLinear(unittest.TestCase):
                 is_per_channel=True,
                 linear_count=2,
                 uses_bias=use_bias,
+                atol=1.5e-1,  # TODO(T212995726): Investigate right atol for rand[n] inputs
             )
 
     def _test_qd8_per_channel_linear(self, dtype: torch.dtype = torch.float):


### PR DESCRIPTION
Summary:

Make the random Llama2 and shared dynamic-quantized linear tests deterministic. Bound the dummy Llama model parameters and floating buffers before fp16 conversion so intermediate values remain finite, and use the established tolerance for the shared-DQ chain.

This supersedes the stale D105619114 and addresses the currently broken TestX entries for TestLlama2ETExample.test_f16 and TestLinear.test_qd8_f32_per_channel_shared_dq_chain.

Reviewed By: rascani

Differential Revision: D117755472


