### PR TITLE
Check dim order in the optimized mm and bmm as the portable ones do

### DIFF
--- a/kernels/optimized/cpu/op_bmm.cpp
+++ b/kernels/optimized/cpu/op_bmm.cpp
@@ -150,6 +150,11 @@ Tensor& opt_bmm_out(
   ET_KERNEL_CHECK(
       ctx, check_bmm_out_args(self, mat2, out), InvalidArgument, out);
 
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_dim_order(self, mat2, out), InvalidArgument, out);
+
+  ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(self), InvalidArgument, out);
+
   static constexpr auto name = "bmm.out";
 
   auto self_type = self.scalar_type();

--- a/kernels/optimized/cpu/op_mm.cpp
+++ b/kernels/optimized/cpu/op_mm.cpp
@@ -34,6 +34,11 @@ Tensor& opt_mm_out(
       InvalidArgument,
       out);
 
+  ET_KERNEL_CHECK(
+      ctx, tensors_have_same_dim_order(in, mat2, out), InvalidArgument, out);
+
+  ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(in), InvalidArgument, out);
+
   if (out.numel() == 0) {
     return out;
   }

--- a/kernels/test/op_bmm_test.cpp
+++ b/kernels/test/op_bmm_test.cpp
@@ -471,3 +471,22 @@ TEST_F(OpBmmOutTest, DISABLED_DynamicShapeUnbound) {
   Tensor ret = op_bmm_out(x, y, out);
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
+
+TEST_F(OpBmmOutTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  // All three tensors share the same non-default dim order, so the kernel's
+  // same dim order check passes and only the default dim order check rejects.
+  Tensor x =
+      tf.make_with_dimorder({2, 3, 4}, std::vector<float>(24, 2), {0, 2, 1});
+  Tensor y =
+      tf.make_with_dimorder({2, 4, 5}, std::vector<float>(40, 3), {0, 2, 1});
+  Tensor out =
+      tf.make_with_dimorder({2, 3, 5}, std::vector<float>(30), {0, 2, 1});
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
+  ET_EXPECT_KERNEL_FAILURE(context_, op_bmm_out(x, y, out));
+}

--- a/kernels/test/op_mm_test.cpp
+++ b/kernels/test/op_mm_test.cpp
@@ -294,3 +294,19 @@ TEST_F(OpMmOutTest, DISABLED_DynamicShapeUnbound) {
   Tensor ret = op_mm_out(x, y, out);
   EXPECT_TENSOR_CLOSE(out, expected_result);
 }
+
+TEST_F(OpMmOutTest, NonDefaultDimOrderDies) {
+  TensorFactory<ScalarType::Float> tf;
+
+  // All three tensors share the same non-default dim order, so the kernel's
+  // same dim order check passes and only the default dim order check rejects.
+  Tensor x = tf.make_with_dimorder({3, 4}, std::vector<float>(12, 2), {1, 0});
+  Tensor y = tf.make_with_dimorder({4, 5}, std::vector<float>(20, 3), {1, 0});
+  Tensor out = tf.make_with_dimorder({3, 5}, std::vector<float>(15), {1, 0});
+
+  ET_SKIP_IF(
+      torch::executor::testing::SupportedFeatures::get()->is_aten,
+      "ATen kernel can handle non-default dim order");
+
+  ET_EXPECT_KERNEL_FAILURE(context_, op_mm_out(x, y, out));
+}


### PR DESCRIPTION
### Summary

Follow-up to #21866, which did the same for the optimized `layer_norm`.

`opt_mm_out` and `opt_bmm_out` carry no dim order check, while portable `mm_out` and `bmm_out` each carry two:

```cpp
ET_KERNEL_CHECK(
    ctx, tensors_have_same_dim_order(in, mat2, out), InvalidArgument, out);
ET_KERNEL_CHECK(ctx, tensor_is_default_dim_order(in), InvalidArgument, out);
```

The shared `check_mm_args` and `check_bmm_args` do not supply them either, so choosing the optimized kernels quietly drops a check the portable path enforces.

`opt_mm_out` passes raw data pointers to `cpublas::gemm` with the leading dimensions taken from sizes rather than strides, which describes a row-major matrix only in the default dim order. `opt_bmm_out` does the same per batch. Thus, the arithmetic also needs it.

This PR adds portable guards to both the kernels, placed in the same position relative to the resize.

Not reachable from export today, in the same way the `select_scatter` half of #21915 was not, since `_get_channels_last_dim_order` raises for any rank other than 4 and so a 2D `mm` or 3D `bmm` input cannot be given a non-default dim order. It is still worth adding because the optimized kernels are currently less strict than the portable ones with nothing recording that as intentional, and because #16429 asks for these layouts to be supported, at which point the optimized path would return wrong numbers where the portable path errors.

### Test plan

A `NonDefaultDimOrderDies` per op. `op_mm_test.cpp` and `op_bmm_test.cpp` are both in `_optimized_kernels_test_sources`, so the same test body runs against both kernel sets, which makes the gap visible directly:

| target | optimized kernels | mm and bmm |
|---|---|---|
| `optimized_kernels_test` | guards reverted, tests kept | both fail |
| `optimized_kernels_test` | with the guards | both pass |
| `portable_kernels_test` | untouched either way | both pass |

All three tensors in each test share the same non-default dim order, so the same dim order check passes and only the default dim order check can reject. Both skip under `is_aten`.


cc @larryliu0820 @manuelcandales @JakeStevens