### PR TITLE
Record why scikit-learn is a real dependency, not a mistaken one

### DIFF
--- a/.ci/scripts/tests/test_coreml_markers.py
+++ b/.ci/scripts/tests/test_coreml_markers.py
@@ -218,18 +218,15 @@ def test_conftest_matches_the_coremltools_marker(system, machine, sys_platform, 
     )
 
 
-@pytest.mark.parametrize("system,machine,sys_platform", PLATFORMS)
-@pytest.mark.parametrize("python", PYTHONS)
-def test_scikit_learn_follows_coremltools(system, machine, sys_platform, python):
-    # scikit-learn is there for coremltools' palettization, so it is only useful where
-    # coremltools is. Nothing else in the wheel imports scikit-learn itself; scipy, which
-    # used to arrive as its transitive dependency, is declared in requirements-examples.txt
-    # for the code that does import it.
-    assert _marker_says_installed(
-        _base_dependency("scikit-learn"), system, machine, sys_platform, python
-    ) == _marker_says_installed(
-        _base_dependency("coremltools"), system, machine, sys_platform, python
-    )
+def test_scikit_learn_is_not_a_base_dependency():
+    # scikit-learn was declared here to follow coremltools, on the understanding that
+    # coremltools needed it for palettization. It does not: the flag it sets, _HAS_SKLEARN,
+    # gates coremltools' converter for scikit-learn's own model types, which nothing here
+    # converts. The declared floor was also above the ceiling coremltools accepts, so the
+    # resolved version was always rejected. requirements-examples.txt declares it for the
+    # example scripts that really do import it.
+    with pytest.raises(AssertionError):
+        _base_dependency("scikit-learn")
 
 
 def test_the_platforms_core_ml_is_used_on_are_still_covered():

--- a/.ci/scripts/tests/test_coreml_markers.py
+++ b/.ci/scripts/tests/test_coreml_markers.py
@@ -218,15 +218,20 @@ def test_conftest_matches_the_coremltools_marker(system, machine, sys_platform, 
     )
 
 
-def test_scikit_learn_is_not_a_base_dependency():
-    # scikit-learn was declared here to follow coremltools, on the understanding that
-    # coremltools needed it for palettization. It does not: the flag it sets, _HAS_SKLEARN,
-    # gates coremltools' converter for scikit-learn's own model types, which nothing here
-    # converts. The declared floor was also above the ceiling coremltools accepts, so the
-    # resolved version was always rejected. requirements-examples.txt declares it for the
-    # example scripts that really do import it.
-    with pytest.raises(AssertionError):
-        _base_dependency("scikit-learn")
+@pytest.mark.parametrize("system,machine,sys_platform", PLATFORMS)
+@pytest.mark.parametrize("python", PYTHONS)
+def test_scikit_learn_follows_coremltools(system, machine, sys_platform, python):
+    # coremltools needs scikit-learn to palettize weights, so it is only useful where
+    # coremltools is. Nothing here imports scikit-learn directly, and coremltools does not
+    # reach it through the _HAS_SKLEARN flag either: quantization_utils.py imports
+    # sklearn.cluster.KMeans at the point of use, on the default clustering path. So the
+    # CODEBOOK_WEIGHT_ONLY recipe fails without this entry even though _HAS_SKLEARN is False,
+    # and the two must stay tied together.
+    assert _marker_says_installed(
+        _base_dependency("scikit-learn"), system, machine, sys_platform, python
+    ) == _marker_says_installed(
+        _base_dependency("coremltools"), system, machine, sys_platform, python
+    )
 
 
 def test_the_platforms_core_ml_is_used_on_are_still_covered():

--- a/setup.py
+++ b/setup.py
@@ -696,6 +696,22 @@ def _base_dependencies() -> List[str]:
         # with coremltools 9.0 on a Linux aarch64 machine. Keep this in sync with the condition
         # in conftest.py; .ci/scripts/tests/test_coreml_markers.py checks that the two agree.
         "coremltools==9.0; (platform_system == 'Darwin' or (platform_system == 'Linux' and platform_machine == 'x86_64')) and python_version < '3.14'",
+        # coremltools needs scikit-learn to palettize weights, so it follows coremltools.
+        # Without a marker it also installed where coremltools does not, most visibly on
+        # Windows, and brought scipy with it.
+        #
+        # Nothing here imports scikit-learn directly. coremltools does, and not through the
+        # _HAS_SKLEARN flag it sets: quantization_utils.py imports sklearn.cluster.KMeans at the
+        # point of use, and that is the default clustering path, taken unless the weight is a
+        # single column of at least ten thousand float16 values. So the CODEBOOK_WEIGHT_ONLY
+        # recipe raises ModuleNotFoundError without this, whatever _HAS_SKLEARN says.
+        #
+        # The floor is above the version coremltools accepts for its own scikit-learn model
+        # converter, which is why that converter reports itself disabled. That is a separate
+        # feature nothing here uses, and palettization does not check the version, so the two
+        # are unrelated. Measured with coremltools 9.0 and scikit-learn 1.9.0: the converter is
+        # off and palettization works.
+        "scikit-learn>=1.7.1; (platform_system == 'Darwin' or (platform_system == 'Linux' and platform_machine == 'x86_64')) and python_version < '3.14'",
         "hydra-core>=1.3.0",
         "omegaconf>=2.3.0",
     ]

--- a/setup.py
+++ b/setup.py
@@ -696,12 +696,6 @@ def _base_dependencies() -> List[str]:
         # with coremltools 9.0 on a Linux aarch64 machine. Keep this in sync with the condition
         # in conftest.py; .ci/scripts/tests/test_coreml_markers.py checks that the two agree.
         "coremltools==9.0; (platform_system == 'Darwin' or (platform_system == 'Linux' and platform_machine == 'x86_64')) and python_version < '3.14'",
-        # coremltools uses scikit-learn for palettization, so it follows coremltools. Without a
-        # marker it also installed where coremltools does not, most visibly on Windows, and
-        # brought scipy with it. Nothing in this repository imports scikit-learn from the Core
-        # ML backend; the example scripts that do import it, and the scripts that import scipy,
-        # now name both in requirements-examples.txt rather than relying on this entry.
-        "scikit-learn>=1.7.1; (platform_system == 'Darwin' or (platform_system == 'Linux' and platform_machine == 'x86_64')) and python_version < '3.14'",
         "hydra-core>=1.3.0",
         "omegaconf>=2.3.0",
     ]


### PR DESCRIPTION
## Summary

This started as a removal and became a comment fix, because the removal was wrong.

The reading was that `scikit-learn>=1.7.1` could never work: coremltools 9.0 accepts scikit-learn
only up to 1.5.1, so `_HAS_SKLEARN` is always False and coremltools reports its scikit-learn
support disabled on every install.

That is all true, and the conclusion drawn from it was still wrong. **coremltools does not reach
scikit-learn only through that flag.** `quantization_utils.py` imports `sklearn.cluster.KMeans` at
the point of use, and that is the *default* clustering path, taken unless the weight is a single
column of at least ten thousand float16 values. So palettization needs scikit-learn whatever
`_HAS_SKLEARN` says, and the `CODEBOOK_WEIGHT_ONLY` recipe this repo exposes fails without it:

```
ModuleNotFoundError: scikit-learn is required for k-means quantization.
```

The version ceiling and the palettization path are simply unrelated. The ceiling gates
coremltools' converter for scikit-learn's *own* model types, which nothing here uses.
Palettization never checks the version.

## So what changed

Nothing functional. The dependency stays exactly as it is.

What was wrong was the comment. It said nothing here imports scikit-learn, which is true but
misleading, and it did not explain why an apparently unsatisfiable pin is correct. Anyone auditing
dependencies would reach the same wrong conclusion I did, and might act on it. The comment now
records the real reason, and the test tying this entry to coremltools says why they cannot be
separated.

## Test plan

Measured with coremltools 9.0 on macOS arm64:

| environment | result |
| --- | --- |
| scikit-learn 1.9.0 present | `_HAS_SKLEARN` False, palettization works, lut shape `(16, 1)` |
| scikit-learn absent | `ModuleNotFoundError` from `quantization_utils.py` |

Which confirms both halves: the converter really is disabled, and palettization is unaffected by
that.

`.ci/scripts/tests/test_coreml_markers.py` passes, 167 tests.
