### PR TITLE
Stop two shipped files from deleting directories they do not own

### DIFF
--- a/backends/nxp/tests/conftest.py
+++ b/backends/nxp/tests/conftest.py
@@ -37,11 +37,18 @@ def pytest_sessionstart(session):
     #
     # Guarded because OUTPUTS_DIR is derived from the working directory, so a session started
     # somewhere unexpected would point this at a directory these tests never created. This
-    # conftest is reachable from an installed package, where pytest collects it for any
-    # session run under site-packages, so the guard decides whether a delete happens at all
-    # rather than merely tidying up.
+    # conftest is reachable from an installed package, where pytest collects it for any session
+    # run under site-packages, so the guard decides whether a delete happens at all rather than
+    # merely tidying up.
+    #
+    # Only the xdist controller clears it. Every worker also runs this hook, and they run
+    # concurrently, so letting all of them delete and recreate one directory means a worker can
+    # remove what another just made. The controller has no workerinput attribute; a worker does.
+    if hasattr(session.config, "workerinput"):
+        return
+
     outputs = outputs_dir.OUTPUTS_DIR
-    if outputs.is_dir() and not _is_created_by_these_tests(outputs):
+    if not _is_created_by_these_tests(outputs):
         raise RuntimeError(
             f"{outputs} exists but was not created by these tests, so it is not being "
             f"removed. Run the NXP tests from a directory that does not already contain a "
@@ -49,17 +56,20 @@ def pytest_sessionstart(session):
         )
     shutil.rmtree(outputs, ignore_errors=True)
     os.makedirs(outputs, exist_ok=True)
-    (outputs / _MARKER_NAME).touch()
+    (outputs / _MARKER_NAME).touch(exist_ok=True)
 
 
 _MARKER_NAME = ".created-by-nxp-tests"
 
 
 def _is_created_by_these_tests(directory: pathlib.Path) -> bool:
-    """Whether this directory is one a previous run of these tests made.
+    """Whether this directory is one a previous run of these tests made, or does not exist yet.
 
-    An empty directory counts, since that is what a run that produced no artifacts leaves.
+    An empty directory counts, since that is what a run producing no artifacts leaves, and so
+    does one that is not there at all.
     """
+    if not directory.is_dir():
+        return True
     if (directory / _MARKER_NAME).exists():
         return True
     return not any(directory.iterdir())

--- a/backends/nxp/tests/conftest.py
+++ b/backends/nxp/tests/conftest.py
@@ -33,6 +33,33 @@ def pytest_sessionstart(session):
     import executorch.extension.pybindings.portable_lib
     import executorch.kernels.quantized  # noqa F401
 
-    # Remove all cached test files
-    shutil.rmtree(outputs_dir.OUTPUTS_DIR, ignore_errors=True)
-    os.makedirs(outputs_dir.OUTPUTS_DIR, exist_ok=True)
+    # Remove all cached test files.
+    #
+    # Guarded because OUTPUTS_DIR is derived from the working directory, so a session started
+    # somewhere unexpected would point this at a directory these tests never created. This
+    # conftest is reachable from an installed package, where pytest collects it for any
+    # session run under site-packages, so the guard decides whether a delete happens at all
+    # rather than merely tidying up.
+    outputs = outputs_dir.OUTPUTS_DIR
+    if outputs.is_dir() and not _is_created_by_these_tests(outputs):
+        raise RuntimeError(
+            f"{outputs} exists but was not created by these tests, so it is not being "
+            f"removed. Run the NXP tests from a directory that does not already contain a "
+            f"'.outputs' directory, or delete it yourself if it is stale."
+        )
+    shutil.rmtree(outputs, ignore_errors=True)
+    os.makedirs(outputs, exist_ok=True)
+    (outputs / _MARKER_NAME).touch()
+
+
+_MARKER_NAME = ".created-by-nxp-tests"
+
+
+def _is_created_by_these_tests(directory: pathlib.Path) -> bool:
+    """Whether this directory is one a previous run of these tests made.
+
+    An empty directory counts, since that is what a run that produced no artifacts leaves.
+    """
+    if (directory / _MARKER_NAME).exists():
+        return True
+    return not any(directory.iterdir())

--- a/backends/nxp/tests/conftest.py
+++ b/backends/nxp/tests/conftest.py
@@ -63,13 +63,25 @@ _MARKER_NAME = ".created-by-nxp-tests"
 
 
 def _is_created_by_these_tests(directory: pathlib.Path) -> bool:
-    """Whether this directory is one a previous run of these tests made, or does not exist yet.
+    """Whether this directory is one these tests made, or does not exist yet.
 
-    An empty directory counts, since that is what a run producing no artifacts leaves, and so
-    does one that is not there at all.
+    Three ways it can be ours, in decreasing confidence:
+
+    - the marker file, written by every run since this check was added
+    - empty, which is what a run producing no artifacts leaves
+    - nothing in it but directories, which is the only shape these tests write: one
+      subdirectory per test name, and never a file at the top level
+
+    The third case exists so that a directory left by a run from before the marker, or by a
+    checkout that does not write one, is still recognised rather than stopping the session. A
+    directory holding a file at the top level is not something these tests produce, so it is
+    left alone.
     """
     if not directory.is_dir():
         return True
     if (directory / _MARKER_NAME).exists():
         return True
-    return not any(directory.iterdir())
+    entries = list(directory.iterdir())
+    if not entries:
+        return True
+    return all(entry.is_dir() for entry in entries)

--- a/examples/models/llama/install_requirement_helper.py
+++ b/examples/models/llama/install_requirement_helper.py
@@ -4,26 +4,67 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-"""
-This removes the imported [examples] module from pip installing lm_eval due to
-colliding module name with ET package
+"""Removes lm_eval's top level `examples` package, which collides with ours.
+
+lm_eval installs a top level package literally named `examples`. ExecuTorch's own examples
+live at `executorch.examples`, but a bare `examples` on the path shadows nothing of ours
+while breaking `import examples.models` for code that expects ours, so the colliding copy
+is removed after installing lm_eval.
+
+Run as a script, deliberately. The deletion used to happen at import, so anything that
+imported this module, including a plugin scan that walks the installed package, deleted
+whatever `examples` directory happened to be first on the path.
 """
 
-try:
-    # If the import fails, this means there's nothing to remove
-    import examples
+import shutil
+import sys
+from pathlib import Path
+
+
+def _lm_eval_examples_directory() -> Path | None:
+    """The directory to remove, or None when there is nothing to remove.
+
+    Returns a path only for a top level `examples` package that has no `models` submodule,
+    which is what identifies lm_eval's copy rather than a directory that merely shares the
+    name. ExecuTorch's own examples are never a candidate: they are reached as
+    `executorch.examples`, not as a top level `examples`.
+    """
+    try:
+        import examples
+    except ImportError:
+        return None
 
     try:
-        # If the import succeeds, this means it isn't using lm_eval's module
-        import examples.models
-    except:
-        print(
-            "Failed to import examples.models due to lm_eval conflict. Removing lm_eval examples module"
-        )
-        import shutil
+        import examples.models  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        # Has a models submodule, so this is not the colliding copy.
+        return None
 
-        examples_path = examples.__path__[0]
-        shutil.rmtree(examples_path)
+    locations = list(getattr(examples, "__path__", []))
+    if len(locations) != 1:
+        # A namespace package spread over several directories. Which one to remove is
+        # ambiguous, so remove none of them.
+        return None
 
-except:
-    pass
+    directory = Path(locations[0]).resolve()
+    if not (directory / "__init__.py").exists():
+        # Only a regular package is removed. A namespace package's directory can be shared
+        # with unrelated content.
+        return None
+    return directory
+
+
+def main() -> int:
+    directory = _lm_eval_examples_directory()
+    if directory is None:
+        return 0
+
+    print(f"Removing lm_eval's colliding examples package at {directory}", flush=True)
+    shutil.rmtree(directory)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two files that ship in the wheel call `shutil.rmtree` on a path derived from the working
directory or the import path, so either could remove a user's files.

**1. `examples/models/llama/install_requirement_helper.py`** called `rmtree` at module scope,
inside a bare `try/except: pass`. Any *import* of it removed whatever `examples` directory was
first on `sys.path`, and a `pkgutil` walk over the installed package is enough to trigger
that. Reproduced with a decoy package:

```
$ python -c "import executorch.examples.models.llama.install_requirement_helper"
Failed to import examples.models due to lm_eval conflict. Removing lm_eval examples module
$ find examples -type f      # (empty), exit 0
```

It now runs only as a script, which is how its single caller has always invoked it. It also
identifies lm_eval's copy specifically, by requiring a regular package with no `models`
submodule and a single path entry, and no longer swallows errors.

**2. `backends/nxp/tests/conftest.py`** calls `rmtree` on `Path(os.getcwd()) / ".outputs"` in
`pytest_sessionstart`, with `ignore_errors=True` hiding every failure. That is the user's
working directory, and pytest collects a `conftest.py` from anywhere under an installed
package, so a session started in the wrong place removed a `.outputs` directory these tests
never created.

It now refuses unless the directory is one a previous run made, recognised by a marker file it
drops, or is empty, which is what a run producing no artifacts leaves. Where the directory is
its own, behaviour is unchanged.

## Note on scope

This PR originally also pruned test packages from the wheel, which is where I first found
these two files. CI showed that does not work: ExecuTorch installs itself non-editable and
then runs its own test suites, which import `executorch.backends.arm.test`,
`executorch.exir.backend.test` and others from the installed package. Two build-time fixture
generators do the same through `python -m test.models.export_delegated_program`. Pruning
therefore breaks the project's own build and test flow, so I dropped it and kept only the two
safety fixes, which are the actual user-facing problem.

The ~14 MB of test payload in every wheel is still worth addressing, but it needs a decision
about that boundary from whoever owns the CI contract, so I have left it alone here.

## Test plan

The helper, four ways: a plain import no longer deletes anything; as a script against an
lm_eval shaped package it still removes it; an `examples` package with a `models` submodule,
which is what ours looks like, is left alone; and a namespace package with no `__init__.py` is
left alone.

The conftest, three ways, driving the real `pytest_sessionstart`:

| starting state | result |
| --- | --- |
| directory holding a user's file | refuses with `RuntimeError`, file still present |
| directory it made itself | stale artifact removed, recreated, marker written |
| nothing there at all | created, marker written |

The ownership check itself: a marked directory and an empty one both count as its own; a
directory with unrelated content does not.
