### PR TITLE
[executorch][native] Map .ptn packages instead of copying them

### DIFF
--- a/backends/native/runtime/deserialize/OwnedBytes.cpp
+++ b/backends/native/runtime/deserialize/OwnedBytes.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/deserialize/OwnedBytes.h>
+
+#include <cerrno>
+#include <fstream>
+#include <stdexcept>
+#include <system_error>
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace ptn {
+namespace {
+
+std::string errno_suffix() {
+  return ": " + std::error_code(errno, std::system_category()).message();
+}
+
+} // namespace
+
+void OwnedBytes::Unmap::operator()(void* base) const noexcept {
+#if !defined(_WIN32)
+  // Nothing useful to do if this fails, and it must not throw: unique_ptr calls
+  // this from its destructor.
+  ::munmap(base, size);
+#endif
+}
+
+OwnedBytes OwnedBytes::from_vector(std::vector<uint8_t> bytes) {
+  return OwnedBytes(std::move(bytes));
+}
+
+OwnedBytes OwnedBytes::from_file(const std::string& path, bool use_mmap) {
+  return use_mmap ? map_file(path) : read_file(path);
+}
+
+OwnedBytes OwnedBytes::read_file(const std::string& path) {
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  if (!file) {
+    throw std::runtime_error("cannot open " + path);
+  }
+  const std::streamsize size = file.tellg();
+  if (size < 0) {
+    throw std::runtime_error("cannot size " + path);
+  }
+  file.seekg(0, std::ios::beg);
+  std::vector<uint8_t> bytes(static_cast<size_t>(size));
+  if (size > 0 && !file.read(reinterpret_cast<char*>(bytes.data()), size)) {
+    throw std::runtime_error("cannot read " + path);
+  }
+  return OwnedBytes(std::move(bytes));
+}
+
+OwnedBytes OwnedBytes::map_file(const std::string& path) {
+#if defined(_WIN32)
+  // TODO: Implement Windows mappings with CreateFileMapping and MapViewOfFile.
+  throw std::runtime_error("cannot mmap " + path + ": unsupported platform");
+#else
+  const int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd < 0) {
+    throw std::runtime_error("cannot open " + path + errno_suffix());
+  }
+
+  struct stat st = {};
+  if (::fstat(fd, &st) < 0) {
+    const std::string suffix = errno_suffix();
+    ::close(fd);
+    throw std::runtime_error("cannot size " + path + suffix);
+  }
+  if (!S_ISREG(st.st_mode)) {
+    ::close(fd);
+    throw std::runtime_error("cannot mmap " + path + ": not a regular file");
+  }
+  const size_t size = static_cast<size_t>(st.st_size);
+  if (size == 0) {
+    ::close(fd);
+    return OwnedBytes(std::vector<uint8_t>());
+  }
+
+  // The whole file from offset 0, so the base is page-aligned and every span
+  // into it has the same alignment it would have in a heap buffer. MAP_SHARED
+  // lets other processes mapping this file share the same physical pages; the
+  // mapping is read-only either way.
+  void* base = ::mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0);
+  const std::string suffix = errno_suffix();
+  // The mapping keeps the file alive on its own, so the descriptor is dead
+  // weight past this point whether or not the map succeeded.
+  ::close(fd);
+  if (base == MAP_FAILED) {
+    throw std::runtime_error("cannot mmap " + path + suffix);
+  }
+  return OwnedBytes(MappedFile(base, Unmap{size}));
+#endif
+}
+
+ByteSpan OwnedBytes::span() const {
+  if (const MappedFile* mapped = std::get_if<MappedFile>(&storage_)) {
+    return ByteSpan(
+        static_cast<const uint8_t*>(mapped->get()), mapped->get_deleter().size);
+  }
+  const std::vector<uint8_t>& bytes = std::get<std::vector<uint8_t>>(storage_);
+  return ByteSpan(bytes.data(), bytes.size());
+}
+
+bool OwnedBytes::is_mapped() const {
+  return std::holds_alternative<MappedFile>(storage_);
+}
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/OwnedBytes.h
+++ b/backends/native/runtime/deserialize/OwnedBytes.h
@@ -1,0 +1,86 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <executorch/backends/native/runtime/deserialize/ByteSpan.h>
+
+namespace ptn {
+
+// Owning, read-only bytes: either a heap buffer or a read-only file mapping.
+//
+// Hands out spans that alias the storage. Both alternatives keep their payload
+// address across a move — std::vector moves its buffer pointer, a mapping moves
+// its base address — so spans taken before a move stay valid, for as long as
+// the OwnedBytes lives. Copy is deleted: this holds a whole model.
+//
+// The mapped alternative is the one that matters for large packages: nothing is
+// copied, the pages are demand-paged, and they are shared with any other
+// process mapping the same file.
+class OwnedBytes {
+ private:
+  // Releases a mapping. Carries the length because that is what munmap needs,
+  // which lets a unique_ptr supply the whole move-only lifetime — no
+  // hand-written destructor or move operations.
+  struct Unmap {
+    size_t size = 0;
+
+    void operator()(void* base) const noexcept;
+  };
+
+  // A read-only mapping of an entire file. Null when this holds heap bytes.
+  using MappedFile = std::unique_ptr<void, Unmap>;
+
+  std::variant<std::vector<uint8_t>, MappedFile> storage_;
+
+  explicit OwnedBytes(std::vector<uint8_t> bytes)
+      : storage_(std::move(bytes)) {}
+  explicit OwnedBytes(MappedFile mapped_file)
+      : storage_(std::move(mapped_file)) {}
+
+ public:
+  // Empty, owning nothing.
+  OwnedBytes() = default;
+
+  ~OwnedBytes() = default;
+  OwnedBytes(OwnedBytes&&) noexcept = default;
+  OwnedBytes& operator=(OwnedBytes&&) noexcept = default;
+  OwnedBytes(const OwnedBytes&) = delete;
+  OwnedBytes& operator=(const OwnedBytes&) = delete;
+
+  // The whole payload. Valid for this OwnedBytes' lifetime.
+  ByteSpan span() const;
+
+  // True when these bytes are a file mapping rather than a heap buffer.
+  bool is_mapped() const;
+
+  // Take ownership of a buffer the caller already has, without copying it.
+  static OwnedBytes from_vector(std::vector<uint8_t> bytes);
+
+  // Acquire the contents of `path`. Maps it read-only by default: nothing is
+  // copied, pages arrive on demand, and they are shared with any other process
+  // mapping the same file. Pass use_mmap=false to read it into the heap
+  // instead, which is worth it only when the file must outlive edits to it on
+  // disk, since a mapping sees those edits.
+  //
+  // Throws std::runtime_error if the file cannot be read, or cannot be mapped
+  // when mapping was asked for (including on a platform with no mmap). An empty
+  // file yields empty heap bytes either way, since mmap rejects a zero length.
+  static OwnedBytes from_file(const std::string& path, bool use_mmap = true);
+
+ private:
+  static OwnedBytes read_file(const std::string& path);
+  static OwnedBytes map_file(const std::string& path);
+};
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/Package.cpp
+++ b/backends/native/runtime/deserialize/Package.cpp
@@ -7,7 +7,6 @@
 #include <executorch/backends/native/runtime/deserialize/Package.h>
 
 #include <algorithm>
-#include <fstream>
 #include <stdexcept>
 #include <string_view>
 
@@ -66,10 +65,10 @@ bool Package::looks_like_package(ByteSpan bytes) {
   return bytes.size() >= 2 && bytes[0] == 'P' && bytes[1] == 'K';
 }
 
-Package Package::load(std::vector<uint8_t> bytes) {
+Package Package::load(OwnedBytes bytes) {
   Package out;
   out.bytes_ = std::move(bytes);
-  const ByteSpan image{out.bytes_.data(), out.bytes_.size()};
+  const ByteSpan image = out.bytes_.span();
 
   out.zip_ = ZipReader::open(image);
 
@@ -100,21 +99,8 @@ Package Package::load(std::vector<uint8_t> bytes) {
   return out;
 }
 
-Package Package::load_file(const std::string& path) {
-  std::ifstream file(path, std::ios::binary | std::ios::ate);
-  if (!file) {
-    throw std::runtime_error("package: cannot open " + path);
-  }
-  const std::streamsize size = file.tellg();
-  if (size < 0) {
-    throw std::runtime_error("package: cannot size " + path);
-  }
-  file.seekg(0, std::ios::beg);
-  std::vector<uint8_t> bytes(static_cast<size_t>(size));
-  if (size > 0 && !file.read(reinterpret_cast<char*>(bytes.data()), size)) {
-    throw std::runtime_error("package: cannot read " + path);
-  }
-  return load(std::move(bytes));
+Package Package::load(const std::string& path, bool use_mmap) {
+  return load(OwnedBytes::from_file(path, use_mmap));
 }
 
 std::optional<Constant> Package::constant(const std::string& key) const {

--- a/backends/native/runtime/deserialize/Package.h
+++ b/backends/native/runtime/deserialize/Package.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <executorch/backends/native/runtime/deserialize/ByteSpan.h>
+#include <executorch/backends/native/runtime/deserialize/OwnedBytes.h>
 #include <executorch/backends/native/runtime/deserialize/SafeTensorsReader.h>
 #include <executorch/backends/native/runtime/deserialize/ZipReader.h>
 #include <executorch/backends/native/runtime/graph/ScalarType.h>
@@ -39,12 +40,12 @@ struct Constant {
 // references.
 //
 // Owns the package bytes; the zip and safetensors readers, and every span
-// handed out, alias into that one buffer. std::vector's move preserves the
-// buffer address, so those views stay valid across a move of the Package. Copy
+// handed out, alias into that one buffer. OwnedBytes keeps its payload address
+// across a move, so those views stay valid across a move of the Package. Copy
 // is deleted: a package is model-sized.
 class Package {
  private:
-  std::vector<uint8_t> bytes_;
+  OwnedBytes bytes_;
   ZipReader zip_;
   ByteSpan program_;
   // Absent when the program references no constants, in which case the package
@@ -61,15 +62,20 @@ class Package {
   Package(const Package&) = delete;
   Package& operator=(const Package&) = delete;
 
-  // Parse a .ptn image. Takes ownership rather than copying, so a
-  // hundred-megabyte package is resident once. Throws std::runtime_error if the
-  // zip, the safetensors index, or the alias map is malformed, or if the
-  // required program member is missing.
-  static Package load(std::vector<uint8_t> bytes);
+  // Open and parse the .ptn at `path`. Maps it by default, so the program and
+  // every constant span points into the mapping and the weights are
+  // demand-paged rather than heap-resident; pass use_mmap=false to read it into
+  // the heap. Throws std::runtime_error if the file cannot be acquired or is
+  // not a well-formed package.
+  static Package load(const std::string& path, bool use_mmap = true);
 
-  // Read and parse a .ptn from disk. Throws std::runtime_error if the file
-  // cannot be read.
-  static Package load_file(const std::string& path);
+  // Parse a .ptn image already in hand. Takes ownership rather than copying, so
+  // a hundred-megabyte package is resident once. For callers that must inspect
+  // the bytes before deciding this is a package at all; everyone else should
+  // use the path overload. Throws std::runtime_error if the zip, the
+  // safetensors index, or the alias map is malformed, or if the required
+  // program member is missing.
+  static Package load(OwnedBytes bytes);
 
   // The serialized native Program flatbuffer (the program.ptg member).
   ByteSpan program_bytes() const {
@@ -87,6 +93,11 @@ class Package {
   // Duplicate key -> owner key.
   const std::unordered_map<std::string, std::string>& aliases() const {
     return aliases_;
+  }
+
+  // True when the package is backed by a file mapping rather than the heap.
+  bool is_mapped() const {
+    return bytes_.is_mapped();
   }
 
   // Constant for `key`, resolving an alias to its owner. nullopt when the

--- a/backends/native/runtime/deserialize/targets.bzl
+++ b/backends/native/runtime/deserialize/targets.bzl
@@ -10,6 +10,15 @@ def define_common_targets():
         visibility = ["//executorch/backends/native/..."],
     )
 
+    # Owning byte buffer behind a package: heap read or read-only mmap.
+    runtime.cxx_library(
+        name = "owned_bytes",
+        srcs = ["OwnedBytes.cpp"],
+        exported_headers = ["OwnedBytes.h"],
+        exported_deps = [":byte_span"],
+        visibility = ["//executorch/backends/native/..."],
+    )
+
     # Minimal JSON reader for the package's index metadata (safetensors header and
     # alias map). Integers only; see JsonParser.h.
     runtime.cxx_library(
@@ -49,6 +58,7 @@ def define_common_targets():
         exported_headers = ["Package.h"],
         exported_deps = [
             ":byte_span",
+            ":owned_bytes",
             ":safetensors_reader",
             ":zip_reader",
             "//executorch/backends/native/runtime/graph:scalar_type",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #22532
* #22471
* #22470
* #22469
* #22468
* #22467
* #22466

`Package` read the whole `.ptn` into a `std::vector<uint8_t>`, so every constant
was heap-resident for the package's lifetime whether or not anything touched it.
Fine for a 14 MB `mobilenet_v2`; disqualifying for a model whose weights are the
reason constants ship out-of-line in the first place.

Adds `OwnedBytes`: owning, read-only bytes that are either a heap buffer or a
read-only file mapping, behind one `span()`. `Package` holds one of these instead
of a vector, so the backing becomes a load-time argument rather than a property
of the type. `Package::load(path)` maps by default; pass `use_mmap=false` to read
into the heap. `load_file` and `map_file` collapse into that one entry point, and
the `read_file` that was duplicated in `Package.cpp` and `ptn_inspector.cpp`
collapses into `OwnedBytes::from_file`.

The mapping covers the whole file from offset 0, which is deliberately simpler
than ExecuTorch's `MmapDataLoader`: mapping a sub-range needs page-rounding on the
way in and again in the unmap callback, since only the interior pointer survives
in the buffer, whereas a whole-file map is already page-aligned. That also means
alignment is unchanged from the heap path -- a page-aligned base is more aligned
than `new[]`'s, so every span keeps the alignment its file offset implies. The
caveat in `SafeTensorsReader.h` about unpadded safetensors payloads applies
equally to both modes; removing it is an AOT change.

`MAP_SHARED`, so two processes running the same model share physical pages, the
way `MmapDataLoader` does. A zero-length file yields empty heap bytes, since
`mmap` rejects a zero length. Platforms without `mmap` throw rather than failing
to compile.

`ptn_inspector` maps by default and takes `--nommap` to opt out. It cannot use
`Package::load(path)`, because it also accepts a bare `.ptg` and so must inspect
the leading bytes before it knows whether to build a package at all;
re-acquiring the file inside the path overload would read it twice under
`--nommap`. That overload therefore has no caller yet -- it is the entry point
the runtime will use -- though both halves it forwards to are exercised here.

One behaviour difference worth knowing: a mapping sees later edits to the file on
disk, a heap read does not.

Differential Revision: [D118480655](https://our.internmc.facebook.com/intern/diff/D118480655/)