### PR TITLE
Arm backend: Remove stale VGF slice xfail for arange_fp32_2d_step4

### DIFF
--- a/backends/arm/test/ops/test_slice.py
+++ b/backends/arm/test/ops/test_slice.py
@@ -386,12 +386,6 @@ def test_slice_tensor_u85_INT_step(test_data: Tuple):
 @common.parametrize(
     "test_data",
     test_data_step_int | test_data_step_fp,
-    xfails={
-        "arange_fp32_2d_step4": (
-            "MLCE-1969: Emlayer 0.10 Interval memory planner corrupts "
-            "multi-input CONCAT output"
-        ),
-    },
 )
 @common.SkipIfNoModelConverter
 def test_slice_tensor_vgf_no_quant_step(test_data: Tuple):


### PR DESCRIPTION
`test_slice_tensor_vgf_no_quant_step[arange_fp32_2d_step4]` was marked xfail in #21809 for MLCE-1969, where the Emlayer 0.10 interval memory planner corrupted multi-input CONCAT output. The case now passes against `ai_ml_emulation_layer_for_vulkan==0.10.0` in internal test environment, where the strict xfail turns that pass into an XPASS failure.

Opening this to confirm the same holds in upstream CI. If CI still reproduces MLCE-1969 then the xfail is still warranted and this should be closed rather than merged.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani

This PR was authored with Claude Code.
