### PR TITLE
Stop importing the SDK downloader to load the Qualcomm package

### DIFF
--- a/backends/qualcomm/__init__.py
+++ b/backends/qualcomm/__init__.py
@@ -1,4 +1,6 @@
 import os
+import platform
+import sys
 import threading
 
 # The Qualcomm SDK setup below is deferred rather than run here, so that importing this
@@ -11,11 +13,33 @@ import threading
 # Nothing about loading this package needs any of that. The native adaptor does not link
 # the SDK; it resolves QNN symbols with dlopen when a model is actually compiled, and says
 # so plainly when they are missing. So setup happens on the first call that needs it.
-from .scripts.download_qnn_sdk import (  # noqa: F401
-    install_qnn_sdk,
-    is_linux_x86,
-    QNN_ZIP_URL,
-)
+
+# Resolved on first use rather than at import, because the downloader lives in a sibling
+# directory that some builds do not package, and importing this package must not require it.
+# A module level __getattr__ keeps these as ordinary attributes, so callers and tests can still
+# reach and replace them.
+_LAZY_NAMES = ("install_qnn_sdk", "QNN_ZIP_URL")
+
+
+def is_linux_x86() -> bool:
+    """True when a prebuilt Qualcomm SDK is published for this platform."""
+    return platform.system().lower() == "linux" and platform.machine().lower() in (
+        "x86_64",
+        "amd64",
+        "i386",
+        "i686",
+    )
+
+
+def __getattr__(name):
+    if name in _LAZY_NAMES:
+        from .scripts.download_qnn_sdk import install_qnn_sdk, QNN_ZIP_URL
+
+        globals()["install_qnn_sdk"] = install_qnn_sdk
+        globals()["QNN_ZIP_URL"] = QNN_ZIP_URL
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 _sdk_ready = False
 # Guards the flag above. Python's import lock does not, because the setup is now called from
@@ -57,16 +81,17 @@ def _setup_qnn_sdk_locked() -> None:
         return
 
     # Downloading a prebuilt SDK is only possible for the platform it is published for.
-    if not is_linux_x86():
+    if not sys.modules[__name__].is_linux_x86():
         _sdk_ready = True
         return
 
-    if not install_qnn_sdk():
+    module = sys.modules[__name__]
+    if not module.install_qnn_sdk():
         raise RuntimeError(
             "Failed to set up QNN SDK.\n\n"
             "To resolve, try one of:\n"
             "  1. Download the SDK manually from:\n"
-            f"       {QNN_ZIP_URL}\n"
+            f"       {module.QNN_ZIP_URL}\n"
             "     Or go to step 2 if QNN SDK already exists.\n"
             "  2. Set QNN_SDK_ROOT to an existing SDK installation:\n"
             "       export QNN_SDK_ROOT=/path/to/qualcomm/sdk\n"

--- a/backends/qualcomm/__init__.py
+++ b/backends/qualcomm/__init__.py
@@ -89,6 +89,10 @@ def _setup_qnn_sdk_locked() -> None:
     try:
         installed = module.install_qnn_sdk()
     except ModuleNotFoundError as error:
+        # Only when the downloader itself is absent. A dependency missing from inside it is a
+        # different problem and is left to speak for itself.
+        if not (error.name or "").startswith(f"{__name__}.scripts"):
+            raise
         # This build does not carry the downloader, so an SDK cannot be fetched here. Say what to
         # do rather than surfacing a missing module from a packaging detail.
         raise RuntimeError(

--- a/backends/qualcomm/__init__.py
+++ b/backends/qualcomm/__init__.py
@@ -86,7 +86,20 @@ def _setup_qnn_sdk_locked() -> None:
         return
 
     module = sys.modules[__name__]
-    if not module.install_qnn_sdk():
+    try:
+        installed = module.install_qnn_sdk()
+    except ModuleNotFoundError as error:
+        # This build does not carry the downloader, so an SDK cannot be fetched here. Say what to
+        # do rather than surfacing a missing module from a packaging detail.
+        raise RuntimeError(
+            "This build cannot download a QNN SDK. Set QNN_SDK_ROOT to an existing "
+            "installation:\n"
+            "       export QNN_SDK_ROOT=/path/to/qualcomm/sdk\n"
+            "       export LD_LIBRARY_PATH="
+            "$QNN_SDK_ROOT/lib/x86_64-linux-clang/:$LD_LIBRARY_PATH"
+        ) from error
+
+    if not installed:
         raise RuntimeError(
             "Failed to set up QNN SDK.\n\n"
             "To resolve, try one of:\n"

--- a/backends/qualcomm/tests/test_import_side_effects.py
+++ b/backends/qualcomm/tests/test_import_side_effects.py
@@ -99,11 +99,16 @@ def test_importing_the_package_does_not_need_the_downloader(monkeypatch):
 
     importlib.reload(qnn)
 
-    assert qnn.setup_qnn_sdk is not None
+    # The case that actually broke: a Linux x86 host with a preinstalled SDK, where setup runs
+    # its early return. That must not touch the downloader.
+    monkeypatch.setattr(qnn, "is_linux_x86", lambda: True)
+    monkeypatch.setattr(qnn, "_sdk_ready", False)
+    monkeypatch.setenv("QNN_SDK_ROOT", "/opt/qcom/sdk")
+    monkeypatch.delenv("EXECUTORCH_BUILDING_WHEEL", raising=False)
+
+    qnn.setup_qnn_sdk()
+
     assert qnn.disable_mkldnn_on_amd is not None
-    # is_linux_x86 has to answer without the downloader, because setup asks it before the
-    # branch that needs one.
-    assert isinstance(qnn.is_linux_x86(), bool)
 
 
 def test_setup_is_idempotent(monkeypatch):

--- a/backends/qualcomm/tests/test_import_side_effects.py
+++ b/backends/qualcomm/tests/test_import_side_effects.py
@@ -84,6 +84,28 @@ def test_importing_the_package_does_not_set_up_the_sdk():
     )
 
 
+def test_importing_the_package_does_not_need_the_downloader(monkeypatch):
+    """Importing must not require the sibling scripts directory.
+
+    Some builds package this backend without it, and a module level import of the downloader
+    made every module that calls setup_qnn_sdk fail to import there with
+    ModuleNotFoundError. Nothing about loading the package needs it: it is only used to
+    download an SDK, which is one branch of setup.
+    """
+    monkeypatch.setitem(
+        sys.modules, "executorch.backends.qualcomm.scripts.download_qnn_sdk", None
+    )
+    monkeypatch.setitem(sys.modules, "executorch.backends.qualcomm.scripts", None)
+
+    importlib.reload(qnn)
+
+    assert qnn.setup_qnn_sdk is not None
+    assert qnn.disable_mkldnn_on_amd is not None
+    # is_linux_x86 has to answer without the downloader, because setup asks it before the
+    # branch that needs one.
+    assert isinstance(qnn.is_linux_x86(), bool)
+
+
 def test_setup_is_idempotent(monkeypatch):
     """The compile paths each call it, so only the first call may do the work."""
     calls = []


### PR DESCRIPTION
## Summary

Deferring the Qualcomm SDK setup left six modules importing the package itself:

```python
from executorch.backends.qualcomm import setup_qnn_sdk
```

That loads the package `__init__`, which imported the SDK downloader from the sibling `scripts`
directory at module level. That directory is not part of the installed package in every build of this
backend, and where it is missing all six modules fail to import:

```
ModuleNotFoundError: No module named 'executorch.backends.qualcomm.scripts'
```

Anything importing one of those six then fails too, which surfaces as a test module that cannot be
collected rather than as a test failure.

Before the setup was deferred, nothing inside the package imported the package `__init__`, so the
missing directory never mattered. That is why this was not caught earlier: an installed source tree or
wheel has `scripts` on disk, so the import resolves there.

## The change

Nothing about loading the package needs the downloader. It is used by one branch of setup, the one
that fetches a prebuilt SDK, and that branch cannot be reached when `QNN_SDK_ROOT` is already set or
when no SDK is published for the platform. So it is imported inside that branch instead.

Three details worth stating, because each one was a wrong turn first:

- `is_linux_x86` is defined here now rather than resolved lazily. Setup asks it *before* the branch
  that needs a downloader, so leaving it lazy pulled the downloader back in for every caller. The
  answer is a short platform test.
- `install_qnn_sdk` and `QNN_ZIP_URL` resolve through a module level `__getattr__`, so they stay
  ordinary module attributes. A function local import is simpler but makes them unpatchable, which
  silently broke four existing tests when I tried it.
- When the downloader is genuinely absent, setup raises a `RuntimeError` naming `QNN_SDK_ROOT` rather
  than letting a missing module escape, since a packaging detail is not something the caller can act
  on. That rewrap is limited to the downloader module by name: the downloader imports `requests`, and
  a missing dependency inside it has to keep reporting itself instead of being blamed on packaging.

## Test plan

| case | result |
| --- | --- |
| package import, `scripts` present | ok |
| package import, `scripts` absent | ok |
| `QNN_SDK_ROOT` set, `scripts` absent | early return, downloader never imported |
| no `QNN_SDK_ROOT`, `scripts` absent, Linux x86 | `RuntimeError` naming `QNN_SDK_ROOT` |
| `scripts` present, `requests` absent | `ModuleNotFoundError` naming `requests` |

The third row is the case that broke. The new test covers it by removing the module from
`sys.modules`, reloading, then forcing that path and calling `setup_qnn_sdk()`. It fails on the
previous revision with the `ModuleNotFoundError` above.

The last two rows were each verified by hiding the relevant piece and reading the error the caller
gets. The full test file passes with `scripts` present and with it absent.

## Not covered

No Qualcomm device, so compiling a model for QNN end to end is not exercised here. What is tested is
which modules can be imported and what setup does in each of the states above.
