### PR TITLE
[ET-VK] Serialize non-finite floats using flatc's spelling

### DIFF
--- a/backends/vulkan/serialization/vulkan_graph_serialize.py
+++ b/backends/vulkan/serialization/vulkan_graph_serialize.py
@@ -11,6 +11,7 @@ import ctypes
 import importlib.resources as _resources
 import json
 import os
+import re
 import tempfile
 from dataclasses import dataclass
 from typing import ClassVar, List
@@ -27,8 +28,64 @@ from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_da
 from executorch.exir._serialize._flatbuffer import _flatc_compile, _flatc_decompile
 
 
+# flatc's JSON dialect spells the non-finite floats "inf" / "-inf"; Python's
+# json module spells them "Infinity" / "-Infinity" and rejects flatc's spelling.
+# Neither side has a spelling the other accepts, so both directions are
+# translated below. A graph carries a non-finite scalar whenever the model
+# does -- the -inf fill value of a transformer attention mask is the common
+# case -- and without this the failure surfaces as a flatc byte offset into a
+# temporary file rather than anything pointing at the graph.
+_JSON_STRING_RE = re.compile(r'"(?:[^"\\]|\\.)*"')
+_FLATC_INF_RE = re.compile(r"(?<![\w.])(-?)inf(?![\w.])")
+
+
+class _VkGraphEncoder(_DataclassEncoder):
+    """Emit non-finite floats using flatc's spelling instead of Python's.
+
+    flatc has no spelling at all for NaN, so that case is reported directly
+    rather than emitting JSON that flatc cannot read.
+    """
+
+    def iterencode(self, o, _one_shot=False):
+        # Force the pure-Python encoder: the C encoder emits containers as
+        # single pre-joined chunks, so the float tokens could not be
+        # substituted here.
+        for chunk in super().iterencode(o, _one_shot=False):
+            if chunk == "Infinity":
+                yield "inf"
+            elif chunk == "-Infinity":
+                yield "-inf"
+            elif chunk == "NaN":
+                raise ValueError(
+                    "Cannot serialize a NaN float value into a Vulkan graph: "
+                    "the FlatBuffers JSON format has no spelling for NaN."
+                )
+            else:
+                yield chunk
+
+
+def _flatc_json_to_python_json(text: str) -> str:
+    """Rewrite flatc's bare ``inf`` / ``-inf`` tokens so json.load accepts them.
+
+    String literals are copied through untouched so that a shader or key name
+    containing "inf" is never rewritten.
+    """
+
+    def sub(segment: str) -> str:
+        return _FLATC_INF_RE.sub(lambda m: m.group(1) + "Infinity", segment)
+
+    out = []
+    last = 0
+    for m in _JSON_STRING_RE.finditer(text):
+        out.append(sub(text[last : m.start()]))
+        out.append(m.group(0))
+        last = m.end()
+    out.append(sub(text[last:]))
+    return "".join(out)
+
+
 def convert_to_flatbuffer(vk_graph: VkGraph) -> bytes:
-    vk_graph_json = json.dumps(vk_graph, cls=_DataclassEncoder)
+    vk_graph_json = json.dumps(vk_graph, cls=_VkGraphEncoder)
 
     with tempfile.TemporaryDirectory() as d:
         schema_path = os.path.join(d, "schema.fbs")
@@ -63,7 +120,8 @@ def flatbuffer_to_vk_graph(flatbuffers: bytes) -> VkGraph:
 
         json_path = os.path.join(d, "schema.json")
         with open(json_path, "rb") as output_file:
-            return _json_to_dataclass(json.load(output_file), VkGraph)
+            raw = output_file.read().decode("utf-8")
+        return _json_to_dataclass(json.loads(_flatc_json_to_python_json(raw)), VkGraph)
 
 
 def extract_vk_flatbuffer(data: bytes) -> bytes:

--- a/backends/vulkan/serialization/vulkan_graph_serialize.py
+++ b/backends/vulkan/serialization/vulkan_graph_serialize.py
@@ -28,52 +28,29 @@ from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_da
 from executorch.exir._serialize._flatbuffer import _flatc_compile, _flatc_decompile
 
 
-# flatc's JSON dialect spells the non-finite floats "inf" / "-inf"; Python's
-# json module spells them "Infinity" / "-Infinity" and rejects flatc's spelling.
-# Neither side has a spelling the other accepts, so both directions are
-# translated below. A graph carries a non-finite scalar whenever the model
-# does -- the -inf fill value of a transformer attention mask is the common
-# case -- and without this the failure surfaces as a flatc byte offset into a
-# temporary file rather than anything pointing at the graph.
+# Python's json module spells the non-finite floats "Infinity" / "-Infinity" /
+# "NaN"; flatc spells the infinities "inf" / "-inf" and rejects Python's
+# spelling, so both directions need translating. A graph carries a non-finite
+# scalar whenever the model does -- the -inf fill value of a transformer
+# attention mask is the common case -- and without this the failure surfaces as
+# a flatc byte offset into a temporary file rather than anything pointing at
+# the graph.
+#
+# The rewrite runs over the serialized text rather than over the encoder's
+# chunks: json only emits a float as a chunk of its own inside an object, and
+# inside a list the chunk carries the delimiter with it ("[-Infinity"), so
+# matching whole chunks silently missed every DoubleList.
 _JSON_STRING_RE = re.compile(r'"(?:[^"\\]|\\.)*"')
-_FLATC_INF_RE = re.compile(r"(?<![\w.])(-?)inf(?![\w.])")
+_PY_NONFINITE_RE = re.compile(r"(?<![\w.])(Infinity|NaN)(?![\w.])")
+_FLATC_INF_RE = re.compile(r"(?<![\w.])inf(?![\w.])")
 
 
-class _VkGraphEncoder(_DataclassEncoder):
-    """Emit non-finite floats using flatc's spelling instead of Python's.
+def _rewrite_outside_strings(text: str, sub) -> str:
+    """Apply ``sub`` to everything in ``text`` that is not a JSON string.
 
-    flatc has no spelling at all for NaN, so that case is reported directly
-    rather than emitting JSON that flatc cannot read.
+    String literals are copied through untouched, so a shader name or a string
+    value that happens to read "inf" is never rewritten.
     """
-
-    def iterencode(self, o, _one_shot=False):
-        # Force the pure-Python encoder: the C encoder emits containers as
-        # single pre-joined chunks, so the float tokens could not be
-        # substituted here.
-        for chunk in super().iterencode(o, _one_shot=False):
-            if chunk == "Infinity":
-                yield "inf"
-            elif chunk == "-Infinity":
-                yield "-inf"
-            elif chunk == "NaN":
-                raise ValueError(
-                    "Cannot serialize a NaN float value into a Vulkan graph: "
-                    "the FlatBuffers JSON format has no spelling for NaN."
-                )
-            else:
-                yield chunk
-
-
-def _flatc_json_to_python_json(text: str) -> str:
-    """Rewrite flatc's bare ``inf`` / ``-inf`` tokens so json.load accepts them.
-
-    String literals are copied through untouched so that a shader or key name
-    containing "inf" is never rewritten.
-    """
-
-    def sub(segment: str) -> str:
-        return _FLATC_INF_RE.sub(lambda m: m.group(1) + "Infinity", segment)
-
     out = []
     last = 0
     for m in _JSON_STRING_RE.finditer(text):
@@ -84,8 +61,39 @@ def _flatc_json_to_python_json(text: str) -> str:
     return "".join(out)
 
 
+def _python_json_to_flatc_json(text: str) -> str:
+    """Rewrite json's ``Infinity`` tokens into the ``inf`` flatc accepts."""
+    if "Infinity" not in text and "NaN" not in text:
+        return text
+
+    def replace(m: "re.Match[str]") -> str:
+        if m.group(1) == "NaN":
+            raise ValueError(
+                "Cannot serialize a NaN float value into a Vulkan graph: "
+                "flatc rejects every spelling of NaN for a value inside a "
+                "union, and every float in the Vulkan schema is a member of "
+                "the VkValue union."
+            )
+        return "inf"
+
+    return _rewrite_outside_strings(
+        text, lambda segment: _PY_NONFINITE_RE.sub(replace, segment)
+    )
+
+
+def _flatc_json_to_python_json(text: str) -> str:
+    """Rewrite flatc's bare ``inf`` tokens so json.loads accepts them."""
+    if "inf" not in text:
+        return text
+    return _rewrite_outside_strings(
+        text, lambda segment: _FLATC_INF_RE.sub("Infinity", segment)
+    )
+
+
 def convert_to_flatbuffer(vk_graph: VkGraph) -> bytes:
-    vk_graph_json = json.dumps(vk_graph, cls=_VkGraphEncoder)
+    vk_graph_json = _python_json_to_flatc_json(
+        json.dumps(vk_graph, cls=_DataclassEncoder)
+    )
 
     with tempfile.TemporaryDirectory() as d:
         schema_path = os.path.join(d, "schema.fbs")

--- a/backends/vulkan/test/test_serialization.py
+++ b/backends/vulkan/test/test_serialization.py
@@ -19,6 +19,7 @@ from executorch.backends.vulkan.serialization import (
 )
 
 from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
+    Double,
     IntList,
     OperatorCall,
     String,
@@ -267,5 +268,61 @@ class TestSerialization(unittest.TestCase):
 
         bs = convert_to_flatbuffer(in_vk_graph)
         out_vk_graph = flatbuffer_to_vk_graph(bs)
+
+        self.assertEqual(in_vk_graph, out_vk_graph)
+
+    def test_serialize_deserialize_non_finite_floats(self) -> None:
+        # flatc's JSON dialect spells the infinities "inf" / "-inf" while
+        # Python's json module spells them "Infinity" / "-Infinity" and rejects
+        # flatc's spelling, so both directions need translating. A graph picks
+        # up a non-finite scalar whenever the model has one -- the -inf fill
+        # value of a transformer attention mask being the usual source.
+        in_vk_graph = VkGraph(
+            version="1",
+            chain=[],
+            values=[
+                VkValue(value=Double(double_val=float("-inf"))),
+                VkValue(value=Double(double_val=float("inf"))),
+                VkValue(value=Double(double_val=1.5)),
+            ],
+            input_ids=[],
+            output_ids=[],
+            constants=[],
+            shaders=[],
+        )
+
+        out_vk_graph = flatbuffer_to_vk_graph(convert_to_flatbuffer(in_vk_graph))
+
+        self.assertEqual(in_vk_graph, out_vk_graph)
+
+    def test_serialize_nan_float_raises(self) -> None:
+        # FlatBuffers JSON has no spelling for NaN at all, so report it rather
+        # than emitting JSON that flatc cannot parse.
+        vk_graph = VkGraph(
+            version="1",
+            chain=[],
+            values=[VkValue(value=Double(double_val=float("nan")))],
+            input_ids=[],
+            output_ids=[],
+            constants=[],
+            shaders=[],
+        )
+
+        with self.assertRaisesRegex(ValueError, "NaN"):
+            convert_to_flatbuffer(vk_graph)
+
+    def test_deserialize_leaves_inf_inside_strings_alone(self) -> None:
+        # The inf-token rewrite must not reach into string literals.
+        in_vk_graph = VkGraph(
+            version="1",
+            chain=[OperatorCall(node_id=1, name="inf_shader", args=[])],
+            values=[VkValue(value=String(string_val="value: inf, -inf"))],
+            input_ids=[],
+            output_ids=[],
+            constants=[],
+            shaders=[],
+        )
+
+        out_vk_graph = flatbuffer_to_vk_graph(convert_to_flatbuffer(in_vk_graph))
 
         self.assertEqual(in_vk_graph, out_vk_graph)

--- a/backends/vulkan/test/test_serialization.py
+++ b/backends/vulkan/test/test_serialization.py
@@ -20,6 +20,7 @@ from executorch.backends.vulkan.serialization import (
 
 from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
     Double,
+    DoubleList,
     IntList,
     OperatorCall,
     String,
@@ -271,58 +272,76 @@ class TestSerialization(unittest.TestCase):
 
         self.assertEqual(in_vk_graph, out_vk_graph)
 
-    def test_serialize_deserialize_non_finite_floats(self) -> None:
-        # flatc's JSON dialect spells the infinities "inf" / "-inf" while
-        # Python's json module spells them "Infinity" / "-Infinity" and rejects
-        # flatc's spelling, so both directions need translating. A graph picks
-        # up a non-finite scalar whenever the model has one -- the -inf fill
-        # value of a transformer attention mask being the usual source.
+    def _round_trip(self, values, chain=None) -> VkGraph:
         in_vk_graph = VkGraph(
             version="1",
-            chain=[],
-            values=[
+            chain=chain if chain is not None else [],
+            values=values,
+            input_ids=[],
+            output_ids=[],
+            constants=[],
+            shaders=[],
+        )
+        out_vk_graph = flatbuffer_to_vk_graph(convert_to_flatbuffer(in_vk_graph))
+        self.assertEqual(in_vk_graph, out_vk_graph)
+        return out_vk_graph
+
+    def test_serialize_deserialize_non_finite_scalars(self) -> None:
+        # Python's json module spells the infinities "Infinity" / "-Infinity"
+        # while flatc spells them "inf" / "-inf" and rejects Python's spelling,
+        # so both directions need translating. A graph picks up a non-finite
+        # scalar whenever the model has one -- the -inf fill value of a
+        # transformer attention mask being the usual source.
+        self._round_trip(
+            [
                 VkValue(value=Double(double_val=float("-inf"))),
                 VkValue(value=Double(double_val=float("inf"))),
                 VkValue(value=Double(double_val=1.5)),
-            ],
-            input_ids=[],
-            output_ids=[],
-            constants=[],
-            shaders=[],
+            ]
         )
 
-        out_vk_graph = flatbuffer_to_vk_graph(convert_to_flatbuffer(in_vk_graph))
-
-        self.assertEqual(in_vk_graph, out_vk_graph)
+    def test_serialize_deserialize_non_finite_floats_in_list(self) -> None:
+        # json only emits a float as a chunk of its own inside an object; in a
+        # list the chunk carries the delimiter with it, so a rewrite that works
+        # on the scalar above can still miss every element of a DoubleList.
+        self._round_trip(
+            [
+                VkValue(value=DoubleList(items=[float("-inf")])),
+                VkValue(
+                    value=DoubleList(items=[1.5, float("inf"), 2.5, float("-inf")])
+                ),
+                VkValue(value=DoubleList(items=[])),
+            ]
+        )
 
     def test_serialize_nan_float_raises(self) -> None:
-        # FlatBuffers JSON has no spelling for NaN at all, so report it rather
-        # than emitting JSON that flatc cannot parse.
-        vk_graph = VkGraph(
-            version="1",
-            chain=[],
-            values=[VkValue(value=Double(double_val=float("nan")))],
-            input_ids=[],
-            output_ids=[],
-            constants=[],
-            shaders=[],
-        )
+        # flatc rejects nan, NaN and Nan alike for a value inside a union, and
+        # every float in the Vulkan schema is a member of the VkValue union, so
+        # report it here rather than emitting JSON that flatc cannot read.
+        for value in (
+            Double(double_val=float("nan")),
+            DoubleList(items=[1.0, float("nan")]),
+        ):
+            vk_graph = VkGraph(
+                version="1",
+                chain=[],
+                values=[VkValue(value=value)],
+                input_ids=[],
+                output_ids=[],
+                constants=[],
+                shaders=[],
+            )
+            with self.assertRaisesRegex(ValueError, "NaN"):
+                convert_to_flatbuffer(vk_graph)
 
-        with self.assertRaisesRegex(ValueError, "NaN"):
-            convert_to_flatbuffer(vk_graph)
-
-    def test_deserialize_leaves_inf_inside_strings_alone(self) -> None:
-        # The inf-token rewrite must not reach into string literals.
-        in_vk_graph = VkGraph(
-            version="1",
+    def test_serialize_deserialize_leaves_strings_alone(self) -> None:
+        # The token rewrites run over the serialized JSON, so they must not
+        # reach into string literals in either direction.
+        self._round_trip(
+            [
+                VkValue(value=String(string_val="value: inf, -inf")),
+                VkValue(value=String(string_val="Infinity NaN nan")),
+                VkValue(value=String(string_val='quoted "inf" and \\ inf')),
+            ],
             chain=[OperatorCall(node_id=1, name="inf_shader", args=[])],
-            values=[VkValue(value=String(string_val="value: inf, -inf"))],
-            input_ids=[],
-            output_ids=[],
-            constants=[],
-            shaders=[],
         )
-
-        out_vk_graph = flatbuffer_to_vk_graph(convert_to_flatbuffer(in_vk_graph))
-
-        self.assertEqual(in_vk_graph, out_vk_graph)


### PR DESCRIPTION
### Summary

Fixes #22305.

The Vulkan graph is serialized by dumping it to JSON with Python's `json` module and handing that to `flatc`. The two disagree on how to spell the non-finite floats: Python emits `Infinity` / `-Infinity` / `NaN`, and `flatc` accepts none of them. Any model whose graph carries a non-finite scalar therefore fails to lower, with the `-inf` fill value of a transformer attention mask being the common source. `all-MiniLM-L6-v2` and CLIP ViT-B/32 both partition cleanly and then die with:

```
schema.json:1: 6012: error: cannot parse value starting with: -
```

which names a byte offset inside a deleted temporary file and points at nothing in the model.

`flatc` does accept `inf` and `-inf` (checked against flatc 24.3.25; `nan`, `NaN`, `infinity` are all rejected), so the infinities round-trip exactly. The decompile direction needs the inverse rewrite, since `flatc` writes bare `inf` tokens that `json.load` will not parse; string literals are stepped over so a shader or key name containing "inf" is left alone. FlatBuffers JSON has no spelling for NaN at all, so that case raises with a message naming the problem rather than emitting JSON `flatc` cannot read.

### Test plan

Three new cases in `backends/vulkan/test/test_serialization.py`: an exact round-trip of `-inf` / `inf` / a finite value, the NaN error, and a string literal containing "inf" surviving the decode rewrite untouched.

```
pytest backends/vulkan/test/test_serialization.py
7 passed
```

Verified end to end that `sentence-transformers/all-MiniLM-L6-v2` now lowers through `VulkanPartitioner` (14 delegate blobs, 3/3 runs at `PYTHONHASHSEED=0`), where before it failed 3/3.


cc @SS-JIA @manuelcandales @digantdesai @cbilgin