### PR TITLE
[ET-VK] Fix out-of-range broadcast size calculation for 0-dim tensors

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.cpp
@@ -18,10 +18,15 @@ std::vector<int64_t> calculate_broadcasted_output_size(
     const std::vector<int64_t>& sizes1,
     const std::vector<int64_t>& sizes2) {
   std::vector<int64_t> out_sizes(std::max(sizes1.size(), sizes2.size()));
+  // ndim must be signed. `-out_sizes.size()` is size_t arithmetic, so when both
+  // inputs are 0-dimensional it evaluates to 0 while `i` promotes to a huge
+  // unsigned value, the guard stays true, and `out_sizes.at(size() - 1)` throws
+  // std::out_of_range instead of the loop being skipped.
+  const int64_t ndim = static_cast<int64_t>(out_sizes.size());
 
   // Match the sizes in reverse because sizes are in NCHW order
-  for (int i = -1; i >= -out_sizes.size(); --i) {
-    out_sizes.at(out_sizes.size() + i) =
+  for (int64_t i = -1; i >= -ndim; --i) {
+    out_sizes.at(static_cast<size_t>(ndim + i)) =
         std::max(utils::val_at(i, sizes1), utils::val_at(i, sizes2));
   }
 

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -1080,6 +1080,20 @@ class TestVulkanBackend(unittest.TestCase):
             sample_inputs,
         )
 
+    def test_vulkan_backend_binary_op_zero_dim(self):
+        # Both operands, and therefore the output, are 0-dimensional. This is
+        # what a reduction to a scalar followed by arithmetic produces, e.g. the
+        # log-mel normalisation in Whisper's preprocessor.
+        class ZeroDimModule(torch.nn.Module):
+            def forward(self, x):
+                m = x.max()
+                return (m - (m - 1.0)).reshape(1)
+
+        self.lower_module_and_test_output(
+            ZeroDimModule(),
+            (torch.randn(size=(64,), dtype=torch.float32),),
+        )
+
     @disable_test("layer norm compute shader not working with swiftshader")
     def test_vulkan_backend_native_layer_norm(self):
         class NativeLayerNormModule(torch.nn.Module):


### PR DESCRIPTION
Fixes #22331.

`calculate_broadcasted_output_size()` guards its loop with `i >= -out_sizes.size()`. That is `size_t` arithmetic, so when both operands are 0-dimensional the bound evaluates to `0`, `i` promotes to `SIZE_MAX`, the guard stays true, and the body runs `out_sizes.at(0 - 1)` on an empty vector, throwing `std::out_of_range`.

`check_binary_op_args()` calls it during graph construction, so any binary op with a 0-dimensional output aborts at load rather than failing at execute time.

Non-empty outputs are unaffected and stay bit-identical: the same unsigned wraparound happens to compare correctly there. With `size() == 2` the bound is `SIZE_MAX - 1`, so `i = -1, -2` pass and `i = -3` fails, exactly as intended. Only the empty case is broken. This holds the bound in a signed local so the loop is simply skipped.

### Why it matters

Whisper's log-mel normalisation subtracts one scalar from another, so its whole `encode` method (mel preprocessor plus encoder) could not be loaded on Vulkan. That is not caused by the dynamic audio dimension (a static 30 s export fails identically) or by multi-method lowering (an encode-only .pte fails identically).

### Verification

Snapdragon SM8850 (Adreno 840):

| model | before | after |
| --- | --- | --- |
| `x.max() - (x.max() - 1.0)`, 0-dim output | abort | exact, max abs diff 0 |
| `x - x.max()`, 0-dim broadcast to rank 1 | ok | exact, max abs diff 0 |
| same arithmetic at rank 1 | ok | exact, max abs diff 0 |
| Whisper-tiny `encode` | abort at load | runs, cosine 0.99998790 vs CPU |

`test_vulkan_backend_binary_op_zero_dim` covers the 0-dim case.
