### PR TITLE
Arm backend: Reject identity permutes from TOSA delegation

### DIFF
--- a/backends/arm/test/ops/test_permute.py
+++ b/backends/arm/test/ops/test_permute.py
@@ -46,6 +46,11 @@ test_data_suite_u55_reject = {
     "rank2_bool": lambda: (torch.randint(0, 2, (5, 5), dtype=torch.bool), [1, 0]),
 }
 
+identity_test_data = {
+    "rank_1": lambda: (torch.rand(512), [0]),
+    "rank_2": lambda: (torch.rand(20, 32), [0, 1]),
+}
+
 
 test_data_suite_bf16 = {
     "rank_2_bf16": lambda: (torch.rand(6, 4, dtype=torch.bfloat16), [1, 0]),
@@ -144,6 +149,27 @@ def test_permute_u55_INT_not_delegated(test_data: torch.Tensor):
         non_delegated_ops={exir_op: 1},
         quantize=True,
         u55_subset=True,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", identity_test_data)
+def test_permute_tosa_INT_identity_not_delegated(test_data: torch.Tensor):
+    """Keep quantized identity permutes outside TOSA delegation.
+
+    Rank-1 ``[0]`` and rank-2 ``[0, 1]`` permutes leave both tensor shape and
+    dimension order unchanged. Together with their boundary Q/DQ nodes, they
+    would be removed completely during TOSA lowering. This test verifies that
+    the partitioner keeps the permute on the portable path instead of creating
+    a TOSA output tensor with no producing operator.
+
+    """
+    test_data, dims = test_data()
+    pipeline = OpNotSupportedPipeline[input_t1](
+        SimplePermute(dims=dims),
+        (test_data,),
+        non_delegated_ops={exir_op: 1},
+        quantize=True,
     )
     pipeline.run()
 

--- a/backends/arm/tosa/partitioner.py
+++ b/backends/arm/tosa/partitioner.py
@@ -191,6 +191,41 @@ def _is_noop_flip(node: torch.fx.node.Node) -> bool:
     return isinstance(dims, (list, tuple)) and len(dims) == 0
 
 
+def _is_noop_permute(node: torch.fx.Node) -> bool:
+    """Return whether a permute preserves the order of every dimension.
+
+    Quantized identity-permute models can produce a partition containing only
+    boundary Q/DQ nodes and the identity permute::
+
+        DQ -> PERMUTE([0, 1, ..., rank - 1]) -> Q
+
+    TOSA lowering removes the boundary Q/DQ nodes and canonicalization removes
+    the identity permute. Delegating that partition would therefore create an
+    empty TOSA graph whose declared output has no writer.
+
+    Args:
+        node (torch.fx.Node): FX node to classify.
+
+    Returns:
+        bool: True when the node is an identity ``permute_copy``.
+
+    """
+    if node.target != exir_ops.edge.aten.permute_copy.default:
+        return False
+
+    dims = node.args[1]
+    if not isinstance(dims, (list, tuple)) or not all(
+        isinstance(dim, int) for dim in dims
+    ):
+        return False
+
+    rank = len(dims)
+    normalized_dims = tuple(
+        dim if dim >= 0 else dim + rank for dim in cast(Sequence[int], dims)
+    )
+    return normalized_dims == tuple(range(rank))
+
+
 def _is_view_copy(node: torch.fx.node.Node) -> bool:
     return node.target == exir_ops.edge.aten.view_copy.default
 
@@ -588,6 +623,7 @@ class TOSAPartitioner(Partitioner):
                     or _is_noop_to_dim_order_copy(node)
                     or _is_noop_squeeze(node)
                     or _is_noop_flip(node)
+                    or _is_noop_permute(node)
                     or _is_view_copy(node)
                     or _is_noop_as_strided_copy(node)
                     or node.target in Q_OPS


### PR DESCRIPTION
### Summary
Treat identity permutations as no-ops when identifying empty TOSA partitions. This prevents quantized graphs from declaring outputs with no writers.

### Test plan
Add regression coverage for rank-1 and rank-2 identity permutations.

  - test_permute_identity[arm_ethos_u85] - Rank-2 identity permutation [0, 1]

  - test_permute_different_shapes[arm_ethos_u85]
      - Rank-1 identity permutation [0]

cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani