### PR TITLE
Fix the Apple event tracer header imports

### DIFF
--- a/extension/apple/BUCK
+++ b/extension/apple/BUCK
@@ -8,6 +8,11 @@ oncall("executorch")
 
 non_fbcode_target(_kind = fb_apple_library,
     name = "ExecuTorch",
+    # The ETDump extension subclasses ExecuTorchEventTracer, which needs the C++
+    # tracer seam this header declares, so export it beyond the target.
+    autoglob_additional_exported_headers = [
+        "ExecuTorch/Internal/ExecuTorchEventTracer+Internal.h",
+    ],
     autoglob_mode = "EXPORT_UNLESS_INTERNAL",
     extension_api_only = True,
     frameworks = [

--- a/extension/apple/ExecuTorch/Exported/ExecuTorchEventTracer.mm
+++ b/extension/apple/ExecuTorch/Exported/ExecuTorchEventTracer.mm
@@ -8,7 +8,7 @@
 
 #import "ExecuTorchEventTracer.h"
 
-#import <executorch/extension/apple/ExecuTorch/Internal/ExecuTorchEventTracer+Internal.h>
+#import "ExecuTorchEventTracer+Internal.h"
 
 using executorch::runtime::EventTracer;
 


### PR DESCRIPTION
### Summary

The event tracer's internal header was imported by its full path in the source tree:

```objc
#import <executorch/extension/apple/ExecuTorch/Internal/ExecuTorchEventTracer+Internal.h>
```

No Apple build makes a header reachable that way, so the file was never found and the core Apple library failed to compile. Both the CMake build and the Buck build fail on it:

```
fatal error: 'executorch/extension/apple/ExecuTorch/Internal/ExecuTorchEventTracer+Internal.h' file not found
```

The fix is to import it by its plain name, which is how every other file in that library imports a private header (see `ExecuTorchModule.mm` and `ExecuTorchBackendOptionsMap.mm`):

```objc
#import "ExecuTorchEventTracer+Internal.h"
```

The ETDump extension is a separate library and needs that same header, because its concrete tracer subclasses the base tracer. Under CMake this already worked, since that build stages the core library's headers into one directory and puts it on the include path. Buck keeps a private header inside the library that owns it, so this exports the single header the extension needs and leaves the rest private.

### Test plan

- Compiled the core tracer against the CMake include layout. It fails before this change and passes after.
- Compiled both the core tracer and the ETDump tracer against a layout mirroring the Buck one: name-only lookup for a library's own headers, and the public set only for a dependent library. Both pass.
- Confirmed each change is needed by reverting it on its own. Restoring the full path reproduces the original error, and removing the export reproduces the same error in the ETDump extension.
- Compiled the other file that imports this header to check for fallout. It still builds, with only a deprecation warning that predates this change.
