### PR TITLE
[ET-VK] Fix squeeze_copy of the outermost dim under dynamic shapes

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/Squeeze.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Squeeze.cpp
@@ -23,21 +23,27 @@ void add_squeeze_copy_dims_node(
     const ValueRef out) {
   const int64_t in_dim = graph.dim_of(in);
   const std::vector<int64_t> in_sizes = graph.sizes_of(in);
-  const std::vector<int64_t> out_sizes = graph.sizes_of(in);
 
   const std::vector<int64_t> dims = graph.extract_int_or_symint_list(dims_ref);
   std::vector<int64_t> squeeze_dims;
-  // Filter out edge cases that we don't need squeeze:
-  // 1. The size of squeeze dim is larger than 1.
-  // 2. Squeeze outter most dim
-  // For these cases, just pass input to output via clone.
+  // Filter out the edge case that we don't need to squeeze: the size of the
+  // squeeze dim is larger than 1. For that case, just pass input to output via
+  // clone.
+  //
+  // Note that the outermost dim must NOT be excluded here. Routing it to
+  // add_clone_node() leaves the output unresized at runtime, because
+  // resize_clone_node() only propagates sizes when input and output have the
+  // same dim count -- which is never true for a squeeze. Under dynamic shapes
+  // the output then keeps its upper-bound extents while consumers read it at
+  // the real size, silently producing wrong values. add_permute_node()'s
+  // resize function handles the rank-reducing case explicitly.
   for (int i = 0; i < dims.size(); ++i) {
     // adjust negative dims
     int64_t dim_val = dims.at(i);
     if (dim_val < 0) {
       dim_val += in_dim;
     }
-    if (dims.at(i) != 0 && in_sizes.at(dim_val) == 1) {
+    if (in_sizes.at(dim_val) == 1) {
       squeeze_dims.push_back(dim_val);
     }
   }


### PR DESCRIPTION
### Summary

`add_squeeze_copy_dims_node()` deliberately skips dim 0 and falls back to `add_clone_node()`. But `resize_clone_node()` only propagates sizes when input and output have the same dim count -- which a squeeze never does, and the code says so:

```cpp
// TODO: support for when dimensionality doesn't match, i.e. clone is used to
// implement squeeze.
if (graph->dim_of(out) == graph->dim_of(in)) {
  graph->virtual_resize(out, graph->sizes_of(in));
}
```

So the output is never resized. With static shapes that is invisible. With dynamic shapes the output keeps its upper-bound extents while consumers read it at the real size, the copy lands in the wrong places, and roughly half the output comes back zeroed. There is no error; the values are just wrong.

`op_registry.py` declares `supports_resize=True` for `squeeze_copy.dims`, so the partitioner accepts the op and the result is a silent wrong answer rather than a rejected partition.

### Fix

Route dim 0 through the permute path like every other squeeze dim. `resize_permute_node()` already has an explicit branch for the rank-reducing case, so no new resize logic is needed.

### Reproduction

Any model that ends up with `torch.cat(list(x), -1)` over a rank-4 tensor with a dynamic dim: the unbind lowers to `slice_copy` + `squeeze_copy.dims`, and the second slice comes back zeroed for every extent below the bound. Reduced:

```python
class M(torch.nn.Module):
    def forward(self, y):
        return y[1:2], y[1:2].squeeze(0)

ep = torch.export.export(M(), (torch.randn(2, 2, 1000, 128),),
                         dynamic_shapes=({2: Dim("L", min=8, max=1000)},))
```

At L=200, `y[1:2]` is correct while `y[1:2].squeeze(0)` returns exactly half zeros -- cosine 0.704 against the reference, which is sqrt(0.5). It is correct only at L=1000, the bound.

### Verification

Galaxy S26 Ultra, Adreno 840, fp16:

| case | before | after |
| --- | --- | --- |
| `y[1:2].squeeze(0)`, L=200 / 500 / 1000 | 0.704 / 0.708 / 1.000000 | 1.000000 at all three |
| TTS model, CFG batch built via `cat(list(x), -1)` | 0.36 | 0.99993 |

The second row is a supertonic TTS vector-estimator whose classifier-free-guidance uncond branch was the zeroed slice; it is now within fp16 noise of its CPU reference at every sequence length tested (64, 200, 500, 1000).

Note that this class of bug is invisible to `executor_runner`, which can only run a model at its dynamic upper bound -- there is no flag to request a smaller shape, and `--inputs` files must match `nbytes()` of the bound. I found it with a local patch adding an `--input_shapes` flag; happy to send that separately if it would be useful.
