### PR TITLE
[ET-VK] Keep unused placeholders in the delegate's input list

### DIFF
--- a/backends/vulkan/serialization/vulkan_graph_builder.py
+++ b/backends/vulkan/serialization/vulkan_graph_builder.py
@@ -418,15 +418,26 @@ class VkGraphBuilder:
             raise RuntimeError(f"Cannot create value for arg of type {type(arg)}")
 
     def process_placeholder_node(self, node: Node) -> None:
-        # ignores any tensors that don't get used in any ops
-        if len(node.users) == 0:
+        # A non-param placeholder occupies a slot in the delegate call's
+        # argument list whether or not this graph goes on to use it, and
+        # VulkanBackend::execute matches `args` to graph inputs positionally.
+        # Dropping an unused one from input_ids desynchronises the two, and the
+        # runtime then rejects the call because it was handed more arguments
+        # than the graph declares inputs and outputs. That happens in practice
+        # when a placeholder's only consumers are folded away by the passes
+        # that run after partitioning, so the graph the partitioner tagged and
+        # the graph serialized here disagree about which inputs are live.
+        if is_param_node(self.program, node):
+            # Params are serialized into the blob rather than passed at call
+            # time, so an unused one costs nothing to skip.
+            if len(node.users) > 0:
+                self.create_node_value(node)
             return None
         ids = self.create_node_value(node)
-        if not is_param_node(self.program, node):
-            if isinstance(ids, int):
-                self.input_ids.append(ids)
-            else:
-                self.input_ids += ids
+        if isinstance(ids, int):
+            self.input_ids.append(ids)
+        else:
+            self.input_ids += ids
 
     def process_getitem_node(self, node: Node) -> None:
         # Find ValueList id from the collection node.

--- a/backends/vulkan/test/test_vulkan_graph_builder.py
+++ b/backends/vulkan/test/test_vulkan_graph_builder.py
@@ -1,0 +1,62 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from executorch.backends.vulkan.serialization.vulkan_graph_builder import (
+    VkGraphBuilder,
+)
+from executorch.backends.vulkan.vulkan_preprocess import apply_passes
+from executorch.exir import to_edge
+from executorch.exir.backend.utils import DelegateMappingBuilder
+from executorch.exir.passes import SpecPropPass
+
+
+class TestVkGraphBuilderInputIds(unittest.TestCase):
+    """The serialized input list has to match the delegate call's arguments.
+
+    VulkanBackend::execute walks `args` positionally against
+    ComputeGraph::inputs() and rejects the call when the counts disagree, so
+    every placeholder that the delegate call passes must appear in input_ids,
+    including ones this graph happens not to use. Unused placeholders are not
+    hypothetical: passes that run after partitioning can fold away a
+    placeholder's only consumers, leaving the argument list and the serialized
+    graph out of step.
+    """
+
+    def _build(self, module: torch.nn.Module, inputs) -> VkGraphBuilder:
+        edge = to_edge(torch.export.export(module, inputs, strict=True))
+        # The builder reads node specs, which the backend's own preprocess
+        # populates before it gets here.
+        program = apply_passes(edge.exported_program(), [SpecPropPass()])
+        builder = VkGraphBuilder(
+            program, DelegateMappingBuilder(generated_identifiers=True)
+        )
+        builder.build_graph()
+        return builder
+
+    def test_unused_placeholder_is_still_declared_as_an_input(self) -> None:
+        class UsesOnlyTheFirstInput(torch.nn.Module):
+            def forward(self, used, unused):
+                return used + used
+
+        builder = self._build(
+            UsesOnlyTheFirstInput(), (torch.randn(2, 3), torch.randn(2, 3))
+        )
+        self.assertEqual(len(builder.input_ids), 2)
+
+    def test_used_placeholders_are_declared_in_order(self) -> None:
+        class UsesBothInputs(torch.nn.Module):
+            def forward(self, first, second):
+                return first + second
+
+        builder = self._build(UsesBothInputs(), (torch.randn(2, 3), torch.randn(2, 3)))
+        self.assertEqual(len(builder.input_ids), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backends/vulkan/test/test_vulkan_graph_builder.py
+++ b/backends/vulkan/test/test_vulkan_graph_builder.py
@@ -7,9 +7,7 @@
 import unittest
 
 import torch
-from executorch.backends.vulkan.serialization.vulkan_graph_builder import (
-    VkGraphBuilder,
-)
+from executorch.backends.vulkan.serialization.vulkan_graph_builder import VkGraphBuilder
 from executorch.backends.vulkan.vulkan_preprocess import apply_passes
 from executorch.exir import to_edge
 from executorch.exir.backend.utils import DelegateMappingBuilder


### PR DESCRIPTION
Fixes #22478.

`VulkanBackend::execute` matches its `args` positionally against `ComputeGraph::inputs()`, but `process_placeholder_node` drops any placeholder with no users before it reaches `input_ids`. The delegate call still passes that argument, so the counts disagree and the model fails at every `execute()` with "Vulkan graph declares N inputs and M outputs, but the delegate call supplied K arguments".

A placeholder can lose its only consumers to the passes that run inside `preprocess`, after partitioning has already fixed the call's argument list. A qwen3 0.6B export with attention kept on the host hits this: the final partition is handed 28 per-layer symints that nothing in the subgraph consumes by serialization time, and declares 2 inputs and 1 output against a 31 argument call.

Params keep the existing skip, since they are serialized into the blob rather than passed at call time.

Test: `test_unused_placeholder_is_still_declared_as_an_input` fails on `main` and passes with the change; the companion test covering used placeholders passes either way. `test_serialization.py`, `test_vulkan_compile_options.py` and `test_vulkan_passes.py` (17 tests) still pass.