### PR TITLE
Arm backend: fix unbound ARM_SETUP_CURL_PROGRESS_ARGS under bash 3.2

### DIFF
--- a/backends/arm/scripts/utils.sh
+++ b/backends/arm/scripts/utils.sh
@@ -93,7 +93,7 @@ function download_with_retry() {
     for attempt in $(seq 1 ${max_attempts}); do
         rm -f "${output}"
         if curl --fail --retry 3 --retry-delay 5 --retry-connrefused --retry-all-errors \
-             "${ARM_SETUP_CURL_PROGRESS_ARGS[@]}" -L --output "${output}" "${url}" \
+             ${ARM_SETUP_CURL_PROGRESS_ARGS[@]+"${ARM_SETUP_CURL_PROGRESS_ARGS[@]}"} -L --output "${output}" "${url}" \
            && verify_md5 "${expected_md5}" "${output}"; then
             return 0
         fi

--- a/backends/arm/scripts/vulkan_utils.sh
+++ b/backends/arm/scripts/vulkan_utils.sh
@@ -53,7 +53,7 @@ function download_and_extract_vulkan_sdk_linux() {
 
     if [[ ! -e "${vulkan_sdk_tar_file}" ]]; then
         log_step "vulkan" "Downloading Vulkan SDK (${vulkan_sdk_version})"
-        curl "${ARM_SETUP_CURL_PROGRESS_ARGS[@]}" -L --output "${vulkan_sdk_tar_file}" "${vulkan_sdk_url}"
+        curl ${ARM_SETUP_CURL_PROGRESS_ARGS[@]+"${ARM_SETUP_CURL_PROGRESS_ARGS[@]}"} -L --output "${vulkan_sdk_tar_file}" "${vulkan_sdk_url}"
         echo "${vulkan_sdk_sha256} ${vulkan_sdk_tar_file}" | sha256sum -c - || exit 1
         rm -fr ${vulkan_sdk_base_dir}
     fi
@@ -67,7 +67,7 @@ function install_vulkan_sdk_macos() {
 
     if [[ ! -e "${vulkan_sdk_zip_file}" ]]; then
         log_step "vulkan" "Downloading Vulkan SDK (${vulkan_sdk_version}) for macOS"
-        curl "${ARM_SETUP_CURL_PROGRESS_ARGS[@]}" -L --output "${vulkan_sdk_zip_file}" "${vulkan_sdk_url}"
+        curl ${ARM_SETUP_CURL_PROGRESS_ARGS[@]+"${ARM_SETUP_CURL_PROGRESS_ARGS[@]}"} -L --output "${vulkan_sdk_zip_file}" "${vulkan_sdk_url}"
         echo "${vulkan_sdk_sha256}  ${vulkan_sdk_zip_file}" | shasum -a 256 -c - || exit 1
         rm -fr ${vulkan_sdk_base_dir}
     fi


### PR DESCRIPTION
### Summary

Fixes #22313

`examples/arm/setup.sh` runs under `set -u`, but `ARM_SETUP_CURL_PROGRESS_ARGS`
is only assigned when `.ci/scripts/detect_ci.sh` detects a CI environment. On a
local run the array is never set, and the first download aborts on macOS's
stock bash:

```
backends/arm/scripts/utils.sh: line 96: ARM_SETUP_CURL_PROGRESS_ARGS[@]: unbound variable
```

CI never sees this because bash >= 4.4 expands an unset array under `set -u`
without error; macOS ships bash 3.2.57.

This PR guards the three expansion sites (`utils.sh:download_with_retry`, and
the two `curl` calls in `vulkan_utils.sh`) with the portable idiom:

```sh
${ARM_SETUP_CURL_PROGRESS_ARGS[@]+"${ARM_SETUP_CURL_PROGRESS_ARGS[@]}"}
```

Why not just initialize the array to `()` near the top of `setup.sh`: bash
before 4.4 raises the same error when expanding an **empty** array under
`set -u`, so that would still crash on macOS. The `+` parameter-expansion
guard handles unset and empty alike, and preserves per-element quoting when
the array is populated (the CI case).

### Test plan

Manual, on macOS 26 / stock `/bin/bash` 3.2.57. Reproduce each state of the
array against both the old and the guarded expansion (`printf` standing in
for `curl`):

```sh
# old form — errors when unset, errors when empty, OK when set:
/bin/bash -uc 'printf "<%s>" x "${A[@]}" y'                  # error: A[@]: unbound variable
/bin/bash -uc 'A=(); printf "<%s>" x "${A[@]}" y'            # error: A[@]: unbound variable
/bin/bash -uc 'A=(--no-progress-meter); printf "<%s>" x "${A[@]}" y'   # <x><--no-progress-meter><y>

# guarded form — OK in all three states, quoting preserved:
/bin/bash -uc 'printf "<%s>" x ${A[@]+"${A[@]}"} y'          # <x><y>
/bin/bash -uc 'A=(); printf "<%s>" x ${A[@]+"${A[@]}"} y'    # <x><y>
/bin/bash -uc 'A=(--no-progress-meter); printf "<%s>" x ${A[@]+"${A[@]}"} y'   # <x><--no-progress-meter><y>
```

Also verified: identical guarded-form behavior on bash 5.3 (no regression for
Linux/CI), and `bash -n` syntax checks pass on both edited scripts under both
bash versions.

---

Developed with Claude's assistance (co-author trailer on the commit); diagnosed
on my machine while working through the Ethos-U getting-started tutorial, and
verified by me on macOS 26 / stock bash 3.2.57.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani