### PR TITLE
[executorch][muse-glimmer] Run DFlash sampling on CUDA

### DIFF
--- a/examples/models/muse-glimmer/CMakeLists.txt
+++ b/examples/models/muse-glimmer/CMakeLists.txt
@@ -53,6 +53,17 @@ list(
 # Backend: CUDA or MLX (exactly one required)
 if(EXECUTORCH_BUILD_CUDA)
   find_package(CUDAToolkit REQUIRED)
+  enable_language(CUDA)
+  add_library(muse_glimmer_sampling_cuda STATIC runtime/engine/sampling_cuda.cu)
+  set_target_properties(
+    muse_glimmer_sampling_cuda
+    PROPERTIES CUDA_STANDARD 17 CUDA_STANDARD_REQUIRED ON
+  )
+  target_include_directories(
+    muse_glimmer_sampling_cuda PUBLIC ${_common_include_directories}
+  )
+  target_link_libraries(muse_glimmer_sampling_cuda PUBLIC CUDA::cudart)
+  list(APPEND link_libraries muse_glimmer_sampling_cuda)
   list(APPEND link_libraries aoti_cuda_backend)
   executorch_target_link_options_shared_lib(aoti_cuda_backend)
   add_compile_definitions(EXECUTORCH_BUILD_CUDA)

--- a/examples/models/muse-glimmer/export/export_dflash.py
+++ b/examples/models/muse-glimmer/export/export_dflash.py
@@ -681,6 +681,26 @@ def _export_dflash_cuda(
     )
     gc.collect()
 
+    # The whole target path is device-resident so the DFlash decode loop never
+    # round-trips activations through the host: embed_text takes the candidate
+    # token ids straight from CUDA and hands its embeddings to the target without
+    # a copy. Host callers (prefill, the image splice, the host-sampler baseline)
+    # stage their own inputs with clone_tensor_ptr_to and read outputs back with
+    # an explicit device-to-host copy.
+    device_resident = PropagateDeviceConfig(
+        skip_h2d_for_method_inputs=True,
+        skip_d2h_for_method_outputs=True,
+    )
+    propagate_device_config = {
+        "embed_text": device_resident,
+        "target_forward_from_embeddings": device_resident,
+        "target_prefill_from_embeddings": device_resident,
+        # draft_forward/draft_prefill still take host tokens and host target
+        # hidden state; only their logits stay on device for CUDA sampling.
+        "draft_forward": PropagateDeviceConfig(skip_d2h_for_method_outputs=True),
+        "draft_prefill": PropagateDeviceConfig(skip_d2h_for_method_outputs=True),
+    }
+
     et_program = et_prog.to_executorch(
         config=ExecutorchBackendConfig(
             extract_delegate_segments=True,
@@ -690,14 +710,7 @@ def _export_dflash_cuda(
                 share_mutable_buffers=_share_graph_mutable_buffers("cuda"),
             ),
             emit_mutable_buffer_names=True,
-            propagate_device_config={
-                "target_prefill_from_embeddings": PropagateDeviceConfig(
-                    skip_d2h_for_method_outputs=True
-                ),
-                "draft_prefill": PropagateDeviceConfig(
-                    skip_d2h_for_method_outputs=True
-                ),
-            },
+            propagate_device_config=propagate_device_config,
         ),
     )
 

--- a/examples/models/muse-glimmer/runtime/engine/dflash_session.cpp
+++ b/examples/models/muse-glimmer/runtime/engine/dflash_session.cpp
@@ -9,6 +9,10 @@
 #include <executorch/examples/models/muse-glimmer/runtime/engine/dflash_session.h>
 
 #include <executorch/examples/models/muse-glimmer/runtime/engine/sampling.h>
+#ifdef EXECUTORCH_BUILD_CUDA
+#include <executorch/backends/aoti/slim/cuda/guard.h>
+#include <executorch/examples/models/muse-glimmer/runtime/engine/sampling_cuda.h>
+#endif
 #include <executorch/extension/tensor/tensor.h>
 #include <executorch/runtime/platform/log.h>
 
@@ -36,6 +40,10 @@ namespace executorch::extension::llm {
 namespace {
 
 using ::executorch::extension::from_blob;
+#ifdef EXECUTORCH_BUILD_CUDA
+using ::executorch::extension::clone_tensor_ptr_to;
+using ::executorch::extension::make_tensor_ptr;
+#endif
 using ::executorch::runtime::Error;
 using ::executorch::runtime::EValue;
 using ::executorch::runtime::Result;
@@ -50,6 +58,7 @@ constexpr const char* kEmbedText = "embed_text";
 constexpr const char* kDraftForward = "draft_forward";
 constexpr const char* kDraftPrefill = "draft_prefill";
 constexpr const char* kMaxContextLen = "get_max_seq_len";
+constexpr const char* kVocabSize = "get_vocab_size";
 
 bool valid_temperature(float temperature) {
   return temperature == -1.0f || (temperature >= 0.0f && temperature <= 2.0f);
@@ -283,10 +292,12 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
     sampling_ = sampling;
     sampling_initialized_ = true;
     seed_rng(sampling_);
+#ifndef EXECUTORCH_BUILD_CUDA
     if (effective_temperature() > 0.0 && n_draft_ > 1 &&
         probability_workers_ == nullptr) {
       probability_workers_ = std::make_unique<ProbabilityWorkers>(n_draft_);
     }
+#endif
     stop_.store(false, std::memory_order_relaxed);
 
     const int64_t token_count = static_cast<int64_t>(tokens.size());
@@ -539,18 +550,238 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
       std::random_device random;
       std::seed_seq seed{random(), random()};
       rng_.seed(seed);
+#ifdef EXECUTORCH_BUILD_CUDA
+      cuda_sampling_seed_ = (static_cast<uint64_t>(random()) << 32) | random();
+      cuda_sampling_seed_initialized_ = false;
+#endif
       return;
     }
     std::seed_seq seed{
         static_cast<uint32_t>(sampling.seed),
         static_cast<uint32_t>(sampling.seed >> 32)};
     rng_.seed(seed);
+#ifdef EXECUTORCH_BUILD_CUDA
+    cuda_sampling_seed_ = sampling.seed;
+    cuda_sampling_seed_initialized_ = false;
+#endif
   }
 
   int64_t max_context_len() const {
     const auto it = config_.metadata.find(kMaxContextLen);
     return it == config_.metadata.end() ? 0 : it->second;
   }
+
+#ifdef EXECUTORCH_BUILD_CUDA
+  // The CUDA target methods are exported device-in/device-out, so every input
+  // they receive must already live on the device and every output they return
+  // stays there. These buffers back that calling convention: the decode loop
+  // reuses them across cycles, and host callers stage into them instead of
+  // letting the runtime insert a copy.
+  Error ensure_cuda_device_buffers() {
+    const auto vocab_it = config_.metadata.find(kVocabSize);
+    const int64_t context_length = max_context_len();
+    ET_CHECK_OR_RETURN_ERROR(
+        vocab_it != config_.metadata.end() && vocab_it->second > 0 &&
+            context_length > 0,
+        InvalidProgram,
+        "CUDA DFlash requires positive vocabulary and context sizes");
+    if (cuda_candidates_ == nullptr) {
+      cuda_vocab_size_ = vocab_it->second;
+      const auto cuda_device =
+          executorch::aten::Device(executorch::aten::DeviceType::CUDA, 0);
+      std::vector<int64_t> zeros(block_length_, 0);
+      cuda_candidates_ = clone_tensor_ptr_to(
+          from_blob(
+              zeros.data(),
+              {1, static_cast<SizesType>(block_length_)},
+              executorch::aten::ScalarType::Long),
+          cuda_device);
+      cuda_target_tokens_ = clone_tensor_ptr_to(
+          from_blob(
+              zeros.data(),
+              {static_cast<SizesType>(block_length_)},
+              executorch::aten::ScalarType::Long),
+          cuda_device);
+      std::vector<int64_t> scalar(1, 0);
+      cuda_accepted_count_ = clone_tensor_ptr_to(
+          from_blob(scalar.data(), {1}, executorch::aten::ScalarType::Long),
+          cuda_device);
+      cuda_correction_token_ = clone_tensor_ptr_to(
+          from_blob(scalar.data(), {1}, executorch::aten::ScalarType::Long),
+          cuda_device);
+      std::vector<float> probabilities(block_length_ * cuda_vocab_size_);
+      cuda_target_probabilities_ = clone_tensor_ptr_to(
+          from_blob(
+              probabilities.data(),
+              {static_cast<SizesType>(block_length_),
+               static_cast<SizesType>(cuda_vocab_size_)},
+              executorch::aten::ScalarType::Float),
+          cuda_device);
+      cuda_draft_probabilities_ = clone_tensor_ptr_to(
+          from_blob(
+              probabilities.data(),
+              {static_cast<SizesType>(block_length_),
+               static_cast<SizesType>(cuda_vocab_size_)},
+              executorch::aten::ScalarType::Float),
+          cuda_device);
+      std::vector<int64_t> positions(context_length);
+      std::iota(positions.begin(), positions.end(), 0);
+      cuda_position_table_ = clone_tensor_ptr_to(
+          from_blob(
+              positions.data(),
+              {static_cast<SizesType>(context_length)},
+              executorch::aten::ScalarType::Long),
+          cuda_device);
+      // Prefill feeds far wider token spans than a decode cycle, so the host
+      // staging buffer is sized for the widest target call the session can make.
+      cuda_staged_token_capacity_ = std::max<int64_t>(
+          {block_length_,
+           config_.max_target_prefill_chunk,
+           kCudaDFlashHiddenRows});
+      std::vector<int64_t> staging(cuda_staged_token_capacity_, 0);
+      cuda_staged_tokens_ = clone_tensor_ptr_to(
+          from_blob(
+              staging.data(),
+              {1, static_cast<SizesType>(cuda_staged_token_capacity_)},
+              executorch::aten::ScalarType::Long),
+          cuda_device);
+    }
+
+    return Error::Ok;
+  }
+
+  TensorPtr device_view(
+      std::vector<SizesType> sizes,
+      void* data,
+      executorch::aten::ScalarType dtype) const {
+    return make_tensor_ptr(
+        std::move(sizes),
+        data,
+        dtype,
+        executorch::aten::Device(executorch::aten::DeviceType::CUDA, 0),
+        executorch::aten::TensorShapeDynamism::DYNAMIC_BOUND);
+  }
+
+  // TODO(gasoonjia): an odd start_pos leaves this view 8- but not 16-byte
+  // aligned, so AOTI copies it into an aligned temporary on every target call.
+  // Staging positions into a base-aligned buffer would only move that copy
+  // here, but it would stop the backend logging it as an error.
+  TensorPtr cuda_position_view(int64_t start_pos, int64_t count) const {
+    return device_view(
+        {static_cast<SizesType>(count)},
+        static_cast<int64_t*>(cuda_position_table_->mutable_data_ptr()) +
+            start_pos,
+        executorch::aten::ScalarType::Long);
+  }
+
+  Result<TensorPtr> stage_cuda_tokens(const uint64_t* tokens, int64_t count) {
+    static_assert(sizeof(uint64_t) == sizeof(int64_t));
+    ET_CHECK_OR_RETURN_ERROR(
+        count > 0 && count <= cuda_staged_token_capacity_,
+        InvalidArgument,
+        "CUDA target token count %" PRId64 " exceeds staged capacity %" PRId64,
+        count,
+        cuda_staged_token_capacity_);
+    auto* destination =
+        static_cast<int64_t*>(cuda_staged_tokens_->mutable_data_ptr());
+    ET_CHECK_OR_RETURN_ERROR(
+        cudaMemcpyAsync(
+            destination,
+            tokens,
+            count * sizeof(int64_t),
+            cudaMemcpyHostToDevice,
+            *cuda_execution_stream_) == cudaSuccess,
+        Internal,
+        "CUDA target token staging failed");
+    return device_view(
+        {1, static_cast<SizesType>(count)},
+        destination,
+        executorch::aten::ScalarType::Long);
+  }
+
+  // Only the image-splice path needs this: it rewrites patch rows on the host
+  // and has to hand the result back to the device-input target.
+  Result<TensorPtr> stage_cuda_embeddings(
+      const uint16_t* embeddings,
+      int64_t count,
+      int64_t embed_dim) {
+    if (cuda_staged_embeddings_ == nullptr) {
+      std::vector<uint16_t> zeros(
+          cuda_staged_token_capacity_ * embed_dim, uint16_t{0});
+      cuda_staged_embeddings_ = clone_tensor_ptr_to(
+          from_blob(
+              zeros.data(),
+              {static_cast<SizesType>(cuda_staged_token_capacity_),
+               static_cast<SizesType>(embed_dim)},
+              hidden_dtype_),
+          executorch::aten::Device(executorch::aten::DeviceType::CUDA, 0));
+    }
+    ET_CHECK_OR_RETURN_ERROR(
+        count * embed_dim <= cuda_staged_embeddings_->numel(),
+        InvalidArgument,
+        "CUDA spliced embeddings exceed the staged capacity");
+    auto* destination =
+        static_cast<uint16_t*>(cuda_staged_embeddings_->mutable_data_ptr());
+    ET_CHECK_OR_RETURN_ERROR(
+        cudaMemcpyAsync(
+            destination,
+            embeddings,
+            count * embed_dim * sizeof(uint16_t),
+            cudaMemcpyHostToDevice,
+            *cuda_execution_stream_) == cudaSuccess,
+        Internal,
+        "CUDA spliced embedding staging failed");
+    return device_view(
+        {1, static_cast<SizesType>(count), static_cast<SizesType>(embed_dim)},
+        destination,
+        hidden_dtype_);
+  }
+
+  Error prepare_cuda_sampling_workspaces(cudaStream_t stream) {
+    cudaError_t error = cuda_target_sampling_workspace_.reserve(
+        n_draft_ + 1, cuda_vocab_size_, stream);
+    if (error == cudaSuccess) {
+      error = cuda_draft_sampling_workspace_.reserve(
+          n_draft_, cuda_vocab_size_, stream);
+    }
+    if (error == cudaSuccess) {
+      error =
+          cuda_single_sampling_workspace_.reserve(1, cuda_vocab_size_, stream);
+    }
+    ET_CHECK_OR_RETURN_ERROR(
+        error == cudaSuccess,
+        Internal,
+        "CUDA DFlash sampling workspace allocation failed: %s",
+        cudaGetErrorString(error));
+    if (!cuda_sampling_seed_initialized_) {
+      error =
+          cuda_target_sampling_workspace_.set_seed(cuda_sampling_seed_, stream);
+      if (error == cudaSuccess) {
+        error = cuda_draft_sampling_workspace_.set_seed(
+            cuda_sampling_seed_ ^ 0x9e3779b97f4a7c15ULL, stream);
+      }
+      if (error == cudaSuccess) {
+        error = cuda_single_sampling_workspace_.set_seed(
+            cuda_sampling_seed_ ^ 0xd1b54a32d192ed03ULL, stream);
+      }
+      ET_CHECK_OR_RETURN_ERROR(
+          error == cudaSuccess,
+          Internal,
+          "CUDA DFlash sampling seed initialization failed: %s",
+          cudaGetErrorString(error));
+      cuda_sampling_seed_initialized_ = true;
+    }
+    return Error::Ok;
+  }
+
+  Error refresh_cuda_execution_stream() {
+    ET_CHECK_OK_OR_RETURN_ERROR(ensure_cuda_device_buffers());
+    auto stream = executorch::backends::cuda::getCurrentCUDAStream(0);
+    ET_CHECK_OK_OR_RETURN_ERROR(stream.error());
+    cuda_execution_stream_ = stream.get();
+    return prepare_cuda_sampling_workspaces(*cuda_execution_stream_);
+  }
+#endif
 
   bool is_eos(uint64_t token) const {
     return !config_.ignore_eos &&
@@ -682,6 +913,290 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
     return Error::Ok;
   }
 
+#ifdef EXECUTORCH_BUILD_CUDA
+  Result<TargetResult> run_cuda_target_device(
+      int64_t count,
+      int64_t start_pos,
+      const SamplingConfig& sampling,
+      bool sample_last,
+      DFlashCycleTiming* timing) {
+    ET_CHECK_OR_RETURN_ERROR(
+        count > 0 && count <= block_length_ && start_pos >= 0 &&
+            start_pos + count <= max_context_len(),
+        InvalidArgument,
+        "Invalid CUDA target token interval");
+    // The candidates and the position table already live on the device, so the
+    // whole verification step runs without touching host memory.
+    std::lock_guard<std::mutex> guard(*config_.exec_mutex);
+    ET_CHECK_OK_OR_RETURN_ERROR(refresh_cuda_execution_stream());
+    return run_target_embedded(
+        device_view(
+            {1, static_cast<SizesType>(count)},
+            cuda_candidates_->mutable_data_ptr(),
+            executorch::aten::ScalarType::Long),
+        cuda_position_view(start_pos, count),
+        /*host_tokens=*/nullptr,
+        count,
+        sampling,
+        sample_last,
+        /*image=*/nullptr,
+        /*next_image_row=*/nullptr,
+        timing,
+        /*use_target_prefill=*/false,
+        /*retain_from_row=*/0);
+  }
+
+  Error run_cuda_target_only_cycle() {
+    ET_CHECK_OK_OR_RETURN_ERROR(ensure_cuda_device_buffers());
+    ET_CHECK_OR_RETURN_ERROR(
+        cuda_execution_stream_.has_value(),
+        InvalidState,
+        "CUDA DFlash execution stream is unavailable");
+    const cudaStream_t stream = *cuda_execution_stream_;
+    DFlashCycleTiming cycle_timing;
+    DFlashCycleTiming* const timing =
+        config_.timing == nullptr ? nullptr : &cycle_timing;
+    const auto cycle_start =
+        timing == nullptr ? Clock::time_point{} : Clock::now();
+    ET_CHECK_OR_RETURN_ERROR(
+        cudaMemcpyAsync(
+            cuda_candidates_->mutable_data_ptr(),
+            cuda_correction_token_->const_data_ptr(),
+            sizeof(uint64_t),
+            cudaMemcpyDeviceToDevice,
+            stream) == cudaSuccess,
+        Internal,
+        "CUDA target-only candidate copy failed");
+    const uint64_t anchor = *pending_token_;
+    auto result = run_cuda_target_device(
+        1, target_pos_, sampling_, /*sample_last=*/true, timing);
+    ET_CHECK_OK_OR_RETURN_ERROR(result.error());
+    const auto commit_start =
+        timing == nullptr ? Clock::time_point{} : Clock::now();
+    append_hidden(result->hidden);
+    ready_tokens_.push_back(anchor);
+    pending_token_ = result->sampled_token;
+    ++target_pos_;
+    if (timing != nullptr) {
+      timing->state_commit_ms += elapsed_ms(commit_start, Clock::now());
+      timing->total_cycle_ms += elapsed_ms(cycle_start, Clock::now());
+      timing->target_only = true;
+      config_.timing->record(*timing);
+    }
+    return Error::Ok;
+  }
+
+  Error run_cuda_speculative_cycle() {
+    ET_CHECK_OK_OR_RETURN_ERROR(ensure_cuda_device_buffers());
+    ET_CHECK_OR_RETURN_ERROR(
+        cuda_execution_stream_.has_value(),
+        InvalidState,
+        "CUDA DFlash execution stream is unavailable");
+    const cudaStream_t stream = *cuda_execution_stream_;
+    const int64_t verify_len = n_draft_ + 1;
+    DFlashCycleTiming cycle_timing;
+    DFlashCycleTiming* const timing =
+        config_.timing == nullptr ? nullptr : &cycle_timing;
+    const auto cycle_start =
+        timing == nullptr ? Clock::time_point{} : Clock::now();
+
+    ET_CHECK_OR_RETURN_ERROR(
+        cudaMemcpyAsync(
+            cuda_candidates_->mutable_data_ptr(),
+            cuda_correction_token_->const_data_ptr(),
+            sizeof(uint64_t),
+            cudaMemcpyDeviceToDevice,
+            stream) == cudaSuccess,
+        Internal,
+        "CUDA draft anchor copy failed");
+    auto draft_logits =
+        run_draft(/*discard_output=*/false, hidden_rows(), timing);
+    ET_CHECK_OK_OR_RETURN_ERROR(draft_logits.error());
+    const auto& draft_tensor = *draft_logits.get();
+    ET_CHECK_OR_RETURN_ERROR(
+        draft_tensor.scalar_type() == executorch::aten::ScalarType::Float &&
+            draft_tensor.size(draft_tensor.dim() - 1) == cuda_vocab_size_,
+        InvalidProgram,
+        "CUDA draft logits have an invalid vocabulary dimension");
+
+    const bool stochastic = effective_temperature() > 0.0;
+    const bool draft_argmax = stochastic && config_.draft_argmax;
+    const auto draft_sampling_start =
+        timing == nullptr ? Clock::time_point{} : Clock::now();
+    auto* candidates =
+        static_cast<uint64_t*>(cuda_candidates_->mutable_data_ptr());
+    auto* draft_probabilities =
+        static_cast<float*>(cuda_draft_probabilities_->mutable_data_ptr());
+    cudaError_t error = muse_glimmer::cuda::sample_token(
+        static_cast<const float*>(draft_tensor.const_data_ptr()) +
+            cuda_vocab_size_,
+        n_draft_,
+        cuda_vocab_size_,
+        draft_argmax ? 0.0 : effective_temperature(),
+        sampling_.top_k,
+        sampling_.top_p,
+        candidates + 1,
+        stochastic && !draft_argmax ? draft_probabilities + cuda_vocab_size_
+                                    : nullptr,
+        /*probabilities_only=*/false,
+        cuda_draft_sampling_workspace_,
+        stream);
+    ET_CHECK_OR_RETURN_ERROR(
+        error == cudaSuccess,
+        Internal,
+        "CUDA draft sampling failed: %s",
+        cudaGetErrorString(error));
+    if (timing != nullptr) {
+      timing->draft_sampling_ms +=
+          elapsed_ms(draft_sampling_start, Clock::now());
+    }
+
+    auto verify = run_cuda_target_device(
+        verify_len,
+        target_pos_,
+        sampling_,
+        /*sample_last=*/false,
+        timing);
+    ET_CHECK_OK_OR_RETURN_ERROR(verify.error());
+    const auto& target_tensor = *last_logits_tensor_;
+    ET_CHECK_OR_RETURN_ERROR(
+        target_tensor.scalar_type() == executorch::aten::ScalarType::Float &&
+            target_tensor.size(target_tensor.dim() - 1) == cuda_vocab_size_,
+        InvalidProgram,
+        "CUDA target logits have an invalid vocabulary dimension");
+
+    const auto accept_start =
+        timing == nullptr ? Clock::time_point{} : Clock::now();
+    auto* accepted_count =
+        static_cast<int64_t*>(cuda_accepted_count_->mutable_data_ptr());
+    auto* correction_token =
+        static_cast<uint64_t*>(cuda_correction_token_->mutable_data_ptr());
+    if (stochastic) {
+      auto* target_probabilities =
+          static_cast<float*>(cuda_target_probabilities_->mutable_data_ptr());
+      error = muse_glimmer::cuda::sample_token(
+          static_cast<const float*>(target_tensor.const_data_ptr()),
+          verify_len,
+          cuda_vocab_size_,
+          effective_temperature(),
+          sampling_.top_k,
+          sampling_.top_p,
+          static_cast<uint64_t*>(cuda_target_tokens_->mutable_data_ptr()),
+          target_probabilities,
+          /*probabilities_only=*/true,
+          cuda_target_sampling_workspace_,
+          stream);
+      if (error == cudaSuccess) {
+        error = muse_glimmer::cuda::stochastic_speculative_sample(
+            target_probabilities,
+            draft_probabilities,
+            candidates,
+            verify_len,
+            cuda_vocab_size_,
+            draft_argmax,
+            accepted_count,
+            correction_token,
+            cuda_target_sampling_workspace_,
+            stream);
+      }
+    } else {
+      error = muse_glimmer::cuda::argmax_index(
+          static_cast<const float*>(target_tensor.const_data_ptr()),
+          verify_len,
+          cuda_vocab_size_,
+          static_cast<uint64_t*>(cuda_target_tokens_->mutable_data_ptr()),
+          stream);
+      if (error == cudaSuccess) {
+        error = muse_glimmer::cuda::greedy_speculative_sample(
+            static_cast<const uint64_t*>(cuda_target_tokens_->const_data_ptr()),
+            candidates,
+            verify_len,
+            accepted_count,
+            correction_token,
+            stream);
+      }
+    }
+    ET_CHECK_OR_RETURN_ERROR(
+        error == cudaSuccess,
+        Internal,
+        "CUDA speculative verification failed: %s",
+        cudaGetErrorString(error));
+
+    int64_t committed = 0;
+    uint64_t correction = 0;
+    std::vector<uint64_t> host_candidates(verify_len);
+    ET_CHECK_OR_RETURN_ERROR(
+        cudaMemcpyAsync(
+            &committed,
+            accepted_count,
+            sizeof(committed),
+            cudaMemcpyDeviceToHost,
+            stream) == cudaSuccess &&
+            cudaMemcpyAsync(
+                &correction,
+                correction_token,
+                sizeof(correction),
+                cudaMemcpyDeviceToHost,
+                stream) == cudaSuccess &&
+            cudaMemcpyAsync(
+                host_candidates.data(),
+                candidates,
+                host_candidates.size() * sizeof(uint64_t),
+                cudaMemcpyDeviceToHost,
+                stream) == cudaSuccess &&
+            cudaStreamSynchronize(stream) == cudaSuccess,
+        Internal,
+        "CUDA speculative result copy failed");
+    ET_CHECK_OR_RETURN_ERROR(
+        committed > 0 && committed <= verify_len,
+        InvalidState,
+        "CUDA speculative verification returned an invalid commit count");
+    if (timing != nullptr) {
+      timing->accept_correction_ms += elapsed_ms(accept_start, Clock::now());
+      const int64_t attempts =
+          committed == verify_len ? verify_len - 1 : committed;
+      const int64_t accepts =
+          committed == verify_len ? verify_len - 1 : committed - 1;
+      timing->draft_attempts_by_row.resize(attempts);
+      timing->draft_accepts_by_row.resize(attempts);
+      for (int64_t row = 0; row < attempts; ++row) {
+        ++timing->draft_attempts_by_row[row];
+        if (row < accepts) {
+          ++timing->draft_accepts_by_row[row];
+        }
+      }
+    }
+
+    const auto commit_start =
+        timing == nullptr ? Clock::time_point{} : Clock::now();
+    cached_ctx_len_ += hidden_rows();
+    hidden_ = std::move(verify->hidden);
+    hidden_.resize(committed * hidden_dim_);
+    int64_t nonterminal_committed = committed;
+    std::optional<uint64_t> terminal;
+    for (int64_t row = 0; row < committed; ++row) {
+      if (is_eos(host_candidates[row])) {
+        nonterminal_committed = row;
+        terminal = host_candidates[row];
+        break;
+      }
+      ready_tokens_.push_back(host_candidates[row]);
+    }
+    if (nonterminal_committed != committed) {
+      hidden_.resize(nonterminal_committed * hidden_dim_);
+      correction = *terminal;
+    }
+    target_pos_ += nonterminal_committed;
+    pending_token_ = correction;
+    if (timing != nullptr) {
+      timing->state_commit_ms += elapsed_ms(commit_start, Clock::now());
+      timing->total_cycle_ms += elapsed_ms(cycle_start, Clock::now());
+      config_.timing->record(*timing);
+    }
+    return Error::Ok;
+  }
+#endif
+
   Error run_decode_cycle() {
     ET_CHECK_OR_RETURN_ERROR(
         pending_token_.has_value(),
@@ -693,13 +1208,13 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
         room > 0, InvalidArgument, "DFlash context capacity exhausted");
 #ifdef EXECUTORCH_BUILD_CUDA
     if (room < n_draft_ + 1) {
-      return run_target_only_cycle();
+      return run_cuda_target_only_cycle();
     }
+    return run_cuda_speculative_cycle();
 #else
     if (room == 1) {
       return run_target_only_cycle();
     }
-#endif
 
     DFlashCycleTiming cycle_timing;
     DFlashCycleTiming* const timing =
@@ -900,8 +1415,10 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
       config_.timing->record(*timing);
     }
     return Error::Ok;
+#endif
   }
 
+#ifndef EXECUTORCH_BUILD_CUDA
   Error run_target_only_cycle() {
     DFlashCycleTiming cycle_timing;
     DFlashCycleTiming* const timing =
@@ -931,11 +1448,13 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
     }
     return Error::Ok;
   }
+#endif
 
   double effective_temperature() const {
     return sampling_.temperature < 0.0f ? 0.0 : sampling_.temperature;
   }
 
+#ifndef EXECUTORCH_BUILD_CUDA
   Result<TargetResult> run_target(
       const uint64_t* tokens,
       int64_t count,
@@ -957,6 +1476,7 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
         use_target_prefill,
         retain_from_row);
   }
+#endif
 
   Result<TargetResult> run_target_from_embeddings(
       const uint64_t* tokens,
@@ -969,21 +1489,74 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
       DFlashCycleTiming* timing = nullptr,
       bool use_target_prefill = false,
       int64_t retain_from_row = 0) {
+#ifdef EXECUTORCH_BUILD_CUDA
+    // The CUDA target methods take device inputs, so this host entry point
+    // stages its tokens itself rather than letting the runtime copy them.
+    ET_CHECK_OR_RETURN_ERROR(
+        start_pos >= 0 && start_pos + count <= max_context_len(),
+        InvalidArgument,
+        "CUDA target position window exceeds the context length");
+    std::lock_guard<std::mutex> guard(*config_.exec_mutex);
+    ET_CHECK_OK_OR_RETURN_ERROR(refresh_cuda_execution_stream());
+    auto staged_tokens = stage_cuda_tokens(tokens, count);
+    ET_CHECK_OK_OR_RETURN_ERROR(staged_tokens.error());
+    return run_target_embedded(
+        staged_tokens.get(),
+        cuda_position_view(start_pos, count),
+        tokens,
+        count,
+        sampling,
+        sample_last,
+        image,
+        next_image_row,
+        timing,
+        use_target_prefill,
+        retain_from_row);
+#else
     std::vector<int64_t> token_data(tokens, tokens + count);
     std::vector<int64_t> positions(count);
     std::iota(positions.begin(), positions.end(), start_pos);
-    auto token_tensor = from_blob(
-        token_data.data(),
-        {1, static_cast<SizesType>(count)},
-        executorch::aten::ScalarType::Long);
-    auto position_tensor = from_blob(
-        positions.data(),
-        {static_cast<SizesType>(count)},
-        executorch::aten::ScalarType::Long);
+    std::lock_guard<std::mutex> guard(*config_.exec_mutex);
+    return run_target_embedded(
+        from_blob(
+            token_data.data(),
+            {1, static_cast<SizesType>(count)},
+            executorch::aten::ScalarType::Long),
+        from_blob(
+            positions.data(),
+            {static_cast<SizesType>(count)},
+            executorch::aten::ScalarType::Long),
+        tokens,
+        count,
+        sampling,
+        sample_last,
+        image,
+        next_image_row,
+        timing,
+        use_target_prefill,
+        retain_from_row);
+#endif
+  }
 
+  // Runs embed_text and feeds its embeddings to the target. Both input tensors
+  // are already staged for the active backend, so the decode loop can hand over
+  // device-resident candidates and pay no copy at all. ``host_tokens`` is read
+  // only to locate the image patch rows that the splice path rewrites. Callers
+  // must hold ``config_.exec_mutex``.
+  Result<TargetResult> run_target_embedded(
+      TensorPtr token_tensor,
+      TensorPtr position_tensor,
+      const uint64_t* host_tokens,
+      int64_t count,
+      const SamplingConfig& sampling,
+      bool sample_last,
+      const PreparedMuseGlimmerImage* image,
+      int64_t* next_image_row,
+      DFlashCycleTiming* timing,
+      bool use_target_prefill,
+      int64_t retain_from_row) {
     const auto execute_start =
         timing == nullptr ? Clock::time_point{} : Clock::now();
-    std::lock_guard<std::mutex> guard(*config_.exec_mutex);
     auto embed_outputs = execute_active(kEmbedText, {EValue(token_tensor)});
     ET_CHECK_OK_OR_RETURN_ERROR(embed_outputs.error());
     ET_CHECK_OR_RETURN_ERROR(
@@ -1008,16 +1581,16 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
     std::vector<EValue> target_inputs;
     if (image != nullptr) {
       ET_CHECK_OR_RETURN_ERROR(
-          next_image_row != nullptr,
+          next_image_row != nullptr && host_tokens != nullptr,
           InvalidState,
-          "DFlash image splice requires an image row cursor");
+          "DFlash image splice requires host tokens and an image row cursor");
       embeddings.resize(count * embed_dim);
       ET_CHECK_OK_OR_RETURN_ERROR(copy_bytes_to_host(
           embeddings.data(),
           embed_tensor.const_data_ptr(),
           embeddings.size() * sizeof(uint16_t)));
       for (int64_t row = 0; row < count; ++row) {
-        if (tokens[row] != kMuseGlimmerImagePatchTokenId) {
+        if (host_tokens[row] != kMuseGlimmerImagePatchTokenId) {
           continue;
         }
         ET_CHECK_OR_RETURN_ERROR(
@@ -1030,12 +1603,20 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
             embed_dim * sizeof(uint16_t));
         ++*next_image_row;
       }
+#ifdef EXECUTORCH_BUILD_CUDA
+      auto staged = stage_cuda_embeddings(embeddings.data(), count, embed_dim);
+      ET_CHECK_OK_OR_RETURN_ERROR(staged.error());
+      embeddings_tensor = staged.get();
+#else
       embeddings_tensor = from_blob(
           embeddings.data(),
           {1, static_cast<SizesType>(count), static_cast<SizesType>(embed_dim)},
           hidden_dtype_);
+#endif
       target_inputs = {EValue(embeddings_tensor), EValue(position_tensor)};
     } else {
+      // embed_text already returned device memory under CUDA, so the target
+      // consumes its embeddings in place.
       target_inputs = {(*embed_outputs)[0], EValue(position_tensor)};
     }
 
@@ -1072,10 +1653,20 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
 
     const auto logits_copy_start =
         timing == nullptr ? Clock::time_point{} : Clock::now();
+#ifdef EXECUTORCH_BUILD_CUDA
+    const auto& output_logits = outputs[0].toTensor();
+    ET_CHECK_OR_RETURN_ERROR(
+        output_logits.scalar_type() == executorch::aten::ScalarType::Float,
+        InvalidProgram,
+        "DFlash logits must be float32");
+    ET_CHECK_OK_OR_RETURN_ERROR(refresh_cuda_execution_stream());
+    last_logits_tensor_ = make_tensor_ptr(output_logits);
+#else
     auto logits =
         copy_float_tensor_to_host(outputs[0].toTensor(), last_logits_storage_);
     ET_CHECK_OK_OR_RETURN_ERROR(logits.error());
     last_logits_tensor_ = std::move(logits.get());
+#endif
     if (timing != nullptr) {
       timing->target_logits_copy_ms +=
           elapsed_ms(logits_copy_start, Clock::now());
@@ -1084,6 +1675,43 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
     if (sample_last) {
       const auto sampling_start =
           timing == nullptr ? Clock::time_point{} : Clock::now();
+#ifdef EXECUTORCH_BUILD_CUDA
+      ET_CHECK_OK_OR_RETURN_ERROR(ensure_cuda_device_buffers());
+      const int64_t vocab_size = output_logits.size(output_logits.dim() - 1);
+      ET_CHECK_OR_RETURN_ERROR(
+          vocab_size == cuda_vocab_size_,
+          InvalidProgram,
+          "DFlash target vocabulary size changed");
+      const int64_t logits_row = use_target_prefill ? 0 : count - 1;
+      const auto error = muse_glimmer::cuda::sample_token(
+          static_cast<const float*>(output_logits.const_data_ptr()) +
+              logits_row * vocab_size,
+          1,
+          vocab_size,
+          sampling.temperature < 0.0f ? 0.0 : sampling.temperature,
+          sampling.top_k,
+          sampling.top_p,
+          static_cast<uint64_t*>(cuda_correction_token_->mutable_data_ptr()),
+          nullptr,
+          false,
+          cuda_single_sampling_workspace_,
+          *cuda_execution_stream_);
+      ET_CHECK_OR_RETURN_ERROR(
+          error == cudaSuccess,
+          Internal,
+          "CUDA target sampling failed: %s",
+          cudaGetErrorString(error));
+      ET_CHECK_OR_RETURN_ERROR(
+          cudaMemcpyAsync(
+              &sampled,
+              cuda_correction_token_->const_data_ptr(),
+              sizeof(sampled),
+              cudaMemcpyDeviceToHost,
+              *cuda_execution_stream_) == cudaSuccess &&
+              cudaStreamSynchronize(*cuda_execution_stream_) == cudaSuccess,
+          Internal,
+          "CUDA target token copy failed");
+#else
       sampled = muse_glimmer::sample_token(
           rng_,
           *last_logits_tensor_,
@@ -1094,6 +1722,7 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
           /*out_probs=*/nullptr,
           /*probs_only=*/false,
           &sampling_workspace_);
+#endif
       if (timing != nullptr) {
         timing->accept_correction_ms +=
             elapsed_ms(sampling_start, Clock::now());
@@ -1119,6 +1748,9 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
         InvalidArgument,
         "Invalid retained target hidden row offset");
     const int64_t retained_rows = count - retain_from_row;
+    // TODO: Keep target hidden on CUDA and feed it directly to the next draft
+    // call. The on-device sampling bring-up intentionally retains this D2H/H2D
+    // path so sampler validation is independent of device-buffer ownership.
     std::vector<uint16_t> hidden(retained_rows * hidden_dim_);
     const auto hidden_copy_start =
         timing == nullptr ? Clock::time_point{} : Clock::now();
@@ -1239,10 +1871,14 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
     }
     const auto logits_copy_start =
         timing == nullptr ? Clock::time_point{} : Clock::now();
+#ifdef EXECUTORCH_BUILD_CUDA
+    draft_logits_tensor_ = make_tensor_ptr((*outputs)[0].toTensor());
+#else
     auto host_logits = copy_float_tensor_to_host(
         (*outputs)[0].toTensor(), draft_logits_storage_);
     ET_CHECK_OK_OR_RETURN_ERROR(host_logits.error());
     draft_logits_tensor_ = std::move(host_logits.get());
+#endif
     if (timing != nullptr) {
       timing->draft_logits_copy_ms +=
           elapsed_ms(logits_copy_start, Clock::now());
@@ -1289,6 +1925,25 @@ class DFlashSession final : public LLMSession, public DFlashMultimodalSession {
   std::vector<std::vector<float>> target_probs_;
   muse_glimmer::SamplingWorkspace sampling_workspace_;
   std::unique_ptr<ProbabilityWorkers> probability_workers_;
+#ifdef EXECUTORCH_BUILD_CUDA
+  int64_t cuda_vocab_size_ = 0;
+  uint64_t cuda_sampling_seed_ = 0;
+  bool cuda_sampling_seed_initialized_ = false;
+  std::optional<cudaStream_t> cuda_execution_stream_;
+  TensorPtr cuda_candidates_;
+  TensorPtr cuda_target_tokens_;
+  TensorPtr cuda_accepted_count_;
+  TensorPtr cuda_correction_token_;
+  TensorPtr cuda_target_probabilities_;
+  TensorPtr cuda_draft_probabilities_;
+  TensorPtr cuda_position_table_;
+  TensorPtr cuda_staged_tokens_;
+  TensorPtr cuda_staged_embeddings_;
+  int64_t cuda_staged_token_capacity_ = 0;
+  muse_glimmer::cuda::SamplingWorkspace cuda_target_sampling_workspace_;
+  muse_glimmer::cuda::SamplingWorkspace cuda_draft_sampling_workspace_;
+  muse_glimmer::cuda::SamplingWorkspace cuda_single_sampling_workspace_;
+#endif
 };
 
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #22492
* #22491
* #22490
* #22489
* #22488
* #22487
* #22486
* #22485
* #22484

Keep the CUDA DFlash decode loop device-resident instead of round-tripping activations and logits through the host.

Export embed_text, target_forward_from_embeddings, and target_prefill_from_embeddings device-in/device-out, and keep draft_forward logits on device. Draft sampling, target sampling, speculative acceptance, and correction then run through the CUDA sampling primitives on the model's shared stream, so a verification step never touches host memory. The candidate, probability, position-table, and token-staging buffers are preallocated before CUDA graph capture so replay stays valid.

A CUDA build always samples on device; there is no runtime switch. The host sampler is reached only by non-CUDA (MLX) builds, so the host speculative cycle, run_target_only_cycle, and the run_target token wrapper are guarded with #ifndef EXECUTORCH_BUILD_CUDA rather than left as unreachable code behind an unconditional return.

The verifier reuses the existing embed_text + target_forward_from_embeddings chain rather than adding a token-input target method: candidate tokens already live on the device, so embed_text consumes them in place and hands its embeddings straight to the target with no copy. The remaining host callers (prefill and the vision splice) stage their own inputs into the preallocated device buffers. Keeping a single target implementation means the CUDA and MLX paths decode through the same method, and it removes both the duplicate complete-target weight blob and the export-time blob surgery that used to omit it -- surgery that depended on runtime method load order and on the AOTI delegate payload's line shape.

Sampling stays a runtime primitive: no sampling method is added to the .pte, and the DFlash timing mechanism is unchanged.

Differential Revision: [D117826290](https://our.internmc.facebook.com/intern/diff/D117826290/)