### PR TITLE
[ET-VK] Do not partition constant_pad_nd with a symbolic pad

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -1508,12 +1508,34 @@ def register_arange():
 # =============================================================================
 
 
+def _check_pad_is_static(node: torch.fx.Node) -> bool:
+    """Only support constant_pad_nd when the pad amounts are static.
+
+    A symbolic pad list is serialized as a VALUELIST rather than an INTLIST, and
+    Pad.cpp reads it with get_int_list(), which throws "Expected value to have
+    type IntList, got VALUELIST instead".
+
+    Supporting it properly is more than swapping in
+    extract_int_or_symint_list(), the way Split.cpp, View.cpp and Expand.cpp
+    read their symbolic lists: add_constant_pad_nd_node() folds the amounts into
+    a per-dim offset and bakes that into a params buffer at BUILD time, so the
+    dispatch would still use stale offsets even if the list were read
+    symbolically. The buffer has to be refreshed on resize first. Decline the
+    node until then.
+    """
+    pad = node.args[1]
+    if not isinstance(pad, (list, tuple)):
+        return False
+    return all(isinstance(p, int) for p in pad)
+
+
 @update_features(exir_ops.edge.aten.constant_pad_nd.default)
 def register_constant_pad_nd():
     return OpFeatures(
         inputs_storage=utils.ANY_STORAGE,
         inputs_dtypes=utils.FP_INT_BOOL_T,
         supports_resize=True,
+        are_node_inputs_supported_fn=_check_pad_is_static,
     )
 
 

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -1464,6 +1464,32 @@ class TestVulkanBackend(unittest.TestCase):
             sample_inputs,
         )
 
+    def test_vulkan_backend_constant_pad_nd_symbolic_pad(self):
+        """A pad amount derived from a dynamic dim, as LSTM padding produces.
+
+        Without the guard this partitions and then aborts at prepack with
+        "Expected value to have type IntList, got VALUELIST instead", because
+        the pad list is serialized as a VALUELIST of Int/SymInt.
+        """
+
+        class TestModule(torch.nn.Module):
+            def forward(self, x):
+                # Pad up to a static length, the shape every unrolled LSTM
+                # wants its input in.
+                return torch.nn.functional.pad(x, (0, 0, 0, 16 - x.shape[1]))
+
+        sample_inputs = (torch.randn(size=(1, 12, 8), dtype=torch.float32),)
+        seq = Dim("seq", min=2, max=16)
+        self.lower_module_and_test_output(
+            TestModule(),
+            sample_inputs,
+            dynamic_shapes={"x": {1: seq}},
+            test_inputs=[
+                (torch.randn(size=(1, 4, 8), dtype=torch.float32),),
+                (torch.randn(size=(1, 16, 8), dtype=torch.float32),),
+            ],
+        )
+
     def test_vulkan_backend_repeat(self):
         class TestModule(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
### Summary

A pad amount derived from a dynamic dimension is serialized as a `VALUELIST` of Int/SymInt, and `Pad.cpp` reads the list with `get_int_list()`, which requires a literal `IntList`. The partitioner claims the node regardless, so the model lowers and then aborts at prepack:

```
Exception raised from toIntList at .../graph/containers/Value.h:272:
(isIntList()) is false! Expected value to have type IntList, got VALUELIST instead
```

This is reachable from ordinary code. Any model that pads a dynamic sequence up to the static length its LSTM wants hits it, which is how kokoro's synthesizer fails:

```python
x = torch.nn.functional.pad(x, (0, 0, 0, target - seq_len))
```

### Why not just read the list symbolically

`Split.cpp`, `View.cpp` and `Expand.cpp` all handle a symbolic list with `extract_int_or_symint_list()`, and `Pad.cpp` was simply missed. Swapping the extractor in is not sufficient on its own, though: `add_constant_pad_nd_node()` folds the amounts into a per-dim offset and bakes that into a params buffer at build time, so the dispatch would use stale offsets even if the list were read symbolically. Refreshing that buffer on resize is the real fix and is left for a follow-up. Until then this declines the node so it falls back instead of aborting.

### Test plan

`test_vulkan_backend_constant_pad_nd` pads by a literal `(1, 2, 3, 4, 5, 6)`, so no test covered a symbolic pad. `test_vulkan_backend_constant_pad_nd_symbolic_pad` aborts on main and falls back cleanly with this change.

### Note on scope

This PR previously also guarded `clamp`/`hardtanh` and `_native_batch_norm_legit_no_training`.

- The clamp guards are **dropped**: #22481 implements a real dynamic-bounds path for `clamp` and `hardtanh` via `add_dynamic_clamp_node`, which is strictly better than declining, and keeping the guard alongside it would decline nodes that now work. `hardshrink` and `leaky_relu` still read their bounds at build time through `get_val_or_inf()`, but a symbolic `lambda` or `negative_slope` is a hyperparameter no real model produces, so that is left alone rather than guarded.
- The batch norm guard moved to its own PR, since it is an unrelated failure.

Merges cleanly with #22481.