### PR TITLE
[Vulkan] Keep Voxtral rotary embeddings fused

### DIFF
--- a/backends/vulkan/patterns/rope.py
+++ b/backends/vulkan/patterns/rope.py
@@ -77,6 +77,13 @@ class RotaryEmbeddingPattern(torch.nn.Module):
         return freqs_cis.view(shape)
 
 
+class VoxtralRotaryEmbeddingPattern(RotaryEmbeddingPattern):
+    """RoPE variant that broadcasts `[S, D/2]` frequencies explicitly."""
+
+    def _reshape_for_broadcast(self, freqs_cis: torch.Tensor, x: torch.Tensor):
+        return freqs_cis.unsqueeze(0).unsqueeze(2)
+
+
 @lru_cache(maxsize=2)
 @register_pattern_graph("export_llama_rope")
 def get_rope_graphs() -> List[torch.fx.GraphModule]:
@@ -105,6 +112,16 @@ def get_rope_graphs() -> List[torch.fx.GraphModule]:
     gm = edge.exported_program().graph_module
     graphs.append(gm)
 
+    edge = to_edge(
+        export(
+            VoxtralRotaryEmbeddingPattern(),
+            (xq, xk, freqs_cos, freqs_sin),
+            strict=True,
+        ),
+        compile_config=EdgeCompileConfig(_check_ir_validity=False),
+    )
+    graphs.append(edge.exported_program().graph_module)
+
     return graphs
 
 
@@ -126,7 +143,108 @@ def identify_rotary_emb_io_nodes(
 
     xq_out, xk_out = output_nodes
 
-    return [xq, xk, freqs_cos, freqs_sin, xq_out, xk_out]
+    io_nodes = [xq, xk, freqs_cos, freqs_sin, xq_out, xk_out]
+    vals = [node.meta.get("val") for node in io_nodes]
+    if not all(isinstance(val, torch.Tensor) for val in vals):
+        return None
+
+    xq_val, xk_val, cos_val, sin_val, xq_out_val, xk_out_val = vals
+    if (
+        xq_val.dtype not in (torch.float16, torch.float32)
+        or any(val.dtype != xq_val.dtype for val in vals[1:])
+        or len(xq_val.shape) != 4
+        or len(xk_val.shape) != 4
+        or len(cos_val.shape) != 2
+        or sin_val.shape != cos_val.shape
+        or xq_out_val.shape != xq_val.shape
+        or xk_out_val.shape != xk_val.shape
+        or xq_val.shape[0] != xk_val.shape[0]
+        or xq_val.shape[1] != xk_val.shape[1]
+        or xq_val.shape[3] != xk_val.shape[3]
+        or cos_val.shape[0] != xq_val.shape[1]
+        or cos_val.shape[1] * 2 != xq_val.shape[3]
+        or xq_val.shape[2] < xk_val.shape[2]
+        or xq_val.shape[3] % 8 != 0
+    ):
+        return None
+
+    slice_nodes = [
+        node
+        for node in match.all_nodes
+        if node.target == exir_ops.edge.aten.slice_copy.Tensor
+    ]
+    slice_args = sorted(
+        (node.args[1], node.args[2], node.args[3]) for node in slice_nodes
+    )
+    if slice_args != [(4, 0, 1), (4, 0, 1), (4, 1, 2), (4, 1, 2)]:
+        return None
+
+    squeeze_nodes = [
+        node
+        for node in match.all_nodes
+        if node.target == exir_ops.edge.aten.squeeze_copy.dims
+    ]
+    if len(squeeze_nodes) != 4 or any(node.args[1] != [4] for node in squeeze_nodes):
+        return None
+
+    cat_nodes = [
+        node
+        for node in match.all_nodes
+        if node.target == exir_ops.edge.aten.cat.default
+    ]
+    if len(cat_nodes) != 2 or any(node.args[1] != -1 for node in cat_nodes):
+        return None
+
+    unsqueeze_dims = sorted(
+        node.args[1]
+        for node in match.all_nodes
+        if node.target == exir_ops.edge.aten.unsqueeze_copy.default
+    )
+    if unsqueeze_dims not in ([4] * 4, [0, 0, 2, 2] + [4] * 4):
+        return None
+
+    return io_nodes
+
+
+def _rewrite_frequency_lookup(
+    graph_module: torch.fx.GraphModule, node: torch.fx.Node
+) -> torch.fx.Node:
+    if node.target != exir_ops.edge.aten.index.Tensor or len(node.args) < 2:
+        return node
+
+    table = node.args[0]
+    indices = node.args[1]
+    if (
+        not isinstance(table, torch.fx.Node)
+        or not isinstance(indices, (list, tuple))
+        or len(indices) != 1
+        or not isinstance(indices[0], torch.fx.Node)
+    ):
+        return node
+
+    table_val = table.meta.get("val")
+    index_val = indices[0].meta.get("val")
+    output_val = node.meta.get("val")
+    if (
+        not isinstance(table_val, torch.Tensor)
+        or not isinstance(index_val, torch.Tensor)
+        or not isinstance(output_val, torch.Tensor)
+        or len(table_val.shape) != 2
+        or len(index_val.shape) != 1
+        or len(output_val.shape) != 2
+        or index_val.dtype not in (torch.int32, torch.int64)
+    ):
+        return node
+
+    with graph_module.graph.inserting_before(node):
+        index_select = graph_module.graph.create_node(
+            "call_function",
+            exir_ops.edge.aten.index_select.default,
+            args=(table, 0, indices[0]),
+        )
+    index_select.meta["val"] = output_val
+    node.replace_all_uses_with(index_select)
+    return index_select
 
 
 @register_pattern_replacement("export_llama_rope")
@@ -134,13 +252,15 @@ def create_rotary_emb_custom_op(
     ep: ExportedProgram,
     graph_module: torch.fx.GraphModule,
     match: PatternMatch,
-):
+) -> bool:
     io_nodes = identify_rotary_emb_io_nodes(ep, graph_module, match)
     if io_nodes is None:
-        return
+        return False
 
     assert len(io_nodes) == 6
     xq, xk, freqs_cos, freqs_sin, xq_out, xk_out = io_nodes
+    freqs_cos = _rewrite_frequency_lookup(graph_module, freqs_cos)
+    freqs_sin = _rewrite_frequency_lookup(graph_module, freqs_sin)
 
     # Create the custom op node
     with graph_module.graph.inserting_before(xq_out):
@@ -171,3 +291,4 @@ def create_rotary_emb_custom_op(
 
     xq_out.replace_all_uses_with(getitem_0)
     xk_out.replace_all_uses_with(getitem_1)
+    return True

--- a/backends/vulkan/test/test_rope_patterns.py
+++ b/backends/vulkan/test/test_rope_patterns.py
@@ -1,0 +1,214 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest import TestCase
+
+import torch
+
+from executorch.backends.vulkan.patterns import replace_all_fusable_subgraphs
+from executorch.exir import EdgeCompileConfig, to_edge
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+def _apply_voxtral_rope(q, k, freqs_cos, freqs_sin, broadcast_dim=2):
+    q_r, q_i = q.float().reshape(q.shape[:-1] + (-1, 2)).unbind(-1)
+    k_r, k_i = k.float().reshape(k.shape[:-1] + (-1, 2)).unbind(-1)
+    cos = freqs_cos.unsqueeze(0).unsqueeze(broadcast_dim)
+    sin = freqs_sin.unsqueeze(0).unsqueeze(broadcast_dim)
+    q_out = torch.stack([q_r * cos - q_i * sin, q_r * sin + q_i * cos], dim=-1).flatten(
+        -2
+    )
+    k_out = torch.stack([k_r * cos - k_i * sin, k_r * sin + k_i * cos], dim=-1).flatten(
+        -2
+    )
+    return q_out.type_as(q), k_out.type_as(k)
+
+
+class _DirectRoPE(torch.nn.Module):
+    def __init__(self, broadcast_dim=2):
+        super().__init__()
+        self.broadcast_dim = broadcast_dim
+
+    def forward(self, q, k, cos, sin):
+        return _apply_voxtral_rope(q, k, cos, sin, self.broadcast_dim)
+
+
+class _OfflineRoPE(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("cos", torch.randn(128, 64))
+        self.register_buffer("sin", torch.randn(128, 64))
+
+    def forward(self, q, k, positions):
+        return _apply_voxtral_rope(
+            q,
+            k,
+            self.cos[positions],
+            self.sin[positions],
+        )
+
+
+class _RepeatedOfflineRoPE(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("cos", torch.randn(128, 64))
+        self.register_buffer("sin", torch.randn(128, 64))
+
+    def forward(self, q1, k1, q2, k2, positions):
+        cos = self.cos[positions]
+        sin = self.sin[positions]
+        return (
+            *_apply_voxtral_rope(q1, k1, cos, sin),
+            *_apply_voxtral_rope(q2, k2, cos, sin),
+        )
+
+
+class _StreamingRoPE(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("inv_freq", torch.randn(64))
+
+    def forward(self, q, k, positions):
+        freqs = torch.outer(positions.float(), self.inv_freq)
+        return _apply_voxtral_rope(q, k, freqs.cos(), freqs.sin())
+
+
+def _export_to_edge(model, sample_inputs):
+    exported = torch.export.export(model.eval(), sample_inputs, strict=True)
+    return to_edge(
+        exported,
+        compile_config=EdgeCompileConfig(_skip_dim_order=False),
+    ).exported_program()
+
+
+def _replace(model, sample_inputs):
+    program = _export_to_edge(model, sample_inputs)
+    count = replace_all_fusable_subgraphs(program, program.graph_module)
+    return program.graph_module.graph, count
+
+
+def _sample_inputs(dtype=torch.float32, heads=(32, 8)):
+    return (
+        torch.randn(1, 4, heads[0], 128, dtype=dtype),
+        torch.randn(1, 4, heads[1], 128, dtype=dtype),
+        torch.randn(4, 64),
+        torch.randn(4, 64),
+    )
+
+
+class TestVoxtralRoPEPatterns(TestCase):
+    def test_replaces_explicit_frequency_broadcast(self) -> None:
+        graph, count = _replace(_DirectRoPE(), _sample_inputs())
+
+        self.assertEqual(count, 1)
+        self.assertEqual(
+            sum(
+                node.target == exir_ops.edge.et_vk.apply_rotary_emb.default
+                for node in graph.nodes
+            ),
+            1,
+        )
+        self.assertFalse(
+            any(node.target == exir_ops.edge.aten.cat.default for node in graph.nodes)
+        )
+
+    def test_fp16_preserves_fp32_compute_and_output_cast(self) -> None:
+        graph, count = _replace(_DirectRoPE(), _sample_inputs(torch.float16))
+
+        self.assertEqual(count, 1)
+        fused = next(
+            node
+            for node in graph.nodes
+            if node.target == exir_ops.edge.et_vk.apply_rotary_emb.default
+        )
+        self.assertTrue(
+            all(arg.meta["val"].dtype == torch.float32 for arg in fused.args)
+        )
+        outputs = next(node for node in graph.nodes if node.op == "output").args[0]
+        self.assertTrue(
+            all(node.meta["val"].dtype == torch.float16 for node in outputs)
+        )
+
+    def test_rewrites_offline_table_lookup_to_index_select(self) -> None:
+        q, k, _, _ = _sample_inputs()
+        positions = torch.tensor([60, 0, 127, 4])
+        graph, count = _replace(_OfflineRoPE(), (q, k, positions))
+
+        self.assertEqual(count, 1)
+        index_selects = [
+            node
+            for node in graph.nodes
+            if node.target == exir_ops.edge.aten.index_select.default
+        ]
+        self.assertEqual(len(index_selects), 2)
+        self.assertTrue(all(node.args[1] == 0 for node in index_selects))
+        self.assertFalse(
+            any(node.target == exir_ops.edge.aten.index.Tensor for node in graph.nodes)
+        )
+
+    def test_replaces_repeated_offline_rope_with_shared_lookup(self) -> None:
+        q, k, _, _ = _sample_inputs()
+        positions = torch.tensor([60, 0, 127, 4])
+        graph, count = _replace(_RepeatedOfflineRoPE(), (q, k, q, k, positions))
+
+        graph.lint()
+        self.assertEqual(count, 2)
+        self.assertEqual(
+            sum(
+                node.target == exir_ops.edge.et_vk.apply_rotary_emb.default
+                for node in graph.nodes
+            ),
+            2,
+        )
+        self.assertEqual(
+            sum(
+                node.target == exir_ops.edge.aten.index_select.default
+                for node in graph.nodes
+            ),
+            2,
+        )
+        self.assertFalse(
+            any(node.target == exir_ops.edge.aten.index.Tensor for node in graph.nodes)
+        )
+
+    def test_replaces_streaming_frequency_form(self) -> None:
+        q, k, _, _ = _sample_inputs()
+        positions = torch.arange(10_000, 10_004)
+        graph, count = _replace(_StreamingRoPE(), (q, k, positions))
+
+        self.assertEqual(count, 1)
+        fused = next(
+            node
+            for node in graph.nodes
+            if node.target == exir_ops.edge.et_vk.apply_rotary_emb.default
+        )
+        self.assertEqual(fused.args[2].target, exir_ops.edge.aten.cos.default)
+        self.assertEqual(fused.args[3].target, exir_ops.edge.aten.sin.default)
+
+    def test_rejects_unsupported_near_matches(self) -> None:
+        cases = (
+            (_DirectRoPE(broadcast_dim=1), _sample_inputs(heads=(4, 4))),
+            (_DirectRoPE(), _sample_inputs(heads=(4, 8))),
+            (
+                _DirectRoPE(),
+                (
+                    torch.randn(1, 4, 4, 12),
+                    torch.randn(1, 4, 4, 12),
+                    torch.randn(4, 6),
+                    torch.randn(4, 6),
+                ),
+            ),
+        )
+        for model, sample_inputs in cases:
+            with self.subTest(model=model, sample_inputs=sample_inputs):
+                graph, count = _replace(model, sample_inputs)
+                self.assertEqual(count, 0)
+                self.assertFalse(
+                    any(
+                        node.target == exir_ops.edge.et_vk.apply_rotary_emb.default
+                        for node in graph.nodes
+                    )
+                )


### PR DESCRIPTION
Streaming export needs dynamic-position RoPE variants to remain inside Vulkan.

AI-assisted-by: Codex

This PR was authored with assistance from Codex.

cc @SS-JIA @manuelcandales @cbilgin