### PR TITLE
Honor range-learned scales in the tied embedding quantization path (#22476)

### DIFF
--- a/examples/models/llama/source_transformation/quantize.py
+++ b/examples/models/llama/source_transformation/quantize.py
@@ -776,6 +776,7 @@ def get_quant_embedding_transform(
     embedding_quantize: str,
     use_shared_embedding: bool = False,
     quantize_with_hqq: bool = True,
+    range_learning: bool = False,
 ):
     if embedding_quantize.startswith("torchao:"):
         from torchao.prototype.quantization.embedding.api import (
@@ -819,6 +820,7 @@ def get_quant_embedding_transform(
                         weight_dtype=weight_dtype,
                         granularity=granularity,
                         mapping_type=mapping_type,
+                        range_learning=range_learning,
                     ).quantize(model)
             return model
 


### PR DESCRIPTION
Summary:

X-link: https://github.com/pytorch/ao/pull/4863

For a `share_emb: true` checkpoint trained with
`weight_quantization_min_max_learning: true`, the tied embedding path silently
discarded every range-learned weight scale and re-derived qparams from the
dequantized weights. The untied path did not, so the same checkpoint exported
two ways differed by ~6.5 dB SNR against the rlformers reference.

Learned ranges survive export only via `QATConfig(step="convert")`, whose
transform pulls `custom_scale`/`custom_zero_point` off the module's
`weight_fake_quantizer` and disables qparam re-derivation. The untied path wraps
both its embedding and linear configs in it. `TiedEmbeddingQuantizer` used a bare
`Int8DynamicActivationIntxWeightConfig`, so the convert step never ran.

`_apply_embedding_quantization` already receives `range_learning`, but returned
early into `apply_torchao_embedding_quantization` without forwarding it. Thread
it through to `TiedEmbeddingQuantizer` and wrap its config the same way the
non-shared path does.

The `QATConfig` import in `TiedEmbeddingQuantizer` is function-local:
`torchao.quantization.qat` pulls in `torchao.prototype.qat`, which cycles back
through this module at import time.

Only the tied path changes. `EmbeddingQuantizer` (torchao embedding quantization
without shared embeddings) has the same gap and is left alone here.

Reviewed By: YIWENX14

Differential Revision: D118365125


