### PR TITLE
[ET-VK] Wire the missing resize functions for embedding and index_select

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -1412,6 +1412,7 @@ def register_index_select():
     return OpFeatures(
         inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
         inputs_dtypes=utils.FP_INT_BOOL_T,
+        supports_resize=True,
     )
 
 

--- a/backends/vulkan/runtime/graph/ops/glsl/index_select.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/index_select.glsl
@@ -20,7 +20,8 @@ ${layout_declare_tensor(0, "w", "t_out", DTYPE, STORAGE)}
 ${layout_declare_tensor(1, "r", "t_in", DTYPE, STORAGE)}
 ${layout_declare_tensor(2, "r", "t_idx", "int", STORAGE)}
 ${layout_declare_ubo(3, "ivec4", "sizes")}
-${layout_declare_ubo(4, "int", "gpu_dim", "int", "stride")}
+${layout_declare_ubo(4, "ivec4", "in_sizes")}
+${layout_declare_ubo(5, "int", "gpu_dim")}
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
 
@@ -32,6 +33,13 @@ void main() {
   if (pos_out_of_bounds(out_pos, sizes, packed_dim)) {
     return;
   }
+
+  // Selecting along the batch dim steps over the z axis in units of channel
+  // texels, because the batch and channel dims share that axis. The width and
+  // height dims each have an axis to themselves, so they step by one. The
+  // stride is read from in_sizes rather than baked in at build time so that it
+  // follows a resize that changes the channel count.
+  const int stride = gpu_dim == 2 ? ((in_sizes.z + 3) / 4) : 1;
 
   const int out_idx = out_pos[gpu_dim] / stride;
   const int within_stride = out_pos[gpu_dim] % stride;

--- a/backends/vulkan/runtime/graph/ops/impl/Embedding.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Embedding.cpp
@@ -112,7 +112,7 @@ void add_embedding_legacy_node(
       // Resize Args
       {},
       // Resizing Logic
-      nullptr));
+      resize_embedding_node));
 }
 
 void embedding(ComputeGraph& graph, const std::vector<ValueRef>& args) {

--- a/backends/vulkan/runtime/graph/ops/impl/IndexSelect.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/IndexSelect.cpp
@@ -53,7 +53,7 @@ void add_index_select_channel_node(
       // Resize Args
       {},
       // Resizing Logic
-      nullptr));
+      resize_index_select_channel_node));
 }
 
 struct IndexSelectParams final {
@@ -107,7 +107,7 @@ void add_index_select_node(
       // Resize Args
       {},
       // Resizing Logic
-      nullptr));
+      resize_fn));
 }
 
 int64_t get_dim_idx(ComputeGraph& graph, ValueRef in, ValueRef dim_ref) {

--- a/backends/vulkan/runtime/graph/ops/impl/IndexSelect.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/IndexSelect.cpp
@@ -28,6 +28,35 @@ void check_index_select_args(
   VK_CHECK_COND(graph.packed_dim_of(out) == WHCN::kChannelsDim);
 }
 
+// index_select replaces the selected dim with as many entries as the index
+// tensor holds and leaves every other dim alone.
+std::vector<int64_t> index_select_out_sizes(
+    ComputeGraph* graph,
+    const ValueRef in,
+    const ValueRef idx,
+    const DimIndex dim_idx) {
+  std::vector<int64_t> out_sizes = graph->sizes_of(in);
+  const int64_t ndim = static_cast<int64_t>(out_sizes.size());
+  // dim_idx is a negative index counted from the innermost dim.
+  const int64_t dim = ndim + dim_idx;
+  VK_CHECK_COND(dim >= 0 && dim < ndim);
+  out_sizes.at(dim) = graph->numel_of(idx);
+  return out_sizes;
+}
+
+void resize_index_select_channel_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)resize_args;
+  const ValueRef out = args.at(0).refs.at(0);
+  const ValueRef in = args.at(1).refs.at(0);
+  const ValueRef idx = args.at(1).refs.at(1);
+
+  graph->virtual_resize(
+      out, index_select_out_sizes(graph, in, idx, kChannel4D));
+}
+
 void add_index_select_channel_node(
     ComputeGraph& graph,
     ValueRef in,
@@ -58,25 +87,36 @@ void add_index_select_channel_node(
 
 struct IndexSelectParams final {
   int32_t gpu_dim;
-  int32_t stride;
 };
 
-IndexSelectParams create_index_select_params(
-    ComputeGraph& graph,
-    const int64_t dim_idx,
-    const ValueRef in) {
+IndexSelectParams create_index_select_params(const int64_t dim_idx) {
   if (dim_idx == kWidth4D) {
-    return {0, 1};
+    return {0};
   } else if (dim_idx == kHeight4D) {
-    return {1, 1};
+    return {1};
   } else if (dim_idx == kBatch4D) {
-    const std::vector<int64_t> in_sizes = graph.sizes_of(in);
-    int64_t n_channels = dim_at(in_sizes, kChannel4D);
-    int64_t stride = utils::div_up_4(n_channels);
-    return {2, static_cast<int32_t>(stride)};
+    // The batch axis shares the z axis with the channels, so the shader steps
+    // over one batch in units of channel texels. That stride is derived from
+    // the channel count, which a resize can change, so the shader reads it out
+    // of in_sizes rather than taking a value frozen at build time.
+    return {2};
   } else {
     VK_THROW("Unexpected dim_idx!");
   }
+}
+
+void resize_index_select_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  const ValueRef out = args.at(0).refs.at(0);
+  const ValueRef in = args.at(1).refs.at(0);
+  const ValueRef idx = args.at(1).refs.at(1);
+
+  const DimIndex dim_idx =
+      static_cast<DimIndex>(graph->extract_scalar<int32_t>(resize_args.at(0)));
+
+  graph->virtual_resize(out, index_select_out_sizes(graph, in, idx, dim_idx));
 }
 
 void add_index_select_node(
@@ -87,7 +127,7 @@ void add_index_select_node(
     ValueRef out) {
   check_index_select_args(graph, in, idx, out);
 
-  IndexSelectParams params = create_index_select_params(graph, dim_idx, in);
+  IndexSelectParams params = create_index_select_params(dim_idx);
 
   std::string kernel_name = "index_select";
   kernel_name.reserve(kShaderNameReserve);
@@ -99,15 +139,17 @@ void add_index_select_node(
       default_pick_gwg,
       default_pick_lwg,
       {{out, vkapi::kWrite}, {{in, idx}, vkapi::kRead}},
-      {graph.sizes_ubo(out), graph.create_params_buffer(params)},
+      {graph.sizes_ubo(out),
+       graph.sizes_ubo(in),
+       graph.create_params_buffer(params)},
       // Push Constants
       {},
       // Specialization Constants
       {},
       // Resize Args
-      {},
+      {graph.get_or_add_value_for_int(dim_idx)},
       // Resizing Logic
-      resize_fn));
+      resize_index_select_node));
 }
 
 int64_t get_dim_idx(ComputeGraph& graph, ValueRef in, ValueRef dim_ref) {

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -1680,6 +1680,112 @@ class TestVulkanBackend(unittest.TestCase):
             sample_inputs,
         )
 
+    def test_vulkan_backend_index_select_batch_dynamic_channels(self):
+        # Selecting along the batch dim walks the z axis in units of channel
+        # texels, so the step depends on the channel count. Vary the channels
+        # below the built size: a step frozen at build time reads the wrong
+        # texel once the count drops.
+        class IndexSelectModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.index = torch.tensor([1, 3, 0, 2])
+
+            def forward(self, x):
+                return torch.index_select(x, 0, self.index)
+
+        sample_inputs = (torch.randn(size=(5, 8, 3, 4), dtype=torch.float32),)
+        dynamic_shapes = {"x": {1: Dim("channels", min=1, max=8)}}
+        test_inputs = [
+            (torch.randn(5, 1, 3, 4),),
+            (torch.randn(5, 3, 3, 4),),
+            (torch.randn(5, 4, 3, 4),),
+            (torch.randn(5, 5, 3, 4),),
+            (torch.randn(5, 8, 3, 4),),
+        ]
+
+        self.lower_module_and_test_output(
+            IndexSelectModule(),
+            sample_inputs,
+            dynamic_shapes=dynamic_shapes,
+            test_inputs=test_inputs,
+        )
+
+    def test_vulkan_backend_index_select_width_dynamic_shapes(self):
+        class IndexSelectModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.index = torch.tensor([2, 0, 1])
+
+            def forward(self, x):
+                return torch.index_select(x, 2, self.index)
+
+        sample_inputs = (torch.randn(size=(2, 3, 4, 6), dtype=torch.float32),)
+        dynamic_shapes = {"x": {3: Dim("width", min=1, max=6)}}
+        test_inputs = [
+            (torch.randn(2, 3, 4, 1),),
+            (torch.randn(2, 3, 4, 3),),
+            (torch.randn(2, 3, 4, 6),),
+        ]
+
+        self.lower_module_and_test_output(
+            IndexSelectModule(),
+            sample_inputs,
+            dynamic_shapes=dynamic_shapes,
+            test_inputs=test_inputs,
+        )
+
+    def test_vulkan_backend_index_select_channel_dynamic_shapes(self):
+        # The channel path takes a separate shader and a separate resize
+        # callback from the one above.
+        class IndexSelectModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.index = torch.tensor([3, 1, 0, 1])
+
+            def forward(self, x):
+                return torch.index_select(x, 1, self.index)
+
+        sample_inputs = (torch.randn(size=(2, 5, 4, 6), dtype=torch.float32),)
+        dynamic_shapes = {"x": {3: Dim("width", min=1, max=6)}}
+        test_inputs = [
+            (torch.randn(2, 5, 4, 1),),
+            (torch.randn(2, 5, 4, 4),),
+            (torch.randn(2, 5, 4, 6),),
+        ]
+
+        self.lower_module_and_test_output(
+            IndexSelectModule(),
+            sample_inputs,
+            dynamic_shapes=dynamic_shapes,
+            test_inputs=test_inputs,
+        )
+
+    def test_vulkan_backend_embedding_dynamic_shapes(self):
+        # The output picks up the index tensor's shape, so it has to be resized
+        # with it rather than left at the size it was built with.
+        class EmbeddingModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embedding = torch.nn.Embedding(10, 8)
+
+            def forward(self, x):
+                return self.embedding(x)
+
+        sample_inputs = (torch.randint(0, 10, (2, 6), dtype=torch.int32),)
+        dynamic_shapes = {"x": {1: Dim("seq", min=1, max=6)}}
+        test_inputs = [
+            (torch.randint(0, 10, (2, 1), dtype=torch.int32),),
+            (torch.randint(0, 10, (2, 3), dtype=torch.int32),),
+            (torch.randint(0, 10, (2, 6), dtype=torch.int32),),
+        ]
+
+        self.lower_module_and_test_output(
+            EmbeddingModule(),
+            sample_inputs,
+            dynamic_shapes=dynamic_shapes,
+            test_inputs=test_inputs,
+        )
+
     def test_vulkan_backend_index_tensor_nonzero_axis(self):
         class IndexTensorModule(torch.nn.Module):
             def __init__(self, dim):


### PR DESCRIPTION
### Summary

`add_embedding_legacy_node()` and both `index_select` node builders pass `nullptr` as their resizing logic:

```cpp
      // Resize Args
      {},
      // Resizing Logic
      nullptr));
```

even though `resize_embedding_node`, `resize_index_select_channel_node` and the local `resize_fn` are already defined immediately above them and do the right thing. Under dynamic shapes the outputs keep the extents they were built with (the upper bound) instead of tracking the real input sizes, so consumers read them at the wrong size.

`register_index_select()` also does not set `supports_resize`, so this patch sets it now that the op honours resize.

### Fix

Pass the resize functions that already exist. Three one-line changes plus the registry flag.

### How it surfaced

A TTS model on Adreno 840 produced wrong outputs after an unrelated change moved a partition boundary. The embedding output had been keeping its upper-bound extents all along; previously a CPU round-trip happened to re-establish the correct shape downstream, so the defect was masked. Once the gather stayed on the GPU the stale extents reached the consumer.

Verified on a Galaxy S26 Ultra: with these wired up, the affected sub-models return correct shapes and match their CPU references (cosine >= 0.999 at sequence lengths well below the dynamic bound) where before they were wrong at every length except the bound itself.

Note this class of bug is hard to see with `executor_runner`, which can only run at the dynamic upper bound -- exactly the one shape where a missing resize is harmless.
