### PR TITLE
Build the flatc host tools for macOS on an iOS build

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -17,6 +17,9 @@ on:
       - scripts/build_apple_llm_demo.sh
       - scripts/create_frameworks.sh
       - Package.swift
+      - CMakePresets.json
+      - third-party/CMakeLists.txt
+      - backends/mlx/**
       - .ci/scripts/test_ios_ci.sh
       - extension/apple/**
       - extension/benchmark/apple/**

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -64,7 +64,7 @@
         "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/ios.cmake",
         "PLATFORM": "OS64",
         "DEPLOYMENT_TARGET": "17.0",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "15.0"
       },
       "condition": {
         "lhs": "${hostSystemName}",
@@ -82,7 +82,7 @@
         "EXECUTORCH_BUILD_PRESET_FILE": "${sourceDir}/tools/cmake/preset/ios.cmake",
         "PLATFORM": "SIMULATORARM64",
         "DEPLOYMENT_TARGET": "17.0",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "15.0"
       },
       "condition": {
         "lhs": "${hostSystemName}",

--- a/backends/mlx/CMakeLists.txt
+++ b/backends/mlx/CMakeLists.txt
@@ -266,12 +266,11 @@ ExternalProject_Add(
   CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${_mlx_build_type}"
              -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
              ${_mlx_cxx_flags_arg}
-             # The preset's DEPLOYMENT_TARGET carries the correct per-slice
-             # minimum (iOS 17, macOS 14); the ios.toolchain leaves
-             # CMAKE_OSX_DEPLOYMENT_TARGET at 12.0 on the iOS slices and only
-             # syncs it for MAC. The shader-flag patch reads
-             # CMAKE_OSX_DEPLOYMENT_TARGET, so feed the preset value in as that,
-             # or the iOS metallib is stamped -mios-version-min=12.0.
+             # Feed the preset's per-slice DEPLOYMENT_TARGET in as
+             # CMAKE_OSX_DEPLOYMENT_TARGET: the ios.toolchain does not reliably
+             # carry it to this sub-build, and the shader-flag patch reads
+             # CMAKE_OSX_DEPLOYMENT_TARGET to stamp the metallib's minimum OS
+             # version, so without this the iOS metallib gets the wrong floor.
              -DCMAKE_OSX_DEPLOYMENT_TARGET=${_mlx_osx_deployment_target}
              -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
              -DPLATFORM=${PLATFORM}

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -46,6 +46,20 @@ else()
   set(_flatbuffers_ep_additional_args)
 endif()
 
+# The flatc and flatcc host tools are built for the build machine. On a non-MAC
+# Apple build the parent's CMAKE_OSX_DEPLOYMENT_TARGET is an iOS floor the host
+# compiler rejects, so the host sub-builds get this macOS floor instead, to
+# match the package's macOS minimum. _executorch_apple_cross is true only for a
+# non-MAC Apple build, where the host tool must not take the app's SDK or floor.
+set(_executorch_host_macos_floor 14.0)
+set(_executorch_apple_cross
+    "$<AND:$<BOOL:${APPLE}>,$<BOOL:$<FILTER:${PLATFORM},EXCLUDE,^MAC>>>"
+)
+set(_executorch_host_osx_args
+    "$<${_executorch_apple_cross}:-DCMAKE_OSX_SYSROOT=>"
+    "-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=$<IF:${_executorch_apple_cross},${_executorch_host_macos_floor},${CMAKE_OSX_DEPLOYMENT_TARGET}>"
+)
+
 # Allow reusing a prebuilt host flatc instead of building it from source. This is
 # required when cross-compiling with the Ninja generator on Windows: the WIN32
 # branch above only supports the Visual Studio generator (it passes the VS-only
@@ -73,10 +87,9 @@ ExternalProject_Add(
     # Unset the toolchain to build for the host instead of the toolchain set for
     # the project.
     -DCMAKE_TOOLCHAIN_FILE=
-    # If building for iOS, "unset" these variables to rely on the host (macOS)
-    # defaults.
-    $<$<AND:$<BOOL:${APPLE}>,$<BOOL:$<FILTER:${PLATFORM},EXCLUDE,^MAC>>>:-DCMAKE_OSX_SYSROOT=>
-    -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
+    # flatc runs on the build machine, so it must target the host, not the app's
+    # iOS platform. See _executorch_host_osx_args above.
+    ${_executorch_host_osx_args}
   BUILD_BYPRODUCTS <INSTALL_DIR>/bin/flatc
                    ${_executorch_external_project_additional_args}
                    ${_flatbuffers_ep_additional_args}
@@ -140,8 +153,7 @@ ExternalProject_Add(
     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     -DCMAKE_TOOLCHAIN_FILE=
-    $<$<AND:$<BOOL:${APPLE}>,$<BOOL:$<FILTER:${PLATFORM},EXCLUDE,^MAC>>>:-DCMAKE_OSX_SYSROOT=>
-    -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}
+    ${_executorch_host_osx_args}
     ${_flatcc_extra_cmake_args}
   BUILD_BYPRODUCTS <INSTALL_DIR>/bin/flatcc
                    ${_executorch_external_project_additional_args}


### PR DESCRIPTION
## Problem

Xcode 26 raised the minimum iOS deployment target to 15. The `ios` and
`ios-simulator` build presets set a lower macOS deployment floor (12.0), so on a
current Xcode they can no longer configure. This is the shipping Xcode, not only
the 27 beta.

There is a second, deeper problem. The `flatc` and `flatcc` schema tools are built
by host sub-projects that run on the build machine. On an iOS build they were
handed the app's iOS deployment target. After the floor rose, that value is an iOS
minimum the host compiler rejects, so the sub-build produced a `flatc` the build
machine could not run, and the Apple builds failed at the schema-generation step.

## Fix

- Raise both iOS presets to 15.0 so the top-level iOS configure is legal.
- Give the `flatc`/`flatcc` host sub-builds an explicit macOS deployment floor
  instead of the iOS target, so they target the host. The SDK root was already
  blanked for non-MAC Apple builds for the same reason; this completes it for the
  deployment target.
- Add `CMakePresets.json` to the Apple workflow's path filter so a preset change
  runs the framework packaging job.
- Fix a stale deployment-target comment in the MLX build.

## Test Plan

On a Mac with the pinned iOS toolchain, the `flatc` host sub-build now configures
with a macOS deployment floor (14.0) rather than the iOS target, so it builds for
the host. Both iOS presets configure at 15.0 on the current Xcode, and 12.0 is
rejected.
