### PR TITLE
Fix RISC-V YOLO26 layout regression

### DIFF
--- a/examples/riscv/aot_riscv.py
+++ b/examples/riscv/aot_riscv.py
@@ -126,6 +126,7 @@ def build_yolo26():
         np.ones((input_h, input_w, 3)),
         imgsz=(input_h, input_w),
         device="cpu",
+        channels_last=False,
     )
 
     class Wrapper(torch.nn.Module):

--- a/examples/riscv/requirements.txt
+++ b/examples/riscv/requirements.txt
@@ -1,3 +1,3 @@
 torchvision
 transformers
-ultralytics
+ultralytics==8.4.137


### PR DESCRIPTION
Ultralytics 8.4.133 enabled channels-last by default for x86 CPU inference, causing the YOLO warmup to mutate model weights before ExecuTorch export. Explicitly disable channels-last and pin the validated Ultralytics version so portable and XNNPACK exports remain reproducible.

Validated portable and XNNPACK YOLO26 AOT export with Ultralytics 8.4.137.