### PR TITLE
Fix SLEEF preprocessor macro name to match ATen vec headers

### DIFF
--- a/kernels/optimized/lib_defs.bzl
+++ b/kernels/optimized/lib_defs.bzl
@@ -25,16 +25,16 @@ def get_vec_preprocessor_flags():
         # various ovr_configs are not available in oss
         preprocessor_flags = select({
             "ovr_config//os:linux-x86_64": [
-                "-DET_BUILD_ARM_VEC256_WITH_SLEEF",
+                "-DAT_BUILD_ARM_VEC256_WITH_SLEEF",
             ] if not runtime.is_oss else [],
             "ovr_config//os:iphoneos-arm64": [
-                "-DET_BUILD_ARM_VEC256_WITH_SLEEF",
+                "-DAT_BUILD_ARM_VEC256_WITH_SLEEF",
             ] if not runtime.is_oss else [],
             "ovr_config//os:macos-arm64": [
-                "-DET_BUILD_ARM_VEC256_WITH_SLEEF",
+                "-DAT_BUILD_ARM_VEC256_WITH_SLEEF",
             ] if not runtime.is_oss else [],
             "ovr_config//os:android-arm64": [
-                "-DET_BUILD_ARM_VEC256_WITH_SLEEF",
+                "-DAT_BUILD_ARM_VEC256_WITH_SLEEF",
             ] if not runtime.is_oss else [],
             "DEFAULT": [],
         })


### PR DESCRIPTION
Summary:
The ATen NEON vectorized math headers check for
`AT_BUILD_ARM_VEC256_WITH_SLEEF` to enable SLEEF intrinsics for functions
such as `exp()` and `log()`. `get_vec_preprocessor_flags()` was defining
`ET_BUILD_ARM_VEC256_WITH_SLEEF`, so the SLEEF path was never enabled.

Use the macro expected by the ATen headers so `Vectorized<float>::exp()`
dispatches to `Sleef_expf4_u10` on ARM.


This recreates `D96044314` as a new
internal change since original author left and the diff is already exported, this seemed easy.

Differential Revision: D118475079


