### PR TITLE
[Vulkan] Reject unsupported Vulkan operator shapes

### DIFF
--- a/backends/vulkan/custom_ops_lib.py
+++ b/backends/vulkan/custom_ops_lib.py
@@ -1117,6 +1117,10 @@ def sdpa_impl(
 ):
     if scale is None:
         scale = 1.0 / (q.size(-1) ** 0.5)
+    if q.size(-3) != k.size(-3):
+        repeats = q.size(-3) // k.size(-3)
+        k = torch.repeat_interleave(k, repeats, dim=-3)
+        v = torch.repeat_interleave(v, repeats, dim=-3)
     attn = torch.matmul(q, k.transpose(-2, -1)) * scale
     if attn_mask is not None:
         attn = attn + attn_mask

--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -49,6 +49,8 @@ class OpFeatures:
         # Optional function to determine valid representation sets for input and outputs
         # once a node's actual inputs are known.
         "pick_io_storage_fn",
+        # Tensor argument indices that must fit the partitioner's buffer limit.
+        "buffer_limit_args",
     ]
 
     def __init__(
@@ -66,6 +68,7 @@ class OpFeatures:
         supports_prepacking: bool = False,
         are_node_inputs_supported_fn: Optional[Callable] = allow_node,
         pick_io_storage_fn: Optional[Callable] = None,
+        buffer_limit_args: Tuple[int, ...] = (),
     ):
         # Dtype initialization
         self.inputs_dtypes: utils.DtypeSetList = utils.DtypeSetList(
@@ -93,6 +96,7 @@ class OpFeatures:
 
         self.are_node_inputs_supported_fn = are_node_inputs_supported_fn
         self.pick_io_storage_fn = pick_io_storage_fn
+        self.buffer_limit_args = buffer_limit_args
 
     def check_dtypes(self, node: torch.fx.Node) -> Tuple[bool, str]:
         """
@@ -339,6 +343,27 @@ def register_eq_scalar():
     )
 
 
+def is_integer_remainder_scalar_node_supported(node: torch.fx.Node) -> bool:
+    if len(node.args) < 2:
+        return False
+    divisor = node.args[1]
+    if isinstance(divisor, bool) or not isinstance(divisor, int):
+        return False
+    return -(2**31) <= divisor < 2**31 and divisor != 0
+
+
+@update_features(exir_ops.edge.aten.remainder.Scalar)
+def register_integer_remainder_scalar():
+    return OpFeatures(
+        inputs_storage=utils.ANY_STORAGE,
+        inputs_dtypes=utils.INT_T,
+        outputs_dtypes=utils.INT_T,
+        supports_resize=True,
+        supports_highdim=True,
+        are_node_inputs_supported_fn=is_integer_remainder_scalar_node_supported,
+    )
+
+
 # =============================================================================
 # ToCopy.cpp
 # =============================================================================
@@ -486,6 +511,7 @@ def register_linear_dq8ca_q4gsw():
             utils.NO_STORAGE,  # bias (prepacked)
         ],
         inputs_dtypes=utils.FP_T,
+        supports_resize=True,
         supports_prepacking=True,
     )
 
@@ -1085,13 +1111,37 @@ def register_sdpa_with_kv_cache():
     )
 
 
-@update_features(
-    [
-        "llama::update_cache",
-        "llama::custom_sdpa",
-    ]
-)
-def register_sdpa_cpp_ops():
+def is_custom_sdpa_node_supported(node: torch.fx.Node) -> bool:
+    def optional_arg(index: int, name: str, default: Any) -> Any:
+        if len(node.args) > index:
+            return node.args[index]
+        return node.kwargs.get(name, default)
+
+    attn_mask = optional_arg(4, "attn_mask", None)
+    dropout_p = optional_arg(5, "drpout_p", 0.0)
+    is_causal = optional_arg(6, "is_causal", False)
+    scale = optional_arg(7, "scale", None)
+    return (
+        attn_mask is None
+        and isinstance(dropout_p, (int, float))
+        and dropout_p == 0
+        and (is_causal is None or is_causal is True)
+        and scale is None
+    )
+
+
+@update_features("llama::custom_sdpa")
+def register_custom_sdpa():
+    return OpFeatures(
+        inputs_storage=utils.CONTIGUOUS_ANY,
+        inputs_dtypes=utils.FP_T,
+        supports_resize=True,
+        are_node_inputs_supported_fn=is_custom_sdpa_node_supported,
+    )
+
+
+@update_features("llama::update_cache")
+def register_update_cache():
     return OpFeatures(
         inputs_storage=utils.CONTIGUOUS_ANY,
         inputs_dtypes=utils.FP_T,
@@ -1104,12 +1154,79 @@ def register_sdpa_cpp_ops():
 # =============================================================================
 
 
+def is_general_sdpa_node_supported(node: torch.fx.Node) -> bool:
+    if len(node.args) < 3:
+        return False
+
+    q, k, v = node.args[:3]
+    attn_mask = (
+        node.args[3]
+        if len(node.args) > 3
+        else getattr(node, "kwargs", {}).get("attn_mask")
+    )
+    scale = (
+        node.args[4] if len(node.args) > 4 else getattr(node, "kwargs", {}).get("scale")
+    )
+    if not all(isinstance(arg, torch.fx.Node) for arg in (q, k, v)):
+        return False
+    if scale is not None and not isinstance(scale, (int, float)):
+        return False
+
+    q_meta = q.meta["val"]
+    k_meta = k.meta["val"]
+    v_meta = v.meta["val"]
+    q_shape = q_meta.shape
+    k_shape = k_meta.shape
+    v_shape = v_meta.shape
+    if (
+        q_meta.dtype not in utils.FP_T
+        or k_meta.dtype != q_meta.dtype
+        or v_meta.dtype != q_meta.dtype
+        or len(q_shape) != 4
+        or len(k_shape) != 4
+        or len(v_shape) != 4
+        or q_shape[0] != k_shape[0]
+        or q_shape[0] != v_shape[0]
+        or k_shape[1] != v_shape[1]
+        or k_shape[2] != v_shape[2]
+        or q_shape[3] != k_shape[3]
+        or q_shape[3] != v_shape[3]
+        or k_shape[1] <= 0
+        or q_shape[1] < k_shape[1]
+        or q_shape[1] % k_shape[1] != 0
+    ):
+        return False
+
+    if attn_mask is None:
+        return True
+    if not isinstance(attn_mask, torch.fx.Node):
+        return False
+
+    mask_meta = attn_mask.meta["val"]
+    mask_shape = mask_meta.shape
+    if mask_meta.dtype != q_meta.dtype or not 2 <= len(mask_shape) <= 4:
+        return False
+
+    output_shape = (q_shape[0], q_shape[1], q_shape[2], k_shape[2])
+    for mask_size, output_size in zip(reversed(mask_shape), reversed(output_shape)):
+        if mask_size != 1 and mask_size != output_size:
+            return False
+    return True
+
+
 @update_features("et_vk::sdpa")
 def register_general_sdpa():
     return OpFeatures(
         inputs_storage=utils.CONTIGUOUS_ANY,
-        inputs_dtypes=utils.FP_T,
+        inputs_dtypes=[
+            utils.FP_T,
+            utils.FP_T,
+            utils.FP_T,
+            utils.FP_T,
+            utils.NONE_T,
+        ],
         supports_resize=True,
+        are_node_inputs_supported_fn=is_general_sdpa_node_supported,
     )
 
 
@@ -1544,10 +1661,15 @@ def register_full_cpp_ops():
 # =============================================================================
 
 
-@update_features(exir_ops.edge.aten.scalar_tensor.default)
+@update_features(
+    [
+        exir_ops.edge.aten.scalar_tensor.default,
+        torch.ops.aten.scalar_tensor.default,
+    ]
+)
 def register_scalar_tensor():
     return OpFeatures(
-        inputs_storage=utils.CHANNELS_PACKED_TEXTURE,
+        inputs_storage=utils.ANY_STORAGE,
         inputs_dtypes=utils.FP_INT_T,
         supports_resize=True,
     )
@@ -1681,20 +1803,12 @@ def register_repeat():
 
 @update_features(exir_ops.edge.aten.embedding.default)
 def register_embedding():
-    def check_embedding_weight_size(node: torch.fx.Node) -> bool:
-        weight = node.args[0]
-        if isinstance(weight, torch.fx.Node) and utils.is_tensor_node(weight):
-            numel = weight.meta["val"].numel()
-            if numel > utils.DEFAULT_BUFFER_LIMIT:
-                return False
-        return True
-
     return OpFeatures(
         inputs_storage=utils.ANY_STORAGE,
         inputs_dtypes=[utils.FP_T, utils.INT_T],
         supports_prepacking=True,
         supports_resize=True,
-        are_node_inputs_supported_fn=check_embedding_weight_size,
+        buffer_limit_args=(0,),
     )
 
 
@@ -1705,19 +1819,11 @@ def register_embedding():
 
 @update_features(exir_ops.edge.quantized_decomposed.embedding_4bit.dtype)
 def register_quantized_decomposed_embedding_4bit():
-    def check_embedding_4bit_weight_size(node: torch.fx.Node) -> bool:
-        weight = node.args[0]
-        if isinstance(weight, torch.fx.Node) and utils.is_tensor_node(weight):
-            numel = weight.meta["val"].numel()
-            if numel > utils.DEFAULT_BUFFER_LIMIT:
-                return False
-        return True
-
     return OpFeatures(
         inputs_storage=utils.ANY_BUFFER,
         supports_prepacking=True,
         supports_resize=True,
-        are_node_inputs_supported_fn=check_embedding_4bit_weight_size,
+        buffer_limit_args=(0,),
     )
 
 
@@ -1822,16 +1928,6 @@ def register_compare_scalar_ops():
         inputs_storage=utils.ANY_STORAGE,
         inputs_dtypes=utils.FP_INT_T,
         outputs_dtypes=utils.BOOL_T,
-        supports_resize=True,
-        supports_highdim=True,
-    )
-
-
-@update_features(exir_ops.edge.aten.logical_not.default)
-def register_logical_not():
-    return OpFeatures(
-        inputs_storage=utils.ANY_STORAGE,
-        inputs_dtypes=utils.BOOL_T,
         supports_resize=True,
         supports_highdim=True,
     )

--- a/backends/vulkan/test/test_op_registry.py
+++ b/backends/vulkan/test/test_op_registry.py
@@ -1,0 +1,174 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from types import SimpleNamespace
+from unittest import TestCase
+
+import torch
+from executorch.backends.vulkan.op_registry import (
+    get_op_features,
+    is_custom_sdpa_node_supported,
+    is_general_sdpa_node_supported,
+    is_integer_remainder_scalar_node_supported,
+    vulkan_supported_ops,
+)
+from executorch.backends.vulkan.partitioner.vulkan_partitioner import (
+    VulkanSupportedOperators,
+)
+from executorch.backends.vulkan import utils
+from executorch.exir import to_edge
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+class TestCustomSDPASupport(TestCase):
+    def test_supported_causal_configuration(self) -> None:
+        node = SimpleNamespace(
+            args=(object(), object(), object(), 0, None, 0.0, True, None),
+            kwargs={},
+        )
+        self.assertTrue(is_custom_sdpa_node_supported(node))
+
+    def test_rejects_masked_non_causal_configuration(self) -> None:
+        node = SimpleNamespace(
+            args=(object(), object(), object(), 0, object()), kwargs={}
+        )
+        self.assertFalse(is_custom_sdpa_node_supported(node))
+
+
+class TestGeneralSDPASupport(TestCase):
+    @staticmethod
+    def _tensor_node(shape, dtype=torch.float32):
+        node = torch.fx.Graph().placeholder("tensor")
+        node.meta["val"] = SimpleNamespace(shape=shape, dtype=dtype)
+        return node
+
+    def _node(
+        self,
+        q_shape=(1, 32, 4, 128),
+        k_shape=(1, 8, 128, 128),
+        v_shape=(1, 8, 128, 128),
+        mask_shape=(4, 128),
+        dtype=torch.float32,
+        mask_dtype=None,
+        scale=None,
+    ):
+        mask = None
+        if mask_shape is not None:
+            mask = self._tensor_node(mask_shape, mask_dtype or dtype)
+        return SimpleNamespace(
+            args=(
+                self._tensor_node(q_shape, dtype),
+                self._tensor_node(k_shape, dtype),
+                self._tensor_node(v_shape, dtype),
+                mask,
+                scale,
+            )
+        )
+
+    def test_accepts_equal_head_and_gqa_contracts(self) -> None:
+        cases = (
+            self._node(
+                q_shape=(1, 32, 4, 64),
+                k_shape=(1, 32, 128, 64),
+                v_shape=(1, 32, 128, 64),
+            ),
+            self._node(),
+            self._node(mask_shape=(1, 1, 4, 128), dtype=torch.float16),
+            self._node(mask_shape=None, scale=0.125),
+        )
+        for node in cases:
+            with self.subTest(args=node.args):
+                self.assertTrue(is_general_sdpa_node_supported(node))
+
+        shortened = self._node()
+        shortened.args = shortened.args[:3]
+        self.assertTrue(is_general_sdpa_node_supported(shortened))
+
+    def test_rejects_unsupported_head_shape_mask_and_dtype(self) -> None:
+        cases = (
+            self._node(q_shape=(1, 30, 4, 128)),
+            self._node(v_shape=(1, 4, 128, 128)),
+            self._node(mask_shape=(2, 4, 128)),
+            self._node(mask_shape=(4, 128), mask_dtype=torch.float16),
+            self._node(scale=object()),
+        )
+        for node in cases:
+            with self.subTest(args=node.args):
+                self.assertFalse(is_general_sdpa_node_supported(node))
+
+
+class TestIntegerRemainderScalarSupport(TestCase):
+    def test_accepts_nonzero_int32_range_divisors(self) -> None:
+        for divisor in (1, -1, 7, -7, 128, -(2**31), 2**31 - 1):
+            with self.subTest(divisor=divisor):
+                node = SimpleNamespace(args=(object(), divisor))
+                self.assertTrue(is_integer_remainder_scalar_node_supported(node))
+
+    def test_rejects_zero_noninteger_bool_and_out_of_range_divisors(self) -> None:
+        for divisor in (0, 1.0, True, False, object(), -(2**31) - 1, 2**31):
+            with self.subTest(divisor=divisor):
+                node = SimpleNamespace(args=(object(), divisor))
+                self.assertFalse(is_integer_remainder_scalar_node_supported(node))
+
+        self.assertFalse(
+            is_integer_remainder_scalar_node_supported(
+                SimpleNamespace(args=(object(),))
+            )
+        )
+
+
+class TestEmbeddingBufferLimit(TestCase):
+    def test_partitioner_option_controls_embedding_weight_limit(self) -> None:
+        class EmbeddingModule(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(5, 4))
+
+            def forward(self, indices: torch.Tensor) -> torch.Tensor:
+                return torch.nn.functional.embedding(indices, self.weight)
+
+        edge = to_edge(
+            torch.export.export(
+                EmbeddingModule().eval(),
+                (torch.tensor([[0, 1]], dtype=torch.int64),),
+            )
+        )
+        embedding_node = next(
+            node
+            for node in edge.exported_program().graph.nodes
+            if node.target == exir_ops.edge.aten.embedding.default
+        )
+        features = get_op_features(embedding_node.target)
+
+        self.assertEqual(features.buffer_limit_args, (0,))
+        self.assertFalse(
+            VulkanSupportedOperators(
+                utils.DEFAULT_TEXTURE_LIMITS, buffer_limit=19
+            )._is_node_supported(embedding_node)
+        )
+        self.assertTrue(
+            VulkanSupportedOperators(
+                utils.DEFAULT_TEXTURE_LIMITS, buffer_limit=20
+            )._is_node_supported(embedding_node)
+        )
+
+
+class TestQuantizedLinearFeatures(TestCase):
+    def test_dynamic_8da4w_linear_supports_resize(self) -> None:
+        features = get_op_features(exir_ops.edge.et_vk.linear_dq8ca_q4gsw.default)
+
+        self.assertTrue(features.supports_resize)
+
+
+class TestScalarTensorSupport(TestCase):
+    def test_registers_edge_and_data_dependent_targets(self) -> None:
+        self.assertIn(exir_ops.edge.aten.scalar_tensor.default, vulkan_supported_ops)
+        self.assertIn(torch.ops.aten.scalar_tensor.default, vulkan_supported_ops)
+
+
+class TestRegistryRuntimeParity(TestCase):
+    def test_does_not_advertise_unimplemented_logical_not(self) -> None:
+        self.assertNotIn(exir_ops.edge.aten.logical_not.default, vulkan_supported_ops)


### PR DESCRIPTION
Unsupported logical-not, attention, scalar, and oversized-buffer
contracts must fail closed before runtime.

AI-assisted-by: Codex

This PR was authored with assistance from Codex.

cc @SS-JIA @manuelcandales @cbilgin