### PR TITLE
Arm backend: Fix corner case in convert int64 pass

### DIFF
--- a/backends/arm/_passes/convert_int64_output_ops_to_int32.py
+++ b/backends/arm/_passes/convert_int64_output_ops_to_int32.py
@@ -242,6 +242,8 @@ class ConvertInt64OutputOpsToInt32Pass(ArmPass):
         ranges: Dict[torch.fx.Node, Tuple[int, int]],
         graph_module: torch.fx.GraphModule,
     ) -> Optional[Tuple[int, int]]:
+        if node.target not in self.aten_index_binary_ops + self.edge_index_binary_ops:
+            return None
         if get_first_fake_tensor(node).dtype != torch.int64 or len(node.args) < 2:
             return None
         lhs = self._operand_range(node.args[0], ranges, graph_module)
@@ -482,7 +484,7 @@ class ConvertInt64OutputOpsToInt32Pass(ArmPass):
         for node in list(graph.nodes):
             if node.op != "call_function":
                 continue
-            if node.target not in self.aten_ops + self.edge_ops:
+            if node.target not in self.aten_ops + self.edge_ops or not node.users:
                 continue
             output_dtype = get_first_fake_tensor(node).dtype
             if output_dtype != torch.int64:

--- a/backends/arm/test/passes/test_convert_int64_output_ops_to_int32.py
+++ b/backends/arm/test/passes/test_convert_int64_output_ops_to_int32.py
@@ -221,6 +221,45 @@ def test_arg_op_direct_output_is_unchanged(arg_op):
     assert result.graph_module(torch.randn(2, 8))[0].dtype == torch.int64
 
 
+def test_arg_op_ignores_unrelated_node_without_value_metadata():
+    from torch._subclasses import FakeTensorMode
+
+    graph = Graph()
+    with FakeTensorMode():
+        fake_input = torch.empty(2, 8)
+        fake_output = torch.empty(2, dtype=torch.int64)
+    x = graph.placeholder("x")
+    x.meta["val"] = fake_input
+    argmax = graph.call_function(torch.ops.aten.argmax.default, (x, 1))
+    argmax.meta["val"] = fake_output
+    graph.call_function(
+        exir_ops.edge.dim_order_ops._to_dim_order_copy.default,
+        (x,),
+        {"dtype": torch.int64},
+    )
+    graph.output(argmax)
+    graph_module = GraphModule(torch.nn.Module(), graph)
+
+    result = ConvertInt64OutputOpsToInt32Pass().call(graph_module)
+
+    assert not result.modified
+
+
+def test_live_supported_node_without_value_metadata_raises():
+    graph = Graph()
+    x = graph.placeholder("x")
+    cast = graph.call_function(
+        exir_ops.edge.dim_order_ops._to_dim_order_copy.default,
+        (x,),
+        {"dtype": torch.int64},
+    )
+    graph.output(cast)
+    graph_module = GraphModule(torch.nn.Module(), graph)
+
+    with pytest.raises(KeyError, match="val"):
+        ConvertInt64OutputOpsToInt32Pass().call(graph_module)
+
+
 ##############################################################
 ## Test on_overflow range check for argmax/argmin           ##
 ##############################################################


### PR DESCRIPTION
Range propagation examines every call-function node while following bounded argmax/argmin outputs. It queried fake-tensor metadata before checking whether a node was supported, so generated cast nodes without meta["val"] raised a KeyError during Stable Diffusion lowering.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @Sebastian-Larsson @robell @rascani