### PR TITLE
[executorch][native] Claim getitem in the partitioner

### DIFF
--- a/backends/native/partitioner.py
+++ b/backends/native/partitioner.py
@@ -13,6 +13,7 @@ cleanup (CSE, reinplace) runs before lowering via transform_passes, since
 ExecuTorch forbids a partitioner from mutating the graph module.
 """
 
+import operator
 from typing import Callable, final, List, Mapping, Optional, Tuple
 
 import torch
@@ -65,6 +66,16 @@ class NativeSupportedOperators(OperatorSupportBase):
             return False
         if isinstance(node.target, torch._ops.HigherOrderOperator):
             return False
+
+        # A multi-output op's results are read through getitem, which the
+        # serializer folds into the producer's Output list. Rejecting it makes
+        # every such op a partition barrier. Claim it only when its producer is
+        # claimed, so an undelegated producer cannot leave a lone getitem behind.
+        if node.target is operator.getitem:
+            producer = node.args[0] if node.args else None
+            return isinstance(producer, Node) and self.is_node_supported(
+                submodules, producer
+            )
 
         from executorch.exir.dialects.edge._ops import EdgeOpOverload
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22471
* #22470
* #22469
* #22468
* #22467
* __->__ #22466

`NativeSupportedOperators.is_node_supported` rejected `operator.getitem`
because it is not an `OpOverload`, and every rejected node is a merge barrier
for `CapabilityBasedPartitioner`. Each multi-output op therefore split the
graph: `mobilenet_v2` reads all 52 of its
`_native_batch_norm_legit_no_training` results through a `getitem`, and
partitioned into 53 delegates.

That was only an inefficiency on the PTE path, which tolerates any number of
delegates. `to_native` requires exactly one delegate covering the whole method,
so the same gap now fails lowering outright and no CNN could be packaged as a
`.ptn`.

The fix claims `getitem` when its producer is claimed rather than
unconditionally, so an undelegated producer cannot leave a lone `getitem`
partition behind. This is sound because the serializer already folds `getitem`
into the producing node's `Output` list, which is what the `topk` and `split`
cases cover.

Differential Revision: [D118480650](https://our.internmc.facebook.com/intern/diff/D118480650/)