### PR TITLE
[ET-VK] Scale reduction workers with the length of the reduction

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/reduce.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/reduce.glsl
@@ -32,12 +32,17 @@ layout(constant_id = 5) const int group_dim = 1;
 // A more verbose name would be NWORKERS_PER_GROUP. This describes the number of
 // threads that will co-operate to compute one reduction output. There may be
 // multiple groups computing distinct reduction outputs within one work group.
-#define NWORKERS 4
+// Supplied by the dispatch so it can scale with the length of the reduction.
+// A global average pool reduces a whole HxW plane into one value, and four
+// workers left the GPU essentially idle for it.
+layout(constant_id = 6) const int NWORKERS = 4;
 
 // Sets an upper limit on the total size of a work group based on how many
 // elements are allocated in the shared memory array below. Each thread in the
 // work group will write into its assigned element in the shared array.
-#define MAX_NTHREADS 16
+// Upper bound on NWORKERS * NGROUPS, and the size of the shared array below.
+// 256 vec4 is 4 KiB of shared memory, well inside the guaranteed 16 KiB.
+#define MAX_NTHREADS 256
 
 
 shared vec4 shared_vecs[MAX_NTHREADS];

--- a/backends/vulkan/runtime/graph/ops/glsl/reduce.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/reduce.glsl
@@ -91,19 +91,30 @@ int tid_to_smi(const ivec2 tid) {
  * This case is simpler because each element of a texel belongs to a separate
  * reduction "group", meaning we don't have to perform reduction along a texel.
  */
-void reduce_nonpacked_dim(const ivec2 tid, ivec3 scan_pos) {
+void reduce_nonpacked_dim(
+    const ivec2 tid,
+    ivec3 scan_pos,
+    const bool in_bounds) {
   // shared memory index of this thread
   const int smi = tid_to_smi(tid);
 
-  scan_pos[reduce_dim] = 0;
-  vec4 accum = INIT_ACCUM(load_texel(tin, scan_pos));
+  // Out of bounds invocations cannot return early: barrier() below has to be
+  // reached by every invocation in the work group, and skipping it is undefined
+  // behaviour that hangs some GPUs. They still take a shared memory slot, but
+  // it is one that no in-bounds group aggregates over, so what they leave in it
+  // is never read.
+  vec4 accum = vec4(0);
+  if (in_bounds) {
+    scan_pos[reduce_dim] = 0;
+    accum = INIT_ACCUM(load_texel(tin, scan_pos));
 
-  scan_pos[reduce_dim] = tid.x;
-  // Partially accumulate over elements i, i + NWORKERS, i + 2*NWORKERS, ... of
-  // the reduction row
-  for (int i = tid.x; i < safe_idx(tin_sizes, reduce_dim);
-       i += NWORKERS, scan_pos[reduce_dim] += NWORKERS) {
-    accum = UPDATE_ACCUM(accum, load_texel(tin, scan_pos));
+    scan_pos[reduce_dim] = tid.x;
+    // Partially accumulate over elements i, i + NWORKERS, i + 2*NWORKERS, ...
+    // of the reduction row
+    for (int i = tid.x; i < safe_idx(tin_sizes, reduce_dim);
+         i += NWORKERS, scan_pos[reduce_dim] += NWORKERS) {
+      accum = UPDATE_ACCUM(accum, load_texel(tin, scan_pos));
+    }
   }
   // Write partial output to shared memory and synchronize work group
   shared_vecs[smi] = accum;
@@ -111,7 +122,7 @@ void reduce_nonpacked_dim(const ivec2 tid, ivec3 scan_pos) {
 
   // Since the reduction row is reduced to only one element, only the "main"
   // thread in the group needs aggregate the partial outputs
-  if (tid.x == 0) {
+  if (in_bounds && tid.x == 0) {
     // Iterate over the partial outputs to obtain the overall output
     int group_i = tid.y * NWORKERS;
     accum = shared_vecs[group_i++];
@@ -146,7 +157,10 @@ void reduce_nonpacked_dim(const ivec2 tid, ivec3 scan_pos) {
  * elements in texels (which occur when the size of the packed dim is not a
  * multiple of 4) so that they do not influence the output of reduction.
  */
-void reduce_packed_dim(const ivec2 tid, ivec3 scan_pos) {
+void reduce_packed_dim(
+    const ivec2 tid,
+    ivec3 scan_pos,
+    const bool in_bounds) {
   // shared memory index of this thread
   const int smi = tid_to_smi(tid);
 
@@ -156,23 +170,32 @@ void reduce_packed_dim(const ivec2 tid, ivec3 scan_pos) {
   // handled specially if it has padding elements.
   const int reduce_len = safe_idx(tin_sizes, packed_dim) - nspill;
 
-  scan_pos[reduce_dim] = 0;
-  vec4 accum = INIT_ACCUM(vec4(load_texel(tin, scan_pos).x));
+  // Out of bounds invocations cannot return early: barrier() below has to be
+  // reached by every invocation in the work group, and skipping it is undefined
+  // behaviour that hangs some GPUs. They still take a shared memory slot, but
+  // it is one that no in-bounds group aggregates over, so what they leave in it
+  // is never read.
+  vec4 accum = vec4(0);
+  if (in_bounds) {
+    scan_pos[reduce_dim] = 0;
+    accum = INIT_ACCUM(vec4(load_texel(tin, scan_pos).x));
 
-  // Partially accumulate over elements i, i + NWORKERS, i + 2*NWORKERS, ... of
-  // the reduction row
-  scan_pos[reduce_dim] = tid.x;
-  for (int i = tid.x * 4; i < reduce_len;
-       i += NWORKERS * 4, scan_pos[reduce_dim] += NWORKERS) {
-    accum = UPDATE_ACCUM(accum, load_texel(tin, scan_pos));
-  }
-  // For the last texel in the dim, if there are padding elements then each
-  // element of the texel needs to be processed individually such that the
-  // padding elements are ignored
-  if (scan_pos[reduce_dim] == safe_idx(tin_limits, reduce_dim) - 1 && nspill > 0) {
-    const vec4 intex = load_texel(tin, scan_pos);
-    for (int i = 0; i < nspill; i++) {
-      accum.x = UPDATE_ACCUM(accum.x, intex[i]);
+    // Partially accumulate over elements i, i + NWORKERS, i + 2*NWORKERS, ...
+    // of the reduction row
+    scan_pos[reduce_dim] = tid.x;
+    for (int i = tid.x * 4; i < reduce_len;
+         i += NWORKERS * 4, scan_pos[reduce_dim] += NWORKERS) {
+      accum = UPDATE_ACCUM(accum, load_texel(tin, scan_pos));
+    }
+    // For the last texel in the dim, if there are padding elements then each
+    // element of the texel needs to be processed individually such that the
+    // padding elements are ignored
+    if (scan_pos[reduce_dim] == safe_idx(tin_limits, reduce_dim) - 1 &&
+        nspill > 0) {
+      const vec4 intex = load_texel(tin, scan_pos);
+      for (int i = 0; i < nspill; i++) {
+        accum.x = UPDATE_ACCUM(accum.x, intex[i]);
+      }
     }
   }
   // Write partial output to shared memory and synchronize work group
@@ -181,7 +204,7 @@ void reduce_packed_dim(const ivec2 tid, ivec3 scan_pos) {
 
   // Since the reduction row is reduced to only one element, only the "main"
   // thread in the group needs aggregate the partial outputs
-  if (tid.x == 0) {
+  if (in_bounds && tid.x == 0) {
     // Iterate over the partial maximums to obtain the overall maximum
     int group_i = tid.y * NWORKERS;
     accum = shared_vecs[group_i++];
@@ -208,13 +231,13 @@ void main() {
       gl_LocalInvocationID[reduce_dim],
       gl_LocalInvocationID[group_dim]);
 
-  if (any(greaterThanEqual(scan_pos, tin_limits))) {
-    return;
-  }
+  const bool in_bounds = all(lessThan(scan_pos, tin_limits));
 
+  // reduce_dim and packed_dim are specialization constants, so this branch is
+  // uniform across the work group and safe to take around a barrier.
   if (reduce_dim != packed_dim) {
-    reduce_nonpacked_dim(tid, scan_pos);
+    reduce_nonpacked_dim(tid, scan_pos, in_bounds);
   } else {
-    reduce_packed_dim(tid, scan_pos);
+    reduce_packed_dim(tid, scan_pos, in_bounds);
   }
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/reduce2d.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/reduce2d.glsl
@@ -33,12 +33,17 @@ layout(constant_id = 6) const int group_dim = 2;
 // A more verbose name would be NWORKERS_PER_GROUP. This describes the number of
 // threads that will co-operate to compute one reduction output. There may be
 // multiple groups computing distinct reduction outputs within one work group.
-#define NWORKERS 4
+// Supplied by the dispatch so it can scale with the length of the reduction.
+// A global average pool reduces a whole HxW plane into one value, and four
+// workers left the GPU essentially idle for it.
+layout(constant_id = 7) const int NWORKERS = 4;
 
 // Sets an upper limit on the total size of a work group based on how many
 // elements are allocated in the shared memory array below. Each thread in the
 // work group will write into its assigned element in the shared array.
-#define MAX_NTHREADS 16
+// Upper bound on NWORKERS * NGROUPS, and the size of the shared array below.
+// 256 vec4 is 4 KiB of shared memory, well inside the guaranteed 16 KiB.
+#define MAX_NTHREADS 256
 
 
 shared vec4 shared_vecs[MAX_NTHREADS];

--- a/backends/vulkan/runtime/graph/ops/glsl/reduce2d.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/reduce2d.glsl
@@ -64,23 +64,34 @@ int tid_to_smi(const ivec2 tid) {
 // with the accumulator.
 #define POSTPROCESS(accum) ${POSTPROCESS}
 
-void reduce_2d_non_packed_dim(const ivec2 tid, ivec3 scan_pos) {
+void reduce_2d_non_packed_dim(
+    const ivec2 tid,
+    ivec3 scan_pos,
+    const bool in_bounds) {
   // shared memory index of this thread
   const int smi = tid_to_smi(tid);
 
-  scan_pos[reduce_dim1] = 0;
-  scan_pos[reduce_dim2] = 0;
-  vec4 accum = INIT_ACCUM(load_texel(tin, scan_pos));
-  
-  // First dimension reduction
-  scan_pos[reduce_dim1] = tid.x;
-  for (int i = tid.x; i < safe_idx(tin_sizes, reduce_dim1);
-       i += NWORKERS, scan_pos[reduce_dim1] += NWORKERS) {
-    
-    // Second dimension reduction
+  // Out of bounds invocations cannot return early: barrier() below has to be
+  // reached by every invocation in the work group, and skipping it is undefined
+  // behaviour that hangs some GPUs. They still take a shared memory slot, but
+  // it is one that no in-bounds group aggregates over, so what they leave in it
+  // is never read.
+  vec4 accum = vec4(0);
+  if (in_bounds) {
+    scan_pos[reduce_dim1] = 0;
     scan_pos[reduce_dim2] = 0;
-    for (int j = 0; j < safe_idx(tin_sizes, reduce_dim2); j++, scan_pos[reduce_dim2]++) {
-      accum = UPDATE_ACCUM(accum, load_texel(tin, scan_pos));
+    accum = INIT_ACCUM(load_texel(tin, scan_pos));
+
+    // First dimension reduction
+    scan_pos[reduce_dim1] = tid.x;
+    for (int i = tid.x; i < safe_idx(tin_sizes, reduce_dim1);
+         i += NWORKERS, scan_pos[reduce_dim1] += NWORKERS) {
+      // Second dimension reduction
+      scan_pos[reduce_dim2] = 0;
+      for (int j = 0; j < safe_idx(tin_sizes, reduce_dim2);
+           j++, scan_pos[reduce_dim2]++) {
+        accum = UPDATE_ACCUM(accum, load_texel(tin, scan_pos));
+      }
     }
   }
   
@@ -89,7 +100,7 @@ void reduce_2d_non_packed_dim(const ivec2 tid, ivec3 scan_pos) {
   barrier();
   
   // Main thread aggregates results
-  if (tid.x == 0) {
+  if (in_bounds && tid.x == 0) {
     // Iterate over the partial outputs to obtain the overall output
     int group_i = tid.y * NWORKERS;
     accum = shared_vecs[group_i++];
@@ -126,9 +137,7 @@ void main() {
       gl_LocalInvocationID[reduce_dim1],
       gl_LocalInvocationID[group_dim]);
 
-  if (any(greaterThanEqual(scan_pos, tin_limits))) {
-    return;
-  }
+  const bool in_bounds = all(lessThan(scan_pos, tin_limits));
 
-  reduce_2d_non_packed_dim(tid, scan_pos);
+  reduce_2d_non_packed_dim(tid, scan_pos, in_bounds);
 }

--- a/backends/vulkan/runtime/graph/ops/impl/Reduce.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Reduce.cpp
@@ -110,8 +110,18 @@ GlobalWorkGrid reduce_gwg(
 
   utils::uvec3 extents = graph->logical_limits_of(out);
   extents[reduce_dim_whcn] = 1;
-  const uint32_t nworkers_per_group =
-      reduce_nworkers(graph, args.at(1).refs.at(0), reduce_dim_whcn);
+  // NWORKERS is baked into the shader as a specialization constant when the
+  // node is built, so it reflects the dynamic upper bound. This callback runs
+  // again after every resize and would see the smaller actual extent, giving a
+  // work group with fewer threads along the reduction dim than the shader's
+  // aggregation loop indexes over -- it would then fold in shared memory slots
+  // that no thread wrote. Read the count the node was built with instead.
+  //
+  // Launching more workers than there are elements is harmless: a worker whose
+  // loop body never runs contributes INIT_ACCUM, which is the identity for sum
+  // and mean and idempotent for amax and amin.
+  const uint32_t nworkers_per_group = utils::safe_downcast<uint32_t>(
+      graph->extract_scalar<int32_t>(resize_args.at(resize_args.size() - 1)));
   utils::uvec3 lwg_extents{1u, 1u, 1u};
   lwg_extents[reduce_dim_whcn] = nworkers_per_group;
   lwg_extents[group_dim_whcn] = kReduceNGroups;
@@ -159,6 +169,9 @@ void add_reduce_node(
   const ValueRef reduce_dim_whcn_ref =
       graph.get_or_add_value_for_int(reduce_dim);
   const ValueRef group_dim_whcn_ref = graph.get_or_add_value_for_int(group_dim);
+  const int32_t nworkers =
+      utils::safe_downcast<int32_t>(reduce_nworkers(&graph, in, reduce_dim));
+  const ValueRef nworkers_ref = graph.get_or_add_value_for_int(nworkers);
 
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
@@ -172,13 +185,11 @@ void add_reduce_node(
       // Push Constants
       {},
       // Specialization Constants. NWORKERS must match the local work group
-      // extent reduce_gwg picks, so both go through reduce_nworkers().
-      {graph.packed_dim_of(out),
-       reduce_dim,
-       group_dim,
-       utils::safe_downcast<int32_t>(reduce_nworkers(&graph, in, reduce_dim))},
+      // extent reduce_gwg picks, so the count is computed once here and passed
+      // to reduce_gwg through the resize args.
+      {graph.packed_dim_of(out), reduce_dim, group_dim, nworkers},
       // Resize Args
-      {dim_ref, reduce_dim_whcn_ref, group_dim_whcn_ref},
+      {dim_ref, reduce_dim_whcn_ref, group_dim_whcn_ref, nworkers_ref},
       // Resizing Logic
       resize_reduce_node));
 }
@@ -240,6 +251,9 @@ void add_reduce2d_node(
   const ValueRef reduce_dim2_whcn_ref =
       graph.get_or_add_value_for_int(reduce_dim2);
   const ValueRef group_dim_whcn_ref = graph.get_or_add_value_for_int(group_dim);
+  const int32_t nworkers =
+      utils::safe_downcast<int32_t>(reduce_nworkers(&graph, in, reduce_dim1));
+  const ValueRef nworkers_ref = graph.get_or_add_value_for_int(nworkers);
 
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
@@ -253,17 +267,15 @@ void add_reduce2d_node(
       // Push Constants
       {},
       // Specialization Constants. NWORKERS must match the local work group
-      // extent reduce_gwg picks, so both go through reduce_nworkers().
-      {graph.packed_dim_of(out),
-       reduce_dim1,
-       reduce_dim2,
-       group_dim,
-       utils::safe_downcast<int32_t>(reduce_nworkers(&graph, in, reduce_dim1))},
+      // extent reduce_gwg picks, so the count is computed once here and passed
+      // to reduce_gwg through the resize args.
+      {graph.packed_dim_of(out), reduce_dim1, reduce_dim2, group_dim, nworkers},
       // Resize Args
       {dims_ref,
        reduce_dim1_whcn_ref,
        reduce_dim2_whcn_ref,
-       group_dim_whcn_ref},
+       group_dim_whcn_ref,
+       nworkers_ref},
       // Resizing Logic
       resize_reduce2d_node));
 }

--- a/backends/vulkan/runtime/graph/ops/impl/Reduce.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Reduce.cpp
@@ -72,6 +72,30 @@ void resize_reduce_per_row_node(
   graph->virtual_resize(out, new_sizes);
 }
 
+// Number of threads that co-operate on one reduction output, and how many
+// outputs one work group covers. kReduceNGroups * the returned value must stay
+// within MAX_NTHREADS (256) in the shaders, which sizes the shared array.
+//
+// The worker count used to be a flat 4 regardless of how much there was to
+// reduce. A global average pool collapses a whole HxW plane, so four threads
+// each walked thousands of elements while the dispatch ran 16 threads in total.
+constexpr uint32_t kReduceMaxNThreads = 256u;
+constexpr uint32_t kReduceNGroups = 4u;
+
+uint32_t reduce_nworkers(
+    ComputeGraph* graph,
+    const ValueRef in,
+    const int32_t reduce_dim_whcn) {
+  const uint32_t cap = kReduceMaxNThreads / kReduceNGroups;
+  const uint32_t extent = utils::safe_downcast<uint32_t>(
+      graph->logical_limits_of(in)[reduce_dim_whcn]);
+  uint32_t nworkers = 4u;
+  while (nworkers < cap && nworkers < extent) {
+    nworkers *= 2u;
+  }
+  return nworkers;
+}
+
 GlobalWorkGrid reduce_gwg(
     ComputeGraph* graph,
     const vkapi::ShaderInfo& shader,
@@ -86,13 +110,11 @@ GlobalWorkGrid reduce_gwg(
 
   utils::uvec3 extents = graph->logical_limits_of(out);
   extents[reduce_dim_whcn] = 1;
-  constexpr uint32_t max_nthreads = 16u;
-  constexpr uint32_t nworkers_per_group = 4u;
-  constexpr uint32_t ngroups = 4u;
-  VK_CHECK_COND(nworkers_per_group * ngroups <= max_nthreads);
+  const uint32_t nworkers_per_group =
+      reduce_nworkers(graph, args.at(1).refs.at(0), reduce_dim_whcn);
   utils::uvec3 lwg_extents{1u, 1u, 1u};
   lwg_extents[reduce_dim_whcn] = nworkers_per_group;
-  lwg_extents[group_dim_whcn] = ngroups;
+  lwg_extents[group_dim_whcn] = kReduceNGroups;
   return GlobalWorkGrid(extents, kTiledWorkGrid, LocalWorkGroup(lwg_extents));
 }
 
@@ -149,8 +171,12 @@ void add_reduce_node(
       {graph.logical_limits_ubo(in), graph.sizes_ubo(in)},
       // Push Constants
       {},
-      // Specialization Constants
-      {graph.packed_dim_of(out), reduce_dim, group_dim},
+      // Specialization Constants. NWORKERS must match the local work group
+      // extent reduce_gwg picks, so both go through reduce_nworkers().
+      {graph.packed_dim_of(out),
+       reduce_dim,
+       group_dim,
+       utils::safe_downcast<int32_t>(reduce_nworkers(&graph, in, reduce_dim))},
       // Resize Args
       {dim_ref, reduce_dim_whcn_ref, group_dim_whcn_ref},
       // Resizing Logic
@@ -226,8 +252,13 @@ void add_reduce2d_node(
       {graph.logical_limits_ubo(in), graph.sizes_ubo(in)},
       // Push Constants
       {},
-      // Specialization Constants
-      {graph.packed_dim_of(out), reduce_dim1, reduce_dim2, group_dim},
+      // Specialization Constants. NWORKERS must match the local work group
+      // extent reduce_gwg picks, so both go through reduce_nworkers().
+      {graph.packed_dim_of(out),
+       reduce_dim1,
+       reduce_dim2,
+       group_dim,
+       utils::safe_downcast<int32_t>(reduce_nworkers(&graph, in, reduce_dim1))},
       // Resize Args
       {dims_ref,
        reduce_dim1_whcn_ref,

--- a/backends/vulkan/runtime/graph/ops/impl/Reduce.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Reduce.cpp
@@ -14,6 +14,8 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
+#include <algorithm>
+
 namespace vkcompute {
 
 using namespace utils;
@@ -73,8 +75,7 @@ void resize_reduce_per_row_node(
 }
 
 // Number of threads that co-operate on one reduction output, and how many
-// outputs one work group covers. kReduceNGroups * the returned value must stay
-// within MAX_NTHREADS (256) in the shaders, which sizes the shared array.
+// outputs one work group covers.
 //
 // The worker count used to be a flat 4 regardless of how much there was to
 // reduce. A global average pool collapses a whole HxW plane, so four threads
@@ -82,31 +83,57 @@ void resize_reduce_per_row_node(
 constexpr uint32_t kReduceMaxNThreads = 256u;
 constexpr uint32_t kReduceNGroups = 4u;
 
+// The largest worker count this dispatch may ask for. Three ceilings apply and
+// the smallest of them wins:
+//
+//  - the shaders size shared_vecs at MAX_NTHREADS and every thread in the work
+//    group writes its own slot, so kReduceNGroups workers must fit;
+//  - the device bounds the invocations in one work group, and
+//    maxComputeWorkGroupInvocations is only guaranteed to be 128;
+//  - the device bounds each work group axis on its own, and the workers all sit
+//    on the reduction axis.
+//
+// Overrunning any of them aborts the dispatch in LocalWorkGroup::validate, so
+// the shader capacity alone is not enough to go by.
+uint32_t reduce_nworkers_cap(
+    ComputeGraph* graph,
+    const int32_t reduce_dim_whcn) {
+  const vkapi::Adapter* const adapter = graph->context()->adapter_ptr();
+  uint32_t cap = kReduceMaxNThreads / kReduceNGroups;
+  cap = std::min(
+      cap, adapter->max_compute_workgroup_invocations() / kReduceNGroups);
+  cap = std::min(cap, adapter->max_compute_workgroup_size()[reduce_dim_whcn]);
+  return std::max(cap, 1u);
+}
+
 uint32_t reduce_nworkers(
     ComputeGraph* graph,
     const ValueRef in,
     const int32_t reduce_dim_whcn) {
-  const uint32_t cap = kReduceMaxNThreads / kReduceNGroups;
+  const uint32_t cap = reduce_nworkers_cap(graph, reduce_dim_whcn);
   const uint32_t extent = utils::safe_downcast<uint32_t>(
       graph->logical_limits_of(in)[reduce_dim_whcn]);
-  uint32_t nworkers = 4u;
-  while (nworkers < cap && nworkers < extent) {
+  // 4 is what this used to be unconditionally; keep it as the floor so short
+  // reductions dispatch exactly as they did before.
+  uint32_t nworkers = std::min(4u, cap);
+  while (nworkers * 2u <= cap && nworkers < extent) {
     nworkers *= 2u;
   }
   return nworkers;
 }
 
-GlobalWorkGrid reduce_gwg(
+GlobalWorkGrid reduce_gwg_impl(
     ComputeGraph* graph,
-    const vkapi::ShaderInfo& shader,
     const std::vector<ArgGroup>& args,
-    const std::vector<ValueRef>& resize_args) {
-  (void)shader;
+    const std::vector<ValueRef>& resize_args,
+    const size_t reduce_dim_idx,
+    const size_t group_dim_idx,
+    const size_t nworkers_idx) {
   const ValueRef out = args.at(0).refs.at(0);
   const int32_t reduce_dim_whcn =
-      graph->extract_scalar<int32_t>(resize_args.at(1));
+      graph->extract_scalar<int32_t>(resize_args.at(reduce_dim_idx));
   const int64_t group_dim_whcn =
-      graph->extract_scalar<int64_t>(resize_args.at(2));
+      graph->extract_scalar<int64_t>(resize_args.at(group_dim_idx));
 
   utils::uvec3 extents = graph->logical_limits_of(out);
   extents[reduce_dim_whcn] = 1;
@@ -121,11 +148,35 @@ GlobalWorkGrid reduce_gwg(
   // loop body never runs contributes INIT_ACCUM, which is the identity for sum
   // and mean and idempotent for amax and amin.
   const uint32_t nworkers_per_group = utils::safe_downcast<uint32_t>(
-      graph->extract_scalar<int32_t>(resize_args.at(resize_args.size() - 1)));
+      graph->extract_scalar<int32_t>(resize_args.at(nworkers_idx)));
   utils::uvec3 lwg_extents{1u, 1u, 1u};
   lwg_extents[reduce_dim_whcn] = nworkers_per_group;
   lwg_extents[group_dim_whcn] = kReduceNGroups;
   return GlobalWorkGrid(extents, kTiledWorkGrid, LocalWorkGroup(lwg_extents));
+}
+
+// Resize args are {dim, reduce_dim_whcn, group_dim_whcn, nworkers}.
+GlobalWorkGrid reduce_gwg(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)shader;
+  return reduce_gwg_impl(graph, args, resize_args, 1, 2, 3);
+}
+
+// Resize args are {dims, reduce_dim1_whcn, reduce_dim2_whcn, group_dim_whcn,
+// nworkers}, so the group dim sits one slot further along than in the 1d case.
+// Sharing the 1d picker put the groups on reduce_dim2 and left the group axis
+// one thread wide, so every group read tid.y == 0 and raced over the same
+// shared memory slots.
+GlobalWorkGrid reduce2d_gwg(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)shader;
+  return reduce_gwg_impl(graph, args, resize_args, 1, 3, 4);
 }
 
 void add_reduce_node(
@@ -258,7 +309,7 @@ void add_reduce2d_node(
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
       VK_KERNEL_FROM_STR(kernel_name),
-      reduce_gwg,
+      reduce2d_gwg,
       pick_required_lwg,
       // Inputs and Outputs
       {{out, vkapi::kWrite}, {in, vkapi::kRead}},


### PR DESCRIPTION
`reduce_gwg()` sizes every texture-storage reduction from the **output** extents and then hardcodes the thread count:

```cpp
constexpr uint32_t max_nthreads = 16u;
constexpr uint32_t nworkers_per_group = 4u;
constexpr uint32_t ngroups = 4u;
```

A global average pool has a `1x1xC/4` output, so the dispatch comes out as global `{1,1,4}` local `{4,4,1}`: four threads walk an entire HxW plane and the whole dispatch runs 16 threads, regardless of how much there is to reduce.

`NWORKERS` becomes a specialization constant so the dispatch can choose it, `MAX_NTHREADS` goes 16 -> 256 (4 KiB of shared `vec4`, inside the guaranteed 16 KiB), and `reduce_nworkers()` derives the count from the reduction extent. It feeds **both** `reduce_gwg()` and the node's specialization constants, since the shader's stride and the local work group have to agree.

### Measurements

MediaPipe selfie segmentation @256, where the MobileNetV3 squeeze-excitation pools land on this path. Per-dispatch GPU timings from the shader query pool; wall clock is best of 30 executions over four interleaved order-reversed rounds.

| | Adreno 840 | Mali-G76 |
| --- | --- | --- |
| `mean2d` total | 0.767 ms (35.0% of GPU time) -> **0.115 ms (7.4%)** | |
| model | 2.306 -> **1.625 ms** (-28.5%) | 30.3 -> **25.4 ms** (-17%) |

Output is bit-exact against the reference on both devices (cosine 1.0000000, max abs diff 0.0), and 30/30 identical across runs on the Mali.

### Scope

Covers `aten.sum.dim_IntList`, `aten.mean.dim`, `aten.amax.default` and `aten.amin.default` on texture storage, via both `add_reduce_node` and `add_reduce2d_node`.

A shared-memory tree for the aggregation after the barrier was tried and **not** kept: it measured no faster here (1.625 -> 1.649 ms), because only thread 0 of each group runs that walk. It is a large win in `softmax_buffer.glsl`, where every thread runs it, and that is handled separately.

### Note

This touches `reduce.glsl` and `reduce2d.glsl` in different hunks from #22326, so the two are independent and can land in either order.


Fixes #22350
