### PR TITLE
[ET-VK] Size the texture-vs-buffer choice by the bound, not the trace hint

### DIFF
--- a/backends/vulkan/utils.py
+++ b/backends/vulkan/utils.py
@@ -1181,6 +1181,33 @@ def make_tensor_repset(tensor_repr: TensorRepr) -> TensorRepSet:
         raise RuntimeError(f"Unsupported storage type {tensor_repr.storage_type}")
 
 
+def upper_bound_size(dim: Union[int, torch.SymInt]) -> Optional[int]:
+    """Largest value a (possibly symbolic) tensor dimension can take.
+
+    Returns None if no finite bound is known.
+
+    A symbolic dim compares against a limit using its *hint* -- the size of the
+    example input the model happened to be traced with -- not the maximum the
+    exported range allows. Sizing decisions must use the bound instead, or a
+    model traced with a small example will make a choice that is invalid once it
+    runs at a larger size.
+    """
+    if not isinstance(dim, torch.SymInt):
+        return int(dim)
+    if not dim.node.expr.free_symbols:
+        return int(dim.node.expr)
+    shape_env = dim.node.shape_env
+    if shape_env is None:
+        return None
+    try:
+        upper = shape_env.bound_sympy(dim.node.expr).upper
+    except Exception:
+        return None
+    if upper is None or not upper.is_finite:
+        return None
+    return int(upper)
+
+
 def filter_invalid_reprs(
     tensor_val: FakeTensor,
     tensor_repset: TensorRepSet,
@@ -1198,11 +1225,17 @@ def filter_invalid_reprs(
     can be used to produce a valid image texture for the given tensor (i.e. fits within
     texture limits).
     """
+    # Size the texture by what the dimension CAN be, not by the example the
+    # model was traced with. An unbounded dim cannot be shown to fit, so it
+    # falls back to buffer storage.
+    bounds = [upper_bound_size(d) for d in tensor_val.shape]
     valid_texture_layouts = set()
-    for memory_layout in tensor_repset.valid_texture_layouts:
-        extents = required_image_extents(tensor_val.shape, memory_layout)
-        if extents_are_valid(extents, texture_limits):
-            valid_texture_layouts.add(memory_layout)
+    if all(b is not None for b in bounds):
+        max_shape = torch.Size(bounds)
+        for memory_layout in tensor_repset.valid_texture_layouts:
+            extents = required_image_extents(max_shape, memory_layout)
+            if extents_are_valid(extents, texture_limits):
+                valid_texture_layouts.add(memory_layout)
 
     # High dimensional tensors require buffer storage
     if len(tensor_val.shape) > 4:


### PR DESCRIPTION
### Summary

`filter_invalid_reprs()` decides whether a tensor can live in a texture by comparing `required_image_extents(tensor_val.shape)` against the device limits. For a **symbolic** dimension that comparison resolves at the dim's *hint* -- the size of the example the model happened to be traced with -- rather than the maximum its exported range allows.

A model traced with a small example therefore picks a texture that is only valid at that size, and **silently produces wrong results** once it runs larger. Nothing raises.

This matters in practice because exporters conventionally trace with a small example input while declaring a large dynamic max, so the failing combination is the common one.

### Reproduction

The Supertonic TTS text encoder (`Supertone/supertonic-3`), dynamic `T` in `[8, 512]`, **always executed at T=512** on a Galaxy S26 Ultra (Adreno 840). Only the trace-time example length differs, and the edge graphs are identical -- 552 `call_function` nodes, same ops, same literal args, same symbolic shapes, zero differing nodes:

| traced at | cosine vs CPU | emitted .pte |
|---|---|---|
| T=64 | 0.537966 | 18147970 bytes |
| T=128 | 0.537966 | 18147970 bytes (identical file) |
| T=192 | **0.999414** | 18149890 bytes |
| T=512 | **0.999414** | 18149890 bytes (identical file) |

The emitted binaries cluster exactly on the correctness boundary, which is what identifies this as a lowering decision rather than a bad kernel. With this change the T=64 export emits the 18149890-byte artifact and scores 0.999414.

Evaluating the bound also handles the unbounded case: a dim with no finite upper bound cannot be shown to fit any texture, so it falls back to buffer storage.

### Test plan

Measured on Supertonic sub-models, against a CPU reference that the XNNPACK delegate reproduces at cosine 1.000000:

| sub-model | before | after |
|---|---|---|
| text_encoder | 0.406303 | **0.999414** |
| vector_estimator | 0.994432 | **0.999994** |
| vocoder | 0.016757 | **0.999977** |

Partitioner/lowering-side only, so no runtime rebuild is needed to reproduce the failure or the fix.

Note: the vocoder and vector_estimator numbers above also require #22399 (clamp with a symbolic bound), which is an instance of the same underlying theme -- a value derived from a dynamic dimension being read once at build time. This PR is independent of that one and touches a different file.

cc @SS-JIA @manuelcandales @digantdesai @cbilgin