### PR TITLE
Mark ~CPUCachingAllocator override

### DIFF
--- a/extension/memory_allocator/cpu_caching_malloc_allocator.h
+++ b/extension/memory_allocator/cpu_caching_malloc_allocator.h
@@ -84,7 +84,7 @@ class CPUCachingAllocator : public executorch::runtime::MemoryAllocator {
       size_t size,
       size_t alignment = kCachingAllocatorDefaultAlignment) override;
   void reset() override;
-  ~CPUCachingAllocator();
+  ~CPUCachingAllocator() override;
 };
 
 } // namespace executorch::extension


### PR DESCRIPTION
Summary:
MemoryAllocator declares a virtual destructor, so ~CPUCachingAllocator
already overrides it implicitly. Without the keyword,
-Winconsistent-missing-destructor-override fires, and it is -Werror on the
iphoneos configs, which breaks every Apple build that reaches this header.

Differential Revision: D117944096


