### PR TITLE
[Voxtral] Make Voxtral Vulkan runnable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@
 #
 # ==============================================================================
 
-.PHONY: voxtral-cuda voxtral-cpu voxtral-metal voxtral-mlx voxtral_realtime-cuda voxtral_realtime-rocm voxtral_realtime-cpu voxtral_realtime-metal voxtral_realtime-mlx voxtral_tts-cpu voxtral_tts-cuda whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal parakeet-mlx parakeet-vulkan dinov2-cuda dinov2-cuda-debug sortformer-cuda sortformer-cpu supertonic-mlx silero-vad-cpu llama-cuda llama-cuda-debug llama-cpu lfm_2_5-mlx llava-cpu gemma3-cuda gemma3-cpu gemma4_31b-cuda gemma4_31b-mlx muse-glimmer-cuda muse-glimmer-mlx qwen3_5_moe-cuda qwen3_5_moe-metal qwen3_5_moe-mlx clean help
+.PHONY: voxtral-cuda voxtral-cpu voxtral-metal voxtral-mlx voxtral_realtime-cuda voxtral_realtime-rocm voxtral_realtime-cpu voxtral_realtime-metal voxtral_realtime-mlx voxtral_realtime-vulkan voxtral_tts-cpu voxtral_tts-cuda whisper-cuda whisper-cuda-debug whisper-cpu whisper-metal parakeet-cuda parakeet-cuda-debug parakeet-cpu parakeet-metal parakeet-mlx parakeet-vulkan dinov2-cuda dinov2-cuda-debug sortformer-cuda sortformer-cpu supertonic-mlx silero-vad-cpu llama-cuda llama-cuda-debug llama-cpu lfm_2_5-mlx llava-cpu gemma3-cuda gemma3-cpu gemma4_31b-cuda gemma4_31b-mlx muse-glimmer-cuda muse-glimmer-mlx qwen3_5_moe-cuda qwen3_5_moe-metal qwen3_5_moe-mlx clean help
 
 help:
 	@echo "This Makefile adds targets to build runners for various models on various backends. Run using \`make <target>\`. Available targets:"
@@ -105,6 +105,7 @@ help:
 	@echo "  voxtral_realtime-cpu - Build Voxtral Realtime runner with CPU backend"
 	@echo "  voxtral_realtime-metal - Build Voxtral Realtime runner with Metal backend (macOS only)"
 	@echo "  voxtral_realtime-mlx - Build Voxtral Realtime runner with MLX backend"
+	@echo "  voxtral_realtime-vulkan - Build Voxtral Realtime runner with Vulkan backend"
 	@echo "  voxtral_tts-cpu     - Build Voxtral TTS runner (CPU)"
 	@echo "  voxtral_tts-cuda    - Build Voxtral TTS runner with CUDA backend"
 	@echo "  whisper-cuda        - Build Whisper runner with CUDA backend"
@@ -352,6 +353,15 @@ voxtral_realtime-mlx:
 	cmake --workflow --preset mlx-release
 	@echo "==> Building Voxtral Realtime runner with MLX..."
 	cd examples/models/voxtral_realtime && cmake --workflow --preset voxtral-realtime-mlx
+	@echo ""
+	@echo "✓ Build complete!"
+	@echo "  Binary: cmake-out/examples/models/voxtral_realtime/voxtral_realtime_runner"
+
+voxtral_realtime-vulkan:
+	@echo "==> Building and installing ExecuTorch with Vulkan..."
+	cmake --workflow --preset llm-debug-vulkan
+	@echo "==> Building Voxtral Realtime runner with Vulkan..."
+	cd examples/models/voxtral_realtime && cmake --workflow --preset voxtral-realtime-vulkan
 	@echo ""
 	@echo "✓ Build complete!"
 	@echo "  Binary: cmake-out/examples/models/voxtral_realtime/voxtral_realtime_runner"

--- a/examples/models/voxtral_realtime/CMakeLists.txt
+++ b/examples/models/voxtral_realtime/CMakeLists.txt
@@ -100,6 +100,12 @@ if(TARGET mlxdelegate)
   executorch_target_link_options_shared_lib(mlxdelegate)
 endif()
 
+# Link Vulkan delegate and preserve its static backend registration.
+if(TARGET vulkan_backend)
+  list(APPEND link_libraries vulkan_backend)
+  executorch_target_link_options_shared_lib(vulkan_backend)
+endif()
+
 # Tokenizer
 list(APPEND link_libraries tokenizers::tokenizers)
 

--- a/examples/models/voxtral_realtime/CMakePresets.json
+++ b/examples/models/voxtral_realtime/CMakePresets.json
@@ -82,6 +82,19 @@
                 "type": "equals",
                 "rhs": "Darwin"
             }
+        },
+        {
+            "name": "voxtral-realtime-vulkan",
+            "displayName": "Voxtral Realtime runner (Vulkan)",
+            "inherits": ["voxtral-realtime-base"],
+            "cacheVariables": {
+                "EXECUTORCH_BUILD_VULKAN": "ON"
+            },
+            "condition": {
+                "type": "inList",
+                "string": "${hostSystemName}",
+                "list": ["Linux", "Windows"]
+            }
         }
     ],
     "buildPresets": [
@@ -125,6 +138,15 @@
             "name": "voxtral-realtime-mlx",
             "displayName": "Build Voxtral Realtime runner (MLX)",
             "configurePreset": "voxtral-realtime-mlx",
+            "configuration": "Release",
+            "targets": [
+                "voxtral_realtime_runner"
+            ]
+        },
+        {
+            "name": "voxtral-realtime-vulkan",
+            "displayName": "Build Voxtral Realtime runner (Vulkan)",
+            "configurePreset": "voxtral-realtime-vulkan",
             "configuration": "Release",
             "targets": [
                 "voxtral_realtime_runner"
@@ -199,6 +221,20 @@
                 {
                     "type": "build",
                     "name": "voxtral-realtime-mlx"
+                }
+            ]
+        },
+        {
+            "name": "voxtral-realtime-vulkan",
+            "displayName": "Configure and build Voxtral Realtime runner (Vulkan)",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "voxtral-realtime-vulkan"
+                },
+                {
+                    "type": "build",
+                    "name": "voxtral-realtime-vulkan"
                 }
             ]
         }

--- a/examples/models/voxtral_realtime/README.md
+++ b/examples/models/voxtral_realtime/README.md
@@ -119,6 +119,7 @@ python export_voxtral_rt.py \
 | `cuda` | ✓ | ✓ | `4w`, `8w` |
 | `cuda-windows` | ✓ | ✓ | `4w`, `8w` |
 | `rocm` | ✓ | ✓ | BF16; packed linear `4w` and embedding `8w` |
+| `vulkan` | ✓ | ✓ | `8w`, `8da4w` |
 
 
 MLX and Metal backends provide Apple GPU acceleration. CUDA provides NVIDIA GPU
@@ -371,6 +372,7 @@ make voxtral_realtime-cpu      # XNNPACK (CPU)
 make voxtral_realtime-metal    # Metal (Apple GPU)
 make voxtral_realtime-cuda     # CUDA (NVIDIA GPU)
 make voxtral_realtime-rocm     # ROCm (AMD GPU, experimental)
+make voxtral_realtime-vulkan   # Vulkan (Linux/Windows GPU)
 ```
 
 The CPU, CUDA, Metal, and MLX targets produce the runner at
@@ -484,8 +486,10 @@ cmake-out/examples/models/voxtral_realtime/voxtral_realtime_runner \
 Omit `--streaming` for offline transcription (requires an offline-exported
 model and offline preprocessor).
 
-For CUDA and ROCm, add
-`--data_path voxtral_rt_exports/aoti_cuda_blob.ptd`.
+For CUDA and ROCm exports, add
+`--data_path voxtral_rt_exports/aoti_cuda_blob.ptd`. For Vulkan exports with
+external constants, pass all generated files in order, for example
+`--data_paths voxtral_rt_exports/model_0.ptd,voxtral_rt_exports/model_1.ptd`.
 
 **Windows (PowerShell):**
 
@@ -522,7 +526,8 @@ Ctrl+C stops recording and flushes remaining text.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--model_path` | `model.pte` | Path to exported model |
-| `--data_path` | (none) | Path to delegate data file (`.ptd`, required for CUDA and ROCm) |
+| `--data_path` | (none) | Path to one delegate data file (`.ptd`, required for CUDA and ROCm) |
+| `--data_paths` | (none) | Comma-separated delegate data files (`.ptd`, for external constants) |
 | `--tokenizer_path` | `tekken.json` | Path to Tekken tokenizer |
 | `--preprocessor_path` | (none) | Path to mel preprocessor `.pte` |
 | `--audio_path` | (none) | Path to 16kHz mono WAV file |

--- a/examples/models/voxtral_realtime/main.cpp
+++ b/examples/models/voxtral_realtime/main.cpp
@@ -23,6 +23,7 @@
 
 #include <csignal>
 #include <cstdio>
+#include <sstream>
 
 #ifndef _WIN32
 #include <fcntl.h>
@@ -67,7 +68,13 @@ DEFINE_int32(
 DEFINE_string(
     data_path,
     "",
-    "Path to data file (.ptd) for delegate data (required for CUDA and ROCm).");
+    "Path to one delegate data file (.ptd; required for CUDA and ROCm). "
+    "Deprecated; use --data_paths.");
+DEFINE_string(
+    data_paths,
+    "",
+    "Comma-separated delegate data files (.ptd), required when the exported "
+    "model uses external constants.");
 DEFINE_string(
     color,
     "",
@@ -83,6 +90,21 @@ voxtral_realtime::StreamingTranscribeConfig make_streaming_config() {
   voxtral_realtime::StreamingTranscribeConfig config;
   config.temperature = static_cast<float>(FLAGS_temperature);
   return config;
+}
+
+std::vector<std::string> parse_data_paths(const std::string& input) {
+  std::vector<std::string> paths;
+  std::stringstream stream(input);
+  std::string item;
+  while (std::getline(stream, item, ',')) {
+    const auto first = item.find_first_not_of(" \t");
+    if (first == std::string::npos) {
+      continue;
+    }
+    const auto last = item.find_last_not_of(" \t");
+    paths.emplace_back(item.substr(first, last - first + 1));
+  }
+  return paths;
 }
 } // namespace
 
@@ -114,6 +136,15 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  if (!FLAGS_data_path.empty() && !FLAGS_data_paths.empty()) {
+    ET_LOG(Error, "--data_path and --data_paths are mutually exclusive.");
+    return 1;
+  }
+  auto data_paths = parse_data_paths(FLAGS_data_paths);
+  if (!FLAGS_data_path.empty()) {
+    data_paths.push_back(FLAGS_data_path);
+  }
+
   // Install signal handler early so Ctrl+C is caught during load/warmup.
   std::signal(SIGINT, sigint_handler);
 
@@ -124,7 +155,7 @@ int main(int argc, char** argv) {
       FLAGS_model_path,
       FLAGS_tokenizer_path,
       FLAGS_preprocessor_path,
-      FLAGS_data_path);
+      data_paths);
 
   stats.model_load_end_ms = ::executorch::extension::llm::time_in_ms();
   stats.inference_start_ms = ::executorch::extension::llm::time_in_ms();

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.cpp
@@ -10,6 +10,7 @@
 
 #include <cstring>
 #include <ctime>
+#include <fstream>
 #include <vector>
 
 #include <executorch/extension/llm/runner/llm_runner_helper.h>
@@ -31,20 +32,45 @@ VoxtralRealtimeRunner::VoxtralRealtimeRunner(
     const std::string& tokenizer_path,
     const std::string& preprocessor_path,
     const std::string& data_path,
+    bool warmup)
+    : VoxtralRealtimeRunner(
+          model_path,
+          tokenizer_path,
+          preprocessor_path,
+          data_path.empty() ? std::vector<std::string>{}
+                            : std::vector<std::string>{data_path},
+          warmup) {}
+
+VoxtralRealtimeRunner::VoxtralRealtimeRunner(
+    const std::string& model_path,
+    const std::string& tokenizer_path,
+    const std::string& preprocessor_path,
+    const std::vector<std::string>& data_paths,
     bool warmup) {
   // Load the main model (.pte with audio_encoder, text_decoder,
   // token_embedding methods). Mmap avoids copying the file into memory.
-  // For CUDA backend, data_path points to the .ptd file with compiled kernels.
+  // Delegate data files hold external constants or compiled kernels.
   ET_LOG(Info, "Loading model from: %s", model_path.c_str());
-  if (!data_path.empty()) {
-    ET_LOG(Info, "Loading data from: %s", data_path.c_str());
-    model_ =
-        std::make_unique<Module>(model_path, data_path, Module::LoadMode::Mmap);
+  if (!data_paths.empty()) {
+    for (const auto& data_path : data_paths) {
+      std::ifstream data_file(data_path, std::ios::binary);
+      ET_CHECK_MSG(
+          data_file.good(),
+          "Delegate data file not found or unreadable: %s",
+          data_path.c_str());
+      ET_LOG(Info, "Loading data from: %s", data_path.c_str());
+    }
+    model_ = std::make_unique<Module>(
+        model_path, data_paths, Module::LoadMode::Mmap);
   } else {
     model_ = std::make_unique<Module>(model_path, Module::LoadMode::Mmap);
   }
   auto load_error = model_->load();
-  ET_CHECK_MSG(load_error == Error::Ok, "Failed to load model.");
+  ET_CHECK_MSG(
+      load_error == Error::Ok,
+      "Failed to load model or %zu delegate data file(s); verify every .ptd "
+      "belongs to this .pte.",
+      data_paths.size());
 
   // Model metadata is exported as constant_methods (zero-input methods that
   // return a scalar). These tell the runner the model's dimensions so it can
@@ -451,9 +477,10 @@ StreamingSession::StreamingSession(
           config.temperature,
           ::executorch::extension::llm::kTopp,
           static_cast<unsigned long long>(std::time(nullptr))),
-      input_embeds_(::executorch::extension::empty(
-          {1, 1, static_cast<int>(runner.dim_)},
-          runner.model_dtype_)) {}
+      input_embeds_(
+          ::executorch::extension::empty(
+              {1, 1, static_cast<int>(runner.dim_)},
+              runner.model_dtype_)) {}
 
 int StreamingSession::feed_audio(const float* data, int64_t num_samples) {
   audio_buf_.insert(audio_buf_.end(), data, data + num_samples);

--- a/examples/models/voxtral_realtime/voxtral_realtime_runner.h
+++ b/examples/models/voxtral_realtime/voxtral_realtime_runner.h
@@ -44,7 +44,14 @@ class VoxtralRealtimeRunner {
       const std::string& model_path,
       const std::string& tokenizer_path,
       const std::string& preprocessor_path = "",
-      const std::string& data_path = "",
+      const std::vector<std::string>& data_paths = {},
+      bool warmup = true);
+
+  VoxtralRealtimeRunner(
+      const std::string& model_path,
+      const std::string& tokenizer_path,
+      const std::string& preprocessor_path,
+      const std::string& data_path,
       bool warmup = true);
 
   // Offline transcription: full encoder first, then step-by-step decode.


### PR DESCRIPTION
A supported build and multi-data runner path is required to validate exported
methods outside Python.

AI-assisted-by: Codex

This PR was authored with assistance from Codex.

cc @SS-JIA @manuelcandales @cbilgin