### PR TITLE
Arm backend: Match PyTorch nearest upsample semantics

### DIFF
--- a/backends/arm/_passes/rewrite_upsample.py
+++ b/backends/arm/_passes/rewrite_upsample.py
@@ -46,6 +46,8 @@ class RewriteUpsamplePass(ArmPass):
         input_size: int | torch.SymInt,
         output_size: int | torch.SymInt,
         align_corners: bool,
+        resize_mode: str = "bilinear",
+        scale_factor: float | None = None,
     ):
         """Compute resize coefficients for a single spatial dimension.
 
@@ -56,6 +58,10 @@ class RewriteUpsamplePass(ArmPass):
                 symbolic.
             align_corners (bool): Whether the resize should align the corner
                 pixels.
+            resize_mode (str): TOSA resize mode, either ``"bilinear"`` or
+                ``"nearest"``.
+            scale_factor (float | None): Explicit PyTorch scale factor for the
+                axis, when one was provided.
 
         Returns:
             tuple[int, int, int, int]: Numerator, denominator, offset, and border
@@ -92,7 +98,16 @@ class RewriteUpsamplePass(ArmPass):
             scale_d = input_size - 1
         else:
             scale_d = input_size
-        ratio = sympy.nsimplify(sympy.simplify(scale_n / scale_d))
+        if resize_mode == "nearest" and scale_factor is not None:
+            # When recompute_scale_factor=False, PyTorch samples using the
+            # supplied scale rather than the ratio implied by the rounded-down
+            # output size.
+            # Quantization may round the exported value to float32 (for
+            # example, 1.6 becomes 1.6000000238). Recover the intended small
+            # rational so it can be represented by TOSA's integer scale.
+            ratio = sympy.nsimplify(scale_factor, tolerance=1e-6, rational=True)
+        else:
+            ratio = sympy.nsimplify(sympy.simplify(scale_n / scale_d))
         if ratio.free_symbols:
             raise RuntimeError(
                 "Resize requires a constant ratio: " + str(ratio) + " is not constant!"
@@ -102,7 +117,22 @@ class RewriteUpsamplePass(ArmPass):
         scale_n = int((2 * ratio_num).evalf())
         scale_d = int((2 * ratio_den).evalf())
 
-        if align_corners:
+        if resize_mode == "nearest":
+            if ratio_den == 1:
+                # For exact integer upscales, the half-pixel encoding selects
+                # the same pixels as PyTorch nearest and is supported by U55.
+                offset = scale_d // 2 - scale_n // 2
+            else:
+                # TOSA nearest samples with a half-scale bias:
+                #
+                #   input_y = floor(
+                #       (out_y * scale_d + offset + scale_n / 2) / scale_n
+                #   )
+                #
+                # PyTorch nearest uses floor(out_y * input_size / output_size).
+                # A negative half-scale offset cancels the TOSA bias.
+                offset = -(scale_n // 2)
+        elif align_corners:
             offset = 0
         else:
             # Half pixel centers so input and output sampling positions are offset by 1/2 pixel.
@@ -143,15 +173,24 @@ class RewriteUpsamplePass(ArmPass):
 
             input_size_yx = node.args[0].meta["val"].shape[2:]
             output_size_yx = node.meta["val"].shape[2:]
+            scale_factors_yx = scale_factors or (None, None)
 
             scale_y_n, scale_y_d, offset_y, border_y = (
                 RewriteUpsamplePass.get_resize_parameters_1d(
-                    input_size_yx[0], output_size_yx[0], align_corners
+                    input_size_yx[0],
+                    output_size_yx[0],
+                    align_corners,
+                    resize_mode,
+                    scale_factors_yx[0],
                 )
             )
             scale_x_n, scale_x_d, offset_x, border_x = (
                 RewriteUpsamplePass.get_resize_parameters_1d(
-                    input_size_yx[1], output_size_yx[1], align_corners
+                    input_size_yx[1],
+                    output_size_yx[1],
+                    align_corners,
+                    resize_mode,
+                    scale_factors_yx[1],
                 )
             )
 

--- a/backends/arm/operator_support/upsample_support.py
+++ b/backends/arm/operator_support/upsample_support.py
@@ -23,20 +23,47 @@ def _is_upsample_node_tosa_supported(
     tosa_spec: TosaSpecification,
     *,
     align_corners: bool,
+    resize_mode: str,
 ) -> bool:
     input_node = ensure_type(fx.Node, node.args[0])
     input_size_yx = get_first_fake_tensor(input_node).shape[2:]
     output_size_yx = get_first_fake_tensor(node).shape[2:]
 
+    scale_factors_yx: tuple[float | None, float | None] = (None, None)
+    if resize_mode == "nearest" and node.args[2] is not None:
+        scale_factors = node.args[2]
+        if not isinstance(scale_factors, (list, tuple)) or len(scale_factors) != 2:
+            support_check.reporter.report_reject(
+                node, "Nearest upsample requires two spatial scale factors."
+            )
+            return False
+        scale_y, scale_x = scale_factors
+        if not isinstance(scale_y, (float, int)) or not isinstance(
+            scale_x, (float, int)
+        ):
+            support_check.reporter.report_reject(
+                node, "Nearest upsample requires constant scale factors."
+            )
+            return False
+        scale_factors_yx = (float(scale_y), float(scale_x))
+
     try:
         scale_y_n, scale_y_d, offset_y, border_y = (
             RewriteUpsamplePass.get_resize_parameters_1d(
-                input_size_yx[0], output_size_yx[0], align_corners
+                input_size_yx[0],
+                output_size_yx[0],
+                align_corners,
+                resize_mode,
+                scale_factors_yx[0],
             )
         )
         scale_x_n, scale_x_d, offset_x, border_x = (
             RewriteUpsamplePass.get_resize_parameters_1d(
-                input_size_yx[1], output_size_yx[1], align_corners
+                input_size_yx[1],
+                output_size_yx[1],
+                align_corners,
+                resize_mode,
+                scale_factors_yx[1],
             )
         )
     except RuntimeError as err:
@@ -70,7 +97,7 @@ class UpsampleNearest2dSupported(SupportedTOSAOperatorCheck):
         self, node: fx.Node, tosa_spec: TosaSpecification
     ) -> bool:  # type: ignore[override, misc]
         return _is_upsample_node_tosa_supported(
-            self, node, tosa_spec, align_corners=False
+            self, node, tosa_spec, align_corners=False, resize_mode="nearest"
         )
 
 
@@ -87,5 +114,5 @@ class UpsampleBilinear2dSupported(SupportedTOSAOperatorCheck):
     ) -> bool:  # type: ignore[override, misc]
         align_corners = ensure_type(bool, node.args[2])
         return _is_upsample_node_tosa_supported(
-            self, node, tosa_spec, align_corners=align_corners
+            self, node, tosa_spec, align_corners=align_corners, resize_mode="bilinear"
         )

--- a/backends/arm/test/ops/test_upsample_nearest2d.py
+++ b/backends/arm/test/ops/test_upsample_nearest2d.py
@@ -212,6 +212,19 @@ def test_upsample_nearest2d_vec_tosa_FP_interpolate(test_data: torch.Tensor):
     pipeline.run()
 
 
+def test_upsample_nearest2d_vec_tosa_FP_explicit_fractional_scale():
+    # The rounded output size implies a 6 / 4 ratio, but PyTorch samples using
+    # the explicitly supplied 1.6 scale factor.
+    pipeline = TosaPipelineFP[input_t1](
+        Interpolate(size=None, scale_factor=1.6),
+        (torch.rand(1, 2, 4, 4),),
+        aten_op,
+        exir_op=[],
+    )
+
+    pipeline.run()
+
+
 def test_upsample_nearest2d_vec_tosa_does_not_delegate_exact_one_sixteenth_downscale():
     pipeline = OpNotSupportedPipeline[input_t1](
         Interpolate(size=None, scale_factor=1.0 / 16.0),

--- a/backends/arm/test/passes/test_rewrite_upsample_pass.py
+++ b/backends/arm/test/passes/test_rewrite_upsample_pass.py
@@ -33,6 +33,69 @@ def test_get_resize_parameters_1d_supports_symbolic_shapes_with_constant_ratio()
     assert (scale_n, scale_d, offset, border) == (4, 2, -1, 1)
 
 
+def test_get_resize_parameters_1d_nearest_matches_pytorch_scale_factor():
+    # PyTorch nearest computes input_index = floor(out_index / scale).
+    # TOSA nearest applies a half-scale sampling bias, so the Arm lowering uses
+    # a negative half-scale offset to cancel that bias:
+    #
+    #   out:    0 1 2 3 4 5 6 7 8
+    #   PyTorch 0 0 1 2 2 3 4 4 5     (input=6, output=9)
+    #   TOSA   floor((out * scale_d + offset + scale_n/2) / scale_n)
+    scale_n, scale_d, offset, border = RewriteUpsamplePass.get_resize_parameters_1d(
+        6, 9, align_corners=False, resize_mode="nearest"
+    )
+
+    assert (scale_n, scale_d, offset, border) == (6, 4, -3, -1)
+
+
+def test_get_resize_parameters_1d_nearest_uses_explicit_scale_factor():
+    # Output size is rounded down from 4 * 1.6 to 6. PyTorch still samples with
+    # the explicit 1.6 scale, not the 6 / 4 ratio implied by the tensor sizes.
+    actual = RewriteUpsamplePass.get_resize_parameters_1d(
+        4,
+        6,
+        align_corners=False,
+        resize_mode="nearest",
+        scale_factor=1.6,
+    )
+
+    assert actual == (16, 10, -8, -6)
+
+    # Quantization can store the same factor as a float32 value. It must map to
+    # the same compact TOSA rational instead of a very large fraction.
+    float32_scale = float(torch.tensor(1.6, dtype=torch.float32))
+    actual = RewriteUpsamplePass.get_resize_parameters_1d(
+        4,
+        6,
+        align_corners=False,
+        resize_mode="nearest",
+        scale_factor=float32_scale,
+    )
+
+    assert actual == (16, 10, -8, -6)
+
+
+@pytest.mark.parametrize(
+    "output_size, expected",
+    [
+        (6, (4, 2, -1, 1)),
+        (12, (8, 2, -3, 3)),
+        (24, (16, 2, -7, 7)),
+    ],
+)
+def test_get_resize_parameters_1d_nearest_preserves_integer_upscale_encoding(
+    output_size, expected
+):
+    # For exact integer upscales, the half-pixel and PyTorch-nearest encodings
+    # select the same input pixels. Keep the half-pixel form because Vela can
+    # lower it to the Ethos-U55 2x, 4x, and 8x nearest-neighbor implementation.
+    actual = RewriteUpsamplePass.get_resize_parameters_1d(
+        3, output_size, align_corners=False, resize_mode="nearest"
+    )
+
+    assert actual == expected
+
+
 def test_get_resize_parameters_1d_rejects_non_constant_symbolic_ratio():
     shape_env = ShapeEnv()
     input_size = _make_symint(shape_env, "input_size", hint=4)


### PR DESCRIPTION
### Summary
Use nearest-specific TOSA RESIZE offsets for fractional resize ratios and honor explicit scale factors instead of reconstructing them from rounded output sizes.

e.g. for this PyTorch operation:

    F.interpolate(x, scale_factor=1.6, mode="nearest")

The 1.6x scale is an explicit operation argument. The exported aten.upsample_nearest2d.vec operation carries it in its scale_factors argument.
For an input size of four, PyTorch rounds the output size down to six. The table shows the sampling indices for one spatial dimension:

Input indices:          0 1 2 3
Output indices:         0 1 2 3 4 5
PyTorch (scale 1.6):    0 0 1 1 2 3  <-- expected
Old TOSA (size 4 -> 6): 0 1 1 2 3 3  <-- inferred 1.5x scale
Fixed TOSA (scale 1.6): 0 0 1 1 2 3  <-- preserves explicit 1.6x scale

The old lowering derived 1.5x from output_size / input_size (6 / 4). PyTorch instead samples with the explicitly supplied 1.6x scale.

Preserve the equivalent half-pixel encoding for exact integer upscales, keeping 2x, 4x, and 8x resizes supported by Ethos-U55.

### Test plan
Add regression coverage for size-derived and explicit fractional sampling and the U55-compatible integer-upscale parameters.

Fixes the flow test:
    test_upsample_nearest2d_scale_factors[*]

cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani