### PR TITLE
Fix nondeterministic mypy CI dependencies and lint error exposed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,16 +41,22 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: requirements-lintrunner.txt
+          cache-dependency-path: |
+            requirements-lintrunner.txt
+            torch_pin.py
 
       - name: Install dependencies
         run: |
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          TORCH_VERSION=$(python -c "from torch_pin import TORCH_VERSION; print(TORCH_VERSION)")
+          pip install \
+            "torch==${TORCH_VERSION}" \
+            torchvision \
+            torchaudio \
+            --index-url https://download.pytorch.org/whl/cpu
           pip install lintrunner==0.12.7 lintrunner-adapters==0.14.1
           pip install -r requirements-lintrunner.txt
           USE_CPP=0 pip install --no-build-isolation third-party/ao
           pip install pytest numpy parameterized huggingface_hub transformers timm expecttest types-requests
-          pip install torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 
       - name: Generate mypy stubs for C++ bindings
         run: |

--- a/backends/arm/_passes/rewrite_conv_pass.py
+++ b/backends/arm/_passes/rewrite_conv_pass.py
@@ -528,7 +528,7 @@ class RewriteConvPass(ArmPass):
             node.op == "call_function"
             and node.target == exir_ops.backend.tosa.RESCALE.default
             and len(node.args) > 1
-            and node.args[1] == torch.int32
+            and node.args[1] is torch.int32
         )
 
     def _get_direct_int32_rescale_users(

--- a/backends/arm/tosa/dialect/ops/resize.py
+++ b/backends/arm/tosa/dialect/ops/resize.py
@@ -96,6 +96,8 @@ def RESIZE(
     validation_error = get_tosa_resize_output_hw_validation_error(output_hw)
     if validation_error is not None:
         raise TosaValueError(validation_error, op="RESIZE")
+    OH: int | torch.SymInt
+    OW: int | torch.SymInt
     if output_hw is None:
         scale_y_n, scale_y_d, scale_x_n, scale_x_d = scale
         offset_y, offset_x = offset

--- a/backends/arm/tosa/partitioner.py
+++ b/backends/arm/tosa/partitioner.py
@@ -50,6 +50,7 @@ from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.graph_module import get_cond_while_submodules
 from torch.export.exported_program import ExportedProgram
 from torch.fx import GraphModule
+from torch.fx.experimental.symbolic_shapes import statically_known_true
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner, Partition
 from torch.fx.passes.operator_support import any_chain, OperatorSupportBase
 
@@ -152,9 +153,22 @@ def _is_noop_as_strided_copy(node: torch.fx.Node) -> bool:
         input_tensor = get_first_fake_tensor(ensure_type(torch.fx.Node, node.args[0]))
         output_tensor = get_first_fake_tensor(node)
         return (
-            input_tensor.shape == output_tensor.shape
-            and input_tensor.stride() == output_tensor.stride()
-            and input_tensor.storage_offset() == output_tensor.storage_offset()
+            len(input_tensor.shape) == len(output_tensor.shape)
+            and all(
+                statically_known_true(input_dim == output_dim)
+                for input_dim, output_dim in zip(
+                    input_tensor.shape, output_tensor.shape
+                )
+            )
+            and all(
+                statically_known_true(input_stride == output_stride)
+                for input_stride, output_stride in zip(
+                    input_tensor.stride(), output_tensor.stride()
+                )
+            )
+            and statically_known_true(
+                input_tensor.storage_offset() == output_tensor.storage_offset()
+            )
         )
 
 


### PR DESCRIPTION
Pin the mypy job to the repository's Torch 2.13 stack before installing timm, and include the Torch pin in its pip cache key. This makes it deterministic instead of depending on order of resolution.

Adapt Arm shape and dtype checks to the SymInt and SymBool annotations exposed by newer Torch releases.



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani