### PR TITLE
[ET-VK] Run weight-only int8 linear on the kernel that still exists

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
@@ -944,6 +944,40 @@ void linear_q8csw(ComputeGraph& graph, const std::vector<ValueRef>& args) {
       output);
 }
 
+// aten._weight_int8pack_mm is what the AOT weight-only int8 fusion
+// (FuseQuantizedOpsTransform) emits. It carries the same operands as
+// et_vk.linear_q8csw minus the bias, so it runs through the same
+// implementation.
+void weight_int8pack_mm(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args) {
+  int32_t idx = 0;
+  const ValueRef fp_input = args.at(idx++);
+  const ValueRef weight_data = args.at(idx++);
+  const ValueRef weight_scales_data = args.at(idx++);
+  const ValueRef output = args.at(idx++);
+
+  const int64_t K = graph.size_at<int64_t>(-1, fp_input);
+
+  QuantizationConfig input_quant_config(32, kNoQuantization, {});
+  QuantizationConfig weight_quant_config(8, kPerChannel, {K});
+
+  quantized_linear_impl(
+      graph,
+      input_quant_config,
+      weight_quant_config,
+      fp_input,
+      kDummyValueRef, // input scale
+      kDummyValueRef, // input zp
+      weight_data,
+      kDummyValueRef, // weight sums
+      weight_scales_data,
+      kDummyValueRef, // weight zeros
+      kDummyValueRef, // group size
+      kDummyValueRef, // bias
+      output);
+}
+
 void linear_dq8ca_q4gsw(
     ComputeGraph& graph,
     const std::vector<ValueRef>& args) {
@@ -982,6 +1016,7 @@ void linear_dq8ca_q4gsw(
 REGISTER_OPERATORS {
   VK_REGISTER_OP(et_vk.linear_q8ta_q8csw.default, linear_q8ta_q8csw);
   VK_REGISTER_OP(et_vk.linear_q8csw.default, linear_q8csw);
+  VK_REGISTER_OP(aten._weight_int8pack_mm.default, weight_int8pack_mm);
   VK_REGISTER_OP(et_vk.linear_dq8ca_q4gsw.default, linear_dq8ca_q4gsw);
 }
 

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinearQCSNW.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinearQCSNW.cpp
@@ -16,34 +16,6 @@
 
 namespace vkcompute {
 
-// Custom global workgroup size function for linear_qcs8w
-GlobalWorkGrid linear_qcs8w_gwg(
-    ComputeGraph* graph,
-    const vkapi::ShaderInfo& shader,
-    const std::vector<ArgGroup>& args,
-    const std::vector<ValueRef>& resize_args) {
-  (void)shader;
-  (void)resize_args;
-  const ValueRef out = args.at(0).refs.at(0);
-  return graph->create_linear_gwg(
-      utils::safe_downcast<uint64_t>(graph->numel_of(out)));
-}
-
-// Custom local workgroup size function for linear_qcs8w
-LocalWorkGroup linear_qcs8w_lwg(
-    ComputeGraph* graph,
-    const vkapi::ShaderInfo& shader,
-    const GlobalWorkGrid& gwg,
-    const std::vector<ArgGroup>& args,
-    const std::vector<ValueRef>& resize_args) {
-  (void)graph;
-  (void)shader;
-  (void)gwg;
-  (void)args;
-  (void)resize_args;
-  return LocalWorkGroup(64u, 1u, 1u);
-}
-
 // Custom global workgroup size function for linear_qcsnw_tiled
 GlobalWorkGrid linear_qcsnw_tiled_gwg(
     ComputeGraph* graph,
@@ -178,81 +150,6 @@ void resize_linear_qcsnw_node(
   graph->virtual_resize(out, new_out_sizes);
 }
 
-void add_linear_qcs8w_node(
-    ComputeGraph& graph,
-    const ValueRef mat1,
-    const ValueRef q_mat2_data,
-    const ValueRef scales_data,
-    const ValueRef out) {
-  auto viewFn = VK_GET_OP_FN("aten.view_copy.default");
-  ValueRef mat1_W_packed = mat1;
-  ValueRef out_W_packed = out;
-  // Create temporary tensors to store the width packed versions of mat1 and out
-  TmpTensor mat1_tmp(
-      &graph, graph.sizes_of(mat1), graph.dtype_of(mat1), utils::kWidthPacked);
-  TmpTensor out_tmp(
-      &graph, graph.sizes_of(out), graph.dtype_of(out), utils::kWidthPacked);
-  if (!graph.is_buffer_storage(out) &&
-      graph.packed_dim_of(mat1) != WHCN::kWidthDim) {
-    // Ensure mat1 is width packed
-    mat1_W_packed = mat1_tmp;
-    viewFn(graph, {mat1, graph.add_none(), mat1_W_packed});
-    // Ensure out is packed correctly
-    out_W_packed = out_tmp;
-  }
-  ValueRef q_mat2 = prepack_standard_hw_transposed(
-      graph, q_mat2_data, graph.storage_type_of(out), utils::kWidthPacked);
-  ValueRef scales = prepack_standard(
-      graph, scales_data, graph.storage_type_of(out), utils::kWidthPacked);
-
-  std::string kernel_name = "linear_qcs8w";
-  kernel_name.reserve(kShaderNameReserve);
-  add_packed_dim_suffix(kernel_name, graph.packed_dim_of(mat1_W_packed));
-  add_packed_dim_suffix(kernel_name, graph.packed_dim_of(q_mat2));
-  add_dtype_suffix(kernel_name, graph.dtype_of(out_W_packed));
-  add_storage_type_suffix(kernel_name, graph.storage_type_of(out_W_packed));
-
-  std::vector<PushConstantDataInfo> pcs;
-  if (graph.is_buffer_storage(out_W_packed)) {
-    pcs = {
-        graph.sizes_pc_of(out_W_packed),
-        graph.strides_pc_of(out_W_packed),
-        graph.sizes_pc_of(mat1_W_packed),
-        graph.strides_pc_of(mat1),
-        graph.strides_pc_of(q_mat2),
-        graph.strides_pc_of(scales),
-        graph.numel_pc_of(out_W_packed)};
-  } else {
-    pcs = {
-        graph.logical_limits_pc_of(out_W_packed),
-        graph.sizes_pc_of(mat1_W_packed),
-        graph.sizes_pc_of(q_mat2)};
-  }
-
-  graph.execute_nodes().emplace_back(new DynamicDispatchNode(
-      graph,
-      VK_KERNEL_FROM_STR(kernel_name),
-      linear_qcs8w_gwg,
-      linear_qcs8w_lwg,
-      // Inputs and Outputs
-      {{out_W_packed, vkapi::MemoryAccessType::WRITE},
-       {{mat1_W_packed, q_mat2, scales}, vkapi::MemoryAccessType::READ}},
-      // Shader params buffers
-      {},
-      // Push Constants
-      pcs,
-      // Specialization Constants
-      {},
-      // Resize Args
-      {},
-      // Resizing Logic
-      resize_linear_qcsnw_node));
-  if (!graph.is_buffer_storage(out) &&
-      graph.packed_dim_of(out) != WHCN::kWidthDim) {
-    viewFn(graph, {out_W_packed, graph.add_none(), out});
-  }
-}
-
 void add_linear_qcsnw_tiled_node(
     ComputeGraph& graph,
     const bool use_coop_algorithm,
@@ -293,6 +190,8 @@ void add_linear_qcsnw_tiled_node(
     kernel_name =
         use_coop_algorithm ? "linear_qcs4w_coop" : "linear_qcs4w_tiled";
   } else {
+    // Unreachable: linear_qcs4w is the only caller of this function and it
+    // always passes quant_nbits == 4. Kept so the 4-bit path is not disturbed.
     kernel_name =
         use_coop_algorithm ? "linear_qcs8w_coop" : "linear_qcs8w_tiled";
   }
@@ -389,18 +288,6 @@ bool can_use_coop_impl(ComputeGraph& graph, const ValueRef mat1) {
   return (graph.size_at<int>(-2, mat1) == 1);
 }
 
-void weight_int8pack_mm(
-    ComputeGraph& graph,
-    const std::vector<ValueRef>& args) {
-  check_linear_qcsnw_args(graph, 8, args[0], args[1], args[2], args[3]);
-  if (can_use_tiled_impl(graph, args[0], args[1], args[2], args[3])) {
-    bool use_coop_algorithm = can_use_coop_impl(graph, args[0]);
-    return add_linear_qcsnw_tiled_node(
-        graph, use_coop_algorithm, 8, args[0], args[1], args[2], args[3]);
-  }
-  return add_linear_qcs8w_node(graph, args[0], args[1], args[2], args[3]);
-}
-
 void linear_qcs4w(ComputeGraph& graph, const std::vector<ValueRef>& args) {
   check_linear_qcsnw_args(graph, 4, args[0], args[1], args[2], args[3]);
 
@@ -411,7 +298,9 @@ void linear_qcs4w(ComputeGraph& graph, const std::vector<ValueRef>& args) {
 }
 
 REGISTER_OPERATORS {
-  VK_REGISTER_OP(aten._weight_int8pack_mm.default, weight_int8pack_mm);
+  // aten._weight_int8pack_mm is registered in QuantizedLinear.cpp, on the
+  // maintained weight-only quantized linear implementation. The 8-bit path
+  // here dispatched to linear_qcs8w_* shaders that no longer exist.
   VK_REGISTER_OP(et_vk.linear_qcs4w.default, linear_qcs4w);
 }
 


### PR DESCRIPTION
### Summary

`FuseQuantizedOpsTransform` rewrites a weight-only int8 linear to
`aten._weight_int8pack_mm`, `op_registry.py` lists it as supported, so the
partitioner takes it. At runtime it dispatched to `linear_qcs8w_tiled` /
`linear_qcs8w_coop`, and those shaders are not in the repo: #14041 replaced them
with `linear_q8csw_tiled` and a different suffix scheme, and the C++ was never
moved over. Every weight-only int8 model aborts on its first execute with

```
Could not find ShaderInfo with name
linear_qcs8w_tiled_texture3d_texture3d_texture2d_texture2d_half_o4x3
```

`aten._weight_int8pack_mm` carries the same operands as `et_vk.linear_q8csw`
minus the bias, and `linear_q8csw` is already registered in
`QuantizedLinear.cpp` on the maintained `quantized_linear_impl`. This registers
the aten op there and removes the 8-bit half of `QuantizedLinearQCSNW.cpp`,
whose shaders are gone.

The 4-bit `et_vk.linear_qcs4w` path is left untouched. It references missing
shaders too, but `linear_q4gsw` is group-wise and is not a drop-in replacement
for per-channel 4-bit, so that one needs its own change.

Fixes #22429

### Test plan

Galaxy S26 Ultra (Adreno 840), `all-mpnet-base-v2` and
`multi-qa-mpnet-base-dot-v1` lowered through `VulkanQuantizer` weight-only int8,
run at the 382-token bound and resized down to 128.

- Before: both abort at the first execute with the message above.
- After: both run. Cosine against the fp32 eager reference is 0.998280 and
  0.995343 at 382 tokens, and 0.998751 for the model resized to 128. The fp16
  build of the same model measures 0.999972 on the same input.

| tokens | fp16 | int8 |
| --- | --- | --- |
| 382 | 79 ms | 59 ms |
| 254 | 49 ms | 36 ms |
| 128 | 29 ms | 26 ms |

Median of 3 rounds with the arm order reversed each round, warm-up execution
discarded, per-execution time taken as the slope between 1 and 11 executions.
File size drops from 217.9 MB to 133.2 MB.
