### PR TITLE
Stop the Qualcomm backend from doing setup work at import time

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1059,6 +1059,10 @@ jobs:
         # Run QNN pass unit tests
         pytest -xvs backends/qualcomm/tests/test_passes.py
 
+        # And the checks that importing the backend has no side effects. These need no SDK and
+        # no device, but they do need the package importable, which this job already arranges.
+        pytest -xvs backends/qualcomm/tests/test_import_side_effects.py
+
   test-qnn-delegate-linux:
     name: test-qnn-delegate-linux
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main

--- a/backends/qualcomm/__init__.py
+++ b/backends/qualcomm/__init__.py
@@ -1,4 +1,5 @@
 import os
+import threading
 
 # The Qualcomm SDK setup below is deferred rather than run here, so that importing this
 # package has no side effects. It used to run at import time, which meant that merely
@@ -17,17 +18,31 @@ from .scripts.download_qnn_sdk import (  # noqa: F401
 )
 
 _sdk_ready = False
+# Guards the flag above. Python's import lock does not, because the setup is now called from
+# several modules rather than from one package __init__, and two threads importing two of them
+# concurrently would otherwise both run an installer that downloads and rewrites the
+# environment.
+_sdk_lock = threading.Lock()
 
 
 def setup_qnn_sdk() -> None:
     """Make the Qualcomm SDK usable in this process, once.
 
-    Safe to call repeatedly: the work happens on the first call and later calls return
-    immediately. Called by the code paths that need the SDK, so a caller does not have to.
+    Safe to call repeatedly and from more than one thread: the work happens on the first call and
+    later calls return immediately. Called by the code paths that need the SDK, so a caller does
+    not have to.
     """
-    global _sdk_ready
     if _sdk_ready:
         return
+    with _sdk_lock:
+        # Another thread may have finished while this one waited.
+        if _sdk_ready:
+            return
+        _setup_qnn_sdk_locked()
+
+
+def _setup_qnn_sdk_locked() -> None:
+    global _sdk_ready
 
     # The wheel build imports this package to collect its files, and has no use for an SDK.
     if os.getenv("EXECUTORCH_BUILDING_WHEEL", "0").lower() in ("1", "true", "yes"):

--- a/backends/qualcomm/__init__.py
+++ b/backends/qualcomm/__init__.py
@@ -80,9 +80,12 @@ def _setup_qnn_sdk_locked() -> None:
 def disable_mkldnn_on_amd() -> None:
     """Turn off PyTorch's MKLDNN backend on an AMD host.
 
-    Compiling for QNN produces wrong results on AMD with MKLDNN enabled. This changes a
-    global PyTorch setting, so it is applied by the QNN compile paths rather than at import,
-    where it would also change how unrelated models run in the same interpreter.
+    MKLDNN crashes on some AMD hosts, which is why this exists. The original comment described
+    it as producing wrong results; what was measured is a core dump, from a plain convolution
+    with nothing from this backend involved.
+
+    This changes a global PyTorch setting, so it is applied by the QNN compile paths rather than
+    at import, where it would also change how unrelated models run in the same interpreter.
     """
     import torch
 

--- a/backends/qualcomm/__init__.py
+++ b/backends/qualcomm/__init__.py
@@ -1,41 +1,81 @@
 import os
 
-import torch
+# The Qualcomm SDK setup below is deferred rather than run here, so that importing this
+# package has no side effects. It used to run at import time, which meant that merely
+# importing the package downloaded the SDK and libc++ over the network, re-executed the
+# interpreter under a staged loader, rewrote QNN_SDK_ROOT and LD_LIBRARY_PATH, and raised
+# when a machine had no network. It also disabled PyTorch's MKLDNN backend for the whole
+# process on any AMD host, which affects every other model in that interpreter.
+#
+# Nothing about loading this package needs any of that. The native adaptor does not link
+# the SDK; it resolves QNN symbols with dlopen when a model is actually compiled, and says
+# so plainly when they are missing. So setup happens on the first call that needs it.
+from .scripts.download_qnn_sdk import (  # noqa: F401
+    install_qnn_sdk,
+    is_linux_x86,
+    QNN_ZIP_URL,
+)
 
-from .scripts.download_qnn_sdk import install_qnn_sdk, is_linux_x86, QNN_ZIP_URL
-
-try:
-    import cpuinfo
-
-    info = cpuinfo.get_cpu_info()
-    vendor = info.get("vendor_id_raw", "").lower()
-    if "amd" in vendor:
-        torch.backends.mkldnn.enabled = False
-except ImportError:
-    raise ImportError("Please install the cpuinfo with pip install py-cpuinfo.")
+_sdk_ready = False
 
 
-env_flag = os.getenv("EXECUTORCH_BUILDING_WHEEL", "0").lower()
-# If users have preinstalled QNN_SDK_ROOT, we will use it.
-qnn_sdk_root_flag = os.getenv("QNN_SDK_ROOT", None)
+def setup_qnn_sdk() -> None:
+    """Make the Qualcomm SDK usable in this process, once.
 
-if env_flag not in ("1", "true", "yes"):
-    if qnn_sdk_root_flag:
-        print(
-            f"[QNN] Using QNN SDK at {qnn_sdk_root_flag} (from QNN_SDK_ROOT)",
-            flush=True,
+    Safe to call repeatedly: the work happens on the first call and later calls return
+    immediately. Called by the code paths that need the SDK, so a caller does not have to.
+    """
+    global _sdk_ready
+    if _sdk_ready:
+        return
+
+    # The wheel build imports this package to collect its files, and has no use for an SDK.
+    if os.getenv("EXECUTORCH_BUILDING_WHEEL", "0").lower() in ("1", "true", "yes"):
+        _sdk_ready = True
+        return
+
+    # A preinstalled SDK is used as it is.
+    qnn_sdk_root = os.getenv("QNN_SDK_ROOT", None)
+    if qnn_sdk_root:
+        print(f"[QNN] Using QNN SDK at {qnn_sdk_root} (from QNN_SDK_ROOT)", flush=True)
+        _sdk_ready = True
+        return
+
+    # Downloading a prebuilt SDK is only possible for the platform it is published for.
+    if not is_linux_x86():
+        _sdk_ready = True
+        return
+
+    if not install_qnn_sdk():
+        raise RuntimeError(
+            "Failed to set up QNN SDK.\n\n"
+            "To resolve, try one of:\n"
+            "  1. Download the SDK manually from:\n"
+            f"       {QNN_ZIP_URL}\n"
+            "     Or go to step 2 if QNN SDK already exists.\n"
+            "  2. Set QNN_SDK_ROOT to an existing SDK installation:\n"
+            "       export QNN_SDK_ROOT=/path/to/qualcomm/sdk\n"
+            "       export LD_LIBRARY_PATH="
+            "$QNN_SDK_ROOT/lib/x86_64-linux-clang/:$LD_LIBRARY_PATH"
         )
-    elif is_linux_x86():
-        ok = install_qnn_sdk()
-        if not ok:
-            raise RuntimeError(
-                "Failed to set up QNN SDK.\n\n"
-                "To resolve, try one of:\n"
-                "  1. Download the SDK manually from:\n"
-                f"       {QNN_ZIP_URL}\n"
-                "     Or go to step 2 if QNN SDK already exists.\n"
-                "  2. Set QNN_SDK_ROOT to an existing SDK installation:\n"
-                "       export QNN_SDK_ROOT=/path/to/qualcomm/sdk\n"
-                "       export LD_LIBRARY_PATH="
-                "$QNN_SDK_ROOT/lib/x86_64-linux-clang/:$LD_LIBRARY_PATH"
-            )
+
+    _sdk_ready = True
+
+
+def disable_mkldnn_on_amd() -> None:
+    """Turn off PyTorch's MKLDNN backend on an AMD host.
+
+    Compiling for QNN produces wrong results on AMD with MKLDNN enabled. This changes a
+    global PyTorch setting, so it is applied by the QNN compile paths rather than at import,
+    where it would also change how unrelated models run in the same interpreter.
+    """
+    import torch
+
+    try:
+        import cpuinfo
+    except ImportError:
+        raise ImportError("Please install the cpuinfo with pip install py-cpuinfo.")
+
+    vendor = cpuinfo.get_cpu_info().get("vendor_id_raw", "") or ""
+    if "amd" in vendor.lower():
+        torch.backends.mkldnn.enabled = False

--- a/backends/qualcomm/builders/node_visitor.py
+++ b/backends/qualcomm/builders/node_visitor.py
@@ -4,10 +4,18 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# The SDK has to be reachable before the native adaptor below is loaded, and every builder
+# in this package imports this module, so this is where it is ensured. It is not done in
+# the package's __init__, because that made simply importing the package fetch an SDK over
+# the network and change a global PyTorch setting.
+from executorch.backends.qualcomm import disable_mkldnn_on_amd, setup_qnn_sdk
+
+setup_qnn_sdk()
+disable_mkldnn_on_amd()
+
 from typing import Any, Dict, Optional, Tuple
 
 import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManager
-
 import numpy as np
 import torch
 from executorch.backends.qualcomm.utils.constants import (
@@ -33,7 +41,6 @@ from executorch.backends.qualcomm.utils.constants import (
     QCOM_ZERO_POINT,
     QCOM_ZERO_POINTS,
 )
-
 from executorch.exir.dialects._ops import ops as exir_ops
 
 from .utils import (
@@ -45,7 +52,6 @@ from .utils import (
     is_mutable_buffer_output,
     is_parameter,
 )
-
 
 QNN_QUANT_TYPE_MAP = {
     torch.int8: PyQnnManager.Qnn_DataType_t.QNN_DATATYPE_SFIXED_POINT_8,

--- a/backends/qualcomm/builders/node_visitor.py
+++ b/backends/qualcomm/builders/node_visitor.py
@@ -4,10 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# The SDK has to be reachable before the native adaptor below is loaded, and every builder
-# in this package imports this module, so this is where it is ensured. It is not done in
-# the package's __init__, because that made simply importing the package fetch an SDK over
-# the network and change a global PyTorch setting.
+# The SDK has to be usable before a model is compiled, and every builder in this package
+# imports this module, so this is where it is arranged. Not in the package's __init__, because
+# that made simply importing the package fetch an SDK over the network and change a global
+# PyTorch setting.
+#
+# The adaptor imported below does not itself need the SDK to load: it links no QNN library and
+# resolves those symbols with dlopen when a backend is started. Placing the call here is about
+# covering the compile paths, not about ordering against that import.
 from executorch.backends.qualcomm import disable_mkldnn_on_amd, setup_qnn_sdk
 
 setup_qnn_sdk()

--- a/backends/qualcomm/debugger/utils.py
+++ b/backends/qualcomm/debugger/utils.py
@@ -6,12 +6,17 @@ import subprocess
 import tempfile
 from typing import Sequence, Tuple
 
+# Loading the native adaptor below needs the SDK reachable. See node_visitor.py for why
+# this is here rather than in the package's __init__.
+from executorch.backends.qualcomm import setup_qnn_sdk
+
+setup_qnn_sdk()
+
 import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManager
 import pandas as pd
 import torch
 from executorch.backends.qualcomm.serialization.qc_schema import QcomChipset
 from executorch.backends.qualcomm.utils.utils import dump_context_from_pte
-
 from graphviz import Digraph
 
 

--- a/backends/qualcomm/debugger/utils.py
+++ b/backends/qualcomm/debugger/utils.py
@@ -6,8 +6,8 @@ import subprocess
 import tempfile
 from typing import Sequence, Tuple
 
-# Loading the native adaptor below needs the SDK reachable. See node_visitor.py for why
-# this is here rather than in the package's __init__.
+# The SDK has to be usable before a model is compiled. See node_visitor.py for why this is
+# here rather than in the package's __init__.
 from executorch.backends.qualcomm import setup_qnn_sdk
 
 setup_qnn_sdk()

--- a/backends/qualcomm/quantizer/validators.py
+++ b/backends/qualcomm/quantizer/validators.py
@@ -8,9 +8,9 @@ import logging
 from dataclasses import dataclass, field
 from typing import cast, Dict, List, Optional, Set, Tuple
 
-# Loading the native adaptor below needs the SDK reachable. See node_visitor.py for why this
-# is here rather than in the package's __init__. Ahead of the adaptor import specifically:
-# this module imports it before it imports node_visitor, so it cannot rely on that.
+# The SDK has to be usable before a model is compiled. See node_visitor.py for why this is
+# here rather than in the package's __init__. Called from this module too because it does not
+# import node_visitor before the adaptor, so it cannot leave the call to that module.
 from executorch.backends.qualcomm import setup_qnn_sdk
 
 setup_qnn_sdk()

--- a/backends/qualcomm/quantizer/validators.py
+++ b/backends/qualcomm/quantizer/validators.py
@@ -8,6 +8,13 @@ import logging
 from dataclasses import dataclass, field
 from typing import cast, Dict, List, Optional, Set, Tuple
 
+# Loading the native adaptor below needs the SDK reachable. See node_visitor.py for why this
+# is here rather than in the package's __init__. Ahead of the adaptor import specifically:
+# this module imports it before it imports node_visitor, so it cannot rely on that.
+from executorch.backends.qualcomm import setup_qnn_sdk
+
+setup_qnn_sdk()
+
 import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManager
 import torch
 from executorch.backends.qualcomm.builders.node_visitor import (

--- a/backends/qualcomm/tests/test_import_side_effects.py
+++ b/backends/qualcomm/tests/test_import_side_effects.py
@@ -17,8 +17,11 @@ These are unit tests because the behaviour under test is what happens during imp
 is observable without a Qualcomm SDK or a Qualcomm device.
 """
 
+import ast
+import importlib
 import sys
 import types
+from pathlib import Path
 
 import executorch.backends.qualcomm as qnn
 import pytest
@@ -40,28 +43,45 @@ def fake_cpuinfo(monkeypatch):
 def test_importing_the_package_leaves_mkldnn_alone(monkeypatch, fake_cpuinfo):
     """Import must not change a global PyTorch setting, even on an AMD host.
 
-    The setting affects every model in the interpreter, not just a Qualcomm one, so an
-    import that flips it changes how unrelated code runs.
+    The setting affects every model in the interpreter, not just a Qualcomm one, so an import
+    that flips it changes how unrelated code runs.
+
+    A reload is used deliberately: it re-executes every module level statement, which is exactly
+    what an import does, and the stubbed cpuinfo is read inside those statements rather than
+    bound at import, so unlike a stubbed installer it survives.
     """
     fake_cpuinfo("AuthenticAMD")
     monkeypatch.setattr(torch.backends.mkldnn, "enabled", True)
 
-    importlib = pytest.importorskip("importlib")
     importlib.reload(qnn)
 
     assert torch.backends.mkldnn.enabled
 
 
-def test_importing_the_package_does_not_set_up_the_sdk(monkeypatch):
-    """Import must not run the installer, which downloads and rewrites the environment."""
-    calls = []
-    monkeypatch.setattr(qnn, "install_qnn_sdk", lambda: calls.append(1) or True)
-    monkeypatch.setattr(qnn, "_sdk_ready", False)
+def test_importing_the_package_does_not_set_up_the_sdk():
+    """Import must not run the installer, which downloads and rewrites the environment.
 
-    importlib = pytest.importorskip("importlib")
-    importlib.reload(qnn)
+    Asserted against the module source rather than by importing with a stub in place. A reload
+    re-executes the module, which rebinds the real installer and discards any stub, so a stubbed
+    reload can only ever observe an empty call list and would pass even if the call came back.
+    What actually matters is that no module level statement calls it.
+    """
+    module = ast.parse(Path(qnn.__file__).read_text())
+    called_at_module_level = {
+        node.func.id
+        for statement in module.body
+        if isinstance(statement, ast.Expr)
+        for node in ast.walk(statement)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
 
-    assert not calls
+    assert "install_qnn_sdk" not in called_at_module_level
+    assert "setup_qnn_sdk" not in called_at_module_level
+    # A guard on the two above, which would pass just as happily if the parse found nothing.
+    assert any(
+        isinstance(statement, ast.FunctionDef) and statement.name == "setup_qnn_sdk"
+        for statement in module.body
+    )
 
 
 def test_setup_is_idempotent(monkeypatch):
@@ -121,6 +141,9 @@ def test_setup_runs_once_under_concurrent_callers(monkeypatch):
     for thread in threads:
         thread.join(timeout=30)
 
+    # Reported before the count, so a hung thread says so rather than showing a confusing
+    # number of installer calls.
+    assert not any(thread.is_alive() for thread in threads)
     assert len(calls) == 1
 
 

--- a/backends/qualcomm/tests/test_import_side_effects.py
+++ b/backends/qualcomm/tests/test_import_side_effects.py
@@ -1,0 +1,121 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests that importing the Qualcomm backend package has no side effects.
+
+The package's __init__ used to do real work at import time. Merely importing it fetched the
+SDK and libc++ over the network, could re-execute the interpreter under a staged loader,
+rewrote QNN_SDK_ROOT and LD_LIBRARY_PATH, raised on a machine with no network, and disabled
+PyTorch's MKLDNN backend for the whole process on any AMD host. None of that is needed to
+load the package: the native adaptor resolves QNN symbols with dlopen when a model is
+compiled, so setup belongs on the paths that compile.
+
+These are unit tests because the behaviour under test is what happens during import, which
+is observable without a Qualcomm SDK or a Qualcomm device.
+"""
+
+import sys
+import types
+
+import executorch.backends.qualcomm as qnn
+import pytest
+import torch
+
+
+@pytest.fixture
+def fake_cpuinfo(monkeypatch):
+    """Replaces cpuinfo so a vendor can be chosen without an AMD host."""
+
+    def install(vendor):
+        module = types.ModuleType("cpuinfo")
+        module.get_cpu_info = lambda: {"vendor_id_raw": vendor}
+        monkeypatch.setitem(sys.modules, "cpuinfo", module)
+
+    return install
+
+
+def test_importing_the_package_leaves_mkldnn_alone(monkeypatch, fake_cpuinfo):
+    """Import must not change a global PyTorch setting, even on an AMD host.
+
+    The setting affects every model in the interpreter, not just a Qualcomm one, so an
+    import that flips it changes how unrelated code runs.
+    """
+    fake_cpuinfo("AuthenticAMD")
+    monkeypatch.setattr(torch.backends.mkldnn, "enabled", True)
+
+    importlib = pytest.importorskip("importlib")
+    importlib.reload(qnn)
+
+    assert torch.backends.mkldnn.enabled
+
+
+def test_importing_the_package_does_not_set_up_the_sdk(monkeypatch):
+    """Import must not run the installer, which downloads and rewrites the environment."""
+    calls = []
+    monkeypatch.setattr(qnn, "install_qnn_sdk", lambda: calls.append(1) or True)
+    monkeypatch.setattr(qnn, "_sdk_ready", False)
+
+    importlib = pytest.importorskip("importlib")
+    importlib.reload(qnn)
+
+    assert not calls
+
+
+def test_setup_is_idempotent(monkeypatch):
+    """The compile paths each call it, so only the first call may do the work."""
+    calls = []
+    monkeypatch.setattr(qnn, "install_qnn_sdk", lambda: calls.append(1) or True)
+    monkeypatch.setattr(qnn, "is_linux_x86", lambda: True)
+    monkeypatch.setattr(qnn, "_sdk_ready", False)
+    monkeypatch.delenv("QNN_SDK_ROOT", raising=False)
+    monkeypatch.delenv("EXECUTORCH_BUILDING_WHEEL", raising=False)
+
+    qnn.setup_qnn_sdk()
+    qnn.setup_qnn_sdk()
+
+    assert len(calls) == 1
+
+
+def test_setup_honours_a_preinstalled_sdk(monkeypatch):
+    calls = []
+    monkeypatch.setattr(qnn, "install_qnn_sdk", lambda: calls.append(1) or True)
+    monkeypatch.setattr(qnn, "_sdk_ready", False)
+    monkeypatch.setenv("QNN_SDK_ROOT", "/opt/qcom/sdk")
+
+    qnn.setup_qnn_sdk()
+
+    assert not calls
+
+
+def test_setup_reports_a_failed_install(monkeypatch):
+    """A failure has to name the two ways out, since it cannot be resolved automatically."""
+    monkeypatch.setattr(qnn, "install_qnn_sdk", lambda: False)
+    monkeypatch.setattr(qnn, "is_linux_x86", lambda: True)
+    monkeypatch.setattr(qnn, "_sdk_ready", False)
+    monkeypatch.delenv("QNN_SDK_ROOT", raising=False)
+    monkeypatch.delenv("EXECUTORCH_BUILDING_WHEEL", raising=False)
+
+    with pytest.raises(RuntimeError, match="QNN_SDK_ROOT"):
+        qnn.setup_qnn_sdk()
+
+
+@pytest.mark.parametrize(
+    "vendor,expected",
+    [
+        # The vendor string an AMD host reports. MKLDNN produces wrong results there.
+        ("AuthenticAMD", False),
+        ("GenuineIntel", True),
+        # A host that reports nothing, such as Apple silicon.
+        ("", True),
+    ],
+)
+def test_mkldnn_is_disabled_only_on_amd(monkeypatch, fake_cpuinfo, vendor, expected):
+    fake_cpuinfo(vendor)
+    monkeypatch.setattr(torch.backends.mkldnn, "enabled", True)
+
+    qnn.disable_mkldnn_on_amd()
+
+    assert torch.backends.mkldnn.enabled is expected

--- a/backends/qualcomm/tests/test_import_side_effects.py
+++ b/backends/qualcomm/tests/test_import_side_effects.py
@@ -90,6 +90,40 @@ def test_setup_honours_a_preinstalled_sdk(monkeypatch):
     assert not calls
 
 
+def test_setup_runs_once_under_concurrent_callers(monkeypatch):
+    """Several modules call it, so two threads can reach it at the same time.
+
+    Without a lock they both see the flag unset and both run the installer, which downloads an
+    SDK and rewrites the environment. The import lock does not cover this, because the calls
+    come from different modules rather than from one package __init__.
+    """
+    import threading
+    import time
+
+    calls = []
+
+    def slow_install():
+        # Widen the window between the check and the flag being set, so an unlocked version
+        # fails reliably rather than occasionally.
+        time.sleep(0.2)
+        calls.append(1)
+        return True
+
+    monkeypatch.setattr(qnn, "install_qnn_sdk", slow_install)
+    monkeypatch.setattr(qnn, "is_linux_x86", lambda: True)
+    monkeypatch.setattr(qnn, "_sdk_ready", False)
+    monkeypatch.delenv("QNN_SDK_ROOT", raising=False)
+    monkeypatch.delenv("EXECUTORCH_BUILDING_WHEEL", raising=False)
+
+    threads = [threading.Thread(target=qnn.setup_qnn_sdk) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert len(calls) == 1
+
+
 def test_setup_reports_a_failed_install(monkeypatch):
     """A failure has to name the two ways out, since it cannot be resolved automatically."""
     monkeypatch.setattr(qnn, "install_qnn_sdk", lambda: False)

--- a/backends/qualcomm/utils/check_qnn_version.py
+++ b/backends/qualcomm/utils/check_qnn_version.py
@@ -9,8 +9,8 @@ import os
 import platform
 import re
 
-# Loading the native adaptor below needs the SDK reachable. See node_visitor.py for why
-# this is here rather than in the package's __init__.
+# The SDK has to be usable before a model is compiled. See node_visitor.py for why this is
+# here rather than in the package's __init__.
 from executorch.backends.qualcomm import setup_qnn_sdk
 
 setup_qnn_sdk()

--- a/backends/qualcomm/utils/check_qnn_version.py
+++ b/backends/qualcomm/utils/check_qnn_version.py
@@ -9,6 +9,12 @@ import os
 import platform
 import re
 
+# Loading the native adaptor below needs the SDK reachable. See node_visitor.py for why
+# this is here rather than in the package's __init__.
+from executorch.backends.qualcomm import setup_qnn_sdk
+
+setup_qnn_sdk()
+
 import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManagerAdaptor
 
 

--- a/backends/qualcomm/utils/qnn_manager_lifecycle.py
+++ b/backends/qualcomm/utils/qnn_manager_lifecycle.py
@@ -3,8 +3,13 @@ import logging
 import threading
 from typing import Dict, List
 
-import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManager
+# Loading the native adaptor below needs the SDK reachable. See node_visitor.py for why
+# this is here rather than in the package's __init__.
+from executorch.backends.qualcomm import setup_qnn_sdk
 
+setup_qnn_sdk()
+
+import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManager
 from executorch.backends.qualcomm.partition.utils import generate_qnn_executorch_option
 from executorch.backends.qualcomm.serialization.qc_schema import (
     QnnExecuTorchBackendType,

--- a/backends/qualcomm/utils/qnn_manager_lifecycle.py
+++ b/backends/qualcomm/utils/qnn_manager_lifecycle.py
@@ -3,8 +3,8 @@ import logging
 import threading
 from typing import Dict, List
 
-# Loading the native adaptor below needs the SDK reachable. See node_visitor.py for why
-# this is here rather than in the package's __init__.
+# The SDK has to be usable before a model is compiled. See node_visitor.py for why this is
+# here rather than in the package's __init__.
 from executorch.backends.qualcomm import setup_qnn_sdk
 
 setup_qnn_sdk()

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -9,16 +9,19 @@ from collections import defaultdict, OrderedDict
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManagerAdaptor
+# Loading the native adaptor below needs the SDK reachable. See node_visitor.py for why
+# this is here rather than in the package's __init__.
+from executorch.backends.qualcomm import setup_qnn_sdk
 
+setup_qnn_sdk()
+
+import executorch.backends.qualcomm.python.PyQnnManagerAdaptor as PyQnnManagerAdaptor
 import executorch.exir as exir
 import torch
-
 from executorch.backends.qualcomm._passes import AnnotateStack, AnnotateUnbind
 from executorch.backends.qualcomm._passes.qnn_pass_manager import (
     get_qnn_pass_manager_cls,
 )
-
 from executorch.backends.qualcomm.builders.node_visitor import (
     QNN_QUANT_TYPE_MAP,
     QNN_TENSOR_TYPE_MAP,
@@ -64,7 +67,6 @@ from executorch.backends.qualcomm.utils.constants import (
     QCOM_QUANTIZED_IO,
 )
 from executorch.backends.qualcomm.utils.qnn_manager_lifecycle import QnnManagerContext
-
 from executorch.exir import ExirExportedProgram, to_edge
 from executorch.exir.backend.compile_spec_schema import CompileSpec
 from executorch.exir.lowered_backend_module import LoweredBackendModule

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -9,8 +9,8 @@ from collections import defaultdict, OrderedDict
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-# Loading the native adaptor below needs the SDK reachable. See node_visitor.py for why
-# this is here rather than in the package's __init__.
+# The SDK has to be usable before a model is compiled. See node_visitor.py for why this is
+# here rather than in the package's __init__.
 from executorch.backends.qualcomm import setup_qnn_sdk
 
 setup_qnn_sdk()


### PR DESCRIPTION
## Summary

`import executorch.backends.qualcomm` did real work as a side effect of the import itself.

On Linux x86_64 it downloaded the Qualcomm SDK and a copy of libc++ over the network, could
re-execute the interpreter under a staged loader, rewrote `QNN_SDK_ROOT` and
`LD_LIBRARY_PATH`, and raised when the machine had no route to the download:

```
[QNN] Downloading libc++ (LLVM 14.0.0)...
[QNN] Failed to stage/load libc++: <urlopen error ...>
RuntimeError: Failed to set up QNN SDK.
```

On every platform it also read the CPU vendor and, on an AMD host, set
`torch.backends.mkldnn.enabled = False`. That is a global PyTorch setting, so importing this
package changed how *unrelated* models ran in the same interpreter.

## Why none of that has to happen at import

The native adaptor does not link the SDK. It resolves QNN symbols with `dlopen` when a model
is actually compiled, and says so plainly if they are missing:

```
QnnImplementation::Load Cannot load symbol QnnInterface_getProviders
```

So loading the package needs nothing, and the setup belongs on the paths that compile.

## The change

Two functions hold what used to run at import:

- `setup_qnn_sdk()` keeps the previous behaviour exactly, including honouring a preinstalled
  `QNN_SDK_ROOT`, skipping on a non-Linux-x86 host, and short-circuiting during a wheel
  build. It is idempotent, so every entry point can simply call it.
- `disable_mkldnn_on_amd()` holds the MKLDNN change.

Both are called by the four modules that load the adaptor. One of those is
`builders/node_visitor.py`, which the 118 op builders all import, so a single call site
covers them.

## Test plan

Added `backends/qualcomm/tests/test_import_side_effects.py`, 8 tests. **All 8 fail against
the previous `__init__`.** I checked that the two behavioural ones fail for the right reason
rather than on a missing attribute: with a stubbed AMD vendor string, the old code flips
`mkldnn.enabled` from `True` to `False` purely on import.

Ran against the installed wheel on macOS arm64:

| check | result |
| --- | --- |
| bare import, stubbed AMD host | `mkldnn` True before and after |
| `setup_qnn_sdk()` | no-op off Linux x86, idempotent on repeat |
| `QNN_SDK_ROOT` set | honoured, installer not called |
| `EXECUTORCH_BUILDING_WHEEL=1` | short-circuits |
| install failure | `RuntimeError` naming both ways out |
| `disable_mkldnn_on_amd()` | `AuthenticAMD` to False, `GenuineIntel` stays True |
| `cpuinfo` absent | same `ImportError` guidance as before |

I do not have a Qualcomm device, so compiling a model for QNN end to end is not covered
here and would be worth a look from someone who does.


cc @cbilgin @psiddh