### PR TITLE
Remove dynamic allocation from Ethos-U backend (#22531)

### DIFF
--- a/backends/arm/runtime/EthosUBackend.cpp
+++ b/backends/arm/runtime/EthosUBackend.cpp
@@ -121,10 +121,11 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
     }
 
     MemoryAllocator* allocator = context.get_runtime_allocator();
-    ExecutionHandle* handle = new (std::nothrow) ExecutionHandle();
+    ExecutionHandle* handle = allocator->allocateInstance<ExecutionHandle>();
     if (handle == nullptr) {
       return Error::MemoryAllocationFailed;
     }
+    new (handle) ExecutionHandle();
 
     EXECUTORCH_PROF_START(
         event_tracer,
@@ -134,7 +135,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
         data, size, context.get_named_data_map(), &handle->handles);
     EXECUTORCH_PROF_END(event_tracer, event_tracer_local_scope);
     if (read_status != Error::Ok) {
-      delete handle;
+      handle->~ExecutionHandle();
       return read_status;
     }
 
@@ -317,7 +318,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
       platform_destroy(exec_handle->platform_state);
     }
 
-    delete exec_handle;
+    exec_handle->~ExecutionHandle();
   }
 
  private:

--- a/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
+++ b/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
@@ -13,7 +13,6 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
-#include <new>
 
 #include <ethosu_driver.h>
 
@@ -60,9 +59,7 @@ PlatformState* platform_init(
   return nullptr;
 }
 
-void platform_destroy(PlatformState* state) {
-  delete state;
-}
+void platform_destroy(PlatformState* /*state*/) {}
 
 bool needs_scratch_allocation() {
   return true;


### PR DESCRIPTION
Summary:

When running ET in embedded Cortex-M we should not dynamically allocate. This `new` call added to support Cortex-A is breaking that contract. 

Instead, allocate ExecutionHandle on the runtime allocator and delegate the platform_state allocation/destruction to the platform. EthosUBackend_Cortex_M does not create a PlatformState so we can safely remove the delete call from platform_destory

Reviewed By: rascani

Differential Revision: D117747705


