### PR TITLE
Add SmolLM2 360M export support (#22459)

### DIFF
--- a/examples/models/llama/export_llama_lib.py
+++ b/examples/models/llama/export_llama_lib.py
@@ -115,6 +115,7 @@ EXECUTORCH_DEFINED_MODELS = [
     "qwen3_5_4b",
     "phi_4_mini",
     "smollm2",
+    "smollm2_360m",
     "lfm2_350m",  # hybrid
     "lfm2_700m",  # hybrid
     "lfm2_1_2b",  # hybrid
@@ -128,6 +129,7 @@ HUGGING_FACE_REPO_IDS = {
     "qwen2_5_coder_32b": "Qwen/Qwen2.5-Coder-32B-Instruct",
     "phi_4_mini": "microsoft/Phi-4-mini-instruct",
     "smollm2": "HuggingFaceTB/SmolLM2-135M",
+    "smollm2_360m": "HuggingFaceTB/SmolLM2-360M",
     "qwen3_0_6b": "Qwen/Qwen3-0.6B",
     "qwen3_1_7b": "Qwen/Qwen3-1.7B",
     "qwen3_4b": "Qwen/Qwen3-4B",
@@ -712,7 +714,7 @@ def export_llama(  # noqa: C901
             from executorch.examples.models.qwen3 import convert_weights
         elif model_name == "phi_4_mini":
             from executorch.examples.models.phi_4_mini import convert_weights
-        elif model_name == "smollm2":
+        elif model_name in ("smollm2", "smollm2_360m"):
             from executorch.examples.models.smollm2 import convert_weights
         elif model_name.startswith("lfm2"):
             from executorch.examples.models.lfm2 import convert_weights

--- a/examples/models/smollm2/360M_config.json
+++ b/examples/models/smollm2/360M_config.json
@@ -1,0 +1,16 @@
+{
+  "dim": 960,
+  "ffn_dim_multiplier": 1,
+  "hidden_dim": 2560,
+  "n_heads": 15,
+  "n_kv_heads": 5,
+  "n_layers": 32,
+  "norm_eps": 1e-05,
+  "rope_theta": 100000.0,
+  "use_scaled_rope": false,
+  "vocab_size": 49152,
+  "use_hf_rope": false,
+  "attention_qkv_bias": false,
+  "bos_idx": 0,
+  "eos_idx": 0
+}

--- a/examples/models/smollm2/BUCK
+++ b/examples/models/smollm2/BUCK
@@ -14,6 +14,7 @@ fbcode_target(_kind = runtime.python_library,
     base_module = "executorch.examples.models.smollm2",
     resources = {
         "135M_config.json": "135M_config.json",
+        "360M_config.json": "360M_config.json",
     },
     deps = [
         "//caffe2:torch",

--- a/extension/llm/export/config/llm_config.py
+++ b/extension/llm/export/config/llm_config.py
@@ -50,6 +50,7 @@ class ModelType(str, Enum):
     qwen3_5_4b = "qwen3_5_4b"
     phi_4_mini = "phi_4_mini"
     smollm2 = "smollm2"
+    smollm2_360m = "smollm2_360m"
     lfm2_350m = "lfm2_350m"
     lfm2_700m = "lfm2_700m"
     lfm2_1_2b = "lfm2_1_2b"


### PR DESCRIPTION
Summary:

Register `smollm2_360m`, map its Hugging Face checkpoint and converter, and package the matching model configuration in both fbcode and xplat.

Reviewed By: rascani

Differential Revision: D118479813


