### PR TITLE
[ET-VK] Clamp the tanh argument in the gelu shader

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/unary_op.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/unary_op.yaml
@@ -31,7 +31,7 @@ unary_op:
     - NAME: exp
       OPERATOR: exp(X)
     - NAME: gelu
-      OPERATOR: 0.5 * X * (1 + tanh(sqrt(2 / 3.141593) * (X + 0.044715 * X * X * X)))
+      OPERATOR: 0.5 * X * (1 + tanh(clamp(sqrt(2 / 3.141593) * (X + 0.044715 * X * X * X), -15.0, 15.0)))
     - NAME: neg
       OPERATOR: -X
     - NAME: sigmoid


### PR DESCRIPTION
Fixes #22323.

The `gelu` shader evaluates the tanh approximation with an unclamped argument. That argument grows cubically in the input, so `x = -13.24` already yields `-93.4`, and a driver that computes `tanh(y)` as `(e^y - e^-y) / (e^y + e^-y)` overflows fp32 at `|y| > ~88` and returns `inf/inf = NaN`.

The `tanh` op in this same file already clamps to `+/-15` for exactly this reason. This change makes `gelu` do the same.

The clamp costs no accuracy: `1 - tanh(15) = 1.9e-13`, well below fp32 epsilon, so the output is bit-identical for every input that gets clamped.

### Verification

Whisper-tiny encoder, Vulkan delegate, Samsung Galaxy S10+ (Mali-G76), against a CPU reference:

| | before | after |
| --- | --- | --- |
| NaN elements in output | 576000 / 576000 | 0 |
| cosine vs reference | n/a | 0.99999702 |
| max abs deviation | n/a | 3.97e-02 |
| distinct outputs over 10 runs | 1 (all NaN) | 1 (all correct) |

Before the fix the failure is silent: the runner reports success and normal per-iteration timings while returning an all-NaN tensor.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani