### PR TITLE
Optimize CPU SDPA for ring attention

### DIFF
--- a/examples/models/llama/attention.py
+++ b/examples/models/llama/attention.py
@@ -262,6 +262,23 @@ class CachePositionsManager(nn.Module):
         return indices
 
 
+def _get_ring_cache_size(
+    max_context_length: int,
+    window_size: int,
+    max_seq_len: Optional[int] = None,
+) -> int:
+    """Size an SWA cache for one retained window plus one in-flight chunk."""
+    assert window_size > 0, "Sliding-window size must be positive"
+    if max_seq_len is None:
+        max_seq_len = max_context_length
+    assert max_seq_len > 0, "Maximum sequence length must be positive"
+    assert window_size <= max_context_length, (
+        f"Sliding-window size ({window_size}) cannot exceed the full context "
+        f"length ({max_context_length})"
+    )
+    return min(max_context_length, window_size + max_seq_len)
+
+
 class RingKVCache(KVCache):
     def __init__(
         self,
@@ -271,10 +288,17 @@ class RingKVCache(KVCache):
         head_dim: int,
         enable_dynamic_shape: bool,
         dtype=torch.float32,
+        *,
+        window_size: int,
+        max_seq_len: Optional[int] = None,
     ):
-        self.window_size = max_context_length
         """
-        Reason why we want the kv cache size to be twice the context length:
+        The cache needs room for the retained sliding window and the current
+        prefill chunk. Its size is window_size + max_seq_len, capped by the
+        full-context cache. If max_seq_len is omitted, the full context length
+        is used.
+
+        Reason why a cache larger than the sliding window is needed:
         Sliding window attention without ringbuffer
         pos   0  1  2  3  4  5  6  7  8  9  10
         0     x  0  0  0  0  0  0  0  0  0  0
@@ -307,20 +331,28 @@ class RingKVCache(KVCache):
         So not having kept 2, 3 and 4 in cache means we will have divergent behavior.
         Worst case of this would have been when update it equal to the length of
         the cache. like in our case pos = 5 seq len = 4.
-        Thus we need to have a cache that is larger. How much larger, as much as
-        the sliding window size. So twice the max_context_length.
+        Thus we need a cache larger than the sliding window by enough space for
+        the largest in-flight input chunk.
         How would that have helped. Lets see. At pos = 5 our cache would have
         [0, 1, 2, 3, 4, NA, NA, NA] After cache update we would have
         [8, 1, 2, 3, 4, 5, 6, 7]. We kicked out token at pos = 0. However, the
         current step still has access to [pos - sliding_window_size, pos] tokens.
-        
+
         To make sure we dont over attend, i.e. we dont have pos = 5
         to attend to pos = 1, mask calculaton has to account for the sliding window
         size.
         """
+        self.window_size = window_size
+        self.full_context_length = max_context_length
+        self.max_seq_len = (
+            max_context_length if max_seq_len is None else int(max_seq_len)
+        )
+        ring_cache_size = _get_ring_cache_size(
+            max_context_length, window_size, self.max_seq_len
+        )
         super().__init__(
             max_batch_size,
-            max_context_length * 2,
+            ring_cache_size,
             n_heads,
             head_dim,
             enable_dynamic_shape,

--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -969,6 +969,7 @@ def _prepare_for_llama_export(llm_config: LlmConfig) -> LLMEdgeManager:
             preq_group_size=llm_config.base.preq_group_size,
             preq_embedding_quantize=llm_config.base.preq_embedding_quantize,
             local_global_attention=llm_config.model.local_global_attention,
+            max_seq_len=llm_config.export.max_seq_length,
             use_torchao_kernels_linear=llm_config.backend.torchao.use_torchao_kernels_linear,
             use_torchao_kernels_tied_embedding=llm_config.backend.torchao.use_torchao_kernels_tied_embedding,
             quantize_with_hqq=llm_config.quantization.use_hqq,
@@ -2064,6 +2065,7 @@ def _get_source_transforms(  # noqa
     preq_group_size: Optional[int] = None,
     preq_embedding_quantize: Optional[str] = None,
     local_global_attention: Optional[List[int]] = None,
+    max_seq_len: Optional[int] = None,
     use_torchao_kernels_linear: bool = False,
     use_torchao_kernels_tied_embedding: bool = False,
     quantize_with_hqq: bool = True,
@@ -2104,6 +2106,8 @@ def _get_source_transforms(  # noqa
         preq_mode: Pre-quantization mode.
         preq_group_size: Pre-quantization group size.
         preq_embedding_quantize: Pre-quantization embedding quantize.
+        max_seq_len: Largest input chunk accepted by local-attention layers. If
+            omitted, each layer's full context length is used.
 
     Returns:
         A list of transformation functions.
@@ -2280,6 +2284,7 @@ def _get_source_transforms(  # noqa
             partial(
                 replace_kv_cache_with_ring_kv_cache,
                 layer_sizes=local_global_attention,
+                max_seq_len=max_seq_len,
             )
         )
 

--- a/examples/models/llama/source_transformation/attention_sink.py
+++ b/examples/models/llama/source_transformation/attention_sink.py
@@ -18,11 +18,34 @@ from executorch.examples.models.llama.attention import (
     _create_causal_mask_for_ring_buffer,
     AttentionMHA,
     KVCache,
-    RingKVCache,
 )
 from executorch.examples.models.llama.model_args import ModelArgs
 from executorch.examples.models.llama.rope import Rope
 from torchao.quantization.quant_api import _replace_with_custom_fn_if_matches_filter
+
+
+def _get_attention_sink_cache_size(
+    max_context_length: int,
+    window_size: int,
+    sink_size: int,
+    max_seq_len: Optional[int] = None,
+) -> int:
+    """Size a sink cache for fixed sinks, one window, and one input chunk."""
+    assert sink_size >= 0, "Attention sink size must be non-negative"
+    assert sink_size < max_context_length, (
+        f"Attention sink size ({sink_size}) must be smaller than the full "
+        f"context length ({max_context_length})"
+    )
+    assert window_size > 0, "Sliding-window size must be positive"
+    assert sink_size + window_size <= max_context_length, (
+        f"Attention sink size ({sink_size}) plus sliding-window size "
+        f"({window_size}) cannot exceed the full context length "
+        f"({max_context_length})"
+    )
+    if max_seq_len is None:
+        max_seq_len = max_context_length
+    assert max_seq_len > 0, "Maximum sequence length must be positive"
+    return sink_size + window_size + max_seq_len
 
 
 class RopeWithAttentionSink(Rope):
@@ -37,10 +60,11 @@ class RopeWithAttentionSink(Rope):
       - Window tokens (pos >= sink_size): wrapped into ring buffer range
         [sink_size, sink_size + ring_size) via modulo
 
-    The ring buffer is 2x window_size for write-ahead headroom, not to keep the
-    live window contiguous -- it can span a wrap. Across a wrap two positions
-    remap to a difference that is not their true distance, so RoPE preserves
-    relative distance only within a wrap.
+    The ring buffer holds one retained window plus one maximum-size input
+    chunk. It is larger than the live window for write-ahead headroom, not to
+    keep the live window contiguous -- it can span a wrap. Across a wrap two
+    positions remap to a difference that is not their true distance, so RoPE
+    preserves relative distance only within a wrap.
     """
 
     def __init__(
@@ -52,7 +76,26 @@ class RopeWithAttentionSink(Rope):
         super().__init__(params)
         self.window_size = window_size
         self.sink_size = sink_size
-        self.ring_size = window_size * 2
+        max_seq_len = (
+            params.max_context_len
+            if getattr(params, "max_seq_len", None) is None
+            else int(params.max_seq_len)
+        )
+        cache_size = _get_attention_sink_cache_size(
+            params.max_context_len,
+            window_size,
+            sink_size,
+            max_seq_len,
+        )
+        self.ring_size = cache_size - sink_size
+        if self.freqs_cos.size(0) < cache_size:
+            freqs_cos, freqs_sin = self.precompute_freqs_cis(
+                self.params.head_dim,
+                cache_size,
+                self.params.rope_freq_base,
+            )
+            self.freqs_cos = freqs_cos
+            self.freqs_sin = freqs_sin
 
     def _remap_input_pos(self, input_pos: torch.Tensor) -> torch.Tensor:
         """Remap positions: sink tokens stay, window tokens wrap in ring buffer."""
@@ -133,7 +176,7 @@ class CachePositionsManagerWithSink(nn.Module):
     For sink_size=0: behaves exactly like original CachePositionsManager.
     For sink_size>0: sink tokens go to fixed positions, rest uses ring buffer.
 
-    IMPORTANT: cache_size should be the actual cache dimension size (2x window for ring buffer).
+    IMPORTANT: cache_size is the actual cache dimension, including sink slots.
     """
 
     def __init__(self, cache_size: int, sink_size: int = 0):
@@ -191,7 +234,7 @@ class KVCacheWithAttentionSink(KVCache):
     Uses a ring buffer approach for the sliding window portion while keeping
     the first sink_size tokens fixed. This avoids dynamic shape operations.
 
-    Cache layout: [sink: 0 to sink_size-1] [ring_buffer: sink_size to sink_size + window_size*2 - 1]
+    Cache layout: [fixed sink tokens] [ring buffer for one window + one chunk]
     """
 
     def __init__(
@@ -202,16 +245,27 @@ class KVCacheWithAttentionSink(KVCache):
         rope: RopeWithAttentionSink,
         window_size: int,
         sink_size: int,
+        max_context_length: int,
+        max_seq_len: Optional[int] = None,
         max_batch_size: int = 1,
         dtype=torch.float32,
     ):
-        # Total cache size is sink_size + window_size * 2.
-        # The ring buffer needs 2x the window size because at the moment a new
-        # token is written, the previous window_size tokens must still be readable
-        # (they haven't been overwritten yet). With only 1x, writing a new entry
-        # would immediately evict the oldest visible token, leaving fewer than
-        # window_size tokens available for attention.
-        total_cache_size = sink_size + window_size * 2
+        self.full_context_length = max_context_length
+        self.max_seq_len = (
+            max_context_length if max_seq_len is None else int(max_seq_len)
+        )
+        # Keep the fixed sinks separate from the ring space needed for the
+        # retained window and the largest in-flight input chunk.
+        total_cache_size = _get_attention_sink_cache_size(
+            max_context_length,
+            window_size,
+            sink_size,
+            self.max_seq_len,
+        )
+        assert rope.ring_size == total_cache_size - sink_size, (
+            f"RoPE ring size ({rope.ring_size}) must match the KV-cache ring "
+            f"size ({total_cache_size - sink_size})"
+        )
         super().__init__(
             max_batch_size=max_batch_size,
             max_context_length=total_cache_size,
@@ -310,6 +364,7 @@ def _replace_attention(
     rope_with_attention_sink: RopeWithAttentionSink,
     sink_size: int,
     window_size: int,
+    max_seq_len: Optional[int],
 ):
     for _, child_module in module._modules.items():
         if len(list(child_module.children())) > 0:  # pyre-ignore [16]
@@ -318,32 +373,23 @@ def _replace_attention(
                 rope_with_attention_sink=rope_with_attention_sink,
                 sink_size=sink_size,
                 window_size=window_size,
+                max_seq_len=max_seq_len,
             )
 
         if isinstance(child_module, AttentionMHA):
             kv_cache = child_module.kv_cache
-            if sink_size == 0:
-                # No sink tokens needed — use standard RingKVCache directly
-                child_module.kv_cache = RingKVCache(
-                    kv_cache.max_batch_size,
-                    window_size,  # RingKVCache expects user-provided window size
-                    kv_cache.n_heads,
-                    kv_cache.head_dim,
-                    kv_cache.enable_dynamic_shape,
-                    kv_cache.k_cache.dtype,
-                )
-            else:
-                kv_cache_with_attention_sink = KVCacheWithAttentionSink(
-                    n_heads=kv_cache.n_heads,
-                    head_dim=kv_cache.head_dim,
-                    enable_dynamic_shape=kv_cache.enable_dynamic_shape,
-                    rope=rope_with_attention_sink,
-                    max_batch_size=kv_cache.max_batch_size,
-                    window_size=window_size,
-                    sink_size=sink_size,
-                    dtype=kv_cache.k_cache.dtype,
-                )
-                child_module.kv_cache = kv_cache_with_attention_sink
+            child_module.kv_cache = KVCacheWithAttentionSink(
+                n_heads=kv_cache.n_heads,
+                head_dim=kv_cache.head_dim,
+                enable_dynamic_shape=kv_cache.enable_dynamic_shape,
+                rope=rope_with_attention_sink,
+                max_batch_size=kv_cache.max_batch_size,
+                window_size=window_size,
+                sink_size=sink_size,
+                max_context_length=kv_cache.max_context_length,
+                max_seq_len=max_seq_len,
+                dtype=kv_cache.k_cache.dtype,
+            )
             # Don't replace forward - let the original AttentionMHA.forward handle it
             # since our KVCache has is_ring_buffer=True, it will use the ring buffer mask
 
@@ -365,11 +411,13 @@ def enable_attention_sink(
         window_size=window_size,
         sink_size=sink_size,
     )
+    max_seq_len = getattr(params, "max_seq_len", None)
     _replace_rope(module, rope_with_attention_sink)
     _replace_attention(
         module=module,
         rope_with_attention_sink=rope_with_attention_sink,
         sink_size=sink_size,
         window_size=window_size,
+        max_seq_len=max_seq_len,
     )
     return module

--- a/examples/models/llama/source_transformation/custom_kv_cache.py
+++ b/examples/models/llama/source_transformation/custom_kv_cache.py
@@ -14,6 +14,7 @@ import torch
 import torch.nn as nn
 from executorch.examples.models.llama.attention import (
     _create_causal_mask_for_ring_buffer,
+    _get_ring_cache_size,
     CachePositionsManager,
     KVCache,
     RingKVCache,
@@ -661,17 +662,19 @@ def _replace_kv_cache_with_custom_kv_cache(module):
             if sdpa is not None and hasattr(sdpa, "use_attention_mask"):
                 sdpa.use_attention_mask = True
         elif isinstance(child, RingKVCache):
-            # RingKVCache (e.g., from attention sink with sink_size=0) needs
-            # CustomRingKVCache, not plain CustomKVCache
+            # Preserve ring-buffer sizing and masking when converting a
+            # local-attention cache to the custom update op.
             setattr(
                 module,
                 name,
                 CustomRingKVCache(
                     child.max_batch_size,
-                    child.window_size,
+                    child.full_context_length,
                     child.n_heads,
                     child.head_dim,
                     dtype=child.k_cache.dtype,
+                    window_size=child.window_size,
+                    max_seq_len=child.max_seq_len,
                 ),
             )
             sdpa = getattr(module, "SDPA", None)
@@ -707,11 +710,20 @@ class QuantizedRingKVCache(QuantizedKVCache):
         cache_type: QuantizedCacheType = QuantizedCacheType.AffineSymmetric,
         use_custom_update_cache_op: bool = False,
         return_float_values: bool = True,
+        *,
+        window_size: int,
+        max_seq_len: Optional[int] = None,
     ):
-        # Look at attention.py for explanation on why max_context_length * 2
+        self.full_context_length = max_context_length
+        self.max_seq_len = (
+            max_context_length if max_seq_len is None else int(max_seq_len)
+        )
+        ring_cache_size = _get_ring_cache_size(
+            max_context_length, window_size, self.max_seq_len
+        )
         super().__init__(
             max_batch_size,
-            max_context_length * 2,
+            ring_cache_size,
             n_heads,
             head_dim,
             cache_type,
@@ -720,7 +732,7 @@ class QuantizedRingKVCache(QuantizedKVCache):
         )
         self.cache_positions_manager = CachePositionsManager(self.max_context_length)
         self.is_ring_buffer = True
-        self.window_size = max_context_length
+        self.window_size = window_size
 
     def create_causal_mask_for_ring_buffer(self, start_pos, seq_len):
         cache_positions = self.cache_positions_manager.cache_positions
@@ -742,7 +754,7 @@ class QuantizedRingKVCache(QuantizedKVCache):
         seq_len = k_val.transpose(1, 2).size(1)
         assert seq_len <= self.k_cache.size(
             1
-        ), f"Update sequence length({seq_len}) for kv cache must be smaller than the cache size({self.k_cache.size(2)})"
+        ), f"Update sequence length({seq_len}) for kv cache must be smaller than the cache size({self.k_cache.size(1)})"
         indices = self.cache_positions_manager.calculate_positions_and_update_indices(
             input_pos, seq_len
         )
@@ -755,19 +767,22 @@ class QuantizedRingKVCache(QuantizedKVCache):
         cls,
         kv_cache,
         sliding_window_size,
+        max_seq_len,
     ):
         assert isinstance(
             kv_cache, QuantizedKVCache
         ), "For QuantizedRingKVCache expect QuantizedKVCache as input kv_cache"
-        max_batch_size, _, n_heads, head_dim = kv_cache.k_cache.shape
+        max_batch_size, max_context_length, n_heads, head_dim = kv_cache.k_cache.shape
         return cls(
             max_batch_size,
-            sliding_window_size,
+            max_context_length,
             n_heads,
             head_dim,
             kv_cache.cache_type,
             kv_cache.use_custom_update_cache_op,
             kv_cache.return_float_values,
+            window_size=sliding_window_size,
+            max_seq_len=max_seq_len,
         )
 
 
@@ -783,19 +798,30 @@ class CustomKVCacheWithAttentionSink(CustomKVCache):
     def __init__(
         self,
         max_batch_size,
+        max_context_length,
         n_heads,
         head_dim,
         window_size,
         sink_size,
+        max_seq_len=None,
         dtype=torch.float32,
     ):
-        # Total cache size: sink slots + ring buffer (2x window for wrap safety)
-        total_cache_size = sink_size + window_size * 2
-        super().__init__(max_batch_size, total_cache_size, n_heads, head_dim, dtype)
         from executorch.examples.models.llama.source_transformation.attention_sink import (
+            _get_attention_sink_cache_size,
             CachePositionsManagerWithSink,
         )
 
+        self.full_context_length = max_context_length
+        self.max_seq_len = (
+            max_context_length if max_seq_len is None else int(max_seq_len)
+        )
+        total_cache_size = _get_attention_sink_cache_size(
+            max_context_length,
+            window_size,
+            sink_size,
+            self.max_seq_len,
+        )
+        super().__init__(max_batch_size, total_cache_size, n_heads, head_dim, dtype)
         self.cache_positions_manager = CachePositionsManagerWithSink(
             total_cache_size, sink_size
         )
@@ -846,10 +872,12 @@ class CustomKVCacheWithAttentionSink(CustomKVCache):
         max_batch_size, n_heads, _, head_dim = kv_cache.k_cache.shape
         return cls(
             max_batch_size,
+            kv_cache.full_context_length,
             n_heads,
             head_dim,
             kv_cache.window_size,
             kv_cache.sink_size,
+            max_seq_len=kv_cache.max_seq_len,
             dtype=kv_cache.k_cache.dtype,
         )
 
@@ -862,14 +890,21 @@ class CustomRingKVCache(CustomKVCache):
         n_heads,
         head_dim,
         dtype=torch.float32,
+        *,
+        window_size: int,
+        max_seq_len: Optional[int] = None,
     ):
-        # Look at attention.py for explanation on why max_context_length * 2
-        super().__init__(
-            max_batch_size, max_context_length * 2, n_heads, head_dim, dtype
+        self.full_context_length = max_context_length
+        self.max_seq_len = (
+            max_context_length if max_seq_len is None else int(max_seq_len)
         )
+        ring_cache_size = _get_ring_cache_size(
+            max_context_length, window_size, self.max_seq_len
+        )
+        super().__init__(max_batch_size, ring_cache_size, n_heads, head_dim, dtype)
         self.cache_positions_manager = CachePositionsManager(self.max_context_length)
         self.is_ring_buffer = True
-        self.window_size = max_context_length
+        self.window_size = window_size
 
     def create_causal_mask_for_ring_buffer(self, start_pos, seq_len):
         cache_positions = self.cache_positions_manager.cache_positions
@@ -891,7 +926,7 @@ class CustomRingKVCache(CustomKVCache):
         seq_len = k_val.transpose(1, 2).size(1)
         assert seq_len <= self.k_cache.size(
             1
-        ), f"Update sequence length({seq_len}) for kv cache must be smaller than the cache size({self.k_cache.size(2)})"
+        ), f"Update sequence length({seq_len}) for kv cache must be smaller than the cache size({self.k_cache.size(1)})"
         indices = self.cache_positions_manager.calculate_positions_and_update_indices(
             input_pos, seq_len
         )
@@ -904,21 +939,24 @@ class CustomRingKVCache(CustomKVCache):
         cls,
         kv_cache,
         sliding_window_size,
+        max_seq_len,
     ):
-        max_batch_size, n_heads, _, head_dim = kv_cache.k_cache.shape
-        if isinstance(kv_cache, CustomKVCache):
-            # If replacing custom kv cache, then the shape is [B, S, H, D]
-            max_batch_size, _, n_heads, head_dim = kv_cache.k_cache.shape
+        # CustomKVCache storage is [B, S, H, D].
+        max_batch_size, max_context_length, n_heads, head_dim = kv_cache.k_cache.shape
         return cls(
             max_batch_size,
-            sliding_window_size,
+            max_context_length,
             n_heads,
             head_dim,
             dtype=kv_cache.k_cache.dtype,
+            window_size=sliding_window_size,
+            max_seq_len=max_seq_len,
         )
 
 
-def _replace_kv_cache_with_ring_kv_cache(attention, layer_size):
+def _replace_kv_cache_with_ring_kv_cache(
+    attention, layer_size: int, max_seq_len: Optional[int]
+):
     sliding_window_size = layer_size
     assert (
         getattr(attention, "kv_cache", None) is not None
@@ -927,23 +965,28 @@ def _replace_kv_cache_with_ring_kv_cache(attention, layer_size):
     if isinstance(kv_cache, KVCache):
         attention.kv_cache = RingKVCache(
             kv_cache.max_batch_size,
-            sliding_window_size,
+            kv_cache.max_context_length,
             kv_cache.n_heads,
             kv_cache.head_dim,
             kv_cache.enable_dynamic_shape,
             kv_cache.k_cache.dtype,
+            window_size=sliding_window_size,
+            max_seq_len=max_seq_len,
         )
     elif isinstance(kv_cache, CustomKVCache):
         attention.kv_cache = CustomRingKVCache.from_custom_kv_cache(
-            kv_cache, layer_size
+            kv_cache, layer_size, max_seq_len
         )
     elif isinstance(kv_cache, QuantizedKVCache):
         attention.kv_cache = QuantizedRingKVCache.from_quantized_kv_cache(
-            kv_cache, layer_size
+            kv_cache, layer_size, max_seq_len
         )
 
 
-def replace_kv_cache_with_ring_kv_cache(module, layer_sizes):
+def replace_kv_cache_with_ring_kv_cache(
+    module, layer_sizes, max_seq_len: Optional[int] = None
+):
+    """Replace local-layer caches with window-plus-in-flight ring caches."""
     # This is needed to ensure that custom ops are registered
     from executorch.extension.llm.custom_ops import custom_ops  # noqa: F401
 
@@ -959,6 +1002,7 @@ def replace_kv_cache_with_ring_kv_cache(module, layer_sizes):
     logging.info(
         f"Applying local sliding window attention with following pattern {layer_sizes}."
     )
+    logged_full_context_cache = False
     assert len(layer_sizes) == len(
         module.layers
     ), f"Length of layer sizes {len(layer_sizes)} must match the number of layers in the module {len(module.layers)}."
@@ -970,7 +1014,23 @@ def replace_kv_cache_with_ring_kv_cache(module, layer_sizes):
             getattr(transformer_block, "attention", None) is not None
         ), f"Transfomer block must have attention module. Transformer block {transformer_block}"
         attention = transformer_block.attention
-        _replace_kv_cache_with_ring_kv_cache(attention, sliding_window_size)
+        full_context_length = attention.kv_cache.max_context_length
+        effective_max_seq_len = (
+            full_context_length if max_seq_len is None else max_seq_len
+        )
+        if (
+            not logged_full_context_cache
+            and sliding_window_size + effective_max_seq_len >= full_context_length
+        ):
+            logging.info(
+                "Local attention KV caches will use the full context length; "
+                "set max_seq_length below max_context_length - window_size "
+                "to retain KV-cache memory savings."
+            )
+            logged_full_context_cache = True
+        _replace_kv_cache_with_ring_kv_cache(
+            attention, sliding_window_size, max_seq_len
+        )
         # if attention's sdpa is custom sdpa then we have to make sure
         # it is not doing causal attention
         if "SDPACustom" in attention.SDPA.__class__.__name__:

--- a/examples/models/llama/source_transformation/test_attention_sink.py
+++ b/examples/models/llama/source_transformation/test_attention_sink.py
@@ -69,7 +69,10 @@ class RopeWithAttentionSinkWrapTest(unittest.TestCase):
         # Ring top is 20. The table is deliberately longer, so a slice running
         # past the ring still lands on real rows instead of going out of bounds.
         self.params = ModelArgs(
-            use_kv_cache=True, enable_dynamic_shape=True, max_context_len=64
+            use_kv_cache=True,
+            enable_dynamic_shape=True,
+            max_context_len=64,
+            max_seq_len=self.WINDOW_SIZE,
         )
         self.rope = RopeWithAttentionSink(
             params=self.params,
@@ -226,14 +229,15 @@ class KVCacheWithAttentionSinkTest(unittest.TestCase):
             use_kv_cache=True,
             enable_dynamic_shape=True,
             max_context_len=256,
+            max_seq_len=self.window_size,
         )
         self.rope = RopeWithAttentionSink(
             params=self.params,
             window_size=self.window_size,
             sink_size=self.sink_size,
         )
-        # Total cache size = sink_size + window_size * 2 = 4 + 56 = 60
-        self.cache_size = self.sink_size + self.window_size * 2
+        # Total cache size = sink_size + window_size + max_seq_len = 60.
+        self.cache_size = self.sink_size + self.window_size + self.params.max_seq_len
         self.kv_cache = KVCacheWithAttentionSink(
             n_heads=self.params.n_heads,
             head_dim=self.params.head_dim,
@@ -242,6 +246,8 @@ class KVCacheWithAttentionSinkTest(unittest.TestCase):
             max_batch_size=self.max_batch_size,
             window_size=self.window_size,
             sink_size=self.sink_size,
+            max_context_length=self.params.max_context_len,
+            max_seq_len=self.params.max_seq_len,
             dtype=self.dtype,
         )
 
@@ -372,11 +378,15 @@ class KVCacheWithAttentionSinkTest(unittest.TestCase):
     )
     def test_no_sink_degenerates_to_ring_buffer(self, sink_size):
         """With sink_size=0, behavior should match a plain ring buffer."""
+        window_size = 100
         params = ModelArgs(
-            use_kv_cache=True, enable_dynamic_shape=True, max_context_len=256
+            use_kv_cache=True,
+            enable_dynamic_shape=True,
+            max_context_len=128,
+            max_seq_len=64,
         )
         rope = RopeWithAttentionSink(
-            params=params, window_size=self.window_size, sink_size=0
+            params=params, window_size=window_size, sink_size=0
         )
         cache = KVCacheWithAttentionSink(
             n_heads=params.n_heads,
@@ -384,11 +394,16 @@ class KVCacheWithAttentionSinkTest(unittest.TestCase):
             enable_dynamic_shape=params.enable_dynamic_shape,
             rope=rope,
             max_batch_size=1,
-            window_size=self.window_size,
+            window_size=window_size,
             sink_size=0,
+            max_context_length=params.max_context_len,
+            max_seq_len=params.max_seq_len,
             dtype=self.dtype,
         )
-        cache_size = self.window_size * 2  # 56
+        cache_size = window_size + params.max_seq_len
+        self.assertEqual(cache_size, 164)
+        self.assertEqual(rope.ring_size, cache_size)
+        self.assertEqual(cache.max_context_length, cache_size)
 
         # Fill and wrap
         k_init, v_init = self._rand_kv(cache_size)
@@ -434,7 +449,10 @@ class AttentionSinkE2ETest(unittest.TestCase):
 
         model = construct_transformer(args)
         model = enable_attention_sink(
-            model, params=args, sink_size=sink_size, window_size=window_size
+            model,
+            params=args,
+            sink_size=sink_size,
+            window_size=window_size,
         )
 
         if use_custom_sdpa:
@@ -502,12 +520,12 @@ class AttentionSinkE2ETest(unittest.TestCase):
         """Generate tokens well beyond the KV cache size using standard SDPA."""
         sink_size = 4
         window_size = 16
-        # KV cache size = sink_size + window_size * 2 = 36
+        # KV cache size = sink_size + window_size + max_seq_len = 52
         # max_context_len = 128 (for RoPE table)
         args = self._make_args(max_context_len=128)
         model = self._build_model(args, sink_size, window_size, use_custom_sdpa=False)
 
-        # Generate 80 tokens — well beyond KV cache size of 36
+        # Generate 80 tokens — beyond the KV cache size of 52
         outputs = self._run_generation(model, args, num_tokens=80)
 
         self.assertEqual(len(outputs), 77)  # 1 prefill + 76 decode steps
@@ -520,10 +538,13 @@ class AttentionSinkE2ETest(unittest.TestCase):
         """Generate tokens beyond max_context_len with RoPE position remapping."""
         sink_size = 4
         window_size = 16
-        # KV cache size = 36, max_context_len = 64
+        # With max_seq_len omitted, the cache is capped at max_context_len.
         # Generate 100 tokens — well beyond max_context_len
         args = self._make_args(max_context_len=64)
+        args.max_seq_len = None
         model = self._build_model(args, sink_size, window_size, use_custom_sdpa=False)
+        cache = model.layers[0].attention.kv_cache
+        self.assertEqual(cache.max_context_length, 84)
 
         outputs = self._run_generation(model, args, num_tokens=100)
 
@@ -537,10 +558,9 @@ class AttentionSinkE2ETest(unittest.TestCase):
     def test_chunked_prefill_across_the_ring_wrap(self):
         """Chunked prefill where a chunk spans the ring wrap.
 
-        sink_size=4, window_size=16, so the ring is slots [4, 36). Feeding 5
-        tokens at a time puts chunk starts at 0, 5, ..., 95. The chunk at 35
-        covers positions 35..39 and needs rows 35, 4, 5, 6, 7; the chunk at 65
-        covers 65..69 and needs rows 33, 34, 35, 4, 5. Both span the wrap.
+        sink_size=4, window_size=16, and max_seq_len=48, so the ring is slots
+        [4, 68). Feeding 40 tokens at a time exceeds the old 2x-window ring and
+        crosses the new ring boundary on the second chunk.
 
         The other beyond-context-window tests decode one token at a time, and a
         chunk of one can never span the wrap however far the position runs, so
@@ -554,27 +574,32 @@ class AttentionSinkE2ETest(unittest.TestCase):
         """
         sink_size = 4
         window_size = 16
-        args = self._make_args(max_context_len=64)
+        chunk_size = 40
+        args = self._make_args(max_context_len=128)
+        args.max_seq_len = 48
 
         torch.manual_seed(0)
         model = self._build_model(args, sink_size, window_size)
-        tokens = torch.randint(0, args.vocab_size, (1, 100))
+        tokens = torch.randint(0, args.vocab_size, (1, 80))
 
-        chunked = self._feed_in_chunks(copy.deepcopy(model), tokens, chunk_size=5)
+        chunked = self._feed_in_chunks(
+            copy.deepcopy(model), tokens, chunk_size=chunk_size
+        )
         one_at_a_time = self._feed_in_chunks(copy.deepcopy(model), tokens, chunk_size=1)
 
-        self.assertEqual(len(chunked), 20)
-        self.assertEqual(len(one_at_a_time), 100)
+        self.assertEqual(len(chunked), 2)
+        self.assertEqual(len(one_at_a_time), 80)
 
         # generate_full_logits is off, so each call returns logits for its last
         # position only. How the input was chunked must not change the result:
-        # chunk i ends on the same token as one_at_a_time[5 * i + 4].
+        # chunk i ends on the same token as the corresponding decode call.
         for i, out in enumerate(chunked):
             self.assertTrue(torch.isfinite(out).all(), f"chunk {i} is not finite")
             torch.testing.assert_close(
                 out,
-                one_at_a_time[5 * i + 4],
-                msg=lambda m, i=i: f"chunk {i}, positions {5 * i}..{5 * i + 4}, "
+                one_at_a_time[chunk_size * (i + 1) - 1],
+                msg=lambda m, i=i: f"chunk {i}, positions {chunk_size * i}.."
+                f"{chunk_size * (i + 1) - 1}, "
                 f"disagrees with feeding the same tokens one at a time:\n{m}",
             )
 
@@ -599,7 +624,7 @@ class AttentionSinkE2ETest(unittest.TestCase):
             found_custom_cache, "Expected CustomKVCacheWithAttentionSink in model"
         )
 
-        # Generate 80 tokens — well beyond KV cache size of 36
+        # Generate 80 tokens — beyond the KV cache size of 52
         outputs = self._run_generation(model, args, num_tokens=80)
 
         self.assertEqual(len(outputs), 77)

--- a/examples/models/llama/tests/test_replace_kv_cache.py
+++ b/examples/models/llama/tests/test_replace_kv_cache.py
@@ -89,13 +89,14 @@ class TestReplaceKVCache(unittest.TestCase):
 
         # Replace KVCache with RingKVCache
         layer_sizes = [8]  # Sliding window size for each layer
-        replace_kv_cache_with_ring_kv_cache(model, layer_sizes)
+        replace_kv_cache_with_ring_kv_cache(model, layer_sizes, max_seq_len=4)
 
         # Verify that KVCache has been replaced with RingKVCache
         self.assertIsInstance(model.layers[0].attention.kv_cache, RingKVCache)
 
         # Verify that the sliding window size is set correctly
         self.assertEqual(model.layers[0].attention.kv_cache.window_size, layer_sizes[0])
+        self.assertEqual(model.layers[0].attention.kv_cache.k_cache.size(2), 12)
 
     def test_replace_custom_kv_cache_with_custom_ring_kv_cache(self):
         """Test replacing CustomKVCache with CustomRingKVCache."""
@@ -112,10 +113,11 @@ class TestReplaceKVCache(unittest.TestCase):
 
         # Replace CustomKVCache with CustomRingKVCache
         layer_sizes = [8]  # Sliding window size for each layer
-        replace_kv_cache_with_ring_kv_cache(model, layer_sizes)
+        replace_kv_cache_with_ring_kv_cache(model, layer_sizes, max_seq_len=4)
 
         # Verify that CustomKVCache has been replaced with CustomRingKVCache
         self.assertIsInstance(model.layers[0].attention.kv_cache, CustomRingKVCache)
+        self.assertEqual(model.layers[0].attention.kv_cache.k_cache.size(1), 12)
 
     def test_replace_quantized_kv_cache_with_quantized_ring_kv_cache(self):
         """Test replacing QuantizedKVCache with QuantizedRingKVCache."""
@@ -134,10 +136,11 @@ class TestReplaceKVCache(unittest.TestCase):
 
         # Replace QuantizedKVCache with QuantizedRingKVCache
         layer_sizes = [8]  # Sliding window size for each layer
-        replace_kv_cache_with_ring_kv_cache(model, layer_sizes)
+        replace_kv_cache_with_ring_kv_cache(model, layer_sizes, max_seq_len=4)
 
         # Verify that QuantizedKVCache has been replaced with QuantizedRingKVCache
         self.assertIsInstance(model.layers[0].attention.kv_cache, QuantizedRingKVCache)
+        self.assertEqual(model.layers[0].attention.kv_cache.k_cache.size(1), 12)
 
     def test_replace_static_quantized_kv_cache(self):
         """Test replacing KVCache with static-qparams int8 KV storage."""
@@ -287,6 +290,7 @@ class TestReplaceKVCache(unittest.TestCase):
             self.n_kv_heads,
             self.head_dim,
             self.enable_dynamic_shape,
+            window_size=self.max_context_len,
         )
         model = self._create_mock_model([attention])
 
@@ -305,7 +309,9 @@ class TestReplaceKVCache(unittest.TestCase):
 
         # Replace KVCache with RingKVCache with different window sizes
         layer_sizes = [4, 8, 16]  # Different sliding window sizes for each layer
-        replace_kv_cache_with_ring_kv_cache(model, layer_sizes)
+        replace_kv_cache_with_ring_kv_cache(
+            model, layer_sizes, max_seq_len=self.max_context_len
+        )
 
         # Verify that each layer has the correct window size
         self.assertIsInstance(model.layers[0].attention.kv_cache, RingKVCache)

--- a/examples/models/llama/tests/test_ring_attention.py
+++ b/examples/models/llama/tests/test_ring_attention.py
@@ -84,7 +84,10 @@ class TestRingAttention(unittest.TestCase):
             return attention
 
     def _create_ring_attention(
-        self, attention, kv_cache_type: KVCacheType = KVCacheType.REGULAR
+        self,
+        attention,
+        max_seq_len,
+        kv_cache_type: KVCacheType = KVCacheType.REGULAR,
     ):
         """Create attention with ring buffer KV cache."""
         assert self.sliding_window is not None
@@ -98,24 +101,81 @@ class TestRingAttention(unittest.TestCase):
             baseline_attention.kv_cache = QuantizedRingKVCache.from_quantized_kv_cache(
                 baseline_attention.kv_cache,
                 self.sliding_window,
+                max_seq_len,
             )
         elif isinstance(baseline_attention.kv_cache, CustomKVCache):
             # Replace CustomKVCache with CustomRingKVCache
             baseline_attention.kv_cache = CustomRingKVCache.from_custom_kv_cache(
                 baseline_attention.kv_cache,
                 self.sliding_window,
+                max_seq_len,
             )
         else:
             # Replace regular KVCache with RingKVCache
             baseline_attention.kv_cache = RingKVCache(
                 self.args.max_batch_size,
-                self.sliding_window,
+                self.args.max_context_len,
                 self.n_kv_heads,
                 self.head_dim,
                 self.args.enable_dynamic_shape,
                 self.dtype,
+                window_size=self.sliding_window,
+                max_seq_len=max_seq_len,
             )
         return baseline_attention
+
+    def test_continuation_prefill_larger_than_window(
+        self, kv_cache_type: KVCacheType = KVCacheType.REGULAR
+    ):
+        """A W+C cache preserves history when the incoming chunk exceeds W."""
+        self.sliding_window = 4
+        chunk_size = 6
+        baseline_attn = self._create_baseline_attention(12, kv_cache_type)
+        ring_attn = self._create_ring_attention(
+            baseline_attn, chunk_size, kv_cache_type
+        )
+
+        self.assertEqual(ring_attn.kv_cache.max_context_length, 10)
+
+        with torch.nn.attention.sdpa_kernel(
+            [SDPBackend.FLASH_ATTENTION]
+        ), torch.no_grad():
+            for pos in (0, chunk_size):
+                x = torch.randn(
+                    (self.batch_size, chunk_size, self.dim), dtype=self.dtype
+                )
+                input_pos = torch.tensor([pos], dtype=torch.long)
+                freqs_cos, freqs_sin = self.rope.get_freqs(input_pos, chunk_size)
+
+                baseline_out, _ = baseline_attn.forward(
+                    x, freqs_cos, freqs_sin, input_pos=input_pos
+                )
+                ring_out, _ = ring_attn.forward(
+                    x, freqs_cos, freqs_sin, input_pos=input_pos
+                )
+
+                tolerance = 1e-6 if kv_cache_type != KVCacheType.REGULAR else 1e-7
+                self.assertTrue(
+                    torch.allclose(
+                        baseline_out,
+                        ring_out,
+                        rtol=tolerance,
+                        atol=tolerance,
+                    ),
+                    f"Outputs differ at position {pos}",
+                )
+
+    def test_continuation_prefill_larger_than_window_quantized(self):
+        self._run_test_with_kv_cache_type(
+            self.test_continuation_prefill_larger_than_window,
+            KVCacheType.QUANTIZED,
+        )
+
+    def test_continuation_prefill_larger_than_window_custom(self):
+        self._run_test_with_kv_cache_type(
+            self.test_continuation_prefill_larger_than_window,
+            KVCacheType.CUSTOM,
+        )
 
     def _create_sliding_window_mask(self, seq_len, context_len, window_size):
         """Create a sliding window mask for the baseline."""
@@ -140,7 +200,7 @@ class TestRingAttention(unittest.TestCase):
         seq_len = 10
         self.sliding_window = 4
         baseline_attn = self._create_baseline_attention(seq_len, kv_cache_type)
-        ring_attn = self._create_ring_attention(baseline_attn, kv_cache_type)
+        ring_attn = self._create_ring_attention(baseline_attn, 1, kv_cache_type)
 
         # Process tokens one by one
         with torch.nn.attention.sdpa_kernel(
@@ -199,7 +259,7 @@ class TestRingAttention(unittest.TestCase):
         baseline_attn = self._create_baseline_attention(seq_len, kv_cache_type)
 
         # Create ring attention with sliding window size
-        ring_attn = self._create_ring_attention(baseline_attn, kv_cache_type)
+        ring_attn = self._create_ring_attention(baseline_attn, 1, kv_cache_type)
 
         # Process tokens one by one
         with torch.nn.attention.sdpa_kernel(
@@ -251,7 +311,7 @@ class TestRingAttention(unittest.TestCase):
         )
 
         # Create ring attention with sliding window size
-        ring_attn = self._create_ring_attention(baseline_attn, kv_cache_type)
+        ring_attn = self._create_ring_attention(baseline_attn, 1, kv_cache_type)
 
         # Process enough tokens to cause wrapping
         seq_len = 1
@@ -277,13 +337,12 @@ class TestRingAttention(unittest.TestCase):
                     f"Outputs differ at position {pos}",
                 )
 
-        # After processing 8 tokens with window size 4, the ring buffer should have wrapped around
+        # With W=3 and max_seq_len=1, the physical cache has 4 slots and wraps.
         # Check the cache positions to verify wrapping
         cache_positions = ring_attn.kv_cache.cache_positions_manager.cache_positions
 
-        # The cache positions should contain the most recent 4 positions (4, 5, 6, 7)
-        # mapped to the ring buffer indices
-        expected_positions = torch.tensor([6, 7, 2, 3, 4, 5], dtype=torch.long)
+        # Positions 4 through 7 occupy physical slots 0 through 3.
+        expected_positions = torch.tensor([4, 5, 6, 7], dtype=torch.long)
 
         self.assertTrue(
             torch.all(cache_positions == expected_positions),
@@ -316,7 +375,9 @@ class TestRingAttention(unittest.TestCase):
         baseline_attn = self._create_baseline_attention(seq_len, kv_cache_type)
 
         # Create ring attention with sliding window size
-        ring_attn = self._create_ring_attention(baseline_attn, kv_cache_type)
+        ring_attn = self._create_ring_attention(
+            baseline_attn, max(token_lens), kv_cache_type
+        )
 
         pos = 0
         with torch.nn.attention.sdpa_kernel(

--- a/examples/models/llama/tests/test_ring_kv_cache.py
+++ b/examples/models/llama/tests/test_ring_kv_cache.py
@@ -14,7 +14,9 @@ class TestRingKVCache(unittest.TestCase):
     def setUp(self):
         # Common test parameters
         self.max_batch_size = 2
-        self.max_context_length = 8
+        self.max_context_length = 16
+        self.window_size = 8
+        self.max_seq_len = 8
         self.n_heads = 4
         self.head_dim = 16
         self.enable_dynamic_shape = True
@@ -32,7 +34,7 @@ class TestRingKVCache(unittest.TestCase):
         self._require_usable_cuda()
         cache = KVCache(
             max_batch_size=1,
-            max_context_length=self.max_context_length,
+            max_context_length=self.window_size,
             n_heads=self.n_heads,
             head_dim=self.head_dim,
             enable_dynamic_shape=True,
@@ -60,6 +62,8 @@ class TestRingKVCache(unittest.TestCase):
             head_dim=self.head_dim,
             enable_dynamic_shape=True,
             dtype=self.dtype,
+            window_size=self.window_size,
+            max_seq_len=self.max_seq_len,
         ).cuda()
         input_pos = torch.tensor([0], dtype=torch.long, device="cuda")
         seq_len = 3
@@ -103,7 +107,10 @@ class TestRingKVCache(unittest.TestCase):
             self.head_dim,
             self.enable_dynamic_shape,
             self.dtype,
+            window_size=self.window_size,
         )
+
+        self.assertEqual(cache.max_seq_len, self.max_context_length)
 
         # Create input tensors
         input_pos = torch.tensor([0], dtype=torch.long)
@@ -129,7 +136,7 @@ class TestRingKVCache(unittest.TestCase):
             self.assertTrue(torch.all(v_out[:, :, i] == 2.0))
 
         # Check that the rest of the cache is still zeros
-        for i in range(seq_len, self.max_context_length):
+        for i in range(seq_len, self.window_size):
             self.assertTrue(torch.all(k_out[:, :, i] == 0.0))
             self.assertTrue(torch.all(v_out[:, :, i] == 0.0))
 
@@ -153,6 +160,8 @@ class TestRingKVCache(unittest.TestCase):
             self.head_dim,
             self.enable_dynamic_shape,
             self.dtype,
+            window_size=self.window_size,
+            max_seq_len=self.max_seq_len,
         )
 
         # Create input tensors for first update
@@ -216,6 +225,8 @@ class TestRingKVCache(unittest.TestCase):
             self.head_dim,
             self.enable_dynamic_shape,
             self.dtype,
+            window_size=self.window_size,
+            max_seq_len=self.max_seq_len,
         )
 
         # First update
@@ -346,6 +357,8 @@ class TestRingKVCache(unittest.TestCase):
             self.head_dim,
             self.enable_dynamic_shape,
             self.dtype,
+            window_size=self.window_size,
+            max_seq_len=self.max_seq_len,
         )
 
         # Create input tensors
@@ -374,7 +387,7 @@ class TestRingKVCache(unittest.TestCase):
         self.assertTrue(torch.all(v_out[:, :, 0] == 12.0))
 
         # Check that the rest of the cache is still zeros
-        for i in range(1, self.max_context_length):
+        for i in range(1, self.window_size):
             self.assertTrue(torch.all(k_out[:, :, i] == 0.0))
             self.assertTrue(torch.all(v_out[:, :, i] == 0.0))
 
@@ -390,7 +403,7 @@ class TestRingKVCache(unittest.TestCase):
         )
 
     def test_edge_case_exceeding_context_length(self):
-        """Test the edge case where input_pos + seq_len > max_context_length."""
+        """Test the edge case where input_pos + seq_len exceeds cache capacity."""
         cache = RingKVCache(
             self.max_batch_size,
             self.max_context_length,
@@ -398,6 +411,8 @@ class TestRingKVCache(unittest.TestCase):
             self.head_dim,
             self.enable_dynamic_shape,
             self.dtype,
+            window_size=self.window_size,
+            max_seq_len=self.max_seq_len,
         )
 
         # Create input tensors
@@ -462,6 +477,8 @@ class TestRingKVCache(unittest.TestCase):
             self.head_dim,
             self.enable_dynamic_shape,
             self.dtype,
+            window_size=self.window_size,
+            max_seq_len=self.max_seq_len,
         )
 
         # First update at position 10 (will be mapped to position 10 in the ring buffer)
@@ -481,7 +498,7 @@ class TestRingKVCache(unittest.TestCase):
 
         # Check that cache_positions correctly tracks the original indices
         # For input_pos=10 and seq_len=4, the original indices should be 10, 11, 12, 13
-        # These map to positions 10, 11, 12, 13 in the ring buffer (since max_context_length=8 but buffer size is 16)
+        # These map directly to positions 10, 11, 12, 13 in the 16-slot cache.
         # Note that positions 0-9 are 0 because in actual ring
         # updates those positions would have been updated for start_pos = 0.
         # So CachePositionsManager thinks they are updated because start_pos > (0-9)
@@ -532,6 +549,8 @@ class TestRingKVCache(unittest.TestCase):
             self.head_dim,
             enable_dynamic_shape=False,
             dtype=self.dtype,
+            window_size=self.window_size,
+            max_seq_len=self.max_seq_len,
         )
 
         # Create input tensors
@@ -561,6 +580,6 @@ class TestRingKVCache(unittest.TestCase):
             self.assertTrue(torch.all(v_out[:, :, i] == 16.0))
 
         # Check that the rest of the cache is still zeros
-        for i in range(seq_len, self.max_context_length):
+        for i in range(seq_len, self.window_size):
             self.assertTrue(torch.all(k_out[:, :, i] == 0.0))
             self.assertTrue(torch.all(v_out[:, :, i] == 0.0))

--- a/extension/llm/custom_ops/op_sdpa_impl.h
+++ b/extension/llm/custom_ops/op_sdpa_impl.h
@@ -16,8 +16,6 @@
 // @lint-ignore CLANGTIDY facebook-unused-include-check
 #include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
 
-#include <vector>
-
 #ifdef ET_USE_THREADPOOL
 #include <executorch/extension/threadpool/threadpool.h>
 #include <executorch/runtime/kernel/thread_parallel_interface.h>
@@ -990,6 +988,193 @@ void cpu_flash_attention(
   scalar_t* buf_reduced_data =
       is_reduced_type ? reinterpret_cast<scalar_t*>(buf_reduced) : nullptr;
 
+  // An explicit mask is shared across batches and heads. Precompute up to two
+  // useful K/V intervals for every (query tile, K/V tile) pair. Ring attention
+  // can mask large portions of its backing cache with -inf; discovering those
+  // ranges once lets every head skip fully masked tiles and trim the boundary
+  // tiles before either GEMM. Arbitrary additive masks retain their existing
+  // behavior because only values that are exactly -inf are excluded.
+  struct MaskBlockRanges {
+    int64_t first_begin;
+    int64_t first_end;
+    int64_t second_begin;
+    int64_t second_end;
+    bool first_mask_is_zero;
+    bool second_mask_is_zero;
+  };
+  const int64_t num_kv_blocks = (kvSize - 1) / kvSplitSize + 1;
+  MaskBlockRanges* mask_block_ranges = nullptr;
+  std::unique_ptr<char[]> allocated_mask_block_ranges;
+  uint8_t* column_states_by_thread = nullptr;
+  std::unique_ptr<char[]> allocated_column_states;
+  bool use_mask_ranges = false;
+  if (has_attn_mask) {
+    const int64_t num_mask_block_ranges = qSlice * num_kv_blocks;
+    const int64_t mask_block_ranges_bytes =
+        num_mask_block_ranges * sizeof(MaskBlockRanges);
+    Result<void*> mask_block_ranges_scratch =
+        ctx.allocate_temp(mask_block_ranges_bytes, 64);
+    if (!mask_block_ranges_scratch.ok()) {
+      allocated_mask_block_ranges =
+          std::make_unique<char[]>(mask_block_ranges_bytes);
+      mask_block_ranges =
+          reinterpret_cast<MaskBlockRanges*>(allocated_mask_block_ranges.get());
+    } else {
+      mask_block_ranges =
+          reinterpret_cast<MaskBlockRanges*>(mask_block_ranges_scratch.get());
+    }
+
+    // Bit 0 means at least one query row can attend to the column. Bit 1
+    // means every query row has a zero additive mask for the column.
+    const int64_t column_states_bytes = kvSplitSize * num_thread + qSlice;
+    Result<void*> column_states_scratch =
+        ctx.allocate_temp(column_states_bytes, 64);
+    if (!column_states_scratch.ok()) {
+      allocated_column_states = std::make_unique<char[]>(column_states_bytes);
+      column_states_by_thread =
+          reinterpret_cast<uint8_t*>(allocated_column_states.get());
+    } else {
+      column_states_by_thread =
+          reinterpret_cast<uint8_t*>(column_states_scratch.get());
+    }
+
+    const accum_t neg_inf = -std::numeric_limits<accum_t>::infinity();
+    uint8_t* useful_mask_ranges =
+        column_states_by_thread + kvSplitSize * num_thread;
+    auto find_mask_ranges = [&](int64_t begin, int64_t end) {
+      const int64_t thread_index = torch::executor::get_thread_num();
+      uint8_t* column_states =
+          column_states_by_thread + thread_index * kvSplitSize;
+      for (int64_t q_block = begin; q_block < end; ++q_block) {
+        bool found_useful_range = false;
+        const int64_t query_begin = q_block * qSplitSize;
+        const int64_t query_end = std::min(query_begin + qSplitSize, qSize);
+        const int64_t causal_end =
+            is_causal ? std::min(start_pos + query_end, kvSize) : kvSize;
+        for (int64_t kv_block = 0; kv_block < num_kv_blocks; ++kv_block) {
+          const int64_t block_begin = kv_block * kvSplitSize;
+          const int64_t block_end =
+              std::min(std::min(block_begin + kvSplitSize, kvSize), causal_end);
+          const int64_t range_index = q_block * num_kv_blocks + kv_block;
+          auto& ranges = mask_block_ranges[range_index];
+          ranges.first_begin = block_begin;
+          ranges.first_end = block_begin;
+          ranges.second_begin = block_begin;
+          ranges.second_end = block_begin;
+          ranges.first_mask_is_zero = false;
+          ranges.second_mask_is_zero = false;
+          if (block_begin >= block_end) {
+            continue;
+          }
+
+          const int64_t block_size = block_end - block_begin;
+          std::fill(column_states, column_states + block_size, uint8_t{2});
+
+          for (int64_t row = query_begin; row < query_end; ++row) {
+            const accum_t* mask_row = mask_data + row * mStrideM;
+            for (int64_t col = block_begin; col < block_end; ++col) {
+              const accum_t mask_value = mask_row[col];
+              auto& state = column_states[col - block_begin];
+              state |= mask_value != neg_inf;
+              if (mask_value != static_cast<accum_t>(0)) {
+                state &= uint8_t{1};
+              }
+            }
+          }
+
+          int64_t active_begin = block_begin;
+          while (active_begin < block_end &&
+                 (column_states[active_begin - block_begin] & uint8_t{1}) ==
+                     0) {
+            ++active_begin;
+          }
+          int64_t active_end = block_end;
+          while (active_end > active_begin &&
+                 (column_states[active_end - 1 - block_begin] & uint8_t{1}) ==
+                     0) {
+            --active_end;
+          }
+          ranges.first_begin = active_begin;
+          ranges.first_end = active_end;
+          ranges.second_begin = block_end;
+          ranges.second_end = block_end;
+          if (active_begin >= active_end) {
+            found_useful_range = true;
+            continue;
+          }
+
+          // A wrapped ring window has at most one interior gap. custom_sdpa
+          // also accepts arbitrary additive masks, which may contain several
+          // gaps, so find the largest one and split around it when it is large
+          // enough to repay the extra pair of GEMM calls. Smaller gaps stay
+          // represented by their existing -inf values inside one bounding
+          // interval.
+          int64_t largest_gap_begin = active_begin;
+          int64_t largest_gap_end = active_begin;
+          int64_t gap_begin = active_begin;
+          while (gap_begin < active_end) {
+            while (gap_begin < active_end &&
+                   (column_states[gap_begin - block_begin] & uint8_t{1}) != 0) {
+              ++gap_begin;
+            }
+            int64_t gap_end = gap_begin;
+            while (gap_end < active_end &&
+                   (column_states[gap_end - block_begin] & uint8_t{1}) == 0) {
+              ++gap_end;
+            }
+            if (gap_end - gap_begin > largest_gap_end - largest_gap_begin) {
+              largest_gap_begin = gap_begin;
+              largest_gap_end = gap_end;
+            }
+            gap_begin = gap_end;
+          }
+
+          constexpr int64_t min_gap_to_split = 64;
+          if (largest_gap_end - largest_gap_begin >= min_gap_to_split) {
+            ranges.first_end = largest_gap_begin;
+            ranges.second_begin = largest_gap_end;
+            ranges.second_end = active_end;
+          }
+
+          auto mask_range_is_zero = [&](int64_t range_begin,
+                                        int64_t range_end) {
+            for (int64_t col = range_begin; col < range_end; ++col) {
+              if ((column_states[col - block_begin] & uint8_t{2}) == 0) {
+                return false;
+              }
+            }
+            return true;
+          };
+          ranges.first_mask_is_zero =
+              mask_range_is_zero(ranges.first_begin, ranges.first_end);
+          if (ranges.second_begin < ranges.second_end) {
+            ranges.second_mask_is_zero =
+                mask_range_is_zero(ranges.second_begin, ranges.second_end);
+          }
+
+          const int64_t retained_size = ranges.first_end - ranges.first_begin +
+              ranges.second_end - ranges.second_begin;
+          if (retained_size < block_size || ranges.first_mask_is_zero ||
+              ranges.second_mask_is_zero) {
+            found_useful_range = true;
+          }
+        }
+        useful_mask_ranges[q_block] = found_useful_range;
+      }
+    };
+    const bool mask_ranges_computed =
+        torch::executor::parallel_for(0, qSlice, 1, find_mask_ranges);
+    ET_KERNEL_CHECK_MSG(
+        ctx,
+        mask_ranges_computed,
+        Internal,
+        ,
+        "parallel_for failed while precomputing attention mask ranges");
+    for (int64_t q_block = 0; q_block < qSlice; ++q_block) {
+      use_mask_ranges |= useful_mask_ranges[q_block];
+    }
+  }
+
   auto compute_lambda = [&](int64_t begin, int64_t end) {
     int64_t i = 0, j = 0, k = 0;
     data_index_init(begin, i, batchSize, j, num_head, k, qSlice);
@@ -1045,11 +1230,38 @@ void cpu_flash_attention(
           is_causal ? std::min(m + start_pos + qBlockSize, kvSize) : kvSize;
       int64_t m_start_pos = m + start_pos;
       auto j_kv = j / num_reps;
-      fill_stub(dst_data, static_cast<accum_t>(0), qSplitSize * headSize);
-      for (int64_t n = 0; n < num_keys; n += kvSplitSize) {
-        int64_t kvBlockSize = std::min(kvSplitSize, kvSize - n);
-        // Calculate scale * q @ k.T
-        fill_stub(qk_data, static_cast<accum_t>(0), qSplitSize * kvSplitSize);
+      fill_stub(dst_data, static_cast<accum_t>(0), qBlockSize * headSize);
+      bool has_processed_kv = false;
+      const int64_t num_ranges = use_mask_ranges
+          ? 2 * num_kv_blocks
+          : (num_keys + kvSplitSize - 1) / kvSplitSize;
+      for (int64_t range = 0; range < num_ranges; ++range) {
+        int64_t kvBlockStart;
+        int64_t kvBlockEnd;
+        bool range_mask_is_zero = false;
+        if (use_mask_ranges) {
+          const int64_t kv_block = range / 2;
+          const bool use_second_range = range % 2 != 0;
+          const auto& ranges = mask_block_ranges[k * num_kv_blocks + kv_block];
+          if (use_second_range) {
+            kvBlockStart = ranges.second_begin;
+            kvBlockEnd = ranges.second_end;
+            range_mask_is_zero = ranges.second_mask_is_zero;
+          } else {
+            kvBlockStart = ranges.first_begin;
+            kvBlockEnd = ranges.first_end;
+            range_mask_is_zero = ranges.first_mask_is_zero;
+          }
+        } else {
+          kvBlockStart = range * kvSplitSize;
+          kvBlockEnd = std::min(kvBlockStart + kvSplitSize, kvSize);
+        }
+        kvBlockEnd = std::min(kvBlockEnd, num_keys);
+        if (kvBlockStart >= kvBlockEnd) {
+          continue;
+        }
+        const int64_t kvBlockSize = kvBlockEnd - kvBlockStart;
+        const bool apply_attn_mask = has_attn_mask && !range_mask_is_zero;
 
         const void* q_sub_matrix_data_ptr;
         const void* k_sub_matrix_data_ptr;
@@ -1058,12 +1270,14 @@ void cpu_flash_attention(
         const int8_t* q_zero_points_ptr = nullptr;
         const int8_t* k_zero_points_ptr = nullptr;
         int64_t q_offset = i * qStrideB + j * qStrideH + m * qStrideM;
-        int64_t k_offset = i * kStrideB + j_kv * kStrideH + n * kStrideN;
+        int64_t k_offset =
+            i * kStrideB + j_kv * kStrideH + kvBlockStart * kStrideN;
         if (is_quantized_sdpa) {
           int64_t q_quant_params_offset = i * q_quant_params_StrideB +
               j * q_quant_params_StrideH + m * q_quant_params_StrideM;
           int64_t k_quant_params_offset = i * k_quant_params_StrideB +
-              j_kv * k_quant_params_StrideH + n * k_quant_params_StrideN;
+              j_kv * k_quant_params_StrideH +
+              kvBlockStart * k_quant_params_StrideN;
           q_scales_ptr =
               q_scales.value().const_data_ptr<float>() + q_quant_params_offset;
           k_scales_ptr =
@@ -1106,57 +1320,31 @@ void cpu_flash_attention(
             (widen_qk && qBlockSize >= kMinQBlockForWidenedQK) ? widen_ptr
                                                                : nullptr);
 
-        // There are 4 cases that is_causal has to cover to fill
-        // not-attendable-position with -inf
-        /* 1. Everything is attended to. This happens when m_start_pos > n +
-        kvSplitSize e.g m_pos [8:15] and n_pos [0:7]. Since you must attend to
-        all previous tokens matrix is full
-        + + + + + + + +
-        + + + + + + + +
-        + + + + + + + +
-        + + + + + + + +
-        + + + + + + + +
-        + + + + + + + +
-        + + + + + + + +
-           2. Everything is not attended to. However only some tokens at the
-        beginning dont attend to everything. This happens when m_start_pos <= n
-        + kvSplitSize but m_start_pos + qBlockSize > n + kvSplitSize m_start_pos
-        = 8 qBlockSize = 8 n = 4 kvSplitSize = 8 For example m_pos [8:15] but
-        n_pos is [4:11]
-        + + + + + - - -
-        + + + + + + - -
-        + + + + + + + -
-        + + + + + + + +
-        + + + + + + + +
-        + + + + + + + +
-        + + + + + + + +
-        + + + + + + + +
-           3. In this case only last few tokens have something to attend to.
-        This happens when m_start_pos < n and m_start_pos + qBlockSize >= n and
-        m_start_pos + qBlockSize <= n + kvSplitSize m_start_pos = 8 qBlockSize =
-        8 n = 13 kvSplitSize = 8 For example m_pos [8:15] but n_pos is [13:20]
-        - - - - - - - -
-        - - - - - - - -
-        - - - - - - - -
-        - - - - - - - -
-        - - - - - - - -
-        + - - - - - - -
-        + + - - - - - -
-        + + + - - - - -
-           4. In this no tokens attend to anything, but we dont really have to
-        take care of this case because the loop for (int64_t n = 0; n <
-        num_keys; n += kvSplitSize) will exit before that.
-        */
-        if (is_causal && m_start_pos <= n + kvSplitSize) {
-          // For this fn to work k_split_size > q_split_size
+        // Apply causal masking relative to the retained KV block. These are
+        // the two overlap configurations; a KV block wholly before the new
+        // query needs no causal masking. Rows are new-query tokens, columns
+        // are KV-block tokens, '+' is attendable, and '-' is causally masked:
+        //
+        // New query begins midway through KV block:  Tail of new query lies in
+        // KV block:
+        //   + + + - - -                         - - - - - -
+        //   + + + + - -                         - - - - - -
+        //   + + + + + -                         + - - - - -
+        //   + + + + + +                         + + - - - -
+        //   + + + + + +                         + + + - - -
+        //
+        // Each row may attend through its own logical position, so last_col
+        // is the number of keys in [kvBlockStart, kvBlockEnd) that are not in
+        // its future.
+        if (is_causal && m_start_pos < kvBlockEnd) {
           for (int32_t row = 0;
-               row < qBlockSize && (m_start_pos + row < n + (kvSplitSize - 1));
+               row < qBlockSize && (m_start_pos + row < kvBlockEnd - 1);
                ++row) {
-            // When last_col is 0, it means that the entire row is not attended
-            // to because m_pos is smaller than n_pos. So everything in n is for
-            // future.
-            int64_t last_col =
-                n > (m_start_pos + row) ? 0 : row + m_start_pos + 1 - n;
+            // When last_col is 0, it means that the entire row is not
+            // attended to because the range begins after the query position.
+            int64_t last_col = kvBlockStart > (m_start_pos + row)
+                ? 0
+                : row + m_start_pos + 1 - kvBlockStart;
             accum_t* row_ptr = qk_data + row * kvBlockSize;
             fill_stub(
                 row_ptr + last_col,
@@ -1167,7 +1355,7 @@ void cpu_flash_attention(
         // Update attention weights with attention mask
         // And apply scaling factor
         // qk <- qk * scaling + attn_mask
-        if (has_attn_mask) {
+        if (apply_attn_mask) {
           for (int64_t row = 0; row < qBlockSize; ++row) {
             vec::map2<accum_t>(
                 [scaling_factor](Vec x, Vec y) {
@@ -1176,14 +1364,14 @@ void cpu_flash_attention(
                 qk_data + row * kvBlockSize,
                 qk_data + row * kvBlockSize,
                 mask_data + i * mStrideB + j * mStrideH + (m + row) * mStrideM +
-                    n,
+                    kvBlockStart,
                 kvBlockSize);
           }
         }
         // Update coefficients with Softmax
         accum_t tmp_max = 0, tmp_sum = 0, exp_tmp = 0;
         for (int64_t row = 0; row < qBlockSize; ++row) {
-          if (has_attn_mask) {
+          if (apply_attn_mask) {
             // max per row
             tmp_max = vec::reduce_all<accum_t>(
                 [](Vec& x, Vec& y) { return vec::maximum(x, y); },
@@ -1220,7 +1408,7 @@ void cpu_flash_attention(
             // max[row] <- max
             qk_max_data[row] = tmp_max;
             // dst <- dst * exp_tmp
-            if (n > 0) {
+            if (has_processed_kv) {
               vec::map<accum_t>(
                   [exp_tmp](Vec x) { return x * Vec(exp_tmp); },
                   dst_data + row * headSize,
@@ -1233,10 +1421,12 @@ void cpu_flash_attention(
         const void* v_sub_matrix_data_ptr;
         const float* v_scales_ptr = nullptr;
         const int8_t* v_zero_points_ptr = nullptr;
-        int64_t v_offset = i * vStrideB + j_kv * vStrideH + n * vStrideN;
+        int64_t v_offset =
+            i * vStrideB + j_kv * vStrideH + kvBlockStart * vStrideN;
         if (is_quantized_sdpa) {
           int64_t v_quant_params_offset = i * v_quant_params_StrideB +
-              j_kv * v_quant_params_StrideH + n * v_quant_params_StrideN;
+              j_kv * v_quant_params_StrideH +
+              kvBlockStart * v_quant_params_StrideN;
           v_scales_ptr =
               v_scales.value().const_data_ptr<float>() + v_quant_params_offset;
           v_zero_points_ptr = v_zero_points.value().const_data_ptr<int8_t>() +
@@ -1287,10 +1477,12 @@ void cpu_flash_attention(
             vStrideN,
             dst_data,
             headSize,
-            n == 0 ? static_cast<accum_t>(0) : static_cast<accum_t>(1),
+            has_processed_kv ? static_cast<accum_t>(1)
+                             : static_cast<accum_t>(0),
             buf_qdq_ptr,
             widen_v,
             use_fp32_qk_weights);
+        has_processed_kv = true;
       }
       // dst <- dst / sum[row]
       // reorder MHA output with strides

--- a/extension/llm/custom_ops/op_sdpa_test.cpp
+++ b/extension/llm/custom_ops/op_sdpa_test.cpp
@@ -33,6 +33,26 @@ executorch::aten::Tensor op_scaled_dot_product_attention(
       context, query, key, value, attn_mask, dropout_p, is_causal, scale, out);
 }
 
+executorch::aten::Tensor op_custom_sdpa(
+    const executorch::aten::Tensor& query,
+    const executorch::aten::Tensor& key,
+    const executorch::aten::Tensor& value,
+    const std::optional<executorch::aten::Tensor>& attn_mask,
+    executorch::aten::Tensor& out) {
+  executorch::runtime::KernelRuntimeContext context{};
+  return torch::executor::native::custom_sdpa_out(
+      context,
+      query,
+      key,
+      value,
+      /*start_pos=*/0,
+      attn_mask,
+      /*dropout_p=*/0.0,
+      /*is_causal=*/false,
+      /*scale=*/std::nullopt,
+      out);
+}
+
 std::tuple<executorch::aten::Tensor&, executorch::aten::Tensor&>
 op_gated_delta_rule(
     executorch::runtime::KernelRuntimeContext& context,
@@ -334,6 +354,151 @@ TEST(OpScaledDotProductAttentionTest, CorrectnessTest_105) {
   executorch::aten::Tensor ret = op_scaled_dot_product_attention(
       query, key, value, attn_mask, dropout_p, is_causal, scale, out);
   EXPECT_TENSOR_CLOSE_WITH_TOL(ret, ret_expected, 1e-4, 1e-4);
+}
+
+TEST(OpScaledDotProductAttentionTest, SparseMaskRangesMatchReference) {
+  TensorFactory<executorch::aten::ScalarType::Float> tfFloat;
+
+  constexpr int32_t q_size = 64;
+  constexpr int32_t kv_size = 1024;
+  std::vector<float> key_values(kv_size, 0.0f);
+  std::vector<float> value_values(kv_size);
+  std::vector<float> mask_values(
+      q_size * kv_size, -std::numeric_limits<float>::infinity());
+  std::vector<float> expected_values(q_size);
+
+  for (int32_t i = 0; i < kv_size; ++i) {
+    value_values[i] = static_cast<float>(i);
+  }
+  // The first 32-row query tile has staggered active columns separated by a
+  // 38-column gap, which is too small to split. This exercises the per-column
+  // union across query rows while retaining the detailed mask inside the range.
+  for (int32_t row = 0; row < 32; ++row) {
+    mask_values[row * kv_size + 10 + row] = 0.0f;
+    mask_values[row * kv_size + 80 + row] = 0.0f;
+    expected_values[row] = 45.0f + row;
+  }
+  // The second query tile uses KV block 1 and has a gap larger than the split
+  // threshold. The zero first range and additive second range exercise both
+  // mask paths while also checking query-tile indexing for k > 0.
+  for (int32_t row = 32; row < q_size; ++row) {
+    mask_values[row * kv_size + 600] = 0.0f;
+    mask_values[row * kv_size + 700] = 1.0986122886681098f; // log(3)
+    expected_values[row] = 675.0f;
+  }
+
+  // custom_sdpa uses [batch, sequence, heads, head_dim].
+  auto query = tfFloat.zeros({1, q_size, 1, 1});
+  auto key = tfFloat.make({1, kv_size, 1, 1}, key_values);
+  auto value = tfFloat.make({1, kv_size, 1, 1}, value_values);
+  auto attn_mask = tfFloat.make({q_size, kv_size}, mask_values);
+  auto out = tfFloat.zeros({1, q_size, 1, 1});
+
+  auto result = op_custom_sdpa(query, key, value, attn_mask, out);
+
+  auto expected = tfFloat.make({1, q_size, 1, 1}, expected_values);
+  EXPECT_TENSOR_CLOSE_WITH_TOL(result, expected, 1e-5, 1e-5);
+}
+
+TEST(
+    OpScaledDotProductAttentionTest,
+    CausalSparseMaskRangesCoverGqaAndReducedPrecision) {
+  TensorFactory<executorch::aten::ScalarType::Half> tfHalf;
+  TensorFactory<executorch::aten::ScalarType::Float> tfFloat;
+
+  constexpr int32_t q_size = 256;
+  constexpr int32_t kv_size = 1024;
+  constexpr int32_t num_query_heads = 2;
+  std::vector<executorch::aten::Half> value_values(kv_size);
+  std::vector<float> mask_values(
+      q_size * kv_size, -std::numeric_limits<float>::infinity());
+  std::vector<executorch::aten::Half> expected_values(num_query_heads * q_size);
+
+  for (int32_t col = 0; col < kv_size; ++col) {
+    value_values[col] = static_cast<executorch::aten::Half>(col);
+  }
+  for (int32_t row = 0; row < q_size; ++row) {
+    mask_values[row * kv_size] = 0.0f;
+    for (int32_t col = 100; col < q_size; ++col) {
+      mask_values[row * kv_size + col] = 0.0f;
+    }
+    const float expected =
+        row < 100 ? 0.0f : (100.0f + row) * (row - 99) / (2.0f * (row - 98));
+    for (int32_t head = 0; head < num_query_heads; ++head) {
+      expected_values[head * q_size + row] =
+          static_cast<executorch::aten::Half>(expected);
+    }
+  }
+
+  auto query = tfHalf.zeros({1, num_query_heads, q_size, 1});
+  auto key = tfHalf.zeros({1, 1, kv_size, 1});
+  auto value = tfHalf.make({1, 1, kv_size, 1}, value_values);
+  auto attn_mask = tfFloat.make({q_size, kv_size}, mask_values);
+  auto out = tfHalf.zeros({1, num_query_heads, q_size, 1});
+
+  auto result = op_scaled_dot_product_attention(
+      query,
+      key,
+      value,
+      attn_mask,
+      /*dropout_p=*/0.0,
+      /*is_causal=*/true,
+      /*scale=*/std::nullopt,
+      out);
+
+  auto expected = tfHalf.make({1, num_query_heads, q_size, 1}, expected_values);
+  EXPECT_TENSOR_CLOSE_WITH_TOL(result, expected, 1e-2, 1e-2);
+}
+
+TEST(OpScaledDotProductAttentionTest, QuantizedSparseMaskTrimmedBoundary) {
+  TensorFactory<executorch::aten::ScalarType::Char> tfChar;
+  TensorFactory<executorch::aten::ScalarType::Float> tfFloat;
+
+  constexpr int32_t kv_size = 1024;
+  std::vector<int8_t> value_values(kv_size);
+  std::vector<float> mask_values(
+      kv_size, -std::numeric_limits<float>::infinity());
+  for (int32_t col = 0; col < kv_size; ++col) {
+    value_values[col] = static_cast<int8_t>(col % 100);
+  }
+  for (int32_t col = 100; col < 200; ++col) {
+    mask_values[col] = 0.0f;
+  }
+
+  auto query = tfChar.zeros({1, 1, 1, 1});
+  auto key = tfChar.zeros({1, kv_size, 1, 1});
+  auto value = tfChar.make({1, kv_size, 1, 1}, value_values);
+  auto query_zero_points = tfChar.zeros({1, 1, 1, 1});
+  auto key_zero_points = tfChar.zeros({1, kv_size, 1, 1});
+  auto value_zero_points = tfChar.zeros({1, kv_size, 1, 1});
+  auto query_scales = tfFloat.ones({1, 1, 1, 1});
+  auto key_scales = tfFloat.ones({1, kv_size, 1, 1});
+  auto value_scales = tfFloat.ones({1, kv_size, 1, 1});
+  auto attn_mask = tfFloat.make({1, kv_size}, mask_values);
+  auto out = tfFloat.zeros({1, 1, 1, 1});
+
+  executorch::runtime::KernelRuntimeContext context{};
+  auto result = torch::executor::native::custom_quantized_sdpa_out(
+      context,
+      query,
+      key,
+      value,
+      /*start_pos=*/0,
+      attn_mask,
+      /*dropout_p=*/0.0,
+      /*is_causal=*/false,
+      /*scale=*/std::nullopt,
+      query_zero_points,
+      query_scales,
+      key_zero_points,
+      key_scales,
+      value_zero_points,
+      value_scales,
+      /*is_seq_at_dim_2=*/false,
+      out);
+
+  auto expected = tfFloat.make({1, 1, 1, 1}, {49.5f});
+  EXPECT_TENSOR_CLOSE_WITH_TOL(result, expected, 1e-4, 1e-4);
 }
 
 TEST(OpScaledDotProductAttentionTest, CorrectnessTest_11) {


### PR DESCRIPTION
## Summary

- skip fully masked KV blocks and trim masked boundaries in CPU custom SDPA
- split wrapped ring windows around large masked gaps while preserving additive-mask semantics
- size local KV caches as sliding window plus the maximum in-flight prefill chunk, capped by full context
- support regular, custom-op, and quantized ring caches
