### PR TITLE
Refresh the apt index before installing ffmpeg for the Mimi test

### DIFF
--- a/examples/models/moshi/mimi/install_requirements.sh
+++ b/examples/models/moshi/mimi/install_requirements.sh
@@ -5,9 +5,12 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-set -x
+set -ex
 
-sudo apt install ffmpeg -y
+# The image's apt index is stale, so refresh it before installing: the .deb
+# versions it lists may already be gone from the archive.
+sudo apt-get update
+sudo apt-get install -y ffmpeg
 pip install torchcodec==0.11.0 --extra-index-url https://download.pytorch.org/whl/test/cpu
 pip install moshi==0.2.11
 pip install bitsandbytes soundfile einops


### PR DESCRIPTION
### Problem

The `test-moshi-linux` job has been failing on `main` since about 15:00 UTC on
September 1. It fails with an error that points at the wrong thing:

```
RuntimeError: Could not load libtorchcodec
OSError: libavutil.so.56: cannot open shared object file: No such file or directory
```

That reads like a torchcodec or FFmpeg version problem. It is not. FFmpeg was
never installed at all.

### Cause

The Mimi install script asks apt for `ffmpeg` without refreshing the package
index first. The index in the CI image is stale, so apt asked for a
`libssh-gcrypt-4` version that Ubuntu had already replaced and got a 404. That
package is a required dependency of `libavformat58`, which `ffmpeg` needs, so the
whole install aborted and no FFmpeg libraries landed on disk. Minutes later the
first `torchaudio.load()` call looked for `libavutil.so.56` and found nothing.

The script also used `set -x` without `set -e`, so it ignored the failed install
and kept going. That is why the job died far away from the real cause.

### Fix

- Run `apt-get update` before installing, so apt asks for versions that still
  exist. `.ci/scripts/test_model_e2e.sh` already does this for the same FFmpeg
  dependency.
- Use `set -ex`, so a failed install stops at the line that broke.

### Verification

On a clean Ubuntu 22.04 machine I compared the two states directly. With a stale
index, apt asks for the old version and the download returns 404. After
`apt-get update`, apt asks for the current version and the download succeeds. So
the fix changes the outcome, and the check still fails when the fix is removed.

I also checked that this job's apt traffic only ever goes to the standard Ubuntu
archive, and that every index `apt-get update` fetches is reachable, so adding it
should not make a passing run fail.

I could not run the CI container locally, so this is verified by reproducing the
mechanism rather than by a green run of the job. CI here should confirm it.
