### PR TITLE
[Vulkan] Keep scalar math on Vulkan

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/binary_op_defs.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_op_defs.glslh
@@ -59,4 +59,31 @@ COMPUTE_VEC4_T power_of(COMPUTE_VEC4_T x, COMPUTE_VEC4_T y) {
 
 #endif // COMPUTE_VEC4_T
 
+#ifdef IS_REMAINDER_OP
+
+COMPUTE_T remainder_of(COMPUTE_T x, COMPUTE_T y) {
+  if (y == 1 || y == -1) {
+    return COMPUTE_T(0);
+  }
+  COMPUTE_T result = x - (x / y) * y;
+  if (result != 0 && ((result < 0) != (y < 0))) {
+    result += y;
+  }
+  return result;
+}
+
+#ifdef COMPUTE_VEC4_T
+
+COMPUTE_VEC4_T remainder_of(COMPUTE_VEC4_T x, COMPUTE_VEC4_T y) {
+  COMPUTE_VEC4_T result;
+  for (int i = 0; i < 4; i++) {
+    result[i] = remainder_of(x[i], y[i]);
+  }
+  return result;
+}
+
+#endif // COMPUTE_VEC4_T
+
+#endif // IS_REMAINDER_OP
+
 #endif // BINARY_OP_DEFS_GLSLH

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_buffer.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_buffer.glsl
@@ -32,6 +32,8 @@ $if IS_COMPARISON_OP:
   #define OUT_T ${buffer_scalar_type("uint8")}
 $else:
   #define OUT_T ${buffer_scalar_type(DTYPE)}
+$if IS_REMAINDER_OP:
+  #define IS_REMAINDER_OP
 
 #define op(X, Y) ${OPERATOR}
 

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_buffer.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_buffer.yaml
@@ -8,6 +8,7 @@ binary_scalar_buffer:
   parameter_names_with_default_values:
     OPERATOR: power_of(X, Y)
     IS_COMPARISON_OP: false
+    IS_REMAINDER_OP: false
     DTYPE: float
     SCALAR_VALUE_TYPE: float
     STORAGE: buffer
@@ -39,3 +40,11 @@ binary_scalar_buffer:
     - NAME: ge_scalar_buffer
       OPERATOR: X >= Y
       IS_COMPARISON_OP: true
+    - NAME: remainder_scalar_buffer
+      OPERATOR: remainder_of(X, Y)
+      IS_REMAINDER_OP: true
+      generate_variant_forall:
+        combination:
+          parameter_names: [DTYPE, SCALAR_VALUE_TYPE]
+          combos:
+            - parameter_values: [int32, int32]

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_texture.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_texture.glsl
@@ -34,6 +34,8 @@ $if IS_COMPARISON_OP:
   #define VEC4_OUT_T ${texel_load_type("uint8", STORAGE)}
 $else:
   #define VEC4_OUT_T VEC4_T
+$if IS_REMAINDER_OP:
+  #define IS_REMAINDER_OP
 
 #define op(X, Y) ${OPERATOR}
 

--- a/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_texture.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/binary_scalar_texture.yaml
@@ -8,6 +8,7 @@ binary_scalar_texture:
   parameter_names_with_default_values:
     OPERATOR: power_of(X, Y)
     IS_COMPARISON_OP: false
+    IS_REMAINDER_OP: false
     DTYPE: float
     SCALAR_VALUE_TYPE: float
     STORAGE: texture3d
@@ -39,3 +40,11 @@ binary_scalar_texture:
     - NAME: ge_scalar_texture3d
       OPERATOR: greaterThanEqual(X, Y)
       IS_COMPARISON_OP: true
+    - NAME: remainder_scalar_texture3d
+      OPERATOR: remainder_of(X, Y)
+      IS_REMAINDER_OP: true
+      generate_variant_forall:
+        combination:
+          parameter_names: [DTYPE, SCALAR_VALUE_TYPE]
+          combos:
+            - parameter_values: [int32, int32]

--- a/backends/vulkan/runtime/graph/ops/impl/BinaryScalarOp.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/BinaryScalarOp.cpp
@@ -147,6 +147,16 @@ void ge_tensor_scalar(ComputeGraph& graph, const std::vector<ValueRef>& args) {
   return add_binary_scalar_op_node(graph, args[0], args[1], args[2], "ge");
 }
 
+void remainder_tensor_scalar(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args) {
+  VK_CHECK_COND(graph.dtype_of(args[0]) == vkapi::kInt);
+  VK_CHECK_COND(graph.dtype_of(args[2]) == vkapi::kInt);
+  VK_CHECK_COND(extract_int32_scalar(graph, args[1]) != 0);
+  return add_binary_scalar_op_node(
+      graph, args[0], args[1], args[2], "remainder");
+}
+
 REGISTER_OPERATORS {
   VK_REGISTER_OP(aten.pow.Tensor_Scalar, pow_tensor_scalar);
   VK_REGISTER_OP(aten.eq.Scalar, eq_tensor_scalar);
@@ -155,6 +165,7 @@ REGISTER_OPERATORS {
   VK_REGISTER_OP(aten.le.Scalar, le_tensor_scalar);
   VK_REGISTER_OP(aten.gt.Scalar, gt_tensor_scalar);
   VK_REGISTER_OP(aten.ge.Scalar, ge_tensor_scalar);
+  VK_REGISTER_OP(aten.remainder.Scalar, remainder_tensor_scalar);
 }
 
 } // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/ScalarTensor.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/ScalarTensor.cpp
@@ -14,19 +14,26 @@
 namespace vkcompute {
 
 void scalar_tensor(ComputeGraph& graph, const std::vector<ValueRef>& args) {
-  // Extract the scalar value from the first argument
-  ValueRef scalar_in = args[0];
-  float scalar_value = graph.extract_scalar<float>(scalar_in);
-
-  // Get the output tensor reference
-  ValueRef out = args[args.size() - 1];
+  const ValueRef scalar_in = args.at(0);
+  const ValueRef out = args.back();
 
   std::string kernel_name("scalar_tensor");
   kernel_name.reserve(kShaderNameReserve);
 
   add_dtype_suffix(kernel_name, graph.dtype_of(out));
   add_storage_type_suffix(kernel_name, graph.storage_type_of(out));
-  add_dtype_suffix(kernel_name, graph.dtype_of(scalar_in));
+  const bool scalar_is_integer =
+      graph.val_is_int(scalar_in) || graph.val_is_symint(scalar_in);
+  add_dtype_suffix(
+      kernel_name, scalar_is_integer ? vkapi::kInt : graph.dtype_of(scalar_in));
+
+  vkapi::BufferBindInfo scalar_param;
+  if (scalar_is_integer) {
+    scalar_param = graph.get_or_create_int_param_buffer(scalar_in);
+  } else {
+    scalar_param =
+        graph.create_params_buffer(graph.extract_scalar<float>(scalar_in));
+  }
 
   graph.execute_nodes().emplace_back(new DispatchNode(
       graph,
@@ -36,7 +43,7 @@ void scalar_tensor(ComputeGraph& graph, const std::vector<ValueRef>& args) {
       // Inputs and Outputs
       {{out, vkapi::kWrite}},
       // Shader params buffers
-      {graph.create_params_buffer(scalar_value)},
+      {scalar_param},
       // Push Constants
       {},
       // Specialization Constants
@@ -49,6 +56,7 @@ void scalar_tensor(ComputeGraph& graph, const std::vector<ValueRef>& args) {
 
 REGISTER_OPERATORS {
   VK_REGISTER_OP(aten.scalar_tensor.default, scalar_tensor);
+  VK_REGISTER_OP(scalar_tensor.default, scalar_tensor);
 }
 
 } // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/ToCopy.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/ToCopy.cpp
@@ -32,15 +32,22 @@ bool is_float_type(vkapi::ScalarType dtype) {
 void add_to_copy_node(ComputeGraph& graph, ValueRef in, ValueRef out) {
   const vkapi::ScalarType in_dtype = graph.dtype_of(in);
   const vkapi::ScalarType out_dtype = graph.dtype_of(out);
+  const bool both_textures = graph.storage_type_of(in) != utils::kBuffer &&
+      graph.storage_type_of(out) != utils::kBuffer;
 
-  // Same-dtype or float<->half conversions can use BlitNode
-  if (in_dtype == out_dtype ||
-      (is_float_type(in_dtype) && is_float_type(out_dtype))) {
+  // Same-dtype or float<->half texture conversions can use BlitNode.
+  if (both_textures &&
+      (in_dtype == out_dtype ||
+       (is_float_type(in_dtype) && is_float_type(out_dtype)))) {
     graph.execute_nodes().emplace_back(new BlitNode(graph, in, out));
     return;
   }
 
-  // Other conversions (e.g. int<->float) use view_convert shaders
+  if (in_dtype == out_dtype) {
+    return add_view_copy_node(graph, in, out, {}, resize_to_copy_op_node);
+  }
+
+  // Buffer-backed and other dtype conversions use view_convert shaders.
   add_view_copy_convert_node(graph, in, out, {}, resize_to_copy_op_node);
 }
 

--- a/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/utils/TensorUtils.cpp
@@ -20,7 +20,7 @@ std::vector<int64_t> calculate_broadcasted_output_size(
   std::vector<int64_t> out_sizes(std::max(sizes1.size(), sizes2.size()));
 
   // Match the sizes in reverse because sizes are in NCHW order
-  for (int i = -1; i >= -out_sizes.size(); --i) {
+  for (int64_t i = -1; i >= -static_cast<int64_t>(out_sizes.size()); --i) {
     out_sizes.at(out_sizes.size() + i) =
         std::max(utils::val_at(i, sizes1), utils::val_at(i, sizes2));
   }

--- a/backends/vulkan/test/op_tests/CMakeLists.txt
+++ b/backends/vulkan/test/op_tests/CMakeLists.txt
@@ -109,6 +109,10 @@ if(TARGET vulkan_backend AND LIB_TORCH)
     )
   endif()
   vulkan_op_test(
+    vulkan_remainder_scalar_test
+    ${CMAKE_CURRENT_SOURCE_DIR}/remainder_scalar_test.cpp test_utils
+  )
+  vulkan_op_test(
     vulkan_rope_test ${CMAKE_CURRENT_SOURCE_DIR}/rotary_embedding_test.cpp
     test_utils
   )

--- a/backends/vulkan/test/op_tests/remainder_scalar_test.cpp
+++ b/backends/vulkan/test/op_tests/remainder_scalar_test.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <ATen/ATen.h>
+
+#include <iostream>
+
+#include <executorch/backends/vulkan/runtime/graph/ComputeGraph.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
+
+#include "test_utils.h"
+
+namespace {
+
+void test_vulkan_remainder_scalar(
+    vkcompute::utils::StorageType storage_type,
+    int64_t divisor) {
+  using namespace vkcompute;
+
+  at::Tensor input_1 =
+      at::tensor(
+          {-129, -128, -127, -1, 0, 1, 60, 67, 127, 128, 129, 255},
+          at::device(at::kCPU).dtype(at::kInt))
+          .reshape({2, 6});
+  at::Tensor input_2 =
+      at::tensor(
+          {256, 257, -257, 383, 384, 385, 61, 68, 126, 130, -2, 2},
+          at::device(at::kCPU).dtype(at::kInt))
+          .reshape({2, 6});
+
+  GraphConfig config;
+  ComputeGraph graph(config);
+  IOValueRef input =
+      graph.add_input_tensor(input_1.sizes().vec(), vkapi::kInt, storage_type);
+  const ValueRef scalar = graph.add_scalar<int64_t>(divisor);
+  const ValueRef output =
+      graph.add_tensor(input_1.sizes().vec(), vkapi::kInt, storage_type);
+
+  VK_GET_OP_FN("aten.remainder.Scalar")
+  (graph, {input.value, scalar, output});
+
+  const ValueRef staging_output = graph.set_output_tensor(output);
+  graph.prepare();
+  graph.prepack();
+
+  for (const at::Tensor& input_tensor : {input_1, input_2}) {
+    graph.maybe_cast_and_copy_into_staging(
+        input.staging,
+        input_tensor.const_data_ptr(),
+        input_tensor.numel(),
+        vkapi::kInt);
+    graph.execute();
+
+    at::Tensor actual = at::empty_like(input_tensor).contiguous();
+    graph.maybe_cast_and_copy_from_staging(
+        staging_output, actual.mutable_data_ptr(), actual.numel(), vkapi::kInt);
+    const at::Tensor expected = at::remainder(input_tensor, divisor);
+    if (!at::equal(expected, actual)) {
+      std::cout << "divisor " << divisor << "\nexpected " << expected
+                << "\nactual " << actual << std::endl;
+    }
+    ASSERT_TRUE(at::equal(expected, actual));
+  }
+}
+
+} // namespace
+
+TEST(VulkanRemainderScalarTest, buffer_positive_divisor) {
+  test_vulkan_remainder_scalar(vkcompute::utils::kBuffer, 128);
+}
+
+TEST(VulkanRemainderScalarTest, texture_positive_divisor) {
+  test_vulkan_remainder_scalar(vkcompute::utils::kTexture3D, 128);
+}
+
+TEST(VulkanRemainderScalarTest, buffer_negative_divisor) {
+  test_vulkan_remainder_scalar(vkcompute::utils::kBuffer, -7);
+}
+
+TEST(VulkanRemainderScalarTest, texture_negative_divisor) {
+  test_vulkan_remainder_scalar(vkcompute::utils::kTexture3D, -7);
+}


### PR DESCRIPTION
Streaming scalar ops and mixed-storage copies must stay delegated
without unsafe indexing or fallback.

AI-assisted-by: Codex

This PR was authored with assistance from Codex.

cc @SS-JIA @manuelcandales @cbilgin