### PR TITLE
Arm backend: Fix test names

### DIFF
--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -56,7 +56,12 @@ def maybe_get_tosa_artifact_path() -> str | None:
         current_test = os.environ.get("PYTEST_CURRENT_TEST")
         if current_test is None:
             raise RuntimeError("Could not determine the current pytest test name")
-        test_name = current_test.split(" (")[0].rsplit("::", 1)[-1]
+        test_name = (
+            current_test.split(" (")[0]
+            .rsplit("::", 1)[-1]
+            .replace(",", "_")
+            .replace(" ", "")
+        )
         return os.path.join(artifact_base_path, test_name)
 
     return maybe_get_tosa_collate_path()

--- a/backends/arm/test/conftest.py
+++ b/backends/arm/test/conftest.py
@@ -10,11 +10,13 @@ import logging
 import os
 import random
 import sys
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 logger: logging.Logger = logging.getLogger(__name__)
+_expected_xfail_nodeids: set[str] = set()
 
 
 # ==== Pytest hooks ====
@@ -42,6 +44,34 @@ def pytest_configure(config):
 
 def pytest_report_header(config):
     return config._test_seed_label
+
+
+def pytest_runtest_logreport(report) -> None:
+    if report.when in ("setup", "call"):
+        wasxfail = getattr(report, "wasxfail", "")
+        if (
+            report.outcome == "skipped"
+            and wasxfail
+            and not wasxfail.startswith("[NOTRUN]")
+        ):
+            _expected_xfail_nodeids.add(report.nodeid)
+        return
+
+    if report.when != "teardown" or report.nodeid not in _expected_xfail_nodeids:
+        return
+
+    _expected_xfail_nodeids.remove(report.nodeid)
+    if report.outcome != "passed":
+        return
+
+    dump_artifacts = getattr(pytest, "_test_options", {}).get("dump_artifacts")
+    if not dump_artifacts:
+        return
+
+    test_name = report.nodeid.rsplit("::", 1)[-1].replace(",", "_").replace(" ", "")
+    artifact_dir = Path(dump_artifacts) / test_name
+    if artifact_dir.is_dir():
+        (artifact_dir / "_xfailed_test").touch()
 
 
 def _mark_rife_vgf_xfails_for_model_converter_below_minimum_version(

--- a/backends/arm/test/misc/test_artifact_dumping.py
+++ b/backends/arm/test/misc/test_artifact_dumping.py
@@ -25,6 +25,25 @@ def test_dump_artifacts_uses_test_name(monkeypatch, tmp_path) -> None:
     )
 
 
+def test_dump_artifacts_sanitizes_commas_and_spaces_in_test_name(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(
+        pytest,
+        "_test_options",
+        {"dump_artifacts": str(tmp_path)},
+        raising=False,
+    )
+    monkeypatch.setenv(
+        "PYTEST_CURRENT_TEST",
+        "backends/arm/test/ops/test_add.py::test_add_tosa_INT[1, 2, 3] (call)",
+    )
+
+    assert common.maybe_get_tosa_artifact_path() == str(
+        tmp_path / "test_add_tosa_INT[1_2_3]"
+    )
+
+
 def test_custom_path_overrides_dump_artifacts(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(
         pytest,

--- a/backends/arm/test/misc/test_artifact_dumping.py
+++ b/backends/arm/test/misc/test_artifact_dumping.py
@@ -3,9 +3,132 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import pytest
+from types import SimpleNamespace
 
+import executorch.backends.arm.test.conftest as arm_conftest
+
+import pytest
 from executorch.backends.arm.test import common
+
+
+def _report(nodeid, outcome, when, **attributes):
+    return SimpleNamespace(nodeid=nodeid, outcome=outcome, when=when, **attributes)
+
+
+def test_expected_xfail_marks_existing_artifact_directory(
+    monkeypatch, tmp_path
+) -> None:
+    nodeid = "test_artifacts.py::test_case[1, 2]"
+    artifact_dir = tmp_path / "test_case[1_2]"
+    artifact_dir.mkdir()
+    monkeypatch.setattr(pytest, "_test_options", {"dump_artifacts": str(tmp_path)})
+    getattr(arm_conftest, "_expected_xfail_nodeids", set()).clear()
+
+    arm_conftest.pytest_runtest_logreport(
+        _report(nodeid, "skipped", "call", wasxfail="expected")
+    )
+    arm_conftest.pytest_runtest_logreport(_report(nodeid, "passed", "teardown"))
+
+    assert (artifact_dir / "_xfailed_test").is_file()
+
+
+def test_setup_expected_xfail_marks_existing_artifact_directory(
+    monkeypatch, tmp_path
+) -> None:
+    nodeid = "test_artifacts.py::test_case[1, 2]"
+    artifact_dir = tmp_path / "test_case[1_2]"
+    artifact_dir.mkdir()
+    monkeypatch.setattr(pytest, "_test_options", {"dump_artifacts": str(tmp_path)})
+    getattr(arm_conftest, "_expected_xfail_nodeids", set()).clear()
+
+    arm_conftest.pytest_runtest_logreport(
+        _report(nodeid, "skipped", "setup", wasxfail="expected")
+    )
+    arm_conftest.pytest_runtest_logreport(_report(nodeid, "passed", "teardown"))
+
+    assert (artifact_dir / "_xfailed_test").is_file()
+
+
+def test_setup_notrun_xfail_does_not_mark(monkeypatch, tmp_path) -> None:
+    nodeid = "test_artifacts.py::test_case"
+    artifact_dir = tmp_path / "test_case"
+    artifact_dir.mkdir()
+    monkeypatch.setattr(pytest, "_test_options", {"dump_artifacts": str(tmp_path)})
+    getattr(arm_conftest, "_expected_xfail_nodeids", set()).clear()
+
+    arm_conftest.pytest_runtest_logreport(
+        _report(nodeid, "skipped", "setup", wasxfail="[NOTRUN] expected")
+    )
+    arm_conftest.pytest_runtest_logreport(_report(nodeid, "passed", "teardown"))
+
+    assert not (artifact_dir / "_xfailed_test").exists()
+
+
+def test_expected_xfail_with_failed_teardown_does_not_mark(
+    monkeypatch, tmp_path
+) -> None:
+    nodeid = "test_artifacts.py::test_case"
+    artifact_dir = tmp_path / "test_case"
+    artifact_dir.mkdir()
+    monkeypatch.setattr(pytest, "_test_options", {"dump_artifacts": str(tmp_path)})
+    getattr(arm_conftest, "_expected_xfail_nodeids", set()).clear()
+
+    arm_conftest.pytest_runtest_logreport(
+        _report(nodeid, "skipped", "call", wasxfail="expected")
+    )
+    arm_conftest.pytest_runtest_logreport(_report(nodeid, "failed", "teardown"))
+
+    assert not (artifact_dir / "_xfailed_test").exists()
+
+
+def test_xpass_does_not_mark(monkeypatch, tmp_path) -> None:
+    nodeid = "test_artifacts.py::test_case"
+    artifact_dir = tmp_path / "test_case"
+    artifact_dir.mkdir()
+    monkeypatch.setattr(pytest, "_test_options", {"dump_artifacts": str(tmp_path)})
+    getattr(arm_conftest, "_expected_xfail_nodeids", set()).clear()
+
+    arm_conftest.pytest_runtest_logreport(
+        _report(nodeid, "passed", "call", wasxfail="expected")
+    )
+    arm_conftest.pytest_runtest_logreport(_report(nodeid, "passed", "teardown"))
+
+    assert not (artifact_dir / "_xfailed_test").exists()
+
+
+@pytest.mark.parametrize(
+    "outcome, attributes", [("passed", {}), ("failed", {}), ("skipped", {})]
+)
+def test_ordinary_outcomes_do_not_mark(
+    monkeypatch, tmp_path, outcome, attributes
+) -> None:
+    nodeid = "test_artifacts.py::test_case"
+    artifact_dir = tmp_path / "test_case"
+    artifact_dir.mkdir()
+    monkeypatch.setattr(pytest, "_test_options", {"dump_artifacts": str(tmp_path)})
+    getattr(arm_conftest, "_expected_xfail_nodeids", set()).clear()
+
+    arm_conftest.pytest_runtest_logreport(
+        _report(nodeid, outcome, "call", **attributes)
+    )
+    arm_conftest.pytest_runtest_logreport(_report(nodeid, "passed", "teardown"))
+
+    assert not (artifact_dir / "_xfailed_test").exists()
+
+
+def test_expected_xfail_does_not_create_missing_artifact_directory(
+    monkeypatch, tmp_path
+) -> None:
+    nodeid = "test_artifacts.py::test_case"
+    monkeypatch.setattr(pytest, "_test_options", {"dump_artifacts": str(tmp_path)})
+    getattr(arm_conftest, "_expected_xfail_nodeids", set()).clear()
+
+    arm_conftest.pytest_runtest_logreport(
+        _report(nodeid, "skipped", "call", wasxfail="expected")
+    )
+    arm_conftest.pytest_runtest_logreport(_report(nodeid, "passed", "teardown"))
+
+    assert not (tmp_path / "test_case").exists()
 
 
 def test_dump_artifacts_uses_test_name(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
### Fixup testnames deduction when dumping test artifacts

Feature to optionally store test artifacts to a defined directory. The feature was already present, and this PR addresses bugfixes for some cornercase and xfail tests.

### Test plan
Tested through CI

cc @digantdesai @freddan80 @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani