### PR TITLE
Arm backend: Resolve inferred view dims

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -184,6 +184,7 @@ from .remove_safe_softmax_guard_pass import RemoveSafeSoftmaxGuardPass  # noqa
 from .replace_scalar_with_tensor_pass import (  # noqa
     ReplaceScalarWithTensorByProfilePass,
 )
+from .resolve_view_copy_inferred_dim_pass import ResolveViewCopyInferredDimPass  # noqa
 from .rewrite_adaptive_avg_pool2d import RewriteAdaptiveAvgPool2dPass  # noqa
 from .rewrite_avg_pool2d_pass import RewriteAvgPool2dPass  # noqa
 from .rewrite_bool_bitwise_to_logical_pass import (  # noqa

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -148,6 +148,7 @@ from executorch.backends.arm._passes import (  # type: ignore[attr-defined]
     RemoveSafeSoftmaxGuardPass,
     ReplaceInfAndLimitValuesPass,
     ReplaceScalarWithTensorByProfilePass,
+    ResolveViewCopyInferredDimPass,
     RewriteAdaptiveAvgPool2dPass,
     RewriteAvgPool2dPass,
     RewriteBoolBitwiseToLogicalPass,
@@ -682,6 +683,7 @@ class ArmPassManager(ExportedProgramPassManager):
                 CanonicalizeViewCopyPermutePass(),
                 # Fuse views again after permutes may have been replaced by views.
                 FuseViewCopyTransformPass(),
+                ResolveViewCopyInferredDimPass(),
                 InsertConstShapesPass(),
                 InsertDataLayoutCastsPass(),
             ]

--- a/backends/arm/_passes/resolve_view_copy_inferred_dim_pass.py
+++ b/backends/arm/_passes/resolve_view_copy_inferred_dim_pass.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from executorch.backends.arm._passes.arm_pass import ArmPass
+from executorch.backends.arm._passes.symbolic_shape_utils import materialize_symints
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import PassResult
+
+
+class ResolveViewCopyInferredDimPass(ArmPass):
+    """Materialize inferred view dimensions before TOSA shape lowering."""
+
+    _passes_required_after = set()
+    target_ops = {
+        torch.ops.aten.view.default,
+        exir_ops.edge.aten.view_copy.default,
+    }
+
+    def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        graph = graph_module.graph
+        modified = False
+
+        for node in graph.nodes:
+            if node.op != "call_function" or node.target not in self.target_ops:
+                continue
+            if len(node.args) < 2 or not isinstance(node.args[1], (list, tuple)):
+                continue
+
+            shape = node.args[1]
+            inferred_dim_indices = [
+                i for i, dim in enumerate(shape) if isinstance(dim, int) and dim == -1
+            ]
+            if not inferred_dim_indices:
+                continue
+            if len(inferred_dim_indices) > 1:
+                raise ValueError("View shape contains more than one inferred dimension")
+            if "val" not in node.meta:
+                raise ValueError(
+                    "Cannot resolve inferred view dimension without metadata"
+                )
+
+            output = node.meta["val"]
+            output_shape = output.shape if hasattr(output, "shape") else output
+            if len(shape) != len(output_shape):
+                raise ValueError(
+                    "Cannot resolve inferred view dimension when view shape rank "
+                    f"does not match output metadata rank: {len(shape)} != "
+                    f"{len(output_shape)}"
+                )
+
+            inferred_dim_index = inferred_dim_indices[0]
+            with graph.inserting_before(node):
+                (inferred_dim,) = materialize_symints(
+                    graph, [output_shape[inferred_dim_index]]
+                )
+
+            resolved_shape = list(shape)
+            resolved_shape[inferred_dim_index] = inferred_dim
+            new_args = list(node.args)
+            new_args[1] = (
+                tuple(resolved_shape) if isinstance(shape, tuple) else resolved_shape
+            )
+            node.args = tuple(new_args)
+            modified = True
+
+        if modified:
+            graph.eliminate_dead_code()
+            graph.lint()
+        return PassResult(graph_module, modified)

--- a/backends/arm/_passes/symbolic_shape_utils.py
+++ b/backends/arm/_passes/symbolic_shape_utils.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Sequence
+
+import torch
+
+
+def materialize_symints(
+    graph: torch.fx.Graph, values: Sequence[int | torch.SymInt]
+) -> list[torch.fx.Node | int]:
+    """Materialize symbolic integers into FX graph values.
+
+    Args:
+        graph (torch.fx.Graph): Graph where producer nodes are inserted.
+        values (Sequence[int | torch.SymInt]): Integer values to materialize.
+
+    Returns:
+        list[torch.fx.Node | int]: Materialized graph nodes or static integers.
+
+    """
+    materialized = graph.materialize_symints(values)
+    if not any(isinstance(value, torch.SymInt) for value in materialized):
+        return materialized
+    raise AssertionError("materialize_symints returned a raw SymInt")

--- a/backends/arm/test/passes/test_resolve_view_copy_inferred_dim_pass.py
+++ b/backends/arm/test/passes/test_resolve_view_copy_inferred_dim_pass.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, cast
+
+import pytest
+
+import sympy  # type: ignore[import-untyped]
+import torch
+from executorch.backends.arm._passes.resolve_view_copy_inferred_dim_pass import (
+    ResolveViewCopyInferredDimPass,
+)
+from executorch.backends.test.graph_builder import GraphBuilder
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import NodeMetadata, ProxyValue
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+
+def _make_symint(
+    shape_env: ShapeEnv, symbol: str, hint: int, min: int = 1, max: int = 64
+) -> torch.SymInt:
+    symint = shape_env.create_symintnode(sympy.Symbol(symbol), hint=hint)
+    assert isinstance(symint, torch.SymInt)
+    shape_env.constrain_symbol_range(
+        symint.node.expr, compiler_min=min, compiler_max=max
+    )
+    return symint
+
+
+def _single_view_graph(
+    op,
+    input_value: torch.Tensor,
+    shape: list[Any] | tuple[Any, ...],
+    output_value: torch.Tensor,
+    fake_tensor_mode: FakeTensorMode | None = None,
+) -> tuple[torch.fx.GraphModule, ProxyValue, ProxyValue]:
+    builder = GraphBuilder(fake_tensor_mode=fake_tensor_mode)
+    x = builder.placeholder("x", input_value)
+    view = builder.call_operator(
+        op,
+        (x, shape),
+        meta=NodeMetadata({"val": output_value}),
+    )
+    builder.output([view])
+    return builder.get_graph_module(), x, view
+
+
+def test_resolve_view_copy_inferred_dim_replaces_static_dim() -> None:
+    graph_module, _, view = _single_view_graph(
+        torch.ops.aten.view.default,
+        torch.empty(2, 12),
+        [2, -1, 4],
+        torch.empty(2, 3, 4),
+    )
+
+    result = ResolveViewCopyInferredDimPass().call(graph_module)
+
+    assert result.modified
+    assert view.node.args[1] == [2, 3, 4]
+    assert torch.ops.aten.sym_size.int not in {
+        node.target for node in graph_module.graph.nodes
+    }
+    graph_module.graph.lint()
+
+
+def test_resolve_view_copy_inferred_dim_materializes_dynamic_dim() -> None:
+    shape_env = ShapeEnv()
+    batch = _make_symint(shape_env, "batch", hint=2)
+    width = _make_symint(shape_env, "width", hint=3)
+
+    with FakeTensorMode(shape_env=shape_env, allow_non_fake_inputs=True) as mode:
+        graph_module, x, view = _single_view_graph(
+            exir_ops.edge.aten.view_copy.default,
+            torch.empty(size=(batch, width, 4)),
+            [batch, -1, 4],
+            torch.empty(size=(batch, width, 4)),
+            mode,
+        )
+
+        result = ResolveViewCopyInferredDimPass().call(graph_module)
+
+    assert result.modified
+    resolved_shape = cast(list[Any], view.node.args[1])
+    assert resolved_shape[0] == batch
+    assert isinstance(resolved_shape[1], torch.fx.Node)
+    assert resolved_shape[1].target == torch.ops.aten.sym_size.int
+    assert resolved_shape[1].args == (x.node, 1)
+    assert resolved_shape[1].meta["val"].node.expr == width.node.expr
+    assert resolved_shape[2] == 4
+    assert -1 not in resolved_shape
+    graph_module.graph.lint()
+
+
+def test_resolve_view_copy_inferred_dim_preserves_tuple_shape() -> None:
+    graph_module, _, view = _single_view_graph(
+        exir_ops.edge.aten.view_copy.default,
+        torch.empty(2, 12),
+        (2, -1, 4),
+        torch.empty(2, 3, 4),
+    )
+
+    result = ResolveViewCopyInferredDimPass().call(graph_module)
+
+    assert result.modified
+    assert view.node.args[1] == (2, 3, 4)
+    graph_module.graph.lint()
+
+
+def test_resolve_view_copy_inferred_dim_ignores_explicit_shape() -> None:
+    graph_module, _, view = _single_view_graph(
+        exir_ops.edge.aten.view_copy.default,
+        torch.empty(2, 3, 4),
+        [2, 3, 4],
+        torch.empty(2, 3, 4),
+    )
+
+    result = ResolveViewCopyInferredDimPass().call(graph_module)
+
+    assert not result.modified
+    assert view.node.args[1] == [2, 3, 4]
+    graph_module.graph.lint()
+
+
+def test_resolve_view_copy_inferred_dim_rejects_multiple_inferred_dims() -> None:
+    graph_module, _, view = _single_view_graph(
+        exir_ops.edge.aten.view_copy.default,
+        torch.empty(24),
+        [2, -1, 4],
+        torch.empty(2, 3, 4),
+    )
+    view.node.args = (view.node.args[0], [2, -1, -1])
+
+    with pytest.raises(ValueError, match="more than one inferred dimension"):
+        ResolveViewCopyInferredDimPass().call(graph_module)


### PR DESCRIPTION
Add a pass that replaces inferred view/view_copy dimensions with explicit dimensions from output metadata before TOSA shape lowering. Dynamic inferred dimensions are materialized into FX shape producers so later lowering does not see raw SymInt values in view shape arguments.

cc @digantdesai @freddan80 @per @zingo @mansnils @Sebastian-Larsson @robell @rascani