### PR TITLE
Fix contiguous dim order target dependencies

### DIFF
--- a/backends/transforms/targets.bzl
+++ b/backends/transforms/targets.bzl
@@ -701,7 +701,6 @@ def define_common_targets():
             "//caffe2:torch",
             "//executorch/exir:pass_base",
             "//executorch/exir/dialects:lib",
-            "//executorch/exir/dialects/_ops:ops",
         ],
     )
 
@@ -713,6 +712,7 @@ def define_common_targets():
         deps = [
             "//caffe2:torch",
             "//executorch/exir:lib",
+            "//executorch/exir/dialects:lib",
             ":enforce_contiguous_dim_order",
         ],
     )


### PR DESCRIPTION
Summary:
Replace the nonexistent `dialects/_ops:ops` dependency with the owning `dialects:lib` target and declare the test direct import dependency.

Authored with Codex.

Reviewed By: rascani

Differential Revision: D118346209


