### PR TITLE
[ET-VK] Do not partition batch norm on a non-4d input

### DIFF
--- a/backends/vulkan/op_registry.py
+++ b/backends/vulkan/op_registry.py
@@ -1756,6 +1756,22 @@ def register_embedding_q4gsw():
 # =============================================================================
 
 
+def _check_batch_norm_is_4d(node: torch.fx.Node) -> bool:
+    """Only support batch norm on a 4d input.
+
+    add_native_batch_norm_node() asserts
+    VK_CHECK_COND(in_sizes.size() == 4, "BatchNorm only support 4d tensor") on
+    both the input and the output, so partitioning a batch norm whose input is
+    not 4d yields a .pte that lowers cleanly and then aborts at execute time.
+    Any conv1d model reaches here with rank-3 activations.
+    """
+    input_node = node.args[0]
+    if not isinstance(input_node, torch.fx.Node):
+        return False
+    val = input_node.meta.get("val")
+    return val is not None and val.dim() == 4
+
+
 @update_features(exir_ops.edge.aten._native_batch_norm_legit_no_training.default)
 def register_native_batch_norm_legit_no_training():
     return OpFeatures(
@@ -1763,6 +1779,7 @@ def register_native_batch_norm_legit_no_training():
         inputs_dtypes=utils.FP_T,
         supports_prepacking=True,
         supports_resize=True,
+        are_node_inputs_supported_fn=_check_batch_norm_is_4d,
     )
 
 


### PR DESCRIPTION
### Summary

`add_native_batch_norm_node()` asserts on both the input and the output sizes:

```cpp
VK_CHECK_COND(in_sizes.size() == 4, "BatchNorm only support 4d tensor");
VK_CHECK_COND(out_sizes.size() == 4, "BatchNorm only support 4d tensor");
```

but the partitioner claims `_native_batch_norm_legit_no_training` at any rank. A batch norm on rank-3 activations, which is every conv1d model, therefore lowers cleanly and aborts at execute time rather than falling back.

This declines the node when the input is not 4d, following the existing `_check_copy_is_noop` / `check_conv_node` precedent.

Split out of #22399, which is now scoped to `constant_pad_nd`.

cc @SS-JIA @manuelcandales @digantdesai @cbilgin