### PR TITLE
Add Python save_ptd/load_ptd for tensor dicts

### DIFF
--- a/extension/flat_tensor/serialize/BUCK
+++ b/extension/flat_tensor/serialize/BUCK
@@ -39,6 +39,9 @@ fbcode_target(_kind = runtime.python_library,
     visibility = ["PUBLIC"],
     deps = [
         ":schema",
+        "//caffe2:torch",
+        "//executorch/exir:tensor",
+        "//executorch/exir:tensor_layout",
         "//executorch/exir/_serialize:lib",
     ],
 )

--- a/extension/flat_tensor/serialize/serialize.py
+++ b/extension/flat_tensor/serialize/serialize.py
@@ -13,14 +13,19 @@ import math
 import os
 import tempfile
 from dataclasses import dataclass
-from typing import ClassVar, Dict, List, Literal, Optional
+from typing import BinaryIO, ClassVar, Dict, List, Literal, Optional, Union
 
 import executorch.extension.flat_tensor.serialize as serialize_package
+
+import torch
 
 from executorch.exir._serialize._cord import Cord
 from executorch.exir._serialize._dataclass import _DataclassEncoder, _json_to_dataclass
 from executorch.exir._serialize._flatbuffer import _flatc_compile, _flatc_decompile
-from executorch.exir._serialize._named_data_store import NamedDataStoreOutput
+from executorch.exir._serialize._named_data_store import (
+    _tensor_to_bytes,
+    NamedDataStoreOutput,
+)
 from executorch.exir._serialize._program import _insert_flatbuffer_header
 from executorch.exir._serialize.data_serializer import (
     DataEntry,
@@ -28,6 +33,8 @@ from executorch.exir._serialize.data_serializer import (
     DataSerializer,
 )
 from executorch.exir._serialize.padding import aligned_size, pad_to, padding_required
+from executorch.exir.tensor import get_scalar_type
+from executorch.exir.tensor_layout import TensorLayout
 from executorch.extension.flat_tensor.serialize.flat_tensor_schema import (
     DataSegment,
     FlatTensor,
@@ -449,3 +456,129 @@ class FlatTensorSerializer(DataSerializer):
             pte_data={},
             external_data={name: data_payload.named_data},
         )
+
+
+# Matches the tensor_alignment passed by the C++ save_ptd callers in
+# extension/training/examples/{CIFAR,XOR}/train.cpp.
+_DEFAULT_TENSOR_ALIGNMENT = 16
+
+
+def _tensor_map_to_payload(
+    tensor_map: Dict[str, torch.Tensor],
+    tensor_alignment: int,
+) -> DataPayload:
+    """Builds a DataPayload from a map of tensor names to tensors."""
+    buffers: List[bytes] = []
+    named_data: Dict[str, DataEntry] = {}
+
+    # Tied weights (eg. an embedding matrix reused as the output projection)
+    # show up under more than one key in a state dict. Point the keys at a
+    # single buffer instead of writing identical bytes twice. Every tensor is
+    # kept alive by tensor_map for the duration of the loop, so id() is stable.
+    buffer_index_by_tensor: Dict[int, int] = {}
+
+    for key, tensor in tensor_map.items():
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(
+                f"Expected a torch.Tensor for key '{key}', got {type(tensor).__name__}."
+            )
+        buffer_index = buffer_index_by_tensor.get(id(tensor))
+        if buffer_index is None:
+            buffer_index = len(buffers)
+            buffer_index_by_tensor[id(tensor)] = buffer_index
+            buffers.append(_tensor_to_bytes(tensor))
+        named_data[key] = DataEntry(
+            buffer_index=buffer_index,
+            alignment=tensor_alignment,
+            tensor_layout=TensorLayout.from_tensor(tensor),
+        )
+
+    return DataPayload(buffers=buffers, named_data=named_data)
+
+
+def _tensor_from_layout(buffer: bytes, tensor_layout: TensorLayout) -> torch.Tensor:
+    """Rebuilds a tensor from its serialized bytes and layout metadata."""
+    dtype = get_scalar_type(tensor_layout.scalar_type)
+    sizes = list(tensor_layout.sizes)
+
+    # An empty tensor has no bytes to read; torch.frombuffer rejects a
+    # zero-length buffer, so construct it directly.
+    if any(size == 0 for size in sizes):
+        return torch.empty(sizes, dtype=dtype)
+
+    # bytearray gives torch a writable copy, so the tensor owns its memory and
+    # torch does not warn about a read-only buffer.
+    flat = torch.frombuffer(bytearray(buffer), dtype=dtype)
+
+    # dim_order lists dimensions outermost-first as laid out in memory, so the
+    # bytes on disk are the sizes permuted into that order. Reshape to the
+    # physical shape, then invert the permutation to recover the logical one.
+    dim_order = list(tensor_layout.dim_order)
+    physical_sizes = [sizes[dim] for dim in dim_order]
+    tensor = flat.reshape(physical_sizes)
+
+    inverse_dim_order = [0] * len(dim_order)
+    for position, dim in enumerate(dim_order):
+        inverse_dim_order[dim] = position
+    return tensor.permute(inverse_dim_order)
+
+
+def save_ptd(
+    path: Union[str, os.PathLike, BinaryIO],
+    tensor_map: Dict[str, torch.Tensor],
+    tensor_alignment: int = _DEFAULT_TENSOR_ALIGNMENT,
+) -> None:
+    """Creates a .ptd from the given tensor map.
+
+    Mirrors the C++ save_ptd in extension/flat_tensor/serialize/serialize.h,
+    which has both a path and a stream overload.
+
+    Args:
+        path: The file path to save the .ptd to, or a binary file-like object
+            to write the .ptd data to.
+        tensor_map: The map of tensor names to tensors to save.
+        tensor_alignment: The bytes tensor data should be aligned to.
+
+    Raises:
+        TypeError: If a value in tensor_map is not a torch.Tensor.
+        ValueError: If a tensor is neither contiguous nor channels-last.
+    """
+    payload = _tensor_map_to_payload(tensor_map, tensor_alignment)
+    blob = FlatTensorSerializer(FlatTensorConfig()).serialize(payload)
+
+    if hasattr(path, "write"):
+        blob.write_to_file(path)
+    else:
+        with open(path, "wb") as outfile:
+            blob.write_to_file(outfile)
+
+
+def load_ptd(path: Union[str, os.PathLike, BinaryIO]) -> Dict[str, torch.Tensor]:
+    """Loads a .ptd into a map of tensor names to tensors.
+
+    Reverses save_ptd. Named data entries that carry no tensor layout are not
+    tensors and are skipped.
+
+    Args:
+        path: The file path to load the .ptd from, or a binary file-like
+            object to read the .ptd data from.
+
+    Returns:
+        A map of tensor names to tensors.
+    """
+    if hasattr(path, "read"):
+        data = path.read()
+    else:
+        with open(path, "rb") as infile:
+            data = infile.read()
+
+    payload = FlatTensorSerializer().deserialize(Cord(data))
+
+    tensor_map: Dict[str, torch.Tensor] = {}
+    for key, entry in payload.named_data.items():
+        if entry.tensor_layout is None:
+            continue
+        tensor_map[key] = _tensor_from_layout(
+            bytes(payload.buffers[entry.buffer_index]), entry.tensor_layout
+        )
+    return tensor_map

--- a/extension/flat_tensor/test/test_serialize.py
+++ b/extension/flat_tensor/test/test_serialize.py
@@ -7,6 +7,7 @@
 # pyre-unsafe
 
 import dataclasses
+import io
 import math
 import os
 import tempfile
@@ -34,9 +35,12 @@ from executorch.extension.flat_tensor.serialize.serialize import (
     _deserialize_to_flat_tensor,
     _FLAT_TENSOR_VERSION,
     _FLATBUFFER_ALIGNMENT,
+    _get_extended_header,
     FlatTensorConfig,
     FlatTensorHeader,
     FlatTensorSerializer,
+    load_ptd,
+    save_ptd,
 )
 
 # The raw data stored in the serialized file segments.
@@ -394,3 +398,141 @@ class TestSerialize(unittest.TestCase):
         self._check_named_data_entries(
             output.external_data[external_tag], output2.external_data[external_tag]
         )
+
+
+class TestSavePtd(unittest.TestCase):
+    """Tests for the save_ptd/load_ptd tensor-map APIs."""
+
+    def _round_trip(
+        self, tensor_map: Dict[str, torch.Tensor]
+    ) -> Dict[str, torch.Tensor]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "test.ptd")
+            save_ptd(path, tensor_map)
+            return load_ptd(path)
+
+    def _assert_same(
+        self, actual: Dict[str, torch.Tensor], expected: Dict[str, torch.Tensor]
+    ) -> None:
+        self.assertEqual(set(actual.keys()), set(expected.keys()))
+        for key, want in expected.items():
+            got = actual[key]
+            self.assertEqual(got.dtype, want.dtype, f"dtype mismatch for '{key}'")
+            self.assertEqual(got.shape, want.shape, f"shape mismatch for '{key}'")
+            self.assertTrue(torch.equal(got, want), f"value mismatch for '{key}'")
+
+    def test_round_trip_preserves_dtypes(self) -> None:
+        # Arrange
+        tensor_map = {
+            "float32": torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            "int64": torch.arange(6, dtype=torch.int64).reshape(2, 3),
+            "uint8": torch.tensor([1, 2, 3], dtype=torch.uint8),
+            "float16": torch.tensor([0.5, 1.5], dtype=torch.float16),
+            "bool": torch.tensor([True, False, True]),
+        }
+
+        # Act
+        loaded = self._round_trip(tensor_map)
+
+        # Assert
+        self._assert_same(loaded, tensor_map)
+
+    def test_round_trip_preserves_bfloat16(self) -> None:
+        # bfloat16 has no numpy equivalent and takes a separate path when
+        # converting to bytes, so it is worth covering on its own.
+        tensor_map = {"bf16": torch.tensor([1.5, -2.25, 3.75], dtype=torch.bfloat16)}
+
+        loaded = self._round_trip(tensor_map)
+
+        self._assert_same(loaded, tensor_map)
+
+    def test_round_trip_preserves_scalar_tensor(self) -> None:
+        tensor_map = {"scalar": torch.tensor(42.0)}
+
+        loaded = self._round_trip(tensor_map)
+
+        self._assert_same(loaded, tensor_map)
+        self.assertEqual(loaded["scalar"].shape, torch.Size([]))
+
+    def test_round_trip_preserves_empty_tensor(self) -> None:
+        tensor_map = {"empty": torch.zeros(0, 3)}
+
+        loaded = self._round_trip(tensor_map)
+
+        self._assert_same(loaded, tensor_map)
+
+    def test_round_trip_preserves_channels_last(self) -> None:
+        # Arrange: channels_last is stored with a permuted dim_order, so the
+        # bytes on disk are not in logical order.
+        tensor = (
+            torch.arange(24, dtype=torch.float32)
+            .reshape(1, 2, 3, 4)
+            .to(memory_format=torch.channels_last)
+        )
+        self.assertFalse(tensor.is_contiguous())
+
+        # Act
+        loaded = self._round_trip({"conv": tensor})["conv"]
+
+        # Assert
+        self.assertTrue(torch.equal(loaded, tensor))
+        self.assertTrue(loaded.is_contiguous(memory_format=torch.channels_last))
+
+    def test_tied_tensors_share_one_buffer(self) -> None:
+        # Arrange: the same tensor object under two keys, as with a tied
+        # embedding and output projection.
+        shared = torch.randn(64, 8)
+
+        # Act
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tied_path = os.path.join(tmpdir, "tied.ptd")
+            copied_path = os.path.join(tmpdir, "copied.ptd")
+            save_ptd(tied_path, {"embedding": shared, "output": shared})
+            save_ptd(copied_path, {"embedding": shared, "output": shared.clone()})
+
+            # Assert: the tied file stores the payload once.
+            self.assertLess(os.path.getsize(tied_path), os.path.getsize(copied_path))
+            loaded = load_ptd(tied_path)
+
+        self.assertTrue(torch.equal(loaded["embedding"], shared))
+        self.assertTrue(torch.equal(loaded["output"], shared))
+
+    def test_save_and_load_with_file_object(self) -> None:
+        # Mirrors the std::ostream overload of the C++ save_ptd.
+        tensor_map = {"weight": torch.tensor([7.0, 8.0])}
+        buffer = io.BytesIO()
+
+        save_ptd(buffer, tensor_map)
+        buffer.seek(0)
+        loaded = load_ptd(buffer)
+
+        self._assert_same(loaded, tensor_map)
+
+    def test_tensor_alignment_is_applied(self) -> None:
+        tensor_map = {"a": torch.ones(5), "b": torch.ones(7)}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "aligned.ptd")
+            save_ptd(path, tensor_map, tensor_alignment=256)
+            with open(path, "rb") as infile:
+                data = infile.read()
+
+        header = _get_extended_header(data)
+        self.assertIsNotNone(header)
+        flat_tensor = _deserialize_to_flat_tensor(
+            data[0 : header.flatbuffer_offset + header.flatbuffer_size]
+        )
+        # Effective alignment is lcm(segment_alignment, tensor_alignment).
+        alignment = math.lcm(FlatTensorConfig().segment_alignment, 256)
+        for segment in flat_tensor.segments:
+            self.assertEqual(segment.offset % alignment, 0)
+
+    def test_save_rejects_non_tensor_value(self) -> None:
+        with self.assertRaises(TypeError):
+            save_ptd(os.devnull, {"bad": "not a tensor"})
+
+    def test_save_rejects_non_contiguous_tensor(self) -> None:
+        # A transposed tensor is neither contiguous nor channels_last, so it
+        # has no representable dim_order.
+        with self.assertRaises(ValueError):
+            save_ptd(os.devnull, {"transposed": torch.randn(4, 5).t()})


### PR DESCRIPTION
Fixes #8542.

ExecuTorch has save_ptd in C++ (extension/flat_tensor/serialize/serialize.h, used by the CIFAR and XOR training examples) but nothing equivalent in Python - grep -rn "save_ptd\|load_ptd" --include=*.py comes back empty. The only Python entry point is FlatTensorSerializer, which takes a DataPayload rather than a plain dict[str, torch.Tensor].

Per @JacobSzwejbka's comment on the issue, the ask is round-tripping dict[str, tensor], which #11779 made straightforward.

Added save_ptd and load_ptd in extension/flat_tensor/serialize/serialize.py, mirroring the C++ argument order and taking either a path or a binary file-like object, which covers both C++ overloads in one function. Pure Python on top of the existing FlatTensorSerializer, so no new pybind11 surface and no second implementation to drift.

```python
save_ptd(path, tensor_map, tensor_alignment=16)   # default matches the C++ call sites
load_ptd(path) -> Dict[str, torch.Tensor]
```

A few things that needed care:

bfloat16 and non-contiguous layouts - tensor bytes go through the existing _tensor_to_bytes helper rather than a fresh .numpy().tobytes(), since bfloat16 has no numpy dtype.

channels_last - dim_order is a real permutation, so the bytes on disk aren't in logical order. load_ptd reshapes to the physical sizes implied by dim_order and then inverts that permutation. Without it the tensor comes back transposed. There's a test asserting both value equality and that the memory format survives.

Tied weights - a tensor under several keys, like an embedding reused as the output projection, is written once with both keys pointing at one buffer.

Empty tensors are built directly, since torch.frombuffer rejects a zero-length buffer. Named data entries with no tensor layout aren't tensors and get skipped rather than mis-decoded.

Ten new tests: dtype round-trips including bfloat16, scalar and empty tensors, channels_last, tied-tensor dedup, the file-object overload, alignment of segment offsets, and the two error paths. All pass, along with the existing TestSerialize cases in the same file.

ruff isn't used here; ufmt (black 24.4.2 + usort) and flake8 6.1.0 are clean on the changed files.

Note that extension/flat_tensor/test/test_serialize.py is in the --ignore list in pytest.ini (pre-existing, for missing flatc), so these run through the internal python_unittest target rather than OSS pytest. I verified them locally against a flatc-provisioned environment.

Two things I'd like your call on. I mirrored the C++ argument order with path first, since the issue framed this as the Python form of the C++ API - the Python-native alternative would be save_ptd(tensor_map, path, ...) matching torch.save(obj, f). Happy to flip it. And I deliberately left extension/flat_tensor/__init__.py empty; populating it would give a tidier import, but no python_library target currently covers that file and it would make importing the subpackage pull in torch. Glad to add it if you'd prefer the shorter import.

cc @JacobSzwejbka