### PR TITLE
Give the QNN test suite enough memory to finish

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1023,7 +1023,9 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-linux: true
-      runner-linux: linux.2xlarge
+      # No runner-linux: the suite exports whole models on one worker per core,
+      # which exhausts a linux.2xlarge and gets the job killed. Inherit the
+      # memory-optimized default instead, as the standalone QNN workflow does.
 
   test-qnn-passes-linux:
     name: test-qnn-passes-linux


### PR DESCRIPTION
### Summary

The QNN backend test suite is killed part way through on every run:

```
4 workers [42 items]
... no output for 38 minutes ...
##[error]Process completed with exit code 137
##[error]The runner has received a shutdown signal
```

Exit code 137 is the process being killed rather than failing, and the long silence before it, well inside the 120 minute limit, points at memory rather than time. The suite exports whole models, and it runs one worker per core, so several models are being converted at once and together they outgrow the machine.

There is precedent for this exact limit: a Llama test was disabled earlier for running out of memory on the same runner size (#20511).

### The same tests already pass on a bigger machine

The standalone QNN workflow (`test-backend-qnn.yml`) runs the same backend and the same suites on `linux.8xlarge.memory`. It was green on all ten of its most recent runs, **including the very commits where this job failed**. The only difference between the two is the machine.

| | Runner | Result |
| --- | --- | --- |
| `test-qnn-testsuite-linux` (in `pull.yml`) | `linux.2xlarge` | failed on 4 of those commits, 5 of 8 sampled branch runs |
| standalone QNN workflow | `linux.8xlarge.memory` | 10 of 10 green, 4 failures in last 100 runs |

### What this changes

This job was overriding the runner to the smallest size. Drop the override so it inherits the memory-optimized default that the shared workflow already defines, which is what every other caller of that workflow uses.

### Why it matters beyond this job

This job is required before a commit can be promoted, so its failures have been holding back the branch that nightly packages are built from. The published nightlies have therefore been carrying a week-old snapshot, and changes landed since then are not reaching users who install a nightly.

### One caveat

This runner size is not itself new, so something else recently pushed memory use over the edge. Raising the ceiling stops the bleeding, and what changed is worth finding separately rather than blocking this on it.

### Test plan

Confirmed the file still parses and that the job now resolves to the shared default of `linux.4xlarge.memory` rather than `linux.2xlarge`, with no other input changed. Checked that no other caller of the shared workflow overrides the runner to a smaller size, and that no other workflow runs this suite on a small machine.

CI on this change exercises the job itself, which is the real test.


cc @cbilgin @psiddh