### PR TITLE
[Vulkan] Preserve Vulkan graph boundary semantics

### DIFF
--- a/backends/vulkan/_passes/tag_memory_meta_pass.py
+++ b/backends/vulkan/_passes/tag_memory_meta_pass.py
@@ -150,17 +150,57 @@ class TagMemoryMetaPass(ExportPass):
         default_storage_type: VkStorageType = VkStorageType.TEXTURE_3D,
         default_memory_layout: VkMemoryLayout = VkMemoryLayout.TENSOR_WIDTH_PACKED,
         force_fp16: bool = False,
+        alias_buffer_mutations: bool = False,
     ):
         super().__init__()
         self.default_storage: VkStorageType = default_storage_type
         self.default_layout: VkMemoryLayout = default_memory_layout
         self.texture_limits = texture_limits
         self.force_fp16 = force_fp16
+        self.alias_buffer_mutations = alias_buffer_mutations
+        self._exported_program = None
+        self.buffer_mutation_inputs: dict[str, torch.fx.Node] = {}
 
         # Limit the total number of nodes explored when tracing through users of
         # an operator to constrain the representation of its arguments/outputs.
         # Without a limit, transformer-style graphs cause exponential blowup.
         self.max_trace_search_depth = 64
+
+    def initialize_buffer_mutation_inputs(self) -> None:
+        if not self.alias_buffer_mutations:
+            return
+        if self._exported_program is None:
+            raise RuntimeError(
+                "alias_buffer_mutations requires an ExportedProgram in TagMemoryMetaPass"
+            )
+
+        nodes_by_name = {
+            node.name: node for node in self._exported_program.graph_module.graph.nodes
+        }
+        buffer_inputs_by_target: dict[str, torch.fx.Node] = {}
+        for (
+            name,
+            target,
+        ) in self._exported_program.graph_signature.inputs_to_buffers.items():
+            if name not in nodes_by_name:
+                continue
+            buffer_input = nodes_by_name[name]
+            prepack = next(
+                (
+                    user
+                    for user in buffer_input.users
+                    if user.op == "call_function"
+                    and user.target == exir_ops.edge.et_vk.prepack.default
+                ),
+                None,
+            )
+            buffer_inputs_by_target[target] = prepack or buffer_input
+
+        self.buffer_mutation_inputs = {
+            output_name: buffer_inputs_by_target[target]
+            for output_name, target in self._exported_program.graph_signature.buffers_to_mutate.items()
+            if target in buffer_inputs_by_target
+        }
 
     def is_valid_op_node(self, node: Any) -> bool:
         """
@@ -497,9 +537,35 @@ class TagMemoryMetaPass(ExportPass):
         features: OpFeatures = get_op_features(op_node.target)
         op_repsets = features.make_op_repsets(op_node, self.texture_limits)
 
+        forced_output_repr = None
+        if op_node.name in self.buffer_mutation_inputs:
+            mutation_input = self.buffer_mutation_inputs[op_node.name]
+            mutation_output_is_input = (
+                mutation_input is op_node or op_node in mutation_input.all_input_nodes
+            )
+            if not mutation_output_is_input:
+                if not utils.has_node_repr(mutation_input):
+                    raise RuntimeError(
+                        f"Aliased mutation input {mutation_input.name} has no tensor representation"
+                    )
+                forced_output_repr = utils.get_node_repr(mutation_input)
+                if not isinstance(forced_output_repr, utils.TensorRepr):
+                    raise RuntimeError(
+                        f"Aliased mutation input {mutation_input.name} must be a single tensor"
+                    )
+                op_repsets.try_constrain_with_out_repset(
+                    utils.make_tensor_repset(forced_output_repr)
+                )
+
         self.constrain_op_repsets(op_repsets)
 
         args_repr_list, outs_repr_list = op_repsets.pick_representations()
+
+        if forced_output_repr is not None and outs_repr_list[0] != forced_output_repr:
+            raise RuntimeError(
+                f"Cannot alias mutation {op_node.name} with representation "
+                f"{outs_repr_list[0]} to input representation {forced_output_repr}"
+            )
 
         if len(outs_repr_list) == 1:
             utils.set_node_repr(op_node, outs_repr_list[0])
@@ -542,6 +608,7 @@ class TagMemoryMetaPass(ExportPass):
                     )
 
     def call(self, graph_module: torch.fx.GraphModule) -> PassResult:
+        self.initialize_buffer_mutation_inputs()
         transition_cache: dict = {}
         for node in graph_module.graph.nodes:
             self.set_op_node_tensor_reprs(graph_module, node, transition_cache)

--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -264,6 +264,21 @@ class VulkanSupportedOperators(OperatorSupportBase):
             self.log_skip(node, dtype_reason)
             return False
 
+        for arg_index in features.buffer_limit_args:
+            if arg_index >= len(node.args):
+                self.log_skip(node, f"missing buffer-limited input[{arg_index}]")
+                return False
+            arg = node.args[arg_index]
+            if not isinstance(arg, torch.fx.Node) or not utils.is_tensor_node(arg):
+                self.log_skip(node, f"invalid buffer-limited input[{arg_index}]")
+                return False
+            if not utils.within_buffer_limit(arg, self.buffer_limit):
+                self.log_skip(
+                    node,
+                    f"input[{arg_index}] exceeds {self.buffer_limit}-element buffer limit",
+                )
+                return False
+
         if not features.are_node_inputs_supported_fn(node):
             self.log_skip(node, "op args not supported")
             return False
@@ -418,7 +433,11 @@ class VulkanPartitioner(Partitioner):
             ),
             allows_single_node_partition=True,
         )
-        partition_list = capability_partitioner.propose_partitions()
+        partition_list = [
+            partition
+            for partition in capability_partitioner.propose_partitions()
+            if any(utils.is_tensor_node(node) for node in partition.nodes)
+        ]
         for partition in partition_list:
             for node in partition.nodes:
                 tag = f"tag{partition.id}"

--- a/backends/vulkan/runtime/VulkanBackend.cpp
+++ b/backends/vulkan/runtime/VulkanBackend.cpp
@@ -507,6 +507,9 @@ class GraphBuilder {
         compute_graph_->set_output_tensor(
             ref, get_staging_scalar_type_of(fb_id));
       } else {
+        if (compute_graph_->val_is_tref(ref)) {
+          compute_graph_->get_tref(ref)->is_graph_output = true;
+        }
         compute_graph_->set_output_value(ref);
       }
     }
@@ -754,7 +757,12 @@ class VulkanBackend final : public ::executorch::runtime::BackendInterface {
     for (size_t i = 0; i < num_inputs; i++) {
       const ValueRef iref = compute_graph->inputs()[i].value;
       if (compute_graph->val_is_tensor(iref)) {
-        VK_CHECK_COND(args[i]->isTensor());
+        VK_CHECK_COND(
+            args[i]->isTensor(),
+            "Expected tensor input at index ",
+            i,
+            ", got EValue tag ",
+            static_cast<uint32_t>(args[i]->tag));
         bool was_resized =
             maybe_resize_input(compute_graph, i, args[i]->toTensor());
         should_propagate_resize = should_propagate_resize || was_resized;
@@ -764,25 +772,21 @@ class VulkanBackend final : public ::executorch::runtime::BackendInterface {
             args[i]->toTensor().numel(),
             equivalent_scalar_type(args[i]->toTensor().scalar_type()));
       } else if (compute_graph->val_is_symint(iref)) {
-        // A SymInt input may arrive either as a scalar tensor (the convention
-        // when the value was lifted from one) or as a plain Int EValue, which
-        // is what the emitter produces when the Method's schema declares the
-        // argument as SymInt. Accept both.
         bool was_updated = false;
-        if (args[i]->isTensor()) {
+        if (args[i]->isInt()) {
+          const int32_t new_value =
+              utils::safe_downcast<int32_t>(args[i]->toInt());
+          was_updated = compute_graph->read_symint(iref) != new_value;
+          compute_graph->set_symint(iref, new_value);
+        } else if (args[i]->isTensor()) {
           was_updated = maybe_update_scalar_tensor(
               compute_graph, iref, args[i]->toTensor());
-        } else if (args[i]->isInt()) {
-          const int32_t cur_val = compute_graph->read_symint(iref);
-          const int32_t new_val = static_cast<int32_t>(args[i]->toInt());
-          if (new_val != cur_val) {
-            compute_graph->set_symint(iref, new_val);
-            was_updated = true;
-          }
         } else {
           VK_THROW(
-              "Could not handle symint arg: caller's EValue is neither "
-              "a scalar tensor nor an Int.");
+              "Expected integer or scalar tensor for SymInt input at index ",
+              i,
+              ", got EValue tag ",
+              static_cast<uint32_t>(args[i]->tag));
         }
         // Since symint inputs may impact tensor's sizes, trigger a resize if
         // any symbolic integer shapes are updated.
@@ -886,12 +890,20 @@ class VulkanBackend final : public ::executorch::runtime::BackendInterface {
               "Could not handle symint output: caller's EValue is neither "
               "a scalar tensor nor an Int.");
         }
-      }
-      // TensorRef values represent constant tensors which will not have been
-      // modified by the graph execution. Therefore, if a constant tensor is
-      // returned as an output, no action is required.
-      else if (compute_graph->val_is_tref(oref)) {
-        continue;
+      } else if (compute_graph->val_is_tref(oref)) {
+        VK_CHECK_COND(args[o]->isTensor());
+        maybe_resize_output(compute_graph, i, args[o]->toTensor());
+        const TensorRefPtr tref = compute_graph->get_tref(oref);
+        VK_CHECK_COND(
+            equivalent_scalar_type(args[o]->toTensor().scalar_type()) ==
+            tref->dtype);
+        VK_CHECK_COND(args[o]->toTensor().nbytes() == tref->nbytes());
+        if (tref->nbytes() > 0) {
+          std::memcpy(
+              args[o]->toTensor().mutable_data_ptr(),
+              tref->data,
+              tref->nbytes());
+        }
       } else {
         VK_THROW(
             "Could not handle output with type ",

--- a/backends/vulkan/runtime/api/containers/Tensor.cpp
+++ b/backends/vulkan/runtime/api/containers/Tensor.cpp
@@ -691,10 +691,9 @@ vkapi::VulkanBuffer allocate_buffer(
       element_size(dtype) * static_cast<size_t>(numel),
       static_cast<size_t>(16));
 
-  // TODO: this check is incorrect. max_buffer_numel() returns
-  // maxStorageBufferRange, which is a size in bytes, so the comparison should
-  // use the buffer's byte size (alloc_nbytes), not the element count.
-  VK_CHECK_COND(numel <= context_ptr->adapter_ptr()->max_buffer_numel());
+  VK_CHECK_COND(
+      alloc_nbytes <= context_ptr->adapter_ptr()->max_buffer_nbytes(),
+      "buffer allocation exceeds maxStorageBufferRange");
 
   return adapter_ptr->vma().create_storage_buffer(
       alloc_nbytes, allocate_memory);

--- a/backends/vulkan/runtime/graph/ComputeGraph.h
+++ b/backends/vulkan/runtime/graph/ComputeGraph.h
@@ -702,8 +702,8 @@ class ComputeGraph final {
 
   bool device_name_contains(const char* substr);
 
-  int64_t max_buffer_numel() {
-    return static_cast<int64_t>(context_->adapter_ptr()->max_buffer_numel());
+  int64_t max_buffer_nbytes() {
+    return static_cast<int64_t>(context_->adapter_ptr()->max_buffer_nbytes());
   }
 
   //

--- a/backends/vulkan/runtime/graph/containers/Constant.h
+++ b/backends/vulkan/runtime/graph/containers/Constant.h
@@ -35,6 +35,10 @@ struct TensorRef final {
   // (e.g. shared/tied weights).
   int32_t prepack_use_count{0};
 
+  // Graph outputs are copied from TensorRef data during execution, so their
+  // backing buffers must remain alive after prepacking completes.
+  bool is_graph_output{false};
+
   explicit TensorRef(
       const std::vector<int64_t>& t_sizes,
       vkapi::ScalarType t_dtype,

--- a/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.cpp
@@ -93,7 +93,7 @@ api::StagingBuffer PrepackNode::create_staging_buffer(ComputeGraph* graph) {
     }
   }
 
-  if (--tref->prepack_use_count == 0) {
+  if (--tref->prepack_use_count == 0 && !tref->is_graph_output) {
     tref->free_buffer();
   }
 

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.cpp
@@ -47,7 +47,7 @@ namespace {
 uint64_t q8ta_conv2d_im2col_scratch_limit(ComputeGraph& graph) {
   constexpr uint64_t kMaxBatchedIm2ColScratchBytes = 32ULL * 1024ULL * 1024ULL;
   const uint64_t device_scratch_limit =
-      graph.context()->adapter_ptr()->max_buffer_numel();
+      graph.context()->adapter_ptr()->max_buffer_nbytes();
   return device_scratch_limit < kMaxBatchedIm2ColScratchBytes
       ? device_scratch_limit
       : kMaxBatchedIm2ColScratchBytes;

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -423,7 +423,7 @@ class Adapter final {
     return physical_device_.properties.limits.maxImageDimension3D;
   }
 
-  inline uint32_t max_buffer_numel() const {
+  inline uint32_t max_buffer_nbytes() const {
     return physical_device_.properties.limits.maxStorageBufferRange;
   }
 

--- a/backends/vulkan/serialization/vulkan_graph_builder.py
+++ b/backends/vulkan/serialization/vulkan_graph_builder.py
@@ -193,13 +193,17 @@ class VkGraphBuilder:
     def create_node_value(self, node: Node) -> int:
         if node.name in self.buffer_mutation_inputs:
             input_node = self.buffer_mutation_inputs[node.name]
-            if input_node not in self.node_to_value_ids:
-                raise AssertionError(
-                    "Cannot alias a buffer mutation before its input is serialized"
-                )
-            value_id = self.node_to_value_ids[input_node]
-            self.node_to_value_ids[node] = value_id
-            return value_id
+            mutation_output_is_input = (
+                input_node is node or node in input_node.all_input_nodes
+            )
+            if not mutation_output_is_input:
+                if input_node not in self.node_to_value_ids:
+                    raise AssertionError(
+                        "Cannot alias a buffer mutation before its input is serialized"
+                    )
+                value_id = self.node_to_value_ids[input_node]
+                self.node_to_value_ids[node] = value_id
+                return value_id
 
         # If the node has been marked as a scalar tensor, create a SymInt instead of a tensor
         if is_symint_node(node) or node.meta.get("etvk_is_scalar_tensor", False):
@@ -230,12 +234,7 @@ class VkGraphBuilder:
         return new_id
 
     def get_or_create_scalar_value(self, scalar: _ScalarType) -> int:
-        scalar_key = scalar
-        # Since Python considers 1 and True to be "equivalent" (as well as 0 and False)
-        # to distinguish entries in the dictionary, if scalar is bool then convert it
-        # to a string representation to use as a key for the dictionary
-        if isinstance(scalar, bool):
-            scalar_key = str(scalar)
+        scalar_key = (type(scalar), scalar)
 
         if scalar_key in self.const_scalar_to_value_ids:
             return self.const_scalar_to_value_ids[scalar_key]
@@ -418,8 +417,10 @@ class VkGraphBuilder:
             raise RuntimeError(f"Cannot create value for arg of type {type(arg)}")
 
     def process_placeholder_node(self, node: Node) -> None:
-        # ignores any tensors that don't get used in any ops
-        if len(node.users) == 0:
+        # Unused parameters do not need to be serialized. User inputs must retain
+        # their original order even if a preprocessing pass removed their users,
+        # since the delegate call ABI still includes those arguments.
+        if len(node.users) == 0 and is_param_node(self.program, node):
             return None
         ids = self.create_node_value(node)
         if not is_param_node(self.program, node):
@@ -492,6 +493,13 @@ class VkGraphBuilder:
             if out_node.name in self.buffer_mutation_inputs:
                 if out_node.name not in self.buffer_mutation_user_outputs:
                     continue
+                mutation_input = self.buffer_mutation_inputs[out_node.name]
+                if mutation_input not in self.node_to_value_ids:
+                    raise AssertionError(
+                        "Cannot find the aliased buffer mutation input in node_to_value_ids"
+                    )
+                self.output_ids.append(self.node_to_value_ids[mutation_input])
+                continue
             elif is_mutable_buffer_node(out_node, self.program):
                 continue
 

--- a/backends/vulkan/serialization/vulkan_graph_serialize.py
+++ b/backends/vulkan/serialization/vulkan_graph_serialize.py
@@ -27,8 +27,24 @@ from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_da
 from executorch.exir._serialize._flatbuffer import _flatc_compile, _flatc_decompile
 
 
+def _flatbuffer_nonfinite_constant(value: str) -> str:
+    return {
+        "-Infinity": "-inf",
+        "Infinity": "inf",
+        "NaN": "nan",
+    }[value]
+
+
 def convert_to_flatbuffer(vk_graph: VkGraph) -> bytes:
-    vk_graph_json = json.dumps(vk_graph, cls=_DataclassEncoder)
+    # Python emits non-finite floats as bare tokens that flatc rejects. Flatc
+    # accepts the same values using its quoted spellings.
+    vk_graph_json = json.dumps(
+        json.loads(
+            json.dumps(vk_graph, cls=_DataclassEncoder),
+            parse_constant=_flatbuffer_nonfinite_constant,
+        ),
+        allow_nan=False,
+    )
 
     with tempfile.TemporaryDirectory() as d:
         schema_path = os.path.join(d, "schema.fbs")

--- a/backends/vulkan/test/test_serialization.py
+++ b/backends/vulkan/test/test_serialization.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import ctypes
+import math
 import random
 import unittest
 from types import SimpleNamespace
@@ -14,15 +15,22 @@ from typing import List, Tuple
 
 import executorch.backends.vulkan.custom_ops_lib  # noqa: F401
 import torch
+from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from executorch.backends.vulkan.serialization import (
     vulkan_graph_builder as graph_builder_module,
 )
 
 from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
+    Bool,
+    Double,
+    DoubleList,
+    Int,
     IntList,
     OperatorCall,
     String,
+    SymInt,
     VkGraph,
+    VkTensor,
     VkValue,
 )
 
@@ -35,6 +43,62 @@ from executorch.backends.vulkan.serialization.vulkan_graph_serialize import (
 
 
 class TestSerialization(unittest.TestCase):
+    def test_scalar_deduplication_preserves_numeric_types(self) -> None:
+        builder = graph_builder_module.VkGraphBuilder(
+            SimpleNamespace(),
+            graph_builder_module.DelegateMappingBuilder(generated_identifiers=True),
+        )
+
+        scalar_ids = [
+            builder.get_or_create_scalar_value(value)
+            for value in (False, 0, 0.0, True, 1, 1.0)
+        ]
+
+        self.assertEqual(len(set(scalar_ids)), 6)
+        self.assertEqual(
+            [type(builder.values[value_id].value) for value_id in scalar_ids],
+            [Bool, Int, Double, Bool, Int, Double],
+        )
+        self.assertEqual(
+            builder.get_or_create_scalar_value(0),
+            scalar_ids[1],
+        )
+
+    def test_unused_user_inputs_preserve_delegate_abi_order(self) -> None:
+        graph = torch.fx.Graph()
+        unused_scalar = graph.placeholder("unused_scalar")
+        used_tensor = graph.placeholder("used_tensor")
+        unused_scalar.meta["val"] = ShapeEnv().create_unbacked_symint()
+        used_tensor.meta["spec"] = graph_builder_module.TensorSpec.from_tensor(
+            torch.ones(4)
+        )
+        graph.output((used_tensor,))
+
+        graph_module = torch.fx.GraphModule({}, graph)
+        signature = SimpleNamespace(
+            buffers_to_mutate={},
+            inputs_to_buffers={},
+            inputs_to_lifted_tensor_constants={},
+            inputs_to_parameters={},
+            non_persistent_buffers=set(),
+            user_outputs=(used_tensor.name,),
+        )
+        program = SimpleNamespace(
+            constants={},
+            graph_module=graph_module,
+            graph_signature=signature,
+            state_dict={},
+        )
+
+        vk_graph = graph_builder_module.VkGraphBuilder(
+            program,
+            graph_builder_module.DelegateMappingBuilder(generated_identifiers=True),
+        ).build_graph()
+
+        self.assertEqual(len(vk_graph.input_ids), 2)
+        self.assertIsInstance(vk_graph.values[vk_graph.input_ids[0]].value, SymInt)
+        self.assertIsInstance(vk_graph.values[vk_graph.input_ids[1]].value, VkTensor)
+
     def _build_mutation_program(
         self, prepack: bool, shared_user_output: bool = False
     ) -> Tuple[SimpleNamespace, torch.fx.Node, torch.fx.Node, torch.fx.Node]:
@@ -166,6 +230,55 @@ class TestSerialization(unittest.TestCase):
                     [builder.node_to_value_ids[mutation]],
                 )
 
+    def test_alias_buffer_mutation_when_input_is_mutation_output(self) -> None:
+        for prepack in (False, True):
+            with self.subTest(prepack=prepack):
+                graph = torch.fx.Graph()
+                state = graph.placeholder("state")
+                state.meta["spec"] = graph_builder_module.TensorSpec.from_tensor(
+                    torch.zeros(4)
+                )
+                mutation_input = state
+                if prepack:
+                    mutation_input = graph.call_function(
+                        graph_builder_module.exir_ops.edge.et_vk.prepack.default,
+                        (state,),
+                    )
+                    mutation_input.meta["spec"] = (
+                        graph_builder_module.TensorSpec.from_tensor(torch.zeros(4))
+                    )
+                graph.output((state,))
+
+                graph_module = torch.fx.GraphModule({}, graph)
+                signature = SimpleNamespace(
+                    buffers_to_mutate={state.name: "state"},
+                    inputs_to_buffers={state.name: "state"},
+                    inputs_to_lifted_tensor_constants={},
+                    inputs_to_parameters={},
+                    non_persistent_buffers=set(),
+                    user_outputs=(state.name,),
+                )
+                program = SimpleNamespace(
+                    constants={},
+                    graph_module=graph_module,
+                    graph_signature=signature,
+                    state_dict={"state": torch.zeros(4)},
+                )
+                builder = graph_builder_module.VkGraphBuilder(
+                    program,
+                    graph_builder_module.DelegateMappingBuilder(
+                        generated_identifiers=True
+                    ),
+                    alias_buffer_mutations=True,
+                )
+
+                serialized_graph = builder.build_graph()
+
+                self.assertEqual(
+                    serialized_graph.output_ids,
+                    [builder.node_to_value_ids[mutation_input]],
+                )
+
     def _generate_random_const_tensors(self, num_tensors: int) -> List[torch.Tensor]:
         """
         Helper function to generate `num_tensor` buffers of random sizes and random contents,
@@ -269,3 +382,29 @@ class TestSerialization(unittest.TestCase):
         out_vk_graph = flatbuffer_to_vk_graph(bs)
 
         self.assertEqual(in_vk_graph, out_vk_graph)
+
+    def test_serialize_nonfinite_scalar_values(self) -> None:
+        vk_graph = VkGraph(
+            version="1",
+            chain=[],
+            values=[
+                VkValue(value=Double(float("-inf"))),
+                VkValue(value=Double(float("inf"))),
+                VkValue(value=Double(float("nan"))),
+                VkValue(
+                    value=DoubleList(
+                        items=[float("-inf"), 0.0, float("inf"), float("nan")]
+                    )
+                ),
+            ],
+            input_ids=[],
+            output_ids=[],
+            constants=[],
+            shaders=[],
+        )
+
+        serialized = convert_to_flatbuffer(vk_graph)
+
+        self.assertGreater(len(serialized), 0)
+        self.assertTrue(math.isinf(vk_graph.values[0].value.double_val))
+        self.assertTrue(math.isnan(vk_graph.values[2].value.double_val))

--- a/backends/vulkan/test/test_vulkan_tensor_repr.py
+++ b/backends/vulkan/test/test_vulkan_tensor_repr.py
@@ -6,9 +6,11 @@
 
 import operator
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import torch
+from executorch.backends.vulkan._passes.tag_memory_meta_pass import TagMemoryMetaPass
 from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
     VkMemoryLayout,
     VkStorageType,
@@ -23,6 +25,7 @@ from executorch.backends.vulkan.utils import (
     CONTIGUOUS_BUFFER,
     DEFAULT_TEXTURE_LIMITS,
     HEIGHT_PACKED_TEXTURE,
+    get_node_repr,
     make_tensor_repset,
     NO_STORAGE,
     OpRepSets,
@@ -35,8 +38,11 @@ from executorch.backends.vulkan.utils import (
     TensorReprList,
     TensorRepSet,
     TensorRepSetList,
+    set_node_repr,
     WIDTH_PACKED_TEXTURE,
 )
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.tensor import TensorSpec
 from torch._subclasses.fake_tensor import FakeTensorMode
 
 
@@ -985,6 +991,66 @@ class TestTensorReprList(unittest.TestCase):
         lst = TensorReprList(tr)
         s = str(lst)
         self.assertIn("TensorRepr", s)
+
+
+class TestTagMemoryMetaPass(unittest.TestCase):
+    def test_alias_buffer_mutation_inserts_source_transition(self):
+        graph = torch.fx.Graph()
+        state = graph.placeholder("state")
+        state.meta["val"] = _make_fake_tensor((1, 1280, 2))
+        state.meta["spec"] = TensorSpec.from_tensor(state.meta["val"])
+
+        prepack = graph.call_function(
+            exir_ops.edge.et_vk.prepack.default,
+            (state,),
+        )
+        prepack.meta["val"] = state.meta["val"]
+        prepack.meta["spec"] = TensorSpec.from_tensor(prepack.meta["val"])
+        buffer_repr = TensorRepr(
+            VkStorageType.BUFFER, VkMemoryLayout.TENSOR_WIDTH_PACKED
+        )
+        set_node_repr(prepack, buffer_repr)
+
+        source = graph.placeholder("source")
+        source.meta["val"] = _make_fake_tensor((1, 1280, 8))
+        source.meta["spec"] = TensorSpec.from_tensor(source.meta["val"])
+        set_node_repr(
+            source,
+            TensorRepr(
+                VkStorageType.TEXTURE_3D,
+                VkMemoryLayout.TENSOR_CHANNELS_PACKED,
+            ),
+        )
+
+        mutation = graph.call_function(
+            exir_ops.edge.aten.slice_copy.Tensor,
+            (source, 2, 6, 8, 1),
+        )
+        mutation.meta["val"] = _make_fake_tensor((1, 1280, 2))
+        mutation.meta["spec"] = TensorSpec.from_tensor(mutation.meta["val"])
+        graph.output((mutation,))
+
+        graph_module = torch.fx.GraphModule({}, graph)
+        graph_signature = SimpleNamespace(
+            buffers_to_mutate={mutation.name: "state"},
+            inputs_to_buffers={state.name: "state"},
+        )
+        tag_pass = TagMemoryMetaPass(
+            DEFAULT_TEXTURE_LIMITS,
+            alias_buffer_mutations=True,
+        )
+        tag_pass._exported_program = SimpleNamespace(
+            graph_module=graph_module,
+            graph_signature=graph_signature,
+        )
+
+        tag_pass.call(graph_module)
+
+        transitioned_source = mutation.args[0]
+        self.assertIsInstance(transitioned_source, torch.fx.Node)
+        self.assertEqual(transitioned_source.target, exir_ops.edge.aten.clone.default)
+        self.assertEqual(get_node_repr(transitioned_source), buffer_repr)
+        self.assertEqual(get_node_repr(mutation), buffer_repr)
 
 
 if __name__ == "__main__":

--- a/backends/vulkan/test/vulkan_compute_api_test.cpp
+++ b/backends/vulkan/test/vulkan_compute_api_test.cpp
@@ -91,6 +91,14 @@ std::vector<std::vector<int64_t>> standard_sizes_to_test = {
     {3, 8, 13, 17},
 };
 
+TEST(TensorUtilsTest, CalculateBroadcastedOutputSizeHandlesScalars) {
+  EXPECT_EQ(
+      calculate_broadcasted_output_size({}, {}), (std::vector<int64_t>{}));
+  EXPECT_EQ(
+      calculate_broadcasted_output_size({}, {2, 3}),
+      (std::vector<int64_t>{2, 3}));
+}
+
 //
 // Compute API Tests
 //
@@ -3308,6 +3316,44 @@ void test_to_copy() {
 
 TEST(VulkanComputeGraphOpsTest, test_to_copy) {
   test_to_copy();
+}
+
+TEST(VulkanComputeGraphOpsTest, test_to_copy_buffer_same_dtype) {
+  GraphConfig config;
+  config.set_storage_type_override(utils::kBuffer);
+  ComputeGraph graph(config);
+
+  const std::vector<int64_t> sizes{2, 3, 4};
+  IOValueRef in = graph.add_input_tensor(
+      sizes, vkapi::kFloat, utils::GPUMemoryLayout::TENSOR_CHANNELS_PACKED);
+  std::vector<float> input_data = create_random_float_buffer(24, -1024, 1024);
+  graph.maybe_cast_and_copy_into_staging(
+      in.staging, input_data.data(), input_data.size(), vkapi::kFloat);
+
+  IOValueRef out;
+  out.value = graph.add_tensor(
+      sizes, vkapi::kFloat, utils::GPUMemoryLayout::TENSOR_CHANNELS_PACKED);
+  VK_GET_OP_FN("aten._to_copy.default")(
+      graph,
+      {in.value,
+       graph.add_none(),
+       graph.add_none(),
+       graph.add_none(),
+       graph.add_none(),
+       graph.add_none(),
+       graph.add_none(),
+       out.value});
+  out.staging = graph.set_output_tensor(out.value);
+
+  graph.prepare();
+  graph.prepack();
+  graph.propagate_resize();
+  graph.execute();
+
+  std::vector<float> output_data(input_data.size());
+  graph.maybe_cast_and_copy_from_staging(
+      out.staging, output_data.data(), output_data.size(), vkapi::kFloat);
+  EXPECT_EQ(input_data, output_data);
 }
 
 vkapi::ShaderInfo pick_dynamic_dispatch_shader(

--- a/backends/vulkan/utils.py
+++ b/backends/vulkan/utils.py
@@ -777,7 +777,7 @@ class PackedDimInfo:
             raise ValueError(f"Unknown memory layout: {memory_layout}")
 
 
-def within_buffer_limit(node: torch.fx.Node, buffer_limit: int) -> int:
+def within_buffer_limit(node: torch.fx.Node, buffer_limit: int) -> bool:
     """
     Checks whether the tensors produced by the given node can fit within the device's
     GPU buffer limit, which represents the maximum number of elements that can be stored
@@ -786,9 +786,9 @@ def within_buffer_limit(node: torch.fx.Node, buffer_limit: int) -> int:
     assert is_tensor_node(node)
 
     if isinstance(node.meta["val"], FakeTensor):
-        return node.meta["val"].numel() < buffer_limit
+        return node.meta["val"].numel() <= buffer_limit
     elif isinstance(node.meta["val"], list) or isinstance(node.meta["val"], tuple):
-        return all(x.numel() < buffer_limit for x in node.meta["val"])
+        return all(x.numel() <= buffer_limit for x in node.meta["val"])
     else:
         raise RuntimeError(f"Cannot get numel for val of type {type(node.meta['val'])}")
 

--- a/backends/vulkan/vulkan_preprocess.py
+++ b/backends/vulkan/vulkan_preprocess.py
@@ -230,6 +230,7 @@ class VulkanBackend(BackendDetails):
                         default_storage_type=default_storage_type,
                         default_memory_layout=default_memory_layout,
                         force_fp16=force_fp16,
+                        alias_buffer_mutations=alias_buffer_mutations,
                     ),
                 ],
             )


### PR DESCRIPTION
Stateful model export depends on stable aliasing, scalar I/O, and serialization
contracts.

AI-assisted-by: Codex

This PR was authored with assistance from Codex.

cc @SS-JIA @manuelcandales @cbilgin