### PR TITLE
[Vulkan] Fuse causal SDPA variants for Vulkan

### DIFF
--- a/backends/vulkan/patterns/sdpa.py
+++ b/backends/vulkan/patterns/sdpa.py
@@ -17,6 +17,21 @@ from executorch.backends.vulkan.patterns.pattern_registry import (
 )
 
 from executorch.exir import ExportedProgram
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+_MISSING = object()
+
+
+def _get_argument(
+    node: torch.fx.Node,
+    index: int,
+    name: str,
+    default: Any = _MISSING,
+) -> Any:
+    if len(node.args) > index:
+        return node.args[index]
+    return node.kwargs.get(name, default)
 
 
 def is_update_cache_node(node: Any) -> bool:
@@ -37,27 +52,35 @@ class CausalSDPAMatch(PatternMatch):
         self.match_found = False
         self.all_nodes = [self.anchor_node]
 
-        # llama.custom_sdpa has signature:
-        # custom_sdpa(query, key_cache, value_cache, start_pos, attn_mask, dropout_p, is_causal, scale) -> output
-        if len(custom_sdpa_node.args) < 4:
+        self.query_node = _get_argument(custom_sdpa_node, 0, "query")
+        self.key_cache_node = _get_argument(custom_sdpa_node, 1, "key")
+        self.value_cache_node = _get_argument(custom_sdpa_node, 2, "value")
+        self.start_pos_node = _get_argument(custom_sdpa_node, 3, "start_pos")
+        if any(
+            value is _MISSING
+            for value in (
+                self.query_node,
+                self.key_cache_node,
+                self.value_cache_node,
+                self.start_pos_node,
+            )
+        ):
             return
 
-        self.query_node = custom_sdpa_node.args[0]
-        self.key_cache_node = custom_sdpa_node.args[1]
-        self.value_cache_node = custom_sdpa_node.args[2]
-        self.start_pos_node = custom_sdpa_node.args[3]
-        self.attn_mask_node = custom_sdpa_node.args[4]
-        self.dropout_p_node = custom_sdpa_node.args[5]
-        self.is_causal_node = custom_sdpa_node.args[6]
-        if len(custom_sdpa_node.args) > 7:
-            self.scale_node = custom_sdpa_node.args[7]
-        else:
-            self.scale_node = None
+        if not isinstance(self.key_cache_node, torch.fx.Node) or not isinstance(
+            self.value_cache_node, torch.fx.Node
+        ):
+            return
+
+        self.attn_mask_node = _get_argument(custom_sdpa_node, 4, "attn_mask", None)
+        self.dropout_p_node = _get_argument(custom_sdpa_node, 5, "drpout_p", 0.0)
+        self.is_causal_node = _get_argument(custom_sdpa_node, 6, "is_causal", False)
+        self.scale_node = _get_argument(custom_sdpa_node, 7, "scale", None)
 
         # try to find update key cache node
         self.update_key_cache_node = None
         for user in self.key_cache_node.users:
-            if is_update_cache_node(user):
+            if is_update_cache_node(user) and user.args:
                 self.update_key_cache_node = user
                 break
 
@@ -68,7 +91,7 @@ class CausalSDPAMatch(PatternMatch):
         # find update value cache node
         self.update_value_cache_node = None
         for user in self.value_cache_node.users:
-            if is_update_cache_node(user):
+            if is_update_cache_node(user) and user.args:
                 self.update_value_cache_node = user
                 break
 
@@ -78,6 +101,94 @@ class CausalSDPAMatch(PatternMatch):
 
         # We have additional optional arguments but we don't need to capture them
         # since the new op doesn't use them
+
+        self.match_found = all(
+            node is not None
+            for node in (
+                self.update_key_cache_node,
+                self.key_projection_node,
+                self.update_value_cache_node,
+                self.value_projection_node,
+            )
+        ) and (
+            self.attn_mask_node is None
+            and self.dropout_p_node == 0
+            and self.is_causal_node is True
+            and self.scale_node is None
+        )
+
+
+class NonCausalSDPAMatch(PatternMatch):
+    def __init__(self, custom_sdpa_node: torch.fx.Node) -> None:
+        self.anchor_node = custom_sdpa_node
+        self.all_nodes = [self.anchor_node]
+        self.match_found = False
+
+        self.query_node = _get_argument(custom_sdpa_node, 0, "query")
+        self.key_node = _get_argument(custom_sdpa_node, 1, "key")
+        self.value_node = _get_argument(custom_sdpa_node, 2, "value")
+        self.attn_mask_node = _get_argument(custom_sdpa_node, 4, "attn_mask", None)
+        self.dropout_p_node = _get_argument(custom_sdpa_node, 5, "drpout_p", 0.0)
+        self.is_causal_node = _get_argument(custom_sdpa_node, 6, "is_causal", False)
+        self.scale_node = _get_argument(custom_sdpa_node, 7, "scale", None)
+
+        if not all(
+            isinstance(node, torch.fx.Node)
+            for node in (self.query_node, self.key_node, self.value_node)
+        ):
+            return
+        if self.attn_mask_node is not None and not isinstance(
+            self.attn_mask_node, torch.fx.Node
+        ):
+            return
+        if self.dropout_p_node != 0 or self.is_causal_node is not False:
+            return
+        if self.scale_node is not None and not isinstance(
+            self.scale_node, (int, float)
+        ):
+            return
+
+        q_meta = self.query_node.meta.get("val")
+        k_meta = self.key_node.meta.get("val")
+        v_meta = self.value_node.meta.get("val")
+        if any(meta is None for meta in (q_meta, k_meta, v_meta)):
+            return
+
+        q_shape = q_meta.shape
+        k_shape = k_meta.shape
+        v_shape = v_meta.shape
+        if (
+            q_meta.dtype not in utils.FP_T
+            or k_meta.dtype != q_meta.dtype
+            or v_meta.dtype != q_meta.dtype
+            or len(q_shape) != 4
+            or len(k_shape) != 4
+            or len(v_shape) != 4
+            or q_shape[0] != k_shape[0]
+            or q_shape[0] != v_shape[0]
+            or k_shape[1] != v_shape[1]
+            or k_shape[2] != v_shape[2]
+            or q_shape[3] != k_shape[3]
+            or q_shape[3] != v_shape[3]
+            or k_shape[2] <= 0
+            or q_shape[2] < k_shape[2]
+            or q_shape[2] % k_shape[2] != 0
+        ):
+            return
+
+        if self.attn_mask_node is not None:
+            mask_meta = self.attn_mask_node.meta.get("val")
+            if mask_meta is None or mask_meta.dtype != q_meta.dtype:
+                return
+            mask_shape = mask_meta.shape
+            output_shape = (q_shape[0], q_shape[2], q_shape[1], k_shape[1])
+            if not 2 <= len(mask_shape) <= 4:
+                return
+            for mask_size, output_size in zip(
+                reversed(mask_shape), reversed(output_shape)
+            ):
+                if mask_size != 1 and mask_size != output_size:
+                    return
 
         self.match_found = True
 
@@ -90,6 +201,20 @@ def find_causal_sdpa_patterns(
         return None
 
     matched_pattern = CausalSDPAMatch(node)
+    if matched_pattern.match_found:
+        return matched_pattern
+
+    return None
+
+
+@register_pattern_detector("noncausal_sdpa")
+def find_noncausal_sdpa_patterns(
+    node: torch.fx.Node,
+) -> Optional[NonCausalSDPAMatch]:
+    if not is_custom_sdpa_node(node):
+        return None
+
+    matched_pattern = NonCausalSDPAMatch(node)
     if matched_pattern.match_found:
         return matched_pattern
 
@@ -153,3 +278,46 @@ def replace_custom_sdpa_with_causal_sdpa(
     # modify inputs (specifically, the cache args are modified)
     graph_module.graph.erase_node(match.update_key_cache_node)
     graph_module.graph.erase_node(match.update_value_cache_node)
+
+
+@register_pattern_replacement("noncausal_sdpa")
+def replace_custom_sdpa_with_noncausal_sdpa(
+    ep: ExportedProgram,
+    graph_module: torch.fx.GraphModule,
+    match: NonCausalSDPAMatch,
+):
+    del ep
+
+    with graph_module.graph.inserting_before(match.anchor_node):
+        query = graph_module.graph.create_node(
+            "call_function",
+            exir_ops.edge.aten.permute_copy.default,
+            args=(match.query_node, [0, 2, 1, 3]),
+        )
+        key = graph_module.graph.create_node(
+            "call_function",
+            exir_ops.edge.aten.permute_copy.default,
+            args=(match.key_node, [0, 2, 1, 3]),
+        )
+        value = graph_module.graph.create_node(
+            "call_function",
+            exir_ops.edge.aten.permute_copy.default,
+            args=(match.value_node, [0, 2, 1, 3]),
+        )
+        sdpa = graph_module.graph.create_node(
+            "call_function",
+            exir_ops.edge.et_vk.sdpa.default,
+            args=(query, key, value, match.attn_mask_node, match.scale_node),
+        )
+        output = graph_module.graph.create_node(
+            "call_function",
+            exir_ops.edge.aten.permute_copy.default,
+            args=(sdpa, [0, 2, 1, 3]),
+        )
+
+    query.meta["val"] = match.query_node.meta["val"].permute(0, 2, 1, 3).contiguous()
+    key.meta["val"] = match.key_node.meta["val"].permute(0, 2, 1, 3).contiguous()
+    value.meta["val"] = match.value_node.meta["val"].permute(0, 2, 1, 3).contiguous()
+    sdpa.meta["val"] = query.meta["val"].contiguous()
+    output.meta["val"] = sdpa.meta["val"].permute(0, 2, 1, 3).contiguous()
+    match.anchor_node.replace_all_uses_with(output)

--- a/backends/vulkan/test/test_sdpa_patterns.py
+++ b/backends/vulkan/test/test_sdpa_patterns.py
@@ -1,0 +1,236 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+import torch
+
+from executorch.backends.vulkan.patterns.sdpa import (
+    CausalSDPAMatch,
+    NonCausalSDPAMatch,
+    replace_custom_sdpa_with_noncausal_sdpa,
+)
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+class _FakeOp:
+    __name__ = "fake_op"
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __call__(self, *args, **kwargs):
+        raise AssertionError("Fake operator must not execute")
+
+    def name(self) -> str:
+        return self._name
+
+
+CUSTOM_SDPA = _FakeOp("llama::custom_sdpa")
+UPDATE_CACHE = _FakeOp("llama::update_cache")
+
+
+def _make_custom_sdpa_node(
+    argument_style: str = "full",
+    *,
+    attn_mask=None,
+    dropout_p=0.0,
+    is_causal=True,
+    scale=None,
+    update_key=True,
+    update_value=True,
+):
+    graph = torch.fx.Graph()
+    query = graph.placeholder("query")
+    key = graph.placeholder("key")
+    value = graph.placeholder("value")
+    start_pos = graph.placeholder("start_pos")
+
+    if argument_style == "full":
+        args = (
+            query,
+            key,
+            value,
+            start_pos,
+            attn_mask,
+            dropout_p,
+            is_causal,
+            scale,
+        )
+        kwargs = {}
+    elif argument_style == "shortened":
+        args = (query, key, value, start_pos)
+        kwargs = {"is_causal": is_causal}
+    elif argument_style == "keyword":
+        args = ()
+        kwargs = {
+            "query": query,
+            "key": key,
+            "value": value,
+            "start_pos": start_pos,
+            "attn_mask": attn_mask,
+            "drpout_p": dropout_p,
+            "is_causal": is_causal,
+            "scale": scale,
+        }
+    elif argument_style == "defaults":
+        args = (query, key, value, start_pos)
+        kwargs = {}
+    elif argument_style == "malformed":
+        args = (query, key)
+        kwargs = {}
+    else:
+        raise AssertionError(f"Unknown argument style: {argument_style}")
+
+    custom_sdpa = graph.call_function(CUSTOM_SDPA, args=args, kwargs=kwargs)
+    key_projection = graph.placeholder("key_projection")
+    value_projection = graph.placeholder("value_projection")
+    if update_key:
+        graph.call_function(UPDATE_CACHE, args=(key_projection, key, start_pos))
+    if update_value:
+        graph.call_function(UPDATE_CACHE, args=(value_projection, value, start_pos))
+    return custom_sdpa
+
+
+class TestCausalSDPAMatch(TestCase):
+    def test_matches_full_positional_arguments(self) -> None:
+        self.assertTrue(CausalSDPAMatch(_make_custom_sdpa_node()).match_found)
+
+    def test_matches_shortened_arguments_with_causal_keyword(self) -> None:
+        node = _make_custom_sdpa_node(argument_style="shortened")
+        self.assertTrue(CausalSDPAMatch(node).match_found)
+
+    def test_matches_keyword_arguments(self) -> None:
+        node = _make_custom_sdpa_node(argument_style="keyword")
+        self.assertTrue(CausalSDPAMatch(node).match_found)
+
+    def test_rejects_omitted_non_causal_default(self) -> None:
+        node = _make_custom_sdpa_node(argument_style="defaults")
+        self.assertFalse(CausalSDPAMatch(node).match_found)
+
+    def test_rejects_malformed_required_arguments(self) -> None:
+        node = _make_custom_sdpa_node(argument_style="malformed")
+        self.assertFalse(CausalSDPAMatch(node).match_found)
+
+    def test_rejects_incomplete_cache_updates(self) -> None:
+        key_only = _make_custom_sdpa_node(update_value=False)
+        value_only = _make_custom_sdpa_node(update_key=False)
+        self.assertFalse(CausalSDPAMatch(key_only).match_found)
+        self.assertFalse(CausalSDPAMatch(value_only).match_found)
+
+    def test_rejects_non_causal_semantics(self) -> None:
+        cases = (
+            {"attn_mask": object()},
+            {"dropout_p": 0.1},
+            {"is_causal": False},
+            {"scale": 0.125},
+        )
+        for kwargs in cases:
+            with self.subTest(**kwargs):
+                node = _make_custom_sdpa_node(**kwargs)
+                self.assertFalse(CausalSDPAMatch(node).match_found)
+
+
+def _make_noncausal_sdpa_node(
+    *,
+    q_shape=(1, 4, 32, 128),
+    k_shape=(1, 128, 8, 128),
+    v_shape=(1, 128, 8, 128),
+    mask_shape=(4, 128),
+    dtype=torch.float32,
+    mask_dtype=None,
+    dropout_p=0.0,
+    is_causal=False,
+    scale=None,
+):
+    graph = torch.fx.Graph()
+
+    def placeholder(name, shape, tensor_dtype=dtype):
+        node = graph.placeholder(name)
+        node.meta["val"] = torch.empty(shape, dtype=tensor_dtype)
+        return node
+
+    query = placeholder("query", q_shape)
+    key = placeholder("key", k_shape)
+    value = placeholder("value", v_shape)
+    start_pos = graph.placeholder("start_pos")
+    attn_mask = None
+    if mask_shape is not None:
+        attn_mask = placeholder("attn_mask", mask_shape, mask_dtype or dtype)
+
+    custom_sdpa = graph.call_function(
+        CUSTOM_SDPA,
+        args=(
+            query,
+            key,
+            value,
+            start_pos,
+            attn_mask,
+            dropout_p,
+            is_causal,
+            scale,
+        ),
+    )
+    custom_sdpa.meta["val"] = torch.empty(q_shape, dtype=dtype)
+    graph.output((custom_sdpa,))
+    return SimpleNamespace(graph=graph), custom_sdpa
+
+
+class TestNonCausalSDPAMatch(TestCase):
+    def test_matches_equal_head_gqa_and_broadcast_masks(self) -> None:
+        cases = (
+            _make_noncausal_sdpa_node(
+                k_shape=(1, 128, 32, 128),
+                v_shape=(1, 128, 32, 128),
+            ),
+            _make_noncausal_sdpa_node(),
+            _make_noncausal_sdpa_node(mask_shape=(1, 1, 4, 128)),
+            _make_noncausal_sdpa_node(mask_shape=None, scale=0.125),
+        )
+        for _, node in cases:
+            with self.subTest(node=node):
+                self.assertTrue(NonCausalSDPAMatch(node).match_found)
+
+    def test_rejects_unsupported_semantics_and_shapes(self) -> None:
+        cases = (
+            _make_noncausal_sdpa_node(is_causal=True),
+            _make_noncausal_sdpa_node(dropout_p=0.1),
+            _make_noncausal_sdpa_node(q_shape=(1, 4, 30, 128)),
+            _make_noncausal_sdpa_node(mask_shape=(2, 4, 128)),
+            _make_noncausal_sdpa_node(mask_dtype=torch.float16),
+        )
+        for _, node in cases:
+            with self.subTest(node=node):
+                self.assertFalse(NonCausalSDPAMatch(node).match_found)
+
+    def test_replacement_uses_fused_sdpa_without_expanding_kv_heads(self) -> None:
+        graph_module, node = _make_noncausal_sdpa_node()
+        match = NonCausalSDPAMatch(node)
+        self.assertTrue(match.match_found)
+
+        replace_custom_sdpa_with_noncausal_sdpa(object(), graph_module, match)
+
+        fused_nodes = [
+            graph_node
+            for graph_node in graph_module.graph.nodes
+            if graph_node.target == exir_ops.edge.et_vk.sdpa.default
+        ]
+        self.assertEqual(len(fused_nodes), 1)
+        fused_node = fused_nodes[0]
+        self.assertEqual(fused_node.meta["val"].shape, (1, 32, 4, 128))
+        self.assertTrue(fused_node.meta["val"].is_contiguous())
+        self.assertEqual(fused_node.args[1].meta["val"].shape, (1, 8, 128, 128))
+        self.assertEqual(fused_node.args[2].meta["val"].shape, (1, 8, 128, 128))
+        self.assertTrue(fused_node.args[0].meta["val"].is_contiguous())
+        self.assertTrue(fused_node.args[1].meta["val"].is_contiguous())
+        self.assertTrue(fused_node.args[2].meta["val"].is_contiguous())
+        self.assertFalse(
+            any(
+                "repeat" in str(graph_node.target)
+                for graph_node in graph_module.graph.nodes
+            )
+        )


### PR DESCRIPTION
Voxtral attention must retain mask and scale semantics without portable
fallback.

AI-assisted-by: Codex

This PR was authored with assistance from Codex.

cc @SS-JIA @manuelcandales @cbilgin