### PR TITLE
Report the MLX backend as unavailable on the iOS simulator

### DIFF
--- a/backends/mlx/runtime/MLXBackend.cpp
+++ b/backends/mlx/runtime/MLXBackend.cpp
@@ -31,6 +31,8 @@
 #include <memory>
 #include <mutex>
 
+#include <TargetConditionals.h>
+
 namespace executorch {
 namespace backends {
 namespace mlx {
@@ -217,7 +219,14 @@ class MLXBackend final : public ::executorch::runtime::BackendInterface {
   ~MLXBackend() override = default;
 
   bool is_available() const override {
+#if TARGET_OS_SIMULATOR
+    // The simulator's Metal device reports no architecture and refuses a
+    // shared storage heap, and MLX requires both without checking, so it
+    // faults on its first device access rather than returning an error.
+    return false;
+#else
     return ::mlx::core::metal::is_available();
+#endif
   }
 
   Result<DelegateHandle*> init(

--- a/backends/mlx/runtime/MLXBackend.cpp
+++ b/backends/mlx/runtime/MLXBackend.cpp
@@ -220,9 +220,11 @@ class MLXBackend final : public ::executorch::runtime::BackendInterface {
 
   bool is_available() const override {
 #if TARGET_OS_SIMULATOR
-    // The simulator's Metal device reports no architecture and refuses a
-    // shared storage heap, and MLX requires both without checking, so it
-    // faults on its first device access rather than returning an error.
+    // The simulator's Metal device reports no architecture, which MLX reads
+    // without a null check while constructing its device. Past that, requesting
+    // a shared storage heap traps inside Metal itself, so MLX never gets a
+    // value it could fall back from. This is a build switch rather than a
+    // probe: it can go once the simulator has a usable Metal device.
     return false;
 #else
     return ::mlx::core::metal::is_available();

--- a/docs/source/backends-overview.md
+++ b/docs/source/backends-overview.md
@@ -23,7 +23,7 @@ Backends are the bridge between your exported model and the hardware it runs on.
 | [XNNPACK](backends/xnnpack/xnnpack-overview.md)              | All           | CPU           | General-purpose, fallback       |
 | [CUDA](backends/cuda/cuda-overview.md)                       | Linux/Windows | GPU           | NVIDIA GPU acceleration         |
 | [Core ML](backends/coreml/coreml-overview.md)                | iOS, macOS    | NPU/GPU/CPU   | Apple devices, high performance |
-| [MLX](/backends/mlx/mlx-overview.md)                         | macOS         | GPU           | Apple Silicon GPU (MLX)         |
+| [MLX](/backends/mlx/mlx-overview.md)                         | iOS (experimental), macOS | GPU | Apple Silicon GPU (MLX)         |
 | [Vulkan](backends/vulkan/vulkan-overview.md)                 | Android, Linux, Windows | GPU  | Android devices (mature); Desktops (experimental) |
 | [WebGPU](backends/webgpu/webgpu-overview.md)                 | Browser, Linux, macOS | GPU | Cross-platform and browser GPU execution (experimental) |
 | [Qualcomm](backends-qualcomm)                                | Android     | NPU           | Qualcomm SoCs                   |

--- a/docs/source/backends/mlx/mlx-overview.md
+++ b/docs/source/backends/mlx/mlx-overview.md
@@ -16,10 +16,14 @@ The MLX delegate is experimental and under active development.
 
 ## Target Requirements
 
-- Apple Silicon Mac (M1 or later)
-- [macOS](https://developer.apple.com/macos) >= 14.0
-- iOS and iPadOS on a real device. The iOS simulator has no Metal device MLX can use, so the
-  backend reports itself unavailable there and a model delegated to it will not load.
+One of:
+
+- [macOS](https://developer.apple.com/macos) >= 14.0 on an Apple Silicon Mac (M1 or later)
+- [iOS](https://developer.apple.com/ios) or [iPadOS](https://developer.apple.com/ipados) >= 17.0
+  on a real device (experimental). The backend is built and shipped for iOS, but
+  running a model on a physical device is not yet covered by CI. The iOS simulator
+  has no Metal device MLX can use, so the backend reports itself unavailable there
+  and a model delegated to it will not load.
 
 ## Development Requirements
 

--- a/docs/source/backends/mlx/mlx-overview.md
+++ b/docs/source/backends/mlx/mlx-overview.md
@@ -18,6 +18,8 @@ The MLX delegate is experimental and under active development.
 
 - Apple Silicon Mac (M1 or later)
 - [macOS](https://developer.apple.com/macos) >= 14.0
+- iOS and iPadOS on a real device. The iOS simulator has no Metal device MLX can use, so the
+  backend reports itself unavailable there and a model delegated to it will not load.
 
 ## Development Requirements
 

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -10,7 +10,7 @@ The ExecuTorch Runtime for iOS and macOS (ARM64) is distributed as a collection 
 * `executorch_dump` - ETDump profiling
 * `executorch_llm` - LLM-specific runtime components
 * `backend_coreml` - Core ML backend
-* `backend_mlx` - MLX backend, on real devices and Mac only, not the iOS simulator
+* `backend_mlx` - MLX backend
 * `backend_xnnpack` - XNNPACK backend
 * `kernels_llm` - Custom kernels for LLMs
 * `kernels_optimized` - Accelerated generic CPU kernels
@@ -22,6 +22,8 @@ Link your binary with the ExecuTorch runtime and any backends or kernels used by
 **Note:** You may need to add some extra linker flags for the build settings of the components that links against ExecuTorch backends or kernels to let them register properly at the app startup. See the [Linkage](#Linkage) section for more details.
 
 **Note:** To access logs, link against the Debug build of the ExecuTorch runtime, i.e., the `executorch_debug` framework. For optimal performance, always link against the Release version of the deliverables (those without the `_debug` suffix), which have all logging overhead removed. See the [Logging](#Logging) section for more details.
+
+**Note:** The MLX backend links and registers on the iOS simulator, so an app builds for both destinations, but it reports itself unavailable there because the simulator has no Metal device it can use. A model delegated to MLX will not load on the simulator. Use a real device or a Mac to run one.
 
 ### Swift Package Manager
 

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -10,7 +10,7 @@ The ExecuTorch Runtime for iOS and macOS (ARM64) is distributed as a collection 
 * `executorch_dump` - ETDump profiling
 * `executorch_llm` - LLM-specific runtime components
 * `backend_coreml` - Core ML backend
-* `backend_mlx` - MLX backend
+* `backend_mlx` - MLX backend, on real devices and Mac only, not the iOS simulator
 * `backend_xnnpack` - XNNPACK backend
 * `kernels_llm` - Custom kernels for LLMs
 * `kernels_optimized` - Accelerated generic CPU kernels

--- a/runtime/executor/test/backend_integration_test.cpp
+++ b/runtime/executor/test/backend_integration_test.cpp
@@ -347,6 +347,28 @@ TEST_P(BackendIntegrationTest, BasicInitSucceeds) {
   EXPECT_EQ(method_res.error(), Error::Ok);
 }
 
+TEST_P(BackendIntegrationTest, UnavailableBackendFailsToLoad) {
+  // A backend that reports itself unavailable must make load_method return
+  // NotFound rather than being initialized anyway. Backends that cannot run on
+  // the current platform rely on this to fail instead of faulting.
+  StubBackend::singleton().install_is_available([]() { return false; });
+
+  Result<FileDataLoader> loader = FileDataLoader::from(program_path());
+  ASSERT_EQ(loader.error(), Error::Ok);
+  Result<Program> program = Program::load(&loader.get());
+  ASSERT_EQ(program.error(), Error::Ok);
+
+  // The gate only means something if this method actually delegates to the
+  // stub, so confirm that before asserting the load fails on availability.
+  EXPECT_TRUE(
+      program->method_meta("forward")->uses_backend(StubBackend::kName));
+
+  ManagedMemoryManager mmm(kDefaultNonConstMemBytes, kDefaultRuntimeMemBytes);
+
+  Result<Method> method_res = program->load_method("forward", &mmm.get());
+  EXPECT_EQ(method_res.error(), Error::NotFound);
+}
+
 TEST_P(BackendIntegrationTest, GetBackendNamesSuccess) {
   // Load the program from file.
   Result<FileDataLoader> loader = FileDataLoader::from(program_path());


### PR DESCRIPTION
## Summary

Loading a model that delegates to MLX crashes the process on an iOS simulator instead of failing
cleanly. In the examples repository the demo app crashes on its MLX menu entry, and the llama and
image classifier tests crash with it.

The simulator's Metal device is real enough to build and dispatch a compute pipeline, but two things
MLX does during startup do not survive it:

| what MLX does | what the simulator does |
| --- | --- |
| reads `device.architecture` while constructing its device | returns nothing, and MLX reads it with no null check |
| asks for a shared storage heap | Metal trips an assertion and aborts the process |

MLX has an opt-out for the heap, but it only fires when the device names itself
`Apple Paravirtual device`. A simulator reports `Apple iOS simulator GPU`, so the request goes
through. Neither failure is reachable as an error, so nothing downstream can report it.

`is_available()` is the interface's own answer to whether a backend can run here, and the runtime
already asks before loading a delegate, so returning false is enough to turn the crash into
`Error::NotFound`. MLX's own `is_available()` returns a constant and checks nothing, which is why the
answer has to come from here.

This does not make MLX work on the simulator. It makes the answer honest, so a caller gets an error it
can handle.

## Documentation

Four pages disagreed with each other about where MLX runs. The MLX overview listed Mac only, while the
build has shipped an iOS slice and declared iOS 17 for some time, so the page was behind the build.
The backend table and the C++ component table also said macOS only. All three now say iOS and macOS,
with the iOS minimum version the build actually enforces.

The iOS page keeps the MLX framework in its list without an exception, because the framework still
builds, ships and links for the simulator: only the runtime answer changed. The simulator behaviour is
called out in a note beside the existing ones instead, so nobody reads the list and starts removing
the simulator slice from their build.

## Test plan

A runtime test that needs no Apple hardware: the executor's stub backend already has a hook to install
a custom availability answer, unused until now. Installing `false` and loading a delegated method
returns `Error::NotFound` rather than initializing the backend. That runs on every pull request, on
Linux, and it fails if the check in `Method::load` is removed.

For the guard itself, the macro decides everything, so it is checked on all three targets it affects:

```
simulator   TARGET_OS_SIMULATOR 1   is_available() false
device      TARGET_OS_SIMULATOR 0   defers to MLX
macOS       TARGET_OS_SIMULATOR 0   defers to MLX
```

A real GPU is unaffected. Compiling the same function with the guard disabled returns true on the
simulator again, which is the crashing path.

The two Metal facts above were measured directly, with a standalone Metal probe run in a booted
simulator: the device reports `Apple iOS simulator GPU` with a null architecture, and the heap request
aborts with `MTLStorageModePrivate is required for heaps`, signal 6.

Not covered: no model was run through MLX on a physical iPhone or iPad as part of this change. The iOS
device rows in the tables reflect what the build already ships, not a new claim measured here.

## Follow-ups, not in this change

- `apple.yml` has a path filter that does not list `backends/mlx`, so the iOS framework job does not
  run for MLX runtime changes. Adding it is one line and belongs in its own change.
- The build still produces and requires the simulator slice of the MLX Metal kernel library. That is
  deliberate for now: if the simulator gains a usable Metal device the guard goes and the file is
  needed again.
