### PR TITLE
[ET-VK] Add the missing int32 -> uint8 view_convert variant

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/view_convert_buffer.yaml
@@ -18,6 +18,7 @@ view_convert_buffer:
         - parameter_values: [uint8, float]
         - parameter_values: [uint8, half]
         - parameter_values: [uint8, int32]
+        - parameter_values: [int32, uint8]
         - parameter_values: [float, int32]
         - parameter_values: [float, half]
         - parameter_values: [half, float]

--- a/backends/vulkan/runtime/graph/ops/glsl/view_convert_texture.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/view_convert_texture.yaml
@@ -18,6 +18,7 @@ view_convert_texture:
         - parameter_values: [uint8, float]
         - parameter_values: [uint8, half]
         - parameter_values: [uint8, int32]
+        - parameter_values: [int32, uint8]
         - parameter_values: [float, int32]
         - parameter_values: [float, half]
         - parameter_values: [half, float]


### PR DESCRIPTION
### Summary

Fixes #22320.

The `view_convert` combo lists generate `uint8 -> int32` but not the reverse, so a graph containing an `int32 -> uint8` view_convert lowers cleanly through `VulkanPartitioner` and then aborts on device:

```
Could not find ShaderInfo with name view_convert_buffer_int32_uint8
(ShaderRegistry.cpp:54, (it != listings_.end()) is false)
```

The partitioner has no visibility into which dtype pairs were generated, so the node is accepted at AOT and the failure only appears at run time. `sentence-transformers/all-MiniLM-L6-v2` hits this through its attention mask on any graph lowered with `VulkanPartitioner`.

`view_convert` is a plain elementwise `OUT_T(t_inp[...])` cast, so the pair needs nothing beyond being listed in the buffer and texture variant lists.

### Test plan

On a Galaxy S26 Ultra (Adreno 840), arm64-v8a, NDK 27.1, `main` @ c27baa8031:

Before, `executor_runner` aborts loading the model with the error above. After, all-MiniLM-L6-v2 loads and runs, and its embedding matches the eager reference:

```
minilm  vulkan vs torch ref   max|dev| 4.0e-04   cosine 0.99999726
minilm  replay 0 vs replay 29 max|dev| 0.0       cosine 1.00000000
```

Bit-identical across 90 in-process replays (3 rounds x 30 executions), so the added cast is stable as well as correct. Median 7.76 ms/iteration against 8.38 ms for the same model on XNNPACK.


cc @SS-JIA @manuelcandales @digantdesai @cbilgin