### PR TITLE
Import transformers only where the LLM runner needs it

### DIFF
--- a/extension/llm/runner/__init__.py
+++ b/extension/llm/runner/__init__.py
@@ -35,10 +35,16 @@ except ImportError:
 
 
 import logging
-from typing import Callable, List, Optional, TYPE_CHECKING, Union
+from typing import Any, Callable, List, Optional, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from transformers.feature_extraction_utils import BatchFeature
+else:
+    # A runtime stand-in, so the annotations below stay resolvable without transformers. They
+    # name BatchFeature as a string, and typing.get_type_hints evaluates those strings in this
+    # module's namespace, so a name that only exists under TYPE_CHECKING makes that call raise
+    # NameError, even on an install that has transformers.
+    BatchFeature = Any
 
 
 def _is_batch_feature(inputs) -> bool:

--- a/extension/llm/runner/__init__.py
+++ b/extension/llm/runner/__init__.py
@@ -41,17 +41,24 @@ if TYPE_CHECKING:
     from transformers.feature_extraction_utils import BatchFeature
 
 
-def _batch_feature_type():
-    """The HuggingFace BatchFeature class, imported on use.
+def _is_batch_feature(inputs) -> bool:
+    """Whether `inputs` is a HuggingFace BatchFeature.
 
-    transformers is not a dependency of this package, and only the generate_hf helpers
-    below need it, so importing it at module scope made the whole runner unimportable on
-    an install that has no transformers, including the compiled extension imported above
-    that has nothing to do with HuggingFace.
+    transformers is not a dependency of this package, and only the generate_hf helpers below
+    need it, so importing it at module scope made the whole runner unimportable on an install
+    that has no transformers, including the compiled extension imported above that has nothing
+    to do with HuggingFace.
+
+    A missing transformers answers no rather than raising. Nothing can be a BatchFeature when
+    the class does not exist, and raising here would turn "this input is the wrong type" into a
+    missing dependency error for a caller who never intended to use HuggingFace at all.
     """
-    from transformers.feature_extraction_utils import BatchFeature
+    try:
+        from transformers.feature_extraction_utils import BatchFeature
+    except ImportError:
+        return False
 
-    return BatchFeature
+    return isinstance(inputs, BatchFeature)
 
 
 def _find_image_token_runs(
@@ -192,15 +199,16 @@ def generate_hf(
     stats_callback: Optional[Callable[[Stats], None]] = None,
 ) -> None:
     """Generate using an BatchFeature by converting to multimodal inputs internally, or using a list of MultimodalInput."""
-    if isinstance(inputs, _batch_feature_type()):
+    # The list form is tested first because it needs nothing from HuggingFace. Resolving
+    # BatchFeature to compare against it would import transformers, which this package does not
+    # declare, so a caller passing a list would fail on a dependency its own input never needs.
+    if isinstance(inputs, list) and all(isinstance(i, MultimodalInput) for i in inputs):
+        converted = inputs
+    elif _is_batch_feature(inputs):
         logging.info(
             "Input is a BatchFeature, assuming it's coming from HF AutoProcessor.apply_chat_template(). Converting to multimodal inputs."
         )
         converted = _hf_to_multimodal_inputs(inputs, image_token_id=image_token_id)
-    elif isinstance(inputs, list) and all(
-        isinstance(i, MultimodalInput) for i in inputs
-    ):
-        converted = inputs
     else:
         raise RuntimeError(
             "inputs must be either a BatchFeature (from HF AutoProcessor) or a list of MultimodalInput"
@@ -216,15 +224,16 @@ def generate_text_hf(
     image_token_id: Optional[int] = None,
 ) -> str:
     """Generate using an BatchFeature by converting to multimodal inputs internally, or using a list of MultimodalInput."""
-    if isinstance(inputs, _batch_feature_type()):
+    # The list form is tested first because it needs nothing from HuggingFace. Resolving
+    # BatchFeature to compare against it would import transformers, which this package does not
+    # declare, so a caller passing a list would fail on a dependency its own input never needs.
+    if isinstance(inputs, list) and all(isinstance(i, MultimodalInput) for i in inputs):
+        converted = inputs
+    elif _is_batch_feature(inputs):
         logging.info(
             "Input is a BatchFeature, assuming it's coming from HF AutoProcessor.apply_chat_template(). Converting to multimodal inputs."
         )
         converted = _hf_to_multimodal_inputs(inputs, image_token_id=image_token_id)
-    elif isinstance(inputs, list) and all(
-        isinstance(i, MultimodalInput) for i in inputs
-    ):
-        converted = inputs
     else:
         raise RuntimeError(
             "inputs must be either a BatchFeature (from HF AutoProcessor) or a list of MultimodalInput"

--- a/extension/llm/runner/__init__.py
+++ b/extension/llm/runner/__init__.py
@@ -35,9 +35,23 @@ except ImportError:
 
 
 import logging
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, TYPE_CHECKING, Union
 
-from transformers.feature_extraction_utils import BatchFeature
+if TYPE_CHECKING:
+    from transformers.feature_extraction_utils import BatchFeature
+
+
+def _batch_feature_type():
+    """The HuggingFace BatchFeature class, imported on use.
+
+    transformers is not a dependency of this package, and only the generate_hf helpers
+    below need it, so importing it at module scope made the whole runner unimportable on
+    an install that has no transformers, including the compiled extension imported above
+    that has nothing to do with HuggingFace.
+    """
+    from transformers.feature_extraction_utils import BatchFeature
+
+    return BatchFeature
 
 
 def _find_image_token_runs(
@@ -68,7 +82,7 @@ def _find_image_token_runs(
 
 
 def _hf_to_multimodal_inputs(  # noqa: C901
-    inputs: BatchFeature, image_token_id: Optional[int] = None
+    inputs: "BatchFeature", image_token_id: Optional[int] = None
 ) -> List[MultimodalInput]:
     """Convert a HuggingFace AutoProcessor dict to ExecuTorch MultimodalInputs.
     Currently only support 1 image inside the input.
@@ -171,14 +185,14 @@ def _hf_to_multimodal_inputs(  # noqa: C901
 
 def generate_hf(
     runner: MultimodalRunner,
-    inputs: Union[BatchFeature, List[MultimodalInput]],
+    inputs: Union["BatchFeature", List[MultimodalInput]],
     config: GenerationConfig,
     image_token_id: Optional[int] = None,
     token_callback: Optional[Callable[[str], None]] = None,
     stats_callback: Optional[Callable[[Stats], None]] = None,
 ) -> None:
     """Generate using an BatchFeature by converting to multimodal inputs internally, or using a list of MultimodalInput."""
-    if isinstance(inputs, BatchFeature):
+    if isinstance(inputs, _batch_feature_type()):
         logging.info(
             "Input is a BatchFeature, assuming it's coming from HF AutoProcessor.apply_chat_template(). Converting to multimodal inputs."
         )
@@ -197,12 +211,12 @@ def generate_hf(
 
 def generate_text_hf(
     runner: MultimodalRunner,
-    inputs: Union[BatchFeature, List[MultimodalInput]],
+    inputs: Union["BatchFeature", List[MultimodalInput]],
     config: GenerationConfig,
     image_token_id: Optional[int] = None,
 ) -> str:
     """Generate using an BatchFeature by converting to multimodal inputs internally, or using a list of MultimodalInput."""
-    if isinstance(inputs, BatchFeature):
+    if isinstance(inputs, _batch_feature_type()):
         logging.info(
             "Input is a BatchFeature, assuming it's coming from HF AutoProcessor.apply_chat_template(). Converting to multimodal inputs."
         )


### PR DESCRIPTION
## Summary

Importing the LLM runner from a plain wheel install fails:

```
>>> import executorch.extension.llm.runner
ModuleNotFoundError: No module named 'transformers'
```

`transformers` is not a dependency of this package and the wheel does not install it, but
`extension/llm/runner/__init__.py` imported `BatchFeature` from it at module scope. So the
entire runner was unreachable, including the compiled `_llm_runner` extension the wheel
ships. That extension is around 3 MB and has nothing to do with HuggingFace.

## The change

Only two functions need that class: `generate_hf` and `generate_text_hf`. Both exist
specifically to accept output from a HuggingFace `AutoProcessor`, so anyone calling them
already has `transformers` installed.

The class is now looked up when one of those functions runs, rather than when the module
loads. The annotations that mention it became strings under `TYPE_CHECKING`, so type
checkers still resolve it normally.

Nothing changes for users who have `transformers`: the same class object is used, so the
`isinstance` checks and the conversion behave exactly as before. For users who do not, the
runner imports fine and only the two `hf` helpers raise, naming the package that is
missing.

## Test plan

Ran against the installed wheel on macOS arm64, from a directory containing no checkout.

Without `transformers`:

| | result |
| --- | --- |
| before | `ModuleNotFoundError: No module named 'transformers'` |
| after | import OK, `MultimodalRunner` present, both `hf` helpers attached |
| after, calling `generate_hf` | still raises, naming `transformers` |

With `transformers` installed, confirming behaviour is unchanged:

```
_batch_feature_type() is transformers' BatchFeature   True
isinstance(BatchFeature(...), resolved)               True
_hf_to_multimodal_inputs(BatchFeature(...))           1 MultimodalInput
```
