### PR TITLE
Run a recipe's edge-manager passes after partitioning

### DIFF
--- a/export/export.py
+++ b/export/export.py
@@ -283,13 +283,17 @@ class ExportSession:
         if self._input_model_type != "ExportedProgram":
             stages.append(StageType.TORCH_EXPORT)
 
-        # Always include edge and executorch stages
-        stages.extend(
-            [
-                StageType.TO_EDGE_TRANSFORM_AND_LOWER,
-                StageType.TO_EXECUTORCH,
-            ]
-        )
+        stages.append(StageType.TO_EDGE_TRANSFORM_AND_LOWER)
+
+        # This is the only stage that runs edge_manager_transform_passes, so a
+        # recipe declaring them would otherwise have them silently dropped.
+        if (
+            self._lowering_recipe
+            and self._lowering_recipe.edge_manager_transform_passes
+        ):
+            stages.append(StageType.EDGE_PROGRAM_MANAGER_TRANSFORM)
+
+        stages.append(StageType.TO_EXECUTORCH)
 
         return stages
 

--- a/export/stages.py
+++ b/export/stages.py
@@ -702,7 +702,7 @@ class EdgeProgramManagerTransformStage(Stage):
     def valid_predecessor_stages(self) -> List["StageType"]:
         return [
             StageType.TO_EDGE,
-            # StageType.TO_EDGE_TRANSFORM_AND_LOWER,  # TODO
+            StageType.TO_EDGE_TRANSFORM_AND_LOWER,
         ]
 
     @property

--- a/export/tests/test_export_session.py
+++ b/export/tests/test_export_session.py
@@ -642,6 +642,36 @@ class TestExportSessionExtendedInputTypes(unittest.TestCase):
         pipeline = session._get_default_pipeline()
         self.assertNotIn(StageType.TORCH_EXPORT, pipeline)
 
+    def test_edge_manager_transform_passes_get_their_stage(self) -> None:
+        # Nothing else in the default pipeline runs them, so without this the
+        # recipe's passes are accepted and then silently never applied.
+        session = ExportSession(
+            model=self.model,
+            example_inputs=[self.example_inputs],
+            export_recipe=ExportRecipe(
+                name="t",
+                lowering_recipe=LoweringRecipe(
+                    edge_manager_transform_passes=[lambda epm: []]
+                ),
+            ),
+        )
+        pipeline = session._get_default_pipeline()
+        self.assertIn(StageType.EDGE_PROGRAM_MANAGER_TRANSFORM, pipeline)
+        self.assertGreater(
+            pipeline.index(StageType.EDGE_PROGRAM_MANAGER_TRANSFORM),
+            pipeline.index(StageType.TO_EDGE_TRANSFORM_AND_LOWER),
+        )
+
+    def test_no_transform_passes_means_no_stage(self) -> None:
+        session = ExportSession(
+            model=self.model,
+            example_inputs=[self.example_inputs],
+            export_recipe=self.recipe,
+        )
+        self.assertNotIn(
+            StageType.EDGE_PROGRAM_MANAGER_TRANSFORM, session._get_default_pipeline()
+        )
+
     def test_example_inputs_required_for_nn_module(self) -> None:
         """Test that example_inputs are required for nn.Module."""
         with self.assertRaises(ValueError) as cm:

--- a/export/tests/test_export_stages.py
+++ b/export/tests/test_export_stages.py
@@ -1231,6 +1231,15 @@ class TestEmptyPassDictIsNotApplied(unittest.TestCase):
         manager.exported_program.return_value = Mock()
         return manager
 
+    def test_edge_program_manager_stage_may_follow_partitioning(self) -> None:
+        # The point of the stage for a delegate recipe: its passes act on what
+        # the partitioner left outside the delegates, so it has to be able to
+        # run after TO_EDGE_TRANSFORM_AND_LOWER and not only after TO_EDGE.
+        self.assertEqual(
+            set(EdgeProgramManagerTransformStage().valid_predecessor_stages),
+            {StageType.TO_EDGE, StageType.TO_EDGE_TRANSFORM_AND_LOWER},
+        )
+
     def test_edge_program_manager_stage_skips_empty_transform(self) -> None:
         manager = self._manager()
         stage = EdgeProgramManagerTransformStage(


### PR DESCRIPTION
### Summary
`LoweringRecipe.edge_manager_transform_passes` has been accepted since the field
was added, but nothing ran it in a default pipeline: the stage that applies it
was never scheduled, and it could only follow `TO_EDGE`, never the partitioning
stage. A recipe declaring such passes had them silently dropped.

Both halves are needed together. Scheduling the stage without allowing it after
`TO_EDGE_TRANSFORM_AND_LOWER` fails pipeline validation, and allowing it there
without scheduling leaves the passes unreachable.

Running after partitioning is the point rather than an incidental ordering. The
passes a backend wants here act on what the partitioner left outside the
delegates -- rewriting the boundary quantize/dequantize pairs, for instance --
so running them earlier would either find nothing or feed the partitioner a
graph it no longer recognises. The commented-out predecessor this enables was
raised in #21516; NXP Neutron wants the same hook.

Authored with Claude Code.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>