### PR TITLE
Enhance workflow to label external PRs

### DIFF
--- a/.github/workflows/add-unanswered-to-project.yml
+++ b/.github/workflows/add-unanswered-to-project.yml
@@ -11,11 +11,12 @@ on:
   pull_request:
     paths:
       - .github/workflows/add-unanswered-to-project.yml
+
 jobs:
   add_to_project:
     runs-on: ubuntu-latest
     steps:
-      - name: Add open issues and open, non-draft PRs to org project (excluding certain authors and bots)
+      - name: Add open issues and open, non-draft PRs to org project and label external PRs (excluding certain authors and bots)
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.ET_EXT_CONTRIB }}
@@ -26,36 +27,36 @@ jobs:
 
             // List of authors to exclude
             const excludedAuthors = new Set([
-              "nil-is-all", "tanvirislam-meta", "cbilgin", "kimishpatel", "psiddh", "digantdesai", "SS-JIA", "ahmtox", "mcr229", 
-              "shoumikhin", "manuelcandales", "metascroy", "cccclai", "rohansjoshi", "kirklandsign", "abhinaykukkadapu", "JacobSzwejbka", 
-              "Conarnar", "rascani", "kiymetakdemir", "JCNTH", "lucylq", "larryliu0820", "BujSet", "Gasoonjia", "Juntian777", "guangy10", 
-              "jackzhxng", "GregoryComer", "leafs1", "swolchok", "mergennachin", "tarun292", "byjlw", "jathu", "Jack-Khuu", "georgehong", 
-              "zhenyan-zhang-meta", "silverguo", "harishs88ss", "AlannaBurke", "Doggeral", "laithsakka", "Reubend", "dbort", "huydhn", "mcremon-meta", 
-              "trivedivivek", "angelayi", "helunwencser", "hsharma35", "zhxchen17", "iseeyuan", "svekars", "nathanaelsee", "dulinriley", 
-              "jerryzh168", "cmodi-meta", "bigfootjon", "sxu", "ydwu4", "Riandy", "tugsbayasgalan", "bsoyluoglu", "yangw-dev", 
+              "nil-is-all", "tanvirislam-meta", "cbilgin", "kimishpatel", "psiddh", "digantdesai", "SS-JIA", "ahmtox", "mcr229",
+              "shoumikhin", "manuelcandales", "metascroy", "cccclai", "rohansjoshi", "kirklandsign", "abhinaykukkadapu", "JacobSzwejbka",
+              "Conarnar", "rascani", "kiymetakdemir", "JCNTH", "lucylq", "larryliu0820", "BujSet", "Gasoonjia", "Juntian777", "guangy10",
+              "jackzhxng", "GregoryComer", "leafs1", "swolchok", "mergennachin", "tarun292", "byjlw", "jathu", "Jack-Khuu", "georgehong",
+              "zhenyan-zhang-meta", "silverguo", "harishs88ss", "AlannaBurke", "Doggeral", "laithsakka", "Reubend", "dbort", "huydhn", "mcremon-meta",
+              "trivedivivek", "angelayi", "helunwencser", "hsharma35", "zhxchen17", "iseeyuan", "svekars", "nathanaelsee", "dulinriley",
+              "jerryzh168", "cmodi-meta", "bigfootjon", "sxu", "ydwu4", "Riandy", "tugsbayasgalan", "bsoyluoglu", "yangw-dev",
               "YIWENX14", "namanahuja", "yushangdi", "limintang", "pianpwk", "viveknayakatmeta", "andreanicastro", "JakeStevens",
               "gmagogsfm", "zonglinpeng", "eigen-k", "derekxu", "salilsdesai", "skrtskrtfb", "pssrawat", "r-barnes",
               "kalpit-meta-1", "Will-MingLun-Li", "KapJI", "piyengar", "j-bahr", "BoyuanFeng", "fgasperij", "DariusHolmgren",
               "sammarden-meta", "kushrast", "meta-emilian", "Rittzz", "jeanschmidt", "copyrightly", "mikekgfb", "vmpuri",
-              "zonglinpengmeta", "maggiemoss", "aorenste", "hoangminhle98", "Solumin", "meyering", "rchen152", "AishwaryaSivaraman", 
-              "migeed-z", "ebgraham", "Esteb37", "nausicaasnow", "Camyll", "ezyang", "huiyujie", "dltn", "cjhopman", "blackm00n", 
-              "agunapal", "SamGondelman", "Ninja91", "ivayloen", "DrJessop", "rodrigos01meta", "akrieger", "cmt0", "yiming0416", 
-              "ethansfng", "ThomasJannaud", "nirvanagth", "marcinkwiatkowski", "3l1", "omerjerk", "nitish2112", "yipjustin", 
-              "ejnguyen", "andrewor14", "phaiting", "mgiordy", "LeeOHzzZ", "adicatana", "Polyomino", "ezrilow", "navsud", 
-              "michaelmaitland", "RahulC7", "seyeong-han", "thdusdl1219", "jaejunku", "felixweilbach", "apullin", "trviv", "junluan01", 
-              "mvartani-meta", "abeakkas", "elpdumont", "corporateshark", "bdemirb", "GeorgeTzoupis", "AdithyaReddy9", "drinkmorewaterr", 
-              "aliafzal", "YifanShenSZ", "RdoubleA", "Olivia-liu", "Abhi-hpp", "Vysarat","azad-meta", "junpi", 
-              "pytorchbot", "pytorchmergebot", "pytorchupdatebot", "facebook-github-bot", "app/dependabot", 
-              "Erik-Lundell", "zingo", "AdrianLundell", "oscarandersson8218", "per", "Sebastian-Larsson", "SaoirseARM", "robell", 
-              "mansnils", "martinlsm", "freddan80", "YufengShi-dudu", "tom-arm", "perheld", "Jerry-Ge", "gggekov", "fumchin", "wwwind", 
-              "benkli01", "Tessil", "maddun01", "Michiel-Olieslagers", "armwaheed", "agrima1304", "emmakujala", "annietllnd", 
-              "MatthiasHertel80", "AlexTawseArm", "jmahbs", "morgolock", "Christoffer-JL", "ArmRyan", "xingguo01", "tgonzalezorlandoarm", 
+              "zonglinpengmeta", "maggiemoss", "aorenste", "hoangminhle98", "Solumin", "meyering", "rchen152", "AishwaryaSivaraman",
+              "migeed-z", "ebgraham", "Esteb37", "nausicaasnow", "Camyll", "ezyang", "huiyujie", "dltn", "cjhopman", "blackm00n",
+              "agunapal", "SamGondelman", "Ninja91", "ivayloen", "DrJessop", "rodrigos01meta", "akrieger", "cmt0", "yiming0416",
+              "ethansfng", "ThomasJannaud", "nirvanagth", "marcinkwiatkowski", "3l1", "omerjerk", "nitish2112", "yipjustin",
+              "ejnguyen", "andrewor14", "phaiting", "mgiordy", "LeeOHzzZ", "adicatana", "Polyomino", "ezrilow", "navsud",
+              "michaelmaitland", "RahulC7", "seyeong-han", "thdusdl1219", "jaejunku", "felixweilbach", "apullin", "trviv", "junluan01",
+              "mvartani-meta", "abeakkas", "elpdumont", "corporateshark", "bdemirb", "GeorgeTzoupis", "AdithyaReddy9", "drinkmorewaterr",
+              "aliafzal", "YifanShenSZ", "RdoubleA", "Olivia-liu", "Abhi-hpp", "Vysarat","azad-meta", "junpi",
+              "pytorchbot", "pytorchmergebot", "pytorchupdatebot", "facebook-github-bot", "app/dependabot",
+              "Erik-Lundell", "zingo", "AdrianLundell", "oscarandersson8218", "per", "Sebastian-Larsson", "SaoirseARM", "robell",
+              "mansnils", "martinlsm", "freddan80", "YufengShi-dudu", "tom-arm", "perheld", "Jerry-Ge", "gggekov", "fumchin", "wwwind",
+              "benkli01", "Tessil", "maddun01", "Michiel-Olieslagers", "armwaheed", "agrima1304", "emmakujala", "annietllnd",
+              "MatthiasHertel80", "AlexTawseArm", "jmahbs", "morgolock", "Christoffer-JL", "ArmRyan", "xingguo01", "tgonzalezorlandoarm",
               "chizkiyahu", "sarah-blades", "itsMarco-G", "usamahz", "Rob-Hughes-Arm", "swha815", "FabulousSuperDude",
-              "haowhsu-quic", "shewu-quic", "winskuo-quic", "chunit-quic", "DannyYuyang-quic", "chuntl", "thchenqti", "jethroqti", 
-              "chenweng-quic", "qti-horodnic", "qti-mmadhava", "quic-boyuc", "zhaoxul-qti", 
-              "cymbalrush", "DenisVieriu97", "billmguo", 
-              "StrycekSimon", "jirioc", "robert-kalmar", "skywall", "MartinPavella", "roman-janik-nxp", "novak-vaclav", "irtrukhina", 
-              "neuropilot-captain", "dijopaul", "cad-rlc", "cad-audio", "ynimmaga", "daniil-lyakhov", 
+              "haowhsu-quic", "shewu-quic", "winskuo-quic", "chunit-quic", "DannyYuyang-quic", "chuntl", "thchenqti", "jethroqti",
+              "chenweng-quic", "qti-horodnic", "qti-mmadhava", "quic-boyuc", "zhaoxul-qti",
+              "cymbalrush", "DenisVieriu97", "billmguo",
+              "StrycekSimon", "jirioc", "robert-kalmar", "skywall", "MartinPavella", "roman-janik-nxp", "novak-vaclav", "irtrukhina",
+              "neuropilot-captain", "dijopaul", "cad-rlc", "cad-audio", "ynimmaga", "daniil-lyakhov",
               "emmanuel-ferdman", "cavusmustafa", "anzr299", "suryasidd", "Jiseong-oh", "alexdean08",
               // explicitly include the dependabot bot login seen in PRs
               "dependabot[bot]"
@@ -69,7 +70,10 @@ jobs:
 
             // Labels on PRs to exclude from being added to the project
             const excludedPrLabels = new Set(["fb-exported", "meta-exported"]);
-            
+
+            // Label applied to PRs that pass every external-contributor check below
+            const communityLabel = "community: contribution";
+
             // Simple cache for user -> boolean (member of excluded org)
             const orgsCache = new Map();
             const companyCache = new Map();
@@ -125,6 +129,31 @@ jobs:
                 return false;
               }
             }
+
+            function hasCommunityLabel(item) {
+              if (!item || !item.labels) return false;
+              return item.labels.some(l => l && l.name && l.name.toLowerCase() === communityLabel);
+            }
+
+            async function addCommunityLabel(pr) {
+              if (hasCommunityLabel(pr)) {
+                console.log(`PR #${pr.number} already has "${communityLabel}"`);
+                return;
+              }
+              try {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  labels: [communityLabel]
+                });
+                console.log(`Labeled PR #${pr.number} with "${communityLabel}"`);
+              } catch (error) {
+                // Labeling is best-effort: a failure here must not stop the rest of the run.
+                console.log(`Error labeling PR #${pr.number}: ${error.message}`);
+              }
+            }
+
             async function addItem(contentId, type, number) {
               try {
                 await github.graphql(`
@@ -156,6 +185,7 @@ jobs:
                   filter: 'all'
                 }
               );
+
               for (const issue of issues) {
                 if (issue.pull_request) {
                   console.log(`Skipping PR #${issue.number} (listed in issues)`);
@@ -185,6 +215,7 @@ jobs:
                   state: 'open',
                 }
               );
+
               for (const pr of prs) {
                 if (pr.draft) {
                   console.log(`Skipping PR #${pr.number} (draft)`);
@@ -207,6 +238,7 @@ jobs:
                   continue;
                 }
                 await addItem(pr.node_id, 'pr', pr.number);
+                await addCommunityLabel(pr);
               }
             } catch (error) {
               core.setFailed(`Workflow failed: ${error.message}`);


### PR DESCRIPTION
Updated the workflow to label external PRs with a community label and refined the exclusion list for authors and bots.

We already have a label - *community: contribution*. Just updating the workflow which adds community contributed PRs to the Project Board to have this label.
