### PR TITLE
Add ExportRecipe support for Arm targets

### DIFF
--- a/backends/arm/README.md
+++ b/backends/arm/README.md
@@ -156,6 +156,49 @@ compile specs, see:
 
 Additional examples are available in `examples/arm`.
 
+#### Export recipes
+
+An `ExportRecipe` bundles those steps for a target, so a standard export needs
+no compile spec, quantizer or partitioner of its own. Each recipe carries the
+settings its target expects:
+
+```python
+from executorch.backends.arm.recipes.arm_recipe_types import ArmRecipeType
+from executorch.export import export, ExportRecipe
+
+session = export(
+    model=model,
+    example_inputs=[example_inputs],
+    export_recipe=ExportRecipe.get_recipe(ArmRecipeType.ETHOS_U55_INT8),
+)
+session.save_to_pte("model")
+```
+
+The recipe quantizes the model, so pass `example_inputs` that are representative
+of real data; they are used to calibrate.
+
+Available recipes:
+
+| Recipe | Target |
+| --- | --- |
+| `ETHOS_U55_INT8`, `ETHOS_U65_INT8`, `ETHOS_U85_INT8` | Ethos-U NPUs, int8 |
+| `TOSA_FP`, `TOSA_INT8`, `TOSA_A16W8` | TOSA, for testing without hardware |
+| `VGF_FP`, `VGF_INT8` | VGF, for the ML SDK for Vulkan |
+
+The Ethos-U recipes accept `macs`, `system_config`, `memory_mode`,
+`extra_flags` and `config_ini`, matching the corresponding Vela options:
+
+```python
+ExportRecipe.get_recipe(ArmRecipeType.ETHOS_U85_INT8, macs=512)
+```
+
+`macs` is validated against the accelerator configurations the installed Vela
+accepts, so an unsupported count fails at recipe construction rather than during
+compilation.
+
+Reach for the step-by-step flow above when a recipe does not fit -- a custom
+quantization scheme, extra passes, or a compile spec the recipe does not expose.
+
 ### Direct Drive (experimental, Ethos-U85 on Linux) workflow
 
 Direct Drive enables execution on Ethos-U85 via the Linux driver stack.

--- a/backends/arm/recipes/BUCK
+++ b/backends/arm/recipes/BUCK
@@ -1,0 +1,61 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+oncall("executorch")
+
+fbcode_target(
+    _kind = runtime.python_library,
+    name = "recipes",
+    srcs = [
+        "__init__.py",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        ":arm_recipe_provider",
+        ":arm_recipe_types",
+        "//executorch/export:recipe_registry",
+    ],
+)
+
+fbcode_target(
+    _kind = runtime.python_library,
+    name = "arm_recipe_provider",
+    srcs = [
+        "arm_recipe_provider.py",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        ":arm_recipe_types",
+        # Imported lazily for the accelerator-config list; declared so the dep
+        # does not rely on reaching vela through :ethosu.
+        "fbsource//third-party/pypi/ethos-u-vela:ethos-u-vela",
+        "//executorch/backends/arm:_factory",
+        "//executorch/backends/arm:arm_compile_spec",
+        "//executorch/backends/arm:ethosu",
+        "//executorch/backends/arm:vgf",
+        "//executorch/backends/arm/quantizer:lib",
+        "//executorch/backends/arm/tosa:compile_spec",
+        "//executorch/backends/cortex_m/passes:replace_quant_nodes_pass",
+        "//executorch/exir:lib",
+        "//executorch/exir/backend:op_backend",
+        "//executorch/export:lib",
+    ],
+)
+
+fbcode_target(
+    _kind = runtime.python_library,
+    name = "arm_recipe_types",
+    srcs = [
+        "arm_recipe_types.py",
+    ],
+    visibility = ["PUBLIC"],
+    deps = [
+        "//executorch/export:recipe",
+    ],
+)

--- a/backends/arm/recipes/__init__.py
+++ b/backends/arm/recipes/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from executorch.export import recipe_registry
+
+from .arm_recipe_provider import ArmRecipeProvider
+from .arm_recipe_types import ArmRecipeType
+
+recipe_registry.register_backend_recipe_provider(ArmRecipeProvider())
+
+
+__all__ = ["ArmRecipeProvider", "ArmRecipeType"]

--- a/backends/arm/recipes/arm_recipe_provider.py
+++ b/backends/arm/recipes/arm_recipe_provider.py
@@ -1,0 +1,287 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Sequence
+
+from executorch.backends.arm.common.arm_compile_spec import ArmCompileSpec
+from executorch.backends.arm.ethosu import EthosUCompileSpec
+from executorch.backends.arm.quantizer import (
+    get_symmetric_a16w8_quantization_config,
+    get_symmetric_quantization_config,
+)
+from executorch.backends.arm.recipes.arm_recipe_types import ARM_BACKEND, ArmRecipeType
+from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
+from executorch.backends.arm.util._factory import create_partitioner, create_quantizer
+from executorch.backends.arm.vgf import VgfCompileSpec
+from executorch.exir.capture import EdgeCompileConfig, ExecutorchBackendConfig
+from executorch.exir.pass_manager import PassType
+from executorch.exir.program import EdgeProgramManager
+from executorch.export import (
+    BackendRecipeProvider,
+    ExportRecipe,
+    LoweringRecipe,
+    QuantizationRecipe,
+    RecipeType,
+)
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# (target prefix, default MAC count). Which counts are *accepted* is Vela's to
+# say, so it is asked at build time rather than restated here.
+_ETHOS_U_FAMILIES: dict[ArmRecipeType, tuple[str, int]] = {
+    ArmRecipeType.ETHOS_U55_INT8: ("ethos-u55", 128),
+    ArmRecipeType.ETHOS_U65_INT8: ("ethos-u65", 256),
+    ArmRecipeType.ETHOS_U85_INT8: ("ethos-u85", 256),
+}
+
+_ETHOS_U_KWARGS: frozenset[str] = frozenset(
+    {"macs", "system_config", "memory_mode", "extra_flags", "config_ini"}
+)
+
+# Prepended to any caller-supplied Vela flags, matching `_get_compile_spec` in
+# aot_arm_compiler.py.
+_VELA_DEFAULT_FLAGS: tuple[str, ...] = (
+    "--verbose-operators",
+    "--verbose-cycle-estimate",
+)
+
+
+@dataclass(frozen=True)
+class _TosaVersionedTarget:
+    """A target with no caller-tunable options: class plus TOSA version."""
+
+    compile_spec: Callable[[str], ArmCompileSpec]
+    tosa_spec: str
+    quant_mode: Optional[str]
+    replace_quant_nodes: bool
+
+
+# VGF keeps the quantized_decomposed QDQ ops it is given; see
+# `_apply_replace_quant_nodes` in aot_arm_compiler.py.
+_TOSA_VERSIONED_TARGETS: dict[ArmRecipeType, _TosaVersionedTarget] = {
+    ArmRecipeType.TOSA_FP: _TosaVersionedTarget(
+        TosaCompileSpec, "TOSA-1.0+FP", None, False
+    ),
+    ArmRecipeType.TOSA_INT8: _TosaVersionedTarget(
+        TosaCompileSpec, "TOSA-1.0+INT", "INT8", True
+    ),
+    ArmRecipeType.TOSA_A16W8: _TosaVersionedTarget(
+        TosaCompileSpec, "TOSA-1.0+INT+int16", "A16W8", True
+    ),
+    ArmRecipeType.VGF_FP: _TosaVersionedTarget(
+        VgfCompileSpec, "TOSA-1.0+FP", None, False
+    ),
+    ArmRecipeType.VGF_INT8: _TosaVersionedTarget(
+        VgfCompileSpec, "TOSA-1.0+INT", "INT8", False
+    ),
+}
+
+
+def _reject_unsupported_accelerator(
+    recipe_type: ArmRecipeType, family: str, target: str, macs: int
+) -> None:
+    """Ask Vela which accelerator configurations it accepts.
+
+    A local copy would go stale on the next Vela bump. Without Vela there is
+    nothing to check against and the compile spec still has to build, so the
+    import is guarded the way `arm_vela` guards its own.
+
+    """
+    try:
+        from ethosu.vela.architecture_features import Accelerator  # type: ignore
+    except ImportError:
+        logger.debug("ethos-u-vela is not installed; macs=%s unvalidated", macs)
+        return
+
+    supported = {accelerator.value for accelerator in Accelerator}
+    if target not in supported:
+        allowed = sorted(
+            int(name.rsplit("-", 1)[1])
+            for name in supported
+            if name.startswith(f"{family}-")
+        )
+        raise ValueError(
+            f"Recipe '{recipe_type.value}' does not support macs={macs}. "
+            f"Allowed: {allowed}"
+        )
+
+
+def _replace_quant_nodes(
+    edge_program_manager: EdgeProgramManager,
+) -> list[PassType]:
+    """Rewrite the QDQ ops left outside the delegate into cortex_m kernels.
+
+    Matches `_apply_replace_quant_nodes` in aot_arm_compiler.py, which applies
+    the same pass to the whole manager once the partitioner has run. Without it
+    the boundary quantize/dequantize keep their `quantized_decomposed` targets,
+    which have no out variants, and `to_executorch` refuses to emit them.
+
+    """
+    # Function-local: an FP recipe must not pull in the cortex_m operator
+    # library, which registers its whole op set on import.
+    from executorch.backends.cortex_m.passes.replace_quant_nodes_pass import (
+        ReplaceQuantNodesPass,
+    )
+
+    return [ReplaceQuantNodesPass()]
+
+
+class ArmRecipeProvider(BackendRecipeProvider):
+    """Builds ExportRecipes for the delegated Arm targets: Ethos-U, TOSA, VGF.
+
+    Each recipe is built to reproduce the default
+    ``backends/arm/scripts/aot_arm_compiler.py`` invocation for its target: the
+    same compile spec, quantizer, pass pipeline and backend config. The CLI
+    options with no recipe equivalent, debug mode and direct drive, are the
+    exceptions.
+    """
+
+    @property
+    def backend_name(self) -> str:
+        return ARM_BACKEND
+
+    def get_supported_recipes(self) -> Sequence[RecipeType]:
+        return list(_ETHOS_U_FAMILIES) + list(_TOSA_VERSIONED_TARGETS)
+
+    def create_recipe(
+        self, recipe_type: RecipeType, **kwargs: Any
+    ) -> Optional[ExportRecipe]:
+        if not isinstance(recipe_type, ArmRecipeType):
+            return None
+
+        if recipe_type in _ETHOS_U_FAMILIES:
+            self._warn_unknown_kwargs(recipe_type, kwargs, _ETHOS_U_KWARGS)
+            return self._build_recipe(
+                recipe_type,
+                self._ethos_u_compile_spec(recipe_type, kwargs),
+                quant_mode="INT8",
+                replace_quant_nodes=True,
+            )
+
+        target = _TOSA_VERSIONED_TARGETS.get(recipe_type)
+        if target is None:
+            return None
+
+        self._warn_unknown_kwargs(recipe_type, kwargs, frozenset())
+        return self._build_recipe(
+            recipe_type,
+            target.compile_spec(target.tosa_spec),
+            quant_mode=target.quant_mode,
+            replace_quant_nodes=target.replace_quant_nodes,
+        )
+
+    @staticmethod
+    def _ethos_u_compile_spec(
+        recipe_type: ArmRecipeType, kwargs: dict[str, Any]
+    ) -> EthosUCompileSpec:
+        family, default_macs = _ETHOS_U_FAMILIES[recipe_type]
+        macs = kwargs.get("macs", default_macs)
+        if not isinstance(macs, int):
+            raise ValueError(f"macs must be an int, got {macs!r}")
+
+        extra_flags = kwargs.get("extra_flags") or []
+        # The list check comes first: a bare string would be iterated into one
+        # flag per character, and anything not iterable would raise TypeError
+        # out of `all` rather than reaching this message.
+        if not isinstance(extra_flags, list) or not all(
+            isinstance(flag, str) for flag in extra_flags
+        ):
+            raise ValueError(
+                f"extra_flags must be a list of strings, got {extra_flags!r}"
+            )
+
+        target = f"{family}-{macs}"
+        _reject_unsupported_accelerator(recipe_type, family, target, macs)
+
+        return EthosUCompileSpec(
+            target=target,
+            system_config=kwargs.get("system_config"),
+            memory_mode=kwargs.get("memory_mode"),
+            extra_flags=list(_VELA_DEFAULT_FLAGS) + list(extra_flags),
+            # EthosUCompileSpec owns the default.
+            config_ini=kwargs.get("config_ini"),
+        )
+
+    @classmethod
+    def _build_recipe(
+        cls,
+        recipe_type: ArmRecipeType,
+        compile_spec: ArmCompileSpec,
+        quant_mode: Optional[str],
+        replace_quant_nodes: bool,
+    ) -> ExportRecipe:
+        # The partitioner snapshots the compile spec and the pipeline config is
+        # materialised on first read, which the CLI gets for free by quantizing
+        # before it partitions.
+        compile_spec.set_pass_pipeline_config(compile_spec._get_pass_pipeline_config())
+
+        return ExportRecipe(
+            name=recipe_type.value,
+            quantization_recipe=cls._build_quantization_recipe(
+                compile_spec, quant_mode
+            ),
+            lowering_recipe=LoweringRecipe(
+                partitioners=[create_partitioner(compile_spec)],
+                # The CLI disables edge verification on every Arm path.
+                edge_compile_config=EdgeCompileConfig(_check_ir_validity=False),
+                edge_manager_transform_passes=(
+                    [_replace_quant_nodes] if replace_quant_nodes else None
+                ),
+            ),
+            # The Arm runtime expects the delegate payload inline rather than
+            # in its own segment, as every other Arm AOT path asks for.
+            executorch_backend_config=ExecutorchBackendConfig(
+                extract_delegate_segments=False
+            ),
+        )
+
+    @staticmethod
+    def _build_quantization_recipe(
+        compile_spec: ArmCompileSpec, quant_mode: Optional[str]
+    ) -> Optional[QuantizationRecipe]:
+        if quant_mode is None:
+            return None
+
+        if quant_mode == "INT8":
+            operator_config = get_symmetric_quantization_config(is_per_channel=True)
+        elif quant_mode == "A16W8":
+            if not compile_spec.tosa_spec.support_extension("int16"):
+                raise ValueError(
+                    f"TOSA spec {compile_spec.tosa_spec} does not support int16 "
+                    "(required for A16W8)"
+                )
+            operator_config = get_symmetric_a16w8_quantization_config(
+                is_per_channel=True
+            )
+        else:
+            raise ValueError(f"Unsupported quant_mode: {quant_mode}")
+
+        quantizer = create_quantizer(compile_spec)
+        quantizer.set_global(operator_config)
+        return QuantizationRecipe(quantizers=[quantizer])
+
+    @staticmethod
+    def _warn_unknown_kwargs(
+        recipe_type: ArmRecipeType,
+        kwargs: dict[str, Any],
+        expected: frozenset[str],
+    ) -> None:
+        # Warn, as XNNPACK and QNN do: `_create_target_recipe` hands every
+        # recipe in a combination the same kwargs.
+        unexpected = set(kwargs.keys()) - expected
+        if unexpected:
+            allowed = sorted(expected) if expected else "none"
+            logger.warning(
+                "Arm recipe '%s' ignoring unexpected parameters: %s. Allowed: %s",
+                recipe_type.value,
+                sorted(unexpected),
+                allowed,
+            )

--- a/backends/arm/recipes/arm_recipe_types.py
+++ b/backends/arm/recipes/arm_recipe_types.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from executorch.export import RecipeType
+
+
+ARM_BACKEND: str = "arm"
+
+
+class ArmRecipeType(RecipeType):
+    """Arm-specific recipe types.
+
+    Covers the delegated targets of ``backends/arm/scripts/aot_arm_compiler.py``.
+    Its non-delegated Cortex-M/CMSIS-NN path is a separate backend and is not
+    reachable from these recipes.
+
+    Ethos-U recipes accept the following kwargs:
+        macs (int): MAC count for the family, validated against the accelerator
+            configurations the installed Vela accepts -- today 32/64/128/256 for
+            U55, 256/512 for U65 and 128/256/512/1024/2048 for U85. Defaults to
+            128 for U55 and 256 for U65 and U85.
+        system_config (str): Vela system config name. Defaults from
+            ``EthosUCompileSpec`` apply when omitted.
+        memory_mode (str): Vela memory mode. Defaults from
+            ``EthosUCompileSpec`` apply when omitted.
+        extra_flags (list[str]): Vela compiler flags, appended to the
+            ``--verbose-operators --verbose-cycle-estimate`` the CLI always
+            passes rather than replacing them.
+        config_ini (str): Path to a Vela .ini configuration file. Defaults to
+            ``"Arm/vela.ini"``.
+
+    """
+
+    ETHOS_U55_INT8 = "arm_ethos_u55_int8"
+    ETHOS_U65_INT8 = "arm_ethos_u65_int8"
+    ETHOS_U85_INT8 = "arm_ethos_u85_int8"
+
+    TOSA_FP = "arm_tosa_fp"
+    TOSA_INT8 = "arm_tosa_int8"
+    TOSA_A16W8 = "arm_tosa_a16w8"
+
+    VGF_FP = "arm_vgf_fp"
+    VGF_INT8 = "arm_vgf_int8"
+
+    @classmethod
+    def get_backend_name(cls) -> str:
+        return ARM_BACKEND

--- a/backends/arm/test/recipes/test_arm_recipes.py
+++ b/backends/arm/test/recipes/test_arm_recipes.py
@@ -1,0 +1,491 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+"""Tests for the Arm ExportRecipe provider.
+
+Building a recipe only assembles a compile spec, a quantizer and a partitioner,
+so none of these tests need Vela, the model converter or an FVP. Class and
+method names route each test to exactly one of the existing target-less, TOSA
+and VGF suites; see the ``-k`` filters in
+``backends/arm/test/test_arm_backend.sh``.
+
+"""
+
+# pyre-strict
+
+import unittest
+from typing import Any, Optional
+
+import torch
+
+from executorch.backends.arm.recipes.arm_recipe_provider import ArmRecipeProvider
+from executorch.backends.arm.recipes.arm_recipe_types import ARM_BACKEND, ArmRecipeType
+from executorch.export import ExportRecipe, recipe_registry, StageType
+from executorch.export.export import ExportSession
+
+
+_PROVIDER_LOGGER = "executorch.backends.arm.recipes.arm_recipe_provider"
+
+try:
+    import ethosu.vela.architecture_features  # type: ignore  # noqa: F401
+
+    _VELA_INSTALLED = True
+except ImportError:
+    # The target-less CI job installs the Arm deps without Vela, and a recipe
+    # has to build there; only the accelerator check needs it.
+    _VELA_INSTALLED = False
+
+
+class _AddModule(torch.nn.Module):
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        return x + y
+
+
+class _ConvReluModule(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 8, kernel_size=3, padding=1)
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.relu(self.conv(x))
+
+
+def _compile_spec_value(partitioner: Any, key: str) -> Optional[str]:
+    for spec in partitioner.delegation_spec.compile_specs:
+        if spec.key == key:
+            value = spec.value
+            return value.decode() if isinstance(value, (bytes, bytearray)) else value
+    return None
+
+
+def _backend_id(recipe: ExportRecipe) -> str:
+    return _first_partitioner(recipe).delegation_spec.backend_id
+
+
+def _first_partitioner(recipe: ExportRecipe) -> Any:
+    assert recipe.lowering_recipe is not None
+    # Arm recipes partition every method the same way, so the list form rather
+    # than the per-method dict `LoweringRecipe` also accepts.
+    partitioners = recipe.lowering_recipe.partitioners
+    assert isinstance(partitioners, list) and partitioners
+    return partitioners[0]
+
+
+def _global_config(recipe: ExportRecipe) -> Any:
+    assert recipe.quantization_recipe is not None
+    assert recipe.quantization_recipe.quantizers is not None
+    return recipe.quantization_recipe.quantizers[0].global_config  # type: ignore[attr-defined]
+
+
+def _input_activation_dtype(recipe: ExportRecipe) -> Optional[torch.dtype]:
+    config = _global_config(recipe)
+    if config is None or config.input_activation is None:
+        return None
+    return config.input_activation.dtype
+
+
+class _ArmRecipeTestCase(unittest.TestCase):
+    """Re-registers the Arm provider before each test.
+
+    Registration happens when ``backends.arm.recipes`` is imported, so it cannot
+    repeat: the module is already loaded. Other suites in the same process clear
+    the singleton registry in teardown, and under ``pytest -n`` their tests can
+    interleave with these.
+
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        recipe_registry.register_backend_recipe_provider(ArmRecipeProvider())
+
+
+class TestArmRecipeRegistration(_ArmRecipeTestCase):
+    def test_backend_registered(self) -> None:
+        self.assertIn(ARM_BACKEND, recipe_registry.list_backends())
+
+    def test_supported_recipes_match_enum(self) -> None:
+        # Catches an enum member added but never wired into a target table.
+        supported = recipe_registry.get_supported_recipes(ARM_BACKEND)
+        self.assertEqual(set(supported), set(ArmRecipeType))
+
+    def test_unknown_recipe_returns_none(self) -> None:
+        from executorch.export import RecipeType
+
+        class _StubRecipeType(RecipeType):
+            FOO = "stub_foo"
+
+            @classmethod
+            def get_backend_name(cls) -> str:
+                return "stub"
+
+        self.assertIsNone(ArmRecipeProvider().create_recipe(_StubRecipeType.FOO))
+
+
+class TestTosaRecipes(_ArmRecipeTestCase):
+    def test_tosa_construction(self) -> None:
+        cases = [
+            (ArmRecipeType.TOSA_FP, "arm_tosa_fp", "TOSA-1.0+FP", None),
+            (ArmRecipeType.TOSA_INT8, "arm_tosa_int8", "TOSA-1.0+INT", torch.int8),
+            (
+                ArmRecipeType.TOSA_A16W8,
+                "arm_tosa_a16w8",
+                "TOSA-1.0+INT+int16",
+                torch.int16,
+            ),
+        ]
+        for recipe_type, expected_name, expected_spec, expected_act_dtype in cases:
+            with self.subTest(recipe_type=recipe_type):
+                recipe = ExportRecipe.get_recipe(recipe_type)
+                self.assertEqual(recipe.name, expected_name)
+                # A VGF spec here would emit a container TOSA cannot consume.
+                self.assertEqual(_backend_id(recipe), "TOSABackend")
+                self.assertEqual(
+                    _compile_spec_value(_first_partitioner(recipe), "tosa_spec"),
+                    expected_spec,
+                )
+                if expected_act_dtype is None:
+                    self.assertIsNone(recipe.quantization_recipe)
+                else:
+                    self.assertEqual(
+                        _input_activation_dtype(recipe), expected_act_dtype
+                    )
+
+    def test_weights_are_per_channel(self) -> None:
+        for recipe_type in (ArmRecipeType.TOSA_INT8, ArmRecipeType.TOSA_A16W8):
+            with self.subTest(recipe_type=recipe_type):
+                weight = _global_config(ExportRecipe.get_recipe(recipe_type)).weight
+                self.assertEqual(weight.qscheme, torch.per_channel_symmetric)
+
+    def test_unexpected_kwarg_warns(self) -> None:
+        with self.assertLogs(_PROVIDER_LOGGER, level="WARNING"):
+            ExportRecipe.get_recipe(ArmRecipeType.TOSA_INT8, foo=1)
+
+
+class TestVgfRecipes(_ArmRecipeTestCase):
+    """Named without the ``_vgf_`` token that routes tests to the VKML suite:
+
+    constructing a compile spec needs no model converter, so these belong in the
+    target-less suite that runs on every PR.
+
+    """
+
+    def test_construction(self) -> None:
+        cases = [
+            (ArmRecipeType.VGF_FP, "arm_vgf_fp", "TOSA-1.0+FP", None),
+            (ArmRecipeType.VGF_INT8, "arm_vgf_int8", "TOSA-1.0+INT", torch.int8),
+        ]
+        for recipe_type, expected_name, expected_spec, expected_act_dtype in cases:
+            with self.subTest(recipe_type=recipe_type):
+                recipe = ExportRecipe.get_recipe(recipe_type)
+                self.assertEqual(recipe.name, expected_name)
+                self.assertEqual(
+                    _compile_spec_value(_first_partitioner(recipe), "tosa_spec"),
+                    expected_spec,
+                )
+                # A TOSA spec here would emit a flatbuffer VKML cannot load.
+                self.assertEqual(_backend_id(recipe), "VgfBackend")
+                self.assertEqual(
+                    _compile_spec_value(_first_partitioner(recipe), "output_format"),
+                    "vgf",
+                )
+                if expected_act_dtype is None:
+                    self.assertIsNone(recipe.quantization_recipe)
+                else:
+                    self.assertEqual(
+                        _input_activation_dtype(recipe), expected_act_dtype
+                    )
+
+    def test_keeps_quantized_decomposed_ops(self) -> None:
+        # VGF consumes the quantized_decomposed QDQ ops, so ReplaceQuantNodesPass
+        # must not run; see _apply_replace_quant_nodes in aot_arm_compiler.py.
+        for recipe_type in (ArmRecipeType.VGF_INT8, ArmRecipeType.VGF_FP):
+            with self.subTest(recipe_type=recipe_type):
+                recipe = ExportRecipe.get_recipe(recipe_type)
+                assert recipe.lowering_recipe is not None
+                self.assertIsNone(recipe.lowering_recipe.edge_manager_transform_passes)
+
+
+class TestEthosURecipes(_ArmRecipeTestCase):
+    def test_ethos_recipes_carry_their_pass_pipeline_config(self) -> None:
+        # Building the partitioner before the config is materialised silently
+        # drops this entry. Only the U55 subset has a non-default config.
+        for recipe_type in (
+            ArmRecipeType.ETHOS_U55_INT8,
+            ArmRecipeType.ETHOS_U65_INT8,
+        ):
+            with self.subTest(recipe_type=recipe_type):
+                partitioner = _first_partitioner(ExportRecipe.get_recipe(recipe_type))
+                self.assertIsNotNone(
+                    _compile_spec_value(partitioner, "transform_pipeline_config")
+                )
+        self.assertIsNone(
+            _compile_spec_value(
+                _first_partitioner(
+                    ExportRecipe.get_recipe(ArmRecipeType.ETHOS_U85_INT8)
+                ),
+                "transform_pipeline_config",
+            )
+        )
+
+    def test_default_macs(self) -> None:
+        cases = [
+            (ArmRecipeType.ETHOS_U55_INT8, "ethos-u55-128"),
+            (ArmRecipeType.ETHOS_U65_INT8, "ethos-u65-256"),
+            (ArmRecipeType.ETHOS_U85_INT8, "ethos-u85-256"),
+        ]
+        for recipe_type, expected_target in cases:
+            with self.subTest(recipe_type=recipe_type):
+                recipe = ExportRecipe.get_recipe(recipe_type)
+                self.assertEqual(recipe.name, recipe_type.value)
+                self.assertEqual(_input_activation_dtype(recipe), torch.int8)
+                partitioner = _first_partitioner(recipe)
+                self.assertEqual(
+                    _compile_spec_value(partitioner, "target"), expected_target
+                )
+
+    def test_custom_macs(self) -> None:
+        cases = [
+            (ArmRecipeType.ETHOS_U55_INT8, 32, "ethos-u55-32"),
+            (ArmRecipeType.ETHOS_U55_INT8, 256, "ethos-u55-256"),
+            (ArmRecipeType.ETHOS_U65_INT8, 512, "ethos-u65-512"),
+            (ArmRecipeType.ETHOS_U85_INT8, 128, "ethos-u85-128"),
+            (ArmRecipeType.ETHOS_U85_INT8, 2048, "ethos-u85-2048"),
+        ]
+        for recipe_type, macs, expected_target in cases:
+            with self.subTest(recipe_type=recipe_type, macs=macs):
+                recipe = ExportRecipe.get_recipe(recipe_type, macs=macs)
+                partitioner = _first_partitioner(recipe)
+                self.assertEqual(
+                    _compile_spec_value(partitioner, "target"), expected_target
+                )
+
+    @unittest.skipUnless(_VELA_INSTALLED, "accelerator configs come from Vela")
+    def test_invalid_macs_raises_u55(self) -> None:
+        cases = [
+            (ArmRecipeType.ETHOS_U55_INT8, 512),
+            (ArmRecipeType.ETHOS_U65_INT8, 128),
+            (ArmRecipeType.ETHOS_U85_INT8, 64),
+            (ArmRecipeType.ETHOS_U55_INT8, 999),
+        ]
+        for recipe_type, macs in cases:
+            with self.subTest(recipe_type=recipe_type, macs=macs):
+                with self.assertRaises(ValueError):
+                    ExportRecipe.get_recipe(recipe_type, macs=macs)
+
+    def test_pass_through_kwargs(self) -> None:
+        recipe = ExportRecipe.get_recipe(
+            ArmRecipeType.ETHOS_U55_INT8,
+            macs=128,
+            system_config="Custom_System",
+            memory_mode="Custom_Memory",
+            extra_flags=["--user-flag"],
+            config_ini="custom/vela.ini",
+        )
+        partitioner = _first_partitioner(recipe)
+        flags = _compile_spec_value(partitioner, "compile_flags") or ""
+        # Vela takes the last occurrence of a repeated flag, so the defaults
+        # have to come first for a caller override to win.
+        self.assertTrue(
+            flags.startswith("--verbose-operators --verbose-cycle-estimate"),
+            f"default flags must be prepended, got {flags}",
+        )
+        self.assertLess(flags.index("--verbose-operators"), flags.index("--user-flag"))
+        self.assertIn("--system-config=Custom_System", flags)
+        self.assertIn("--memory-mode=Custom_Memory", flags)
+        self.assertIn("--verbose-operators", flags)
+        self.assertIn("--verbose-cycle-estimate", flags)
+        self.assertIn("--user-flag", flags)
+        self.assertIn("--config=custom/vela.ini", flags)
+
+    def test_default_vela_flags(self) -> None:
+        # test_pass_through_kwargs supplies every kwarg, so the defaults would
+        # otherwise never be built. A wrong default config path only surfaces
+        # when Vela runs.
+        partitioner = _first_partitioner(
+            ExportRecipe.get_recipe(ArmRecipeType.ETHOS_U55_INT8)
+        )
+        flags = _compile_spec_value(partitioner, "compile_flags") or ""
+        self.assertIn("--config=Arm/vela.ini", flags)
+        self.assertIn("--verbose-operators", flags)
+        self.assertIn("--verbose-cycle-estimate", flags)
+
+    def test_documented_kwargs_do_not_warn(self) -> None:
+        # Every one of these is honoured, so reporting it as ignored would be
+        # a lie about what the recipe did.
+        with self.assertNoLogs(_PROVIDER_LOGGER, level="WARNING"):
+            ExportRecipe.get_recipe(
+                ArmRecipeType.ETHOS_U55_INT8,
+                macs=128,
+                system_config="Custom_System",
+                memory_mode="Custom_Memory",
+                extra_flags=["--user-flag"],
+                config_ini="custom/vela.ini",
+            )
+
+    def test_unexpected_kwarg_warns(self) -> None:
+        # Flags typos like `mac=128` (instead of `macs=128`), which would
+        # otherwise silently produce a default-target binary.
+        with self.assertLogs(_PROVIDER_LOGGER, level="WARNING"):
+            ExportRecipe.get_recipe(ArmRecipeType.ETHOS_U55_INT8, mac=128)
+
+    def test_extra_flags_must_be_a_list(self) -> None:
+        # A bare string is iterable, so it would reach Vela as one flag per
+        # character instead of failing.
+        with self.assertRaisesRegex(ValueError, "extra_flags must be a list"):
+            ExportRecipe.get_recipe(
+                ArmRecipeType.ETHOS_U55_INT8, extra_flags="--enable-debug-db"
+            )
+        with self.assertRaisesRegex(ValueError, "extra_flags must be a list"):
+            ExportRecipe.get_recipe(ArmRecipeType.ETHOS_U55_INT8, extra_flags=[1])
+        # Not iterable at all: checking the elements first raises TypeError out
+        # of `all` and the caller never sees the real complaint.
+        with self.assertRaisesRegex(ValueError, "extra_flags must be a list"):
+            ExportRecipe.get_recipe(ArmRecipeType.ETHOS_U55_INT8, extra_flags=7)
+
+    def test_macs_must_be_an_int(self) -> None:
+        with self.assertRaisesRegex(ValueError, "macs must be an int"):
+            ExportRecipe.get_recipe(ArmRecipeType.ETHOS_U55_INT8, macs="128")
+
+    def test_program_config_matches_the_cli(self) -> None:
+        # The Arm runtime has only ever been run against an inline delegate
+        # payload, and quantized Arm graphs do not survive the edge verifier.
+        recipe = ExportRecipe.get_recipe(ArmRecipeType.TOSA_INT8)
+        assert recipe.executorch_backend_config is not None
+        self.assertFalse(recipe.executorch_backend_config.extract_delegate_segments)
+        assert recipe.lowering_recipe is not None
+        assert recipe.lowering_recipe.edge_compile_config is not None
+        self.assertFalse(recipe.lowering_recipe.edge_compile_config._check_ir_validity)
+
+    def test_fp_recipes_run_no_post_partition_transform(self) -> None:
+        # No QDQ ops to rewrite, so the extra stage must not be scheduled.
+        recipe = ExportRecipe.get_recipe(ArmRecipeType.TOSA_FP)
+        assert recipe.lowering_recipe is not None
+        self.assertIsNone(recipe.lowering_recipe.edge_manager_transform_passes)
+
+    def test_recipes_do_not_share_config_objects(self) -> None:
+        # _combine_recipes compares configs by value on the assumption that
+        # each provider hands out a fresh one.
+        first = ExportRecipe.get_recipe(ArmRecipeType.TOSA_INT8)
+        second = ExportRecipe.get_recipe(ArmRecipeType.TOSA_INT8)
+        assert first.lowering_recipe is not None
+        assert second.lowering_recipe is not None
+        self.assertIsNot(
+            first.lowering_recipe.edge_compile_config,
+            second.lowering_recipe.edge_compile_config,
+        )
+        self.assertIsNot(
+            first.executorch_backend_config, second.executorch_backend_config
+        )
+
+
+class TestQuantizedRecipeLowering(_ArmRecipeTestCase):
+    """Every quantized recipe has to rewrite the QDQ ops left outside the
+    delegate, and can only do so from a stage that runs after partitioning.
+    """
+
+    QUANTIZED_RECIPES = (
+        ArmRecipeType.TOSA_INT8,
+        ArmRecipeType.TOSA_A16W8,
+        ArmRecipeType.ETHOS_U55_INT8,
+        ArmRecipeType.ETHOS_U65_INT8,
+        ArmRecipeType.ETHOS_U85_INT8,
+    )
+
+    def test_replace_quant_nodes_is_wired(self) -> None:
+        for recipe_type in self.QUANTIZED_RECIPES:
+            with self.subTest(recipe_type=recipe_type):
+                recipe = ExportRecipe.get_recipe(recipe_type)
+                assert recipe.lowering_recipe is not None
+                self.assertTrue(
+                    recipe.lowering_recipe.edge_manager_transform_passes,
+                    "quantized recipes must run ReplaceQuantNodesPass",
+                )
+
+    def test_session_schedules_the_stage(self) -> None:
+        session = ExportSession(
+            model=_ConvReluModule(),
+            example_inputs=[(torch.randn(1, 3, 8, 8),)],
+            export_recipe=ExportRecipe.get_recipe(ArmRecipeType.TOSA_INT8),
+        )
+        stages = session._pipeline_stages
+        self.assertIn(StageType.EDGE_PROGRAM_MANAGER_TRANSFORM, stages)
+        self.assertGreater(
+            stages.index(StageType.EDGE_PROGRAM_MANAGER_TRANSFORM),
+            stages.index(StageType.TO_EDGE_TRANSFORM_AND_LOWER),
+        )
+
+
+class TestTosaAOTRoundTrip(_ArmRecipeTestCase):
+    """End-to-end exports through the recipe pipeline.
+
+    Ethos-U and VGF round-trips need a real compiler and are deferred to an FVP-
+    bearing follow-up.
+
+    """
+
+    def _export(
+        self,
+        recipe: ExportRecipe,
+        model: torch.nn.Module,
+        example_inputs: tuple,
+    ):
+        from executorch.export import export
+
+        session = export(
+            model=model,
+            example_inputs=[example_inputs],
+            export_recipe=recipe,
+        )
+        return session.get_executorch_program()
+
+    def _instruction_kinds(self, program) -> tuple[list, list]:
+        from executorch.exir.schema import DelegateCall, KernelCall
+
+        instructions = program.execution_plan[0].chains[0].instructions
+        assert instructions is not None
+        operators = program.execution_plan[0].operators
+        delegate_calls = [
+            i for i in instructions if isinstance(i.instr_args, DelegateCall)
+        ]
+        kernel_op_names = [
+            operators[i.instr_args.op_index].name
+            for i in instructions
+            if isinstance(i.instr_args, KernelCall)
+        ]
+        return delegate_calls, kernel_op_names
+
+    def test_tosa_fp_export(self) -> None:
+        # FP path: no quant ops, expect full delegation (Add is supported by TOSA).
+        program = self._export(
+            ExportRecipe.get_recipe(ArmRecipeType.TOSA_FP),
+            _AddModule(),
+            (torch.randn(2, 3), torch.randn(2, 3)),
+        )
+        delegates, kernels = self._instruction_kinds(program)
+        self.assertEqual(len(delegates), 1, "Add should produce one TOSA delegate")
+        self.assertEqual(
+            kernels, [], f"Expected full delegation, got kernels {kernels}"
+        )
+
+    def test_tosa_int8_export(self) -> None:
+        # INT8 path: boundary quantize/dequantize remain outside the delegate
+        # and ReplaceQuantNodesPass rewrites them to cortex_m::*.
+        program = self._export(
+            ExportRecipe.get_recipe(ArmRecipeType.TOSA_INT8),
+            _ConvReluModule(),
+            (torch.randn(1, 3, 8, 8),),
+        )
+        delegates, kernels = self._instruction_kinds(program)
+        self.assertGreaterEqual(len(delegates), 1, "Conv+ReLU should delegate")
+        for op_name in kernels:
+            self.assertTrue(
+                op_name.startswith("cortex_m::"),
+                f"Non-delegate kernels must be cortex_m boundary ops; got {op_name}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -48,6 +48,11 @@ def define_arm_tests():
         "ops/test_split.py",
     ]
 
+    # Export recipes
+    test_files += [
+        "recipes/test_arm_recipes.py",
+    ]
+
     # Quantization
     test_files += [
         "quantizer/test_generic_annotater.py",
@@ -131,6 +136,7 @@ def define_arm_tests():
                 "//executorch/backends/arm/test/misc:dw_convs_shared_weights_module",
                 "//executorch/backends/arm:ao_ext",
                 "//executorch/backends/arm:ethosu",
+                "//executorch/backends/arm/recipes:recipes",
                 "//executorch/backends/arm/tosa:compile_spec",
                 "//executorch/backends/arm/tosa:partitioner",
                 "//executorch/backends/arm:vgf",


### PR DESCRIPTION
### Summary
`ArmRecipeProvider` reaches the Ethos-U, TOSA and VGF targets through
`ExportRecipe` instead of `aot_arm_compiler.py`, mirroring the XNNPACK and QNN
providers. Eight recipes: Ethos-U55/U65/U85 INT8 with `macs`, `system_config`,
`memory_mode`, `extra_flags` and `config_ini` kwargs; TOSA FP, INT8 and A16W8;
VGF FP and INT8.

Each reproduces the default CLI invocation for its target byte for byte. Two
things are easy to get wrong there and worth review attention: the CLI pins
`extract_delegate_segments=False`, which is the delegate layout
`arm_executor_runner` has actually been run against; and the partitioner
snapshots the compile spec, so the pass pipeline config has to be populated
first or the U55 and U65 delegates silently lose it.

Accepted MAC counts come from the installed Vela rather than a local copy, so a
Vela bump cannot leave the recipe rejecting a target its compiler accepts. That
import is guarded — the target-less CI job has no Vela and a recipe still has to
build there.

Review order: the two target tables, then `_build_recipe`, then the tests. The
tests are named so the existing target-less and TOSA suites each collect a
disjoint subset pre-merge; no new CI job.

Authored with Claude Code.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell