### PR TITLE
Cortex-M: add explicit layout pooling kernels

### DIFF
--- a/backends/cortex_m/ops/cortex_m_ops_common.h
+++ b/backends/cortex_m/ops/cortex_m_ops_common.h
@@ -209,7 +209,7 @@ inline bool prepare_cmsis_pool2d_config(
     int64_t activation_min,
     int64_t activation_max,
     CmsisPool2DConfig& config,
-    bool require_channels_last = true,
+    ActivationLayout layout,
     bool allow_ceil_mode = false) {
   if (input.dim() != 4 || output.dim() != 4) {
     ET_LOG(Error, "%s: tensors must be 4-D", op_name);
@@ -224,7 +224,9 @@ inline bool prepare_cmsis_pool2d_config(
     return false;
   }
 
-  if (input.size(0) != output.size(0) || input.size(1) != output.size(1)) {
+  const int64_t channel_dim = layout == ActivationLayout::NHWCLogical ? 3 : 1;
+  if (input.size(0) != output.size(0) ||
+      input.size(channel_dim) != output.size(channel_dim)) {
     ET_LOG(
         Error,
         "%s: batch and channel dimensions must match between input and output",
@@ -233,13 +235,21 @@ inline bool prepare_cmsis_pool2d_config(
     return false;
   }
 
-  if (require_channels_last) {
-    if (!is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
-      ET_LOG(
-          Error, "%s: tensors must use channels_last dimension order", op_name);
+  if (layout == ActivationLayout::NHWCLogical) {
+    if (!executorch::runtime::is_contiguous_dim_order(
+            input.dim_order().data(), input.dim_order().size()) ||
+        !executorch::runtime::is_contiguous_dim_order(
+            output.dim_order().data(), output.dim_order().size())) {
+      ET_LOG(Error, "%s: tensors must use contiguous dimension order", op_name);
       context.fail(Error::InvalidArgument);
       return false;
     }
+  } else if (
+      !is_channels_last_tensor(input) || !is_channels_last_tensor(output)) {
+    ET_LOG(
+        Error, "%s: tensors must use channels_last dimension order", op_name);
+    context.fail(Error::InvalidArgument);
+    return false;
   }
 
   auto check_tuple_len = [&](const Int64ArrayRef& arr,
@@ -318,19 +328,29 @@ inline bool prepare_cmsis_pool2d_config(
     return false;
   }
 
+  const int64_t height_dim = layout == ActivationLayout::NHWCLogical ? 1 : 2;
+  const int64_t width_dim = layout == ActivationLayout::NHWCLogical ? 2 : 3;
   int32_t batch, channels, input_h, input_w, output_h, output_w;
   if (!check_int32_within_range(
           context, op_name, input.size(0), "input batch", batch) ||
       !check_int32_within_range(
-          context, op_name, input.size(1), "input channels", channels) ||
+          context,
+          op_name,
+          input.size(channel_dim),
+          "input channels",
+          channels) ||
       !check_int32_within_range(
-          context, op_name, input.size(2), "input height", input_h) ||
+          context, op_name, input.size(height_dim), "input height", input_h) ||
       !check_int32_within_range(
-          context, op_name, input.size(3), "input width", input_w) ||
+          context, op_name, input.size(width_dim), "input width", input_w) ||
       !check_int32_within_range(
-          context, op_name, output.size(2), "output height", output_h) ||
+          context,
+          op_name,
+          output.size(height_dim),
+          "output height",
+          output_h) ||
       !check_int32_within_range(
-          context, op_name, output.size(3), "output width", output_w)) {
+          context, op_name, output.size(width_dim), "output width", output_w)) {
     return false;
   }
 

--- a/backends/cortex_m/ops/op_quantized_avg_pool2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_avg_pool2d.cpp
@@ -1,5 +1,7 @@
 /*
  * Copyright 2025-2026 Arm Limited and/or its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -66,7 +68,7 @@ bool validate_avg_pool2d_output_size(
 } // namespace
 
 // cppcheck-suppress unusedFunction
-Tensor& quantized_avg_pool2d_out(
+static Tensor& quantized_avg_pool2d_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Int64ArrayRef kernel_size,
@@ -77,6 +79,7 @@ Tensor& quantized_avg_pool2d_out(
     const int64_t multiplier,
     const int64_t shift,
     const Tensor& scratch,
+    ActivationLayout layout,
     Tensor& out) {
   constexpr int32_t activation_min = std::numeric_limits<int8_t>::min();
   constexpr int32_t activation_max = std::numeric_limits<int8_t>::max();
@@ -97,7 +100,7 @@ Tensor& quantized_avg_pool2d_out(
           activation_min,
           activation_max,
           pool_config,
-          true,
+          layout,
           true)) {
     return out;
   }
@@ -151,6 +154,62 @@ Tensor& quantized_avg_pool2d_out(
   (void)shift;
 
   return out;
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_avg_pool2d_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef kernel_size,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const bool ceil_mode,
+    const int64_t zero_point,
+    const int64_t multiplier,
+    const int64_t shift,
+    const Tensor& scratch,
+    Tensor& out) {
+  return quantized_avg_pool2d_out_impl(
+      context,
+      input,
+      kernel_size,
+      stride,
+      padding,
+      ceil_mode,
+      zero_point,
+      multiplier,
+      shift,
+      scratch,
+      ActivationLayout::NCHWLogical,
+      out);
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_avg_pool2d_nhwc_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef kernel_size,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const bool ceil_mode,
+    const int64_t zero_point,
+    const int64_t multiplier,
+    const int64_t shift,
+    const Tensor& scratch,
+    Tensor& out) {
+  return quantized_avg_pool2d_out_impl(
+      context,
+      input,
+      kernel_size,
+      stride,
+      padding,
+      ceil_mode,
+      zero_point,
+      multiplier,
+      shift,
+      scratch,
+      ActivationLayout::NHWCLogical,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/op_quantized_max_pool2d.cpp
+++ b/backends/cortex_m/ops/op_quantized_max_pool2d.cpp
@@ -1,5 +1,7 @@
 /*
- * Copyright 2026 Arm Limited and/or its affiliates.
+ * Copyright 2026 Arm Limited
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
@@ -11,7 +13,7 @@ namespace cortex_m {
 namespace native {
 
 // cppcheck-suppress unusedFunction
-Tensor& quantized_max_pool2d_out(
+static Tensor& quantized_max_pool2d_out_impl(
     KernelRuntimeContext& context,
     const Tensor& input,
     const Int64ArrayRef kernel_size,
@@ -23,6 +25,7 @@ Tensor& quantized_max_pool2d_out(
     const int64_t output_zero_point,
     const int64_t activation_min,
     const int64_t activation_max,
+    ActivationLayout layout,
     Tensor& out) {
   CmsisPool2DConfig pool_config;
   if (!prepare_cmsis_pool2d_config(
@@ -37,7 +40,8 @@ Tensor& quantized_max_pool2d_out(
           ceil_mode,
           activation_min,
           activation_max,
-          pool_config)) {
+          pool_config,
+          layout)) {
     return out;
   }
 
@@ -93,6 +97,66 @@ Tensor& quantized_max_pool2d_out(
   }
 
   return out;
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_max_pool2d_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef kernel_size,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef dilation,
+    const bool ceil_mode,
+    const int64_t input_zero_point,
+    const int64_t output_zero_point,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    Tensor& out) {
+  return quantized_max_pool2d_out_impl(
+      context,
+      input,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      ceil_mode,
+      input_zero_point,
+      output_zero_point,
+      activation_min,
+      activation_max,
+      ActivationLayout::NCHWLogical,
+      out);
+}
+
+// cppcheck-suppress unusedFunction
+Tensor& quantized_max_pool2d_nhwc_out(
+    KernelRuntimeContext& context,
+    const Tensor& input,
+    const Int64ArrayRef kernel_size,
+    const Int64ArrayRef stride,
+    const Int64ArrayRef padding,
+    const Int64ArrayRef dilation,
+    const bool ceil_mode,
+    const int64_t input_zero_point,
+    const int64_t output_zero_point,
+    const int64_t activation_min,
+    const int64_t activation_max,
+    Tensor& out) {
+  return quantized_max_pool2d_out_impl(
+      context,
+      input,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      ceil_mode,
+      input_zero_point,
+      output_zero_point,
+      activation_min,
+      activation_max,
+      ActivationLayout::NHWCLogical,
+      out);
 }
 
 } // namespace native

--- a/backends/cortex_m/ops/operators.py
+++ b/backends/cortex_m/ops/operators.py
@@ -1642,6 +1642,73 @@ def quantized_avg_pool2d_impl(
     return output.to(torch.int8)
 
 
+lib.define(
+    "quantized_avg_pool2d_nhwc("
+    "Tensor input, int[] kernel_size, int[] stride, int[] padding, "
+    "bool ceil_mode, int zero_point, int multiplier, int shift, "
+    "Tensor scratch) -> Tensor"
+)
+lib.define(
+    "quantized_avg_pool2d_nhwc.out("
+    "Tensor input, int[] kernel_size, int[] stride, int[] padding, "
+    "bool ceil_mode, int zero_point, int multiplier, int shift, "
+    "Tensor scratch, *, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+@register_fake("cortex_m::quantized_avg_pool2d_nhwc")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def quantized_avg_pool2d_nhwc_meta(
+    input: torch.Tensor,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    ceil_mode: bool,
+    zero_point: int,
+    multiplier: int,
+    shift: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_avg_pool2d_meta(
+        input.permute(0, 3, 1, 2),
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        zero_point,
+        multiplier,
+        shift,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@impl(lib, "quantized_avg_pool2d_nhwc", "CompositeExplicitAutograd")  # type: ignore[misc]
+def quantized_avg_pool2d_nhwc_impl(
+    input: torch.Tensor,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    ceil_mode: bool,
+    zero_point: int,
+    multiplier: int,
+    shift: int,
+    scratch: torch.Tensor,
+) -> torch.Tensor:
+    nchw = quantized_avg_pool2d_impl(
+        input.permute(0, 3, 1, 2).contiguous(),
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        zero_point,
+        multiplier,
+        shift,
+        scratch,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
 # ===================================================================
 # QUANTIZED MAX POOL2D OPERATION DEFINITION
 # ===================================================================
@@ -1797,3 +1864,75 @@ def quantized_max_pool2d_impl(
     )
     result = torch.clamp(result, activation_min, activation_max)
     return result.to(torch.int8).contiguous(memory_format=torch.channels_last)
+
+
+lib.define(
+    "quantized_max_pool2d_nhwc("
+    "Tensor input, int[] kernel_size, int[] stride, int[] padding, "
+    "int[] dilation, bool ceil_mode, int input_zero_point, "
+    "int output_zero_point, int activation_min, int activation_max) -> Tensor"
+)
+lib.define(
+    "quantized_max_pool2d_nhwc.out("
+    "Tensor input, int[] kernel_size, int[] stride, int[] padding, "
+    "int[] dilation, bool ceil_mode, int input_zero_point, "
+    "int output_zero_point, int activation_min, int activation_max, "
+    "*, Tensor(a!) out) -> Tensor(a!)"
+)
+
+
+@register_fake("cortex_m::quantized_max_pool2d_nhwc")  # type: ignore[misc]
+@experimental(_EXPLICIT_LAYOUT_EXPERIMENTAL)  # type: ignore[misc]
+def quantized_max_pool2d_nhwc_meta(
+    input: torch.Tensor,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    ceil_mode: bool,
+    input_zero_point: int,
+    output_zero_point: int,
+    activation_min: int,
+    activation_max: int,
+) -> torch.Tensor:
+    nchw = quantized_max_pool2d_meta(
+        input.permute(0, 3, 1, 2),
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        input_zero_point,
+        output_zero_point,
+        activation_min,
+        activation_max,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@impl(lib, "quantized_max_pool2d_nhwc", "CompositeExplicitAutograd")  # type: ignore[misc]
+def quantized_max_pool2d_nhwc_impl(
+    input: torch.Tensor,
+    kernel_size: Sequence[int],
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    ceil_mode: bool,
+    input_zero_point: int,
+    output_zero_point: int,
+    activation_min: int,
+    activation_max: int,
+) -> torch.Tensor:
+    nchw = quantized_max_pool2d_impl(
+        input.permute(0, 3, 1, 2).contiguous(),
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        input_zero_point,
+        output_zero_point,
+        activation_min,
+        activation_max,
+    )
+    return nchw.permute(0, 2, 3, 1).contiguous()

--- a/backends/cortex_m/ops/operators.yaml
+++ b/backends/cortex_m/ops/operators.yaml
@@ -119,11 +119,24 @@
   kernels:
     - arg_meta: null
       kernel_name: cortex_m::quantized_avg_pool2d_out
+
+- func: cortex_m::quantized_avg_pool2d_nhwc.out(Tensor input, int[] kernel_size, int[] stride, int[] padding, bool ceil_mode, int zero_point, int multiplier, int shift, Tensor scratch, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: cortex_m::quantized_avg_pool2d_nhwc_out
+
 - func: cortex_m::quantized_max_pool2d.out(Tensor input, int[] kernel_size, int[] stride, int[] padding, int[] dilation, bool ceil_mode, int input_zero_point, int output_zero_point, int activation_min, int activation_max, *, Tensor(a!) out) -> Tensor(a!)
   variants: function
   kernels:
     - arg_meta: null
       kernel_name: cortex_m::quantized_max_pool2d_out
+
+- func: cortex_m::quantized_max_pool2d_nhwc.out(Tensor input, int[] kernel_size, int[] stride, int[] padding, int[] dilation, bool ceil_mode, int input_zero_point, int output_zero_point, int activation_min, int activation_max, *, Tensor(a!) out) -> Tensor(a!)
+  variants: function
+  kernels:
+    - arg_meta: null
+      kernel_name: cortex_m::quantized_max_pool2d_nhwc_out
 
 - func: cortex_m::quantized_batch_matmul.out(Tensor lhs, int lhs_zero_point, Tensor rhs_transposed, int rhs_zero_point, int output_zero_point, int output_multiplier, int output_shift, Tensor scratch, *, Tensor(a!) out) -> Tensor(a!)
   variants: function

--- a/backends/cortex_m/passes/scratch_buffer_sizes.py
+++ b/backends/cortex_m/passes/scratch_buffer_sizes.py
@@ -259,13 +259,16 @@ def cmsis_nn_transpose_conv_buffer_size(
 def cmsis_nn_avgpool_buffer_size(
     backend: cmsis_nn.Backend,
     pool_node: torch.fx.Node,
+    nhwc_logical: bool = False,
 ) -> list[int]:
     x = cast(torch.fx.Node, pool_node.args[0])
 
-    # Input is NCHW (PyTorch); CMSIS-NN's avgpool buffer sizer only needs the
-    # input channel count and output width.
-    _, c_in, _, _ = _shape_from_node(x)
-    _, _, _, out_w = _shape_from_node(pool_node)
+    if nhwc_logical:
+        _, _, _, c_in = _shape_from_node(x)
+        _, _, out_w, _ = _shape_from_node(pool_node)
+    else:
+        _, c_in, _, _ = _shape_from_node(x)
+        _, _, _, out_w = _shape_from_node(pool_node)
 
     return [
         int(
@@ -294,6 +297,9 @@ _target_to_buffer_sizes_registry: dict[Any, BufferSizeFunction] = {
         cmsis_nn_transpose_conv_buffer_size, nhwc_logical=True
     ),
     exir_ops.edge.cortex_m.quantized_avg_pool2d.default: cmsis_nn_avgpool_buffer_size,
+    exir_ops.edge.cortex_m.quantized_avg_pool2d_nhwc.default: partial(
+        cmsis_nn_avgpool_buffer_size, nhwc_logical=True
+    ),
 }
 
 

--- a/backends/cortex_m/test/build_test_runner.sh
+++ b/backends/cortex_m/test/build_test_runner.sh
@@ -73,7 +73,9 @@ ops_list=(
     cortex_m::quantized_transpose_conv2d.out
     cortex_m::quantized_transpose_conv2d_nhwc.out
     cortex_m::quantized_avg_pool2d.out
+    cortex_m::quantized_avg_pool2d_nhwc.out
     cortex_m::quantized_max_pool2d.out
+    cortex_m::quantized_max_pool2d_nhwc.out
     cortex_m::quantized_batch_matmul.out
 )
 

--- a/backends/cortex_m/test/ops/test_nhwc_pool.py
+++ b/backends/cortex_m/test/ops/test_nhwc_pool.py
@@ -1,0 +1,67 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from executorch.backends.cortex_m.test.ops.nhwc_test_utils import (
+    int8_values,
+    run_on_fvp,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+
+# Direct-op coverage is temporary until CortexMTester uses explicit layout by default.
+
+
+class AvgPool2dNhwc(torch.nn.Module):
+    def forward(self, x, scratch):
+        return torch.ops.cortex_m.quantized_avg_pool2d_nhwc.default(
+            x,
+            [2, 3],
+            [2, 1],
+            [0, 1],
+            False,
+            0,
+            1 << 30,
+            1,
+            scratch,
+        )
+
+
+class MaxPool2dNhwc(torch.nn.Module):
+    def forward(self, x):
+        return torch.ops.cortex_m.quantized_max_pool2d_nhwc.default(
+            x,
+            [2, 3],
+            [2, 1],
+            [0, 1],
+            [1, 1],
+            False,
+            0,
+            0,
+            -128,
+            127,
+        )
+
+
+def test_avg_pool2d_nhwc_runs_on_fvp(cortex_m_target):
+    run_on_fvp(
+        AvgPool2dNhwc(),
+        int8_values((1, 7, 9, 3)),
+        exir_ops.edge.cortex_m.quantized_avg_pool2d_nhwc.default,
+        cortex_m_target,
+        1,
+        atol=1,
+    )
+
+
+def test_max_pool2d_nhwc_runs_on_fvp(cortex_m_target):
+    run_on_fvp(
+        MaxPool2dNhwc(),
+        int8_values((1, 7, 9, 3)),
+        exir_ops.edge.cortex_m.quantized_max_pool2d_nhwc.default,
+        cortex_m_target,
+        0,
+    )


### PR DESCRIPTION
### Summary

Add and register NHWC average- and max-pooling implementations using the shared layout-aware CMSIS-NN validation and configuration path.

### Why separate operators

The legacy pooling symbols consume logical NCHW tensors represented with channels-last dim order. Explicit layout consumes ordinary contiguous NHWC tensors. Separate experimental symbols keep those contracts visible and prevent silent interpretation of one representation as the other, while shared helpers retain one implementation of the common CMSIS-NN mechanics.

The registration entries and FVP selected-op list live beside these C++ kernels so this PR is independently loadable and testable through serialized programs.

AI-assisted: Codex.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>