### PR TITLE
Keep const-tensor dim order canonical when a dimension has size 1

### DIFF
--- a/exir/emit/_emitter.py
+++ b/exir/emit/_emitter.py
@@ -83,7 +83,7 @@ from executorch.exir.schema import (
 )
 from executorch.exir.tensor import (
     AddressSpaceOverflowException,
-    dim_order_from_stride,
+    dim_order_from_tensor,
     layout_enum,
     make_allocation_info,
     make_tensor_value,
@@ -2034,7 +2034,10 @@ class _TopLevelEmitter(_Emitter):
 
                 spec.storage = real_tensor.untyped_storage()
                 spec.stride = real_tensor.stride()
-                spec.dim_order = dim_order_from_stride(spec.stride)
+                # Not dim_order_from_stride: a size-1 dimension makes strides
+                # ambiguous, and the guard above has already established that
+                # this tensor is contiguous or channels-last.
+                spec.dim_order = dim_order_from_tensor(real_tensor)
             # User inputs and mutable buffers are not constants, other buffers or parameters are.
             if initialize_buffer and is_mutable_buffer:
                 spec.const = True

--- a/exir/tensor.py
+++ b/exir/tensor.py
@@ -96,6 +96,29 @@ def dim_order_from_stride(stride: Tuple[int]) -> Tuple[bytes]:
     return tuple(typing.cast(Tuple[bytes], sorted_dims))
 
 
+def dim_order_from_tensor(tensor: torch.Tensor) -> Tuple[bytes]:
+    """Dim order of a real tensor, preferring torch's own answer.
+
+    ``dim_order_from_stride`` only sees strides, so it cannot tell that a
+    size-1 dimension's stride is arbitrary. A depthwise convolution weight is
+    the case that bites: ``(C_out, 1, kH, kW)`` in channels-last carries strides
+    like ``(9, 1, 3, 1)``, where dims 1 and 3 tie at stride 1 purely because the
+    input-channel dim has size 1. A stable descending sort then keeps dim 1
+    ahead of dim 3 and yields ``(0, 2, 1, 3)`` -- neither contiguous nor
+    channels-last, so the portable kernels reject the tensor at runtime even
+    though the layout is a perfectly ordinary channels-last weight.
+
+    ``torch.Tensor.dim_order()`` resolves the ambiguity against the tensor's
+    sizes and reports a canonical order. Fall back to the stride-only
+    computation for tensors it cannot answer for, such as those carrying
+    unbacked symbolic strides.
+    """
+    try:
+        return typing.cast(Tuple[bytes], tuple(int(d) for d in tensor.dim_order()))
+    except Exception:
+        return dim_order_from_stride(tensor.stride())
+
+
 def stride_from_dim_order(sizes: List[int], dim_order: List[int]) -> List[int]:
     """
     Converts dim order to stride using sizes
@@ -201,7 +224,7 @@ class TensorSpec:
             is_sparse=tensor.is_sparse,
         )
         spec.stride = tensor.stride()
-        spec.dim_order = dim_order_from_stride(spec.stride)
+        spec.dim_order = dim_order_from_tensor(tensor)
         spec.requires_grad = tensor.requires_grad
         spec.storage = tensor.untyped_storage() if const else None
 

--- a/exir/tests/test_channels_last_depthwise_conv.py
+++ b/exir/tests/test_channels_last_depthwise_conv.py
@@ -1,0 +1,98 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+import unittest
+
+import torch
+from executorch.exir import to_edge_transform_and_lower
+from executorch.exir.capture._config import ExecutorchBackendConfig
+from executorch.extension.pybindings.portable_lib import (  # @manual
+    _load_for_executorch_from_buffer,
+)
+from torch.export import export
+
+
+class ConvModule(torch.nn.Module):
+    def __init__(self, channels: int, groups: int, kernel_size: int) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(
+            channels, channels, kernel_size, padding=kernel_size // 2, groups=groups
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+class TestChannelsLastDepthwiseConv(unittest.TestCase):
+    """A channels-last weight with a size-1 input-channel dim must stay canonical.
+
+    Such a weight -- any depthwise convolution, and any single-channel one --
+    has two dimensions tied at stride 1, so ordering by stride alone reports
+    ``(0, 2, 1, 3)``. That is neither contiguous nor channels-last, and the
+    portable convolution kernel rejects it:
+
+        Expected tensor to have default or channels last dim order, but got
+        dim_order(0): 0 dim_order(1): 2 dim_order(2): 1 dim_order(3): 3
+
+    See https://github.com/pytorch/executorch/issues/22520.
+    """
+
+    def _assert_runtime_matches_eager(
+        self, module: torch.nn.Module, sample_input: torch.Tensor
+    ) -> None:
+        program = to_edge_transform_and_lower(
+            export(module, (sample_input,), strict=True),
+            partitioner=[],
+        ).to_executorch(config=ExecutorchBackendConfig(extract_delegate_segments=False))
+
+        runtime_output = _load_for_executorch_from_buffer(program.buffer).run_method(
+            "forward", (sample_input,)
+        )[0]
+        with torch.no_grad():
+            expected = module(sample_input)
+        torch.testing.assert_close(runtime_output, expected, atol=1e-5, rtol=1e-5)
+
+    def test_channels_last_depthwise_conv_runs(self) -> None:
+        module = (
+            ConvModule(channels=8, groups=8, kernel_size=3)
+            .eval()
+            .to(memory_format=torch.channels_last)
+        )
+        sample_input = torch.randn(1, 8, 8, 8).to(memory_format=torch.channels_last)
+        self._assert_runtime_matches_eager(module, sample_input)
+
+    def test_channels_last_single_channel_conv_runs(self) -> None:
+        # Not depthwise, but the weight is still (C_out, 1, kH, kW).
+        module = (
+            ConvModule(channels=1, groups=1, kernel_size=3)
+            .eval()
+            .to(memory_format=torch.channels_last)
+        )
+        sample_input = torch.randn(1, 1, 8, 8).to(memory_format=torch.channels_last)
+        self._assert_runtime_matches_eager(module, sample_input)
+
+    def test_conv_layout_matrix_runs(self) -> None:
+        for channels, depthwise, kernel_size, channels_last in itertools.product(
+            (1, 4, 8), (False, True), (1, 3), (False, True)
+        ):
+            groups = channels if depthwise else 1
+            with self.subTest(
+                channels=channels,
+                groups=groups,
+                kernel_size=kernel_size,
+                channels_last=channels_last,
+            ):
+                module = ConvModule(channels, groups, kernel_size).eval()
+                sample_input = torch.randn(1, channels, 8, 8)
+                if channels_last:
+                    module = module.to(memory_format=torch.channels_last)
+                    sample_input = sample_input.to(memory_format=torch.channels_last)
+                self._assert_runtime_matches_eager(module, sample_input)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/exir/tests/test_tensor.py
+++ b/exir/tests/test_tensor.py
@@ -18,6 +18,7 @@ import torch
 from executorch.exir.tensor import (
     contiguous_stride_from_shape,
     dim_order_from_stride,
+    dim_order_from_tensor,
     make_allocation_info,
     make_tensor_value,
     num_bytes_from_shape_and_dtype,
@@ -204,6 +205,45 @@ class TestTensor(unittest.TestCase):
         shape = (2, 3, 4)
         stride = contiguous_stride_from_shape(torch.Size(shape))
         self.assertEqual((12, 4, 1), stride)
+
+    def test_dim_order_from_tensor_disambiguates_size_one_dims(self) -> None:
+        """A size-1 dimension makes strides ambiguous; the reported order must stay canonical.
+
+        A depthwise convolution weight is ``(C_out, 1, kH, kW)``. In channels-last
+        that is strides like ``(9, 1, 3, 1)``, where dims 1 and 3 tie at stride 1
+        only because the input-channel dim has size 1. Sorting strides alone puts
+        dim 1 first and yields ``(0, 2, 1, 3)``, which is neither contiguous nor
+        channels-last, so the portable kernels reject the tensor at runtime.
+        """
+        contiguous = (0, 1, 2, 3)
+        channels_last = (0, 2, 3, 1)
+
+        weight = torch.randn(8, 1, 3, 3).to(memory_format=torch.channels_last)
+        # Precondition: the stride-only view is the ambiguous one.
+        self.assertEqual((0, 2, 1, 3), tuple(dim_order_from_stride(weight.stride())))
+        self.assertIn(tuple(dim_order_from_tensor(weight)), (contiguous, channels_last))
+
+        # Ordinary weights are unaffected, in either layout.
+        for shape in ((8, 2, 3, 3), (16, 4, 5, 5)):
+            for tensor in (
+                torch.randn(*shape),
+                torch.randn(*shape).to(memory_format=torch.channels_last),
+            ):
+                self.assertEqual(
+                    tuple(dim_order_from_stride(tensor.stride())),
+                    tuple(dim_order_from_tensor(tensor)),
+                )
+
+    def test_dim_order_from_tensor_falls_back_for_unanswerable_tensors(self) -> None:
+        class NoDimOrder(torch.Tensor):
+            def dim_order(self, *args: object, **kwargs: object) -> object:
+                raise RuntimeError("cannot be determined")
+
+        tensor = torch.randn(2, 3, 4).as_subclass(NoDimOrder)
+        self.assertEqual(
+            tuple(dim_order_from_stride(tensor.stride())),
+            tuple(dim_order_from_tensor(tensor)),
+        )
 
     def test_dim_order_from_stride(self) -> None:
         # shape = (4)


### PR DESCRIPTION
Fixes #22520.

The tensor the portable kernel rejects is the weight, not the activation:

```
Expected tensor to have default or channels last dim order, but got
  dim_order(0): 0  dim_order(1): 2  dim_order(2): 1  dim_order(3): 3
[kernel_ops_util.cpp:386] Check failed (tensor_is_default_or_channels_last_dim_order(weight))
```

A depthwise weight is (C_out, 1, kH, kW). In channels-last that's strides like (9, 1, 3, 1), where dims 1 and 3 tie at stride 1 only because the input-channel dim has size 1. dim_order_from_stride sees strides alone and its stable descending sort keeps dim 1 ahead of dim 3:

```python
>>> w = torch.randn(8, 1, 3, 3).to(memory_format=torch.channels_last)
>>> w.stride()
(9, 1, 3, 1)
>>> w.dim_order()                        # torch
(0, 2, 3, 1)                             # channels-last, accepted
>>> dim_order_from_stride(w.stride())    # executorch
(0, 2, 1, 3)                             # neither, rejected
```

For (8, 2, 3, 3) both agree on (0, 2, 3, 1) - you need the size-1 dim to see the disagreement.

The emitter had already decided the tensor was fine, leaving it alone precisely because is_contiguous() or is_contiguous(channels_last) held, and then contradicted itself a line later by deriving the dim order from strides:

```python
if not (real_tensor.is_contiguous() or real_tensor.is_contiguous(memory_format=torch.channels_last)):
    real_tensor = real_tensor.contiguous()
...
spec.dim_order = dim_order_from_stride(spec.stride)   # can now say "neither"
```

So take the order from torch.Tensor.dim_order(), which resolves the tie against the tensor's sizes, and fall back to the stride-only computation for tensors it can't answer for, like ones with unbacked symbolic strides. Applied at the two places that hold a real tensor: TensorSpec.from_tensor and the emitter's constant path.

It isn't only depthwise - any weight with a size-1 input-channel dim hits it, including a plain single-channel conv. Over 24 convolutions (channels 1/4/8, dense and depthwise, 1x1 and 3x3, contiguous and channels-last), 6 fail before this change and all 24 pass after. Every failure is channels-last with a size-1 channel dim.

Repro needs no quantization and no backend:

```python
m = torch.nn.Conv2d(8, 8, 3, padding=1, groups=8).eval().to(memory_format=torch.channels_last)
x = torch.randn(1, 8, 8, 8).to(memory_format=torch.channels_last)
prog = to_edge_transform_and_lower(export(m, (x,), strict=True), partitioner=[]).to_executorch()
_load_for_executorch_from_buffer(prog.buffer).run_method("forward", (x,))   # 0x12 before this change
```

Testing: new exir/tests/test_channels_last_depthwise_conv.py, 3 tests plus 24 subtests, and 8 of them fail without the fix. New unit tests in exir/tests/test_tensor.py including the symbolic-stride fallback. test_tensor.py 13 passed, exir/emit/test/ 69 passed, test_dim_order_utils.py and test_legalize_portable_dim_order_pass.py 20 passed. flake8 and ufmt clean.

The end-to-end test compares runtime output against eager rather than only checking it runs, so a silently wrong layout would fail too.

One limitation worth stating: I ran these against an installed ExecuTorch wheel with the two changed modules overlaid, because the source tree isn't importable without a full build on my machine. A few repo tests (test_memory_planning.py) reference symbols newer than the wheel and couldn't be collected that way, so CI is the real check for those.

On #21621 - it reports the same dim_order(0, 2, 1, 3) signature for yolo26 on the portable backend, and that model uses depthwise convolutions, so it's plausibly the same cause. I couldn't run yolo26 to confirm, so I haven't marked it fixed.

cc @JacobSzwejbka @angelayi @larryliu0820 @lucylq