### PR TITLE
[Vulkan] Reject tensors the runtime cannot represent

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -1149,7 +1149,9 @@ def register_update_cache():
     )
 
 
-def is_update_cache_with_indices_node_supported(node: torch.fx.Node) -> bool:
+def _get_update_cache_with_indices_tensor_args(
+    node: torch.fx.Node,
+) -> Optional[Tuple[torch.fx.Node, torch.fx.Node, torch.fx.Node]]:
     if node.target == torch.ops.higher_order.auto_functionalized_v2:
         all_bases = node.kwargs.get("_all_bases", ())
         cache_base_index = node.kwargs.get("_cache_base_index")
@@ -1158,7 +1160,7 @@ def is_update_cache_with_indices_node_supported(node: torch.fx.Node) -> bool:
             or cache_base_index < 0
             or cache_base_index >= len(all_bases)
         ):
-            return False
+            return None
         value = node.kwargs.get("value")
         cache = all_bases[cache_base_index]
         indices = node.kwargs.get("indices")
@@ -1169,11 +1171,32 @@ def is_update_cache_with_indices_node_supported(node: torch.fx.Node) -> bool:
     elif len(node.args) >= 4:
         value, cache, _, indices = node.args[:4]
     else:
-        return False
+        return None
 
     if not all(isinstance(arg, torch.fx.Node) for arg in (value, cache, indices)):
+        return None
+
+    return value, cache, indices
+
+
+def is_update_cache_with_indices_dtype_supported(
+    node: torch.fx.Node, downcast_64_bit: bool = True
+) -> bool:
+    tensor_args = _get_update_cache_with_indices_tensor_args(node)
+    if tensor_args is None:
+        return False
+    indices_dtype = tensor_args[2].meta["val"].dtype
+    return indices_dtype == torch.int32 or (
+        indices_dtype == torch.int64 and downcast_64_bit
+    )
+
+
+def is_update_cache_with_indices_node_supported(node: torch.fx.Node) -> bool:
+    tensor_args = _get_update_cache_with_indices_tensor_args(node)
+    if tensor_args is None:
         return False
 
+    value, cache, indices = tensor_args
     value_meta = value.meta["val"]
     cache_meta = cache.meta["val"]
     indices_meta = indices.meta["val"]
@@ -1183,7 +1206,8 @@ def is_update_cache_with_indices_node_supported(node: torch.fx.Node) -> bool:
     return (
         value_meta.dtype in utils.FP_T
         and cache_meta.dtype == value_meta.dtype
-        and indices_meta.dtype == torch.int64
+        # The partitioner repeats this check with its actual downcast setting.
+        and is_update_cache_with_indices_dtype_supported(node)
         and len(value_shape) == 4
         and len(cache_shape) == 4
         and len(indices_shape) == 2
@@ -1203,7 +1227,12 @@ def register_update_cache_with_indices():
             utils.NO_STORAGE,  # start_pos
             utils.CONTIGUOUS_BUFFER,  # indices
         ],
-        inputs_dtypes=[utils.FP_T, utils.FP_T, utils.NONE_T, {torch.int64}],
+        inputs_dtypes=[
+            utils.FP_T,
+            utils.FP_T,
+            utils.NONE_T,
+            {torch.int32, torch.int64},
+        ],
         outputs_dtypes=utils.FP_T,
         supports_resize=True,
         are_node_inputs_supported_fn=is_update_cache_with_indices_node_supported,

--- a/backends/vulkan/partitioner/vulkan_partitioner.py
+++ b/backends/vulkan/partitioner/vulkan_partitioner.py
@@ -17,6 +17,7 @@ import torch
 from executorch.backends.vulkan.op_registry import (
     get_op_features,
     has_impl,
+    is_update_cache_with_indices_dtype_supported,
     OpFeatures,
     OpKey,
     vulkan_supported_ops,
@@ -60,6 +61,7 @@ class VulkanSupportedOperators(OperatorSupportBase):
         self,
         texture_limits: utils.ImageExtents,
         buffer_limit: int,
+        downcast_64_bit: bool = True,
         require_dynamic_shape: bool = False,
         skip_bool_tensors: bool = False,
         operator_blocklist: Optional[Set[OpKey]] = None,
@@ -70,7 +72,8 @@ class VulkanSupportedOperators(OperatorSupportBase):
     ) -> None:
         super().__init__()
         self.texture_limits: utils.ImageExtents = texture_limits
-        self.buffer_limit = buffer_limit
+        self.buffer_limit_bytes = buffer_limit
+        self.downcast_64_bit = downcast_64_bit
         self.require_dynamic_shapes = require_dynamic_shape
         self.skip_bool_tensors = skip_bool_tensors
         self.operator_blocklist: Set[OpKey] = (
@@ -264,6 +267,21 @@ class VulkanSupportedOperators(OperatorSupportBase):
             self.log_skip(node, dtype_reason)
             return False
 
+        target_name = target.name() if hasattr(target, "name") else target
+        if (
+            target_name == "llama::update_cache_with_indices"
+            and not is_update_cache_with_indices_dtype_supported(
+                node, self.downcast_64_bit
+            )
+        ):
+            self.log_skip(
+                node,
+                "int64 cache indices require downcast_64_bit=True",
+            )
+            return False
+
+        # Buffer-limited operators are currently ordinary ops. A future
+        # auto-functionalized user must first map these indices to HOP kwargs.
         for arg_index in features.buffer_limit_args:
             if arg_index >= len(node.args):
                 self.log_skip(node, f"missing buffer-limited input[{arg_index}]")
@@ -272,10 +290,11 @@ class VulkanSupportedOperators(OperatorSupportBase):
             if not isinstance(arg, torch.fx.Node) or not utils.is_tensor_node(arg):
                 self.log_skip(node, f"invalid buffer-limited input[{arg_index}]")
                 return False
-            if not utils.within_buffer_limit(arg, self.buffer_limit):
+            if not utils.within_buffer_limit(arg, self.buffer_limit_bytes):
                 self.log_skip(
                     node,
-                    f"input[{arg_index}] exceeds {self.buffer_limit}-element buffer limit",
+                    f"input[{arg_index}] exceeds "
+                    f"{self.buffer_limit_bytes}-byte buffer limit",
                 )
                 return False
 
@@ -417,12 +436,15 @@ class VulkanPartitioner(Partitioner):
             texture_limits = utils.SMALL_TEXTURE_LIMITS
         else:
             texture_limits = utils.DEFAULT_TEXTURE_LIMITS
-        buffer_limit: int = self.options.get("buffer_limit", utils.DEFAULT_BUFFER_LIMIT)
+        buffer_limit_bytes: int = self.options.get(
+            "buffer_limit", utils.DEFAULT_BUFFER_LIMIT
+        )
         capability_partitioner = CapabilityBasedPartitioner(
             exported_program.graph_module,
             VulkanSupportedOperators(
                 texture_limits,
-                buffer_limit,
+                buffer_limit_bytes,
+                downcast_64_bit=self.options.get("downcast_64_bit", True),
                 require_dynamic_shape=self.options.get("require_dynamic_shapes", False),
                 skip_bool_tensors=self.options.get("skip_bool_tensors", False),
                 operator_blocklist=self.operator_blocklist,

--- a/backends/vulkan/test/test_op_registry.py
+++ b/backends/vulkan/test/test_op_registry.py
@@ -14,6 +14,7 @@ from executorch.backends.vulkan.op_registry import (
     is_general_sdpa_node_supported,
     is_integer_remainder_scalar_node_supported,
     is_ring_sdpa_node_supported,
+    is_update_cache_with_indices_dtype_supported,
     is_update_cache_with_indices_node_supported,
     vulkan_supported_ops,
 )
@@ -23,6 +24,8 @@ from executorch.backends.vulkan.partitioner.vulkan_partitioner import (
 from executorch.backends.vulkan import utils
 from executorch.exir import to_edge
 from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.extension.llm.custom_ops import custom_ops as _custom_ops  # noqa: F401
+from torch._subclasses.fake_tensor import FakeTensorMode
 
 
 class TestCustomSDPASupport(TestCase):
@@ -47,6 +50,25 @@ class TestUpdateCacheWithIndicesSupport(TestCase):
         node.meta["val"] = SimpleNamespace(shape=shape, dtype=dtype)
         return node
 
+    @staticmethod
+    def _fx_node(indices_dtype):
+        graph = torch.fx.Graph()
+        with FakeTensorMode() as mode:
+            value = graph.placeholder("value")
+            value.meta["val"] = mode.from_tensor(torch.empty((1, 4, 8, 128)))
+            cache = graph.placeholder("cache")
+            cache.meta["val"] = mode.from_tensor(torch.empty((1, 32, 8, 128)))
+            indices = graph.placeholder("indices")
+            indices.meta["val"] = mode.from_tensor(
+                torch.empty((1, 4), dtype=indices_dtype)
+            )
+            node = graph.call_function(
+                exir_ops.edge.llama.update_cache_with_indices.default,
+                args=(value, cache, 0, indices),
+            )
+            node.meta["val"] = cache.meta["val"]
+        return node
+
     def test_accepts_production_contract(self) -> None:
         node = SimpleNamespace(
             target=None,
@@ -58,6 +80,46 @@ class TestUpdateCacheWithIndicesSupport(TestCase):
             ),
         )
         self.assertTrue(is_update_cache_with_indices_node_supported(node))
+
+    def test_accepts_int32_indices_without_downcast(self) -> None:
+        node = SimpleNamespace(
+            target=None,
+            args=(
+                self._tensor_node((1, 4, 8, 128)),
+                self._tensor_node((1, 32, 8, 128)),
+                0,
+                self._tensor_node((1, 4), torch.int32),
+            ),
+        )
+        self.assertTrue(is_update_cache_with_indices_node_supported(node))
+        self.assertTrue(
+            is_update_cache_with_indices_dtype_supported(node, downcast_64_bit=False)
+        )
+
+    def test_int64_indices_require_downcast(self) -> None:
+        node = SimpleNamespace(
+            target=None,
+            args=(
+                self._tensor_node((1, 4, 8, 128)),
+                self._tensor_node((1, 32, 8, 128)),
+                0,
+                self._tensor_node((1, 4), torch.int64),
+            ),
+        )
+        self.assertTrue(is_update_cache_with_indices_dtype_supported(node))
+        self.assertFalse(
+            is_update_cache_with_indices_dtype_supported(node, downcast_64_bit=False)
+        )
+
+    def test_partitioner_enforces_downcast_contract(self) -> None:
+        supported_ops = VulkanSupportedOperators(
+            utils.DEFAULT_TEXTURE_LIMITS,
+            buffer_limit=utils.DEFAULT_BUFFER_LIMIT,
+            downcast_64_bit=False,
+        )
+
+        self.assertTrue(supported_ops._is_node_supported(self._fx_node(torch.int32)))
+        self.assertFalse(supported_ops._is_node_supported(self._fx_node(torch.int64)))
 
     def test_rejects_batch_greater_than_one(self) -> None:
         node = SimpleNamespace(
@@ -123,7 +185,7 @@ class TestUpdateCacheWithIndicesSupport(TestCase):
                 (1, 4, 8, 128),
                 (1, 32, 8, 128),
                 (1, 4),
-                torch.int32,
+                torch.float32,
             ),
         )
         for value_shape, cache_shape, indices_shape, indices_dtype in cases:
@@ -305,12 +367,12 @@ class TestEmbeddingBufferLimit(TestCase):
         self.assertEqual(features.buffer_limit_args, (0,))
         self.assertFalse(
             VulkanSupportedOperators(
-                utils.DEFAULT_TEXTURE_LIMITS, buffer_limit=19
+                utils.DEFAULT_TEXTURE_LIMITS, buffer_limit=79
             )._is_node_supported(embedding_node)
         )
         self.assertTrue(
             VulkanSupportedOperators(
-                utils.DEFAULT_TEXTURE_LIMITS, buffer_limit=20
+                utils.DEFAULT_TEXTURE_LIMITS, buffer_limit=80
             )._is_node_supported(embedding_node)
         )
 

--- a/backends/vulkan/utils.py
+++ b/backends/vulkan/utils.py
@@ -777,18 +777,20 @@ class PackedDimInfo:
             raise ValueError(f"Unknown memory layout: {memory_layout}")
 
 
-def within_buffer_limit(node: torch.fx.Node, buffer_limit: int) -> bool:
+def within_buffer_limit(node: torch.fx.Node, buffer_limit_bytes: int) -> bool:
     """
     Checks whether the tensors produced by the given node can fit within the device's
-    GPU buffer limit, which represents the maximum number of elements that can be stored
-    in a GPU buffer.
+    GPU buffer limit, expressed in bytes.
     """
     assert is_tensor_node(node)
 
     if isinstance(node.meta["val"], FakeTensor):
-        return node.meta["val"].numel() <= buffer_limit
+        val = node.meta["val"]
+        return val.numel() * val.element_size() <= buffer_limit_bytes
     elif isinstance(node.meta["val"], list) or isinstance(node.meta["val"], tuple):
-        return all(x.numel() <= buffer_limit for x in node.meta["val"])
+        return all(
+            x.numel() * x.element_size() <= buffer_limit_bytes for x in node.meta["val"]
+        )
     else:
         raise RuntimeError(f"Cannot get numel for val of type {type(node.meta['val'])}")
 

--- a/examples/models/voxtral_realtime/export_voxtral_rt.py
+++ b/examples/models/voxtral_realtime/export_voxtral_rt.py
@@ -57,6 +57,27 @@ from executorch.exir.passes import MemoryPlanningPass
 from torch.export import Dim, export
 
 VULKAN_EXTERNAL_CONSTANTS_MAX_DATA_BYTES = 1_500_000_000
+TOKEN_EMBEDDING_TARGETS = {
+    "aten.embedding.default",
+    "quantized_decomposed.embedding_4bit.dtype",
+}
+
+
+def _token_embedding_weight_nbytes(program: torch.export.ExportedProgram) -> int:
+    weight_nbytes = []
+    for node in program.graph.nodes:
+        if str(node.target) not in TOKEN_EMBEDDING_TARGETS or not node.args:
+            continue
+        weight = node.args[0]
+        weight_val = getattr(weight, "meta", {}).get("val")
+        if isinstance(weight_val, torch.Tensor):
+            weight_nbytes.append(int(weight_val.numel()) * weight_val.element_size())
+    if len(weight_nbytes) != 1:
+        raise RuntimeError(
+            "Expected exactly one token embedding weight, "
+            f"found {len(weight_nbytes)}"
+        )
+    return weight_nbytes[0]
 
 
 # ---------------------------------------------------------------------------
@@ -625,8 +646,8 @@ def lower_to_executorch(
             if key in ("encode_audio_chunk", "text_decoder"):
                 compile_options["alias_buffer_mutations"] = True
             if key == "token_embedding":
-                compile_options["buffer_limit"] = (
-                    metadata["vocab_size"] * metadata["dim"]
+                compile_options["buffer_limit"] = _token_embedding_weight_nbytes(
+                    programs[key]
                 )
                 compile_options["storage_type_override"] = VkStorageType.BUFFER
             partitioner[key] = [VulkanPartitioner(compile_options=compile_options)]

--- a/examples/models/voxtral_realtime/tests/test_export_vulkan.py
+++ b/examples/models/voxtral_realtime/tests/test_export_vulkan.py
@@ -15,6 +15,7 @@ import torch
 from executorch.backends.vulkan.serialization.vulkan_graph_schema import VkStorageType
 from executorch.examples.models.voxtral_realtime.export_voxtral_rt import (
     _requires_explicit_output_weight_clone,
+    _token_embedding_weight_nbytes,
     audit_vulkan_delegation,
     export_streaming,
     lower_to_executorch,
@@ -225,6 +226,27 @@ class TestVulkanExportOptions(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     validate_vulkan_options(self.make_args(**overrides), parser)
 
+    def test_token_embedding_weight_match_is_exact_and_unique(self):
+        weight = torch.empty((64, 32), device="meta")
+        embedding = SimpleNamespace(
+            target=torch.ops.aten.embedding.default,
+            args=(SimpleNamespace(meta={"val": weight}),),
+        )
+        unrelated = SimpleNamespace(
+            target="custom.embedding_projection.default",
+            args=(SimpleNamespace(meta={"val": torch.empty(7, device="meta")}),),
+        )
+        program = SimpleNamespace(graph=SimpleNamespace(nodes=[unrelated, embedding]))
+
+        self.assertEqual(_token_embedding_weight_nbytes(program), 64 * 32 * 4)
+
+        embedding.target = "quantized_decomposed.embedding_4bit.dtype"
+        self.assertEqual(_token_embedding_weight_nbytes(program), 64 * 32 * 4)
+
+        program.graph.nodes.append(embedding)
+        with self.assertRaisesRegex(RuntimeError, "found 2"):
+            _token_embedding_weight_nbytes(program)
+
     @patch(
         "executorch.backends.vulkan.partitioner.vulkan_partitioner.VulkanPartitioner"
     )
@@ -247,6 +269,13 @@ class TestVulkanExportOptions(unittest.TestCase):
             "text_decoder": MagicMock(),
             "token_embedding": MagicMock(),
         }
+        weight = torch.empty((131072, 3072), device="meta")
+        programs["token_embedding"].graph.nodes = [
+            SimpleNamespace(
+                target=torch.ops.aten.embedding.default,
+                args=(SimpleNamespace(meta={"val": weight}),),
+            )
+        ]
         metadata = {"vocab_size": 131072, "dim": 3072}
 
         lower_to_executorch(programs, metadata, backend="vulkan")
@@ -278,7 +307,7 @@ class TestVulkanExportOptions(unittest.TestCase):
                         "external_constants_max_data_bytes": (
                             VULKAN_EXTERNAL_CONSTANTS_MAX_DATA_BYTES
                         ),
-                        "buffer_limit": 402653184,
+                        "buffer_limit": 1610612736,
                         "storage_type_override": VkStorageType.BUFFER,
                     }
                 ),
@@ -309,6 +338,14 @@ class TestVulkanExportOptions(unittest.TestCase):
             "text_decoder": MagicMock(),
             "token_embedding": MagicMock(),
         }
+        programs["token_embedding"].graph.nodes = [
+            SimpleNamespace(
+                target=torch.ops.aten.embedding.default,
+                args=(
+                    SimpleNamespace(meta={"val": torch.empty((64, 32), device="meta")}),
+                ),
+            )
+        ]
         metadata = {"vocab_size": 131072, "dim": 3072}
 
         lower_to_executorch(


### PR DESCRIPTION
Partitioning must size the exact embedding weight and keep buffer and
indexed-cache dtype checks consistent with runtime contracts.

AI-assisted-by: Codex

This PR was authored with assistance from Codex.

cc @SS-JIA @manuelcandales @cbilgin