### PR TITLE
NXP backend: handle tests of mlperf tiny keyword spotting

### DIFF
--- a/backends/nxp/tests/generic_tests/test_aot_example.py
+++ b/backends/nxp/tests/generic_tests/test_aot_example.py
@@ -186,6 +186,9 @@ def test_aot_example__mlperf_tiny_ic():
     """Test that the MLPerf Tiny image classification model (ResNet-8) can be lowered to Neutron backend via
     `aot_neutron_compile.py` and all ops are delegated."""
 
+    # Number of random samples to generate, must be divisible by number of classes
+    num_random_samples = 60
+
     # Run the compilation script as a module (like run_aot_example.sh does).
     # The calibration data of this model is generated randomly, so no dataset download is needed.
     cmd = [
@@ -199,6 +202,8 @@ def test_aot_example__mlperf_tiny_ic():
         "--target",
         "imxrt700",
         "--use_random_dataset",
+        "--num_random_samples",
+        str(num_random_samples),
     ]
 
     # Output file will be created in executorch_root
@@ -215,7 +220,10 @@ def test_aot_example__mlperf_tiny_ic():
 
 def test_aot_example__mlperf_tiny_ic__profiling():
     """Test that the MLPerf Tiny image classification model (ResNet-8) can be lowered to Neutron backend via
-    `aot_neutron_compile.py` and all ops are delegated."""
+    `aot_neutron_compile.py` and profiling works as intended."""
+
+    # Number of random samples to generate, must be divisible by number of classes
+    num_random_samples = 60
 
     # Run the compilation script as a module (like run_aot_example.sh does)
     # Channels-last is buggy, so channels-first is used instead
@@ -232,6 +240,8 @@ def test_aot_example__mlperf_tiny_ic__profiling():
         "--remove-quant-io-ops",
         "--use_profiling",  # Generate profilable model and create ETRecord
         "--use_random_dataset",  # Avoid downloading the dataset.
+        "--num_random_samples",
+        str(num_random_samples),
     ]
 
     # Output files will be created in executorch_root.
@@ -243,6 +253,80 @@ def test_aot_example__mlperf_tiny_ic__profiling():
     etrecord_file = Path(
         os.path.join(
             EXECUTORCH_ROOT, "etrecord", "mlperf_tiny_image_classification_etrecord.bin"
+        )
+    )
+
+    with _cleanup_generated_files(pte_file, etrecord_file):
+        result = _run_compile(cmd)
+        _assert_profiling(result, pte_file, etrecord_file)
+
+
+def test_aot_example__mlperf_tiny_kws():
+    """Test that the MLPerf Tiny keyword spotting model (DS-CNN) can be lowered to Neutron backend via
+    `aot_neutron_compile.py` and all ops are delegated."""
+
+    # Number of random samples to generate, must be divisible by number of classes
+    num_random_samples = 60
+
+    # Run the compilation script as a module (like run_aot_example.sh does).
+    cmd = [
+        sys.executable,
+        "-m",
+        "examples.nxp.aot_neutron_compile",
+        "--model_name",
+        "mlperf_tiny_keyword_spotting",
+        "--delegate",
+        "--quantize",
+        "--target",
+        "imxrt700",
+        "--use_random_dataset",
+        "--num_random_samples",
+        str(num_random_samples),
+    ]
+
+    # Output file will be created in executorch_root
+    pte_file = Path(
+        os.path.join(EXECUTORCH_ROOT, "mlperf_tiny_keyword_spotting_nxp_delegate.pte")
+    )
+
+    with _cleanup_generated_files(pte_file):
+        result = _run_compile(cmd)
+        _assert_delegation(result, pte_file)
+
+
+def test_aot_example__mlperf_tiny_kws__profiling():
+    """Test that the MLPerf Tiny keyword spotting model (DS-CNN) can be lowered to Neutron backend via
+    `aot_neutron_compile.py` and profiling works as intended."""
+
+    # Number of random samples to generate, must be divisible by number of classes
+    num_random_samples = 60
+
+    # Run the compilation script as a module (like run_aot_example.sh does)
+    cmd = [
+        sys.executable,
+        "-m",
+        "examples.nxp.aot_neutron_compile",
+        "--model_name",
+        "mlperf_tiny_keyword_spotting",
+        "--delegate",
+        "--quantize",
+        "--target",
+        "imxrt700",
+        "--remove-quant-io-ops",
+        "--use_profiling",  # Generate profilable model and create ETRecord
+        "--use_random_dataset",
+        "--num_random_samples",
+        str(num_random_samples),
+    ]
+
+    pte_file = Path(
+        os.path.join(
+            EXECUTORCH_ROOT, "mlperf_tiny_keyword_spotting_nxp_delegate_profile.pte"
+        )
+    )
+    etrecord_file = Path(
+        os.path.join(
+            EXECUTORCH_ROOT, "etrecord", "mlperf_tiny_keyword_spotting_etrecord.bin"
         )
     )
 

--- a/backends/nxp/tests/models/test_mlperf_tiny_keyword_spotting.py
+++ b/backends/nxp/tests/models/test_mlperf_tiny_keyword_spotting.py
@@ -6,6 +6,7 @@
 from functools import partial
 
 import numpy as np
+import pytest
 import torch
 from executorch.backends.nxp.tests.dataset_creator import (
     FromCalibrationDataDatasetCreator,
@@ -16,21 +17,25 @@ from executorch.backends.nxp.tests.model_output_comparator import (
     ClassificationAccuracyOutputComparator,
     NumericalStatsOutputComparator,
 )
-
 from executorch.backends.nxp.tests.nsys_testing import (
     lower_run_compare,
     lower_run_compare_ptq_qat,
     ReferenceModel,
 )
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
-import pytest
-from executorch.examples.nxp.models.mlperf_tiny.image_classification.mlperf_tiny_image_classification import (
-    MLPerfTinyImageClassification,
+from executorch.examples.nxp.models.mlperf_tiny.keyword_spotting.mlperf_tiny_keyword_spotting import (
+    MLPerfTinyKeywordSpotting,
 )
 
 BOUNDS_MSE = {
-    "PTQ": {"channels-last": 1.859e-05, "channels-first": 7.432e-09},
-    "QAT": {"channels-last": 2.751e-07, "channels-first": 5.205e-06},
+    "PTQ": {
+        "channels-last": np.inf,
+        "channels-first": 5.5e-7,
+    },
+    "QAT": {
+        "channels-last": np.inf,
+        "channels-first": 3.3e-5,
+    },
 }
 
 
@@ -40,50 +45,55 @@ def reseed_model_per_test_run():
     np.random.seed(23)
 
 
-@pytest.mark.parametrize("channels_last", [False, True])
-def test_mlperf_tiny_classification_mse_cpu_vs_npu(
-    mocker, request, channels_last, use_qat
-):
-    # 10 samples per class
+@pytest.mark.parametrize(
+    "channels_last",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="EIEX-1082, don't forget to readjust bounds when it start working",
+                strict=True,
+            ),
+        ),
+    ],
+)
+def test_mlperf_tiny_kws_mse_cpu_vs_npu(mocker, request, channels_last, use_qat):
+    # approx. 5 samples per class
     num_samples = 60
 
-    img_classification = MLPerfTinyImageClassification(
-        num_samples=num_samples, use_random_dataset=True
-    )
-    model = img_classification.get_eager_model()
-    dataset = img_classification.dataset
-    labels = img_classification.labels
+    kws = MLPerfTinyKeywordSpotting(num_samples=num_samples, use_random_dataset=True)
+    model = kws.get_eager_model()
+    dataset = kws.dataset
+    labels = kws.labels
 
     dataset_creator = FromCalibrationDataDatasetCreator(
         dataset, num_examples=num_samples, idx_to_label=labels
     )
 
-    input_spec = ModelInputSpec(img_classification.input_shape)
+    input_spec = ModelInputSpec(kws.input_shape)
     if channels_last:
         model.to(memory_format=torch.channels_last)
         input_spec.dim_order = torch.channels_last
 
     quant_type_key = "QAT" if use_qat else "PTQ"
     format_key = "channels-last" if channels_last else "channels-first"
-
     mse = BOUNDS_MSE[quant_type_key][format_key]
     comparator = NumericalStatsOutputComparator(
-        max_mse_error=mse, use_softmax=True, is_classification_task=True
+        max_mse_error=mse, is_classification_task=True
     )
     model_verifier = BaseGraphVerifier(1, [])
     train_fn = (
-        partial(img_classification.train_model_fn, channels_last=channels_last)
-        if use_qat
-        else None
+        partial(kws.train_model_fn, channels_last=channels_last) if use_qat else None
     )
 
-    # This model does not work in channels-last format and QAT when running using portable kernels.
+    # This model does not work in channels-last format when running with portable kernels.
     # See more information below.
-    # Github issue: https://github.com/pytorch/executorch/issues/22179
-    # NXP internal issue ID: EIEX-1065
+    # Github issue: https://github.com/pytorch/executorch/issues/22520
+    # NXP internal issue ID: EIEX-1074
     ref_model = (
         ReferenceModel.QUANTIZED_EDGE_PYTHON
-        if channels_last and use_qat
+        if channels_last
         else ReferenceModel.QUANTIZED_EXECUTORCH_CPP
     )
 
@@ -94,31 +104,29 @@ def test_mlperf_tiny_classification_mse_cpu_vs_npu(
         request,
         dataset_creator=dataset_creator,
         output_comparator=comparator,
-        reference_model=ref_model,
         mocker=mocker,
+        reference_model=ref_model,
         use_qat=use_qat,
         train_fn=train_fn,
     )
 
 
-def test_mlperf_tiny_image_classification_ptq_qat_equivalence(request):
-    # 10 samples per class
+def test_mlperf_tiny_kws_ptq_qat_equivalence(request):
+    # approx. 5 samples per class
     num_samples = 60
 
-    img_classification = MLPerfTinyImageClassification(
-        num_samples=num_samples, use_random_dataset=True
-    )
+    kws = MLPerfTinyKeywordSpotting(num_samples=num_samples, use_random_dataset=True)
 
-    model = img_classification.get_eager_model()
-    dataset = img_classification.dataset
-    labels = img_classification.labels
+    model = kws.get_eager_model()
+    dataset = kws.dataset
+    labels = kws.labels
 
     dataset_creator = FromCalibrationDataDatasetCreator(
         dataset, num_examples=num_samples, idx_to_label=labels
     )
     comparator = ClassificationAccuracyOutputComparator(class_dict=labels)
 
-    input_spec = ModelInputSpec(img_classification.input_shape)
+    input_spec = ModelInputSpec(kws.input_shape)
     model_verifier = BaseGraphVerifier(1, [])
 
     lower_run_compare_ptq_qat(
@@ -126,7 +134,7 @@ def test_mlperf_tiny_image_classification_ptq_qat_equivalence(request):
         [input_spec],
         model_verifier,
         request,
-        train_fn=img_classification.train_model_fn,
+        train_fn=kws.train_model_fn,
         dataset_creator=dataset_creator,
         output_comparator=comparator,
     )

--- a/examples/nxp/aot_neutron_compile.py
+++ b/examples/nxp/aot_neutron_compile.py
@@ -46,6 +46,9 @@ from executorch.examples.nxp.experimental.cifar_net.cifar_net import (
 from executorch.examples.nxp.models.mlperf_tiny.image_classification.mlperf_tiny_image_classification import (
     MLPerfTinyImageClassification,
 )
+from executorch.examples.nxp.models.mlperf_tiny.keyword_spotting.mlperf_tiny_keyword_spotting import (
+    MLPerfTinyKeywordSpotting,
+)
 from executorch.examples.nxp.models.mobilenet_v2 import MobilenetV2
 from executorch.exir import (
     EdgeCompileConfig,
@@ -65,6 +68,7 @@ MODELS = {
     "cifar10": CifarNet,
     "mobilenetv2": MobilenetV2,
     "mlperf_tiny_image_classification": MLPerfTinyImageClassification,
+    "mlperf_tiny_keyword_spotting": MLPerfTinyKeywordSpotting,
 }
 
 FORMAT = "[%(levelname)s %(asctime)s %(filename)s:%(lineno)s] %(message)s"
@@ -100,7 +104,10 @@ def _print_ops_in_edge_program(edge_program):
 
 
 def _get_model_info_from_name(
-    model_name: str, dataset_path: str | None, use_random_dataset: bool
+    model_name: str,
+    dataset_path: str | None,
+    use_random_dataset: bool,
+    num_samples: int | None,
 ):
     """Given the name of an example pytorch model and args, return the model, its class instance (can be None), example inputs and calibration inputs (can be None).
 
@@ -119,9 +126,11 @@ def _get_model_info_from_name(
                 )
             model_cls_inst = model_cls()
 
-        elif model_cls is MLPerfTinyImageClassification:
+        elif model_cls in (MLPerfTinyImageClassification, MLPerfTinyKeywordSpotting):
             model_cls_inst = model_cls(
-                dataset_path=dataset_path, use_random_dataset=use_random_dataset
+                dataset_path=dataset_path,
+                use_random_dataset=use_random_dataset,
+                num_samples=num_samples,
             )
 
         else:
@@ -258,6 +267,13 @@ def _get_arg_parser():
         help="The calibration and testing datasets will be generated randomly instead of being downloaded.",
     )
     parser.add_argument(
+        "--num_random_samples",
+        required=False,
+        default=None,
+        type=int,
+        help="Number of random samples to generate, required when `--use_random_dataset` flag is set.",
+    )
+    parser.add_argument(
         "-dst",
         "--dataset_path",
         required=False,
@@ -286,7 +302,10 @@ if __name__ == "__main__":  # noqa C901
     # 1. pick model from one of the supported lists
     model, example_inputs, calibration_inputs, model_cls_inst = (
         _get_model_info_from_name(
-            args.model_name, args.dataset_path, args.use_random_dataset
+            args.model_name,
+            args.dataset_path,
+            args.use_random_dataset,
+            args.num_random_samples,
         )
     )
     model = model.eval()
@@ -317,7 +336,8 @@ if __name__ == "__main__":  # noqa C901
         quantizer = NeutronQuantizer(neutron_target_spec, is_qat=args.use_qat)
         if args.use_qat:
             if not isinstance(
-                model_cls_inst, (CifarNet, MLPerfTinyImageClassification)
+                model_cls_inst,
+                (CifarNet, MLPerfTinyImageClassification, MLPerfTinyKeywordSpotting),
             ):
                 raise ValueError(
                     f"QAT training is not supported for model '{args.model_name}'"

--- a/examples/nxp/models/mlperf_tiny/image_classification/mlperf_tiny_image_classification.py
+++ b/examples/nxp/models/mlperf_tiny/image_classification/mlperf_tiny_image_classification.py
@@ -4,105 +4,49 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from pathlib import Path
 
 import torch
 
-from executorch.backends.nxp.tests.calibration_dataset import (
-    CalibrationDataset,
-    RandomCalibrationDataset,
-)
-
 from executorch.examples.models.mlperf_tiny import ResNet8
 from executorch.examples.nxp.models.mlperf_tiny.mlperf_tiny_model import MLPerfTinyModel
-from torch.utils.data import Dataset
-from torchao.quantization.pt2e import disable_observer
-from tqdm import tqdm
 
 log = logging.getLogger(__name__)
-
-INPUT_SHAPE = (1, 3, 32, 32)
-IDX_TO_LABEL = {
-    0: "airplane",
-    1: "automobile",
-    2: "bird",
-    3: "cat",
-    4: "deer",
-    5: "dog",
-    6: "frog",
-    7: "horse",
-    8: "ship",
-    9: "truck",
-}
 
 
 class MLPerfTinyImageClassification(MLPerfTinyModel):
     """MLPerf Tiny image classification model (ResNet-8)."""
 
-    def __init__(
-        self,
-        num_samples: int = 200,
-        dataset_path: Path | str | None = None,
-        use_random_dataset: bool = False,
-    ):
-        self._num_samples = num_samples
-        self._use_random_dataset = use_random_dataset
-        self._dataset_path = dataset_path
+    # ResNet-8 specific QAT training hyperparameters.
+    TRAIN_HYPERPARAMETERS = {
+        "num_epochs": 15,
+        "batch_size": 20,
+        "lr": 1e-5,
+        "eps": 1e-8,
+        "weight_decay": 1e-4,
+    }
 
-        super().__init__()
+    INPUT_SHAPE = (1, 3, 32, 32)
+    IDX_TO_LABEL = {
+        0: "airplane",
+        1: "automobile",
+        2: "bird",
+        3: "cat",
+        4: "deer",
+        5: "dog",
+        6: "frog",
+        7: "horse",
+        8: "ship",
+        9: "truck",
+    }
 
     @property
     def input_shape(self):
-        return INPUT_SHAPE
+        return self.INPUT_SHAPE
 
     @property
     def labels(self):
-        return IDX_TO_LABEL
-
-    def _init_dataset(self) -> Dataset:
-        if self._use_random_dataset:
-            num_classes = len(self.labels)
-            sample_shape = tuple(self.input_shape)[1:]
-            return RandomCalibrationDataset(
-                self._num_samples, sample_shape, num_classes
-            )
-        else:
-            if self._dataset_path is None:
-                raise ValueError(
-                    "Path to dataset data cannot be empty. If you want to use random data, set `use_random_dataset = True`"
-                )
-            return CalibrationDataset(self._dataset_path)
+        return self.IDX_TO_LABEL
 
     def _init_eager_model(self) -> torch.nn.Module:
         num_classes = len(self.labels)
-        return ResNet8(num_classes)
-
-    def train_model_fn(self, model, num_epochs=15, batch_size=20, channels_last=False):
-        torch.manual_seed(42)
-        torch.use_deterministic_algorithms(True)
-
-        optimizer = torch.optim.Adam(
-            params=model.parameters(),
-            lr=1e-5,
-            weight_decay=1e-4,
-        )
-        loss_fn = torch.nn.CrossEntropyLoss()
-
-        logging.warning("Starting training...")
-
-        data = self.get_qat_train_inputs(batch_size=batch_size)
-        for nepoch in range(num_epochs):
-            for images, labels in tqdm(data):
-                if channels_last:
-                    images = images.to(memory_format=torch.channels_last)
-
-                optimizer.zero_grad()
-                outputs = model(images)
-                loss = loss_fn(outputs, labels)
-                loss.backward()
-                optimizer.step()
-
-            if nepoch >= num_epochs / 3:
-                model.apply(disable_observer)
-
-        return model
+        return ResNet8(num_classes).eval()

--- a/examples/nxp/models/mlperf_tiny/keyword_spotting/__init__.py
+++ b/examples/nxp/models/mlperf_tiny/keyword_spotting/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/nxp/models/mlperf_tiny/keyword_spotting/mlperf_tiny_keyword_spotting.py
+++ b/examples/nxp/models/mlperf_tiny/keyword_spotting/mlperf_tiny_keyword_spotting.py
@@ -1,0 +1,60 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+import torch
+
+from executorch.examples.models.mlperf_tiny import DSCNNKWS
+from executorch.examples.nxp.models.mlperf_tiny.mlperf_tiny_model import MLPerfTinyModel
+
+log = logging.getLogger(__name__)
+
+
+class MLPerfTinyKeywordSpotting(MLPerfTinyModel):
+    """MLPerf Tiny keyword spotting model (DS-CNN)."""
+
+    INPUT_SHAPE = (1, 1, 49, 10)
+    # Because of the architecture of the model,
+    # non-scaled random weights tend to produce zero tensors,
+    # making it hard to compute numerical accuracy of the delegated model.
+    # Scaling the random weights makes the model produce reasonable results.
+    WEIGHT_INIT_SCALE = 2.0
+
+    IDX_TO_LABEL = {
+        0: "Down",
+        1: "Go",
+        2: "Left",
+        3: "No",
+        4: "Off",
+        5: "On",
+        6: "Right",
+        7: "Stop",
+        8: "Up",
+        9: "Yes",
+        10: "Silence",
+        11: "Unknown",
+    }
+
+    @property
+    def input_shape(self):
+        return self.INPUT_SHAPE
+
+    @property
+    def labels(self):
+        return self.IDX_TO_LABEL
+
+    def _init_weights(self, model: torch.nn.Module):
+        with torch.no_grad():
+            for module in model.modules():
+                if isinstance(module, (torch.nn.Conv2d, torch.nn.Linear)):
+                    module.weight *= self.WEIGHT_INIT_SCALE
+
+    def _init_eager_model(self) -> torch.nn.Module:
+        num_classes = len(self.labels)
+        model = DSCNNKWS(num_classes)
+        self._init_weights(model)
+
+        return model.eval()

--- a/examples/nxp/models/mlperf_tiny/mlperf_tiny_model.py
+++ b/examples/nxp/models/mlperf_tiny/mlperf_tiny_model.py
@@ -4,20 +4,56 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
+import logging
+import os
 from abc import abstractmethod
+from pathlib import Path
 from typing import Iterator
 
 import torch
+from executorch.backends.nxp.tests.calibration_dataset import (
+    CalibrationDataset,
+    RandomCalibrationDataset,
+)
 from executorch.examples.models import model_base
 from torch.utils.data import DataLoader, Dataset
+from torchao.quantization.pt2e import disable_observer
+from tqdm import tqdm
+
+log = logging.getLogger(__name__)
 
 
 class MLPerfTinyModel(model_base.EagerModelBase):
     """Base class of the MLPerf Tiny models."""
 
-    def __init__(self):
-        """Create the model wrapper along with the dataset it owns."""
-        self._num_workers = 4
+    # Default QAT training hyperparameters. Subclasses may override them.
+    TRAIN_HYPERPARAMETERS = {
+        "num_epochs": 15,
+        "batch_size": 64,
+        "lr": 5e-6,
+        "eps": 1e-7,
+        "weight_decay": 1e-4,
+    }
+
+    def __init__(
+        self,
+        dataset_path: Path | str | None = None,
+        use_random_dataset: bool = False,
+        num_samples: int | None = None,
+        num_workers: int = 4,
+    ):
+        """
+        Create the model wrapper along with the dataset it owns.
+        If `use_random_dataset = True`, then `num_samples` must be set.
+        If `use_random_dataset = False`, then `dataset_path` must be set.
+        """
+        self._num_workers = num_workers
+        self._num_samples = num_samples
+        self._use_random_dataset = use_random_dataset
+        self._dataset_path = dataset_path
+
+        # throws ValueError if validation fails
+        self._validate_args()
 
         self._eager_model = self._init_eager_model()
         self.dataset = self._init_dataset()
@@ -26,10 +62,6 @@ class MLPerfTinyModel(model_base.EagerModelBase):
     def _collate_fn(data: list[tuple]):
         data, labels = zip(*data)
         return torch.stack(list(data)), torch.tensor(list(labels))
-
-    @abstractmethod
-    def _init_dataset(self) -> Dataset:
-        pass
 
     @abstractmethod
     def _init_eager_model(self) -> torch.nn.Module:
@@ -44,6 +76,26 @@ class MLPerfTinyModel(model_base.EagerModelBase):
     @abstractmethod
     def labels(self):
         pass
+
+    def _validate_args(self):
+        valid_num_samples = isinstance(self._num_samples, int) and self._num_samples > 0
+
+        if self._use_random_dataset:
+            if not valid_num_samples:
+                raise ValueError(
+                    f"Invalid number of samples to randomly generate. Got {self._num_samples}."
+                )
+
+        else:
+            if valid_num_samples:
+                raise ValueError(
+                    "Num samples was supplied, but it is omitted because `use_random_dataset=False`."
+                )
+
+            if self._dataset_path is None or not os.path.exists(self._dataset_path):
+                raise ValueError(
+                    f"Invalid dataset path for loading the data. Got {self._dataset_path}."
+                )
 
     def get_qat_train_inputs(
         self, batch_size: int = 5, dataset_portion: float = 0.1
@@ -79,3 +131,54 @@ class MLPerfTinyModel(model_base.EagerModelBase):
 
     def get_example_inputs(self) -> tuple[torch.Tensor]:
         return (torch.randn(self.input_shape, dtype=torch.float32),)
+
+    def train_model_fn(
+        self, model, num_epochs=None, batch_size=None, channels_last=False
+    ):
+        hyperparameters = self.TRAIN_HYPERPARAMETERS
+        num_epochs = (
+            num_epochs if num_epochs is not None else hyperparameters["num_epochs"]
+        )
+        batch_size = (
+            batch_size if batch_size is not None else hyperparameters["batch_size"]
+        )
+
+        torch.manual_seed(42)
+        torch.use_deterministic_algorithms(True)
+
+        optimizer = torch.optim.Adam(
+            params=model.parameters(),
+            lr=hyperparameters["lr"],
+            eps=hyperparameters["eps"],
+            weight_decay=hyperparameters["weight_decay"],
+        )
+        loss_fn = torch.nn.CrossEntropyLoss()
+
+        log.warning("Starting training...")
+
+        data = self.get_qat_train_inputs(batch_size=batch_size)
+        for nepoch in range(num_epochs):
+            for samples, labels in tqdm(data):
+                if channels_last:
+                    samples = samples.to(memory_format=torch.channels_last)
+
+                optimizer.zero_grad()
+                outputs = model(samples)
+                loss = loss_fn(outputs, labels)
+                loss.backward()
+                optimizer.step()
+
+            if nepoch >= num_epochs / 3:
+                model.apply(disable_observer)
+
+        return model
+
+    def _init_dataset(self) -> Dataset:
+        if self._use_random_dataset:
+            num_classes = len(self.labels)
+            sample_shape = tuple(self.input_shape)[1:]
+            return RandomCalibrationDataset(
+                self._num_samples, sample_shape, num_classes
+            )
+        else:
+            return CalibrationDataset(self._dataset_path)


### PR DESCRIPTION
### Summary

Enable and refactor MLPerf Tiny Keyword Spotting tests.

### Test plan

tests can be manually run using `pytest -c /dev/null backends/nxp/tests/`

cc @robert-kalmar @JakeStevens @digantdesai @rascani @roman-janik-nxp 