### PR TITLE
Arm backend: Add runner CMake API manifest

### DIFF
--- a/backends/arm/cmake/ArmRunnerUtils.cmake
+++ b/backends/arm/cmake/ArmRunnerUtils.cmake
@@ -3,751 +3,158 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 
-# Internal helper routines shared by Arm runner examples and superbuilds. These
-# functions are not a stable public CMake API.
-
-get_filename_component(
-  _arm_runner_executorch_root "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE
+# Stable CMake API for in-tree and external Arm runner consumers. Incompatible
+# changes require a migration path for existing consumers.
+# cmake-format: off
+set(ARM_RUNNER_UTILS_API_COMMANDS
+    arm_runner_add_minimal_executable
+    arm_runner_add_standalone_executorch
+    arm_runner_configure_ethos_u_platform
+    arm_runner_configure_linker_script
+    arm_runner_configure_model
+    arm_runner_configure_runtime_output
+    arm_runner_create_default_selected_ops_libs
+    arm_runner_create_selected_ops_lib
+    arm_runner_define_cache_options
+    arm_runner_link_minimal_specs
+    arm_runner_link_registration_libraries
+    arm_runner_require_baremetal_targets
+    arm_runner_require_python
+    arm_runner_validate_model_source
 )
-if(NOT EXECUTORCH_ROOT)
-  set(EXECUTORCH_ROOT "${_arm_runner_executorch_root}")
-endif()
 
-# Make sure codegen function used below is loaded.
-if(NOT COMMAND gen_selected_ops)
-  include(${EXECUTORCH_ROOT}/tools/cmake/Codegen.cmake)
-endif()
-include(${EXECUTORCH_ROOT}/backends/arm/scripts/corstone_utils.cmake)
-include(${EXECUTORCH_ROOT}/backends/arm/cmake/ArmEthosUSDK.cmake)
+# KIND distinguishes functions from macros; SIGNATURE records the stable call
+# interface.
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_add_minimal_executable function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_add_minimal_executable
+    "arm_runner_add_minimal_executable(*, TARGET, SOURCE, OPS_PREFIX, COMPILE_DEFINITIONS=())"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_add_standalone_executorch macro)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_add_standalone_executorch
+    "arm_runner_add_standalone_executorch()"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_configure_ethos_u_platform function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_configure_ethos_u_platform
+    "arm_runner_configure_ethos_u_platform(*, SDK_PATH, SYSTEM_CONFIG, MEMORY_MODE)"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_configure_linker_script function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_configure_linker_script
+    "arm_runner_configure_linker_script(*, TARGET, SYSTEM_CONFIG, OUTPUT_NAME=None)"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_configure_model function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_configure_model
+    "arm_runner_configure_model(*, TARGET, PTE_FILE=None, MODEL_PTE_ADDR=None, MODEL_PTE_SIZE=None, PUBLIC=False)"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_configure_runtime_output function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_configure_runtime_output
+    "arm_runner_configure_runtime_output(TARGET_NAME, FALLBACK_DIR)"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_create_default_selected_ops_libs
+    function
+)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_create_default_selected_ops_libs
+    "arm_runner_create_default_selected_ops_libs(*, PREFIX, SUFFIX=None, OP_LIST=None, OPS_FROM_MODEL=None, DTYPE_SELECTIVE_BUILD=None, OUT_LIBS=None, DEPS=())"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_create_selected_ops_lib function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_create_selected_ops_lib
+    "arm_runner_create_selected_ops_lib(*, LIB_NAME, FUNCTIONS_YAML=None, CUSTOM_OPS_YAML=None, OP_LIST=None, OPS_FROM_MODEL=None, DTYPE_SELECTIVE_BUILD=None, KERNEL_LIBS=(), DEPS=(), INCLUDE_ALL_OPS=False, PRIM_OPS=False)"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_define_cache_options function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_define_cache_options
+    "arm_runner_define_cache_options(*, METHOD_ALLOCATOR_SIZE=None)"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_link_minimal_specs function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_link_minimal_specs
+    "arm_runner_link_minimal_specs(TARGET_NAME)"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_link_registration_libraries function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_link_registration_libraries
+    "arm_runner_link_registration_libraries(*, TARGET, SCOPE=None, BASE_LIBS=(), REGISTRATION_LIBS=(), NORMAL_LIBS=(), SUPPRESS_LIBS=())"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_require_baremetal_targets function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_require_baremetal_targets
+    "arm_runner_require_baremetal_targets()"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_require_python macro)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_require_python
+    "arm_runner_require_python()"
+)
+set(ARM_RUNNER_UTILS_API_KIND_arm_runner_validate_model_source function)
+set(ARM_RUNNER_UTILS_API_SIGNATURE_arm_runner_validate_model_source
+    "arm_runner_validate_model_source(*, ALLOW_SEMIHOSTING=False)"
+)
+# cmake-format: on
 
-macro(arm_runner_require_python)
-  if(NOT PYTHON_EXECUTABLE)
-    find_package(
-      Python3
-      COMPONENTS Interpreter
-      REQUIRED
-    )
-    set(PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
-  endif()
-endmacro()
-
-macro(arm_runner_add_standalone_executorch)
-  if(DEFINED CMAKE_SKIP_INSTALL_RULES)
-    set(_arm_runner_skip_install_rules_was_defined TRUE)
-    set(_arm_runner_skip_install_rules "${CMAKE_SKIP_INSTALL_RULES}")
-  else()
-    set(_arm_runner_skip_install_rules_was_defined FALSE)
-  endif()
-  if(DEFINED CACHE{CMAKE_SKIP_INSTALL_RULES})
-    set(_arm_runner_skip_install_rules_cache_was_defined TRUE)
-    get_property(
-      _arm_runner_skip_install_rules_cache_type
-      CACHE CMAKE_SKIP_INSTALL_RULES
-      PROPERTY TYPE
-    )
-    set(_arm_runner_skip_install_rules_cache "$CACHE{CMAKE_SKIP_INSTALL_RULES}")
-  else()
-    set(_arm_runner_skip_install_rules_cache_was_defined FALSE)
-  endif()
-
-  arm_runner_require_python()
-
-  include(${EXECUTORCH_ROOT}/tools/cmake/common/preset.cmake)
-  if(NOT DEFINED EXECUTORCH_BUILD_PRESET_FILE)
-    set(EXECUTORCH_BUILD_PRESET_FILE
-        "${EXECUTORCH_ROOT}/tools/cmake/preset/arm_baremetal.cmake"
-        CACHE PATH "ExecuTorch build preset"
-    )
-  endif()
-  load_build_preset()
-  foreach(
-    _arm_runner_option
-    EXECUTORCH_BUILD_ARM_BAREMETAL EXECUTORCH_BUILD_CORTEX_M
-    EXECUTORCH_BUILD_KERNELS_QUANTIZED EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL
-  )
-    set(${_arm_runner_option}
-        ON
-        CACHE BOOL "" FORCE
-    )
-  endforeach()
-  set(EXECUTORCH_SKIP_ARM_EXECUTOR_RUNNER
-      ON
-      CACHE BOOL "" FORCE
-  )
-  set(MAX_KERNEL_NUM
-      2000
-      CACHE STRING "Maximum registered kernels"
-  )
-
-  set(_arm_runner_select_ops "${EXECUTORCH_SELECT_OPS_LIST}")
-  set(EXECUTORCH_SELECT_OPS_LIST "")
-  set(CMAKE_SKIP_INSTALL_RULES ON)
-  add_subdirectory(
-    ${EXECUTORCH_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/executorch EXCLUDE_FROM_ALL
-  )
-  if(_arm_runner_skip_install_rules_cache_was_defined)
-    set(CMAKE_SKIP_INSTALL_RULES
-        "${_arm_runner_skip_install_rules_cache}"
-        CACHE "${_arm_runner_skip_install_rules_cache_type}" "" FORCE
-    )
-  else()
-    unset(CMAKE_SKIP_INSTALL_RULES CACHE)
-  endif()
-  if(_arm_runner_skip_install_rules_was_defined)
-    set(CMAKE_SKIP_INSTALL_RULES "${_arm_runner_skip_install_rules}")
-  else()
-    unset(CMAKE_SKIP_INSTALL_RULES)
-  endif()
-  unset(_arm_runner_skip_install_rules)
-  unset(_arm_runner_skip_install_rules_was_defined)
-  unset(_arm_runner_skip_install_rules_cache)
-  unset(_arm_runner_skip_install_rules_cache_type)
-  unset(_arm_runner_skip_install_rules_cache_was_defined)
-  set(EXECUTORCH_SELECT_OPS_LIST "${_arm_runner_select_ops}")
-  include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
-endmacro()
-
-function(arm_runner_add_minimal_executable)
-  set(one_value_args TARGET SOURCE OPS_PREFIX)
-  set(multi_value_args COMPILE_DEFINITIONS)
-  cmake_parse_arguments(
-    ARG "" "${one_value_args}" "${multi_value_args}" ${ARGN}
-  )
-  if(NOT ARG_TARGET
-     OR NOT ARG_SOURCE
-     OR NOT ARG_OPS_PREFIX
-  )
-    message(FATAL_ERROR "TARGET, SOURCE, and OPS_PREFIX are required.")
-  endif()
-
-  add_executable(
-    ${ARG_TARGET}
-    ${ARG_SOURCE}
-    ${EXECUTORCH_ROOT}/examples/arm/common/arm_memory_allocator.cpp
-  )
-  target_include_directories(
-    ${ARG_TARGET}
-    PRIVATE ${EXECUTORCH_ROOT}
-            ${EXECUTORCH_ROOT}/runtime/core/portable_type/c10
-            ${EXECUTORCH_ROOT}/examples/arm/common ${CMAKE_CURRENT_BINARY_DIR}
-  )
-  target_compile_definitions(
-    ${ARG_TARGET}
-    PRIVATE
-      C10_USING_CUSTOM_GENERATED_MACROS
-      ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=${ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE}
-      ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE=${ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE}
-      ${ARG_COMPILE_DEFINITIONS}
-  )
-  arm_runner_configure_model(
-    TARGET
-    ${ARG_TARGET}
-    PTE_FILE
-    "${ET_PTE_FILE_PATH}"
-    MODEL_PTE_ADDR
-    "${ET_MODEL_PTE_ADDR}"
-    MODEL_PTE_SIZE
-    "${ET_MODEL_PTE_SIZE}"
-  )
-  arm_runner_configure_linker_script(
-    TARGET ${ARG_TARGET} SYSTEM_CONFIG "${SYSTEM_CONFIG}"
-  )
-  arm_runner_link_minimal_specs(${ARG_TARGET})
-  arm_runner_link_registration_libraries(
-    TARGET
-    ${ARG_TARGET}
-    BASE_LIBS
-    extension_runner_util
-    ethosu_target_init
-    REGISTRATION_LIBS
-    executorch
-    executorch_delegate_ethos_u
-    ${ARG_OPS_PREFIX}_portable_ops
-    ${ARG_OPS_PREFIX}_quantized_ops
-    ${ARG_OPS_PREFIX}_cortex_m_ops
-    NORMAL_LIBS
-    cortex_m_kernels
-    quantized_kernels
-    portable_kernels
-    kernels_util_all_deps
-  )
-  target_link_options(${ARG_TARGET} PRIVATE LINKER:-Map=${ARG_TARGET}.map)
-endfunction()
-
-function(arm_runner_define_cache_options)
-  set(one_value_args METHOD_ALLOCATOR_SIZE)
-  cmake_parse_arguments(ARG "" "${one_value_args}" "" ${ARGN})
-  set(ET_PTE_FILE_PATH
-      ""
-      CACHE PATH "Path to an ExecuTorch model PTE"
-  )
-  set(ET_MODEL_PTE_ADDR
-      ""
-      CACHE STRING "Address of a memory-mapped PTE"
-  )
-  set(ET_MODEL_PTE_SIZE
-      ""
-      CACHE STRING "Size in bytes of a memory-mapped PTE"
-  )
-  set(EXECUTORCH_SELECT_OPS_LIST
-      ""
-      CACHE STRING "Explicit operator selection"
-  )
-  set(ETHOS_SDK_PATH
-      "${EXECUTORCH_ROOT}/examples/arm/arm-scratch/ethos-u"
-      CACHE PATH "Path to the Ethos-U bare-metal SDK"
-  )
-  set(SYSTEM_CONFIG
-      "Ethos_U55_High_End_Embedded"
-      CACHE STRING "Ethos-U system configuration"
-  )
-  set(MEMORY_MODE
-      "Shared_Sram"
-      CACHE STRING "Ethos-U memory mode"
-  )
-  if(MEMORY_MODE MATCHES "^Dedicated_Sram($|_)")
-    set(_scratch_size 0x4000000)
-  else()
-    set(_scratch_size 0x200000)
-  endif()
-  if(NOT DEFINED ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
-    set(ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE
-        ${_scratch_size}
-        PARENT_SCOPE
-    )
-  endif()
-  set(ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE
-      "${ARG_METHOD_ALLOCATOR_SIZE}"
-      CACHE STRING "Persistent method allocator size"
-  )
-endfunction()
-
-function(arm_runner_validate_model_source)
-  cmake_parse_arguments(ARG "ALLOW_SEMIHOSTING" "" "" ${ARGN})
-  if(NOT (ARG_ALLOW_SEMIHOSTING AND SEMIHOSTING)
-     AND NOT ET_MODEL_PTE_ADDR
-     AND "${ET_PTE_FILE_PATH}" STREQUAL ""
-  )
-    message(FATAL_ERROR "Set ET_PTE_FILE_PATH or ET_MODEL_PTE_ADDR.")
-  endif()
-  if(NOT "${ET_PTE_FILE_PATH}" STREQUAL "" AND NOT EXISTS "${ET_PTE_FILE_PATH}")
-    message(FATAL_ERROR "ET_PTE_FILE_PATH does not exist: ${ET_PTE_FILE_PATH}")
-  endif()
-  if(ET_MODEL_PTE_ADDR AND NOT ET_MODEL_PTE_SIZE)
-    message(
-      WARNING
-        "ET_MODEL_PTE_SIZE is unset; using the legacy 0x10000000 upper bound."
-    )
-    set(ET_MODEL_PTE_SIZE
-        0x10000000
-        PARENT_SCOPE
-    )
-  endif()
-  if(ET_MODEL_PTE_SIZE AND NOT ET_MODEL_PTE_ADDR)
-    message(FATAL_ERROR "ET_MODEL_PTE_SIZE requires ET_MODEL_PTE_ADDR.")
-  endif()
-endfunction()
-
-#[[
-Configure how an ExecuTorch model is made available to a runner target.
-
-Arguments:
-  TARGET: Existing runner target to configure.
-  PTE_FILE: PTE file to convert into a generated model_pte.h header.
-  MODEL_PTE_ADDR: Address of a PTE already present in target memory. This takes
-    precedence over PTE_FILE.
-  MODEL_PTE_SIZE: Size in bytes of the PTE at MODEL_PTE_ADDR. If omitted, the
-    legacy 0x10000000 upper bound is used.
-  PUBLIC: Propagate the selected model compile definition to dependants.
-]]
-function(arm_runner_configure_model)
-  set(options PUBLIC)
-  set(one_value_args TARGET PTE_FILE MODEL_PTE_ADDR MODEL_PTE_SIZE)
-  cmake_parse_arguments(ARG "${options}" "${one_value_args}" "" ${ARGN})
-  if(NOT ARG_TARGET)
-    message(FATAL_ERROR "TARGET is required.")
-  endif()
-
-  if(ARG_PUBLIC)
-    set(_scope PUBLIC)
-  else()
-    set(_scope PRIVATE)
-  endif()
-
-  if(ARG_MODEL_PTE_ADDR)
-    target_compile_definitions(
-      ${ARG_TARGET} ${_scope} ET_MODEL_PTE_ADDR=${ARG_MODEL_PTE_ADDR}
-                    ET_MODEL_PTE_SIZE=${ARG_MODEL_PTE_SIZE}
-    )
-  elseif(NOT "${ARG_PTE_FILE}" STREQUAL "")
-    if(Python3_EXECUTABLE)
-      set(_python_executable "${Python3_EXECUTABLE}")
-    elseif(PYTHON_EXECUTABLE)
-      set(_python_executable "${PYTHON_EXECUTABLE}")
-    else()
-      find_package(
-        Python3
-        COMPONENTS Interpreter
-        REQUIRED
-      )
-      set(_python_executable "${Python3_EXECUTABLE}")
-    endif()
-    set(_model_header "${CMAKE_CURRENT_BINARY_DIR}/model_pte.h")
-    add_custom_command(
-      OUTPUT ${_model_header}
-      COMMAND
-        ${_python_executable}
-        ${EXECUTORCH_ROOT}/examples/arm/common/pte_to_header.py --pte
-        ${ARG_PTE_FILE} --outdir ${CMAKE_CURRENT_BINARY_DIR}
-      DEPENDS ${ARG_PTE_FILE}
-    )
-    add_custom_target(${ARG_TARGET}_model_header DEPENDS ${_model_header})
-    add_dependencies(${ARG_TARGET} ${ARG_TARGET}_model_header)
-    target_compile_definitions(${ARG_TARGET} ${_scope} ET_COMPILED_PTE)
-  endif()
-endfunction()
-
-function(arm_runner_configure_ethos_u_platform)
-  set(one_value_args SDK_PATH SYSTEM_CONFIG MEMORY_MODE)
-  cmake_parse_arguments(ARG "" "${one_value_args}" "" ${ARGN})
-  if(NOT ARG_SDK_PATH
-     OR NOT ARG_SYSTEM_CONFIG
-     OR NOT ARG_MEMORY_MODE
-  )
-    message(
-      FATAL_ERROR "SDK_PATH, SYSTEM_CONFIG, and MEMORY_MODE are required."
-    )
-  endif()
-
-  arm_ethos_u_default_fetch("${ARG_SDK_PATH}" _fetch_ethos_u_default)
-  option(FETCH_ETHOS_U_CONTENT "Fetch Ethos-U dependencies"
-         ${_fetch_ethos_u_default}
-  )
-  arm_ensure_ethos_u_content(
-    "${ARG_SDK_PATH}" "${EXECUTORCH_ROOT}" ${FETCH_ETHOS_U_CONTENT}
-  )
-  add_corstone_subdirectory(${ARG_SYSTEM_CONFIG} ${ARG_SDK_PATH})
-  configure_timing_adapters(${ARG_SYSTEM_CONFIG} ${ARG_MEMORY_MODE})
-  foreach(_platform_variable TARGET_BOARD ETHOSU_MODEL ETHOSU_ARENA)
-    if(DEFINED ${_platform_variable})
-      set(${_platform_variable}
-          "${${_platform_variable}}"
-          PARENT_SCOPE
-      )
-    endif()
-  endforeach()
-
-  if(NOT CMAKE_SKIP_INSTALL_RULES AND TARGET ethosu_core_driver)
-    get_property(
-      _ethosu_core_driver_exported GLOBAL
-      PROPERTY ET_ETHOSU_CORE_DRIVER_EXPORTED
-    )
-    if(NOT _ethosu_core_driver_exported)
-      install(
-        TARGETS ethosu_core_driver
-        EXPORT ExecuTorchTargets
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-      )
-      set_property(GLOBAL PROPERTY ET_ETHOSU_CORE_DRIVER_EXPORTED TRUE)
-    endif()
-  endif()
-endfunction()
-
-# Verify that targets required for building the executor runner are present.
-function(arm_runner_require_baremetal_targets)
-  if(NOT TARGET extension_runner_util)
-    message(
-      FATAL_ERROR
-        "extension_runner_util target missing. Configure ExecuTorch (or the standalone runner) with EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=ON."
-    )
-  endif()
-
-endfunction()
-
-function(verify_targets_exist)
-  cmake_parse_arguments(ARG "" "CONTEXT" "TARGETS" ${ARGN})
-
-  set(_targets ${ARG_TARGETS} ${ARG_UNPARSED_ARGUMENTS})
-  if(NOT ARG_CONTEXT)
-    set(ARG_CONTEXT "verify_targets_exist")
-  endif()
-
-  foreach(_target IN LISTS _targets)
-    if(NOT TARGET ${_target})
-      message(FATAL_ERROR "${ARG_CONTEXT} requires missing target ${_target}.")
-    endif()
-  endforeach()
-endfunction()
-
-#[[
-Create a selected operator registration library for one operator family.
-
-Arguments:
-  LIB_NAME: Name of the generated registration library target.
-	example: arm_cortex_m_ops_lib
-
-  FUNCTIONS_YAML: Portable ATen operator YAML used to generate bindings.
-	example: ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
-
-  CUSTOM_OPS_YAML: Custom/backend operator YAML used to generate bindings.
-	example: ${EXECUTORCH_ROOT}/backends/cortex_m/ops/operators.yaml
-
-  OP_LIST: Operators to select.
-	example: ${EXECUTORCH_SELECT_OPS_LIST}
-
-  OPS_FROM_MODEL: ExecuTorch model file used to select operators.
-	example: ${ET_PTE_FILE_PATH}
-
-  DTYPE_SELECTIVE_BUILD: Enables dtype filtering for operator libraries that support it.
-	example: ${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}
-
-  KERNEL_LIBS: Kernel implementation libraries used by the generated target.
-	example: cortex_m_kernels
-
-  DEPS: Additional libraries required by the generated registration target.
-	example: executorch
-
-  INCLUDE_ALL_OPS: Generate a non-selective registration library for the
-	selected operator family.
-
-  PRIM_OPS: Build a selective prim ops library instead of a codegen operators lib.
-
-The lib will always be created, even when no operators are selected.
-OP_LIST and OPS_FROM_MODEL can be used additively.
-If neither OP_LIST nor OPS_FROM_MODEL is set, the generated registration
-library is empty. INCLUDE_ALL_OPS explicitly builds a full registration library.
-]]
-function(arm_runner_create_selected_ops_lib)
-  # Parse arguments
-  set(options INCLUDE_ALL_OPS PRIM_OPS)
-  set(one_value_args LIB_NAME FUNCTIONS_YAML CUSTOM_OPS_YAML OP_LIST
-                     OPS_FROM_MODEL DTYPE_SELECTIVE_BUILD
-  )
-  set(multi_value_args KERNEL_LIBS DEPS)
-  cmake_parse_arguments(
-    ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
-  )
-
-  # Validate and normalize arguments
-  if(ARG_LIB_NAME)
-    set(_arm_runner_create_selected_ops_lib_context
-        "arm_runner_create_selected_ops_lib(${ARG_LIB_NAME})"
-    )
-  else()
-    set(_arm_runner_create_selected_ops_lib_context
-        "arm_runner_create_selected_ops_lib"
-    )
-  endif()
-
-  if(ARG_UNPARSED_ARGUMENTS)
-    message(
-      FATAL_ERROR
-        "${_arm_runner_create_selected_ops_lib_context} got unexpected arguments: ${ARG_UNPARSED_ARGUMENTS}."
-    )
-  endif()
-
-  if(NOT ARG_LIB_NAME)
-    message(
-      FATAL_ERROR
-        "${_arm_runner_create_selected_ops_lib_context} requires LIB_NAME."
-    )
-  endif()
-
-  if(NOT ARG_PRIM_OPS
-     AND NOT ARG_FUNCTIONS_YAML
-     AND NOT ARG_CUSTOM_OPS_YAML
+# Validate the API metadata before loading the implementation.
+foreach(_arm_runner_api_command IN LISTS ARM_RUNNER_UTILS_API_COMMANDS)
+  if(NOT DEFINED ARM_RUNNER_UTILS_API_KIND_${_arm_runner_api_command}
+     OR NOT DEFINED ARM_RUNNER_UTILS_API_SIGNATURE_${_arm_runner_api_command}
   )
     message(
       FATAL_ERROR
-        "${_arm_runner_create_selected_ops_lib_context} requires FUNCTIONS_YAML or CUSTOM_OPS_YAML unless PRIM_OPS is set."
+        "Arm runner CMake API metadata is missing for ${_arm_runner_api_command}."
     )
   endif()
-
-  if(ARG_DTYPE_SELECTIVE_BUILD)
-    executorch_load_build_variables()
-  endif()
-
-  verify_targets_exist(
-    CONTEXT "${_arm_runner_create_selected_ops_lib_context}" TARGETS
-    ${ARG_KERNEL_LIBS} ${ARG_DEPS}
+  if(NOT ARM_RUNNER_UTILS_API_KIND_${_arm_runner_api_command} MATCHES
+     "^(function|macro)$"
   )
-
-  # Generate selected operator list file.
-  set(_arm_runner_selected_ops_args
-      LIB_NAME
-      "${ARG_LIB_NAME}"
-      ROOT_OPS
-      "${ARG_OP_LIST}"
-      OPS_FROM_MODEL
-      "${ARG_OPS_FROM_MODEL}"
-      DTYPE_SELECTIVE_BUILD
-      "${ARG_DTYPE_SELECTIVE_BUILD}"
-  )
-  set(_arm_runner_include_all_ops OFF)
-  if(ARG_INCLUDE_ALL_OPS)
-    set(_arm_runner_include_all_ops ON)
-    list(APPEND _arm_runner_selected_ops_args INCLUDE_ALL_OPS "ON")
-  endif()
-  gen_selected_ops(${_arm_runner_selected_ops_args})
-
-  if(ARG_PRIM_OPS)
-    set(_arm_runner_prim_ops_args
-        LIB_NAME "${ARG_LIB_NAME}" SELECTED_OPS_YAML
-        "${gen_selected_ops_output_yaml}" DEPS ${ARG_DEPS}
-    )
-    if(_arm_runner_include_all_ops)
-      list(APPEND _arm_runner_prim_ops_args INCLUDE_ALL_OPS)
-    endif()
-    gen_selected_prim_ops_lib(${_arm_runner_prim_ops_args})
-    return()
-  endif()
-
-  # Codegen for operator library.
-  set(_arm_ops_binding_args LIB_NAME "${ARG_LIB_NAME}")
-  if(ARG_FUNCTIONS_YAML)
-    list(APPEND _arm_ops_binding_args FUNCTIONS_YAML "${ARG_FUNCTIONS_YAML}")
-  endif()
-  if(ARG_CUSTOM_OPS_YAML)
-    list(APPEND _arm_ops_binding_args CUSTOM_OPS_YAML "${ARG_CUSTOM_OPS_YAML}")
-  endif()
-  if(ARG_DTYPE_SELECTIVE_BUILD)
-    list(APPEND _arm_ops_binding_args DTYPE_SELECTIVE_BUILD
-         "${ARG_DTYPE_SELECTIVE_BUILD}"
+    message(
+      FATAL_ERROR
+        "Arm runner CMake API kind must be function or macro for ${_arm_runner_api_command}."
     )
   endif()
-  generate_bindings_for_kernels(${_arm_ops_binding_args})
-
-  # Finally, build operator library.
-  gen_operators_lib(
-    LIB_NAME
-    "${ARG_LIB_NAME}"
-    KERNEL_LIBS
-    ${ARG_KERNEL_LIBS}
-    DEPS
-    ${ARG_DEPS}
-    DTYPE_SELECTIVE_BUILD
-    "${ARG_DTYPE_SELECTIVE_BUILD}"
+  if(NOT ARM_RUNNER_UTILS_API_SIGNATURE_${_arm_runner_api_command} MATCHES
+     "^${_arm_runner_api_command}\\("
   )
-endfunction()
-
-function(arm_runner_create_default_selected_ops_libs)
-  set(one_value_args PREFIX SUFFIX OP_LIST OPS_FROM_MODEL DTYPE_SELECTIVE_BUILD
-                     OUT_LIBS
-  )
-  set(multi_value_args DEPS)
-  cmake_parse_arguments(
-    ARG "" "${one_value_args}" "${multi_value_args}" ${ARGN}
-  )
-  if(NOT ARG_PREFIX)
-    message(FATAL_ERROR "PREFIX is required.")
-  endif()
-
-  if(ARG_DEPS)
-    set(_portable_deps ${ARG_DEPS})
-    set(_quantized_deps ${ARG_DEPS})
-    set(_cortex_m_deps ${ARG_DEPS})
-  else()
-    set(_portable_deps executorch)
-    set(_quantized_deps executorch_core)
-    set(_cortex_m_deps executorch)
-  endif()
-
-  set(_portable_ops "${ARG_PREFIX}_portable_ops${ARG_SUFFIX}")
-  set(_quantized_ops "${ARG_PREFIX}_quantized_ops${ARG_SUFFIX}")
-  set(_cortex_m_ops "${ARG_PREFIX}_cortex_m_ops${ARG_SUFFIX}")
-
-  arm_runner_create_selected_ops_lib(
-    LIB_NAME
-    ${_portable_ops}
-    FUNCTIONS_YAML
-    "${EXECUTORCH_ROOT}/kernels/portable/functions.yaml"
-    OP_LIST
-    "${ARG_OP_LIST}"
-    OPS_FROM_MODEL
-    "${ARG_OPS_FROM_MODEL}"
-    DTYPE_SELECTIVE_BUILD
-    "${ARG_DTYPE_SELECTIVE_BUILD}"
-    KERNEL_LIBS
-    portable_kernels
-    DEPS
-    ${_portable_deps}
-  )
-  arm_runner_create_selected_ops_lib(
-    LIB_NAME
-    ${_quantized_ops}
-    CUSTOM_OPS_YAML
-    "${EXECUTORCH_ROOT}/kernels/quantized/quantized.yaml"
-    OP_LIST
-    "${ARG_OP_LIST}"
-    OPS_FROM_MODEL
-    "${ARG_OPS_FROM_MODEL}"
-    KERNEL_LIBS
-    quantized_kernels
-    DEPS
-    ${_quantized_deps}
-  )
-  arm_runner_create_selected_ops_lib(
-    LIB_NAME
-    ${_cortex_m_ops}
-    CUSTOM_OPS_YAML
-    "${EXECUTORCH_ROOT}/backends/cortex_m/ops/operators.yaml"
-    OP_LIST
-    "${ARG_OP_LIST}"
-    OPS_FROM_MODEL
-    "${ARG_OPS_FROM_MODEL}"
-    KERNEL_LIBS
-    cortex_m_kernels
-    DEPS
-    ${_cortex_m_deps}
-  )
-  if(ARG_OUT_LIBS)
-    set(${ARG_OUT_LIBS}
-        ${_portable_ops} ${_quantized_ops} ${_cortex_m_ops}
-        PARENT_SCOPE
+    message(
+      FATAL_ERROR
+        "Arm runner CMake API signature does not match ${_arm_runner_api_command}."
     )
   endif()
-endfunction()
+endforeach()
 
-# Ensure a runner target emits its binary to a predictable location. Uses
-# FALLBACK_DIR when TARGET_NAME has no runtime output directory set, and also
-# fills per-configuration runtime output directories for multi-config generators
-# when they are unset.
-function(arm_runner_link_registration_libraries)
-  set(one_value_args TARGET SCOPE)
-  set(multi_value_args BASE_LIBS REGISTRATION_LIBS NORMAL_LIBS SUPPRESS_LIBS)
-  cmake_parse_arguments(
-    ARG "" "${one_value_args}" "${multi_value_args}" ${ARGN}
-  )
-  if(NOT ARG_TARGET)
-    message(FATAL_ERROR "TARGET is required.")
-  endif()
-  if(NOT ARG_SCOPE)
-    set(ARG_SCOPE PRIVATE)
-  endif()
-
-  foreach(_registration_target IN LISTS ARG_REGISTRATION_LIBS ARG_SUPPRESS_LIBS)
-    if(TARGET ${_registration_target})
-      set_property(
-        TARGET ${_registration_target} PROPERTY INTERFACE_LINK_OPTIONS ""
+if(ARM_RUNNER_UTILS_API_METADATA_ONLY)
+  if(ARM_RUNNER_UTILS_API_EMIT_MANIFEST)
+    foreach(_arm_runner_api_command IN LISTS ARM_RUNNER_UTILS_API_COMMANDS)
+      set(_kind "${ARM_RUNNER_UTILS_API_KIND_${_arm_runner_api_command}}")
+      set(_signature
+          "${ARM_RUNNER_UTILS_API_SIGNATURE_${_arm_runner_api_command}}"
       )
-    endif()
-  endforeach()
-
-  target_link_libraries(
-    ${ARG_TARGET}
-    ${ARG_SCOPE}
-    -Wl,--start-group
-    ${ARG_BASE_LIBS}
-    -Wl,--whole-archive
-    ${ARG_REGISTRATION_LIBS}
-    -Wl,--no-whole-archive
-    ${ARG_NORMAL_LIBS}
-    -Wl,--end-group
-  )
-endfunction()
-
-function(arm_runner_configure_runtime_output TARGET_NAME FALLBACK_DIR)
-  if(NOT TARGET ${TARGET_NAME})
-    return()
-  endif()
-
-  get_target_property(_base_runtime_dir ${TARGET_NAME} RUNTIME_OUTPUT_DIRECTORY)
-  if(NOT _base_runtime_dir
-     OR _base_runtime_dir STREQUAL "_base_runtime_dir-NOTFOUND"
-     OR "${_base_runtime_dir}" STREQUAL ""
-  )
-    set_target_properties(
-      ${TARGET_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${FALLBACK_DIR}"
-    )
-    set(_base_runtime_dir "${FALLBACK_DIR}")
-  endif()
-
-  if(CMAKE_CONFIGURATION_TYPES)
-    foreach(_cfg ${CMAKE_CONFIGURATION_TYPES})
-      string(TOUPPER ${_cfg} _cfg_upper)
-      set(_cfg_prop "RUNTIME_OUTPUT_DIRECTORY_${_cfg_upper}")
-      get_target_property(_cfg_dir ${TARGET_NAME} ${_cfg_prop})
-      if(NOT _cfg_dir
-         OR _cfg_dir STREQUAL "_cfg_dir-NOTFOUND"
-         OR "${_cfg_dir}" STREQUAL ""
+      message(
+        "ARM_RUNNER_UTILS_API|${_arm_runner_api_command}|${_kind}|${_signature}"
       )
-        set_target_properties(
-          ${TARGET_NAME} PROPERTIES ${_cfg_prop} "${_base_runtime_dir}/${_cfg}"
-        )
-      endif()
     endforeach()
   endif()
-endfunction()
+  return()
+endif()
 
-# Link the provided target with minimal specs. This minimizes code size, but
-# comes with limited support. Notably, printing with %zu is not supported.
-function(arm_runner_link_minimal_specs TARGET_NAME)
-  verify_targets_exist(
-    CONTEXT arm_runner_link_minimal_specs TARGETS ${TARGET_NAME}
-  )
-  if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_link_options(
-      ${TARGET_NAME} PRIVATE --specs=nano.specs -u _printf_float
-    )
-  endif()
-endfunction()
+get_cmake_property(_arm_runner_commands_before_include COMMANDS)
+include(${CMAKE_CURRENT_LIST_DIR}/ArmRunnerUtilsInternal.cmake)
 
-#[[
-Preprocess and attach the Corstone linker script for a runner target.
-
-Arguments:
-  TARGET: Existing runner target to configure.
-  SYSTEM_CONFIG: Ethos-U system configuration used to select the Corstone FVP.
-  OUTPUT_NAME: Optional basename for the generated linker script.
-]]
-function(arm_runner_configure_linker_script)
-  set(one_value_args TARGET SYSTEM_CONFIG OUTPUT_NAME)
-  cmake_parse_arguments(ARG "" "${one_value_args}" "" ${ARGN})
-
-  if(NOT ARG_TARGET OR NOT ARG_SYSTEM_CONFIG)
+foreach(_arm_runner_api_command IN LISTS ARM_RUNNER_UTILS_API_COMMANDS)
+  if(NOT COMMAND ${_arm_runner_api_command})
     message(
       FATAL_ERROR
-        "arm_runner_configure_linker_script requires TARGET and SYSTEM_CONFIG."
+        "Arm runner CMake API requires missing command ${_arm_runner_api_command}."
     )
   endif()
-  verify_targets_exist(
-    CONTEXT arm_runner_configure_linker_script TARGETS ${ARG_TARGET}
-  )
+endforeach()
 
-  get_corstone_linker_script(_linker_script "${ARG_SYSTEM_CONFIG}")
-
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(LINK_FILE_EXT ld)
-    set(LINK_FILE_OPTION "-T")
-    set(COMPILER_PREPROCESSOR_OPTIONS -E -x c -P)
-  else()
+get_cmake_property(_arm_runner_commands COMMANDS)
+list(REMOVE_ITEM _arm_runner_commands ${_arm_runner_commands_before_include})
+list(FILTER _arm_runner_commands INCLUDE REGEX "^arm_runner_")
+foreach(_arm_runner_command IN LISTS _arm_runner_commands)
+  if(NOT _arm_runner_command IN_LIST ARM_RUNNER_UTILS_API_COMMANDS)
     message(
       FATAL_ERROR
-        "arm_runner_configure_linker_script only supports the GNU compiler."
+        "Arm runner CMake command ${_arm_runner_command} is not declared in ARM_RUNNER_UTILS_API_COMMANDS. Add it to the API or use the _arm_runner_ prefix for a private helper."
     )
   endif()
+endforeach()
 
-  if(NOT ARG_OUTPUT_NAME)
-    set(ARG_OUTPUT_NAME "${ARG_TARGET}_linker_script")
-  endif()
-  set(_linker_script_out
-      "${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT_NAME}.${LINK_FILE_EXT}"
-  )
-  set(_preprocessor_options ${COMPILER_PREPROCESSOR_OPTIONS})
-  foreach(_define IN ITEMS HEAP_SIZE STACK_SIZE ETHOSU_MODEL ETHOSU_ARENA)
-    if(DEFINED ${_define})
-      list(APPEND _preprocessor_options "-D${_define}=${${_define}}")
-    endif()
-  endforeach()
-
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${_preprocessor_options} -o
-            ${_linker_script_out} ${_linker_script} COMMAND_ERROR_IS_FATAL ANY
-  )
-  target_link_options(
-    ${ARG_TARGET} PRIVATE "${LINK_FILE_OPTION}" "${_linker_script_out}"
-  )
-endfunction()
+unset(_arm_runner_api_command)
+unset(_arm_runner_command)
+unset(_arm_runner_commands)
+unset(_arm_runner_commands_before_include)

--- a/backends/arm/cmake/ArmRunnerUtilsInternal.cmake
+++ b/backends/arm/cmake/ArmRunnerUtilsInternal.cmake
@@ -1,0 +1,753 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+include_guard(GLOBAL)
+
+# Implementation of the stable API declared by ArmRunnerUtils.cmake. Consumers
+# should include that facade instead of this file directly.
+
+get_filename_component(
+  _arm_runner_executorch_root "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE
+)
+if(NOT EXECUTORCH_ROOT)
+  set(EXECUTORCH_ROOT "${_arm_runner_executorch_root}")
+endif()
+
+# Make sure codegen function used below is loaded.
+if(NOT COMMAND gen_selected_ops)
+  include(${EXECUTORCH_ROOT}/tools/cmake/Codegen.cmake)
+endif()
+include(${EXECUTORCH_ROOT}/backends/arm/scripts/corstone_utils.cmake)
+include(${EXECUTORCH_ROOT}/backends/arm/cmake/ArmEthosUSDK.cmake)
+
+macro(arm_runner_require_python)
+  if(NOT PYTHON_EXECUTABLE)
+    find_package(
+      Python3
+      COMPONENTS Interpreter
+      REQUIRED
+    )
+    set(PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+  endif()
+endmacro()
+
+macro(arm_runner_add_standalone_executorch)
+  if(DEFINED CMAKE_SKIP_INSTALL_RULES)
+    set(_arm_runner_skip_install_rules_was_defined TRUE)
+    set(_arm_runner_skip_install_rules "${CMAKE_SKIP_INSTALL_RULES}")
+  else()
+    set(_arm_runner_skip_install_rules_was_defined FALSE)
+  endif()
+  if(DEFINED CACHE{CMAKE_SKIP_INSTALL_RULES})
+    set(_arm_runner_skip_install_rules_cache_was_defined TRUE)
+    get_property(
+      _arm_runner_skip_install_rules_cache_type
+      CACHE CMAKE_SKIP_INSTALL_RULES
+      PROPERTY TYPE
+    )
+    set(_arm_runner_skip_install_rules_cache "$CACHE{CMAKE_SKIP_INSTALL_RULES}")
+  else()
+    set(_arm_runner_skip_install_rules_cache_was_defined FALSE)
+  endif()
+
+  arm_runner_require_python()
+
+  include(${EXECUTORCH_ROOT}/tools/cmake/common/preset.cmake)
+  if(NOT DEFINED EXECUTORCH_BUILD_PRESET_FILE)
+    set(EXECUTORCH_BUILD_PRESET_FILE
+        "${EXECUTORCH_ROOT}/tools/cmake/preset/arm_baremetal.cmake"
+        CACHE PATH "ExecuTorch build preset"
+    )
+  endif()
+  load_build_preset()
+  foreach(
+    _arm_runner_option
+    EXECUTORCH_BUILD_ARM_BAREMETAL EXECUTORCH_BUILD_CORTEX_M
+    EXECUTORCH_BUILD_KERNELS_QUANTIZED EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL
+  )
+    set(${_arm_runner_option}
+        ON
+        CACHE BOOL "" FORCE
+    )
+  endforeach()
+  set(EXECUTORCH_SKIP_ARM_EXECUTOR_RUNNER
+      ON
+      CACHE BOOL "" FORCE
+  )
+  set(MAX_KERNEL_NUM
+      2000
+      CACHE STRING "Maximum registered kernels"
+  )
+
+  set(_arm_runner_select_ops "${EXECUTORCH_SELECT_OPS_LIST}")
+  set(EXECUTORCH_SELECT_OPS_LIST "")
+  set(CMAKE_SKIP_INSTALL_RULES ON)
+  add_subdirectory(
+    ${EXECUTORCH_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/executorch EXCLUDE_FROM_ALL
+  )
+  if(_arm_runner_skip_install_rules_cache_was_defined)
+    set(CMAKE_SKIP_INSTALL_RULES
+        "${_arm_runner_skip_install_rules_cache}"
+        CACHE "${_arm_runner_skip_install_rules_cache_type}" "" FORCE
+    )
+  else()
+    unset(CMAKE_SKIP_INSTALL_RULES CACHE)
+  endif()
+  if(_arm_runner_skip_install_rules_was_defined)
+    set(CMAKE_SKIP_INSTALL_RULES "${_arm_runner_skip_install_rules}")
+  else()
+    unset(CMAKE_SKIP_INSTALL_RULES)
+  endif()
+  unset(_arm_runner_skip_install_rules)
+  unset(_arm_runner_skip_install_rules_was_defined)
+  unset(_arm_runner_skip_install_rules_cache)
+  unset(_arm_runner_skip_install_rules_cache_type)
+  unset(_arm_runner_skip_install_rules_cache_was_defined)
+  set(EXECUTORCH_SELECT_OPS_LIST "${_arm_runner_select_ops}")
+  include(${EXECUTORCH_ROOT}/tools/cmake/Utils.cmake)
+endmacro()
+
+function(arm_runner_add_minimal_executable)
+  set(one_value_args TARGET SOURCE OPS_PREFIX)
+  set(multi_value_args COMPILE_DEFINITIONS)
+  cmake_parse_arguments(
+    ARG "" "${one_value_args}" "${multi_value_args}" ${ARGN}
+  )
+  if(NOT ARG_TARGET
+     OR NOT ARG_SOURCE
+     OR NOT ARG_OPS_PREFIX
+  )
+    message(FATAL_ERROR "TARGET, SOURCE, and OPS_PREFIX are required.")
+  endif()
+
+  add_executable(
+    ${ARG_TARGET}
+    ${ARG_SOURCE}
+    ${EXECUTORCH_ROOT}/examples/arm/common/arm_memory_allocator.cpp
+  )
+  target_include_directories(
+    ${ARG_TARGET}
+    PRIVATE ${EXECUTORCH_ROOT}
+            ${EXECUTORCH_ROOT}/runtime/core/portable_type/c10
+            ${EXECUTORCH_ROOT}/examples/arm/common ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  target_compile_definitions(
+    ${ARG_TARGET}
+    PRIVATE
+      C10_USING_CUSTOM_GENERATED_MACROS
+      ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE=${ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE}
+      ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE=${ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE}
+      ${ARG_COMPILE_DEFINITIONS}
+  )
+  arm_runner_configure_model(
+    TARGET
+    ${ARG_TARGET}
+    PTE_FILE
+    "${ET_PTE_FILE_PATH}"
+    MODEL_PTE_ADDR
+    "${ET_MODEL_PTE_ADDR}"
+    MODEL_PTE_SIZE
+    "${ET_MODEL_PTE_SIZE}"
+  )
+  arm_runner_configure_linker_script(
+    TARGET ${ARG_TARGET} SYSTEM_CONFIG "${SYSTEM_CONFIG}"
+  )
+  arm_runner_link_minimal_specs(${ARG_TARGET})
+  arm_runner_link_registration_libraries(
+    TARGET
+    ${ARG_TARGET}
+    BASE_LIBS
+    extension_runner_util
+    ethosu_target_init
+    REGISTRATION_LIBS
+    executorch
+    executorch_delegate_ethos_u
+    ${ARG_OPS_PREFIX}_portable_ops
+    ${ARG_OPS_PREFIX}_quantized_ops
+    ${ARG_OPS_PREFIX}_cortex_m_ops
+    NORMAL_LIBS
+    cortex_m_kernels
+    quantized_kernels
+    portable_kernels
+    kernels_util_all_deps
+  )
+  target_link_options(${ARG_TARGET} PRIVATE LINKER:-Map=${ARG_TARGET}.map)
+endfunction()
+
+function(arm_runner_define_cache_options)
+  set(one_value_args METHOD_ALLOCATOR_SIZE)
+  cmake_parse_arguments(ARG "" "${one_value_args}" "" ${ARGN})
+  set(ET_PTE_FILE_PATH
+      ""
+      CACHE PATH "Path to an ExecuTorch model PTE"
+  )
+  set(ET_MODEL_PTE_ADDR
+      ""
+      CACHE STRING "Address of a memory-mapped PTE"
+  )
+  set(ET_MODEL_PTE_SIZE
+      ""
+      CACHE STRING "Size in bytes of a memory-mapped PTE"
+  )
+  set(EXECUTORCH_SELECT_OPS_LIST
+      ""
+      CACHE STRING "Explicit operator selection"
+  )
+  set(ETHOS_SDK_PATH
+      "${EXECUTORCH_ROOT}/examples/arm/arm-scratch/ethos-u"
+      CACHE PATH "Path to the Ethos-U bare-metal SDK"
+  )
+  set(SYSTEM_CONFIG
+      "Ethos_U55_High_End_Embedded"
+      CACHE STRING "Ethos-U system configuration"
+  )
+  set(MEMORY_MODE
+      "Shared_Sram"
+      CACHE STRING "Ethos-U memory mode"
+  )
+  if(MEMORY_MODE MATCHES "^Dedicated_Sram($|_)")
+    set(_scratch_size 0x4000000)
+  else()
+    set(_scratch_size 0x200000)
+  endif()
+  if(NOT DEFINED ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE)
+    set(ET_ARM_BAREMETAL_SCRATCH_TEMP_ALLOCATOR_POOL_SIZE
+        ${_scratch_size}
+        PARENT_SCOPE
+    )
+  endif()
+  set(ET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE
+      "${ARG_METHOD_ALLOCATOR_SIZE}"
+      CACHE STRING "Persistent method allocator size"
+  )
+endfunction()
+
+function(arm_runner_validate_model_source)
+  cmake_parse_arguments(ARG "ALLOW_SEMIHOSTING" "" "" ${ARGN})
+  if(NOT (ARG_ALLOW_SEMIHOSTING AND SEMIHOSTING)
+     AND NOT ET_MODEL_PTE_ADDR
+     AND "${ET_PTE_FILE_PATH}" STREQUAL ""
+  )
+    message(FATAL_ERROR "Set ET_PTE_FILE_PATH or ET_MODEL_PTE_ADDR.")
+  endif()
+  if(NOT "${ET_PTE_FILE_PATH}" STREQUAL "" AND NOT EXISTS "${ET_PTE_FILE_PATH}")
+    message(FATAL_ERROR "ET_PTE_FILE_PATH does not exist: ${ET_PTE_FILE_PATH}")
+  endif()
+  if(ET_MODEL_PTE_ADDR AND NOT ET_MODEL_PTE_SIZE)
+    message(
+      WARNING
+        "ET_MODEL_PTE_SIZE is unset; using the legacy 0x10000000 upper bound."
+    )
+    set(ET_MODEL_PTE_SIZE
+        0x10000000
+        PARENT_SCOPE
+    )
+  endif()
+  if(ET_MODEL_PTE_SIZE AND NOT ET_MODEL_PTE_ADDR)
+    message(FATAL_ERROR "ET_MODEL_PTE_SIZE requires ET_MODEL_PTE_ADDR.")
+  endif()
+endfunction()
+
+#[[
+Configure how an ExecuTorch model is made available to a runner target.
+
+Arguments:
+  TARGET: Existing runner target to configure.
+  PTE_FILE: PTE file to convert into a generated model_pte.h header.
+  MODEL_PTE_ADDR: Address of a PTE already present in target memory. This takes
+    precedence over PTE_FILE.
+  MODEL_PTE_SIZE: Size in bytes of the PTE at MODEL_PTE_ADDR. If omitted, the
+    legacy 0x10000000 upper bound is used.
+  PUBLIC: Propagate the selected model compile definition to dependants.
+]]
+function(arm_runner_configure_model)
+  set(options PUBLIC)
+  set(one_value_args TARGET PTE_FILE MODEL_PTE_ADDR MODEL_PTE_SIZE)
+  cmake_parse_arguments(ARG "${options}" "${one_value_args}" "" ${ARGN})
+  if(NOT ARG_TARGET)
+    message(FATAL_ERROR "TARGET is required.")
+  endif()
+
+  if(ARG_PUBLIC)
+    set(_scope PUBLIC)
+  else()
+    set(_scope PRIVATE)
+  endif()
+
+  if(ARG_MODEL_PTE_ADDR)
+    target_compile_definitions(
+      ${ARG_TARGET} ${_scope} ET_MODEL_PTE_ADDR=${ARG_MODEL_PTE_ADDR}
+                    ET_MODEL_PTE_SIZE=${ARG_MODEL_PTE_SIZE}
+    )
+  elseif(NOT "${ARG_PTE_FILE}" STREQUAL "")
+    if(Python3_EXECUTABLE)
+      set(_python_executable "${Python3_EXECUTABLE}")
+    elseif(PYTHON_EXECUTABLE)
+      set(_python_executable "${PYTHON_EXECUTABLE}")
+    else()
+      find_package(
+        Python3
+        COMPONENTS Interpreter
+        REQUIRED
+      )
+      set(_python_executable "${Python3_EXECUTABLE}")
+    endif()
+    set(_model_header "${CMAKE_CURRENT_BINARY_DIR}/model_pte.h")
+    add_custom_command(
+      OUTPUT ${_model_header}
+      COMMAND
+        ${_python_executable}
+        ${EXECUTORCH_ROOT}/examples/arm/common/pte_to_header.py --pte
+        ${ARG_PTE_FILE} --outdir ${CMAKE_CURRENT_BINARY_DIR}
+      DEPENDS ${ARG_PTE_FILE}
+    )
+    add_custom_target(${ARG_TARGET}_model_header DEPENDS ${_model_header})
+    add_dependencies(${ARG_TARGET} ${ARG_TARGET}_model_header)
+    target_compile_definitions(${ARG_TARGET} ${_scope} ET_COMPILED_PTE)
+  endif()
+endfunction()
+
+function(arm_runner_configure_ethos_u_platform)
+  set(one_value_args SDK_PATH SYSTEM_CONFIG MEMORY_MODE)
+  cmake_parse_arguments(ARG "" "${one_value_args}" "" ${ARGN})
+  if(NOT ARG_SDK_PATH
+     OR NOT ARG_SYSTEM_CONFIG
+     OR NOT ARG_MEMORY_MODE
+  )
+    message(
+      FATAL_ERROR "SDK_PATH, SYSTEM_CONFIG, and MEMORY_MODE are required."
+    )
+  endif()
+
+  arm_ethos_u_default_fetch("${ARG_SDK_PATH}" _fetch_ethos_u_default)
+  option(FETCH_ETHOS_U_CONTENT "Fetch Ethos-U dependencies"
+         ${_fetch_ethos_u_default}
+  )
+  arm_ensure_ethos_u_content(
+    "${ARG_SDK_PATH}" "${EXECUTORCH_ROOT}" ${FETCH_ETHOS_U_CONTENT}
+  )
+  add_corstone_subdirectory(${ARG_SYSTEM_CONFIG} ${ARG_SDK_PATH})
+  configure_timing_adapters(${ARG_SYSTEM_CONFIG} ${ARG_MEMORY_MODE})
+  foreach(_platform_variable TARGET_BOARD ETHOSU_MODEL ETHOSU_ARENA)
+    if(DEFINED ${_platform_variable})
+      set(${_platform_variable}
+          "${${_platform_variable}}"
+          PARENT_SCOPE
+      )
+    endif()
+  endforeach()
+
+  if(NOT CMAKE_SKIP_INSTALL_RULES AND TARGET ethosu_core_driver)
+    get_property(
+      _ethosu_core_driver_exported GLOBAL
+      PROPERTY ET_ETHOSU_CORE_DRIVER_EXPORTED
+    )
+    if(NOT _ethosu_core_driver_exported)
+      install(
+        TARGETS ethosu_core_driver
+        EXPORT ExecuTorchTargets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      )
+      set_property(GLOBAL PROPERTY ET_ETHOSU_CORE_DRIVER_EXPORTED TRUE)
+    endif()
+  endif()
+endfunction()
+
+# Verify that targets required for building the executor runner are present.
+function(arm_runner_require_baremetal_targets)
+  if(NOT TARGET extension_runner_util)
+    message(
+      FATAL_ERROR
+        "extension_runner_util target missing. Configure ExecuTorch (or the standalone runner) with EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL=ON."
+    )
+  endif()
+
+endfunction()
+
+function(_arm_runner_verify_targets_exist)
+  cmake_parse_arguments(ARG "" "CONTEXT" "TARGETS" ${ARGN})
+
+  set(_targets ${ARG_TARGETS} ${ARG_UNPARSED_ARGUMENTS})
+  if(NOT ARG_CONTEXT)
+    set(ARG_CONTEXT "_arm_runner_verify_targets_exist")
+  endif()
+
+  foreach(_target IN LISTS _targets)
+    if(NOT TARGET ${_target})
+      message(FATAL_ERROR "${ARG_CONTEXT} requires missing target ${_target}.")
+    endif()
+  endforeach()
+endfunction()
+
+#[[
+Create a selected operator registration library for one operator family.
+
+Arguments:
+  LIB_NAME: Name of the generated registration library target.
+	example: arm_cortex_m_ops_lib
+
+  FUNCTIONS_YAML: Portable ATen operator YAML used to generate bindings.
+	example: ${EXECUTORCH_ROOT}/kernels/portable/functions.yaml
+
+  CUSTOM_OPS_YAML: Custom/backend operator YAML used to generate bindings.
+	example: ${EXECUTORCH_ROOT}/backends/cortex_m/ops/operators.yaml
+
+  OP_LIST: Operators to select.
+	example: ${EXECUTORCH_SELECT_OPS_LIST}
+
+  OPS_FROM_MODEL: ExecuTorch model file used to select operators.
+	example: ${ET_PTE_FILE_PATH}
+
+  DTYPE_SELECTIVE_BUILD: Enables dtype filtering for operator libraries that support it.
+	example: ${EXECUTORCH_ENABLE_DTYPE_SELECTIVE_BUILD}
+
+  KERNEL_LIBS: Kernel implementation libraries used by the generated target.
+	example: cortex_m_kernels
+
+  DEPS: Additional libraries required by the generated registration target.
+	example: executorch
+
+  INCLUDE_ALL_OPS: Generate a non-selective registration library for the
+	selected operator family.
+
+  PRIM_OPS: Build a selective prim ops library instead of a codegen operators lib.
+
+The lib will always be created, even when no operators are selected.
+OP_LIST and OPS_FROM_MODEL can be used additively.
+If neither OP_LIST nor OPS_FROM_MODEL is set, the generated registration
+library is empty. INCLUDE_ALL_OPS explicitly builds a full registration library.
+]]
+function(arm_runner_create_selected_ops_lib)
+  # Parse arguments
+  set(options INCLUDE_ALL_OPS PRIM_OPS)
+  set(one_value_args LIB_NAME FUNCTIONS_YAML CUSTOM_OPS_YAML OP_LIST
+                     OPS_FROM_MODEL DTYPE_SELECTIVE_BUILD
+  )
+  set(multi_value_args KERNEL_LIBS DEPS)
+  cmake_parse_arguments(
+    ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
+  )
+
+  # Validate and normalize arguments
+  if(ARG_LIB_NAME)
+    set(_arm_runner_create_selected_ops_lib_context
+        "arm_runner_create_selected_ops_lib(${ARG_LIB_NAME})"
+    )
+  else()
+    set(_arm_runner_create_selected_ops_lib_context
+        "arm_runner_create_selected_ops_lib"
+    )
+  endif()
+
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(
+      FATAL_ERROR
+        "${_arm_runner_create_selected_ops_lib_context} got unexpected arguments: ${ARG_UNPARSED_ARGUMENTS}."
+    )
+  endif()
+
+  if(NOT ARG_LIB_NAME)
+    message(
+      FATAL_ERROR
+        "${_arm_runner_create_selected_ops_lib_context} requires LIB_NAME."
+    )
+  endif()
+
+  if(NOT ARG_PRIM_OPS
+     AND NOT ARG_FUNCTIONS_YAML
+     AND NOT ARG_CUSTOM_OPS_YAML
+  )
+    message(
+      FATAL_ERROR
+        "${_arm_runner_create_selected_ops_lib_context} requires FUNCTIONS_YAML or CUSTOM_OPS_YAML unless PRIM_OPS is set."
+    )
+  endif()
+
+  if(ARG_DTYPE_SELECTIVE_BUILD)
+    executorch_load_build_variables()
+  endif()
+
+  _arm_runner_verify_targets_exist(
+    CONTEXT "${_arm_runner_create_selected_ops_lib_context}" TARGETS
+    ${ARG_KERNEL_LIBS} ${ARG_DEPS}
+  )
+
+  # Generate selected operator list file.
+  set(_arm_runner_selected_ops_args
+      LIB_NAME
+      "${ARG_LIB_NAME}"
+      ROOT_OPS
+      "${ARG_OP_LIST}"
+      OPS_FROM_MODEL
+      "${ARG_OPS_FROM_MODEL}"
+      DTYPE_SELECTIVE_BUILD
+      "${ARG_DTYPE_SELECTIVE_BUILD}"
+  )
+  set(_arm_runner_include_all_ops OFF)
+  if(ARG_INCLUDE_ALL_OPS)
+    set(_arm_runner_include_all_ops ON)
+    list(APPEND _arm_runner_selected_ops_args INCLUDE_ALL_OPS "ON")
+  endif()
+  gen_selected_ops(${_arm_runner_selected_ops_args})
+
+  if(ARG_PRIM_OPS)
+    set(_arm_runner_prim_ops_args
+        LIB_NAME "${ARG_LIB_NAME}" SELECTED_OPS_YAML
+        "${gen_selected_ops_output_yaml}" DEPS ${ARG_DEPS}
+    )
+    if(_arm_runner_include_all_ops)
+      list(APPEND _arm_runner_prim_ops_args INCLUDE_ALL_OPS)
+    endif()
+    gen_selected_prim_ops_lib(${_arm_runner_prim_ops_args})
+    return()
+  endif()
+
+  # Codegen for operator library.
+  set(_arm_ops_binding_args LIB_NAME "${ARG_LIB_NAME}")
+  if(ARG_FUNCTIONS_YAML)
+    list(APPEND _arm_ops_binding_args FUNCTIONS_YAML "${ARG_FUNCTIONS_YAML}")
+  endif()
+  if(ARG_CUSTOM_OPS_YAML)
+    list(APPEND _arm_ops_binding_args CUSTOM_OPS_YAML "${ARG_CUSTOM_OPS_YAML}")
+  endif()
+  if(ARG_DTYPE_SELECTIVE_BUILD)
+    list(APPEND _arm_ops_binding_args DTYPE_SELECTIVE_BUILD
+         "${ARG_DTYPE_SELECTIVE_BUILD}"
+    )
+  endif()
+  generate_bindings_for_kernels(${_arm_ops_binding_args})
+
+  # Finally, build operator library.
+  gen_operators_lib(
+    LIB_NAME
+    "${ARG_LIB_NAME}"
+    KERNEL_LIBS
+    ${ARG_KERNEL_LIBS}
+    DEPS
+    ${ARG_DEPS}
+    DTYPE_SELECTIVE_BUILD
+    "${ARG_DTYPE_SELECTIVE_BUILD}"
+  )
+endfunction()
+
+function(arm_runner_create_default_selected_ops_libs)
+  set(one_value_args PREFIX SUFFIX OP_LIST OPS_FROM_MODEL DTYPE_SELECTIVE_BUILD
+                     OUT_LIBS
+  )
+  set(multi_value_args DEPS)
+  cmake_parse_arguments(
+    ARG "" "${one_value_args}" "${multi_value_args}" ${ARGN}
+  )
+  if(NOT ARG_PREFIX)
+    message(FATAL_ERROR "PREFIX is required.")
+  endif()
+
+  if(ARG_DEPS)
+    set(_portable_deps ${ARG_DEPS})
+    set(_quantized_deps ${ARG_DEPS})
+    set(_cortex_m_deps ${ARG_DEPS})
+  else()
+    set(_portable_deps executorch)
+    set(_quantized_deps executorch_core)
+    set(_cortex_m_deps executorch)
+  endif()
+
+  set(_portable_ops "${ARG_PREFIX}_portable_ops${ARG_SUFFIX}")
+  set(_quantized_ops "${ARG_PREFIX}_quantized_ops${ARG_SUFFIX}")
+  set(_cortex_m_ops "${ARG_PREFIX}_cortex_m_ops${ARG_SUFFIX}")
+
+  arm_runner_create_selected_ops_lib(
+    LIB_NAME
+    ${_portable_ops}
+    FUNCTIONS_YAML
+    "${EXECUTORCH_ROOT}/kernels/portable/functions.yaml"
+    OP_LIST
+    "${ARG_OP_LIST}"
+    OPS_FROM_MODEL
+    "${ARG_OPS_FROM_MODEL}"
+    DTYPE_SELECTIVE_BUILD
+    "${ARG_DTYPE_SELECTIVE_BUILD}"
+    KERNEL_LIBS
+    portable_kernels
+    DEPS
+    ${_portable_deps}
+  )
+  arm_runner_create_selected_ops_lib(
+    LIB_NAME
+    ${_quantized_ops}
+    CUSTOM_OPS_YAML
+    "${EXECUTORCH_ROOT}/kernels/quantized/quantized.yaml"
+    OP_LIST
+    "${ARG_OP_LIST}"
+    OPS_FROM_MODEL
+    "${ARG_OPS_FROM_MODEL}"
+    KERNEL_LIBS
+    quantized_kernels
+    DEPS
+    ${_quantized_deps}
+  )
+  arm_runner_create_selected_ops_lib(
+    LIB_NAME
+    ${_cortex_m_ops}
+    CUSTOM_OPS_YAML
+    "${EXECUTORCH_ROOT}/backends/cortex_m/ops/operators.yaml"
+    OP_LIST
+    "${ARG_OP_LIST}"
+    OPS_FROM_MODEL
+    "${ARG_OPS_FROM_MODEL}"
+    KERNEL_LIBS
+    cortex_m_kernels
+    DEPS
+    ${_cortex_m_deps}
+  )
+  if(ARG_OUT_LIBS)
+    set(${ARG_OUT_LIBS}
+        ${_portable_ops} ${_quantized_ops} ${_cortex_m_ops}
+        PARENT_SCOPE
+    )
+  endif()
+endfunction()
+
+# Ensure a runner target emits its binary to a predictable location. Uses
+# FALLBACK_DIR when TARGET_NAME has no runtime output directory set, and also
+# fills per-configuration runtime output directories for multi-config generators
+# when they are unset.
+function(arm_runner_link_registration_libraries)
+  set(one_value_args TARGET SCOPE)
+  set(multi_value_args BASE_LIBS REGISTRATION_LIBS NORMAL_LIBS SUPPRESS_LIBS)
+  cmake_parse_arguments(
+    ARG "" "${one_value_args}" "${multi_value_args}" ${ARGN}
+  )
+  if(NOT ARG_TARGET)
+    message(FATAL_ERROR "TARGET is required.")
+  endif()
+  if(NOT ARG_SCOPE)
+    set(ARG_SCOPE PRIVATE)
+  endif()
+
+  foreach(_registration_target IN LISTS ARG_REGISTRATION_LIBS ARG_SUPPRESS_LIBS)
+    if(TARGET ${_registration_target})
+      set_property(
+        TARGET ${_registration_target} PROPERTY INTERFACE_LINK_OPTIONS ""
+      )
+    endif()
+  endforeach()
+
+  target_link_libraries(
+    ${ARG_TARGET}
+    ${ARG_SCOPE}
+    -Wl,--start-group
+    ${ARG_BASE_LIBS}
+    -Wl,--whole-archive
+    ${ARG_REGISTRATION_LIBS}
+    -Wl,--no-whole-archive
+    ${ARG_NORMAL_LIBS}
+    -Wl,--end-group
+  )
+endfunction()
+
+function(arm_runner_configure_runtime_output TARGET_NAME FALLBACK_DIR)
+  if(NOT TARGET ${TARGET_NAME})
+    return()
+  endif()
+
+  get_target_property(_base_runtime_dir ${TARGET_NAME} RUNTIME_OUTPUT_DIRECTORY)
+  if(NOT _base_runtime_dir
+     OR _base_runtime_dir STREQUAL "_base_runtime_dir-NOTFOUND"
+     OR "${_base_runtime_dir}" STREQUAL ""
+  )
+    set_target_properties(
+      ${TARGET_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${FALLBACK_DIR}"
+    )
+    set(_base_runtime_dir "${FALLBACK_DIR}")
+  endif()
+
+  if(CMAKE_CONFIGURATION_TYPES)
+    foreach(_cfg ${CMAKE_CONFIGURATION_TYPES})
+      string(TOUPPER ${_cfg} _cfg_upper)
+      set(_cfg_prop "RUNTIME_OUTPUT_DIRECTORY_${_cfg_upper}")
+      get_target_property(_cfg_dir ${TARGET_NAME} ${_cfg_prop})
+      if(NOT _cfg_dir
+         OR _cfg_dir STREQUAL "_cfg_dir-NOTFOUND"
+         OR "${_cfg_dir}" STREQUAL ""
+      )
+        set_target_properties(
+          ${TARGET_NAME} PROPERTIES ${_cfg_prop} "${_base_runtime_dir}/${_cfg}"
+        )
+      endif()
+    endforeach()
+  endif()
+endfunction()
+
+# Link the provided target with minimal specs. This minimizes code size, but
+# comes with limited support. Notably, printing with %zu is not supported.
+function(arm_runner_link_minimal_specs TARGET_NAME)
+  _arm_runner_verify_targets_exist(
+    CONTEXT arm_runner_link_minimal_specs TARGETS ${TARGET_NAME}
+  )
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_link_options(
+      ${TARGET_NAME} PRIVATE --specs=nano.specs -u _printf_float
+    )
+  endif()
+endfunction()
+
+#[[
+Preprocess and attach the Corstone linker script for a runner target.
+
+Arguments:
+  TARGET: Existing runner target to configure.
+  SYSTEM_CONFIG: Ethos-U system configuration used to select the Corstone FVP.
+  OUTPUT_NAME: Optional basename for the generated linker script.
+]]
+function(arm_runner_configure_linker_script)
+  set(one_value_args TARGET SYSTEM_CONFIG OUTPUT_NAME)
+  cmake_parse_arguments(ARG "" "${one_value_args}" "" ${ARGN})
+
+  if(NOT ARG_TARGET OR NOT ARG_SYSTEM_CONFIG)
+    message(
+      FATAL_ERROR
+        "arm_runner_configure_linker_script requires TARGET and SYSTEM_CONFIG."
+    )
+  endif()
+  _arm_runner_verify_targets_exist(
+    CONTEXT arm_runner_configure_linker_script TARGETS ${ARG_TARGET}
+  )
+
+  get_corstone_linker_script(_linker_script "${ARG_SYSTEM_CONFIG}")
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(LINK_FILE_EXT ld)
+    set(LINK_FILE_OPTION "-T")
+    set(COMPILER_PREPROCESSOR_OPTIONS -E -x c -P)
+  else()
+    message(
+      FATAL_ERROR
+        "arm_runner_configure_linker_script only supports the GNU compiler."
+    )
+  endif()
+
+  if(NOT ARG_OUTPUT_NAME)
+    set(ARG_OUTPUT_NAME "${ARG_TARGET}_linker_script")
+  endif()
+  set(_linker_script_out
+      "${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT_NAME}.${LINK_FILE_EXT}"
+  )
+  set(_preprocessor_options ${COMPILER_PREPROCESSOR_OPTIONS})
+  foreach(_define IN ITEMS HEAP_SIZE STACK_SIZE ETHOSU_MODEL ETHOSU_ARENA)
+    if(DEFINED ${_define})
+      list(APPEND _preprocessor_options "-D${_define}=${${_define}}")
+    endif()
+  endforeach()
+
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${_preprocessor_options} -o
+            ${_linker_script_out} ${_linker_script} COMMAND_ERROR_IS_FATAL ANY
+  )
+  target_link_options(
+    ${ARG_TARGET} PRIVATE "${LINK_FILE_OPTION}" "${_linker_script_out}"
+  )
+endfunction()

--- a/backends/arm/public_api_manifests/api_manifest_running.toml
+++ b/backends/arm/public_api_manifests/api_manifest_running.toml
@@ -219,3 +219,61 @@ signature = "get_symmetric_a16w8_quantization_config(is_per_channel: 'bool' = Tr
 [python.get_symmetric_quantization_config]
 kind = "function"
 signature = "get_symmetric_quantization_config(is_per_channel: 'bool' = True, is_qat: 'bool' = False, is_dynamic: 'bool' = False, act_qmin: 'int' = -128, act_qmax: 'int' = 127, weight_qmin: 'int' = -127, weight_qmax: 'int' = 127, eps: 'float' = 1.52587890625e-05) -> 'QuantizationConfig'"
+
+[cmake]
+
+[cmake.arm_runner_add_minimal_executable]
+kind = "function"
+signature = "arm_runner_add_minimal_executable(*, TARGET, SOURCE, OPS_PREFIX, COMPILE_DEFINITIONS=())"
+
+[cmake.arm_runner_add_standalone_executorch]
+kind = "macro"
+signature = "arm_runner_add_standalone_executorch()"
+
+[cmake.arm_runner_configure_ethos_u_platform]
+kind = "function"
+signature = "arm_runner_configure_ethos_u_platform(*, SDK_PATH, SYSTEM_CONFIG, MEMORY_MODE)"
+
+[cmake.arm_runner_configure_linker_script]
+kind = "function"
+signature = "arm_runner_configure_linker_script(*, TARGET, SYSTEM_CONFIG, OUTPUT_NAME=None)"
+
+[cmake.arm_runner_configure_model]
+kind = "function"
+signature = "arm_runner_configure_model(*, TARGET, PTE_FILE=None, MODEL_PTE_ADDR=None, MODEL_PTE_SIZE=None, PUBLIC=False)"
+
+[cmake.arm_runner_configure_runtime_output]
+kind = "function"
+signature = "arm_runner_configure_runtime_output(TARGET_NAME, FALLBACK_DIR)"
+
+[cmake.arm_runner_create_default_selected_ops_libs]
+kind = "function"
+signature = "arm_runner_create_default_selected_ops_libs(*, PREFIX, SUFFIX=None, OP_LIST=None, OPS_FROM_MODEL=None, DTYPE_SELECTIVE_BUILD=None, OUT_LIBS=None, DEPS=())"
+
+[cmake.arm_runner_create_selected_ops_lib]
+kind = "function"
+signature = "arm_runner_create_selected_ops_lib(*, LIB_NAME, FUNCTIONS_YAML=None, CUSTOM_OPS_YAML=None, OP_LIST=None, OPS_FROM_MODEL=None, DTYPE_SELECTIVE_BUILD=None, KERNEL_LIBS=(), DEPS=(), INCLUDE_ALL_OPS=False, PRIM_OPS=False)"
+
+[cmake.arm_runner_define_cache_options]
+kind = "function"
+signature = "arm_runner_define_cache_options(*, METHOD_ALLOCATOR_SIZE=None)"
+
+[cmake.arm_runner_link_minimal_specs]
+kind = "function"
+signature = "arm_runner_link_minimal_specs(TARGET_NAME)"
+
+[cmake.arm_runner_link_registration_libraries]
+kind = "function"
+signature = "arm_runner_link_registration_libraries(*, TARGET, SCOPE=None, BASE_LIBS=(), REGISTRATION_LIBS=(), NORMAL_LIBS=(), SUPPRESS_LIBS=())"
+
+[cmake.arm_runner_require_baremetal_targets]
+kind = "function"
+signature = "arm_runner_require_baremetal_targets()"
+
+[cmake.arm_runner_require_python]
+kind = "macro"
+signature = "arm_runner_require_python()"
+
+[cmake.arm_runner_validate_model_source]
+kind = "function"
+signature = "arm_runner_validate_model_source(*, ALLOW_SEMIHOSTING=False)"

--- a/backends/arm/scripts/public_api_manifest/README.md
+++ b/backends/arm/scripts/public_api_manifest/README.md
@@ -4,6 +4,14 @@ Manifests are used to track the current public API of the Arm backend. They are
 generated with
 `python backends/arm/scripts/public_api_manifest/generate_public_api_manifest.py`.
 
+The `[python]` section is generated from `executorch.backends.arm.LAZY_IMPORTS`.
+The `[cmake]` section is generated from the command kinds and signatures in
+`backends/arm/cmake/ArmRunnerUtils.cmake`. CMake keyword-only arguments are
+represented after `*`, optional one-value arguments use `None`, options use
+`False`, and optional multi-value arguments use `()`. A static manifest without
+a `[cmake]` section predates the stable CMake API and does not establish a CMake
+compatibility contract.
+
 ## Running manifest
 
 There is always one running manifest which has the main purpose of tracking the

--- a/backends/arm/scripts/public_api_manifest/generate_public_api_manifest.py
+++ b/backends/arm/scripts/public_api_manifest/generate_public_api_manifest.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import enum
 import inspect
+import shutil
+import subprocess  # nosec B404
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
@@ -30,6 +32,7 @@ MANIFEST_PATH = (
     / "public_api_manifests"
     / "api_manifest_running.toml"
 )
+CMAKE_API_PREFIX = "ARM_RUNNER_UTILS_API|"
 
 
 def _copyright_year_range() -> str:
@@ -123,18 +126,63 @@ def _collect_public_api(
     return entries
 
 
-def _render_manifest(entries: dict[str, dict[str, str]]) -> str:
-    lines = [HEADER.format(years=_copyright_year_range()).rstrip(), "", "[python]", ""]
-    for path in sorted(entries):
-        entry = entries[path]
+def _collect_cmake_public_api(repo_path: Path) -> dict[str, dict[str, str]]:
+    cmake = shutil.which("cmake")
+    if cmake is None:
+        raise RuntimeError("cmake is required to generate the CMake API manifest")
+    facade = repo_path / "backends" / "arm" / "cmake" / "ArmRunnerUtils.cmake"
+    if not facade.is_file():
+        raise RuntimeError(f"Arm runner CMake API facade does not exist: {facade}")
+    result = subprocess.run(  # nosec B603
+        [
+            cmake,
+            "-DARM_RUNNER_UTILS_API_METADATA_ONLY=ON",
+            "-DARM_RUNNER_UTILS_API_EMIT_MANIFEST=ON",
+            "-P",
+            str(facade),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to read the CMake API from {facade}:\n{result.stderr}"
+        )
+    entries: dict[str, dict[str, str]] = {}
+    for line in (result.stdout + result.stderr).splitlines():
+        if not line.startswith(CMAKE_API_PREFIX):
+            continue
+        name, kind, signature = line.removeprefix(CMAKE_API_PREFIX).split("|", 2)
+        entries[name] = {"kind": kind, "signature": signature}
+    if not entries:
+        raise RuntimeError("CMake API emitter returned no entries")
+    return entries
+
+
+def _render_section(
+    section: str,
+    entries: dict[str, dict[str, str]],
+) -> list[str]:
+    lines = [f"[{section}]", ""]
+    for path, entry in sorted(entries.items()):
         lines.extend(
             [
-                f"[python.{path}]",
+                f"[{section}.{path}]",
                 f'kind = "{entry["kind"]}"',
                 f'signature = "{entry["signature"]}"',
                 "",
             ]
         )
+    return lines
+
+
+def _render_manifest(
+    python_entries: dict[str, dict[str, str]],
+    cmake_entries: dict[str, dict[str, str]],
+) -> str:
+    lines = [HEADER.format(years=_copyright_year_range()).rstrip(), ""]
+    lines.extend(_render_section("python", python_entries))
+    lines.extend(_render_section("cmake", cmake_entries))
     return "\n".join(lines)
 
 
@@ -143,8 +191,14 @@ def generate_manifest_from_init(
     repo_path: Path | None = None,
     include_deprecated: bool = False,
 ) -> str:
-    del repo_path
-    return _render_manifest(_collect_public_api(include_deprecated=include_deprecated))
+    if repo_path is None:
+        repo_path = Path(__file__).resolve().parents[4]
+    else:
+        repo_path = repo_path.resolve()
+    return _render_manifest(
+        _collect_public_api(include_deprecated=include_deprecated),
+        _collect_cmake_public_api(repo_path),
+    )
 
 
 def main() -> None:

--- a/backends/arm/scripts/public_api_manifest/validate_public_api_manifest.py
+++ b/backends/arm/scripts/public_api_manifest/validate_public_api_manifest.py
@@ -88,6 +88,15 @@ def get_manifest_python_symbols(manifest: dict) -> dict[str, dict[str, str]]:
     return _collect_python_symbols(python_manifest)
 
 
+def get_manifest_cmake_symbols(manifest: dict) -> dict[str, dict[str, str]]:
+    cmake_manifest = manifest.get("cmake")
+    if cmake_manifest is None:
+        return {}
+    if not isinstance(cmake_manifest, dict):
+        raise ValueError("Manifest [cmake] section must be a table")
+    return _collect_python_symbols(cmake_manifest)
+
+
 def get_current_python_symbols(
     *,
     include_deprecated: bool = False,
@@ -323,16 +332,29 @@ def format_validation_report(manifest_path: Path, issues: list[Issue]) -> str:
 
 
 def validate_manifest(manifest_path: Path) -> list[Issue]:
-    return validate_symbols(
-        get_manifest_python_symbols(read_manifest(manifest_path)),
-        get_current_python_symbols(
-            include_deprecated=manifest_path.name != MANIFEST_PATH.name,
-        ),
-        ignore_new_api_symbols=manifest_path.name != MANIFEST_PATH.name,
-        allow_backward_compatible_signature_changes=(
-            manifest_path.name != MANIFEST_PATH.name
-        ),
+    is_static = manifest_path.name != MANIFEST_PATH.name
+    manifest = read_manifest(manifest_path)
+    current = tomllib.loads(
+        gpam.generate_manifest_from_init(
+            repo_path=REPO_PATH,
+            include_deprecated=is_static,
+        )
     )
+    issues = validate_symbols(
+        get_manifest_python_symbols(manifest),
+        get_manifest_python_symbols(current),
+        ignore_new_api_symbols=is_static,
+        allow_backward_compatible_signature_changes=is_static,
+    )
+    issues.extend(
+        validate_symbols(
+            get_manifest_cmake_symbols(manifest),
+            get_manifest_cmake_symbols(current),
+            ignore_new_api_symbols=is_static,
+            allow_backward_compatible_signature_changes=is_static,
+        )
+    )
+    return issues
 
 
 def parse_args() -> argparse.Namespace:

--- a/backends/arm/test/misc/test_public_api_manifest.py
+++ b/backends/arm/test/misc/test_public_api_manifest.py
@@ -3,11 +3,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import shutil
+import subprocess  # nosec B404
 from pathlib import Path
 
 import executorch.backends.arm as arm
 from executorch.backends.arm import LAZY_IMPORTS
 from executorch.backends.arm.scripts.public_api_manifest.generate_public_api_manifest import (
+    _collect_cmake_public_api,
     _collect_entry,
     _collect_public_api,
     _is_unstable_api,
@@ -15,6 +18,7 @@ from executorch.backends.arm.scripts.public_api_manifest.generate_public_api_man
 )
 from executorch.exir._warnings import deprecated
 
+REPO_PATH = Path(__file__).resolve().parents[4]
 RUNNING_MANIFEST_PATH = (
     Path(__file__).resolve().parents[2]
     / "public_api_manifests"
@@ -53,16 +57,70 @@ def test_public_api_manifest_entries_are_well_formed():
 
 def test_public_api_manifest_matches_generator():
     entries = _collect_public_api()
-    manifest = _render_manifest(entries)
+    cmake_entries = _collect_cmake_public_api(REPO_PATH)
+    manifest = _render_manifest(entries, cmake_entries)
 
-    assert manifest == _render_manifest(entries)
+    assert manifest == _render_manifest(entries, cmake_entries)
     assert manifest.startswith("# Copyright ")
     assert "[python]" in manifest
+    assert "[cmake]" in manifest
 
     for path, entry in entries.items():
         assert _entry_block(path, entry) in manifest
 
+    for path, entry in cmake_entries.items():
+        assert entry["kind"] in {"function", "macro"}
+        assert entry["signature"].startswith(f"{path}(")
+        assert (
+            "\n".join(
+                [
+                    f"[cmake.{path}]",
+                    f'kind = "{entry["kind"]}"',
+                    f'signature = "{entry["signature"]}"',
+                ]
+            )
+            in manifest
+        )
+
     assert manifest == Path(RUNNING_MANIFEST_PATH).read_text(encoding="utf-8")
+
+
+def test_cmake_public_api_uses_explicit_repo_path(tmp_path):
+    facade = tmp_path / "backends" / "arm" / "cmake" / "ArmRunnerUtils.cmake"
+    facade.parent.mkdir(parents=True)
+    facade.write_text(
+        'message("ARM_RUNNER_UTILS_API|arm_runner_foo|function|arm_runner_foo()")',
+        encoding="utf-8",
+    )
+
+    assert _collect_cmake_public_api(tmp_path) == {
+        "arm_runner_foo": {
+            "kind": "function",
+            "signature": "arm_runner_foo()",
+        }
+    }
+
+
+def test_cmake_facade_ignores_consumer_commands(tmp_path):
+    cmake = shutil.which("cmake")
+    assert cmake is not None
+    facade = REPO_PATH / "backends" / "arm" / "cmake" / "ArmRunnerUtils.cmake"
+    script = tmp_path / "consumer.cmake"
+    script.write_text(
+        "cmake_minimum_required(VERSION 3.24)\n"
+        "function(arm_runner_consumer_helper)\n"
+        "endfunction()\n"
+        'include("{}")\n'.format(facade),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(  # nosec B603
+        [cmake, "-P", str(script)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_public_api_manifest_collection_handles_deprecated_symbols():

--- a/backends/arm/test/misc/test_validate_public_api_manifest.py
+++ b/backends/arm/test/misc/test_validate_public_api_manifest.py
@@ -15,6 +15,7 @@ except ModuleNotFoundError:
 from executorch.backends.arm.scripts.public_api_manifest.validate_public_api_manifest import (
     format_validation_report,
     get_current_python_symbols,
+    get_manifest_cmake_symbols,
     get_manifest_python_symbols,
     validate_symbols,
 )
@@ -62,6 +63,63 @@ def test_get_manifest_python_symbols_flattens_nested_tables():
         "Foo": {"kind": "class", "signature": "Foo()"},
         "Foo.bar": {"kind": "function", "signature": "Foo.bar() -> None"},
     }
+
+
+def test_get_manifest_cmake_symbols_flattens_command_tables():
+    manifest = tomllib.loads(
+        """
+        [python]
+
+        [cmake.arm_runner_foo]
+        kind = "function"
+        signature = "arm_runner_foo(*, TARGET)"
+        """
+    )
+
+    assert get_manifest_cmake_symbols(manifest) == {
+        "arm_runner_foo": {
+            "kind": "function",
+            "signature": "arm_runner_foo(*, TARGET)",
+        }
+    }
+
+
+def test_static_manifest_without_cmake_section_has_no_cmake_contract():
+    manifest = tomllib.loads("[python]\n")
+
+    assert get_manifest_cmake_symbols(manifest) == {}
+
+
+def test_running_manifest_validation_rejects_cmake_drift(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "api_manifest_running.toml"
+    manifest_path.write_text(
+        """
+        [python]
+
+        [cmake.arm_runner_foo]
+        kind = "function"
+        signature = "arm_runner_foo(*, TARGET)"
+        """,
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        vpam.gpam,
+        "generate_manifest_from_init",
+        lambda **_: """
+            [python]
+
+            [cmake.arm_runner_foo]
+            kind = "function"
+            signature = "arm_runner_foo(*, TARGET, REQUIRED_ARG)"
+        """,
+    )
+
+    issues = vpam.validate_manifest(manifest_path)
+
+    assert len(issues) == 1
+    assert issues[0][0] == "arm_runner_foo"
+    assert issues[0][1] == "signature changed"
 
 
 def test_nested_python_manifest_entries_are_validated():

--- a/examples/arm/executor_runner/CMakeLists.txt
+++ b/examples/arm/executor_runner/CMakeLists.txt
@@ -193,11 +193,6 @@ set(_arm_runner_normal_archive_libs
     portable_kernels kernels_util_all_deps arm_prim_ops_lib_impl
     quantized_kernels cortex_m_kernels cmsis-nn
 )
-verify_targets_exist(
-  CONTEXT arm_executor_runner TARGETS ${_arm_runner_selected_ops_libs}
-  ${_arm_runner_normal_archive_libs}
-)
-
 arm_runner_link_registration_libraries(
   TARGET
   arm_executor_runner

--- a/examples/arm/image_classification_example_ethos_u/runtime/CMakeLists.txt
+++ b/examples/arm/image_classification_example_ethos_u/runtime/CMakeLists.txt
@@ -78,7 +78,6 @@ include(${ET_DIR_PATH}/backends/arm/cmake/ArmRunnerUtils.cmake)
 add_subdirectory(${ETHOS_SDK_PATH}/core_platform/targets/corstone-320 target)
 
 add_executable(img_class_example main.cpp)
-include(${ET_DIR_PATH}/backends/arm/cmake/ArmRunnerUtils.cmake)
 arm_runner_link_minimal_specs(img_class_example)
 
 target_sources(
@@ -97,11 +96,6 @@ arm_runner_create_selected_ops_lib(
   cortex_m_kernels
   DEPS
   executorch
-)
-
-verify_targets_exist(
-  CONTEXT img_class_example TARGETS image_classification_cortex_m_ops_lib
-  cortex_m_kernels portable_kernels
 )
 
 target_link_libraries(


### PR DESCRIPTION
Make ArmRunnerUtils.cmake the stable facade for in-tree and external consumers. Back it with an explicit command allowlist and a separate internal implementation. Keep target verification private and reject missing or undeclared arm_runner commands.

This commit was authored with Codex.

Change-Id: I0854d339dcad5d222ed715b3f30d882735e16cee


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani