### PR TITLE
Arm backend: Test minimal Classic ML runner in CI

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -261,6 +261,7 @@ jobs:
           - test_arm_backend: test_pytest_ops_ethos_u55
           - test_arm_backend: test_pytest_models_ethos_u55
           - test_arm_backend: test_run_ethos_u55
+          - test_arm_backend: test_minimal_classic_ml_ethos_u55
           - test_arm_backend: test_pytest_ops_ethos_u85
           - test_arm_backend: test_pytest_models_ethos_u85
           - test_arm_backend: test_run_ethos_u85

--- a/backends/arm/test/test_arm_backend.sh
+++ b/backends/arm/test/test_arm_backend.sh
@@ -193,6 +193,44 @@ test_run_ethos_u55() {
     echo "${TEST_SUITE_NAME}: PASS"
 }
 
+test_minimal_classic_ml_ethos_u55() {
+    echo "${TEST_SUITE_NAME}: Test minimal classic ML runner on Ethos-U55"
+
+    local build_dir="${et_root_dir}/arm_test/minimal_classic_ml"
+    local pte_path="${build_dir}/mv2.pte"
+    local fvp_log="${build_dir}/run_fvp.log"
+    mkdir -p "${build_dir}"
+
+    python3 -m backends.arm.scripts.aot_arm_compiler \
+        --model_name=mv2 \
+        --target=ethos-u55-128 \
+        --delegate \
+        --quantize \
+        --intermediates="${build_dir}" \
+        --output="${pte_path}" \
+        --system_config=Ethos_U55_High_End_Embedded \
+        --memory_mode=Shared_Sram
+
+    cmake \
+        -S examples/arm/minimal_classic_ml \
+        -B "${build_dir}" \
+        -DCMAKE_TOOLCHAIN_FILE="${et_root_dir}/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DET_PTE_FILE_PATH="${pte_path}" \
+        -DSYSTEM_CONFIG=Ethos_U55_High_End_Embedded \
+        -DMEMORY_MODE=Shared_Sram
+    cmake --build "${build_dir}" --target arm_classic_ml_runner -j"$(nproc)"
+
+    backends/arm/scripts/run_fvp.sh \
+        --elf="${build_dir}/arm_classic_ml_runner" \
+        --target=ethos-u55-128 | tee "${fvp_log}"
+    local fvp_status="${PIPESTATUS[0]}"
+    [[ "${fvp_status}" -eq 0 ]]
+    grep -Fq "Inference complete: 1 output(s)" "${fvp_log}"
+
+    echo "${TEST_SUITE_NAME}: PASS"
+}
+
 # ----------------------------------------------
 # -------- Arm Ethos-U85 specific tests --------
 # ----------------------------------------------


### PR DESCRIPTION
Add an Ethos-U55 trunk shard that exports MobileNetV2, builds the standalone minimal Classic ML runner, executes it on the Corstone-300 FVP, and checks its inference completion marker.

This commit was authored with Codex.


Change-Id: Iea1eb7402e5a4e1f6f440c3b12d39dced9181506


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani