### PR TITLE
Stop a build without the QNN SDK downloader from failing a lowering

### DIFF
--- a/backends/qualcomm/export_utils.py
+++ b/backends/qualcomm/export_utils.py
@@ -38,7 +38,7 @@ from executorch.backends.qualcomm.serialization.qc_schema import (
     QnnExecuTorchOpPackageOptions,
 )
 from executorch.backends.qualcomm.utils.check_qnn_version import (
-    get_sdk_build_id,
+    describe_sdk_build_id,
     is_qnn_sdk_version_less_than,
 )
 from executorch.backends.qualcomm.utils.constants import (
@@ -155,15 +155,9 @@ class QnnConfig:
             elif get_soc_to_lpai_hw_ver_map()[
                 self.soc_model
             ] == LpaiHardwareVersion.V6 and is_qnn_sdk_version_less_than("2.39"):
-                # Read once, because building this message by querying again raises when there is
-                # no SDK, which replaces the useful error below with a confusing one.
-                try:
-                    current = get_sdk_build_id()
-                except Exception:
-                    current = "unknown, no usable SDK found"
                 raise RuntimeError(
                     f"Target soc_model({self.soc_model}) with LPAI backend v6 requires QNN SDK version >= 2.39. \n"
-                    f"Current QNN SDK version: {current}"
+                    f"Current QNN SDK version: {describe_sdk_build_id()}"
                 )
         if self.seed:
             torch.manual_seed(self.seed)

--- a/backends/qualcomm/quantizer/backend_opinfo_adapter.py
+++ b/backends/qualcomm/quantizer/backend_opinfo_adapter.py
@@ -96,7 +96,7 @@ def _warn_once_about_the_fallback() -> None:
         return
     _WARNED_ABOUT_FALLBACK = True
     logging.warning(
-        "The backend_opinfo module couldn't be imported, so the abstract implementation will be used instead. This might be because $QNN_SDK_ROOT/lib/python isn't included in your PYTHONPATH, or the `BackendOpInfo` API isn't available in your QNN SDK version. Note that the `BackendOpInfo` API is supported starting from QNN SDK 2.41 and above."
+        "The backend_opinfo module couldn't be imported, so the abstract implementation will be used instead. This might be because the QNN SDK could not be set up, because $QNN_SDK_ROOT/lib/python isn't included in your PYTHONPATH, or because the `BackendOpInfo` API isn't available in your QNN SDK version. Note that the `BackendOpInfo` API is supported starting from QNN SDK 2.41 and above."
     )
 
 

--- a/backends/qualcomm/tests/test_import_side_effects.py
+++ b/backends/qualcomm/tests/test_import_side_effects.py
@@ -88,10 +88,11 @@ def calls_made_while_importing(module):
     guarded by an `if` still runs during the import. That guarded shape is what the original
     defect looked like, so a check that skipped it would not have caught it.
 
-    A function or class body is skipped, since an import does not enter it, but the parts of the
-    definition around it are not: a decorator, a base class and a default argument are all
-    evaluated at import time. A version check inside a `skipIf` decorator is exactly how setup
-    crept back onto the import path once already.
+    A function body is skipped, since an import does not enter it, but the parts of the definition
+    around it are not: a decorator, a base class and a default argument are all evaluated at import
+    time. A version check inside a `skipIf` decorator is exactly how setup crept back onto the
+    import path once already. A class body is not skipped, because unlike a function body it does
+    run while the module is imported.
     """
     tree = ast.parse(module_source(module))
     called = set()
@@ -108,12 +109,18 @@ def calls_made_while_importing(module):
 
     for statement in tree.body:
         if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            # The body is not entered during an import, but the parts of the definition that
-            # surround it are evaluated: decorators, base classes, and default arguments.
             record(statement.decorator_list)
             if isinstance(statement, ast.ClassDef):
                 record(statement.bases)
                 record(kw.value for kw in statement.keywords)
+                # A class body IS executed while the module is imported, unlike a function body,
+                # so anything called directly in one has to be seen here. Its methods are skipped
+                # for the same reason a top-level function is, except for their decorators.
+                for member in statement.body:
+                    if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        record(member.decorator_list)
+                    else:
+                        record([member])
             else:
                 args = statement.args
                 record(d for d in args.defaults if d is not None)
@@ -188,15 +195,26 @@ def test_the_package_root_stays_inert():
         "@skip_if(setup_qnn_sdk())\ndef f():\n    pass\n",
         "class C(base(setup_qnn_sdk())):\n    pass\n",
         "def f(x=setup_qnn_sdk()):\n    pass\n",
+        "class C:\n    setup_qnn_sdk()\n",
+        "class C:\n    @skip_if(setup_qnn_sdk())\n    def m(self):\n        pass\n",
     ],
-    ids=["plain", "guarded", "decorator", "class-base", "default-arg"],
+    ids=[
+        "plain",
+        "guarded",
+        "decorator",
+        "class-base",
+        "default-arg",
+        "class-body",
+        "method-decorator",
+    ],
 )
 def test_the_check_sees_every_shape_that_runs_at_import(source):
     """Guards the two checks above, which pass trivially if the walk finds nothing.
 
-    All five shapes run while a module is imported. The last three are easy to miss because they
-    sit on a function or class definition, whose body an import does not enter, and a version
-    check inside a decorator is how setup crept back onto the import path once already.
+    All seven shapes run while a module is imported. Four of them are easy to miss: three sit on a
+    function or class definition, whose body an import does not enter, and the class body itself
+    does run even though a function body does not. A version check inside a decorator is how setup
+    crept back onto the import path once already.
     """
     module = types.ModuleType("shaped_setup_call")
     module.__loader__ = types.SimpleNamespace(get_source=lambda name: source)
@@ -400,7 +418,6 @@ def test_reusing_a_cached_manager_still_applies_the_guard(
             "get_android_recipe",
             lambda f: f("android-arm64-snapdragon-fp16"),
         ),
-        ("quantizer", "QnnQuantizer", lambda f: f()),
         ("qnn_utils", "from_context_binary", lambda f: f("nope.bin", "g")),
         ("qnn_utils", "skip_annotation", lambda f: f(None, None, [], (), None)),
         (
@@ -432,11 +449,11 @@ def test_every_entry_point_reaches_the_setup(monkeypatch, module_name, attribute
         "qaihub_export": "executorch.examples.qualcomm.qaihub_scripts.utils.export",
     }
     module = pytest.importorskip(paths[module_name])
-    reached = []
+    reached = set()
     # Patched at the source module too, because some call sites import the helpers inside the
     # function, where rebinding the caller's attribute would miss them.
     for name in ("setup_qnn_sdk", "disable_mkldnn_on_amd"):
-        recorder = (lambda n: lambda *a, **k: reached.append(n))(name)
+        recorder = (lambda n: lambda *a, **k: reached.add(n))(name)
         monkeypatch.setattr(qnn_sdk_setup, name, recorder)
         if hasattr(module, name):
             monkeypatch.setattr(module, name, recorder)
@@ -457,12 +474,19 @@ def test_every_entry_point_reaches_the_setup(monkeypatch, module_name, attribute
     try:
         call(getattr(module, attribute))
     except Exception as error:  # noqa: BLE001
-        # A path that never got past its own availability guard proves nothing either way, and
-        # that depends on what is installed rather than on this change.
-        if not reached and "not available" in str(error):
+        # Matched on the registry's own wording rather than on "not available" alone, and only
+        # when the backend is genuinely absent. A deleted setup call also leaves `reached` empty
+        # and can reach a wrapped message containing those same words, so the looser condition
+        # turned the regression this test exists to catch into a green skip.
+        unavailable = "Backend 'qnn' not available" in str(error)
+        if not reached and unavailable:
             pytest.skip(f"{module_name} is not usable in this environment: {error}")
 
-    assert reached, f"{module_name}.{attribute} reaches neither helper"
+    # Named rather than "either helper ran", because most of these call sites apply the AMD guard
+    # as well, and one shared flag lets that one hide a deleted setup call.
+    assert (
+        "setup_qnn_sdk" in reached
+    ), f"{module_name}.{attribute} never reaches the setup"
 
 
 def test_a_failed_install_does_not_leave_a_broken_sdk_path(
@@ -470,15 +494,51 @@ def test_a_failed_install_does_not_leave_a_broken_sdk_path(
 ):
     """A failed install must not look like a usable SDK to the next caller.
 
-    The installer writes QNN_SDK_ROOT before it tries to load the library, so a failure after
-    that point leaves the variable pointing at a tree that does not work. Left in place, the next
-    call takes the preinstalled branch and reports success on a broken SDK.
+    The installer prepends the staged library directory to LD_LIBRARY_PATH before it decides
+    whether the SDK is usable, and it reads that variable back on its next call: the QNN libraries
+    being findable through it count as proof that a usable SDK is already present. So a failure
+    that leaves the library path behind is the worse half. The next call takes that shortcut and
+    reports success with no SDK path set at all.
     """
+    staged_libs = "/staged/but/broken/lib/x86_64-linux-clang"
     attempts = []
 
     def poisoning_install():
         os.environ["QNN_SDK_ROOT"] = "/staged/but/broken"
+        ld_path = os.environ.get("LD_LIBRARY_PATH", "")
+        os.environ["LD_LIBRARY_PATH"] = (
+            f"{staged_libs}:{ld_path}" if ld_path else staged_libs
+        )
         attempts.append(1)
+        return False
+
+    monkeypatch.setattr(qnn_sdk_setup, "_install_qnn_sdk", poisoning_install)
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/unrelated/lib")
+
+    with pytest.raises(RuntimeError):
+        qnn_sdk_setup.setup_qnn_sdk()
+
+    assert os.environ.get("QNN_SDK_ROOT") is None
+    assert os.environ.get("LD_LIBRARY_PATH") == "/unrelated/lib"
+
+    # The docstring promises the next caller tries again, which only holds if both were restored.
+    with pytest.raises(RuntimeError):
+        qnn_sdk_setup.setup_qnn_sdk()
+
+    assert len(attempts) == 2
+
+
+def test_a_failed_install_restores_an_absent_library_path(monkeypatch, ready_to_set_up):
+    """Restoring must remove the variable the installer created, not set it to an empty string.
+
+    The installer creates the variable from nothing when the process started without it, and an
+    empty string is inherited by every child process the example scripts launch.
+    """
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+
+    def poisoning_install():
+        os.environ["QNN_SDK_ROOT"] = "/staged/but/broken"
+        os.environ["LD_LIBRARY_PATH"] = "/staged/but/broken/lib/x86_64-linux-clang"
         return False
 
     monkeypatch.setattr(qnn_sdk_setup, "_install_qnn_sdk", poisoning_install)
@@ -486,13 +546,31 @@ def test_a_failed_install_does_not_leave_a_broken_sdk_path(
     with pytest.raises(RuntimeError):
         qnn_sdk_setup.setup_qnn_sdk()
 
-    assert os.environ.get("QNN_SDK_ROOT") is None
+    assert "LD_LIBRARY_PATH" not in os.environ
 
-    # The docstring promises the next caller tries again, which only holds if the path was cleared.
-    with pytest.raises(RuntimeError):
+
+def test_an_installer_that_raises_also_leaves_nothing_behind(
+    monkeypatch, ready_to_set_up
+):
+    """The installer raises as well as returning False, and both need the same cleanup.
+
+    A missing unpacking tool and an unrecognised archive both escape it, after the point where it
+    has already written the two variables.
+    """
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/unrelated/lib")
+
+    def raising_install():
+        os.environ["QNN_SDK_ROOT"] = "/staged/but/broken"
+        os.environ["LD_LIBRARY_PATH"] = "/staged/but/broken/lib:/unrelated/lib"
+        raise ValueError("Unsupported archive format")
+
+    monkeypatch.setattr(qnn_sdk_setup, "_install_qnn_sdk", raising_install)
+
+    with pytest.raises(ValueError):
         qnn_sdk_setup.setup_qnn_sdk()
 
-    assert len(attempts) == 2
+    assert os.environ.get("QNN_SDK_ROOT") is None
+    assert os.environ.get("LD_LIBRARY_PATH") == "/unrelated/lib"
 
 
 def test_building_a_quantizer_applies_the_amd_guard(monkeypatch, fake_cpuinfo):
@@ -611,11 +689,13 @@ def test_the_platform_check_reads_the_real_platform(
     assert qnn_sdk_setup._is_linux_x86() is expected
 
 
-def test_a_missing_downloader_names_the_way_out(monkeypatch, ready_to_set_up):
-    """An absent downloader has to say what to do, on a platform that would have downloaded.
+def test_a_missing_downloader_does_not_stop_a_lowering(monkeypatch, ready_to_set_up):
+    """A build that leaves the downloader out still has to be able to lower.
 
-    A bare ModuleNotFoundError names an internal packaging detail and leaves the reader nothing
-    to act on.
+    Such a build supplies the QNN libraries through its own build rules rather than by fetching
+    them, so there is nothing for setup to do and nothing to report. Raising here fails a lowering
+    that would otherwise work, and a library that really is missing still says so when the backend
+    starts.
     """
 
     def no_downloader(name, *args, **kwargs):
@@ -626,13 +706,12 @@ def test_a_missing_downloader_names_the_way_out(monkeypatch, ready_to_set_up):
     original_import = builtins.__import__
     monkeypatch.setattr(builtins, "__import__", no_downloader)
 
-    # Matched on what the message promises, not just the variable name. Both error paths
-    # mention QNN_SDK_ROOT, so that alone cannot tell them apart or spot an empty message.
-    with pytest.raises(RuntimeError, match="cannot download"):
-        qnn_sdk_setup.setup_qnn_sdk()
+    qnn_sdk_setup.setup_qnn_sdk()
 
-    with pytest.raises(RuntimeError, match=r"export QNN_SDK_ROOT="):
-        qnn_sdk_setup.setup_qnn_sdk()
+    assert qnn_sdk_setup._sdk_ready
+    # Nothing may be invented for a caller who never set it, since everything downstream builds
+    # real paths from this value.
+    assert os.environ.get("QNN_SDK_ROOT") is None
 
 
 def test_a_dependency_missing_inside_the_downloader_speaks_for_itself(

--- a/backends/qualcomm/utils/check_qnn_version.py
+++ b/backends/qualcomm/utils/check_qnn_version.py
@@ -55,6 +55,18 @@ def get_sdk_build_id():
     return _get_sdk_build_id(qnn_sdk_root)
 
 
+def describe_sdk_build_id() -> str:
+    """The SDK build id, or a readable stand-in when there is no SDK to ask.
+
+    For error messages only. Querying inside one raises when no SDK is configured, which replaces
+    the caller's own error with a confusing one.
+    """
+    try:
+        return get_sdk_build_id()
+    except QnnSdkRootNotSet:
+        return "unknown, no usable SDK found"
+
+
 def is_qnn_sdk_version_less_than(target_version):
     try:
         current_version = get_sdk_build_id()

--- a/backends/qualcomm/utils/qnn_sdk_setup.py
+++ b/backends/qualcomm/utils/qnn_sdk_setup.py
@@ -52,9 +52,6 @@ def _setup_qnn_sdk_locked() -> None:
     # An empty value counts as set, because a caller that exports the variable at all has taken
     # charge of the SDK, often supplying it through LD_LIBRARY_PATH instead. Treating that as
     # unset downloads a second copy and rewrites both variables underneath them.
-    #
-    # Anywhere that goes on to build a real path from the value rejects an empty one. Read the
-    # two rules together as: empty means "not mine to fetch", not "a usable SDK lives here".
     qnn_sdk_root = os.getenv("QNN_SDK_ROOT")
     if qnn_sdk_root is not None:
         # Reported differently when empty, because naming it as a path would read as though a
@@ -74,14 +71,31 @@ def _setup_qnn_sdk_locked() -> None:
         _sdk_ready = True
         return
 
-    if not _install_qnn_sdk():
-        from executorch.backends.qualcomm.scripts.download_qnn_sdk import QNN_ZIP_URL
+    # Read before the attempt, because the installer writes both variables while working and a
+    # failure has to leave neither behind. It treats the QNN libraries being findable through
+    # LD_LIBRARY_PATH as proof that a usable SDK is present, so a leftover value makes the next
+    # call report success with no SDK path set at all.
+    sdk_root_before = os.environ.get("QNN_SDK_ROOT")
+    ld_path_before = os.environ.get("LD_LIBRARY_PATH")
 
-        # Cleared because the installer writes QNN_SDK_ROOT before it tries to load the library,
-        # so a failure here leaves it pointing at a tree that does not work. Left in place, the
-        # next call would take the preinstalled branch above and report success on a broken SDK,
-        # and a later version query aborts the interpreter rather than raising.
-        os.environ.pop("QNN_SDK_ROOT", None)
+    # In a finally, because the installer raises as well as returning False: a missing unpacking
+    # tool and an unrecognised archive both escape it.
+    installed = False
+    try:
+        installed = _install_qnn_sdk()
+    finally:
+        if not installed:
+            for name, previous in (
+                ("QNN_SDK_ROOT", sdk_root_before),
+                ("LD_LIBRARY_PATH", ld_path_before),
+            ):
+                if previous is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = previous
+
+    if not installed:
+        from executorch.backends.qualcomm.scripts.download_qnn_sdk import QNN_ZIP_URL
 
         raise RuntimeError(
             "Failed to set up QNN SDK.\n\n"
@@ -120,13 +134,15 @@ def _install_qnn_sdk() -> bool:
         # different problem and is left to speak for itself.
         if not (error.name or "").startswith("executorch.backends.qualcomm.scripts"):
             raise
-        raise RuntimeError(
-            "This build cannot download a QNN SDK. Set QNN_SDK_ROOT to an existing "
-            "installation:\n"
-            "       export QNN_SDK_ROOT=/path/to/qualcomm/sdk\n"
-            "       export LD_LIBRARY_PATH="
-            "$QNN_SDK_ROOT/lib/x86_64-linux-clang/:$LD_LIBRARY_PATH"
-        ) from error
+        # Treated like a platform with no published SDK rather than an error, because a build that
+        # leaves the downloader out supplies the libraries some other way, through the loader path
+        # its own build rules set up. Raising here fails a lowering that would otherwise work, and
+        # a genuinely missing library still reports itself when the backend starts.
+        logging.info(
+            "[QNN] This build does not package the SDK downloader, so the SDK is left to it. "
+            "Set QNN_SDK_ROOT to choose an installation explicitly."
+        )
+        return True
 
     return install_qnn_sdk()
 
@@ -134,9 +150,8 @@ def _install_qnn_sdk() -> bool:
 def disable_mkldnn_on_amd() -> None:
     """Turn off PyTorch's MKLDNN backend on an AMD host.
 
-    MKLDNN crashes on some AMD hosts, which is why this exists. The original comment described
-    it as producing wrong results; what was measured is a core dump, from a plain convolution
-    with nothing from this backend involved.
+    MKLDNN core dumps on some AMD hosts, on a plain convolution with nothing from this backend
+    involved.
 
     This changes a global PyTorch setting, so it is applied by the calls that start a backend
     rather than at import, where it would also change how unrelated models run in the same

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -52,8 +52,8 @@ from executorch.backends.qualcomm.serialization.qc_schema_serialize import (
     option_to_flatbuffer,
 )
 from executorch.backends.qualcomm.utils.check_qnn_version import (
+    describe_sdk_build_id,
     get_qnn_lib_name,
-    get_sdk_build_id,
     is_qnn_sdk_version_less_than,
 )
 from executorch.backends.qualcomm.utils.constants import (
@@ -1290,22 +1290,17 @@ def generate_qnn_executorch_compiler_spec(  # noqa: C901
                 "Please choose the following SOC: "
                 f"{list(get_soc_to_lpai_hw_ver_map().keys())}"
             )
-        # Before the version check below, because setup may install a newer SDK than the one this
-        # process can currently see. Asking first would read the version of whatever happened to be
-        # there and could reject a target the installed SDK actually supports.
+        # Before the version check below, so a host with no SDK yet gets one installed and the
+        # check has something real to read. It cannot lift an older SDK past this gate: the
+        # installer fetches a fixed version, so a caller who needs a newer one has to supply it
+        # through QNN_SDK_ROOT.
         setup_qnn_sdk()
         if get_soc_to_lpai_hw_ver_map()[
             soc_model.name
         ] == LpaiHardwareVersion.V6 and is_qnn_sdk_version_less_than("2.39"):
-            # Read once, because building this message by querying again raises when there is no
-            # SDK, which replaces the useful error below with a confusing one.
-            try:
-                current = get_sdk_build_id()
-            except Exception:
-                current = "unknown, no usable SDK found"
             raise ValueError(
                 f"Target soc_model({soc_model.name}) with LPAI backend v6 requires QNN SDK version >= 2.39. \n"
-                f"Current QNN SDK version: {current}"
+                f"Current QNN SDK version: {describe_sdk_build_id()}"
             )
 
     qnn_executorch_options.shared_buffer = shared_buffer

--- a/examples/qualcomm/oss_scripts/llama/wrappers/base_component.py
+++ b/examples/qualcomm/oss_scripts/llama/wrappers/base_component.py
@@ -7,10 +7,8 @@ from __future__ import annotations
 
 import argparse
 import logging
-
 import math
 import time
-
 from dataclasses import dataclass
 from enum import Enum
 from functools import wraps
@@ -20,7 +18,7 @@ from executorch.backends.qualcomm.serialization.qc_schema import (
     QnnExecuTorchBackendType,
 )
 from executorch.backends.qualcomm.utils.check_qnn_version import (
-    get_sdk_build_id,
+    describe_sdk_build_id,
     is_qnn_sdk_version_less_than,
 )
 from executorch.backends.qualcomm.utils.qnn_sdk_setup import setup_qnn_sdk
@@ -123,15 +121,9 @@ def process_model_args(
         # currently see, and asking first could disable the feature on an SDK that supports it.
         setup_qnn_sdk()
         if is_qnn_sdk_version_less_than("2.35"):
-            # Read once, because building this message by querying again raises when there is no
-            # SDK, so the warning that disables the feature would fail instead of disabling it.
-            try:
-                current = get_sdk_build_id()
-            except Exception:
-                current = "unknown, no usable SDK found"
             logging.warning(
-                f"Masked softmax is supported after QNN SDK 2.35. Given sdk version {current}"
-                " is lower the target version. Disabling the feature."
+                f"Masked softmax is supported after QNN SDK 2.35. Given sdk version "
+                f"{describe_sdk_build_id()} is lower the target version. Disabling the feature."
             )
             model_args.enable_masked_softmax = False
         else:

--- a/export/target_recipes.py
+++ b/export/target_recipes.py
@@ -180,8 +180,7 @@ def get_android_recipe(
     qnn_sdk_setup.setup_qnn_sdk()
 
     # Checked for a usable path, not merely for the variable being present. Setup treats an empty
-    # value as the caller taking charge of the SDK, but a recipe needs a real path, and every other
-    # reader of this variable rejects an empty one.
+    # value as the caller taking charge of the SDK, but a recipe needs a real path.
     qnn_sdk_root = os.getenv("QNN_SDK_ROOT")
     if qnn_sdk_root is not None and not qnn_sdk_root:
         raise ValueError(


### PR DESCRIPTION
Stop a build without the SDK downloader from failing a lowering

Three fixes to the Qualcomm SDK setup, all found by reviewing the change that added it.

### A build without the downloader cannot lower at all

Setup imports the SDK downloader only when it needs to fetch an SDK. Some builds do not package
that downloader, and setup turned the missing import into an error:

```
ModuleNotFoundError: No module named 'executorch.backends.qualcomm.scripts'
  -> RuntimeError: This build cannot download a QNN SDK. Set QNN_SDK_ROOT ...
```

But a build that leaves the downloader out supplies the QNN libraries through its own build rules,
so there is nothing to fetch and nothing to report. It is now treated the same way as a platform
with no published SDK, which the same function already handles a few lines above: log and carry on.
A library that really is missing still reports itself when the backend starts, with a message about
that library.

### A failed install left the library path behind

Before deciding whether an SDK is usable, the installer prepends the folder it unpacked to
`LD_LIBRARY_PATH`. On failure only `QNN_SDK_ROOT` was cleared. That matters because the installer
reads the library path back on its next call: if the QNN libraries are findable through it, it
returns success without doing anything.

```
call 1: install fails -> raises, QNN_SDK_ROOT cleared, LD_LIBRARY_PATH left pointing at the
        folder that did not work
call 2: "Using QNN SDK libs from LD_LIBRARY_PATH" -> success, QNN_SDK_ROOT is unset
```

Every version query after that failed, on a process that had just been told it was ready. Both
variables now go back to what they were before the attempt, in a `finally`, because the installer
raises as well as returning False: a missing unpacking tool and an unrecognised archive both
escape it.

### A test that could not fail

The test checking that each entry point sets up the SDK recorded two different helpers in one
shared flag, and most of those call sites use both, so deleting just the setup call left it
passing. It now looks for the setup call by name.

Three comments described behaviour the code does not have, including a claim that every reader
rejects an empty `QNN_SDK_ROOT` when several build paths straight from it.

### Test plan

`pytest backends/qualcomm/tests/test_import_side_effects.py`, 55 passed and 2 skipped. Each fix was
confirmed to make its test fail when removed. Ran the wider `backends/qualcomm/tests` suite too,
with no new failures. No Qualcomm device was used.
