### PR TITLE
Let a recipe run operator backends after partitioning

### DIFF
--- a/export/BUCK
+++ b/export/BUCK
@@ -13,6 +13,7 @@ fbcode_target(
     deps = [
         "//caffe2:torch",
         "//executorch/exir/backend:backend_api",
+        "//executorch/exir/backend:op_backend",
         "//executorch/exir:pass_manager",
         "//executorch/extension/export_util:export_util",
     ]
@@ -46,6 +47,7 @@ fbcode_target(
         ":types",
         "//executorch/devtools/backend_debug:delegation_info",
         "//executorch/exir/backend:backend_api",
+        "//executorch/exir/backend:op_backend",
         "//executorch/exir:pass_manager",
         "//caffe2:torch",
         "//executorch/devtools/backend_debug:delegation_info",

--- a/export/export.py
+++ b/export/export.py
@@ -115,7 +115,9 @@ class ExportSession:
     1. (Optional) Quantize - Apply post-training quantization to the model
     2. Export - Export PyTorch model to ExportedProgram
     3. EdgeTransformAndLower - Transform and lower to EdgeProgramManager
-    4. Executorch - Convert to ExecutorchProgramManager for final execution
+    4. (Optional) EdgeProgramManagerTransform - apply the lowering recipe's
+       op_backends; included only when the recipe sets them
+    5. Executorch - Convert to ExecutorchProgramManager for final execution
     """
 
     def __init__(
@@ -283,13 +285,14 @@ class ExportSession:
         if self._input_model_type != "ExportedProgram":
             stages.append(StageType.TORCH_EXPORT)
 
-        # Always include edge and executorch stages
-        stages.extend(
-            [
-                StageType.TO_EDGE_TRANSFORM_AND_LOWER,
-                StageType.TO_EXECUTORCH,
-            ]
-        )
+        stages.append(StageType.TO_EDGE_TRANSFORM_AND_LOWER)
+
+        # Operator backends only run in their own stage, so a lowering recipe
+        # that declares them would otherwise have them dropped.
+        if self._lowering_recipe and self._lowering_recipe.op_backends:
+            stages.append(StageType.EDGE_PROGRAM_MANAGER_TRANSFORM)
+
+        stages.append(StageType.TO_EXECUTORCH)
 
         return stages
 
@@ -321,7 +324,9 @@ class ExportSession:
                 stage = ToEdgeStage.from_recipe(self._lowering_recipe)
             elif stage_type == StageType.EDGE_PROGRAM_MANAGER_TRANSFORM:
                 stage = EdgeProgramManagerTransformStage.from_recipe(
-                    self._lowering_recipe
+                    self._lowering_recipe,
+                    with_transform_passes=StageType.TO_EDGE_TRANSFORM_AND_LOWER
+                    not in stages,
                 )
             elif stage_type == StageType.TO_BACKEND:
                 stage = ToBackendStage.from_recipe(self._lowering_recipe)
@@ -513,11 +518,18 @@ class ExportSession:
         """
         Get the EdgeProgramManager after edge lowering stages.
 
-        This method checks multiple stages in order of preference:
-        1. TO_EDGE_TRANSFORM_AND_LOWER (combined stage)
-        2. TO_BACKEND (separate stage with backend delegation)
-        3. EDGE_PROGRAM_MANAGER_TRANSFORM (separate stage after TO_EDGE)
-        4. TO_EDGE (separate stage without backend delegation)
+        Of the built-in edge stages -- TO_EDGE, TO_EDGE_TRANSFORM_AND_LOWER,
+        TO_BACKEND and EDGE_PROGRAM_MANAGER_TRANSFORM -- returns the artifact of
+        whichever ran last, so the result matches the program that was emitted
+        rather than an earlier form of it. A stage supplied through
+        `register_stage` is not recognised as edge-producing.
+
+        This replaced a fixed preference order, which cannot express the answer
+        once EDGE_PROGRAM_MANAGER_TRANSFORM can follow the partitioning stages:
+        ranking TO_EDGE_TRANSFORM_AND_LOWER first returns the program from
+        before the operator backends ran, and ranking the transform stage first
+        breaks TO_EDGE -> transform -> TO_BACKEND. For every pipeline that was
+        legal before, the two agree.
 
         Returns:
             The EdgeProgramManager
@@ -525,13 +537,15 @@ class ExportSession:
         Raises:
             RuntimeError: If no edge stage has been run
         """
-        # Check stages in order of preference
-        for stage_type in [
+        edge_stages = {
             StageType.TO_EDGE_TRANSFORM_AND_LOWER,
             StageType.TO_BACKEND,
             StageType.EDGE_PROGRAM_MANAGER_TRANSFORM,
             StageType.TO_EDGE,
-        ]:
+        }
+        for stage_type in reversed(self._pipeline_stages):
+            if stage_type not in edge_stages:
+                continue
             artifact = self._stage_to_artifacts.get(stage_type)
             if artifact is not None and artifact.data is not None:
                 logging.info(f"Returning edge program manager from stage {stage_type}")

--- a/export/recipe.py
+++ b/export/recipe.py
@@ -16,6 +16,7 @@ from executorch.exir import EdgeProgramManager, ExportedProgram
 
 from executorch.exir._warnings import experimental
 
+from executorch.exir.backend.op_backend import OpBackend
 from executorch.exir.backend.partitioner import Partitioner
 from executorch.exir.capture import EdgeCompileConfig, ExecutorchBackendConfig
 from executorch.exir.pass_manager import PassManager, PassType
@@ -165,8 +166,12 @@ class LoweringRecipe:
                       backends need per-method compile specs.
         edge_transform_passes: Optional list of callables that take (method_name: str, exported_program: ExportedProgram)
                                and return either List[PassType] or PassManager to be applied during edge lowering.
-        edge_manager_transform_passes: Optional list of callables that take EdgeProgramManager as argument
-                                        and return passes to be applied. Applied sequentially after TO_EDGE stage.
+        op_backends: Optional list of OpBackends, which lower by rewriting
+                               operators rather than by delegating a subgraph. Run in
+                               their own stage after partitioning, so they see what
+                               the delegates left behind.
+        edge_manager_transform_passes: Optional list of callables handed the whole
+                               EdgeProgramManager, which return passes to apply to it.
         edge_compile_config: Optional edge compilation configuration
     """
 
@@ -182,6 +187,8 @@ class LoweringRecipe:
     ) = None
     # pyre-ignore[11]: Type not defined
     edge_compile_config: Optional[EdgeCompileConfig] = None
+    # pyre-ignore[11]: Type not defined
+    op_backends: Optional[List[OpBackend]] = None
 
 
 @experimental(
@@ -313,6 +320,7 @@ class ExportRecipe:
         all_ao_quantization_configs = []
         all_pre_edge_passes = []
         all_transform_passes = []
+        all_op_backends = []
         combined_backend_config = None
 
         for recipe in backend_recipes:
@@ -336,6 +344,9 @@ class ExportRecipe:
                 all_transform_passes.extend(
                     recipe.lowering_recipe.edge_transform_passes
                 )
+
+            if recipe.lowering_recipe and recipe.lowering_recipe.op_backends:
+                all_op_backends.extend(recipe.lowering_recipe.op_backends)
 
             # Collect for quantize stage
             if quantization_recipe := recipe.quantization_recipe:
@@ -395,12 +406,18 @@ class ExportRecipe:
         edge_compile_config = copy.deepcopy(distinct[0][1]) if distinct else None
 
         combined_lowering_recipe = None
-        if combined_partitioners or all_transform_passes or edge_compile_config:
+        if (
+            combined_partitioners
+            or all_transform_passes
+            or all_op_backends
+            or edge_compile_config
+        ):
             combined_lowering_recipe = LoweringRecipe(
                 partitioners=combined_partitioners if combined_partitioners else None,
                 edge_transform_passes=(
                     all_transform_passes if all_transform_passes else None
                 ),
+                op_backends=(all_op_backends if all_op_backends else None),
                 edge_compile_config=edge_compile_config or EdgeCompileConfig(),
             )
 

--- a/export/stages.py
+++ b/export/stages.py
@@ -16,6 +16,7 @@ import torch
 from executorch.devtools.backend_debug import get_delegation_info
 from executorch.exir import EdgeCompileConfig, EdgeProgramManager, ExportedProgram
 from executorch.exir.backend.backend_api import validation_disabled
+from executorch.exir.backend.op_backend import OpBackend
 from executorch.exir.program import to_edge, to_edge_transform_and_lower
 from executorch.export.recipe import LoweringRecipe, QuantizationRecipe
 from executorch.export.types import StageType
@@ -564,6 +565,10 @@ class EdgeProgramManagerTransformStage(Stage):
     This stage enables dynamic pass generation where passes need access to the
     EdgeProgramManager instance. Passes are applied sequentially, allowing
     to control order and dependencies between pass groups.
+
+    It also runs the recipe's `op_backends`, which lower by rewriting operators
+    rather than by delegating a subgraph. Placed after a partitioning stage,
+    they see what was left outside the delegates.
     """
 
     def __init__(
@@ -582,6 +587,7 @@ class EdgeProgramManagerTransformStage(Stage):
                 Callable[[EdgeProgramManager], List[PassType] | GraphModulePassManager]
             ]
         ) = None,
+        op_backends: Optional[List[OpBackend]] = None,
     ) -> None:
         """
         Initialize the EdgeProgramManagerTransformStage.
@@ -591,21 +597,31 @@ class EdgeProgramManagerTransformStage(Stage):
                                            and return either List[PassType] or PassManager.
                                            Each callable is applied sequentially, allowing
                                            backends to control pass ordering and dependencies.
+            op_backends: Backends that lower by rewriting operators, applied in
+                order to every method.
         """
         super().__init__()
         self._edge_transform_passes = edge_transform_passes or []
         self._edge_manager_transform_passes = edge_manager_transform_passes or []
+        self._op_backends = op_backends or []
 
     @classmethod
     def from_recipe(
-        cls, lowering_recipe: Optional[LoweringRecipe]
+        cls,
+        lowering_recipe: Optional[LoweringRecipe],
+        with_transform_passes: bool = True,
     ) -> "EdgeProgramManagerTransformStage":
+        """`with_transform_passes` is False when TO_EDGE_TRANSFORM_AND_LOWER is
+        also in the pipeline and has already consumed them."""
         if lowering_recipe is None:
             return cls()
 
         return cls(
-            edge_transform_passes=lowering_recipe.edge_transform_passes,
+            edge_transform_passes=(
+                lowering_recipe.edge_transform_passes if with_transform_passes else None
+            ),
             edge_manager_transform_passes=lowering_recipe.edge_manager_transform_passes,
+            op_backends=lowering_recipe.op_backends,
         )
 
     @property
@@ -614,10 +630,18 @@ class EdgeProgramManagerTransformStage(Stage):
 
     @property
     def valid_predecessor_stages(self) -> List["StageType"]:
-        return [
-            StageType.TO_EDGE,
-            # StageType.TO_EDGE_TRANSFORM_AND_LOWER,  # TODO
+        partitioned = [
+            StageType.TO_EDGE_TRANSFORM_AND_LOWER,
+            StageType.TO_BACKEND,
         ]
+        if self._op_backends:
+            # An operator backend lowers what a partitioner declined, so it has
+            # to follow one. TO_EDGE here would hand it the whole graph and the
+            # delegate would then partition around its kernels.
+            return partitioned
+        # The stage predates op_backends and still serves recipes that only
+        # transform, which have no such requirement.
+        return [StageType.TO_EDGE, *partitioned]
 
     @property
     def can_start_pipeline(self) -> bool:
@@ -637,8 +661,11 @@ class EdgeProgramManagerTransformStage(Stage):
                 f"Expected EdgeProgramManager but got {type(edge_program_manager)}"
             )
 
+        for op_backend in self._op_backends:
+            edge_program_manager = edge_program_manager.to_op_backend(op_backend)
+
         if not self._edge_transform_passes and not self._edge_manager_transform_passes:
-            self._artifact = artifact
+            self._artifact = artifact.copy_with_new_data(edge_program_manager)
             return
 
         # Detect if any callable returns PassManager

--- a/export/tests/BUCK
+++ b/export/tests/BUCK
@@ -31,6 +31,8 @@ fbcode_target(
     deps = [
         "//executorch/export:lib",
         "//executorch/exir:lib",
+        "//executorch/exir/backend:op_backend",
+        "//executorch/backends/xnnpack/partition:xnnpack_partitioner",
         "//executorch/devtools/backend_debug:delegation_info",
         "//executorch/runtime:runtime",
     ]

--- a/export/tests/test_export_recipe.py
+++ b/export/tests/test_export_recipe.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 
 import torch
 
+from executorch.exir.backend.op_backend import OpBackend
 from executorch.export.recipe import ExportRecipe, RecipeType
 from executorch.export.recipe_provider import BackendRecipeProvider
 from executorch.export.recipe_registry import recipe_registry
@@ -132,6 +133,11 @@ class TestExportRecipeGetRecipe(unittest.TestCase):
         # Verify that the kwargs were passed to the backend provider's create_recipe method
         self.assertIsNotNone(self.provider.last_kwargs)
         self.assertEqual(self.provider.last_kwargs, kwargs)
+
+
+class _StubOpBackend(OpBackend):
+    def lower(self, exported_program, method_name):
+        return exported_program
 
 
 class TestExportRecipeCombine(unittest.TestCase):
@@ -334,3 +340,18 @@ class TestExportRecipeCombine(unittest.TestCase):
         self.assertEqual(
             combined.lowering_recipe.edge_transform_passes, [first, second]
         )
+
+    def test_combine_keeps_every_op_backend(self) -> None:
+        # One contributor may supply several; all of them have to survive.
+        first, second = _StubOpBackend(), _StubOpBackend()
+        combined = ExportRecipe.combine(
+            [
+                ExportRecipe(
+                    name="a",
+                    lowering_recipe=self._lowering(op_backends=[first, second]),
+                ),
+                ExportRecipe(name="b"),
+            ]
+        )
+        assert combined.lowering_recipe is not None
+        self.assertEqual(combined.lowering_recipe.op_backends, [first, second])

--- a/export/tests/test_export_session.py
+++ b/export/tests/test_export_session.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List
 from unittest.mock import call, Mock, patch
 
 import torch
+from executorch.exir.backend.op_backend import OpBackend
 from executorch.export import ExportRecipe, ExportSession
 from executorch.export.recipe import (
     AOQuantizationConfig,
@@ -1092,3 +1093,166 @@ class TestStageArtifactsAreScopedToOneRun(unittest.TestCase):
         with self.assertRaises(ValueError):
             session.export()
         self.assertIs(session.get_executorch_program_manager(), before)
+
+
+class _RecordingOpBackend(OpBackend):
+    """Records the methods it lowered; optionally applies a real pass."""
+
+    def __init__(self, apply_pass: bool = False) -> None:
+        self.seen: List[str] = []
+        self._apply_pass = apply_pass
+
+    def lower(self, exported_program, method_name):
+        from executorch.exir.pass_base import ExportPass
+        from executorch.exir.program._program import _transform
+
+        self.seen.append(method_name)
+        return (
+            _transform(exported_program, ExportPass())
+            if self._apply_pass
+            else exported_program
+        )
+
+
+class TestOpBackendPipeline(unittest.TestCase):
+    """A lowering recipe that declares op_backends has to get the
+    stage that runs them, whatever the input model type."""
+
+    def setUp(self) -> None:
+        self.model = SimpleTestModel()
+        self.inputs = [(torch.randn(1, 10),)]
+
+    def _recipe(self, real_pass: bool = False, **kwargs) -> ExportRecipe:
+        self.backend = _RecordingOpBackend(apply_pass=real_pass)
+        return ExportRecipe(
+            name="ppt",
+            lowering_recipe=LoweringRecipe(op_backends=[self.backend]),
+            **kwargs,
+        )
+
+    def test_stage_added_to_default_pipeline(self) -> None:
+        session = ExportSession(
+            model=self.model, example_inputs=self.inputs, export_recipe=self._recipe()
+        )
+        stages = session._pipeline_stages
+        self.assertGreater(
+            stages.index(StageType.EDGE_PROGRAM_MANAGER_TRANSFORM),
+            stages.index(StageType.TO_EDGE_TRANSFORM_AND_LOWER),
+        )
+        session.export()
+        self.assertEqual(self.backend.seen, ["forward"])
+
+    def test_stage_absent_without_op_backends(self) -> None:
+        session = ExportSession(
+            model=self.model,
+            example_inputs=self.inputs,
+            export_recipe=ExportRecipe(name="plain"),
+        )
+        self.assertNotIn(
+            StageType.EDGE_PROGRAM_MANAGER_TRANSFORM, session._pipeline_stages
+        )
+
+    def test_edge_program_manager_getter_returns_the_lowered_program(self) -> None:
+        session = ExportSession(
+            model=self.model,
+            example_inputs=self.inputs,
+            export_recipe=self._recipe(real_pass=True),
+        )
+        session.export()
+        artifacts = session.get_stage_artifacts()
+        lowered = artifacts[StageType.TO_EDGE_TRANSFORM_AND_LOWER].data
+        transformed = artifacts[StageType.EDGE_PROGRAM_MANAGER_TRANSFORM].data
+        # Guard the guard: the stage always rebuilds the manager, so comparing
+        # managers proves nothing -- it is the programs that must differ.
+        self.assertIsNot(
+            lowered.exported_program("forward"),
+            transformed.exported_program("forward"),
+        )
+        self.assertIs(session.get_edge_program_manager(), transformed)
+
+
+class TestOpBackendsSeeDelegates(unittest.TestCase):
+    """The premise of the stage: transforms run after the partitioner, so they
+    see what was left outside the delegates."""
+
+    def test_op_backend_observes_a_partitioned_program(self) -> None:
+        from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+            XnnpackPartitioner,
+        )
+        from executorch.exir.pass_base import ExportPass
+        from executorch.exir.program._program import _transform
+
+        observed = {}
+
+        class Observer(OpBackend):
+            def lower(self, exported_program, method_name):
+                observed["delegates"] = sum(
+                    1
+                    for n in exported_program.graph.nodes
+                    if n.op == "call_function"
+                    and n.target is torch.ops.higher_order.executorch_call_delegate
+                )
+                return _transform(exported_program, ExportPass())
+
+        session = ExportSession(
+            model=SimpleTestModel(),
+            example_inputs=[(torch.randn(1, 10),)],
+            export_recipe=ExportRecipe(
+                name="delegated",
+                lowering_recipe=LoweringRecipe(
+                    partitioners=[XnnpackPartitioner()],
+                    op_backends=[Observer()],
+                ),
+            ),
+        )
+        session.export()
+
+        self.assertGreater(observed["delegates"], 0)
+        self.assertGreater(len(session.get_executorch_program_manager().buffer), 0)
+
+
+class TestEdgeProgramManagerGetterArms(unittest.TestCase):
+    """Each edge stage the getter recognises has to be the one it returns when
+    that stage ran last."""
+
+    def setUp(self) -> None:
+        self.model = SimpleTestModel()
+        self.inputs = [(torch.randn(1, 10),)]
+
+    def _run(self, stages, **lowering):
+        session = ExportSession(
+            model=self.model,
+            example_inputs=self.inputs,
+            export_recipe=ExportRecipe(
+                name="arms",
+                lowering_recipe=LoweringRecipe(**lowering) if lowering else None,
+                pipeline_stages=stages,
+            ),
+        )
+        session.export()
+        return session
+
+    def test_to_backend_last(self) -> None:
+        from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
+            XnnpackPartitioner,
+        )
+
+        session = self._run(
+            [
+                StageType.TORCH_EXPORT,
+                StageType.TO_EDGE,
+                StageType.TO_BACKEND,
+                StageType.TO_EXECUTORCH,
+            ],
+            partitioners=[XnnpackPartitioner()],
+        )
+        artifacts = session.get_stage_artifacts()
+        # Without a partitioner these are the same object and the assertion
+        # below would hold whichever arm the getter took.
+        self.assertIsNot(
+            artifacts[StageType.TO_EDGE].data, artifacts[StageType.TO_BACKEND].data
+        )
+        self.assertIs(
+            session.get_edge_program_manager(),
+            artifacts[StageType.TO_BACKEND].data,
+        )

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -7,11 +7,18 @@
 # pyre-strict
 
 import unittest
+from typing import List
 from unittest.mock import call, Mock, patch
 
 import torch
+from executorch.exir.backend.op_backend import OpBackend
 from executorch.exir.program import EdgeProgramManager, ExecutorchProgramManager
-from executorch.export import AOQuantizationConfig, QuantizationRecipe, StageType
+from executorch.export import (
+    AOQuantizationConfig,
+    LoweringRecipe,
+    QuantizationRecipe,
+    StageType,
+)
 from executorch.export.stages import (
     EdgeProgramManagerTransformStage,
     EdgeTransformAndLowerStage,
@@ -698,6 +705,135 @@ class TestEmptyPassDictIsNotApplied(unittest.TestCase):
         )
 
         self.assertIsNone(mock_lower.call_args.kwargs["transform_passes"])
+
+
+class _StubOpBackend(OpBackend):
+    """Records what it lowered and optionally applies a real pass.
+
+    Each instance stamps its name into the graph module's metadata and records
+    the stamps already there, which is how a later backend can be shown the
+    earlier one's output. Identity cannot show it: every backend is handed its
+    own copy.
+
+    """
+
+    def __init__(self, apply_pass: bool = False, name: str = "stub") -> None:
+        self.seen: List[str] = []
+        self.upstream: List[List[str]] = []
+        self._apply_pass = apply_pass
+        self._name = name
+
+    def lower(self, exported_program, method_name):
+        from executorch.exir.pass_base import ExportPass
+        from executorch.exir.program._program import _transform
+
+        self.seen.append(method_name)
+        self.upstream.append(
+            list(exported_program.graph_module.meta.get("lowered_by", []))
+        )
+        lowered = (
+            _transform(exported_program, ExportPass())
+            if self._apply_pass
+            else exported_program
+        )
+        lowered.graph_module.meta.setdefault("lowered_by", []).append(self._name)
+        return lowered
+
+
+def _real_manager(methods=("forward",)) -> EdgeProgramManager:
+    from executorch.exir import to_edge
+
+    model = SimpleTestModel()
+    inputs = (torch.randn(1, 10),)
+    return to_edge({name: torch.export.export(model, inputs) for name in methods})
+
+
+class TestOpBackends(unittest.TestCase):
+    def test_every_backend_sees_every_method(self) -> None:
+        first, second = _StubOpBackend(), _StubOpBackend()
+        stage = EdgeProgramManagerTransformStage(op_backends=[first, second])
+        stage.run(PipelineArtifact(data=_real_manager(("beta", "alpha")), context={}))
+
+        self.assertCountEqual(first.seen, ["alpha", "beta"])
+        self.assertCountEqual(second.seen, ["alpha", "beta"])
+
+    def test_a_backend_receives_the_previous_backend_s_output(self) -> None:
+        first = _StubOpBackend(apply_pass=True, name="first")
+        second = _StubOpBackend(name="second")
+        stage = EdgeProgramManagerTransformStage(op_backends=[first, second])
+        stage.run(PipelineArtifact(data=_real_manager(), context={}))
+
+        self.assertEqual(first.upstream[0], [])
+        self.assertEqual(second.upstream[0], ["first"])
+
+    def test_input_manager_is_not_rewritten(self) -> None:
+        # It is also the previous stage's recorded artifact.
+        manager = _real_manager()
+        before = manager.exported_program("forward")
+        stage = EdgeProgramManagerTransformStage(
+            op_backends=[_StubOpBackend(apply_pass=True)]
+        )
+        stage.run(PipelineArtifact(data=manager, context={}))
+
+        self.assertIsNot(stage.get_artifacts().data, manager)
+        self.assertIs(manager.exported_program("forward"), before)
+
+    def test_transform_passes_are_suppressed_when_tetal_has_them(self) -> None:
+        # Both stages read edge_transform_passes. The session hands them to
+        # only one; without that, the default pipeline applies each pass twice.
+        seen = []
+        recipe = LoweringRecipe(
+            edge_transform_passes=[lambda name, ep: seen.append(name) or []]
+        )
+
+        with_them = EdgeProgramManagerTransformStage.from_recipe(recipe)
+        with_them.run(PipelineArtifact(data=_real_manager(), context={}))
+        self.assertEqual(seen, ["forward"])
+
+        seen.clear()
+        without = EdgeProgramManagerTransformStage.from_recipe(
+            recipe, with_transform_passes=False
+        )
+        without.run(PipelineArtifact(data=_real_manager(), context={}))
+        self.assertEqual(seen, [])
+
+    def test_no_backends_passes_the_manager_through(self) -> None:
+        manager = _real_manager()
+        stage = EdgeProgramManagerTransformStage()
+        stage.run(PipelineArtifact(data=manager, context={}))
+        self.assertIs(stage.get_artifacts().data, manager)
+
+    def test_from_recipe_reads_the_lowering_recipe(self) -> None:
+        backend = _StubOpBackend()
+        stage = EdgeProgramManagerTransformStage.from_recipe(
+            LoweringRecipe(op_backends=[backend])
+        )
+        self.assertEqual(stage._op_backends, [backend])
+        self.assertEqual(
+            EdgeProgramManagerTransformStage.from_recipe(None)._op_backends, []
+        )
+
+    def test_a_transform_only_stage_follows_any_edge_stage(self) -> None:
+        # TO_EDGE is kept because the stage predates op_backends and still
+        # serves recipes that only transform.
+        self.assertEqual(
+            set(EdgeProgramManagerTransformStage().valid_predecessor_stages),
+            {
+                StageType.TO_EDGE,
+                StageType.TO_EDGE_TRANSFORM_AND_LOWER,
+                StageType.TO_BACKEND,
+            },
+        )
+
+    def test_op_backends_require_a_partitioning_predecessor(self) -> None:
+        # Otherwise TO_EDGE -> EPMT -> TO_BACKEND is a legal pipeline that runs
+        # the operator backends first, against the documented contract.
+        stage = EdgeProgramManagerTransformStage(op_backends=[_StubOpBackend()])
+        self.assertNotIn(StageType.TO_EDGE, stage.valid_predecessor_stages)
+        self.assertEqual(
+            set(stage.valid_predecessor_stages),
+            {StageType.TO_EDGE_TRANSFORM_AND_LOWER, StageType.TO_BACKEND},
+        )
 
 
 class TestUnknownStageIsNotRegistered(unittest.TestCase):


### PR DESCRIPTION
### Summary
`EdgeProgramManagerTransformStage` runs over the whole edge program, which is
where a backend that rewrites operators rather than delegating a subgraph needs
to be. It only accepted `TO_EDGE` as a predecessor though, behind a `# TODO`,
so it could not see what partitioning left on the CPU. This adds
`TO_EDGE_TRANSFORM_AND_LOWER` and `TO_BACKEND` alongside it.

`LoweringRecipe` grows `op_backends`, which the stage applies through
`EdgeProgramManager.to_op_backend`, and which places the stage in the default
pipeline. Backends can therefore stop hardcoding `pipeline_stages`, and thereby
stop rejecting the GraphModule and ExportedProgram inputs the default adapts
to. A recipe declaring `op_backends` must disable `_check_ir_validity`, since
its kernels are outside the edge dialect and programs keep the verifier
`to_edge` gave them; forgetting raises a `SpecViolationError` naming the
operator.

Two behaviour changes fall out of the stage being able to run last, both
affecting only pipelines that contain it:

`get_edge_program_manager()` returns whichever edge stage ran last rather than
consulting a fixed preference list, because the list would return the program
from before the backends ran. Reordering the list cannot fix it: putting the
transform stage first breaks `TO_EDGE -> transform -> TO_BACKEND`. Enumerating
every previously legal pipeline of the built-in stages, and every prefix of
one, the two agree everywhere. A pipeline whose stages were replaced through
`register_stage` can differ, and there the new answer is the correct one.

The stage no longer hands back its predecessor's `PipelineArtifact` when it has
nothing to do. That aliasing let it overwrite the previous stage's recorded
duration, and leaked `add_context` between the two.

`edge_transform_passes` is handed to whichever of its two consuming stages the
pipeline actually contains, rather than to both, which is what stops the
default pipeline applying every pass twice.

Authored with Claude Code.