### PR TITLE
Scope -Wno-missing-prototypes to non-GCC compilers

### DIFF
--- a/kernels/aten/cpu/util/targets.bzl
+++ b/kernels/aten/cpu/util/targets.bzl
@@ -15,11 +15,13 @@ def define_common_targets():
             "copy_ops_util.h",
         ],
         compiler_flags = select({
-                "DEFAULT": ["-Wno-missing-prototypes"],
+                "DEFAULT": select({
+                    "DEFAULT": ["-Wno-missing-prototypes"],
+                    # GCC's C++ frontend rejects this C-only flag under -Werror.
+                    # Nested under DEFAULT so windows and gcc can't both match.
+                    "ovr_config//compiler:gcc": [],
+                }),
                 "ovr_config//os:windows": [],
-                # ovr_config//os:zephyr is fbsource-internal; OSS bypasses
-                # this branch via runtime.is_oss.
-                "ovr_config//os:zephyr": [],
             }) if not runtime.is_oss else select({
                 "DEFAULT": ["-Wno-missing-prototypes"],
                 "ovr_config//os:windows": [],

--- a/kernels/portable/cpu/pattern/targets.bzl
+++ b/kernels/portable/cpu/pattern/targets.bzl
@@ -56,8 +56,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         exported_deps = [
             "//executorch/kernels/portable/cpu/util:broadcast_util",

--- a/kernels/portable/cpu/util/targets.bzl
+++ b/kernels/portable/cpu/util/targets.bzl
@@ -49,8 +49,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         deps = [
             "//executorch/runtime/core/exec_aten/util:tensor_shape_to_c_string",
@@ -103,8 +103,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
@@ -119,8 +119,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         exported_deps = [
             ":broadcast_indexes_range",
@@ -155,8 +155,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         deps = [
             ":broadcast_util",
@@ -174,8 +174,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         exported_deps = [
             ":broadcast_util",
@@ -194,8 +194,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
@@ -214,8 +214,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
@@ -231,8 +231,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         deps = [
             ":broadcast_util",
@@ -252,8 +252,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         deps = [
             "//executorch/runtime/kernel:kernel_includes",
@@ -269,8 +269,8 @@ def define_common_targets():
         ],
         compiler_flags = select({
             "DEFAULT": ["-Wno-missing-prototypes"],
-            # ovr_config//os:zephyr is fbsource-internal; OSS bypasses this select via runtime.is_oss.
-            "ovr_config//os:zephyr": [],
+            # GCC's C++ frontend rejects this C-only flag under -Werror.
+            "ovr_config//compiler:gcc": [],
         }) if not runtime.is_oss else ["-Wno-missing-prototypes"],
         deps = [
             "//executorch/runtime/kernel:kernel_includes",

--- a/shim_et/xplat/executorch/codegen/codegen.bzl
+++ b/shim_et/xplat/executorch/codegen/codegen.bzl
@@ -633,13 +633,10 @@ def build_portable_lib(
     # Currently fbcode links all dependent libraries through shared
     # library, and it blocks users like unit tests to use kernel
     # implementation directly. So we enable this for xplat only.
-    # -Wno-missing-prototypes is Clang-only for C++; GCC (used by Zephyr ARM
-    # cross-compilation) rejects it with -Werror, so exclude it for Zephyr.
-    # OSS bypasses the select since ovr_config//os:zephyr is not in the OSS
-    # buck2 prelude.
+    # GCC's C++ frontend rejects this C-only flag under -Werror.
     compiler_flags = select({
         "DEFAULT": ["-Wno-missing-prototypes"],
-        "ovr_config//os:zephyr": [],
+        "ovr_config//compiler:gcc": [],
     }) if not runtime.is_oss else ["-Wno-missing-prototypes"]
     if not expose_operator_symbols and is_xplat():
         # Removing '-fvisibility=hidden' exposes operator symbols.
@@ -686,13 +683,11 @@ def build_optimized_lib(name, oplist_header_name, portable_header_lib, feature =
     # Currently fbcode links all dependent libraries through shared
     # library, and it blocks users like unit tests to use kernel
     # implementation directly. So we enable this for xplat only.
-    # -Wno-missing-prototypes and -Wno-global-constructors are Clang-only for
-    # C++; GCC (used by Zephyr ARM cross-compilation) rejects them with
-    # -Werror, so exclude them for Zephyr. OSS bypasses the select since
-    # ovr_config//os:zephyr is not in the OSS buck2 prelude.
+    # Drop the Clang-only flags for GCC: its C++ frontend rejects
+    # -Wno-missing-prototypes under -Werror.
     compiler_flags = select({
         "DEFAULT": ["-Wno-missing-prototypes", "-Wno-pass-failed", "-Wno-global-constructors", "-Wno-shadow"],
-        "ovr_config//os:zephyr": ["-Wno-pass-failed", "-Wno-shadow"],
+        "ovr_config//compiler:gcc": ["-Wno-pass-failed", "-Wno-shadow"],
     }) if not runtime.is_oss else ["-Wno-missing-prototypes", "-Wno-pass-failed", "-Wno-global-constructors", "-Wno-shadow"]
     if not expose_operator_symbols and is_xplat():
         # Removing '-fvisibility=hidden' exposes operator symbols.

--- a/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/optimized/op_registration_util.bzl
@@ -96,19 +96,19 @@ def define_op_library(name, compiler_flags, deps):
         compiler_flags = (select({
             # kernels often have helpers with no prototypes just disabling the warning here as the headers
             # are codegend and linked in later
-            # -Wno-missing-prototypes is Clang-only for C++; GCC (used by
-            # Zephyr ARM cross-compilation) rejects it with -Werror, so
-            # exclude it for Zephyr. OSS bypasses the select since
-            # ovr_config//os:zephyr is not in the OSS buck2 prelude.
-            "DEFAULT": [
-                "-Wno-missing-prototypes",
-                # pragma unroll fails with -Os, don't need to warn us and
-                # fail Werror builds; see https://godbolt.org/z/zvf85vTsr
-                "-Wno-pass-failed",
-            ],
-            "ovr_config//os:zephyr": [
-                "-Wno-pass-failed",
-            ],
+            # GCC's C++ frontend rejects this C-only flag under -Werror. Nested
+            # under DEFAULT so the windows (OS) and gcc keys can't both match.
+            "DEFAULT": select({
+                "DEFAULT": [
+                    "-Wno-missing-prototypes",
+                    # pragma unroll fails with -Os, don't need to warn us and
+                    # fail Werror builds; see https://godbolt.org/z/zvf85vTsr
+                    "-Wno-pass-failed",
+                ],
+                "ovr_config//compiler:gcc": [
+                    "-Wno-pass-failed",
+                ],
+            }),
             # The vendored ATen vec headers trip several -Werror warnings on
             # the Windows (clang) host, so disable warnings-as-errors there.
             "ovr_config//os:windows": select({

--- a/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
+++ b/shim_et/xplat/executorch/kernels/portable/op_registration_util.bzl
@@ -119,21 +119,20 @@ def define_op_library(name, deps, android_deps, aten_target, _allow_third_party_
         visibility = ["PUBLIC"],
         # kernels often have helpers with no prototypes just disabling the warning here as the headers
         # are codegend and linked in later
-        # -Wno-missing-prototypes is Clang-only for C++; GCC (used by Zephyr
-        # ARM cross-compilation) rejects it with -Werror, so exclude it for
-        # Zephyr and Windows builds. OSS bypasses the zephyr branch via
-        # runtime.is_oss since ovr_config//os:zephyr is not in the OSS
-        # buck2 prelude.
+        # GCC's C++ frontend rejects this C-only flag under -Werror. Nested under
+        # DEFAULT so the windows (OS) and gcc (compiler) keys can't both match.
         # The vendored ATen vec headers pulled in on the Windows host trip
         # several -Werror warnings (e.g. -Wundef on __GNUC__), so disable
         # warnings-as-errors for the Windows (clang) kernel compiles.
         compiler_flags = (select({
-                "DEFAULT": ["-Wno-missing-prototypes"],
+                "DEFAULT": select({
+                    "DEFAULT": ["-Wno-missing-prototypes"],
+                    "ovr_config//compiler:gcc": [],
+                }),
                 "ovr_config//os:windows": select({
                     "DEFAULT": ["-Wno-error"],
                     "ovr_config//compiler:msvc": [],
                 }),
-                "ovr_config//os:zephyr": [],
             }) if not runtime.is_oss else select({
                 "DEFAULT": ["-Wno-missing-prototypes"],
                 # OSS buck2 has no compiler constraint (ovr_config//compiler:msvc


### PR DESCRIPTION
Summary:
D100626340 keyed the `-Wno-missing-prototypes` carve-out on
`ovr_config//os:zephyr`, but GCC's C++ frontend rejects the flag regardless of
OS, so every non-Zephyr GCC config still fails — including the arm32 FVP config
in T285774316:

```
cc1plus: error: command-line option '-Wno-missing-prototypes' is valid for
C/ObjC but not for C++ [-Werror]
```

Re-key on `ovr_config//compiler:gcc`. The OS axis cannot express this: the
failing GCC config and the working Clang config are both `os[embedded]`.

Clang keeps the flag — it is load-bearing there (portable kernels define
non-static ops whose prototypes live in generated headers the TU does not
include).

Where `os:windows` is also a key, the gcc check is nested under `DEFAULT`
instead of made a sibling, since the two axes do not refine each other.
Windows resolution unchanged.

Same 12 files as D100626340.

Differential Revision: D118128860


