### PR TITLE
Arm backend: Adjust loglevel in noop-removal

### DIFF
--- a/backends/arm/_passes/convert_expand_copy_to_repeat.py
+++ b/backends/arm/_passes/convert_expand_copy_to_repeat.py
@@ -71,7 +71,7 @@ class ConvertExpandCopyToRepeatPass(ArmOpTargetedPass):
         if all((x == 1 for x in multiples)) and not changes_rank:
             # All dimensions/repetitions occur only once. Remove node
             # altogether since it's in practice just a copy.
-            logger.warning("Found redundant expand node (no-op). Removing it.")
+            logger.info("Found redundant expand node (no-op). Removing it.")
 
             return args[0]
 


### PR DESCRIPTION
ConvertExpandCopyRepeatPass logged removed repeats with loglevel warning. For larger models, this floods the log with these removed noops.

cc @digantdesai @freddan80 @per @zingo @mansnils @Sebastian-Larsson @robell @rascani