### PR TITLE
[Vulkan] Make q4 GEMV activation quantization deterministic

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/choose_qparams_per_row.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/choose_qparams_per_row.glsl
@@ -46,7 +46,9 @@ layout(push_constant) uniform PushConstants {
 shared T shared_min[NUM_OUTPUTS_PER_WG][NUM_WORKERS_PER_OUTPUT];
 shared T shared_max[NUM_OUTPUTS_PER_WG][NUM_WORKERS_PER_OUTPUT];
 
-const float SMALL_SCALE_THRESHOLD = 6.1e-5;
+// Keep fp16 scales above the normal-value boundary on devices that flush
+// denormals to zero.
+const float SMALL_SCALE_THRESHOLD = 6.25e-5;
 
 void calculate_scale_and_zero_point(
     float min_val,

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_int8_input_block.glslh
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_int8_input_block.glslh
@@ -38,7 +38,7 @@ ivec4 quantize(
     const VEC4_T val,
     const float q_inv_scale,
     const int q_zero_point) {
-  vec4 quantized = round(vec4(val) * q_inv_scale) + q_zero_point;
+  vec4 quantized = roundEven(vec4(val) * q_inv_scale) + q_zero_point;
   // hard-code 8 bit quantization range
   return clamp(ivec4(quantized), -128, 127);
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/linear_q4gsw_coop.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/linear_q4gsw_coop.glsl
@@ -97,6 +97,13 @@ void main() {
   FPInputTile in_tile;
   Int4WeightTile int4_weight_tile;
 
+$if DYNAMIC_QUANT_VARIANT:
+  const T input_scale = T(texelFetch(t_input_scale, ivec3(0, 0, 0), 0).x);
+  $if ZP_DTYPE_MODE == "zpint8":
+    const int input_zp = texelFetch(t_input_zp, ivec3(0, 0, 0), 0).x;
+  $else:
+    const int input_zp = int(texelFetch(t_input_zp, ivec3(0, 0, 0), 0).x);
+
   FPPerOutChannelParams weight_scales_tile;
   FPPerOutChannelParams weight_zeros_tile;
   weight_zeros_tile.data[0] = VEC4_T(0.0);
@@ -116,6 +123,17 @@ void main() {
     }
 
     load_input_tile_no_checks(in_tile, k4, 0, K4, 1);
+    $if DYNAMIC_QUANT_VARIANT:
+      const float input_inv_scale = 1.0 / float(input_scale);
+      // Keep this quantization in sync with linear_int8_input_block.glslh.
+      const vec4 quantized_input = clamp(
+          roundEven(vec4(in_tile.data[0][0]) * input_inv_scale) +
+              float(input_zp),
+          vec4(-128.0),
+          vec4(127.0));
+      in_tile.data[0][0] =
+          (VEC4_T(quantized_input) - VEC4_T(input_zp)) *
+          VEC4_T(input_scale);
     load_int4_weight_tile(int4_weight_tile, k4, n8, K4);
 
     fp_accumulate_with_int4_weight(

--- a/backends/vulkan/test/custom_ops/test_choose_qparams_per_row.cpp
+++ b/backends/vulkan/test/custom_ops/test_choose_qparams_per_row.cpp
@@ -18,7 +18,7 @@ using namespace executorch::vulkan::prototyping;
 using namespace vkcompute;
 
 static constexpr int64_t kRefDimSizeLimit = 2050;
-static constexpr float SMALL_SCALE_THRESHOLD = 6.1e-5f;
+static constexpr float SMALL_SCALE_THRESHOLD = 6.25e-5f;
 
 // ChooseQParams configuration struct
 struct ChooseQParamsConfig {

--- a/backends/vulkan/test/custom_ops/test_q4gsw_linear.cpp
+++ b/backends/vulkan/test/custom_ops/test_q4gsw_linear.cpp
@@ -463,15 +463,6 @@ void linear_dq8ca_q4gsw_reference_impl(TestCase& test_case) {
         "One or more dimensions (batch_size, in_features, out_features) exceed the allowed limit for reference implementation.");
   }
 
-  // Skip correctness for kHalf: this reference quantizes the activation in fp32
-  // (round(x/scale)+zp), but the GPU does the dynamic int8 activation quant in
-  // fp16, so the round-trip diverges. dq8ca_q4gsw coopmat half-validation needs
-  // an fp16-accurate reference (Step 2). Perf timings still run.
-  if (input_spec.dtype == vkapi::kHalf) {
-    throw std::invalid_argument(
-        "dq8ca_q4gsw reference skipped for kHalf (fp16 dyn-act quant diverges)");
-  }
-
   if (input_spec.dtype != vkapi::kFloat && input_spec.dtype != vkapi::kHalf) {
     throw std::invalid_argument("Unsupported dtype");
   }
@@ -495,6 +486,7 @@ void linear_dq8ca_q4gsw_reference_impl(TestCase& test_case) {
   for (int64_t b = 0; b < batch_size; ++b) {
     // Use per-input channel scale and zero point - index by batch dimension
     float input_scale = input_scale_spec.get_element(b); // {1, M}
+    const float input_inv_scale = 1.0f / input_scale;
     int8_t input_zero_point = input_zero_point_data[b];
 
     for (int64_t out_f = 0; out_f < out_features; ++out_f) {
@@ -509,7 +501,7 @@ void linear_dq8ca_q4gsw_reference_impl(TestCase& test_case) {
         float input_val = input_spec.get_element(input_idx);
 
         float quant_input_f =
-            std::round(input_val / input_scale) + input_zero_point;
+            std::nearbyint(input_val * input_inv_scale) + input_zero_point;
         quant_input_f = std::min(std::max(quant_input_f, -128.0f), 127.0f);
         int8_t quantized_input = static_cast<int8_t>(quant_input_f);
 

--- a/backends/vulkan/test/test_vulkan_delegate.py
+++ b/backends/vulkan/test/test_vulkan_delegate.py
@@ -8,6 +8,7 @@
 
 import ctypes
 import functools
+import os
 import unittest
 from typing import Tuple
 
@@ -45,7 +46,7 @@ except:
     pass
 
 
-def disable_test(reason):
+def disable_test(reason, enable_env=None):
     """Disable a test while still reporting it as executed.
 
     Some test runners do not handle skipped results consistently, so this keeps
@@ -55,6 +56,8 @@ def disable_test(reason):
     def decorator(fn):
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
+            if enable_env is not None and os.getenv(enable_env) == "1":
+                return fn(*args, **kwargs)
             print(f"DISABLED_TEST: {fn.__qualname__}: {reason}")
             return None
 
@@ -2935,7 +2938,10 @@ class TestVulkanBackend(unittest.TestCase):
             rtol=1e-1,
         )
 
-    @disable_test("Cannot run on swiftshader due to no 8-bit int support")
+    @disable_test(
+        "Cannot run on swiftshader due to no 8-bit int support",
+        enable_env="ETVK_RUN_8DA4W_TESTS",
+    )
     def test_vulkan_backend_torchao_8da4w_quantized_linear(self):
         """
         Test TorchAO 8da4w quantization (int8 dynamic activation + int4 weight) with Vulkan backend.
@@ -2973,7 +2979,9 @@ class TestVulkanBackend(unittest.TestCase):
                 quantize_(
                     self,
                     Int8DynamicActivationIntxWeightConfig(
-                        weight_dtype=torch.int4, granularity=PerGroup(self.group_size)
+                        weight_dtype=torch.int4,
+                        weight_granularity=PerGroup(self.group_size),
+                        intx_choose_qparams_algorithm="hqq_scale_only",
                     ),
                 )
                 unwrap_tensor_subclass(self)
@@ -2996,6 +3004,57 @@ class TestVulkanBackend(unittest.TestCase):
         # Use higher tolerance since quantization introduces some error
         self.lower_module_and_test_output(
             quantized_linear_module, sample_inputs, atol=1e-2, rtol=1e-2
+        )
+
+        # Exercise the dynamic GEMV shader with sparse outliers. Ignoring
+        # activation quantization degenerates to weight-only 4w math and
+        # diverges well beyond the 8da4w tolerance.
+        outlier_input = torch.randn(size=(1, 1, in_features), dtype=torch.float32) * 0.2
+        outlier_input[0, 0, 17] = -264.0
+        outlier_input[0, 0, 731] = 135.0
+        self.lower_module_and_test_output(
+            quantized_linear_module,
+            (outlier_input,),
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+        # The dynamic quantization producer converts fp16 input to fp32 before
+        # applying the reciprocal scale. Exercise a value on a rounding
+        # boundary so the GEMV consumer must match the producer's fp32
+        # quantization instead of re-quantizing in fp16.
+        half_linear_module = TorchAO8da4wQuantizedLinearModule(
+            in_features=128,
+            out_features=8,
+            bias=bias,
+            group_size=128,
+        ).half()
+        with torch.no_grad():
+            half_linear_module.linear.weight.zero_()
+            half_linear_module.linear.weight[:, 2] = 1.0
+        half_linear_module = half_linear_module.apply_8da4w_quantization()
+        boundary_input = torch.zeros(size=(1, 128), dtype=torch.float16)
+        boundary_input[0, 0] = -0.005001068115234375
+        boundary_input[0, 1] = 0.01152801513671875
+        boundary_input[0, 2] = 0.0081939697265625
+        self.lower_module_and_test_output(
+            half_linear_module,
+            (boundary_input,),
+            atol=2e-5,
+            rtol=0.0,
+            compile_options={"storage_type_override": VkStorageType.BUFFER},
+        )
+
+        # Keep a near-silent fp16 row finite on devices that flush half
+        # denormals to zero.
+        near_silent_input = torch.zeros(size=(1, 128), dtype=torch.float16)
+        near_silent_input[0, 2] = 0.001
+        self.lower_module_and_test_output(
+            half_linear_module,
+            (near_silent_input,),
+            atol=1e-4,
+            rtol=0.0,
+            compile_options={"storage_type_override": VkStorageType.BUFFER},
         )
 
         # Test with GEMM pattern (batch_size > 1)


### PR DESCRIPTION
Vulkan q4 GEMV and its TorchAO producer must agree across FP16 paths
and GPU tie-breaking behavior.

AI-assisted-by: Codex

This PR was authored with assistance from Codex.

cc @SS-JIA @manuelcandales @cbilgin