### PR TITLE
NXP backend: Fix NeutronConfig copy callback signature to match the d…

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1716,7 +1716,7 @@ jobs:
         conda activate "${CONDA_ENV}"
 
         # Build
-        cmake -DEXECUTORCH_BUILD_NXP_NEUTRON=ON -Bcmake-out .
+        cmake -DEXECUTORCH_BUILD_NXP_NEUTRON=ON -DCMAKE_CXX_FLAGS="-DEXTERNAL_MEM" -Bcmake-out .
         cmake --build cmake-out --target executorch_delegate_neutron --config Release
 
         # Build check for the neutron backend library

--- a/backends/nxp/runtime/NeutronBackend.cpp
+++ b/backends/nxp/runtime/NeutronBackend.cpp
@@ -104,7 +104,8 @@ typedef struct {
 // Neutron compute has no access to FLASH.
 // Prefetch weights from FLASH to SRAM using memcpy.
 // For a model converted with --fetch_constants_to_sram.
-void copy(void* dst, const void* src, uint32_t size, uint32_t channel) {
+// cppcheck-suppress constParameterCallback
+void copy(void* dst, void* src, uint32_t size, uint32_t channel) {
   memcpy(dst, src, size);
 }
 void wait(uint32_t channel) {}


### PR DESCRIPTION
### Summary
Fix NeutronConfig copy callback signature to match the driver header.

### Test plan
Modified the nxp-build-test to test this.

cc @robert-kalmar @JakeStevens @digantdesai @rascani