### PR TITLE
Correct the runner comment, and tighten the moshi installer

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1023,9 +1023,10 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-linux: true
-      # No runner-linux: the suite exports whole models on one worker per core,
-      # which exhausts a linux.2xlarge and gets the job killed. Inherit the
-      # memory-optimized default instead, as the standalone QNN workflow does.
+      # No runner-linux, so this takes the memory-optimized default. The suite
+      # runs one export worker per core, so what matters is memory per core, not
+      # core count: the previous instance gave each worker about 4 GiB and the
+      # job was killed. The memory-optimized default gives each worker more.
 
   test-qnn-passes-linux:
     name: test-qnn-passes-linux

--- a/examples/models/moshi/mimi/install_requirements.sh
+++ b/examples/models/moshi/mimi/install_requirements.sh
@@ -7,13 +7,17 @@
 
 set -ex
 
-# The image's apt index is stale, so refresh it before installing: the .deb
-# versions it lists may already be gone from the archive.
-sudo apt-get update
-sudo apt-get install -y ffmpeg
+# A prebuilt index can list .deb versions the archive has already dropped, and
+# the install then fails on a 404 rather than on anything about this package.
+# Guarded so a machine without apt still gets everything below, as the sibling
+# scripts in this repository do.
+if command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y --no-install-recommends ffmpeg
+fi
 pip install torchcodec==0.11.0 --extra-index-url https://download.pytorch.org/whl/test/cpu
 pip install moshi==0.2.11
 pip install bitsandbytes soundfile einops
 # Run llama2/install requirements for torchao deps
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-bash "$SCRIPT_DIR"/../../llama/install_requirements.sh
+bash -e "$SCRIPT_DIR"/../../llama/install_requirements.sh


### PR DESCRIPTION
## Summary

Review of the two CI changes that just landed found one comment that is false and two small gaps in the
same installer. All three are corrected here.

## The false comment

The QNN test suite takes the memory-optimized default runner rather than naming one, and the comment
explaining why said it was following the standalone QNN workflow. That is backwards: the standalone
workflow is the one caller that *overrides* the default, with a larger memory instance, and it does so
because the default was judged not enough for this suite. Citing it as precedent for inheriting the
default says the opposite of what happened.

```
standalone QNN workflow   runner-linux: linux.8xlarge.memory   (an override)
the shared default        default: linux.4xlarge.memory        (what this job gets)
```

The comment now states what actually fixes the failure: the suite runs one export worker per core, and
the previous instance left each worker about 4 GiB, which was not enough and the job was killed.

## Three gaps in the moshi installer

The apt path is guarded on `apt-get` being present. Adding `set -e` turned an unguarded `sudo apt-get`
into a hard gate, so a machine without apt now installed nothing at all where it previously installed
everything except ffmpeg. Two sibling scripts here already guard it exactly this way.

`ffmpeg` is installed with `--no-install-recommends`, matching those same scripts, which avoids pulling
packages this job never uses.

The nested requirements script is invoked with `bash -e`. Without it, `set -e` in the outer script does
not reach the inner one, so a failure inside it was ignored and the script carried on reporting success.

The comment above the refresh also stated a passing condition as a permanent fact and restated the
command below it. It now gives only the durable reason.

## Test plan

`bash -n` on the installer and a YAML parse of the workflow both pass. The workflow change is
comment-only, so it cannot alter which runner is selected. The installer changes are shape-preserving on
a Debian host: the same two apt commands run, with one extra flag, inside a test that passes there.

## Not included

Two real things came out of the same review that do not belong in a comment fix:

The QNN suite now runs twice on every pull request, once from the shared workflow and once from the
standalone one, since both trigger on `pull_request` and they publish artifacts to the same hourly key.
Deciding which of the two owns the suite is an ownership question for whoever maintains that workflow,
not something to settle inside this change.

An operator crash truncates the suite early. That predates both changes reviewed here.
