### PR TITLE
[Voxtral] Route Voxtral streaming through ring attention

### DIFF
--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -577,6 +577,7 @@ def lower_to_executorch(
     backend="xnnpack",
     codesign_identity=None,
     packed_linear_counts=None,
+    vulkan_force_fp16=False,
 ):
     """Lower exported programs to ExecuTorch."""
     transform_passes = None
@@ -609,6 +610,8 @@ def lower_to_executorch(
                     VULKAN_EXTERNAL_CONSTANTS_MAX_DATA_BYTES
                 ),
             }
+            if vulkan_force_fp16:
+                compile_options["force_fp16"] = True
             if key in ("encode_audio_chunk", "text_decoder"):
                 compile_options["alias_buffer_mutations"] = True
             if key == "token_embedding":
@@ -858,6 +861,12 @@ def main():
         help="Model dtype (default: fp32).",
     )
     parser.add_argument(
+        "--vulkan-force-fp16",
+        action="store_true",
+        help="Store and execute Vulkan floating-point tensors as fp16 while "
+        "preserving fp32 model inputs and outputs.",
+    )
+    parser.add_argument(
         "--codesign-identity",
         default=None,
         help="macOS code signing identity for the Metal backend .so. "
@@ -869,6 +878,8 @@ def main():
         "cuda" if args.backend in ("cuda-windows", "rocm") else args.backend
     )
     _validate_export_args(parser, args, backend_for_export)
+    if args.vulkan_force_fp16 and args.backend != "vulkan":
+        parser.error("--vulkan-force-fp16 requires --backend=vulkan")
     validate_vulkan_options(args, parser)
 
     os.makedirs(args.output_dir, exist_ok=True)
@@ -932,6 +943,7 @@ def main():
         backend=args.backend,
         codesign_identity=args.codesign_identity,
         packed_linear_counts=packed_linear_counts,
+        vulkan_force_fp16=args.vulkan_force_fp16,
     )
 
     # Save

--- a/examples/models/voxtral_realtime/model.py
+++ b/examples/models/voxtral_realtime/model.py
@@ -425,6 +425,38 @@ class SDPA(nn.Module):
         return y.view(bsz, seqlen, self.dim).to(dtype=input_dtype)
 
 
+class VulkanRingSDPA(nn.Module):
+    """Sliding-window SDPA over a wrapped Vulkan KV cache."""
+
+    def __init__(self, n_heads: int, head_dim: int, window_size: int):
+        super().__init__()
+        self.dim = n_heads * head_dim
+        self.window_size = window_size
+
+    def forward(
+        self,
+        input_pos: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        bsz: int,
+        seqlen: int,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del mask
+        input_dtype = q.dtype
+        start_pos = input_pos[0].item()
+        torch._check_is_size(start_pos)
+        y = torch.ops.et_vk.ring_sdpa(
+            q.to(dtype=torch.float32),
+            k.to(dtype=torch.float32),
+            v.to(dtype=torch.float32),
+            start_pos,
+            self.window_size,
+        )
+        return y.reshape(bsz, seqlen, self.dim).to(dtype=input_dtype)
+
+
 def _build_attn_mask(
     input_pos: torch.Tensor,
     max_seq_len: int,
@@ -726,6 +758,13 @@ class LMAttention(nn.Module):
                     config.sliding_window, self.n_kv_heads, self.head_dim
                 )
                 self.sdpa = StandardSDPA(self.n_heads, self.n_kv_heads, self.head_dim)
+            elif self.backend == "vulkan":
+                self.kv_cache = RingKVCache(
+                    config.sliding_window, self.n_kv_heads, self.head_dim
+                )
+                self.sdpa = VulkanRingSDPA(
+                    self.n_heads, self.head_dim, config.sliding_window
+                )
             else:
                 self.kv_cache = RingKVCache(
                     config.sliding_window, self.n_kv_heads, self.head_dim
@@ -891,15 +930,18 @@ class MistralDecoder(nn.Module):
             freqs_cos = freqs.cos()
             freqs_sin = freqs.sin()
 
-            # Sliding window mask from the ring buffer, computed once for
-            # all 26 layers.
-            seqlen = input_pos.shape[0]
-            attn_mask = self.layers[0].attention.kv_cache.create_causal_mask(
-                input_pos[0],
-                seqlen,
-                bool_mask=self.bool_mask,
-                dtype=input_embeds.dtype,
-            )
+            if self.config.backend == "vulkan":
+                attn_mask = None
+            else:
+                # Sliding window mask from the ring buffer, computed once for
+                # all 26 layers.
+                seqlen = input_pos.shape[0]
+                attn_mask = self.layers[0].attention.kv_cache.create_causal_mask(
+                    input_pos[0],
+                    seqlen,
+                    bool_mask=self.bool_mask,
+                    dtype=input_embeds.dtype,
+                )
         else:
             # Precomputed RoPE table lookup.
             freqs_cos = self.freqs_cos[input_pos]
@@ -1140,14 +1182,14 @@ class StandardRingKVCache(nn.Module):
 
 
 class StreamingAudioEncoderExport(nn.Module):
-    """Streaming encoder: processes one 8-mel-frame chunk at a time.
+    """Streaming encoder for one or more contiguous 8-mel-frame chunks.
 
     Shares conv/transformer/adapter weights with the offline encoder.
     Owns separate KV caches and SDPA for incremental KV-cached attention.
     Conv states are maintained as internal buffers.
 
     Forward:
-        mel_chunk(1,128,8) + enc_input_pos(4,) -> audio_embeds(1,1,3072)
+        mel_chunk(1,128,8*N) + enc_input_pos(4*N,) -> audio_embeds(1,N,3072)
     """
 
     def __init__(self, model: VoxtralRealtimeModel, max_enc_len: int = 750):
@@ -1217,6 +1259,16 @@ class StreamingAudioEncoderExport(nn.Module):
                 config.enc_n_heads,
                 config.enc_n_heads,
                 config.enc_head_dim,
+            )
+        elif config.backend == "vulkan":
+            self.kv_caches = nn.ModuleList(
+                [
+                    RingKVCache(max_enc_len, config.enc_n_heads, config.enc_head_dim)
+                    for _ in range(config.enc_n_layers)
+                ]
+            )
+            self.sdpa = VulkanRingSDPA(
+                config.enc_n_heads, config.enc_head_dim, max_enc_len
             )
         else:
             self.kv_caches = nn.ModuleList(
@@ -1293,15 +1345,13 @@ class StreamingAudioEncoderExport(nn.Module):
         self.conv1_state.mul_(1.0 - is_start)
         self.conv2_state.mul_(1.0 - is_start)
 
-        # Conv1: cat state + chunk, raw Conv1d (no CausalConv1d padding)
-        # (1, 128, 2+8=10) -> conv1(k=3, s=1) -> (1, 1280, 8)
+        # Conv1: cat state + chunk, raw Conv1d (no CausalConv1d padding).
         conv1_input = torch.cat([self.conv1_state, mel_chunk], dim=2)
         conv1_out = F.gelu(self.conv1(conv1_input))
         # Update conv1 state with last 2 frames from mel_chunk
         self.conv1_state.copy_(mel_chunk[:, :, -2:])
 
-        # Conv2: cat state + conv1_out, raw Conv1d
-        # (1, 1280, 2+8=10) -> conv2(k=3, s=2) -> (1, 1280, 4)
+        # Conv2: cat state + conv1_out, raw Conv1d.
         conv2_input = torch.cat([self.conv2_state, conv1_out], dim=2)
         conv2_out = F.gelu(self.conv2(conv2_input))
         # Update conv2 state with last 2 frames from conv1_out
@@ -1314,25 +1364,27 @@ class StreamingAudioEncoderExport(nn.Module):
         freqs_cos = freqs.cos()
         freqs_sin = freqs.sin()
 
-        # Sliding window mask — identical for all layers, compute once.
         T = x.size(1)
-        # Pass start position as tensor (not .item()) to avoid unbacked symbols in AOTI
-        mask = self.kv_caches[0].create_causal_mask(
-            enc_input_pos[0], T, bool_mask=self.bool_mask, dtype=x.dtype
-        )
+        if self.backend == "vulkan":
+            mask = None
+        else:
+            # Pass start position as tensor (not .item()) to avoid unbacked symbols in AOTI
+            mask = self.kv_caches[0].create_causal_mask(
+                enc_input_pos[0], T, bool_mask=self.bool_mask, dtype=x.dtype
+            )
 
         for i, layer in enumerate(self.layers):
             x = self._streaming_encoder_layer(
                 x, freqs_cos, freqs_sin, enc_input_pos, mask, layer, i
             )
 
-        x = self.enc_norm(x)  # (1, 4, 1280)
+        x = self.enc_norm(x)
 
-        # Downsample: concat 4 consecutive frames -> (1, 1, 5120)
+        # Downsample by concatenating consecutive encoder frames.
         B, T, D = x.shape
         x = x.reshape(B, T // self.downsample_factor, D * self.downsample_factor)
 
-        audio_embeds = self.adapter(x)  # (1, 1, 3072)
+        audio_embeds = self.adapter(x)
 
         return audio_embeds
 
@@ -1415,9 +1467,11 @@ def load_model(
             f"Unknown backend '{backend}'. Must be one of {_VALID_BACKENDS}."
         )
 
-    # Import MLX custom ops for mlx backend
+    # Import backend custom ops before model construction.
     if backend == "mlx":
         import executorch.backends.mlx.custom_ops as _mlx_custom_ops  # noqa: F401
+    elif backend == "vulkan":
+        import executorch.backends.vulkan.custom_ops_lib as _vk_custom_ops  # noqa: F401
 
     from safetensors import safe_open
 

--- a/examples/models/voxtral_realtime/tests/test_ring_kv_cache.py
+++ b/examples/models/voxtral_realtime/tests/test_ring_kv_cache.py
@@ -4,17 +4,25 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import unittest
 from types import ModuleType
 from unittest.mock import patch
 
 import torch
+import executorch.backends.vulkan.custom_ops_lib  # noqa: F401
 
 with patch.dict(
     "sys.modules",
     {"executorch.extension.llm.custom_ops.custom_ops": ModuleType("custom_ops")},
 ):
-    from executorch.examples.models.voxtral_realtime.model import StandardRingKVCache
+    from executorch.examples.models.voxtral_realtime.model import (
+        RingKVCache,
+        StandardRingKVCache,
+        StreamingAudioEncoderExport,
+        VoxtralRealtimeConfig,
+        VoxtralRealtimeModel,
+    )
 
 
 class StandardRingKVCacheTest(unittest.TestCase):
@@ -36,6 +44,103 @@ class StandardRingKVCacheTest(unittest.TestCase):
         mask = cache.create_causal_mask(torch.tensor(3), seq_len=2, bool_mask=True)
 
         self.assertEqual(mask.dtype, torch.bool)
+
+
+class VulkanRingSDPATest(unittest.TestCase):
+    def test_matches_explicit_physical_cache_mask_across_wraps(self):
+        window_size = 4
+        num_heads = 4
+        num_kv_heads = 2
+        head_dim = 8
+
+        for start_pos, seq_len in (
+            (0, 1),
+            (3, 1),
+            (4, 1),
+            (8, 1),
+            (0, 4),
+            (4, 4),
+            (8, 4),
+        ):
+            with self.subTest(start_pos=start_pos, seq_len=seq_len):
+                torch.manual_seed(20260816 + start_pos + seq_len)
+                cache = RingKVCache(window_size, num_kv_heads, head_dim)
+                for pos in range(start_pos + seq_len):
+                    cache.k_cache[:, pos % cache.buf_size].copy_(
+                        torch.randn(1, num_kv_heads, head_dim)
+                    )
+                    cache.v_cache[:, pos % cache.buf_size].copy_(
+                        torch.randn(1, num_kv_heads, head_dim)
+                    )
+
+                q = torch.randn(1, seq_len, num_heads, head_dim)
+                mask = cache.create_causal_mask(start_pos, seq_len)
+                k = torch.repeat_interleave(
+                    cache.k_cache, num_heads // num_kv_heads, dim=2
+                )
+                v = torch.repeat_interleave(
+                    cache.v_cache, num_heads // num_kv_heads, dim=2
+                )
+                q_bhsd = q.transpose(1, 2)
+                k_bhsd = k.transpose(1, 2)
+                v_bhsd = v.transpose(1, 2)
+                attn = torch.matmul(q_bhsd, k_bhsd.transpose(-2, -1))
+                attn = attn / (head_dim**0.5) + mask
+                expected = torch.matmul(torch.softmax(attn, dim=-1), v_bhsd)
+                expected = expected.transpose(1, 2)
+
+                actual = torch.ops.et_vk.ring_sdpa(
+                    q,
+                    cache.k_cache,
+                    cache.v_cache,
+                    start_pos,
+                    window_size,
+                )
+                torch.testing.assert_close(actual, expected)
+
+    def test_two_chunk_encoder_matches_sequential_calls(self):
+        config = VoxtralRealtimeConfig(
+            dim=32,
+            n_layers=1,
+            n_heads=4,
+            n_kv_heads=2,
+            head_dim=8,
+            hidden_dim=64,
+            vocab_size=64,
+            ada_rms_norm_t_cond_dim=8,
+            enc_dim=32,
+            enc_n_layers=1,
+            enc_n_heads=4,
+            enc_head_dim=8,
+            enc_hidden_dim=64,
+            num_mel_bins=8,
+            downsample_factor=4,
+            max_seq_len=8,
+            sliding_window=8,
+            streaming=True,
+            backend="cuda",
+        )
+        torch.manual_seed(20260817)
+        model = VoxtralRealtimeModel(config).eval()
+        sequential = StreamingAudioEncoderExport(
+            copy.deepcopy(model), max_enc_len=8
+        ).eval()
+        batched = StreamingAudioEncoderExport(
+            copy.deepcopy(model), max_enc_len=8
+        ).eval()
+        mel = torch.randn(1, config.num_mel_bins, 16)
+
+        with torch.inference_mode():
+            expected = torch.cat(
+                (
+                    sequential(mel[:, :, :8], torch.arange(4)),
+                    sequential(mel[:, :, 8:], torch.arange(4, 8)),
+                ),
+                dim=1,
+            )
+            actual = batched(mel, torch.arange(8))
+
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Decoder and encoder caches must keep the full logical window without
materializing doubled masks.

AI-assisted-by: Codex

This PR was authored with assistance from Codex.