### PR TITLE
Stop reading a backend config field that no longer exists

### DIFF
--- a/examples/models/llama/tests/test_export_llama_lib.py
+++ b/examples/models/llama/tests/test_export_llama_lib.py
@@ -24,6 +24,7 @@ except ImportError:
     TOSAQuantizer = None
     VgfQuantizer = None
 
+from executorch.examples.models.llama import export_llama_lib
 from executorch.examples.models.llama.export_llama_lib import (
     _export_llama,
     build_args_parser,
@@ -42,35 +43,51 @@ UNWANTED_OPS = [
 
 
 class ExportLlamaLibTest(unittest.TestCase):
-    def _assert_export_reaches(self, target, **backends):
-        """Run an export and assert which lowering it routes to."""
+    def _assert_routes_to(self, lowering, coreml=False, vulkan=False, qnn=False):
+        """Assert which lowering an export routes to, without running one."""
         llm_config = LlmConfig()
-        llm_config.backend.coreml.enabled = True
-        for name, enabled in backends.items():
-            getattr(llm_config.backend, name).enabled = enabled
-        # Core ML and QNN reject dynamic shapes, and _validate_args runs before the lowering.
+        llm_config.backend.coreml.enabled = coreml
+        llm_config.backend.vulkan.enabled = vulkan
+        llm_config.backend.qnn.enabled = qnn
+        # _validate_args rejects dynamic shapes when Core ML or QNN is enabled.
         llm_config.model.enable_dynamic_shape = False
 
-        with patch(
-            f"executorch.examples.models.llama.export_llama_lib.{target}",
-            side_effect=RuntimeError("reached"),
-        ) as lowering:
-            with self.assertRaises(RuntimeError):
+        class Reached(Exception):
+            pass
+
+        with patch.object(export_llama_lib, lowering, side_effect=Reached) as target:
+            with self.assertRaises(Reached):
                 _export_llama(llm_config)
-        lowering.assert_called_once()
+        target.assert_called_once()
+        return target
 
-    def test_core_ml_alone_reaches_the_core_ml_lowering(self):
-        """The guard used to read a backend config field that no longer existed, so this raised
-        AttributeError before reaching any lowering."""
-        self._assert_export_reaches("_to_edge_and_lower_llama_coreml")
+    def test_core_ml_alone_routes_to_the_core_ml_lowering(self):
+        """Core ML on its own must reach the Core ML lowering.
 
-    def test_core_ml_with_qnn_reaches_the_combined_lowering(self):
-        """The other case the removed read broke, and the one that pins the exclusion clause.
-
-        Core ML with QNN must fall through to the combined lowering, which still lowers Core ML but
-        keeps the QNN partitioner. Without this, deleting the whole clause passes.
+        The guard read a backend config field that no longer exists, so this raised AttributeError
+        before reaching any lowering.
         """
-        self._assert_export_reaches("_to_edge_and_lower_llama", qnn=True)
+        self._assert_routes_to("_to_edge_and_lower_llama_coreml", coreml=True)
+
+    def test_core_ml_with_qnn_routes_to_the_combined_lowering(self):
+        """Core ML with QNN must keep the QNN partitioner, so it takes the combined lowering."""
+        target = self._assert_routes_to(
+            "_to_edge_and_lower_llama", coreml=True, qnn=True
+        )
+        self.assertTrue(target.call_args.kwargs["coreml"])
+        self.assertTrue(target.call_args.kwargs["qnn"])
+
+    def test_core_ml_with_vulkan_routes_to_the_combined_lowering(self):
+        """Core ML with Vulkan must keep the Vulkan partitioner the same way.
+
+        This is what pins the Vulkan half of the exclusion clause: the Core ML lowering takes no
+        Vulkan argument, so routing there would drop the partitioner silently.
+        """
+        target = self._assert_routes_to(
+            "_to_edge_and_lower_llama", coreml=True, vulkan=True
+        )
+        self.assertTrue(target.call_args.kwargs["coreml"])
+        self.assertTrue(target.call_args.kwargs["vulkan"])
 
     def test_has_expected_ops_and_op_counts(self):
         """

--- a/examples/models/llama/tests/test_export_llama_lib.py
+++ b/examples/models/llama/tests/test_export_llama_lib.py
@@ -51,11 +51,18 @@ class ExportLlamaLibTest(unittest.TestCase):
         llm_config.backend.qnn.enabled = qnn
         # _validate_args rejects dynamic shapes when Core ML or QNN is enabled.
         llm_config.model.enable_dynamic_shape = False
+        # With the KV cache on, the source transforms import the Qualcomm SDK, which routing
+        # does not need and which is not present on most machines.
+        llm_config.model.use_kv_cache = False
 
         class Reached(Exception):
             pass
 
-        with patch.object(export_llama_lib, lowering, side_effect=Reached) as target:
+        # Routing is decided before the model is touched, so the export is stubbed out: without
+        # this each case traces and lowers the whole model to check one branch.
+        with patch.object(
+            export_llama_lib, lowering, side_effect=Reached
+        ) as target, patch.object(export_llama_lib, "_prepare_for_llama_export"):
             with self.assertRaises(Reached):
                 _export_llama(llm_config)
         target.assert_called_once()

--- a/examples/models/llama/tests/test_export_llama_lib.py
+++ b/examples/models/llama/tests/test_export_llama_lib.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from unittest.mock import patch
 
 from executorch.devtools.backend_debug import get_delegation_info
 
@@ -41,6 +42,36 @@ UNWANTED_OPS = [
 
 
 class ExportLlamaLibTest(unittest.TestCase):
+    def test_core_ml_export_reaches_its_lowering(self):
+        """The Core ML branch must be reachable, not stopped by its own guard.
+
+        The guard used to read a backend config field that no longer existed, so any Core ML
+        export raised AttributeError before reaching the lowering. Patching the lowering to raise
+        a marker keeps this off macOS and away from coremltools: what is asserted is that control
+        arrives there at all.
+
+        The macOS Core ML llama job that would otherwise catch this lives in the trunk workflow,
+        which does not start for a change to this file, so without this test nothing on a pull
+        request notices the field coming back.
+        """
+        llm_config = LlmConfig()
+        llm_config.backend.coreml.enabled = True
+        # The Core ML recipe rejects dynamic shapes, and that validation runs first.
+        llm_config.model.enable_dynamic_shape = False
+
+        class _ReachedCoreMLLowering(Exception):
+            pass
+
+        def _marker(*args, **kwargs):
+            raise _ReachedCoreMLLowering
+
+        with patch(
+            "executorch.examples.models.llama.export_llama_lib._to_edge_and_lower_llama_coreml",
+            _marker,
+        ):
+            with self.assertRaises(_ReachedCoreMLLowering):
+                _export_llama(llm_config)
+
     def test_has_expected_ops_and_op_counts(self):
         """
         Checks the presence of unwanted expensive ops.

--- a/examples/models/llama/tests/test_export_llama_lib.py
+++ b/examples/models/llama/tests/test_export_llama_lib.py
@@ -42,35 +42,35 @@ UNWANTED_OPS = [
 
 
 class ExportLlamaLibTest(unittest.TestCase):
-    def test_core_ml_export_reaches_its_lowering(self):
-        """The Core ML branch must be reachable, not stopped by its own guard.
-
-        The guard used to read a backend config field that no longer existed, so any Core ML
-        export raised AttributeError before reaching the lowering. Patching the lowering to raise
-        a marker keeps this off macOS and away from coremltools: what is asserted is that control
-        arrives there at all.
-
-        The macOS Core ML llama job that would otherwise catch this lives in the trunk workflow,
-        which does not start for a change to this file, so without this test nothing on a pull
-        request notices the field coming back.
-        """
+    def _assert_export_reaches(self, target, **backends):
+        """Run an export and assert which lowering it routes to."""
         llm_config = LlmConfig()
         llm_config.backend.coreml.enabled = True
-        # The Core ML recipe rejects dynamic shapes, and that validation runs first.
+        for name, enabled in backends.items():
+            getattr(llm_config.backend, name).enabled = enabled
+        # Core ML and QNN reject dynamic shapes, and _validate_args runs before the lowering.
         llm_config.model.enable_dynamic_shape = False
 
-        class _ReachedCoreMLLowering(Exception):
-            pass
-
-        def _marker(*args, **kwargs):
-            raise _ReachedCoreMLLowering
-
         with patch(
-            "executorch.examples.models.llama.export_llama_lib._to_edge_and_lower_llama_coreml",
-            _marker,
-        ):
-            with self.assertRaises(_ReachedCoreMLLowering):
+            f"executorch.examples.models.llama.export_llama_lib.{target}",
+            side_effect=RuntimeError("reached"),
+        ) as lowering:
+            with self.assertRaises(RuntimeError):
                 _export_llama(llm_config)
+        lowering.assert_called_once()
+
+    def test_core_ml_alone_reaches_the_core_ml_lowering(self):
+        """The guard used to read a backend config field that no longer existed, so this raised
+        AttributeError before reaching any lowering."""
+        self._assert_export_reaches("_to_edge_and_lower_llama_coreml")
+
+    def test_core_ml_with_qnn_reaches_the_combined_lowering(self):
+        """The other case the removed read broke, and the one that pins the exclusion clause.
+
+        Core ML with QNN must fall through to the combined lowering, which still lowers Core ML but
+        keeps the QNN partitioner. Without this, deleting the whole clause passes.
+        """
+        self._assert_export_reaches("_to_edge_and_lower_llama", qnn=True)
 
     def test_has_expected_ops_and_op_counts(self):
         """


### PR DESCRIPTION
## Summary

The code fix this pull request opened with has since landed on main separately, so what is left here is
the test that keeps it from coming back.

The bug: exporting llama for Core ML failed before it started, because the branch selecting the Core ML
lowering read a backend config field that no longer existed.

```
AttributeError: 'BackendConfig' object has no attribute 'mps'
```

`or` short-circuits, so this raised only when Vulkan was off. Core ML alone and Core ML with QNN
raised; Core ML with Vulkan did not, because the first term was already true.

## What is in this change now

Three tests, one per route through that branch, with the lowering patched so they need no macOS and no
coremltools:

| case | routes to |
| --- | --- |
| Core ML alone | the Core ML lowering |
| Core ML with QNN | the combined lowering, QNN partitioner kept |
| Core ML with Vulkan | the combined lowering, Vulkan partitioner kept |

The second and third cases matter on their own. The exclusion clause exists to keep those two
partitioners, and the Core ML lowering takes neither as an argument, so routing there would drop them
in silence. Both cases assert the backend flags actually reach the shared lowering, since a call count
cannot see them.

The mutation matrix is complete:

```
drop the vulkan term       the Vulkan case fails
drop the qnn term          the QNN case fails
delete the whole clause    both combined cases fail
restore the removed field  both Core ML cases fail
```

The model preparation is stubbed, because routing is decided before the model is touched. That takes
the three cases from about 4.3 GB of peak memory to 420 MB. The KV cache is pinned off with a comment
saying why: with it on, the source transforms import the Qualcomm SDK, which routing does not need.

## Test plan

All three pass against main as it stands now, and each fails on the mutation named above.
