### PR TITLE
Cortex-M: add explicit layout convolution kernels

### DIFF
--- a/backends/cortex_m/ops/BUCK
+++ b/backends/cortex_m/ops/BUCK
@@ -32,6 +32,7 @@ fbcode_target(_kind = runtime.python_library,
         "fbcode//caffe2:torch",
         "//executorch/backends/cortex_m/passes:passes_utils",
         "//executorch/backends/cortex_m/quantizer:quantization_configs",
+        "//executorch/exir:_warnings",
     ],
 )
 

--- a/backends/cortex_m/ops/cortex_m_ops_common.h
+++ b/backends/cortex_m/ops/cortex_m_ops_common.h
@@ -14,6 +14,7 @@
 
 #include <executorch/kernels/portable/cpu/util/elementwise_util.h>
 #include <executorch/kernels/portable/cpu/util/kernel_ops_util.h>
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 #include <executorch/runtime/platform/assert.h>
 
 #include <cinttypes>
@@ -35,6 +36,11 @@ using KernelRuntimeContext = torch::executor::KernelRuntimeContext;
 
 // 16-byte alignment for MVE vector operations.
 constexpr size_t kCortexMMveAlignment = 16;
+
+enum class ActivationLayout {
+  NCHWLogical,
+  NHWCLogical,
+};
 
 // Basic tensor type / layout validation and dimension order checking
 inline void validate_cmsis_nn_tensor_requirements(

--- a/backends/cortex_m/ops/op_quantized_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_conv2d.cpp
@@ -1,9 +1,13 @@
 /*
  * Copyright 2025-2026 Arm Limited and/or its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 
 #include "cortex_m_ops_common.h"
 
@@ -25,7 +29,8 @@ bool validate_conv2d_arguments(
     const Int64ArrayRef& padding,
     const Int64ArrayRef& dilation,
     const Tensor& requantize_multipliers,
-    const Tensor& requantize_shifts) {
+    const Tensor& requantize_shifts,
+    ActivationLayout layout) {
   if (input.dim() != kConvDim || weight.dim() != kConvDim ||
       output.dim() != kConvDim) {
     ET_LOG(Error, "quantized_conv2d_out: tensors must be 4-D");
@@ -33,20 +38,22 @@ bool validate_conv2d_arguments(
     return false;
   }
 
-  // Check for channels_last dim_order (NHWC: 0, 2, 3, 1)
-  // Skip check if channels == 1, as dim_order is ambiguous in that case
-  if (input.size(1) > 1 && !is_channels_last_tensor(input)) {
+  if (layout == ActivationLayout::NHWCLogical) {
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            output.dim_order().data(), output.dim_order().size())) {
+      ET_LOG(
+          Error,
+          "quantized_conv2d_nhwc_out: input and output must have contiguous dim_order");
+      context.fail(Error::InvalidArgument);
+      return false;
+    }
+  } else if (
+      !is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
     ET_LOG(
         Error,
-        "quantized_conv2d_out: input must have channels_last dim_order (NHWC)");
-    context.fail(Error::InvalidArgument);
-    return false;
-  }
-
-  if (output.size(1) > 1 && !is_channels_last_tensor(output)) {
-    ET_LOG(
-        Error,
-        "quantized_conv2d_out: output must have channels_last dim_order (NHWC)");
+        "quantized_conv2d_out: input and output must have channels_last dim_order");
     context.fail(Error::InvalidArgument);
     return false;
   }
@@ -78,7 +85,8 @@ bool validate_conv2d_arguments(
     return false;
   }
 
-  const int64_t out_channels = output.size(1);
+  const int64_t out_channels =
+      output.size(layout == ActivationLayout::NHWCLogical ? 3 : 1);
   if (requantize_multipliers.size(0) != out_channels ||
       requantize_shifts.size(0) != out_channels) {
     ET_LOG(
@@ -94,7 +102,7 @@ bool validate_conv2d_arguments(
 } // namespace
 
 // cppcheck-suppress unusedFunction
-Tensor& quantized_conv2d_out(
+static Tensor& quantized_conv2d_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Tensor& weight,
@@ -109,6 +117,7 @@ Tensor& quantized_conv2d_out(
     const int64_t activation_min,
     const int64_t activation_max,
     const Tensor& scratch,
+    ActivationLayout layout,
     Tensor& out) {
   if (!validate_conv2d_arguments(
           context,
@@ -120,23 +129,30 @@ Tensor& quantized_conv2d_out(
           padding,
           dilation,
           requantize_multipliers,
-          requantize_shifts)) {
+          requantize_shifts,
+          layout)) {
     return out;
   }
 
   const int32_t batch = static_cast<int32_t>(input.size(0));
-  const int32_t input_channels = static_cast<int32_t>(input.size(1));
-  const int32_t input_height = static_cast<int32_t>(input.size(2));
-  const int32_t input_width = static_cast<int32_t>(input.size(3));
+  const int32_t input_channels = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t input_height = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t input_width = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   const int32_t kernel_output_channels = static_cast<int32_t>(weight.size(0));
   const int32_t kernel_height = static_cast<int32_t>(weight.size(1));
   const int32_t kernel_width = static_cast<int32_t>(weight.size(2));
   const int32_t kernel_input_channels = static_cast<int32_t>(weight.size(3));
 
-  const int32_t output_channels = static_cast<int32_t>(out.size(1));
-  const int32_t output_height = static_cast<int32_t>(out.size(2));
-  const int32_t output_width = static_cast<int32_t>(out.size(3));
+  const int32_t output_channels = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t output_height = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t output_width = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   const int32_t input_offset_val = static_cast<int32_t>(input_offset);
   const int32_t output_offset_val = static_cast<int32_t>(output_offset);
@@ -226,6 +242,78 @@ Tensor& quantized_conv2d_out(
   }
 
   return out;
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_conv2d_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef dilation,
+    const int64_t input_offset,
+    const int64_t output_offset,
+    const Tensor& requantize_multipliers,
+    const Tensor& requantize_shifts,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    const Tensor& scratch,
+    Tensor& out) {
+  return quantized_conv2d_out_impl(
+      context,
+      input,
+      weight,
+      bias,
+      stride,
+      padding,
+      dilation,
+      input_offset,
+      output_offset,
+      requantize_multipliers,
+      requantize_shifts,
+      activation_min,
+      activation_max,
+      scratch,
+      ActivationLayout::NCHWLogical,
+      out);
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_conv2d_nhwc_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef dilation,
+    const int64_t input_offset,
+    const int64_t output_offset,
+    const Tensor& requantize_multipliers,
+    const Tensor& requantize_shifts,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    const Tensor& scratch,
+    Tensor& out) {
+  return quantized_conv2d_out_impl(
+      context,
+      input,
+      weight,
+      bias,
+      stride,
+      padding,
+      dilation,
+      input_offset,
+      output_offset,
+      requantize_multipliers,
+      requantize_shifts,
+      activation_min,
+      activation_max,
+      scratch,
+      ActivationLayout::NHWCLogical,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/op_quantized_depthwise_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_depthwise_conv2d.cpp
@@ -1,9 +1,13 @@
 /*
  * Copyright 2025-2026 Arm Limited and/or its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+#include <executorch/runtime/core/exec_aten/util/dim_order_util.h>
 
 #include "cortex_m_ops_common.h"
 
@@ -26,7 +30,8 @@ bool validate_depthwise_conv2d_arguments(
     const Int64ArrayRef& dilation,
     const int64_t depth_multiplier,
     const Tensor& requantize_multipliers,
-    const Tensor& requantize_shifts) {
+    const Tensor& requantize_shifts,
+    ActivationLayout layout) {
   if (input.dim() != kConvDim || weight.dim() != kConvDim ||
       output.dim() != kConvDim) {
     ET_LOG(Error, "quantized_depthwise_conv2d_out: tensors must be 4-D");
@@ -55,7 +60,8 @@ bool validate_depthwise_conv2d_arguments(
   }
 
   const int64_t weight_output_channels = weight.size(3);
-  const int64_t output_channels = output.size(1);
+  const int64_t output_channels =
+      output.size(layout == ActivationLayout::NHWCLogical ? 3 : 1);
   if (weight_output_channels != output_channels) {
     ET_LOG(
         Error,
@@ -66,16 +72,22 @@ bool validate_depthwise_conv2d_arguments(
     return false;
   }
 
-  if (!is_channels_last_tensor(input)) {
+  if (layout == ActivationLayout::NHWCLogical) {
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            output.dim_order().data(), output.dim_order().size())) {
+      ET_LOG(
+          Error,
+          "quantized_depthwise_conv2d_nhwc_out: input and output must have contiguous dim_order");
+      context.fail(Error::InvalidArgument);
+      return false;
+    }
+  } else if (
+      !is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
     ET_LOG(
-        Error, "quantized_depthwise_conv2d_out: input must be channels_last");
-    context.fail(Error::InvalidArgument);
-    return false;
-  }
-
-  if (!is_channels_last_tensor(output)) {
-    ET_LOG(
-        Error, "quantized_depthwise_conv2d_out: output must be channels_last");
+        Error,
+        "quantized_depthwise_conv2d_out: input and output must be channels_last");
     context.fail(Error::InvalidArgument);
     return false;
   }
@@ -108,7 +120,8 @@ bool validate_depthwise_conv2d_arguments(
     return false;
   }
 
-  const int64_t input_channels = input.size(1);
+  const int64_t input_channels =
+      input.size(layout == ActivationLayout::NHWCLogical ? 3 : 1);
   // output_channels already extracted above for weight validation
   if (output_channels != input_channels * depth_multiplier) {
     ET_LOG(
@@ -136,7 +149,7 @@ bool validate_depthwise_conv2d_arguments(
 } // namespace
 
 // cppcheck-suppress unusedFunction
-Tensor& quantized_depthwise_conv2d_out(
+static Tensor& quantized_depthwise_conv2d_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Tensor& weight,
@@ -152,6 +165,7 @@ Tensor& quantized_depthwise_conv2d_out(
     const int64_t activation_min,
     const int64_t activation_max,
     const Tensor& scratch,
+    ActivationLayout layout,
     Tensor& out) {
   if (!validate_depthwise_conv2d_arguments(
           context,
@@ -164,23 +178,30 @@ Tensor& quantized_depthwise_conv2d_out(
           dilation,
           depth_multiplier,
           requantize_multipliers,
-          requantize_shifts)) {
+          requantize_shifts,
+          layout)) {
     return out;
   }
 
   const int32_t batch = static_cast<int32_t>(input.size(0));
-  const int32_t input_channels = static_cast<int32_t>(input.size(1));
-  const int32_t input_height = static_cast<int32_t>(input.size(2));
-  const int32_t input_width = static_cast<int32_t>(input.size(3));
+  const int32_t input_channels = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t input_height = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t input_width = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   // Weight is in IHWO layout after permutation in the pass: [1, H, W, C_OUT]
   // For depthwise conv, this matches CMSIS-NN's expected format
   const int32_t kernel_height = static_cast<int32_t>(weight.size(1));
   const int32_t kernel_width = static_cast<int32_t>(weight.size(2));
 
-  const int32_t output_channels = static_cast<int32_t>(out.size(1));
-  const int32_t output_height = static_cast<int32_t>(out.size(2));
-  const int32_t output_width = static_cast<int32_t>(out.size(3));
+  const int32_t output_channels = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t output_height = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t output_width = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   const int32_t depth_multiplier_val = static_cast<int32_t>(depth_multiplier);
 
@@ -270,6 +291,82 @@ Tensor& quantized_depthwise_conv2d_out(
   }
 
   return out;
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_depthwise_conv2d_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef dilation,
+    const int64_t depth_multiplier,
+    const int64_t input_offset,
+    const int64_t output_offset,
+    const Tensor& requantize_multipliers,
+    const Tensor& requantize_shifts,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    const Tensor& scratch,
+    Tensor& out) {
+  return quantized_depthwise_conv2d_out_impl(
+      context,
+      input,
+      weight,
+      bias,
+      stride,
+      padding,
+      dilation,
+      depth_multiplier,
+      input_offset,
+      output_offset,
+      requantize_multipliers,
+      requantize_shifts,
+      activation_min,
+      activation_max,
+      scratch,
+      ActivationLayout::NCHWLogical,
+      out);
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_depthwise_conv2d_nhwc_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef dilation,
+    const int64_t depth_multiplier,
+    const int64_t input_offset,
+    const int64_t output_offset,
+    const Tensor& requantize_multipliers,
+    const Tensor& requantize_shifts,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    const Tensor& scratch,
+    Tensor& out) {
+  return quantized_depthwise_conv2d_out_impl(
+      context,
+      input,
+      weight,
+      bias,
+      stride,
+      padding,
+      dilation,
+      depth_multiplier,
+      input_offset,
+      output_offset,
+      requantize_multipliers,
+      requantize_shifts,
+      activation_min,
+      activation_max,
+      scratch,
+      ActivationLayout::NHWCLogical,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/op_quantized_transpose_conv2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_transpose_conv2d.cpp
@@ -24,7 +24,8 @@ bool validate_transpose_conv2d_arguments(
     const std::optional<Tensor>& bias,
     const Tensor& output,
     const Tensor& requantize_multipliers,
-    const Tensor& requantize_shifts) {
+    const Tensor& requantize_shifts,
+    ActivationLayout layout) {
   if (input.dim() != kConvTransposeDim || weight.dim() != kConvTransposeDim ||
       output.dim() != kConvTransposeDim) {
     ET_LOG(Error, "quantized_transpose_conv2d_out: tensors must be 4-D");
@@ -32,16 +33,22 @@ bool validate_transpose_conv2d_arguments(
     return false;
   }
 
-  if (!is_channels_last_tensor(input)) {
+  if (layout == ActivationLayout::NHWCLogical) {
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            output.dim_order().data(), output.dim_order().size())) {
+      ET_LOG(
+          Error,
+          "quantized_transpose_conv2d_nhwc_out: input and output must have contiguous dim_order");
+      context.fail(Error::InvalidArgument);
+      return false;
+    }
+  } else if (
+      !is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
     ET_LOG(
-        Error, "quantized_transpose_conv2d_out: input must be channels_last");
-    context.fail(Error::InvalidArgument);
-    return false;
-  }
-
-  if (!is_channels_last_tensor(output)) {
-    ET_LOG(
-        Error, "quantized_transpose_conv2d_out: output must be channels_last");
+        Error,
+        "quantized_transpose_conv2d_out: input and output must be channels_last");
     context.fail(Error::InvalidArgument);
     return false;
   }
@@ -68,7 +75,8 @@ bool validate_transpose_conv2d_arguments(
     return false;
   }
 
-  const int64_t out_channels = output.size(1);
+  const int64_t out_channels =
+      output.size(layout == ActivationLayout::NHWCLogical ? 3 : 1);
   if (requantize_multipliers.size(0) != out_channels ||
       requantize_shifts.size(0) != out_channels) {
     ET_LOG(
@@ -84,7 +92,7 @@ bool validate_transpose_conv2d_arguments(
 } // namespace
 
 // cppcheck-suppress unusedFunction
-Tensor& quantized_transpose_conv2d_out(
+static Tensor& quantized_transpose_conv2d_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Tensor& weight,
@@ -101,6 +109,7 @@ Tensor& quantized_transpose_conv2d_out(
     const int64_t activation_max,
     const Tensor& scratch,
     const Tensor& output_scratch,
+    ActivationLayout layout,
     Tensor& out) {
   if (!validate_transpose_conv2d_arguments(
           context,
@@ -109,23 +118,30 @@ Tensor& quantized_transpose_conv2d_out(
           bias,
           out,
           requantize_multipliers,
-          requantize_shifts)) {
+          requantize_shifts,
+          layout)) {
     return out;
   }
 
   const int32_t batch = static_cast<int32_t>(input.size(0));
-  const int32_t input_channels = static_cast<int32_t>(input.size(1));
-  const int32_t input_height = static_cast<int32_t>(input.size(2));
-  const int32_t input_width = static_cast<int32_t>(input.size(3));
+  const int32_t input_channels = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t input_height = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t input_width = static_cast<int32_t>(
+      input.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   const int32_t kernel_output_channels = static_cast<int32_t>(weight.size(0));
   const int32_t kernel_height = static_cast<int32_t>(weight.size(1));
   const int32_t kernel_width = static_cast<int32_t>(weight.size(2));
   const int32_t kernel_input_channels = static_cast<int32_t>(weight.size(3));
 
-  const int32_t output_channels = static_cast<int32_t>(out.size(1));
-  const int32_t output_height = static_cast<int32_t>(out.size(2));
-  const int32_t output_width = static_cast<int32_t>(out.size(3));
+  const int32_t output_channels = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 3 : 1));
+  const int32_t output_height = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 1 : 2));
+  const int32_t output_width = static_cast<int32_t>(
+      out.size(layout == ActivationLayout::NHWCLogical ? 2 : 3));
 
   if (kernel_output_channels != output_channels) {
     ET_LOG(
@@ -244,6 +260,86 @@ Tensor& quantized_transpose_conv2d_out(
   }
 
   return out;
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_transpose_conv2d_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef output_padding,
+    const Int64ArrayRef dilation,
+    const int64_t input_offset,
+    const int64_t output_offset,
+    const Tensor& requantize_multipliers,
+    const Tensor& requantize_shifts,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    const Tensor& scratch,
+    const Tensor& output_scratch,
+    Tensor& out) {
+  return quantized_transpose_conv2d_out_impl(
+      context,
+      input,
+      weight,
+      bias,
+      stride,
+      padding,
+      output_padding,
+      dilation,
+      input_offset,
+      output_offset,
+      requantize_multipliers,
+      requantize_shifts,
+      activation_min,
+      activation_max,
+      scratch,
+      output_scratch,
+      ActivationLayout::NCHWLogical,
+      out);
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_transpose_conv2d_nhwc_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Tensor& weight,
+    const std::optional<Tensor>& bias,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef output_padding,
+    const Int64ArrayRef dilation,
+    const int64_t input_offset,
+    const int64_t output_offset,
+    const Tensor& requantize_multipliers,
+    const Tensor& requantize_shifts,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    const Tensor& scratch,
+    const Tensor& output_scratch,
+    Tensor& out) {
+  return quantized_transpose_conv2d_out_impl(
+      context,
+      input,
+      weight,
+      bias,
+      stride,
+      padding,
+      output_padding,
+      dilation,
+      input_offset,
+      output_offset,
+      requantize_multipliers,
+      requantize_shifts,
+      activation_min,
+      activation_max,
+      scratch,
+      output_scratch,
+      ActivationLayout::NHWCLogical,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/operators.py
+++ b/backends/cortex_m/ops/operators.py
@@ -23,6 +23,7 @@ from executorch.backends.cortex_m.quantizer.quantization_configs import (
     CMSIS_SOFTMAX_SCALE,
     CMSIS_SOFTMAX_ZERO_POINT,
 )
+from executorch.exir._warnings import experimental
 from executorch.exir.dialects._ops import ops as exir_ops
 
 # To provide the implementation of the operators
@@ -30,6 +31,11 @@ from torch.library import impl, Library, register_fake
 
 # New operator library with a custom namespace to allow fusion etc.
 lib = Library("cortex_m", "DEF")
+
+_EXPLICIT_LAYOUT_EXPERIMENTAL = (
+    "This explicit-layout Cortex-M operator may change while the legacy "
+    "dim-order operators remain supported."
+)
 
 SOFTMAX_INPUT_INTEGER_BITS = 5
 
@@ -915,6 +921,92 @@ def quantized_conv2d_impl(
     return result.to(torch.int8, memory_format=torch.channels_last)
 
 
+lib.define(
+    "quantized_conv2d_nhwc("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] dilation, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch) -> Tensor"
+)
+lib.define(
+    "quantized_conv2d_nhwc.out("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] dilation, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch, "
+    "*, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+@register_fake("cortex_m::quantized_conv2d_nhwc")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def quantized_conv2d_nhwc_meta(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_conv2d_meta(
+        input.permute(0, 3, 1, 2),
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@impl(lib, "quantized_conv2d_nhwc", "CompositeExplicitAutograd")  # type: ignore[misc]
+def quantized_conv2d_nhwc_impl(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_conv2d_impl(
+        input.permute(0, 3, 1, 2).contiguous(),
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
 # ===================================================================
 # QUANTIZED DEPTHWISE CONV2D OPERATION DEFINITION
 # ===================================================================
@@ -1060,6 +1152,96 @@ def quantized_depthwise_conv2d_impl(
     result = torch.clamp(result, activation_min, activation_max)
 
     return result.to(torch.int8, memory_format=torch.channels_last)
+
+
+lib.define(
+    "quantized_depthwise_conv2d_nhwc("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] dilation, int depth_multiplier, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch) -> Tensor"
+)
+lib.define(
+    "quantized_depthwise_conv2d_nhwc.out("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] dilation, int depth_multiplier, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch, "
+    "*, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+@register_fake("cortex_m::quantized_depthwise_conv2d_nhwc")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def quantized_depthwise_conv2d_nhwc_meta(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    depth_multiplier: int,
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_depthwise_conv2d_meta(
+        input.permute(0, 3, 1, 2),
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        depth_multiplier,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@impl(lib, "quantized_depthwise_conv2d_nhwc", "CompositeExplicitAutograd")  # type: ignore[misc]
+def quantized_depthwise_conv2d_nhwc_impl(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    depth_multiplier: int,
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_depthwise_conv2d_impl(
+        input.permute(0, 3, 1, 2).contiguous(),
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        depth_multiplier,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
 
 
 # ===================================================================
@@ -1268,6 +1450,101 @@ def quantized_transpose_conv2d_impl(
     result = result.clamp(activation_min, activation_max)
 
     return result.to(torch.int8).to(memory_format=torch.channels_last)
+
+
+lib.define(
+    "quantized_transpose_conv2d_nhwc("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] output_padding, int[] dilation, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch, "
+    "Tensor output_scratch) -> Tensor"
+)
+lib.define(
+    "quantized_transpose_conv2d_nhwc.out("
+    "Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, "
+    "int[] output_padding, int[] dilation, int input_offset, int output_offset, "
+    "Tensor requantize_multipliers, Tensor requantize_shifts, "
+    "int activation_min, int activation_max, Tensor scratch, "
+    "Tensor output_scratch, *, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+@register_fake("cortex_m::quantized_transpose_conv2d_nhwc")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def quantized_transpose_conv2d_nhwc_meta(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    output_padding: Sequence[int],
+    dilation: Sequence[int],
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+    output_scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_transpose_conv2d_meta(
+        input.permute(0, 3, 1, 2),
+        weight,
+        bias,
+        stride,
+        padding,
+        output_padding,
+        dilation,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+        output_scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@impl(lib, "quantized_transpose_conv2d_nhwc", "CompositeExplicitAutograd")  # type: ignore[misc]
+def quantized_transpose_conv2d_nhwc_impl(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    output_padding: Sequence[int],
+    dilation: Sequence[int],
+    input_offset: int,
+    output_offset: int,
+    requantize_multipliers: torch.Tensor,
+    requantize_shifts: torch.Tensor,
+    activation_min: int,
+    activation_max: int,
+    scratch: torch.Tensor,
+    output_scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_transpose_conv2d_impl(
+        input.permute(0, 3, 1, 2).contiguous(),
+        weight,
+        bias,
+        stride,
+        padding,
+        output_padding,
+        dilation,
+        input_offset,
+        output_offset,
+        requantize_multipliers,
+        requantize_shifts,
+        activation_min,
+        activation_max,
+        scratch,
+        output_scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
 
 
 # ===================================================================

--- a/backends/cortex_m/ops/operators.yaml
+++ b/backends/cortex_m/ops/operators.yaml
@@ -83,6 +83,12 @@
     - arg_meta: null
       kernel_name: cortex_m::quantized_conv2d_out
 
+- func: cortex_m::quantized_conv2d_nhwc.out(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, Tensor scratch, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: cortex_m::quantized_conv2d_nhwc_out
+
 
 - func: cortex_m::quantized_depthwise_conv2d.out(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int depth_multiplier, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, Tensor scratch, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
@@ -90,11 +96,23 @@
     - arg_meta: null
       kernel_name: cortex_m::quantized_depthwise_conv2d_out
 
+- func: cortex_m::quantized_depthwise_conv2d_nhwc.out(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int depth_multiplier, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, Tensor scratch, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: cortex_m::quantized_depthwise_conv2d_nhwc_out
+
 - func: cortex_m::quantized_transpose_conv2d.out(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] output_padding, int[] dilation, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, Tensor scratch, Tensor output_scratch, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null
       kernel_name: cortex_m::quantized_transpose_conv2d_out
+
+- func: cortex_m::quantized_transpose_conv2d_nhwc.out(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] output_padding, int[] dilation, int input_offset, int output_offset, Tensor requantize_multipliers, Tensor requantize_shifts, int activation_min, int activation_max, Tensor scratch, Tensor output_scratch, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: cortex_m::quantized_transpose_conv2d_nhwc_out
 
 - func: cortex_m::quantized_avg_pool2d.out(Tensor input, int[] kernel_size, int[] stride, int[] padding, bool ceil_mode, int zero_point, int multiplier, int shift, Tensor scratch, *, Tensor(a!) out) -> Tensor(a!)
   variants: function

--- a/backends/cortex_m/passes/scratch_buffer_sizes.py
+++ b/backends/cortex_m/passes/scratch_buffer_sizes.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections.abc import Callable
+from functools import partial
 from typing import Any, cast
 
 import executorch.backends.cortex_m.ops.operators  # noqa
@@ -37,6 +38,7 @@ def _shape_from_node(node: torch.fx.Node) -> torch.Size:
 def _get_common_conv_buffer_size_inputs(
     conv_node: torch.fx.Node,
     *,
+    nhwc_logical: bool = False,
     stride_arg_idx: int = 3,
     padding_arg_idx: int = 4,
     dilation_arg_idx: int = 5,
@@ -54,13 +56,14 @@ def _get_common_conv_buffer_size_inputs(
     padding = cast(list[int], conv_node.args[padding_arg_idx])
     dilation = cast(list[int], conv_node.args[dilation_arg_idx])
 
-    # Input is NCHW (PyTorch); CMSIS-NN wants NHWC dims.
-    n, c_in, height, width = _shape_from_node(x)
-
     weight_shape = _shape_from_node(weight)
 
-    # Output is NCHW; convert to NHWC dims.
-    out_n, out_c, out_h, out_w = _shape_from_node(conv_node)
+    if nhwc_logical:
+        n, height, width, c_in = _shape_from_node(x)
+        out_n, out_h, out_w, out_c = _shape_from_node(conv_node)
+    else:
+        n, c_in, height, width = _shape_from_node(x)
+        out_n, out_c, out_h, out_w = _shape_from_node(conv_node)
 
     input_nhwc = [n, height, width, c_in]
     output_nhwc = [out_n, out_h, out_w, out_c]
@@ -81,6 +84,7 @@ def _get_common_conv_buffer_size_inputs(
 def cmsis_nn_conv_buffer_size(
     backend: cmsis_nn.Backend,
     conv_node: torch.fx.Node,
+    nhwc_logical: bool = False,
 ) -> list[int]:
     (
         input_nhwc,
@@ -89,7 +93,9 @@ def cmsis_nn_conv_buffer_size(
         stride_hw,
         padding_hw,
         dilation_hw,
-    ) = _get_common_conv_buffer_size_inputs(conv_node=conv_node)
+    ) = _get_common_conv_buffer_size_inputs(
+        conv_node=conv_node, nhwc_logical=nhwc_logical
+    )
     input_offset = cast(int, conv_node.args[6])
     output_offset = cast(int, conv_node.args[7])
     output_qmin = cast(int, conv_node.args[10])
@@ -122,6 +128,7 @@ def cmsis_nn_conv_buffer_size(
 def cmsis_nn_depthwise_conv_buffer_size(
     backend: cmsis_nn.Backend,
     conv_node: torch.fx.Node,
+    nhwc_logical: bool = False,
 ) -> list[int]:
     (
         input_nhwc,
@@ -130,7 +137,9 @@ def cmsis_nn_depthwise_conv_buffer_size(
         stride_hw,
         padding_hw,
         dilation_hw,
-    ) = _get_common_conv_buffer_size_inputs(conv_node=conv_node)
+    ) = _get_common_conv_buffer_size_inputs(
+        conv_node=conv_node, nhwc_logical=nhwc_logical
+    )
     depth_multiplier = cast(int, conv_node.args[6])
     input_offset = cast(int, conv_node.args[7])
     output_offset = cast(int, conv_node.args[8])
@@ -185,6 +194,7 @@ def cmsis_nn_batch_matmul_buffer_size(
 def cmsis_nn_transpose_conv_buffer_size(
     backend: cmsis_nn.Backend,
     conv_node: torch.fx.Node,
+    nhwc_logical: bool = False,
 ) -> list[int]:
     (
         input_nhwc,
@@ -195,6 +205,7 @@ def cmsis_nn_transpose_conv_buffer_size(
         dilation_hw,
     ) = _get_common_conv_buffer_size_inputs(
         conv_node=conv_node,
+        nhwc_logical=nhwc_logical,
         stride_arg_idx=3,
         padding_arg_idx=4,
         dilation_arg_idx=6,
@@ -270,9 +281,18 @@ def cmsis_nn_avgpool_buffer_size(
 
 _target_to_buffer_sizes_registry: dict[Any, BufferSizeFunction] = {
     exir_ops.edge.cortex_m.quantized_conv2d.default: cmsis_nn_conv_buffer_size,
+    exir_ops.edge.cortex_m.quantized_conv2d_nhwc.default: partial(
+        cmsis_nn_conv_buffer_size, nhwc_logical=True
+    ),
     exir_ops.edge.cortex_m.quantized_depthwise_conv2d.default: cmsis_nn_depthwise_conv_buffer_size,
+    exir_ops.edge.cortex_m.quantized_depthwise_conv2d_nhwc.default: partial(
+        cmsis_nn_depthwise_conv_buffer_size, nhwc_logical=True
+    ),
     exir_ops.edge.cortex_m.quantized_batch_matmul.default: cmsis_nn_batch_matmul_buffer_size,
     exir_ops.edge.cortex_m.quantized_transpose_conv2d.default: cmsis_nn_transpose_conv_buffer_size,
+    exir_ops.edge.cortex_m.quantized_transpose_conv2d_nhwc.default: partial(
+        cmsis_nn_transpose_conv_buffer_size, nhwc_logical=True
+    ),
     exir_ops.edge.cortex_m.quantized_avg_pool2d.default: cmsis_nn_avgpool_buffer_size,
 }
 

--- a/backends/cortex_m/test/build_test_runner.sh
+++ b/backends/cortex_m/test/build_test_runner.sh
@@ -67,8 +67,11 @@ ops_list=(
     cortex_m::transpose.out
     cortex_m::pad.out
     cortex_m::quantized_conv2d.out
+    cortex_m::quantized_conv2d_nhwc.out
     cortex_m::quantized_depthwise_conv2d.out
+    cortex_m::quantized_depthwise_conv2d_nhwc.out
     cortex_m::quantized_transpose_conv2d.out
+    cortex_m::quantized_transpose_conv2d_nhwc.out
     cortex_m::quantized_avg_pool2d.out
     cortex_m::quantized_max_pool2d.out
     cortex_m::quantized_batch_matmul.out

--- a/backends/cortex_m/test/ops/nhwc_test_utils.py
+++ b/backends/cortex_m/test/ops/nhwc_test_utils.py
@@ -1,0 +1,42 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+
+import torch
+
+from executorch.backends.cortex_m.passes.cortex_m_pass_manager import CortexMPassManager
+from executorch.backends.cortex_m.passes.scratch_buffer_sizes import (
+    required_cmsis_nn_buffer_sizes,
+)
+from executorch.backends.cortex_m.test.tester import CortexMTester
+from executorch.backends.test.harness.stages import RunPasses, StageType
+
+
+def int8_values(shape):
+    values = torch.arange(math.prod(shape), dtype=torch.int32)
+    return (values.remainder(7) - 3).to(torch.int8).reshape(shape)
+
+
+def run_on_fvp(module, x, target, target_config, scratch_count, atol=0):
+    sizing_inputs = (x,) + tuple(
+        torch.empty(0, dtype=torch.uint8) for _ in range(scratch_count)
+    )
+    tester = CortexMTester(module, sizing_inputs, target_config=target_config)
+    tester.export().to_edge()
+    program = tester.get_artifact(StageType.TO_EDGE).exported_program()
+    [node] = [n for n in program.graph.nodes if n.target == target]
+    scratch_sizes = required_cmsis_nn_buffer_sizes(node, target_config.backend) or []
+    assert len(scratch_sizes) == scratch_count
+
+    inputs = (x,) + tuple(
+        torch.empty(size, dtype=torch.uint8) for size in scratch_sizes
+    )
+    tester = CortexMTester(module, inputs, target_config=target_config)
+    tester.export().to_edge()
+    tester.run_passes(RunPasses(CortexMPassManager, pass_list=[]))
+    tester.to_executorch().serialize()
+    tester.run_method_and_compare_outputs(inputs=inputs, atol=atol)

--- a/backends/cortex_m/test/ops/test_nhwc_conv.py
+++ b/backends/cortex_m/test/ops/test_nhwc_conv.py
@@ -1,0 +1,145 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from executorch.backends.cortex_m.test.ops.nhwc_test_utils import (
+    int8_values,
+    run_on_fvp,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+
+# Direct-op coverage is temporary until CortexMTester uses explicit layout by default.
+
+
+class Conv2dNhwc(torch.nn.Module):
+    def __init__(self, grouped=False):
+        super().__init__()
+        in_channels = 4 if grouped else 3
+        self.register_buffer(
+            "weight", int8_values((4, 2, 3, 2 if grouped else in_channels))
+        )
+        self.register_buffer("bias", torch.arange(4, dtype=torch.int32) - 2)
+        self.register_buffer(
+            "multipliers", torch.full((4,), 1 << 30, dtype=torch.int32)
+        )
+        self.register_buffer("shifts", torch.full((4,), -1, dtype=torch.int32))
+
+    def forward(self, x, scratch):
+        return torch.ops.cortex_m.quantized_conv2d_nhwc.default(
+            x,
+            self.weight,
+            self.bias,
+            [2, 1],
+            [1, 0],
+            [1, 1],
+            0,
+            0,
+            self.multipliers,
+            self.shifts,
+            -128,
+            127,
+            scratch,
+        )
+
+
+class DepthwiseConv2dNhwc(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("weight", int8_values((1, 3, 2, 4)))
+        self.register_buffer("bias", torch.arange(4, dtype=torch.int32) - 2)
+        self.register_buffer(
+            "multipliers", torch.full((4,), 1 << 30, dtype=torch.int32)
+        )
+        self.register_buffer("shifts", torch.full((4,), -1, dtype=torch.int32))
+
+    def forward(self, x, scratch):
+        return torch.ops.cortex_m.quantized_depthwise_conv2d_nhwc.default(
+            x,
+            self.weight,
+            self.bias,
+            [2, 1],
+            [1, 0],
+            [1, 1],
+            1,
+            0,
+            0,
+            self.multipliers,
+            self.shifts,
+            -128,
+            127,
+            scratch,
+        )
+
+
+class TransposeConv2dNhwc(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("weight", int8_values((4, 2, 4, 2)))
+        self.register_buffer("bias", torch.arange(4, dtype=torch.int32) - 2)
+        self.register_buffer(
+            "multipliers", torch.full((4,), 1 << 30, dtype=torch.int32)
+        )
+        self.register_buffer("shifts", torch.full((4,), -1, dtype=torch.int32))
+
+    def forward(self, x, scratch, output_scratch):
+        return torch.ops.cortex_m.quantized_transpose_conv2d_nhwc.default(
+            x,
+            self.weight,
+            self.bias,
+            [1, 1],
+            [0, 0],
+            [0, 0],
+            [1, 1],
+            0,
+            0,
+            self.multipliers,
+            self.shifts,
+            -128,
+            127,
+            scratch,
+            output_scratch,
+        )
+
+
+def test_conv2d_nhwc_runs_on_fvp(cortex_m_target):
+    run_on_fvp(
+        Conv2dNhwc(),
+        int8_values((1, 7, 10, 3)),
+        exir_ops.edge.cortex_m.quantized_conv2d_nhwc.default,
+        cortex_m_target,
+        1,
+    )
+
+
+def test_grouped_conv2d_nhwc_runs_on_fvp(cortex_m_target):
+    run_on_fvp(
+        Conv2dNhwc(grouped=True),
+        int8_values((1, 7, 10, 4)),
+        exir_ops.edge.cortex_m.quantized_conv2d_nhwc.default,
+        cortex_m_target,
+        1,
+    )
+
+
+def test_depthwise_conv2d_nhwc_runs_on_fvp(cortex_m_target):
+    run_on_fvp(
+        DepthwiseConv2dNhwc(),
+        int8_values((1, 7, 10, 4)),
+        exir_ops.edge.cortex_m.quantized_depthwise_conv2d_nhwc.default,
+        cortex_m_target,
+        1,
+    )
+
+
+def test_transpose_conv2d_nhwc_runs_on_fvp(cortex_m_target):
+    run_on_fvp(
+        TransposeConv2dNhwc(),
+        int8_values((1, 5, 6, 2)),
+        exir_ops.edge.cortex_m.quantized_transpose_conv2d_nhwc.default,
+        cortex_m_target,
+        2,
+    )


### PR DESCRIPTION
### Summary

Add and register NHWC implementations for regular, depthwise, and transpose convolution while preserving the existing channels-last entry points.

### Why separate operators

The legacy kernels interpret logical NCHW tensors through channels-last dim order. Explicit layout instead passes ordinary contiguous tensors whose logical shape is NHWC. Separate experimental symbols make that contract unambiguous, prevent either mode from guessing layout, and allow validation to fail closed. The implementations share their CMSIS-NN setup paths where the two contracts are genuinely identical.

The registration entries and FVP selected-op list live in this PR because this is the first layer containing the corresponding C++ kernels. A serialized program using any of these symbols can therefore load as soon as this PR lands.

AI-assisted: Codex.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>