### PR TITLE
Cortex-M: add explicit-layout runtime primitives

### DIFF
--- a/backends/cortex_m/ops/BUCK
+++ b/backends/cortex_m/ops/BUCK
@@ -32,6 +32,7 @@ fbcode_target(_kind = runtime.python_library,
         "fbcode//caffe2:torch",
         "//executorch/backends/cortex_m/passes:passes_utils",
         "//executorch/backends/cortex_m/quantizer:quantization_configs",
+        "//executorch/exir:_warnings",
     ],
 )
 

--- a/backends/cortex_m/ops/cortex_m_ops_common.h
+++ b/backends/cortex_m/ops/cortex_m_ops_common.h
@@ -14,6 +14,7 @@
 
 #include <executorch/kernels/portable/cpu/util/elementwise_util.h>
 #include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 #include <executorch/runtime/platform/assert.h>
 
 #include <cinttypes>
@@ -35,6 +36,11 @@ using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
 // 16-byte alignment for MVE vector operations.
 constexpr size_t kCortexMMveAlignment = 16;
+
+enum class ActivationLayout {
+  NCHWLogical,
+  NHWCLogical,
+};
 
 // Basic tensor type / layout validation and dimension order checking
 inline void validate_cmsis_nn_tensor_requirements(
@@ -143,23 +149,49 @@ inline bool is_channels_last_tensor(const Tensor& tensor) {
   return tensor.dim_order() == channels_last_order;
 }
 
+// A channel broadcast the elementwise kernels can serve as a flat repeat: one
+// operand holds a single value per channel, and that channel axis is innermost
+// in the larger operand's physical layout.
 inline bool is_channel_broadcast(const Tensor& tensor1, const Tensor& tensor2) {
-  if (tensor1.dim() != tensor2.dim()) {
+  if (tensor1.dim() != tensor2.dim() || tensor1.dim() != 4) {
+    return false;
+  }
+  if (tensor1.numel() == tensor2.numel()) {
     return false;
   }
 
-  if (tensor1.dim() != 4) {
+  const bool first_is_larger = tensor1.numel() > tensor2.numel();
+  const Tensor& larger = first_is_larger ? tensor1 : tensor2;
+  const Tensor& smaller = first_is_larger ? tensor2 : tensor1;
+  if (smaller.numel() == 0) {
     return false;
   }
 
-  if (tensor1.size(1) != tensor2.size(1)) {
-    return false;
+  int64_t channel_axis = -1;
+  for (int64_t i = 0; i < smaller.dim(); ++i) {
+    if (smaller.size(i) != 1) {
+      if (channel_axis != -1) {
+        return false;
+      }
+      channel_axis = i;
+    }
   }
-
-  const bool tensor1_channels_only = tensor1.numel() == tensor1.size(1);
-  const bool tensor2_channels_only = tensor2.numel() == tensor2.size(1);
-
-  return tensor1_channels_only || tensor2_channels_only;
+  if (channel_axis != -1) {
+    if (larger.size(channel_axis) != smaller.size(channel_axis)) {
+      return false;
+    }
+    bool found_channel_axis = false;
+    for (const auto dim : larger.dim_order()) {
+      if (static_cast<int64_t>(dim) == channel_axis) {
+        found_channel_axis = true;
+      } else if (found_channel_axis && larger.size(dim) != 1) {
+        return false;
+      }
+    }
+  }
+  // The smaller tensor is now either scalar or has one extent that exactly
+  // matches the larger tensor, so its flat run tiles the larger tensor.
+  return true;
 }
 
 inline bool check_int32_within_range(
@@ -203,7 +235,7 @@ inline bool prepare_cmsis_pool2d_config(
     int64_t activation_min,
     int64_t activation_max,
     CmsisPool2DConfig& config,
-    bool require_channels_last = true,
+    ActivationLayout layout,
     bool allow_ceil_mode = false) {
   if (input.dim() != 4 || output.dim() != 4) {
     ET_LOG(Error, "%s: tensors must be 4-D", op_name);
@@ -218,7 +250,9 @@ inline bool prepare_cmsis_pool2d_config(
     return false;
   }
 
-  if (input.size(0) != output.size(0) || input.size(1) != output.size(1)) {
+  const int64_t channel_dim = layout == ActivationLayout::NHWCLogical ? 3 : 1;
+  if (input.size(0) != output.size(0) ||
+      input.size(channel_dim) != output.size(channel_dim)) {
     ET_LOG(
         Error,
         "%s: batch and channel dimensions must match between input and output",
@@ -227,13 +261,21 @@ inline bool prepare_cmsis_pool2d_config(
     return false;
   }
 
-  if (require_channels_last) {
-    if (!is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
-      ET_LOG(
-          Error, "%s: tensors must use channels_last dimension order", op_name);
+  if (layout == ActivationLayout::NHWCLogical) {
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            output.dim_order().data(), output.dim_order().size())) {
+      ET_LOG(Error, "%s: tensors must use contiguous dimension order", op_name);
       context.fail(Error::InvalidArgument);
       return false;
     }
+  } else if (
+      !is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
+    ET_LOG(
+        Error, "%s: tensors must use channels_last dimension order", op_name);
+    context.fail(Error::InvalidArgument);
+    return false;
   }
 
   auto check_tuple_len = [&](const Int64ArrayRef& arr,
@@ -312,19 +354,29 @@ inline bool prepare_cmsis_pool2d_config(
     return false;
   }
 
+  const int64_t height_dim = layout == ActivationLayout::NHWCLogical ? 1 : 2;
+  const int64_t width_dim = layout == ActivationLayout::NHWCLogical ? 2 : 3;
   int32_t batch, channels, input_h, input_w, output_h, output_w;
   if (!check_int32_within_range(
           context, op_name, input.size(0), "input batch", batch) ||
       !check_int32_within_range(
-          context, op_name, input.size(1), "input channels", channels) ||
+          context,
+          op_name,
+          input.size(channel_dim),
+          "input channels",
+          channels) ||
       !check_int32_within_range(
-          context, op_name, input.size(2), "input height", input_h) ||
+          context, op_name, input.size(height_dim), "input height", input_h) ||
       !check_int32_within_range(
-          context, op_name, input.size(3), "input width", input_w) ||
+          context, op_name, input.size(width_dim), "input width", input_w) ||
       !check_int32_within_range(
-          context, op_name, output.size(2), "output height", output_h) ||
+          context,
+          op_name,
+          output.size(height_dim),
+          "output height",
+          output_h) ||
       !check_int32_within_range(
-          context, op_name, output.size(3), "output width", output_w)) {
+          context, op_name, output.size(width_dim), "output width", output_w)) {
     return false;
   }
 

--- a/backends/cortex_m/ops/op_pad.cpp
+++ b/backends/cortex_m/ops/op_pad.cpp
@@ -17,21 +17,19 @@ namespace {
 
 constexpr size_t kMaxSupportedDims = 4;
 
-} // namespace
-
-// cppcheck-suppress unusedFunction
-Tensor& pad_out(
+Tensor& pad_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Int64ArrayRef pre_pad,
     const Int64ArrayRef post_pad,
     int64_t pad_value,
+    bool require_contiguous,
     Tensor& out) {
   if (input.scalar_type() != ScalarType::Char ||
       out.scalar_type() != ScalarType::Char) {
     ET_LOG(
         Error,
-        "pad_out: only int8 tensors are supported (input=%d, out=%d)",
+        "cortex_m::pad: only int8 tensors are supported (input=%d, out=%d)",
         static_cast<int>(input.scalar_type()),
         static_cast<int>(out.scalar_type()));
     context.fail(Error::InvalidArgument);
@@ -42,22 +40,48 @@ Tensor& pad_out(
   if (rank == 0 || rank > kMaxSupportedDims) {
     ET_LOG(
         Error,
-        "pad_out: expected tensor rank in [1, %zu], got %zu",
+        "cortex_m::pad: expected tensor rank in [1, %zu], got %zu",
         kMaxSupportedDims,
         rank);
     context.fail(Error::InvalidArgument);
     return out;
+  }
+  if (pre_pad.size() != kMaxSupportedDims ||
+      post_pad.size() != kMaxSupportedDims) {
+    ET_LOG(Error, "cortex_m::pad: pre_pad and post_pad must have length 4");
+    context.fail(Error::InvalidArgument);
+    return out;
+  }
+
+  if (require_contiguous) {
+    // This entry point infers nothing: it requires the dim order to say the
+    // tensor is contiguous, and then indexes the padding by logical axis.
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            out.dim_order().data(), out.dim_order().size())) {
+      ET_LOG(
+          Error,
+          "cortex_m::pad_contiguous: input and output must use contiguous dim order");
+      context.fail(Error::InvalidArgument);
+      return out;
+    }
   }
 
   // Permute logical sizes to physical memory order.
   // Padding is already in physical order from the AOT pass.
   constexpr size_t kNhwcDimOrder[] = {0, 2, 3, 1};
   const size_t offset = kMaxSupportedDims - rank;
-  const bool nhwc = is_channels_last_tensor(input);
+  // Only the legacy entry point infers the layout. Its predicate is tolerant on
+  // purpose: the tolerance short-circuits before the dim order is consulted,
+  // which is what keeps it agreeing with the AOT pass for shapes whose
+  // serialized dim order cannot name the channel axis.
+  const bool legacy_channels_last =
+      !require_contiguous && is_channels_last_tensor(input);
 
   int32_t dims[kMaxSupportedDims] = {1, 1, 1, 1};
   for (size_t i = 0; i < rank; ++i) {
-    const size_t src = nhwc ? kNhwcDimOrder[offset + i] : i;
+    const size_t src = legacy_channels_last ? kNhwcDimOrder[offset + i] : i;
     dims[offset + i] = static_cast<int32_t>(input.size(src));
   }
 
@@ -87,13 +111,51 @@ Tensor& pad_out(
   if (status != ARM_CMSIS_NN_SUCCESS) {
     ET_LOG(
         Error,
-        "pad_out: arm_pad_s8 failed with status [%d]",
+        "cortex_m::pad: arm_pad_s8 failed with status [%d]",
         static_cast<int>(status));
     context.fail(Error::Internal);
     return out;
   }
 
   return out;
+}
+
+} // namespace
+
+// cppcheck-suppress unusedFunction
+Tensor& pad_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef pre_pad,
+    const Int64ArrayRef post_pad,
+    int64_t pad_value,
+    Tensor& out) {
+  return pad_out_impl(
+      context,
+      input,
+      pre_pad,
+      post_pad,
+      pad_value,
+      /*require_contiguous=*/false,
+      out);
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& pad_contiguous_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef pre_pad,
+    const Int64ArrayRef post_pad,
+    int64_t pad_value,
+    Tensor& out) {
+  return pad_out_impl(
+      context,
+      input,
+      pre_pad,
+      post_pad,
+      pad_value,
+      /*require_contiguous=*/true,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/op_quantized_add.cpp
+++ b/backends/cortex_m/ops/op_quantized_add.cpp
@@ -13,6 +13,12 @@
 
 namespace cortex_m {
 namespace native {
+namespace {
+
+constexpr int32_t kScalarBroadcastBlockSize = 32;
+
+} // namespace
+
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
 // cppcheck-suppress unusedFunction
@@ -101,6 +107,7 @@ Tensor& quantized_add_out(
   // addition. To preserve precision when rescaling the inputs, they are first
   // upscaled as much as possible, Hence the left_shift parameter required here.
 
+  int8_t scalar_broadcast_buffer[kScalarBroadcastBlockSize];
   int32_t adds_per_loop = 0;
   if (channel_broadcast) {
     if (input1_int8.numel() < input2_int8.numel()) {
@@ -109,16 +116,23 @@ Tensor& quantized_add_out(
       std::swap<int>(input1_shift_val, input2_shift_val);
       std::swap<int8_t*>(input1_ptr, input2_ptr);
     }
-    // The broadcast operand holds one value per channel and channels are
-    // contiguous, so its element count is the repeat length.
     adds_per_loop = static_cast<int32_t>(
         std::min(input1_int8.numel(), input2_int8.numel()));
+    if (adds_per_loop == 1) {
+      // CMSIS-NN has no scalar-broadcast entry point. A small repeated tile
+      // preserves its quantized arithmetic without one function call per item.
+      std::fill_n(
+          scalar_broadcast_buffer, kScalarBroadcastBlockSize, input2_ptr[0]);
+      input2_ptr = scalar_broadcast_buffer;
+      adds_per_loop = kScalarBroadcastBlockSize;
+    }
   } else {
     adds_per_loop = out.numel();
   }
 
-  for (int32_t broadcast_offset = 0; broadcast_offset < out.numel();
-       broadcast_offset += adds_per_loop) {
+  for (int64_t broadcast_offset = 0; broadcast_offset < out.numel();) {
+    const int32_t block_size = static_cast<int32_t>(
+        std::min<int64_t>(adds_per_loop, out.numel() - broadcast_offset));
     // Call CMSIS-NN kernel with precomputed parameters
     arm_cmsis_nn_status status = arm_elementwise_add_s8(
         input1_ptr + broadcast_offset,
@@ -136,7 +150,7 @@ Tensor& quantized_add_out(
         output_shift_val,
         act_min,
         act_max,
-        adds_per_loop);
+        block_size);
 
     if (status != ARM_CMSIS_NN_SUCCESS) {
       ET_LOG(
@@ -147,6 +161,7 @@ Tensor& quantized_add_out(
       context.fail(Error::Internal); // Fail the execution context
       return out;
     }
+    broadcast_offset += block_size;
   }
   ET_LOG(
       Debug,

--- a/backends/cortex_m/ops/op_quantized_add.cpp
+++ b/backends/cortex_m/ops/op_quantized_add.cpp
@@ -9,6 +9,8 @@
 
 #include "cortex_m_ops_common.h"
 
+#include <algorithm>
+
 namespace cortex_m {
 namespace native {
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
@@ -30,15 +32,21 @@ Tensor& quantized_add_out(
     const int64_t activation_min,
     const int64_t activation_max,
     Tensor& out) {
-  // Validate tensor types and dim order
   bool channel_broadcast = is_channel_broadcast(input1_int8, input2_int8);
   validate_cmsis_nn_tensor_requirements(
       input1_int8,
       input2_int8,
       out,
       ScalarType::Char,
-      /*require_channels_last=*/channel_broadcast,
+      /*require_channels_last=*/false,
       /*require_same_sizes=*/!channel_broadcast);
+  if (channel_broadcast) {
+    const Tensor& full_input =
+        input1_int8.numel() > input2_int8.numel() ? input1_int8 : input2_int8;
+    ET_CHECK_MSG(
+        out.sizes() == full_input.sizes(),
+        "quantized_add_out: output must have the broadcast result shape");
+  }
 
   // Validate quantization parameters
   validate_quantization_params(
@@ -101,7 +109,10 @@ Tensor& quantized_add_out(
       std::swap<int>(input1_shift_val, input2_shift_val);
       std::swap<int8_t*>(input1_ptr, input2_ptr);
     }
-    adds_per_loop = input1_int8.size(1);
+    // The broadcast operand holds one value per channel and channels are
+    // contiguous, so its element count is the repeat length.
+    adds_per_loop = static_cast<int32_t>(
+        std::min(input1_int8.numel(), input2_int8.numel()));
   } else {
     adds_per_loop = out.numel();
   }

--- a/backends/cortex_m/ops/op_quantized_add.cpp
+++ b/backends/cortex_m/ops/op_quantized_add.cpp
@@ -11,14 +11,10 @@
 
 #include <algorithm>
 
+#include "arm_nnsupportfunctions.h"
+
 namespace cortex_m {
 namespace native {
-namespace {
-
-constexpr int32_t kScalarBroadcastBlockSize = 32;
-
-} // namespace
-
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
 // cppcheck-suppress unusedFunction
@@ -107,7 +103,6 @@ Tensor& quantized_add_out(
   // addition. To preserve precision when rescaling the inputs, they are first
   // upscaled as much as possible, Hence the left_shift parameter required here.
 
-  int8_t scalar_broadcast_buffer[kScalarBroadcastBlockSize];
   int32_t adds_per_loop = 0;
   if (channel_broadcast) {
     if (input1_int8.numel() < input2_int8.numel()) {
@@ -119,20 +114,31 @@ Tensor& quantized_add_out(
     adds_per_loop = static_cast<int32_t>(
         std::min(input1_int8.numel(), input2_int8.numel()));
     if (adds_per_loop == 1) {
-      // CMSIS-NN has no scalar-broadcast entry point. A small repeated tile
-      // preserves its quantized arithmetic without one function call per item.
-      std::fill_n(
-          scalar_broadcast_buffer, kScalarBroadcastBlockSize, input2_ptr[0]);
-      input2_ptr = scalar_broadcast_buffer;
-      adds_per_loop = kScalarBroadcastBlockSize;
+      // CMSIS-NN's add API only accepts equal-length vectors. Follow its
+      // shape-aware min/max kernels by handling scalar broadcast directly.
+      const int32_t input2 = arm_nn_requantize(
+          (static_cast<int32_t>(input2_ptr[0]) - zp2) << left_shift,
+          input2_mult,
+          input2_shift_val);
+      int8_t* output = out.mutable_data_ptr<int8_t>();
+      for (int64_t i = 0; i < out.numel(); ++i) {
+        int32_t input1 = (static_cast<int32_t>(input1_ptr[i]) - zp1)
+            << left_shift;
+        input1 = arm_nn_requantize(input1, input1_mult, input1_shift_val);
+        int32_t sum =
+            arm_nn_requantize(input1 + input2, output_mult, output_shift_val) +
+            out_zp;
+        output[i] =
+            static_cast<int8_t>(std::max(act_min, std::min(act_max, sum)));
+      }
+      return out;
     }
   } else {
     adds_per_loop = out.numel();
   }
 
-  for (int64_t broadcast_offset = 0; broadcast_offset < out.numel();) {
-    const int32_t block_size = static_cast<int32_t>(
-        std::min<int64_t>(adds_per_loop, out.numel() - broadcast_offset));
+  for (int32_t broadcast_offset = 0; broadcast_offset < out.numel();
+       broadcast_offset += adds_per_loop) {
     // Call CMSIS-NN kernel with precomputed parameters
     arm_cmsis_nn_status status = arm_elementwise_add_s8(
         input1_ptr + broadcast_offset,
@@ -150,7 +156,7 @@ Tensor& quantized_add_out(
         output_shift_val,
         act_min,
         act_max,
-        block_size);
+        adds_per_loop);
 
     if (status != ARM_CMSIS_NN_SUCCESS) {
       ET_LOG(
@@ -161,7 +167,6 @@ Tensor& quantized_add_out(
       context.fail(Error::Internal); // Fail the execution context
       return out;
     }
-    broadcast_offset += block_size;
   }
   ET_LOG(
       Debug,

--- a/backends/cortex_m/ops/op_quantized_add.cpp
+++ b/backends/cortex_m/ops/op_quantized_add.cpp
@@ -11,8 +11,6 @@
 
 #include <algorithm>
 
-#include "arm_nnsupportfunctions.h"
-
 namespace cortex_m {
 namespace native {
 using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
@@ -111,28 +109,10 @@ Tensor& quantized_add_out(
       std::swap<int>(input1_shift_val, input2_shift_val);
       std::swap<int8_t*>(input1_ptr, input2_ptr);
     }
+    // The broadcast operand holds one value per channel and channels are
+    // contiguous, so its element count is the repeat length.
     adds_per_loop = static_cast<int32_t>(
         std::min(input1_int8.numel(), input2_int8.numel()));
-    if (adds_per_loop == 1) {
-      // CMSIS-NN's add API only accepts equal-length vectors. Follow its
-      // shape-aware min/max kernels by handling scalar broadcast directly.
-      const int32_t input2 = arm_nn_requantize(
-          (static_cast<int32_t>(input2_ptr[0]) - zp2) << left_shift,
-          input2_mult,
-          input2_shift_val);
-      int8_t* output = out.mutable_data_ptr<int8_t>();
-      for (int64_t i = 0; i < out.numel(); ++i) {
-        int32_t input1 = (static_cast<int32_t>(input1_ptr[i]) - zp1)
-            << left_shift;
-        input1 = arm_nn_requantize(input1, input1_mult, input1_shift_val);
-        int32_t sum =
-            arm_nn_requantize(input1 + input2, output_mult, output_shift_val) +
-            out_zp;
-        output[i] =
-            static_cast<int8_t>(std::max(act_min, std::min(act_max, sum)));
-      }
-      return out;
-    }
   } else {
     adds_per_loop = out.numel();
   }

--- a/backends/cortex_m/ops/op_quantized_avg_pool2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_avg_pool2d.cpp
@@ -97,7 +97,7 @@ Tensor& quantized_avg_pool2d_out(
           activation_min,
           activation_max,
           pool_config,
-          true,
+          ActivationLayout::NCHWLogical,
           true)) {
     return out;
   }

--- a/backends/cortex_m/ops/op_quantized_max_pool2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_max_pool2d.cpp
@@ -37,7 +37,8 @@ Tensor& quantized_max_pool2d_out(
           ceil_mode,
           activation_min,
           activation_max,
-          pool_config)) {
+          pool_config,
+          ActivationLayout::NCHWLogical)) {
     return out;
   }
 

--- a/backends/cortex_m/ops/op_quantized_mul.cpp
+++ b/backends/cortex_m/ops/op_quantized_mul.cpp
@@ -7,6 +7,8 @@
 
 #include "cortex_m_ops_common.h"
 
+#include <algorithm>
+
 namespace cortex_m {
 namespace native {
 namespace {
@@ -29,16 +31,21 @@ Tensor& quantized_mul_out(
     const int64_t output_multiplier,
     const int64_t output_shift,
     Tensor& out) {
-  // Validate tensor types and quantization parameters
-
   bool channel_broadcast = is_channel_broadcast(input1_int8, input2_int8);
   validate_cmsis_nn_tensor_requirements(
       input1_int8,
       input2_int8,
       out,
       ScalarType::Char,
-      /*require_channels_last=*/channel_broadcast,
+      /*require_channels_last=*/false,
       /*require_same_sizes=*/!channel_broadcast);
+  if (channel_broadcast) {
+    const Tensor& full_input =
+        input1_int8.numel() > input2_int8.numel() ? input1_int8 : input2_int8;
+    ET_CHECK_MSG(
+        out.sizes() == full_input.sizes(),
+        "quantized_mul_out: output must have the broadcast result shape");
+  }
 
   const int32_t kIdentityMultiplier(/*value=*/1);
   const int32_t kZeroShift(/*value=*/0);
@@ -70,7 +77,10 @@ Tensor& quantized_mul_out(
       std::swap<int8_t*>(input1_ptr, input2_ptr);
     }
 
-    muls_per_loop = input1_int8.size(1);
+    // The broadcast operand holds one value per channel and channels are
+    // contiguous, so its element count is the repeat length.
+    muls_per_loop = static_cast<int32_t>(
+        std::min(input1_int8.numel(), input2_int8.numel()));
   } else {
     muls_per_loop = out.numel();
   }

--- a/backends/cortex_m/ops/op_quantized_mul.cpp
+++ b/backends/cortex_m/ops/op_quantized_mul.cpp
@@ -9,13 +9,14 @@
 
 #include <algorithm>
 
+#include "arm_nnsupportfunctions.h"
+
 namespace cortex_m {
 namespace native {
 namespace {
 
 constexpr int32_t kInt8ActivationMin = std::numeric_limits<int8_t>::min();
 constexpr int32_t kInt8ActivationMax = std::numeric_limits<int8_t>::max();
-constexpr int32_t kScalarBroadcastBlockSize = 32;
 
 } // namespace
 
@@ -70,7 +71,6 @@ Tensor& quantized_mul_out(
   const int32_t output_mult = static_cast<int32_t>(output_multiplier);
   const int32_t output_shift_val = static_cast<int32_t>(output_shift);
 
-  int8_t scalar_broadcast_buffer[kScalarBroadcastBlockSize];
   int32_t muls_per_loop = 0;
 
   if (channel_broadcast) {
@@ -82,12 +82,18 @@ Tensor& quantized_mul_out(
     muls_per_loop = static_cast<int32_t>(
         std::min(input1_int8.numel(), input2_int8.numel()));
     if (muls_per_loop == 1) {
-      // CMSIS-NN has no scalar-broadcast entry point. A small repeated tile
-      // preserves its quantized arithmetic without one function call per item.
-      std::fill_n(
-          scalar_broadcast_buffer, kScalarBroadcastBlockSize, input2_ptr[0]);
-      input2_ptr = scalar_broadcast_buffer;
-      muls_per_loop = kScalarBroadcastBlockSize;
+      // CMSIS-NN's mul API only accepts equal-length vectors. Follow its
+      // shape-aware min/max kernels by handling scalar broadcast directly.
+      const int32_t input2 = static_cast<int32_t>(input2_ptr[0]) - zp2;
+      int8_t* output = out.mutable_data_ptr<int8_t>();
+      for (int64_t i = 0; i < out.numel(); ++i) {
+        int32_t product = (static_cast<int32_t>(input1_ptr[i]) - zp1) * input2;
+        product =
+            arm_nn_requantize(product, output_mult, output_shift_val) + out_zp;
+        output[i] = static_cast<int8_t>(std::max(
+            kInt8ActivationMin, std::min(kInt8ActivationMax, product)));
+      }
+      return out;
     }
   } else {
     muls_per_loop = out.numel();
@@ -107,9 +113,8 @@ Tensor& quantized_mul_out(
   //    effective_scale = (scale_in1 * scale_in2 / scale_out)
   // Hence no input quantization params required here.
 
-  for (int64_t broadcast_offset = 0; broadcast_offset < out.numel();) {
-    const int32_t block_size = static_cast<int32_t>(
-        std::min<int64_t>(muls_per_loop, out.numel() - broadcast_offset));
+  for (int32_t broadcast_offset = 0; broadcast_offset < out.numel();
+       broadcast_offset += muls_per_loop) {
     // Call CMSIS-NN elementwise multiply kernel
     arm_cmsis_nn_status status = arm_elementwise_mul_s8(
         input1_ptr + broadcast_offset,
@@ -122,7 +127,7 @@ Tensor& quantized_mul_out(
         output_shift_val,
         kInt8ActivationMin,
         kInt8ActivationMax,
-        block_size);
+        muls_per_loop);
 
     if (status != ARM_CMSIS_NN_SUCCESS) {
       ET_LOG(
@@ -132,7 +137,6 @@ Tensor& quantized_mul_out(
       context.fail(Error::Internal);
       return out;
     }
-    broadcast_offset += block_size;
   }
   return out;
 }

--- a/backends/cortex_m/ops/op_quantized_mul.cpp
+++ b/backends/cortex_m/ops/op_quantized_mul.cpp
@@ -9,8 +9,6 @@
 
 #include <algorithm>
 
-#include "arm_nnsupportfunctions.h"
-
 namespace cortex_m {
 namespace native {
 namespace {
@@ -79,22 +77,10 @@ Tensor& quantized_mul_out(
       std::swap<int8_t*>(input1_ptr, input2_ptr);
     }
 
+    // The broadcast operand holds one value per channel and channels are
+    // contiguous, so its element count is the repeat length.
     muls_per_loop = static_cast<int32_t>(
         std::min(input1_int8.numel(), input2_int8.numel()));
-    if (muls_per_loop == 1) {
-      // CMSIS-NN's mul API only accepts equal-length vectors. Follow its
-      // shape-aware min/max kernels by handling scalar broadcast directly.
-      const int32_t input2 = static_cast<int32_t>(input2_ptr[0]) - zp2;
-      int8_t* output = out.mutable_data_ptr<int8_t>();
-      for (int64_t i = 0; i < out.numel(); ++i) {
-        int32_t product = (static_cast<int32_t>(input1_ptr[i]) - zp1) * input2;
-        product =
-            arm_nn_requantize(product, output_mult, output_shift_val) + out_zp;
-        output[i] = static_cast<int8_t>(std::max(
-            kInt8ActivationMin, std::min(kInt8ActivationMax, product)));
-      }
-      return out;
-    }
   } else {
     muls_per_loop = out.numel();
   }

--- a/backends/cortex_m/ops/op_quantized_mul.cpp
+++ b/backends/cortex_m/ops/op_quantized_mul.cpp
@@ -15,6 +15,7 @@ namespace {
 
 constexpr int32_t kInt8ActivationMin = std::numeric_limits<int8_t>::min();
 constexpr int32_t kInt8ActivationMax = std::numeric_limits<int8_t>::max();
+constexpr int32_t kScalarBroadcastBlockSize = 32;
 
 } // namespace
 
@@ -69,6 +70,7 @@ Tensor& quantized_mul_out(
   const int32_t output_mult = static_cast<int32_t>(output_multiplier);
   const int32_t output_shift_val = static_cast<int32_t>(output_shift);
 
+  int8_t scalar_broadcast_buffer[kScalarBroadcastBlockSize];
   int32_t muls_per_loop = 0;
 
   if (channel_broadcast) {
@@ -77,10 +79,16 @@ Tensor& quantized_mul_out(
       std::swap<int8_t*>(input1_ptr, input2_ptr);
     }
 
-    // The broadcast operand holds one value per channel and channels are
-    // contiguous, so its element count is the repeat length.
     muls_per_loop = static_cast<int32_t>(
         std::min(input1_int8.numel(), input2_int8.numel()));
+    if (muls_per_loop == 1) {
+      // CMSIS-NN has no scalar-broadcast entry point. A small repeated tile
+      // preserves its quantized arithmetic without one function call per item.
+      std::fill_n(
+          scalar_broadcast_buffer, kScalarBroadcastBlockSize, input2_ptr[0]);
+      input2_ptr = scalar_broadcast_buffer;
+      muls_per_loop = kScalarBroadcastBlockSize;
+    }
   } else {
     muls_per_loop = out.numel();
   }
@@ -99,8 +107,9 @@ Tensor& quantized_mul_out(
   //    effective_scale = (scale_in1 * scale_in2 / scale_out)
   // Hence no input quantization params required here.
 
-  for (int32_t broadcast_offset = 0; broadcast_offset < out.numel();
-       broadcast_offset += muls_per_loop) {
+  for (int64_t broadcast_offset = 0; broadcast_offset < out.numel();) {
+    const int32_t block_size = static_cast<int32_t>(
+        std::min<int64_t>(muls_per_loop, out.numel() - broadcast_offset));
     // Call CMSIS-NN elementwise multiply kernel
     arm_cmsis_nn_status status = arm_elementwise_mul_s8(
         input1_ptr + broadcast_offset,
@@ -113,7 +122,7 @@ Tensor& quantized_mul_out(
         output_shift_val,
         kInt8ActivationMin,
         kInt8ActivationMax,
-        muls_per_loop);
+        block_size);
 
     if (status != ARM_CMSIS_NN_SUCCESS) {
       ET_LOG(
@@ -123,6 +132,7 @@ Tensor& quantized_mul_out(
       context.fail(Error::Internal);
       return out;
     }
+    broadcast_offset += block_size;
   }
   return out;
 }

--- a/backends/cortex_m/ops/operators.py
+++ b/backends/cortex_m/ops/operators.py
@@ -13,8 +13,8 @@ import torch
 import torch.nn.functional as F
 from executorch.backends.cortex_m.passes.passes_utils import (
     dequantize_per_tensor_cmsis,
-    is_channel_broadcast,
     is_channels_last,
+    is_flat_channel_broadcast,
     quantize_per_tensor_cmsis,
     requantize_cmsis,
     SHIFT_INT8,
@@ -23,10 +23,23 @@ from executorch.backends.cortex_m.quantizer.quantization_configs import (
     CMSIS_SOFTMAX_SCALE,
     CMSIS_SOFTMAX_ZERO_POINT,
 )
+from executorch.exir._warnings import experimental
 from executorch.exir.dialects._ops import ops as exir_ops
 
 # To provide the implementation of the operators
 from torch.library import impl, Library, register_fake
+
+# The explicit-layout operators are one half of a migration: they exist
+# alongside the dim-order operators they will eventually replace, and their
+# names say so. Once the dim-order half retires the distinguishing suffix
+# stops earning its keep, so mark these experimental rather than let them
+# inherit the stable-by-default state of an unannotated API and lose the
+# option of renaming. See docs/source/api-life-cycle.md.
+_EXPLICIT_LAYOUT_EXPERIMENTAL = (
+    "The explicit-layout Cortex-M operators are experimental and may be "
+    "renamed or removed without notice while the dim-order operators they "
+    "replace are still supported."
+)
 
 # New operator library with a custom namespace to allow fusion etc.
 lib = Library("cortex_m", "DEF")
@@ -154,7 +167,7 @@ def quantized_add_meta(
     activation_min: int,
     activation_max: int,
 ) -> torch.Tensor:
-    assert self.shape == other.shape or is_channel_broadcast(self, other), (
+    assert self.shape == other.shape or is_flat_channel_broadcast(self, other), (
         "Cortex-M quantized_add: broadcasting is not yet supported except for channel dim — "
         f"got self.shape={self.shape}, other.shape={other.shape}"
     )
@@ -181,7 +194,7 @@ def quantized_add_impl(
     activation_min: int,
     activation_max: int,
 ) -> torch.Tensor:
-    assert self.shape == other.shape or is_channel_broadcast(self, other), (
+    assert self.shape == other.shape or is_flat_channel_broadcast(self, other), (
         "Cortex-M quantized_add: broadcasting is not yet supported except for channel dim — "
         f"got self.shape={self.shape}, other.shape={other.shape}"
     )
@@ -199,9 +212,6 @@ def quantized_add_impl(
     return result
 
 
-# ===================================================================
-# QUANTIZED MUL OPERATION DEFINITION
-# ===================================================================
 lib.define(
     "quantized_mul("
     "Tensor self, int self_zero_point, "
@@ -228,7 +238,7 @@ def quantized_mul_meta(
     output_shift: int,
 ) -> torch.Tensor:
     # Broadcast to output shape
-    assert self.shape == other.shape or is_channel_broadcast(self, other), (
+    assert self.shape == other.shape or is_flat_channel_broadcast(self, other), (
         "Cortex-M quantized_mul: broadcasting is not yet supported except for channel dim — "
         f"got self.shape={self.shape}, other.shape={other.shape}"
     )
@@ -252,7 +262,7 @@ def quantized_mul_impl(
     # CMSIS-NN kernel multiplies raw int8 tensors (after zero-point offset) and
     # only uses the output multiplier/shift for rescaling. Mirror that here to
     # keep the composite implementation numerically aligned with the backend.
-    assert self.shape == other.shape or is_channel_broadcast(self, other), (
+    assert self.shape == other.shape or is_flat_channel_broadcast(self, other), (
         "Cortex-M quantized_mul: broadcasting is not yet supported except for channel dim — "
         f"got self.shape={self.shape}, other.shape={other.shape}"
     )
@@ -264,9 +274,6 @@ def quantized_mul_impl(
     return result
 
 
-# ===================================================================
-# QUANTIZED DIV OPERATION DEFINITION
-# ===================================================================
 lib.define(
     "quantized_div("
     "Tensor self, int self_zero_point, "
@@ -669,6 +676,13 @@ lib.define(
     "pad.out(Tensor input, int[] pre_pad, int[] post_pad, int pad_value, "
     "*, Tensor(a!) out) -> Tensor(a!)"
 )
+lib.define(
+    "pad_contiguous(Tensor input, int[] pre_pad, int[] post_pad, int pad_value) -> Tensor"
+)
+lib.define(
+    "pad_contiguous.out(Tensor input, int[] pre_pad, int[] post_pad, int pad_value, "
+    "*, Tensor(a!) out) -> Tensor(a!)"
+)
 
 
 _NHWC_INV_ORDER = [0, 3, 1, 2]
@@ -689,6 +703,10 @@ def pad_meta(
     pad_value: int,
 ) -> torch.Tensor:
     rank = input.dim()
+    if rank == 0 or rank > 4:
+        raise RuntimeError(f"cortex_m.pad expects a rank in [1, 4], got {rank}")
+    if len(pre_pad) != 4 or len(post_pad) != 4:
+        raise RuntimeError("cortex_m.pad expects four padding values per side")
     offset = 4 - rank
     logical_pre = _pad_to_logical_order(pre_pad, input)
     logical_post = _pad_to_logical_order(post_pad, input)
@@ -710,6 +728,10 @@ def pad_impl(
     pad_value: int,
 ) -> torch.Tensor:
     rank = input.dim()
+    if rank == 0 or rank > 4:
+        raise RuntimeError(f"cortex_m.pad expects a rank in [1, 4], got {rank}")
+    if len(pre_pad) != 4 or len(post_pad) != 4:
+        raise RuntimeError("cortex_m.pad expects four padding values per side")
     offset = 4 - rank
     logical_pre = _pad_to_logical_order(pre_pad, input)
     logical_post = _pad_to_logical_order(post_pad, input)
@@ -717,6 +739,55 @@ def pad_impl(
     padding = []
     for i in reversed(range(rank)):
         padding.extend([logical_pre[offset + i], logical_post[offset + i]])
+    return F.pad(input, padding, mode="constant", value=pad_value)
+
+
+@register_fake("cortex_m::pad_contiguous")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def pad_contiguous_meta(
+    input: torch.Tensor,
+    pre_pad: list[int],
+    post_pad: list[int],
+    pad_value: int,
+) -> torch.Tensor:
+    del pad_value
+    rank = input.dim()
+    if rank == 0 or rank > 4:
+        raise RuntimeError(
+            f"cortex_m.pad_contiguous expects a rank in [1, 4], got {rank}"
+        )
+    if len(pre_pad) != 4 or len(post_pad) != 4:
+        raise RuntimeError(
+            "cortex_m.pad_contiguous expects four padding values per side"
+        )
+    offset = 4 - rank
+    output_shape = [
+        input.shape[dim] + pre_pad[offset + dim] + post_pad[offset + dim]
+        for dim in range(rank)
+    ]
+    return torch.empty(output_shape, dtype=input.dtype, device=input.device)
+
+
+@impl(lib, "pad_contiguous", "CompositeExplicitAutograd")  # type: ignore[misc]
+def pad_contiguous_impl(
+    input: torch.Tensor,
+    pre_pad: list[int],
+    post_pad: list[int],
+    pad_value: int,
+) -> torch.Tensor:
+    rank = input.dim()
+    if rank == 0 or rank > 4:
+        raise RuntimeError(
+            f"cortex_m.pad_contiguous expects a rank in [1, 4], got {rank}"
+        )
+    if len(pre_pad) != 4 or len(post_pad) != 4:
+        raise RuntimeError(
+            "cortex_m.pad_contiguous expects four padding values per side"
+        )
+    offset = 4 - rank
+    padding = []
+    for dim in reversed(range(rank)):
+        padding.extend([pre_pad[offset + dim], post_pad[offset + dim]])
     return F.pad(input, padding, mode="constant", value=pad_value)
 
 
@@ -915,6 +986,92 @@ def quantized_conv2d_impl(
     return result.to(torch.int8, memory_format=torch.channels_last)
 
 
+lib.define(
+    "quantized_conv2d_nhwc("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] dilation, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch) -> Tensor"
+)
+lib.define(
+    "quantized_conv2d_nhwc.out("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] dilation, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch, "
+    "*, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+@register_fake("cortex_m::quantized_conv2d_nhwc")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def quantized_conv2d_nhwc_meta(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_conv2d_meta(
+        input.permute(0, 3, 1, 2),
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@impl(lib, "quantized_conv2d_nhwc", "CompositeExplicitAutograd")  # type: ignore[misc]
+def quantized_conv2d_nhwc_impl(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_conv2d_impl(
+        input.permute(0, 3, 1, 2).contiguous(),
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
 # ===================================================================
 # QUANTIZED DEPTHWISE CONV2D OPERATION DEFINITION
 # ===================================================================
@@ -1060,6 +1217,96 @@ def quantized_depthwise_conv2d_impl(
     result = torch.clamp(result, activation_min, activation_max)
 
     return result.to(torch.int8, memory_format=torch.channels_last)
+
+
+lib.define(
+    "quantized_depthwise_conv2d_nhwc("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] dilation, int depth_multiplier, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch) -> Tensor"
+)
+lib.define(
+    "quantized_depthwise_conv2d_nhwc.out("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] dilation, int depth_multiplier, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch, "
+    "*, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+@register_fake("cortex_m::quantized_depthwise_conv2d_nhwc")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def quantized_depthwise_conv2d_nhwc_meta(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    depth_multiplier: int,
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_depthwise_conv2d_meta(
+        input.permute(0, 3, 1, 2),
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        depth_multiplier,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@impl(lib, "quantized_depthwise_conv2d_nhwc", "CompositeExplicitAutograd")  # type: ignore[misc]
+def quantized_depthwise_conv2d_nhwc_impl(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    depth_multiplier: int,
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_depthwise_conv2d_impl(
+        input.permute(0, 3, 1, 2).contiguous(),
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        depth_multiplier,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
 
 
 # ===================================================================
@@ -1270,6 +1517,101 @@ def quantized_transpose_conv2d_impl(
     return result.to(torch.int8).to(memory_format=torch.channels_last)
 
 
+lib.define(
+    "quantized_transpose_conv2d_nhwc("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] output_padding, int[] dilation, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch, "
+    "Tensor output_scratch) -> Tensor"
+)
+lib.define(
+    "quantized_transpose_conv2d_nhwc.out("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] output_padding, int[] dilation, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch, "
+    "Tensor output_scratch, *, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+@register_fake("cortex_m::quantized_transpose_conv2d_nhwc")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def quantized_transpose_conv2d_nhwc_meta(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    output_padding: Sequence[int],
+    dilation: Sequence[int],
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+    output_scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_transpose_conv2d_meta(
+        input.permute(0, 3, 1, 2),
+        weight,
+        bias,
+        stride,
+        padding,
+        output_padding,
+        dilation,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+        output_scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@impl(lib, "quantized_transpose_conv2d_nhwc", "CompositeExplicitAutograd")  # type: ignore[misc]
+def quantized_transpose_conv2d_nhwc_impl(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    output_padding: Sequence[int],
+    dilation: Sequence[int],
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+    output_scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_transpose_conv2d_impl(
+        input.permute(0, 3, 1, 2).contiguous(),
+        weight,
+        bias,
+        stride,
+        padding,
+        output_padding,
+        dilation,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+        output_scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
 # ===================================================================
 # QUANTIZED AVG_POOL2D OPERATION DEFINITION
 # ===================================================================
@@ -1363,6 +1705,73 @@ def quantized_avg_pool2d_impl(
     result = quantize_per_tensor_cmsis(result, zero_point, multiplier, shift)
     output = torch.clamp(result, -128, 127)
     return output.to(torch.int8)
+
+
+lib.define(
+    "quantized_avg_pool2d_nhwc("
+    "Tensor input, int[] kernel_size, int[] stride, int[] padding, "
+    "bool ceil_mode, int zero_point, int multiplier, int shift, "
+    "Tensor scratch) -> Tensor"
+)
+lib.define(
+    "quantized_avg_pool2d_nhwc.out("
+    "Tensor input, int[] kernel_size, int[] stride, int[] padding, "
+    "bool ceil_mode, int zero_point, int multiplier, int shift, "
+    "Tensor scratch, *, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+@register_fake("cortex_m::quantized_avg_pool2d_nhwc")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def quantized_avg_pool2d_nhwc_meta(
+    input: torch.Tensor,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    ceil_mode: bool,
+    zero_point: int,
+    multiplier: int,
+    shift: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_avg_pool2d_meta(
+        input.permute(0, 3, 1, 2),
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        zero_point,
+        multiplier,
+        shift,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@impl(lib, "quantized_avg_pool2d_nhwc", "CompositeExplicitAutograd")  # type: ignore[misc]
+def quantized_avg_pool2d_nhwc_impl(
+    input: torch.Tensor,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    ceil_mode: bool,
+    zero_point: int,
+    multiplier: int,
+    shift: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_avg_pool2d_impl(
+        input.permute(0, 3, 1, 2).contiguous(),
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        zero_point,
+        multiplier,
+        shift,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
 
 
 # ===================================================================
@@ -1520,3 +1929,75 @@ def quantized_max_pool2d_impl(
     )
     result = torch.clamp(result, activation_min, activation_max)
     return result.to(torch.int8).contiguous(memory_format=torch.channels_last)
+
+
+lib.define(
+    "quantized_max_pool2d_nhwc("
+    "Tensor input, int[] kernel_size, int[] stride, int[] padding, "
+    "int[] dilation, bool ceil_mode, int input_zero_point, "
+    "int output_zero_point, int activation_min, int activation_max) -> Tensor"
+)
+lib.define(
+    "quantized_max_pool2d_nhwc.out("
+    "Tensor input, int[] kernel_size, int[] stride, int[] padding, "
+    "int[] dilation, bool ceil_mode, int input_zero_point, "
+    "int output_zero_point, int activation_min, int activation_max, "
+    "*, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+@register_fake("cortex_m::quantized_max_pool2d_nhwc")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def quantized_max_pool2d_nhwc_meta(
+    input: torch.Tensor,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    ceil_mode: bool,
+    input_zero_point: int,
+    output_zero_point: int,
+    activation_min: int,
+    activation_max: int,
+) -> torch.Tensor:
+    nchw = quantized_max_pool2d_meta(
+        input.permute(0, 3, 1, 2),
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        input_zero_point,
+        output_zero_point,
+        activation_min,
+        activation_max,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@impl(lib, "quantized_max_pool2d_nhwc", "CompositeExplicitAutograd")  # type: ignore[misc]
+def quantized_max_pool2d_nhwc_impl(
+    input: torch.Tensor,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    ceil_mode: bool,
+    input_zero_point: int,
+    output_zero_point: int,
+    activation_min: int,
+    activation_max: int,
+) -> torch.Tensor:
+    nchw = quantized_max_pool2d_impl(
+        input.permute(0, 3, 1, 2).contiguous(),
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        input_zero_point,
+        output_zero_point,
+        activation_min,
+        activation_max,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()

--- a/backends/cortex_m/ops/operators.yaml
+++ b/backends/cortex_m/ops/operators.yaml
@@ -77,6 +77,12 @@
     - arg_meta: null
       kernel_name: cortex_m::pad_out
 
+- func: cortex_m::pad_contiguous.out(Tensor input, int[] pre_pad, int[] post_pad, int pad_value, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: cortex_m::pad_contiguous_out
+
 - func: cortex_m::quantized_conv2d.out(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, Tensor scratch, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:

--- a/backends/cortex_m/passes/passes_utils.py
+++ b/backends/cortex_m/passes/passes_utils.py
@@ -409,16 +409,14 @@ def to_physical_order(logical_pad: list[int], tensor: torch.Tensor) -> list[int]
     return [logical_pad[_NHWC_DIM_ORDER[i]] for i in range(4)]
 
 
-def is_channel_broadcast(tensor1: torch.Tensor, tensor2: torch.Tensor) -> bool:
-    """
-    Check if tensor1 is broadcasted to tensor2 along channel dimension.
-    Assumes tensor2 has shape [N, C, ...] and tensor1 has shape [N, 1, ...] or [1, C, ...].
-    """
-    if tensor1.dim() != tensor2.dim():
-        return False
-    if not is_channels_last(tensor1):
-        return False
-    if not is_channels_last(tensor2):
+def is_logical_channel_broadcast(tensor1: torch.Tensor, tensor2: torch.Tensor) -> bool:
+    """Check for a broadcast of one value per channel in logical NCHW."""
+    if (
+        tensor1.dim() != tensor2.dim()
+        or tensor1.dim() != 4
+        or tensor1.numel() == 0
+        or tensor2.numel() == 0
+    ):
         return False
 
     channel_match = tensor1.size(1) == tensor2.size(1)
@@ -426,3 +424,56 @@ def is_channel_broadcast(tensor1: torch.Tensor, tensor2: torch.Tensor) -> bool:
     tensor2_channels_only = tensor2.numel() == tensor2.size(1)
 
     return channel_match and (tensor1_channels_only or tensor2_channels_only)
+
+
+def is_channel_broadcast(tensor1: torch.Tensor, tensor2: torch.Tensor) -> bool:
+    """Check for a legacy channels-last channel broadcast."""
+    return (
+        is_logical_channel_broadcast(tensor1, tensor2)
+        and is_channels_last(tensor1)
+        and is_channels_last(tensor2)
+    )
+
+
+def is_flat_channel_broadcast(tensor1: torch.Tensor, tensor2: torch.Tensor) -> bool:
+    """Check that a broadcast is a flat repeat in memory, as the kernels need.
+
+    The kernels repeat the broadcast operand along the innermost axis: element
+    ``i`` of the result reads ``small[i % small.numel()]``. The operand itself is
+    a flat run whatever its dim order, since it has at most one non-unit extent.
+    What has to hold is that the *larger* operand carries that same axis
+    innermost in memory, and its dim order is what says so.
+
+    Both activation contracts satisfy this and disagree on which logical axis it
+    is -- legacy is a channels-last ``[N, C, H, W]``, explicit a contiguous
+    ``[N, H, W, C]`` -- so the axis is taken from the broadcast operand's own
+    non-unit extent rather than assumed. A genuinely contiguous ``[N, C, H, W]``
+    is refused: its innermost axis is W, and the flat repeat would stride across
+    the wrong elements.
+
+    An operand with no non-unit extent repeats a single value and is accepted
+    without consulting a dim order, which is the one case where the dim order
+    cannot identify the channel axis.
+    """
+    if tensor1.dim() != tensor2.dim() or tensor1.dim() != 4:
+        return False
+    if tensor1.numel() == tensor2.numel():
+        return False
+
+    larger, smaller = (
+        (tensor1, tensor2) if tensor1.numel() > tensor2.numel() else (tensor2, tensor1)
+    )
+    if smaller.numel() == 0:
+        return False
+    non_unit_dims = [dim for dim, size in enumerate(smaller.shape) if size != 1]
+    if len(non_unit_dims) > 1:
+        return False
+    if non_unit_dims:
+        channel_axis = non_unit_dims[0]
+        if larger.shape[channel_axis] != smaller.shape[channel_axis]:
+            return False
+        dim_order = larger.dim_order()
+        channel_position = dim_order.index(channel_axis)
+        if any(larger.shape[dim] != 1 for dim in dim_order[channel_position + 1 :]):
+            return False
+    return larger.numel() % smaller.numel() == 0

--- a/backends/cortex_m/passes/scratch_buffer_sizes.py
+++ b/backends/cortex_m/passes/scratch_buffer_sizes.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections.abc import Callable
+from functools import partial
 from typing import Any, cast
 
 import executorch.backends.cortex_m.ops.operators  # noqa
@@ -37,6 +38,7 @@ def _shape_from_node(node: torch.fx.Node) -> torch.Size:
 def _get_common_conv_buffer_size_inputs(
     conv_node: torch.fx.Node,
     *,
+    nhwc_logical: bool = False,
     stride_arg_idx: int = 3,
     padding_arg_idx: int = 4,
     dilation_arg_idx: int = 5,
@@ -54,13 +56,14 @@ def _get_common_conv_buffer_size_inputs(
     padding = cast(list[int], conv_node.args[padding_arg_idx])
     dilation = cast(list[int], conv_node.args[dilation_arg_idx])
 
-    # Input is NCHW (PyTorch); CMSIS-NN wants NHWC dims.
-    n, c_in, height, width = _shape_from_node(x)
-
     weight_shape = _shape_from_node(weight)
 
-    # Output is NCHW; convert to NHWC dims.
-    out_n, out_c, out_h, out_w = _shape_from_node(conv_node)
+    if nhwc_logical:
+        n, height, width, c_in = _shape_from_node(x)
+        out_n, out_h, out_w, out_c = _shape_from_node(conv_node)
+    else:
+        n, c_in, height, width = _shape_from_node(x)
+        out_n, out_c, out_h, out_w = _shape_from_node(conv_node)
 
     input_nhwc = [n, height, width, c_in]
     output_nhwc = [out_n, out_h, out_w, out_c]
@@ -81,6 +84,7 @@ def _get_common_conv_buffer_size_inputs(
 def cmsis_nn_conv_buffer_size(
     backend: cmsis_nn.Backend,
     conv_node: torch.fx.Node,
+    nhwc_logical: bool = False,
 ) -> list[int]:
     (
         input_nhwc,
@@ -89,7 +93,9 @@ def cmsis_nn_conv_buffer_size(
         stride_hw,
         padding_hw,
         dilation_hw,
-    ) = _get_common_conv_buffer_size_inputs(conv_node=conv_node)
+    ) = _get_common_conv_buffer_size_inputs(
+        conv_node=conv_node, nhwc_logical=nhwc_logical
+    )
     input_offset = cast(int, conv_node.args[6])
     output_offset = cast(int, conv_node.args[7])
     output_qmin = cast(int, conv_node.args[10])
@@ -122,6 +128,7 @@ def cmsis_nn_conv_buffer_size(
 def cmsis_nn_depthwise_conv_buffer_size(
     backend: cmsis_nn.Backend,
     conv_node: torch.fx.Node,
+    nhwc_logical: bool = False,
 ) -> list[int]:
     (
         input_nhwc,
@@ -130,7 +137,9 @@ def cmsis_nn_depthwise_conv_buffer_size(
         stride_hw,
         padding_hw,
         dilation_hw,
-    ) = _get_common_conv_buffer_size_inputs(conv_node=conv_node)
+    ) = _get_common_conv_buffer_size_inputs(
+        conv_node=conv_node, nhwc_logical=nhwc_logical
+    )
     depth_multiplier = cast(int, conv_node.args[6])
     input_offset = cast(int, conv_node.args[7])
     output_offset = cast(int, conv_node.args[8])
@@ -185,6 +194,7 @@ def cmsis_nn_batch_matmul_buffer_size(
 def cmsis_nn_transpose_conv_buffer_size(
     backend: cmsis_nn.Backend,
     conv_node: torch.fx.Node,
+    nhwc_logical: bool = False,
 ) -> list[int]:
     (
         input_nhwc,
@@ -195,6 +205,7 @@ def cmsis_nn_transpose_conv_buffer_size(
         dilation_hw,
     ) = _get_common_conv_buffer_size_inputs(
         conv_node=conv_node,
+        nhwc_logical=nhwc_logical,
         stride_arg_idx=3,
         padding_arg_idx=4,
         dilation_arg_idx=6,
@@ -248,13 +259,16 @@ def cmsis_nn_transpose_conv_buffer_size(
 def cmsis_nn_avgpool_buffer_size(
     backend: cmsis_nn.Backend,
     pool_node: torch.fx.Node,
+    nhwc_logical: bool = False,
 ) -> list[int]:
     x = cast(torch.fx.Node, pool_node.args[0])
 
-    # Input is NCHW (PyTorch); CMSIS-NN's avgpool buffer sizer only needs the
-    # input channel count and output width.
-    _, c_in, _, _ = _shape_from_node(x)
-    _, _, _, out_w = _shape_from_node(pool_node)
+    if nhwc_logical:
+        _, _, _, c_in = _shape_from_node(x)
+        _, _, out_w, _ = _shape_from_node(pool_node)
+    else:
+        _, c_in, _, _ = _shape_from_node(x)
+        _, _, _, out_w = _shape_from_node(pool_node)
 
     return [
         int(
@@ -270,10 +284,22 @@ def cmsis_nn_avgpool_buffer_size(
 
 _target_to_buffer_sizes_registry: dict[Any, BufferSizeFunction] = {
     exir_ops.edge.cortex_m.quantized_conv2d.default: cmsis_nn_conv_buffer_size,
+    exir_ops.edge.cortex_m.quantized_conv2d_nhwc.default: partial(
+        cmsis_nn_conv_buffer_size, nhwc_logical=True
+    ),
     exir_ops.edge.cortex_m.quantized_depthwise_conv2d.default: cmsis_nn_depthwise_conv_buffer_size,
+    exir_ops.edge.cortex_m.quantized_depthwise_conv2d_nhwc.default: partial(
+        cmsis_nn_depthwise_conv_buffer_size, nhwc_logical=True
+    ),
     exir_ops.edge.cortex_m.quantized_batch_matmul.default: cmsis_nn_batch_matmul_buffer_size,
     exir_ops.edge.cortex_m.quantized_transpose_conv2d.default: cmsis_nn_transpose_conv_buffer_size,
+    exir_ops.edge.cortex_m.quantized_transpose_conv2d_nhwc.default: partial(
+        cmsis_nn_transpose_conv_buffer_size, nhwc_logical=True
+    ),
     exir_ops.edge.cortex_m.quantized_avg_pool2d.default: cmsis_nn_avgpool_buffer_size,
+    exir_ops.edge.cortex_m.quantized_avg_pool2d_nhwc.default: partial(
+        cmsis_nn_avgpool_buffer_size, nhwc_logical=True
+    ),
 }
 
 

--- a/backends/cortex_m/test/build_test_runner.sh
+++ b/backends/cortex_m/test/build_test_runner.sh
@@ -66,6 +66,7 @@ ops_list=(
     cortex_m::softmax.out
     cortex_m::transpose.out
     cortex_m::pad.out
+    cortex_m::pad_contiguous.out
     cortex_m::quantized_conv2d.out
     cortex_m::quantized_depthwise_conv2d.out
     cortex_m::quantized_transpose_conv2d.out

--- a/backends/cortex_m/test/ops/test_add.py
+++ b/backends/cortex_m/test/ops/test_add.py
@@ -215,13 +215,6 @@ test_cases = {
             ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
         ),
     ),
-    "broadcast_single_channel": McuTestCase(
-        CortexMTensorAdd(),
-        (
-            ramp_tensor(-5, 5, (2, 1, 5, 5)).to(memory_format=torch.channels_last),
-            ramp_tensor(-2, 2, (1, 1, 1, 1)).to(memory_format=torch.channels_last),
-        ),
-    ),
     "broadcast_channels_continous": McuTestCase(
         CortexMTensorAdd(),
         (

--- a/backends/cortex_m/test/ops/test_add.py
+++ b/backends/cortex_m/test/ops/test_add.py
@@ -215,6 +215,13 @@ test_cases = {
             ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
         ),
     ),
+    "broadcast_single_channel": McuTestCase(
+        CortexMTensorAdd(),
+        (
+            ramp_tensor(-5, 5, (2, 1, 5, 5)).to(memory_format=torch.channels_last),
+            ramp_tensor(-2, 2, (1, 1, 1, 1)).to(memory_format=torch.channels_last),
+        ),
+    ),
     "broadcast_channels_continous": McuTestCase(
         CortexMTensorAdd(),
         (

--- a/backends/cortex_m/test/ops/test_add.py
+++ b/backends/cortex_m/test/ops/test_add.py
@@ -208,6 +208,13 @@ test_cases = {
             ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
         ),
     ),
+    "broadcast_channels_degenerate_spatial": McuTestCase(
+        CortexMTensorAdd(),
+        (
+            ramp_tensor(-5, 5, (2, 8, 1, 1)).to(memory_format=torch.channels_last),
+            ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
+        ),
+    ),
     "broadcast_channels_continous": McuTestCase(
         CortexMTensorAdd(),
         (

--- a/backends/cortex_m/test/ops/test_mul.py
+++ b/backends/cortex_m/test/ops/test_mul.py
@@ -124,6 +124,13 @@ test_cases = {
             ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
         ),
     ),
+    "broadcast_single_channel": McuTestCase(
+        CortexMTensorMul(),
+        (
+            ramp_tensor(-5, 5, (2, 1, 5, 5)).to(memory_format=torch.channels_last),
+            ramp_tensor(-2, 2, (1, 1, 1, 1)).to(memory_format=torch.channels_last),
+        ),
+    ),
     "broadcast_channels_continous": McuTestCase(
         CortexMTensorMul(),
         (

--- a/backends/cortex_m/test/ops/test_mul.py
+++ b/backends/cortex_m/test/ops/test_mul.py
@@ -117,6 +117,13 @@ test_cases = {
             ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
         ),
     ),
+    "broadcast_channels_degenerate_spatial": McuTestCase(
+        CortexMTensorMul(),
+        (
+            ramp_tensor(-5, 5, (2, 8, 1, 1)).to(memory_format=torch.channels_last),
+            ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
+        ),
+    ),
     "broadcast_channels_continous": McuTestCase(
         CortexMTensorMul(),
         (

--- a/backends/cortex_m/test/ops/test_mul.py
+++ b/backends/cortex_m/test/ops/test_mul.py
@@ -124,13 +124,6 @@ test_cases = {
             ramp_tensor(-2, 2, (1, 8, 1, 1)).to(memory_format=torch.channels_last),
         ),
     ),
-    "broadcast_single_channel": McuTestCase(
-        CortexMTensorMul(),
-        (
-            ramp_tensor(-5, 5, (2, 1, 5, 5)).to(memory_format=torch.channels_last),
-            ramp_tensor(-2, 2, (1, 1, 1, 1)).to(memory_format=torch.channels_last),
-        ),
-    ),
     "broadcast_channels_continous": McuTestCase(
         CortexMTensorMul(),
         (

--- a/backends/cortex_m/test/test_quantized_conv2d_layout.py
+++ b/backends/cortex_m/test/test_quantized_conv2d_layout.py
@@ -1,0 +1,513 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from executorch.backends.cortex_m.passes.scratch_buffer_sizes import (
+    required_cmsis_nn_buffer_sizes,
+)
+from executorch.backends.cortex_m.target_config import CortexM, CortexMTargetConfig
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+
+def _run_conv2d(op, x, weight, bias):
+    out_channels = weight.shape[0]
+    return op(
+        x,
+        weight,
+        bias,
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        5,
+        -3,
+        torch.full((out_channels,), 1 << 30, dtype=torch.int32),
+        torch.full((out_channels,), -2, dtype=torch.int32),
+        -128,
+        127,
+        torch.zeros(0, dtype=torch.uint8),
+    )
+
+
+def _run_depthwise_conv2d(op, x, weight, bias):
+    out_channels = weight.shape[3]
+    return op(
+        x,
+        weight,
+        bias,
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        1,
+        5,
+        -3,
+        torch.full((out_channels,), 1 << 30, dtype=torch.int32),
+        torch.full((out_channels,), -2, dtype=torch.int32),
+        -128,
+        127,
+        torch.zeros(0, dtype=torch.uint8),
+    )
+
+
+def _run_transpose_conv2d(op, x, weight, bias):
+    out_channels = weight.shape[0]
+    return op(
+        x,
+        weight,
+        bias,
+        [2, 2],
+        [1, 1],
+        [0, 0],
+        [1, 1],
+        5,
+        -3,
+        torch.full((out_channels,), 1 << 30, dtype=torch.int32),
+        torch.full((out_channels,), -2, dtype=torch.int32),
+        -128,
+        127,
+        torch.zeros(0, dtype=torch.uint8),
+        torch.zeros(0, dtype=torch.uint8),
+    )
+
+
+def _run_avg_pool2d(op, x):
+    return op(
+        x,
+        [2, 2],
+        [2, 2],
+        [0, 0],
+        False,
+        0,
+        1 << 30,
+        1,
+        torch.zeros(0, dtype=torch.uint8),
+    )
+
+
+def _run_max_pool2d(op, x):
+    return op(
+        x,
+        [2, 2],
+        [2, 2],
+        [0, 0],
+        [1, 1],
+        False,
+        0,
+        0,
+        -128,
+        127,
+    )
+
+
+def _run_add(op, x, bias):
+    return op(
+        x,
+        0,
+        1 << 30,
+        -1,
+        bias,
+        0,
+        1 << 30,
+        -1,
+        0,
+        1 << 30,
+        -1,
+        -128,
+        127,
+    )
+
+
+def _run_mul(op, x, bias):
+    return op(x, 0, bias, 0, 0, 1 << 30, -1)
+
+
+def test_nhwc_conv2d_matches_legacy_layout():
+    torch.manual_seed(0)
+    x = torch.randint(-8, 8, (1, 3, 8, 8), dtype=torch.int8)
+    weight = torch.randint(-4, 4, (4, 3, 3, 3), dtype=torch.int8)
+    bias = torch.randint(-50, 50, (4,), dtype=torch.int32)
+
+    legacy = _run_conv2d(
+        torch.ops.cortex_m.quantized_conv2d,
+        x.to(memory_format=torch.channels_last),
+        weight,
+        bias,
+    )
+    explicit = _run_conv2d(
+        torch.ops.cortex_m.quantized_conv2d_nhwc,
+        x.permute(0, 2, 3, 1).contiguous(),
+        weight,
+        bias,
+    )
+
+    torch.testing.assert_close(explicit, legacy.permute(0, 2, 3, 1))
+
+
+def test_nhwc_depthwise_conv2d_matches_legacy_layout():
+    torch.manual_seed(0)
+    x = torch.randint(-8, 8, (1, 4, 8, 8), dtype=torch.int8)
+    weight = torch.randint(-4, 4, (1, 3, 3, 4), dtype=torch.int8)
+    bias = torch.randint(-50, 50, (4,), dtype=torch.int32)
+
+    legacy = _run_depthwise_conv2d(
+        torch.ops.cortex_m.quantized_depthwise_conv2d,
+        x.to(memory_format=torch.channels_last),
+        weight,
+        bias,
+    )
+    explicit = _run_depthwise_conv2d(
+        torch.ops.cortex_m.quantized_depthwise_conv2d_nhwc,
+        x.permute(0, 2, 3, 1).contiguous(),
+        weight,
+        bias,
+    )
+
+    torch.testing.assert_close(explicit, legacy.permute(0, 2, 3, 1))
+
+
+def test_nhwc_transpose_conv2d_matches_legacy_layout():
+    torch.manual_seed(0)
+    x = torch.randint(-8, 8, (1, 3, 6, 6), dtype=torch.int8)
+    weight = torch.randint(-4, 4, (4, 3, 3, 3), dtype=torch.int8)
+    bias = torch.randint(-50, 50, (4,), dtype=torch.int32)
+
+    legacy = _run_transpose_conv2d(
+        torch.ops.cortex_m.quantized_transpose_conv2d,
+        x.to(memory_format=torch.channels_last),
+        weight,
+        bias,
+    )
+    explicit = _run_transpose_conv2d(
+        torch.ops.cortex_m.quantized_transpose_conv2d_nhwc,
+        x.permute(0, 2, 3, 1).contiguous(),
+        weight,
+        bias,
+    )
+
+    torch.testing.assert_close(explicit, legacy.permute(0, 2, 3, 1))
+
+
+def test_nhwc_avg_pool2d_matches_legacy_layout():
+    x = torch.randint(-8, 8, (1, 4, 8, 8), dtype=torch.int8)
+
+    legacy = _run_avg_pool2d(
+        torch.ops.cortex_m.quantized_avg_pool2d,
+        x.to(memory_format=torch.channels_last),
+    )
+    explicit = _run_avg_pool2d(
+        torch.ops.cortex_m.quantized_avg_pool2d_nhwc,
+        x.permute(0, 2, 3, 1).contiguous(),
+    )
+
+    torch.testing.assert_close(explicit, legacy.permute(0, 2, 3, 1))
+
+
+def test_nhwc_max_pool2d_matches_legacy_layout():
+    x = torch.randint(-8, 8, (1, 4, 8, 8), dtype=torch.int8)
+
+    legacy = _run_max_pool2d(
+        torch.ops.cortex_m.quantized_max_pool2d,
+        x.to(memory_format=torch.channels_last),
+    )
+    explicit = _run_max_pool2d(
+        torch.ops.cortex_m.quantized_max_pool2d_nhwc,
+        x.permute(0, 2, 3, 1).contiguous(),
+    )
+
+    torch.testing.assert_close(explicit, legacy.permute(0, 2, 3, 1))
+
+
+def test_nhwc_channel_broadcast_add_matches_legacy_layout():
+    x = torch.randint(-8, 8, (1, 4, 5, 7), dtype=torch.int8)
+    bias = torch.randint(-4, 4, (1, 4, 1, 1), dtype=torch.int8)
+
+    legacy = _run_add(
+        torch.ops.cortex_m.quantized_add,
+        x.to(memory_format=torch.channels_last),
+        bias.to(memory_format=torch.channels_last),
+    )
+    explicit = _run_add(
+        torch.ops.cortex_m.quantized_add,
+        x.permute(0, 2, 3, 1).contiguous(),
+        bias.permute(0, 2, 3, 1).contiguous(),
+    )
+
+    torch.testing.assert_close(explicit, legacy.permute(0, 2, 3, 1))
+
+
+def test_nhwc_channel_broadcast_mul_matches_legacy_layout():
+    x = torch.randint(-8, 8, (1, 4, 5, 7), dtype=torch.int8)
+    bias = torch.randint(-4, 4, (1, 4, 1, 1), dtype=torch.int8)
+
+    legacy = _run_mul(
+        torch.ops.cortex_m.quantized_mul,
+        x.to(memory_format=torch.channels_last),
+        bias.to(memory_format=torch.channels_last),
+    )
+    explicit = _run_mul(
+        torch.ops.cortex_m.quantized_mul,
+        x.permute(0, 2, 3, 1).contiguous(),
+        bias.permute(0, 2, 3, 1).contiguous(),
+    )
+
+    torch.testing.assert_close(explicit, legacy.permute(0, 2, 3, 1))
+
+
+@pytest.mark.parametrize(
+    "run_op,op",
+    [
+        (_run_add, torch.ops.cortex_m.quantized_add),
+        (_run_mul, torch.ops.cortex_m.quantized_mul),
+    ],
+)
+def test_degenerate_spatial_channel_broadcast_matches_expanded_input(run_op, op):
+    activation = torch.randint(-8, 8, (2, 4, 1, 1), dtype=torch.int8)
+    bias = torch.randint(-4, 4, (1, 4, 1, 1), dtype=torch.int8)
+
+    actual = run_op(op, activation, bias)
+    expected = run_op(op, activation, bias.expand_as(activation).contiguous())
+
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "run_op,op",
+    [
+        (_run_add, torch.ops.cortex_m.quantized_add),
+        (_run_mul, torch.ops.cortex_m.quantized_mul),
+    ],
+)
+def test_non_channel_broadcast_is_rejected(run_op, op):
+    activation = torch.ones((1, 2, 3, 4), dtype=torch.int8)
+    spatial_bias = torch.ones((1, 1, 3, 1), dtype=torch.int8)
+
+    with pytest.raises(AssertionError, match="broadcasting is not yet supported"):
+        run_op(op, activation, spatial_bias)
+
+
+@pytest.mark.parametrize(
+    "run_op,op",
+    [
+        (_run_add, torch.ops.cortex_m.quantized_add),
+        (_run_mul, torch.ops.cortex_m.quantized_mul),
+    ],
+)
+def test_zero_sized_channel_broadcast_is_rejected(run_op, op):
+    activation = torch.empty((1, 0, 3, 4), dtype=torch.int8)
+    channel_bias = torch.empty((1, 0, 1, 1), dtype=torch.int8)
+
+    with pytest.raises(AssertionError, match="broadcasting is not yet supported"):
+        run_op(op, activation, channel_bias)
+
+
+def test_nhwc_conv2d_fake_shape_is_logical_nhwc():
+    with FakeTensorMode():
+        output = _run_conv2d(
+            torch.ops.cortex_m.quantized_conv2d_nhwc,
+            torch.empty(2, 10, 6, 3, dtype=torch.int8),
+            torch.empty(5, 3, 3, 3, dtype=torch.int8),
+            torch.empty(5, dtype=torch.int32),
+        )
+
+    assert output.shape == torch.Size([2, 10, 6, 5])
+    assert output.dim_order() == (0, 1, 2, 3)
+
+
+def test_pad_contiguous_preserves_singleton_height_layout():
+    x = torch.arange(1 * 1 * 5 * 3, dtype=torch.int8).reshape(1, 1, 5, 3)
+    pre_pad = [0, 0, 1, 0]
+    post_pad = [0, 0, 2, 0]
+
+    actual = torch.ops.cortex_m.pad_contiguous(x, pre_pad, post_pad, -7)
+    expected = torch.nn.functional.pad(x, (0, 0, 1, 2, 0, 0, 0, 0), value=-7)
+
+    assert actual.shape == torch.Size([1, 1, 8, 3])
+    torch.testing.assert_close(actual, expected)
+
+
+def test_pad_contiguous_handles_every_supported_rank():
+    """Ranks below four are contiguous by construction, so this entry point
+    covers them too. That is what lets it eventually replace ``cortex_m::pad``
+    outright rather than sitting beside it forever."""
+    for shape, pad in (
+        ((2, 3, 4, 5), [0, 0, 1, 2]),
+        ((2, 3, 4), [0, 0, 1, 2]),
+        ((3, 5), [0, 0, 1, 2]),
+        ((6,), [0, 0, 0, 2]),
+    ):
+        x = torch.randint(-8, 8, shape, dtype=torch.int8)
+        rank = len(shape)
+        offset = 4 - rank
+        actual = torch.ops.cortex_m.pad_contiguous(x, pad, pad, -7)
+        flat = []
+        for dim in reversed(range(rank)):
+            flat.extend([pad[offset + dim], pad[offset + dim]])
+        expected = torch.nn.functional.pad(x, flat, value=-7)
+        assert actual.shape == expected.shape, shape
+        torch.testing.assert_close(actual, expected)
+
+
+def test_pad_contiguous_rejects_invalid_padding_length():
+    with pytest.raises(RuntimeError, match="expects four padding values per side"):
+        torch.ops.cortex_m.pad_contiguous(
+            torch.zeros((1, 1, 5, 3), dtype=torch.int8),
+            [0, 0, 0],
+            [0, 0, 0, 0],
+            0,
+        )
+
+    with FakeTensorMode():
+        with pytest.raises(RuntimeError, match="expects four padding values per side"):
+            torch.ops.cortex_m.pad_contiguous(
+                torch.zeros((1, 1, 5, 3), dtype=torch.int8),
+                [0, 0, 0],
+                [0, 0, 0, 0],
+                0,
+            )
+
+
+def test_nhwc_and_legacy_scratch_sizes_match():
+    backends = tuple(
+        CortexMTargetConfig(cpu=cpu).backend for cpu in (CortexM.M33, CortexM.M55)
+    )
+
+    def make_node(
+        target,
+        input_shape,
+        output_shape,
+        weight_shape,
+        trailing_args,
+    ):
+        graph = torch.fx.Graph()
+        with FakeTensorMode() as mode:
+            input_node = graph.placeholder("input")
+            input_node.meta["val"] = mode.from_tensor(
+                torch.empty(input_shape, dtype=torch.int8)
+            )
+            args = [input_node]
+            if weight_shape is not None:
+                weight_node = graph.placeholder("weight")
+                weight_node.meta["val"] = mode.from_tensor(
+                    torch.empty(weight_shape, dtype=torch.int8)
+                )
+                args.extend((weight_node, None))
+            args.extend(trailing_args)
+            node = graph.call_function(target, args=tuple(args))
+            node.meta["val"] = mode.from_tensor(
+                torch.empty(output_shape, dtype=torch.int8)
+            )
+        return node
+
+    cases = (
+        (
+            exir_ops.edge.cortex_m.quantized_conv2d.default,
+            exir_ops.edge.cortex_m.quantized_conv2d_nhwc.default,
+            (1, 3, 10, 6),
+            (1, 10, 6, 3),
+            (1, 4, 10, 6),
+            (1, 10, 6, 4),
+            (4, 3, 3, 3),
+            ([1, 1], [1, 1], [1, 1], 5, -3, None, None, -128, 127, None),
+        ),
+        (
+            exir_ops.edge.cortex_m.quantized_depthwise_conv2d.default,
+            exir_ops.edge.cortex_m.quantized_depthwise_conv2d_nhwc.default,
+            (1, 4, 10, 6),
+            (1, 10, 6, 4),
+            (1, 4, 5, 5),
+            (1, 5, 5, 4),
+            (1, 3, 2, 4),
+            ([2, 1], [1, 0], [1, 1], 1, 5, -3, None, None, -128, 127, None),
+        ),
+        (
+            exir_ops.edge.cortex_m.quantized_transpose_conv2d.default,
+            exir_ops.edge.cortex_m.quantized_transpose_conv2d_nhwc.default,
+            (1, 3, 5, 6),
+            (1, 5, 6, 3),
+            (1, 4, 9, 8),
+            (1, 9, 8, 4),
+            (4, 2, 3, 3),
+            (
+                [2, 1],
+                [1, 0],
+                [0, 0],
+                [1, 1],
+                5,
+                -3,
+                None,
+                None,
+                -128,
+                127,
+                None,
+                None,
+            ),
+        ),
+        (
+            exir_ops.edge.cortex_m.quantized_avg_pool2d.default,
+            exir_ops.edge.cortex_m.quantized_avg_pool2d_nhwc.default,
+            (1, 4, 10, 6),
+            (1, 10, 6, 4),
+            (1, 4, 5, 3),
+            (1, 5, 3, 4),
+            None,
+            ([2, 2], [2, 2], [0, 0], False, 0, 1 << 30, 1, None),
+        ),
+    )
+
+    for (
+        legacy_target,
+        explicit_target,
+        legacy_input_shape,
+        explicit_input_shape,
+        legacy_output_shape,
+        explicit_output_shape,
+        weight_shape,
+        trailing_args,
+    ) in cases:
+        legacy = make_node(
+            legacy_target,
+            legacy_input_shape,
+            legacy_output_shape,
+            weight_shape,
+            trailing_args,
+        )
+        explicit = make_node(
+            explicit_target,
+            explicit_input_shape,
+            explicit_output_shape,
+            weight_shape,
+            trailing_args,
+        )
+        for backend in backends:
+            assert required_cmsis_nn_buffer_sizes(
+                legacy, backend
+            ) == required_cmsis_nn_buffer_sizes(explicit, backend)
+
+
+def test_single_channel_broadcast_add_matches_legacy_layout():
+    """A single-channel broadcast is the case a dim-order derivation gets wrong.
+
+    A channels-last tensor with one channel serializes its dim order as
+    (0, 2, 1, 3), which names no channel axis at all, so the repeat length has
+    to come from the broadcast operand's element count instead.
+    """
+    x = torch.randint(-8, 8, (1, 1, 5, 7), dtype=torch.int8)
+    bias = torch.randint(-4, 4, (1, 1, 1, 1), dtype=torch.int8)
+
+    legacy = _run_add(
+        torch.ops.cortex_m.quantized_add,
+        x.to(memory_format=torch.channels_last),
+        bias.to(memory_format=torch.channels_last),
+    )
+    explicit = _run_add(
+        torch.ops.cortex_m.quantized_add,
+        x.permute(0, 2, 3, 1).contiguous(),
+        bias.permute(0, 2, 3, 1).contiguous(),
+    )
+
+    torch.testing.assert_close(explicit, legacy.permute(0, 2, 3, 1))


### PR DESCRIPTION
### Summary

Define the experimental NHWC operator contracts and reference implementations needed by explicit-layout lowering. Add and register the contiguous-padding runtime kernel, and allow the existing quantized add and multiply channel-broadcast path to operate on both legacy channels-last tensors and contiguous NHWC tensors.

Keep runtime shape and layout validation aligned with the AOT eligibility checks, and make pooling configuration and scratch sizing interpret dimensions through an explicit activation-layout contract.

### Why these changes
Explicit layout stores NHWC tensors as ordinary contiguous tensors, so the legacy padding operator cannot infer the intended logical axes from dim order. A distinct `pad_contiguous` contract makes that difference visible and is registered here alongside its C++ implementation.

Quantized add and multiply already support a per-channel CMSIS-NN loop when the broadcast operand is contiguous in physical memory. The implementation previously identified the loop length through the legacy logical channel axis. This PR instead derives it from the broadcast operand itself, allowing the same path to serve contiguous NHWC tensors while preserving legacy behavior. General and scalar broadcasting remain out of scope.

The remaining NHWC schemas establish Python fake and reference contracts for the following kernel PRs. Their runtime registrations land with their C++ implementations so each kernel PR is independently executable.

AI-assisted: Codex.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>