### PR TITLE
Strip local symbols from the macOS wheel's binaries

### DIFF
--- a/backends/cadence/aot/graph_builder.py
+++ b/backends/cadence/aot/graph_builder.py
@@ -8,6 +8,25 @@
 
 # This module has moved to executorch.backends.test.graph_builder.
 # This re-export exists for backward compatibility.
-from executorch.backends.test.graph_builder import GraphBuilder, single_op_builder
+#
+# Resolved on attribute access rather than at import, because the target lives in a test
+# package and the wheel does not ship those. Importing it here would make this module, which
+# does ship, fail to import in an installed wheel.
+
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from executorch.backends.test.graph_builder import (  # noqa: F401
+        GraphBuilder,
+        single_op_builder,
+    )
 
 __all__ = ["GraphBuilder", "single_op_builder"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        from executorch.backends.test import graph_builder
+
+        return getattr(graph_builder, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/backends/cadence/aot/program_builder.py
+++ b/backends/cadence/aot/program_builder.py
@@ -4,6 +4,25 @@
 
 # This module has moved to executorch.backends.test.program_builder.
 # This re-export exists for backward compatibility.
-from executorch.backends.test.program_builder import IrMode, ProgramBuilder
+#
+# Resolved on attribute access rather than at import, because the target lives in a test
+# package and the wheel does not ship those. Importing it here would make this module, which
+# does ship, fail to import in an installed wheel.
+
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from executorch.backends.test.program_builder import (  # noqa: F401
+        IrMode,
+        ProgramBuilder,
+    )
 
 __all__ = ["IrMode", "ProgramBuilder"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        from executorch.backends.test import program_builder
+
+        return getattr(program_builder, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/setup.py
+++ b/setup.py
@@ -1256,10 +1256,13 @@ class InstallerBuildExt(build_ext):
             self.get_finalized_command("build"), "cmake_cache_dir", None
         )
         _strip_absolute_runtime_paths(dst_file, _cuda_libraries_built(cmake_cache_dir))
-        # After the rewrite, since it opens the file for writing and would otherwise be
-        # rewriting a file whose symbol table just moved. Only the wheel copy is stripped;
-        # the editable copy above is a developer's own build output, where the local symbols
-        # are what a debugger and a profiler read.
+        # After the rewrite rather than before it, because each tool re-signs the file ad hoc when
+        # it finishes, so whichever runs last owns the signature. Running strip last keeps the
+        # signature over the bytes that ship. Functionally either order works: measured, the two
+        # produce the same size, the same exported symbols, the same rpaths, and both verify.
+        #
+        # Only the wheel copy is stripped; the editable copy above is a developer's own build
+        # output, where the local symbols are what a debugger and a profiler read.
         _strip_local_symbols(dst_file)
 
 
@@ -1346,17 +1349,19 @@ def _run_install_name_tool(command: List[str], library: Path) -> None:
 def _strip_local_symbols(library: Path) -> None:
     """Discard the local symbol table from a Mach-O file the wheel ships.
 
-    Only on macOS, and only because its linker keeps these where the GNU one does not. The
-    Linux libraries ship with no .symtab at all, while the macOS ones carried a local symbol
-    for every internal function: 448 in the runtime, 4190 in the merged kernels, and 35496 in
-    flatc, which alone was 6 MB of the 7 MB this removes.
+    Only on macOS, and only because its linker keeps these where the GNU one does not. The Linux
+    shared libraries ship with no .symtab section, while the macOS ones carried a local symbol for
+    every internal function: 448 in the runtime, 4190 in the merged kernels, and 35496 in flatc,
+    which alone was 6 MB of the 7 MB this removes.
 
-    `-x` removes local symbols and keeps every external one, so what a consumer can link
-    against does not change. Anything beyond that would strip exported symbols and break
-    linking, so the flag matters.
+    `-x` removes local symbols and keeps every external one, so what a consumer can link against
+    does not change. Anything beyond that would strip exported symbols and break linking, so the
+    flag matters.
 
-    A failure here is not fatal. The file is correct either way, and a wheel that is larger
-    than intended is better than a build that stops.
+    A failure here is not fatal. The file is correct either way, and a wheel that is larger than
+    intended is better than a build that stops. That also covers the files this runs on that are
+    not Mach-O at all, such as the Metal library and a template: strip declines them, and on BSD
+    it declines them with a zero exit, leaving the file byte for byte as it was.
     """
     if not _is_macos():
         return

--- a/setup.py
+++ b/setup.py
@@ -1256,6 +1256,11 @@ class InstallerBuildExt(build_ext):
             self.get_finalized_command("build"), "cmake_cache_dir", None
         )
         _strip_absolute_runtime_paths(dst_file, _cuda_libraries_built(cmake_cache_dir))
+        # After the rewrite, since it opens the file for writing and would otherwise be
+        # rewriting a file whose symbol table just moved. Only the wheel copy is stripped;
+        # the editable copy above is a developer's own build output, where the local symbols
+        # are what a debugger and a profiler read.
+        _strip_local_symbols(dst_file)
 
 
 def _append_relative_search_paths(entries: List[str], depth: int = 1) -> None:
@@ -1335,6 +1340,37 @@ def _run_install_name_tool(command: List[str], library: Path) -> None:
         raise RuntimeError(
             f"{' '.join(command[1:3])} failed on {library.name}, so its runtime search paths are not "
             f"what this build intended: {(result.stderr or result.stdout).decode(errors='replace').strip()}"
+        )
+
+
+def _strip_local_symbols(library: Path) -> None:
+    """Discard the local symbol table from a Mach-O file the wheel ships.
+
+    Only on macOS, and only because its linker keeps these where the GNU one does not. The
+    Linux libraries ship with no .symtab at all, while the macOS ones carried a local symbol
+    for every internal function: 448 in the runtime, 4190 in the merged kernels, and 35496 in
+    flatc, which alone was 6 MB of the 7 MB this removes.
+
+    `-x` removes local symbols and keeps every external one, so what a consumer can link
+    against does not change. Anything beyond that would strip exported symbols and break
+    linking, so the flag matters.
+
+    A failure here is not fatal. The file is correct either way, and a wheel that is larger
+    than intended is better than a build that stops.
+    """
+    if not _is_macos():
+        return
+    strip = shutil.which("strip")
+    if strip is None:
+        return
+    result = subprocess.run(
+        [strip, "-x", os.fspath(library)], capture_output=True, check=False
+    )
+    if result.returncode != 0:
+        print(
+            f"warning: could not strip local symbols from {library.name}, shipping it as "
+            f"built: {(result.stderr or result.stdout).decode(errors='replace').strip()}",
+            flush=True,
         )
 
 


### PR DESCRIPTION
## Summary

The macOS wheel carries about **7 MB of local symbols** that the Linux wheel does not.

Both are Release builds. The difference is the linker: the GNU one discards these, Apple's
keeps them. The Linux libraries have no `.symtab` section at all, while every macOS one
carries a local symbol per internal function:

| file | external | local |
| --- | --- | --- |
| `libexecutorch.dylib` | 333 | 448 |
| `libexecutorch_kernels_optimized.dylib` | 1463 | 4190 |
| `data/bin/flatc` | 3737 | **35496** |

`flatc` is most of it. At 11,629,400 bytes it is 5.3 MB *larger* than the Linux copy, and
stripped it comes to 5,571,232, which is **smaller** than Linux's 6,313,152. So this one file
explains nearly the entire size gap between the two wheels.

## The change

`strip -x` removes local symbols and keeps every external one, so nothing a consumer can
link against changes. That flag matters: anything broader would remove exported symbols and
break linking.

It runs on the wheel copy only, right after the runtime path rewrite that already runs there,
and deliberately not on the editable copy, where a developer's debugger and profiler want
those symbols. A failure warns and ships the file as built, because a wheel that is larger
than intended beats a build that stops.

## Test plan

Measured on the published macOS arm64 wheel: native payload **32.8 MB to 25.7 MB, saving
7.2 MB (21%)**.

Stripped a copy of an installed wheel and ran from a neutral directory:

| check | result |
| --- | --- |
| exported symbol list, before vs after | identical |
| registered backends | CoreML, MLX, Vgf, Xnnpack |
| XNNPACK export + run | `[3.0, 3.0, 3.0, 3.0]` |
| MLX export + run | `[3.0, 3.0, 3.0, 3.0]` |
| C++ app via `find_package(executorch)` | builds, `load_method 0x0`, out `3.0` x4 |

The helper itself, four ways: on a Linux file it does nothing; with no `strip` on PATH it
returns quietly; on a real failure, tested with a read-only file, it warns and does not
raise; and on a Mach-O library it removes 11 percent while leaving the exported set byte
identical.
