### PR TITLE
[Voxtral] Enable Voxtral methods for Vulkan export

### DIFF
--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -18,6 +18,8 @@ With --streaming, produces a streaming .pte instead:
 
 Backend support:
   - XNNPACK (default): Uses custom SDPA op (torch.ops.llama.custom_sdpa) for optimal performance
+  - Vulkan: Uses Vulkan-compatible SDPA/cache forms and requires every tensor-compute
+            operator to lower to Vulkan
   - Metal/AOTI: Uses MetalSDPA (_scaled_dot_product_attention_math_for_mps) for both text_decoder
                 and streaming encoder (transpose_kv=True), avoiding custom_sdpa which is
                 incompatible with AOTI. Uses Dim.AUTO for audio encoder dynamic shapes
@@ -31,12 +33,14 @@ Backend support:
 Usage:
     python export_voxtral_rt.py --model-path ~/models/Voxtral-Mini-4B-Realtime-2602
     python export_voxtral_rt.py --model-path ~/models/Voxtral-Mini-4B-Realtime-2602 --streaming
+    python export_voxtral_rt.py --model-path ~/models/Voxtral-Mini-4B-Realtime-2602 --backend vulkan --dtype fp32
     python export_voxtral_rt.py --model-path ~/models/Voxtral-Mini-4B-Realtime-2602 --backend metal --dtype bf16 --qlinear-encoder fpa4w --qlinear fpa4w
     python export_voxtral_rt.py --model-path ~/models/Voxtral-Mini-4B-Realtime-2602 --backend cuda --qlinear 4w
     python export_voxtral_rt.py --model-path ~/models/Voxtral-Mini-4B-Realtime-2602 --backend rocm --dtype bf16 --streaming
 """
 
 import argparse
+import operator
 import os
 
 import torch
@@ -47,8 +51,13 @@ from executorch.exir import (
     ExecutorchBackendConfig,
     to_edge_transform_and_lower,
 )
+from executorch.exir.delegate import executorch_call_delegate
+from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.passes import MemoryPlanningPass
 from torch.export import Dim, export
+
+VULKAN_EXTERNAL_CONSTANTS_MAX_DATA_BYTES = 1_500_000_000
+
 
 # ---------------------------------------------------------------------------
 # Export wrappers
@@ -152,6 +161,13 @@ def _export_decoder_and_embedding(
     print("\nExporting text_decoder...")
     text_decoder = TextDecoderExport(model)
     text_decoder.eval()
+    tied_embedding_weight = None
+    tied_embedding_version = None
+    tied_embedding_storage = None
+    if model.decoder.output.weight is model.decoder.tok_embeddings.weight:
+        tied_embedding_weight = model.decoder.tok_embeddings.weight
+        tied_embedding_version = tied_embedding_weight._version
+        tied_embedding_storage = tied_embedding_weight.untyped_storage().data_ptr()
 
     packed_linear_count = 0
     use_packed_matvec = use_aoti_packed_int4 and qlinear == "4w"
@@ -163,6 +179,20 @@ def _export_decoder_and_embedding(
             qlinear_group_size=qlinear_group_size,
             qlinear_packing_format=qlinear_packing_format,
         )
+        if tied_embedding_weight is not None:
+            if model.decoder.output.weight is tied_embedding_weight:
+                raise RuntimeError(
+                    "Linear quantization did not split the tied output/embedding weight"
+                )
+            if (
+                model.decoder.tok_embeddings.weight is not tied_embedding_weight
+                or tied_embedding_weight._version != tied_embedding_version
+                or tied_embedding_weight.untyped_storage().data_ptr()
+                != tied_embedding_storage
+            ):
+                raise RuntimeError(
+                    "Linear quantization mutated the tied FP32 embedding weight"
+                )
         if use_packed_matvec:
             packed_linear_count = _pack_aoti_int4_weights(
                 text_decoder,
@@ -447,6 +477,100 @@ def _linear_bias_decomposition(input, weight, bias=None):
     return out
 
 
+_VULKAN_PORTABLE_CONSTRUCTORS = {
+    exir_ops.edge.aten.arange.start_step,
+    exir_ops.edge.aten.full.default,
+}
+_VULKAN_PORTABLE_SCALAR_GLUE = {
+    torch.ops.aten.sym_size.int,
+}
+
+
+def _format_vulkan_audit_failure(method_name, node, reason):
+    val = node.meta.get("val")
+    dtype = getattr(val, "dtype", None)
+    shape = getattr(val, "shape", None)
+    spec = node.meta.get("spec")
+    layout = getattr(spec, "etvk_node_repr", None)
+    return (
+        f"method={method_name}, target={node.target}, dtype={dtype}, "
+        f"shape={shape}, layout={layout}, reason={reason}"
+    )
+
+
+def audit_vulkan_delegation(edge_program):
+    failures = []
+    for method_name in edge_program.methods:
+        graph_module = edge_program.exported_program(method_name).graph_module
+        vulkan_segments = 0
+        for node in graph_module.graph.nodes:
+            if node.op == "get_attr" and node.name.startswith("lowered_module_"):
+                lowered_module = getattr(graph_module, node.name)
+                if lowered_module.backend_id != "VulkanBackend":
+                    failures.append(
+                        _format_vulkan_audit_failure(
+                            method_name,
+                            node,
+                            f"delegated to {lowered_module.backend_id}",
+                        )
+                    )
+                else:
+                    vulkan_segments += 1
+                continue
+
+            if node.op != "call_function":
+                continue
+            if (
+                node.target
+                in (
+                    executorch_call_delegate,
+                    operator.getitem,
+                )
+                or node.target in _VULKAN_PORTABLE_CONSTRUCTORS
+                or node.target in _VULKAN_PORTABLE_SCALAR_GLUE
+            ):
+                continue
+            failures.append(
+                _format_vulkan_audit_failure(
+                    method_name,
+                    node,
+                    "tensor compute remains outside Vulkan",
+                )
+            )
+
+        if vulkan_segments == 0:
+            failures.append(f"method={method_name}, reason=no Vulkan delegate segment")
+
+    if failures:
+        details = "\n  ".join(failures)
+        raise RuntimeError(f"Incomplete Vulkan delegation:\n  {details}")
+
+
+def validate_vulkan_options(args, parser):
+    if args.backend != "vulkan":
+        return
+    if args.dtype != "fp32":
+        parser.error("--backend=vulkan currently requires --dtype=fp32")
+    for option_name in ("qlinear", "qlinear_encoder"):
+        value = getattr(args, option_name)
+        if value not in (None, "8da4w"):
+            parser.error(
+                f"--{option_name.replace('_', '-')}={value} is not supported by Vulkan"
+            )
+    if args.qembedding not in (None, "4w"):
+        parser.error(f"--qembedding={args.qembedding} is not supported by Vulkan")
+    if args.qlinear_packing_format is not None:
+        parser.error("--qlinear-packing-format is not supported by Vulkan")
+    if args.qlinear_encoder_packing_format is not None:
+        parser.error("--qlinear-encoder-packing-format is not supported by Vulkan")
+
+
+def _requires_explicit_output_weight_clone(backend, qlinear, qembedding):
+    if not (qlinear or qembedding):
+        return False
+    return not (backend == "vulkan" and qlinear == "8da4w" and qembedding == "4w")
+
+
 def lower_to_executorch(
     programs,
     metadata,
@@ -468,6 +592,31 @@ def lower_to_executorch(
             key: [XnnpackDynamicallyQuantizedPartitioner(), XnnpackPartitioner()]
             for key in programs
         }
+    elif backend == "vulkan":
+        from executorch.backends.vulkan.partitioner.vulkan_partitioner import (
+            VulkanPartitioner,
+        )
+        from executorch.backends.vulkan.serialization.vulkan_graph_schema import (
+            VkStorageType,
+        )
+
+        print("\nLowering to ExecuTorch with Vulkan...")
+        partitioner = {}
+        for key in programs:
+            compile_options = {
+                "require_dynamic_shapes": True,
+                "external_constants_max_data_bytes": (
+                    VULKAN_EXTERNAL_CONSTANTS_MAX_DATA_BYTES
+                ),
+            }
+            if key in ("encode_audio_chunk", "text_decoder"):
+                compile_options["alias_buffer_mutations"] = True
+            if key == "token_embedding":
+                compile_options["buffer_limit"] = (
+                    metadata["vocab_size"] * metadata["dim"]
+                )
+                compile_options["storage_type_override"] = VkStorageType.BUFFER
+            partitioner[key] = [VulkanPartitioner(compile_options=compile_options)]
     elif backend == "metal":
         from executorch.backends.apple.metal.metal_backend import MetalBackend
         from executorch.backends.apple.metal.metal_partitioner import MetalPartitioner
@@ -542,6 +691,9 @@ def lower_to_executorch(
         constant_methods=metadata,
     )
 
+    if backend == "vulkan":
+        audit_vulkan_delegation(et_prog)
+
     return et_prog.to_executorch(
         config=ExecutorchBackendConfig(
             extract_delegate_segments=True,
@@ -606,6 +758,7 @@ def main():
         choices=[
             "portable",
             "xnnpack",
+            "vulkan",
             "mlx",
             "metal",
             "cuda",
@@ -716,6 +869,7 @@ def main():
         "cuda" if args.backend in ("cuda-windows", "rocm") else args.backend
     )
     _validate_export_args(parser, args, backend_for_export)
+    validate_vulkan_options(args, parser)
 
     os.makedirs(args.output_dir, exist_ok=True)
 
@@ -737,9 +891,11 @@ def main():
         print("Moving model to CUDA...")
         model.to(torch.device("cuda:0"))
 
-    # Untie output/embedding weights before quantization so each layer gets
-    # its own quantization config (embedding: 8w, output linear: 8da4w).
-    if args.qlinear or args.qembedding:
+    # TorchAO's Vulkan 8da4w transform replaces the output weight and breaks
+    # the tie without modifying the FP32 embedding consumed by the 4w pass.
+    if _requires_explicit_output_weight_clone(
+        backend_for_export, args.qlinear, args.qembedding
+    ):
         model.decoder.output.weight = torch.nn.Parameter(
             model.decoder.tok_embeddings.weight.clone()
         )

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -51,7 +51,8 @@ class VoxtralRealtimeConfig:
     max_seq_len: int = 4096
     sliding_window: int = 8192
     streaming: bool = False
-    backend: str = "xnnpack"  # "xnnpack", "mlx", "metal", "cuda", or "portable"
+    # "xnnpack", "vulkan", "mlx", "metal", "cuda", or "portable"
+    backend: str = "xnnpack"
 
     @staticmethod
     def from_params_json(path: str) -> "VoxtralRealtimeConfig":
@@ -180,6 +181,10 @@ class EncoderAttention(nn.Module):
         k = self.wk(x).view(B, T, self.n_heads, self.head_dim)
         v = self.wv(x).view(B, T, self.n_heads, self.head_dim)
         q, k = apply_rotary_emb(q, k, freqs_cos, freqs_sin)
+        if self.backend == "vulkan":
+            y = torch.ops.llama.custom_sdpa(q, k, v, 0, None, 0.0, True)
+            return self.wo(y.contiguous().view(B, T, -1))
+
         q, k, v = (t.transpose(1, 2) for t in (q, k, v))
         if self.backend == "mlx":
             # Use MLX custom SDPA for Apple Silicon GPU
@@ -1403,7 +1408,7 @@ def load_model(
         streaming: If True, use ring buffer KV cache for unlimited streaming.
         sliding_window: Override decoder sliding window size (default: from params.json).
     """
-    _VALID_BACKENDS = ("xnnpack", "mlx", "metal", "cuda", "portable")
+    _VALID_BACKENDS = ("xnnpack", "vulkan", "mlx", "metal", "cuda", "portable")
 
     if backend not in _VALID_BACKENDS:
         raise ValueError(

--- a/examples/models/voxtral_realtime/tests/test_export_vulkan.py
+++ b/examples/models/voxtral_realtime/tests/test_export_vulkan.py
@@ -1,0 +1,280 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import operator
+import copy
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import torch
+from executorch.backends.vulkan.serialization.vulkan_graph_schema import VkStorageType
+from executorch.examples.models.voxtral_realtime.export_voxtral_rt import (
+    VULKAN_EXTERNAL_CONSTANTS_MAX_DATA_BYTES,
+    _requires_explicit_output_weight_clone,
+    audit_vulkan_delegation,
+    lower_to_executorch,
+    validate_vulkan_options,
+)
+from executorch.exir.delegate import executorch_call_delegate
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+def make_node(op, name, target, val=None, layout=None):
+    spec = SimpleNamespace()
+    if layout is not None:
+        spec.etvk_node_repr = layout
+    return SimpleNamespace(
+        op=op,
+        name=name,
+        target=target,
+        meta={"val": val, "spec": spec},
+    )
+
+
+def make_edge(nodes, backend_id="VulkanBackend"):
+    graph_module = SimpleNamespace(graph=SimpleNamespace(nodes=nodes))
+    graph_module.lowered_module_0 = SimpleNamespace(backend_id=backend_id)
+    exported_program = SimpleNamespace(graph_module=graph_module)
+    return SimpleNamespace(
+        methods=["method"],
+        exported_program=lambda _: exported_program,
+    )
+
+
+class TestVulkanDelegationAudit(unittest.TestCase):
+    def test_accepts_vulkan_delegate_and_dynamic_constructors(self):
+        nodes = [
+            make_node("get_attr", "lowered_module_0", "lowered_module_0"),
+            make_node("call_function", "delegate", executorch_call_delegate),
+            make_node("call_function", "getitem", operator.getitem),
+            make_node(
+                "call_function",
+                "arange",
+                exir_ops.edge.aten.arange.start_step,
+            ),
+            make_node("call_function", "full", exir_ops.edge.aten.full.default),
+            make_node(
+                "call_function",
+                "sym_size",
+                torch.ops.aten.sym_size.int,
+            ),
+        ]
+
+        audit_vulkan_delegation(make_edge(nodes))
+
+    def test_rejects_portable_tensor_compute_with_diagnostics(self):
+        tensor = SimpleNamespace(dtype=torch.float32, shape=torch.Size([2, 3]))
+        nodes = [
+            make_node("get_attr", "lowered_module_0", "lowered_module_0"),
+            make_node(
+                "call_function",
+                "add",
+                exir_ops.edge.aten.add.Tensor,
+                tensor,
+                "texture3d/channels",
+            ),
+        ]
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"method=method.*aten.add.Tensor.*torch.float32.*\[2, 3\].*texture3d/channels",
+        ):
+            audit_vulkan_delegation(make_edge(nodes))
+
+    def test_rejects_non_vulkan_delegate(self):
+        nodes = [make_node("get_attr", "lowered_module_0", "lowered_module_0")]
+
+        with self.assertRaisesRegex(RuntimeError, "delegated to XnnpackBackend"):
+            audit_vulkan_delegation(make_edge(nodes, "XnnpackBackend"))
+
+
+class TestVulkanExportOptions(unittest.TestCase):
+    def make_args(self, **overrides):
+        values = {
+            "backend": "vulkan",
+            "dtype": "fp32",
+            "qlinear": None,
+            "qlinear_encoder": None,
+            "qembedding": None,
+            "qlinear_packing_format": None,
+            "qlinear_encoder_packing_format": None,
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    def test_accepts_fp32_and_vulkan_quantization(self):
+        parser = MagicMock()
+        validate_vulkan_options(
+            self.make_args(
+                qlinear="8da4w",
+                qlinear_encoder="8da4w",
+                qembedding="4w",
+            ),
+            parser,
+        )
+        parser.error.assert_not_called()
+
+    def test_vulkan_quantization_uses_torchao_to_split_tied_weight(self):
+        self.assertFalse(
+            _requires_explicit_output_weight_clone("vulkan", "8da4w", "4w")
+        )
+        self.assertTrue(
+            _requires_explicit_output_weight_clone("xnnpack", "8da4w", "4w")
+        )
+
+    def test_torchao_split_matches_explicit_clone(self):
+        from executorch.extension.llm.export.quantize import quantize_model_
+
+        class TiedModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embedding = torch.nn.Embedding(64, 32)
+                self.output = torch.nn.Linear(32, 64, bias=False)
+                self.output.weight = self.embedding.weight
+
+        torch.manual_seed(20260814)
+        tied = TiedModule().eval()
+        cloned = copy.deepcopy(tied)
+        cloned.output.weight = torch.nn.Parameter(cloned.embedding.weight.clone())
+        original_embedding = tied.embedding.weight.detach().clone()
+
+        for module in (tied, cloned):
+            quantize_model_(
+                module,
+                qlinear_config="8da4w",
+                qlinear_group_size=32,
+            )
+
+        self.assertIsNot(tied.output.weight, tied.embedding.weight)
+        self.assertTrue(torch.equal(tied.embedding.weight, original_embedding))
+        self.assertIs(type(tied.output.weight), type(cloned.output.weight))
+        self.assertEqual(tied.output.weight.shape, cloned.output.weight.shape)
+        self.assertEqual(tied.output.weight.block_size, cloned.output.weight.block_size)
+        self.assertTrue(
+            torch.equal(tied.output.weight.scale, cloned.output.weight.scale)
+        )
+        self.assertTrue(
+            torch.equal(tied.output.weight.zero_point, cloned.output.weight.zero_point)
+        )
+        self.assertTrue(
+            torch.equal(
+                tied.output.weight.dequantize(), cloned.output.weight.dequantize()
+            )
+        )
+
+        for module in (tied, cloned):
+            quantize_model_(
+                module,
+                qembedding_config="4w",
+                qembedding_group_size=32,
+            )
+
+        self.assertIs(type(tied.embedding.weight), type(cloned.embedding.weight))
+        self.assertEqual(tied.embedding.weight.shape, cloned.embedding.weight.shape)
+        self.assertEqual(
+            tied.embedding.weight.block_size, cloned.embedding.weight.block_size
+        )
+        self.assertTrue(
+            torch.equal(tied.embedding.weight.scale, cloned.embedding.weight.scale)
+        )
+        self.assertTrue(
+            torch.equal(
+                tied.embedding.weight.zero_point, cloned.embedding.weight.zero_point
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                tied.embedding.weight.dequantize(),
+                cloned.embedding.weight.dequantize(),
+            )
+        )
+
+    def test_rejects_incompatible_dtype_quantization_and_packing(self):
+        def parser_error(message):
+            raise ValueError(message)
+
+        for overrides, message in (
+            ({"dtype": "bf16"}, "requires --dtype=fp32"),
+            ({"qlinear": "4w"}, "--qlinear=4w"),
+            ({"qlinear_encoder": "8w"}, "--qlinear-encoder=8w"),
+            ({"qembedding": "8w"}, "--qembedding=8w"),
+            (
+                {"qlinear_packing_format": "tile_packed_to_4d"},
+                "--qlinear-packing-format",
+            ),
+        ):
+            with self.subTest(overrides=overrides):
+                parser = MagicMock()
+                parser.error.side_effect = parser_error
+                with self.assertRaisesRegex(ValueError, message):
+                    validate_vulkan_options(self.make_args(**overrides), parser)
+
+    @patch(
+        "executorch.backends.vulkan.partitioner.vulkan_partitioner.VulkanPartitioner"
+    )
+    @patch(
+        "executorch.examples.models.voxtral_realtime.export_voxtral_rt.audit_vulkan_delegation"
+    )
+    @patch(
+        "executorch.examples.models.voxtral_realtime.export_voxtral_rt.to_edge_transform_and_lower"
+    )
+    def test_vulkan_lowering_is_method_scoped(
+        self,
+        lower_mock,
+        audit_mock,
+        partitioner_mock,
+    ):
+        edge = MagicMock()
+        lower_mock.return_value = edge
+        programs = {
+            "encode_audio_chunk": MagicMock(),
+            "text_decoder": MagicMock(),
+            "token_embedding": MagicMock(),
+        }
+        metadata = {"vocab_size": 131072, "dim": 3072}
+
+        lower_to_executorch(programs, metadata, backend="vulkan")
+
+        self.assertEqual(
+            partitioner_mock.call_args_list,
+            [
+                call(
+                    compile_options={
+                        "require_dynamic_shapes": True,
+                        "external_constants_max_data_bytes": (
+                            VULKAN_EXTERNAL_CONSTANTS_MAX_DATA_BYTES
+                        ),
+                        "alias_buffer_mutations": True,
+                    }
+                ),
+                call(
+                    compile_options={
+                        "require_dynamic_shapes": True,
+                        "external_constants_max_data_bytes": (
+                            VULKAN_EXTERNAL_CONSTANTS_MAX_DATA_BYTES
+                        ),
+                        "alias_buffer_mutations": True,
+                    }
+                ),
+                call(
+                    compile_options={
+                        "require_dynamic_shapes": True,
+                        "external_constants_max_data_bytes": (
+                            VULKAN_EXTERNAL_CONSTANTS_MAX_DATA_BYTES
+                        ),
+                        "buffer_limit": 402653184,
+                        "storage_type_override": VkStorageType.BUFFER,
+                    }
+                ),
+            ],
+        )
+        audit_mock.assert_called_once_with(edge)
+        edge.to_executorch.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The model needs backend-scoped lowering, quantization, and mutable state
without changing other backends.

AI-assisted-by: Codex

This PR was authored with assistance from Codex.

cc @SS-JIA @manuelcandales @cbilgin