### PR TITLE
Add an executor for batched generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -997,7 +997,9 @@ if(EXECUTORCH_BUILD_EXTENSION_LLM)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/llm/cache)
   list(APPEND _executorch_extensions extension_llm_cache)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extension/llm/batching)
-  list(APPEND _executorch_extensions extension_llm_batching)
+  list(APPEND _executorch_extensions extension_llm_batching
+       extension_llm_batching_module
+  )
 endif()
 
 if(EXECUTORCH_BUILD_EXTENSION_RUNNER_UTIL)

--- a/extension/llm/batching/CMakeLists.txt
+++ b/extension/llm/batching/CMakeLists.txt
@@ -9,6 +9,10 @@
 # scheduler and the executor seam are header-only and free of ExecuTorch runtime
 # types; the runner owns a thread, so this is a static library rather than an
 # INTERFACE target.
+#
+# extension_llm_batching_module is a separate target because it implements that
+# seam against a program and a KV cache, and so carries the runtime types the
+# seam itself is kept clear of.
 
 if(NOT EXECUTORCH_ROOT)
   set(EXECUTORCH_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
@@ -26,8 +30,22 @@ target_compile_options(extension_llm_batching PUBLIC ${_common_compile_options})
 find_package(Threads REQUIRED)
 target_link_libraries(extension_llm_batching PUBLIC Threads::Threads)
 
+add_library(extension_llm_batching_module module_executor.cpp)
+target_link_libraries(
+  extension_llm_batching_module
+  PUBLIC extension_llm_batching extension_llm_cache extension_module
+         extension_tensor
+  PRIVATE extension_llm_sampler
+)
+target_include_directories(
+  extension_llm_batching_module PUBLIC ${_common_include_directories}
+)
+target_compile_options(
+  extension_llm_batching_module PUBLIC ${_common_compile_options}
+)
+
 install(
-  TARGETS extension_llm_batching
+  TARGETS extension_llm_batching extension_llm_batching_module
   EXPORT ExecuTorchTargets
   DESTINATION ${CMAKE_INSTALL_LIBDIR}
   INCLUDES

--- a/extension/llm/batching/module_executor.cpp
+++ b/extension/llm/batching/module_executor.cpp
@@ -1,0 +1,519 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/extension/llm/batching/module_executor.h>
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstring>
+#include <random>
+#include <utility>
+
+#include <executorch/extension/llm/sampler/sampler.h>
+#include <executorch/extension/llm/sampler/util.h>
+#include <executorch/extension/tensor/tensor.h>
+#include <executorch/runtime/backend/backend_options_map.h>
+#include <executorch/runtime/core/exec_aten/util/scalar_type_util.h>
+#include <executorch/runtime/platform/log.h>
+
+namespace executorch {
+namespace extension {
+namespace llm {
+namespace batching {
+
+using ::executorch::extension::make_tensor_ptr;
+using ::executorch::runtime::Error;
+using ::executorch::runtime::Result;
+
+namespace {
+
+// Constant methods carry no delegate, so the layout reads with the program
+// loaded and the method not. Sizing is the caller's and is left unset.
+Result<cache::CacheConfig> config_from_program(Module& module) {
+  const auto read_int = [&module](const char* name) -> std::optional<int64_t> {
+    const auto r = module.execute(name);
+    if (!r.ok() || r->empty() || !r->at(0).isInt()) {
+      return std::nullopt;
+    }
+    return r->at(0).toInt();
+  };
+  const auto read_ints =
+      [&module](const char* name) -> std::optional<std::vector<int>> {
+    const auto r = module.execute(name);
+    if (!r.ok() || r->empty() || !r->at(0).isTensor()) {
+      return std::nullopt;
+    }
+    const auto t = r->at(0).toTensor();
+    if (t.scalar_type() != ::executorch::aten::ScalarType::Int) {
+      return std::nullopt;
+    }
+    const int32_t* p = t.const_data_ptr<int32_t>();
+    return std::vector<int>(p, p + t.numel());
+  };
+
+  const auto n_caches = read_int("get_n_caches");
+  const auto kv_heads = read_ints("get_kv_heads");
+  const auto head_dims = read_ints("get_head_dims");
+  const auto windows = read_ints("get_windows");
+  ET_CHECK_OR_RETURN_ERROR(
+      n_caches && kv_heads && head_dims && windows,
+      InvalidArgument,
+      "ModuleExecutor: the program publishes no KV layout");
+  const auto n = static_cast<size_t>(*n_caches);
+  ET_CHECK_OR_RETURN_ERROR(
+      kv_heads->size() == n && head_dims->size() == n && windows->size() == n,
+      InvalidArgument,
+      "ModuleExecutor: the published KV layout names %zu caches inconsistently",
+      n);
+
+  cache::CacheConfig cfg{};
+  cfg.n_layers = static_cast<int>(n);
+  cfg.layers.reserve(n);
+  for (size_t l = 0; l < n; ++l) {
+    cache::LayerConfig lc{};
+    lc.n_kv_heads = (*kv_heads)[l];
+    lc.head_dim = (*head_dims)[l];
+    lc.policy = (*windows)[l] > 0
+        ? cache::LayerPolicy{cache::LayerPolicy::Kind::Ring, (*windows)[l]}
+        : cache::LayerPolicy{cache::LayerPolicy::Kind::Flat, 0};
+    cfg.layers.push_back(lc);
+  }
+  return cfg;
+}
+
+// The backend-load option the delegate resolves the cache through.
+constexpr char kCacheKeyOption[] = "cache_key";
+
+std::uint64_t nondeterministic_seed() {
+  std::random_device device;
+  return device();
+}
+
+// One forward's inputs, flattened across the batch. Entry i of `tokens` and of
+// `positions` names the same token, which is how the cache pairs them.
+struct Step {
+  // Signed to match the model's token input, not Token.
+  std::vector<std::int64_t> tokens;
+  std::vector<std::int64_t> positions;
+  // The sequence each token belongs to, declared to the cache one slice at a
+  // time so a declaration always matches the forward that places it.
+  std::vector<std::int32_t> seq_ids;
+  // Per input: the logits row it draws from, or -1 when its prediction is
+  // discarded. An input of any width contributes one, since only its last row
+  // predicts a token the session does not hold.
+  std::vector<int> logit_indices;
+};
+
+// Flatten the batch and truncate whatever it reopens; execute() declares each
+// slice to the cache as it runs it. A per-sequence cursor carries the batch's
+// own writes, so consecutive chunks of one prompt abut and only the first can
+// reopen committed ground. Every input is checked before any is truncated, so
+// a refusal leaves the cache untouched.
+Result<Step> build_step(
+    cache::BatchControl& ctl,
+    const BatchInput& batch,
+    const std::unordered_map<SessionId, SessionInfo>& sessions,
+    int max_session_tokens) {
+  Step step;
+  const std::size_t total = batch.size();
+  step.tokens.reserve(total);
+  step.positions.reserve(total);
+  step.logit_indices.reserve(batch.inputs.size());
+
+  step.seq_ids.reserve(total);
+  // Truncations the batch asks for, held until every input has been checked.
+  std::vector<std::pair<std::int32_t, int>> rewinds;
+  // Where each sequence stands mid-batch: the cache still reports what it held
+  // before the step, so the batch's own writes live here.
+  std::unordered_map<std::int32_t, int> cursor;
+
+  for (const Input& input : batch.inputs) {
+    const auto seq_it = sessions.find(input.sid);
+    if (seq_it == sessions.end()) {
+      ET_LOG(Error, "build_step: session %" PRId64 " is not open", input.sid);
+      return Error::InvalidArgument;
+    }
+    const std::int32_t seq_id = seq_it->second.seq_id;
+    if (input.size == 0 || !input.tokens ||
+        input.offset + input.size > input.tokens->size()) {
+      ET_LOG(
+          Error,
+          "build_step: session %" PRId64 " gave a slice its tokens do not hold",
+          input.sid);
+      return Error::InvalidArgument;
+    }
+
+    const std::int64_t start = static_cast<std::int64_t>(input.position) +
+        static_cast<std::int64_t>(input.offset);
+    const auto [cursor_it, first_for_seq] =
+        cursor.try_emplace(seq_id, ctl.next_pos(seq_id));
+    int& at = cursor_it->second;
+    if (start > at) {
+      // Positions nothing attended, and nothing later reaches back to fill.
+      ET_LOG(
+          Error,
+          "build_step: session %" PRId64 " starts at %" PRId64
+          " over a sequence holding %d",
+          input.sid,
+          start,
+          at);
+      return Error::InvalidArgument;
+    }
+    if (start < at) {
+      if (!first_for_seq) {
+        // Its predecessor in this batch has already been laid down, so a
+        // rewind now would truncate committed cells for a step whose
+        // positions repeat and cannot be placed.
+        ET_LOG(
+            Error,
+            "build_step: session %" PRId64 " overlaps its earlier input",
+            input.sid);
+        return Error::InvalidArgument;
+      }
+      if (start == 0) {
+        // Emptying a sequence hands its id back, and the step names it.
+        ET_LOG(
+            Error,
+            "build_step: session %" PRId64 " reopens from the start",
+            input.sid);
+        return Error::InvalidArgument;
+      }
+      rewinds.emplace_back(seq_id, static_cast<int>(start));
+      at = static_cast<int>(start);
+    }
+
+    const std::int64_t end = start + static_cast<std::int64_t>(input.size);
+    if (end > max_session_tokens) {
+      ET_LOG(
+          Error,
+          "build_step: session %" PRId64 " reaches %" PRId64 " of %d cells",
+          input.sid,
+          end,
+          max_session_tokens);
+      return Error::OutOfResources;
+    }
+
+    const Token* slice = input.tokens->data() + input.offset;
+    for (std::size_t k = 0; k < input.size; ++k) {
+      step.tokens.push_back(static_cast<std::int64_t>(slice[k]));
+    }
+    for (std::size_t k = 0; k < input.size; ++k) {
+      step.positions.push_back(start + static_cast<std::int64_t>(k));
+    }
+    step.seq_ids.insert(step.seq_ids.end(), input.size, seq_id);
+    at = static_cast<int>(end);
+    step.logit_indices.push_back(
+        input.produce_output ? static_cast<int>(step.tokens.size()) - 1 : -1);
+  }
+
+  for (const auto& [seq_id, from] : rewinds) {
+    if (!ctl.seq_rm(seq_id, from, std::nullopt)) {
+      ET_LOG(Error, "build_step: sequence %d would not truncate", seq_id);
+      return Error::Internal;
+    }
+  }
+  return step;
+}
+
+} // namespace
+
+ModuleExecutor::ModuleExecutor(
+    std::unique_ptr<Module> module,
+    std::shared_ptr<cache::CacheBase> cache,
+    std::unique_ptr<cache::CacheSession> session,
+    int max_sessions,
+    int max_session_tokens,
+    std::string backend_id,
+    std::string method,
+    std::int32_t vocab_size,
+    int max_step_tokens)
+    : session_(std::move(session)),
+      cache_(std::move(cache)),
+      module_(std::move(module)),
+      ctl_(cache_->as_batch_control()),
+      max_sessions_(max_sessions),
+      max_session_tokens_(max_session_tokens),
+      backend_id_(std::move(backend_id)),
+      method_(std::move(method)),
+      vocab_size_(vocab_size),
+      max_step_tokens_(max_step_tokens) {}
+
+ModuleExecutor::~ModuleExecutor() = default;
+
+std::unique_ptr<ModuleExecutor> ModuleExecutor::create(
+    std::unique_ptr<Module> module,
+    int max_sessions,
+    int max_session_tokens,
+    int kv_dtype,
+    int initial_capacity,
+    std::string cache_kind,
+    std::string method) {
+  if (module == nullptr) {
+    ET_LOG(Error, "ModuleExecutor: no program");
+    return nullptr;
+  }
+  if (max_sessions <= 0 || max_session_tokens <= 0) {
+    ET_LOG(Error, "ModuleExecutor: session limits must be positive");
+    return nullptr;
+  }
+  if (module->load() != Error::Ok) { // a no-op once the caller has loaded it
+    ET_LOG(Error, "ModuleExecutor: the program did not load");
+    return nullptr;
+  }
+
+  auto cfg = config_from_program(*module);
+  if (!cfg.ok()) {
+    return nullptr;
+  }
+  cfg->capacity = max_sessions * max_session_tokens;
+  cfg->kv_dtype = kv_dtype;
+  if (initial_capacity >= 0) {
+    cfg->initial_capacity = initial_capacity;
+  }
+  if (!cache::valid(*cfg)) {
+    ET_LOG(Error, "ModuleExecutor: the program's layout is unusable");
+    return nullptr;
+  }
+
+  const auto meta = module->method_meta(method);
+  if (!meta.ok()) {
+    ET_LOG(Error, "ModuleExecutor: %s has no metadata", method.c_str());
+    return nullptr;
+  }
+
+  std::string backend_id;
+  for (std::size_t i = 0; i < meta->num_backends(); ++i) {
+    const auto name = meta->get_backend_name(i);
+    if (!name.ok()) {
+      ET_LOG(
+          Error, "ModuleExecutor: %s has an unnamed delegate", method.c_str());
+      return nullptr;
+    }
+    if (backend_id.empty()) {
+      backend_id = name.get();
+    } else if (backend_id != name.get()) {
+      ET_LOG(
+          Error,
+          "ModuleExecutor: %s spans more than one backend, so which holds the "
+          "cache is ambiguous",
+          method.c_str());
+      return nullptr;
+    }
+  }
+  if (backend_id.empty()) {
+    ET_LOG(Error, "ModuleExecutor: %s delegates to nothing", method.c_str());
+    return nullptr;
+  }
+
+  auto built =
+      cache::CacheBuilderRegistry::global().build(backend_id, cache_kind, *cfg);
+  if (!built.ok()) {
+    ET_LOG(
+        Error,
+        "ModuleExecutor: backend %s registers no %s cache",
+        backend_id.c_str(),
+        cache_kind.c_str());
+    return nullptr;
+  }
+  std::shared_ptr<cache::CacheBase> cache = built.get();
+  if (cache->as_batch_control() == nullptr) {
+    ET_LOG(Error, "ModuleExecutor: the cache carries no sequence identity");
+    return nullptr;
+  }
+
+  if (meta->num_outputs() == 0) {
+    ET_LOG(Error, "ModuleExecutor: %s publishes no outputs", method.c_str());
+    return nullptr;
+  }
+  const auto logits_info = meta->output_tensor_meta(0);
+  if (!logits_info.ok() || logits_info->sizes().empty()) {
+    ET_LOG(Error, "ModuleExecutor: %s has no logits shape", method.c_str());
+    return nullptr;
+  }
+  const auto logits_sizes = logits_info->sizes();
+
+  const auto tokens_info = meta->input_tensor_meta(0);
+  if (!tokens_info.ok() || tokens_info->sizes().empty()) {
+    ET_LOG(
+        Error, "ModuleExecutor: %s has no token input shape", method.c_str());
+    return nullptr;
+  }
+  const auto tokens_sizes = tokens_info->sizes();
+
+  auto session =
+      std::make_unique<cache::CacheSession>(cache::make_unique_key(), cache);
+
+  return std::unique_ptr<ModuleExecutor>(new ModuleExecutor(
+      std::move(module),
+      std::move(cache),
+      std::move(session),
+      max_sessions,
+      max_session_tokens,
+      std::move(backend_id),
+      std::move(method),
+      logits_sizes[logits_sizes.size() - 1],
+      tokens_sizes[tokens_sizes.size() - 1]));
+}
+
+bool ModuleExecutor::initialize() {
+  // The delegate resolves the cache from this key while the method loads.
+  char key[::executorch::runtime::kMaxOptionKeyLength] = {};
+  std::memcpy(key, kCacheKeyOption, sizeof(kCacheKeyOption) - 1);
+  ::executorch::runtime::BackendOptions<1> options;
+  ::executorch::runtime::LoadBackendOptionsMap options_map;
+  if (options.set_option(key, session_->key().c_str()) != Error::Ok ||
+      options_map.set_options(backend_id_.c_str(), options.view()) !=
+          Error::Ok) {
+    ET_LOG(Error, "ModuleExecutor: could not name the cache to the backend");
+    return false;
+  }
+  if (module_->load_method(
+          method_,
+          /*planned_memory=*/nullptr,
+          /*event_tracer=*/nullptr,
+          &options_map) != Error::Ok) {
+    ET_LOG(Error, "ModuleExecutor: could not load %s", method_.c_str());
+    return false;
+  }
+  return true;
+}
+
+std::optional<SessionId> ModuleExecutor::open_session() {
+  if (static_cast<int>(sessions_.size()) >= max_sessions_) {
+    return std::nullopt;
+  }
+  const std::optional<std::int32_t> seq_id = ctl_->seq_new();
+  if (!seq_id) {
+    return std::nullopt;
+  }
+  const SessionId session = next_session_++;
+  sessions_.emplace(session, SessionInfo{*seq_id, nullptr});
+  return session;
+}
+
+void ModuleExecutor::close_session(SessionId session) {
+  const auto it = sessions_.find(session);
+  if (it == sessions_.end()) {
+    return;
+  }
+  // Frees the cells and hands the sequence id back. The session id is not.
+  ctl_->seq_rm(it->second.seq_id, 0, std::nullopt);
+  sessions_.erase(it);
+}
+
+void ModuleExecutor::set_sampling(
+    SessionId session,
+    const SamplingParams& params,
+    std::optional<std::uint64_t> seed) {
+  const auto it = sessions_.find(session);
+  if (it == sessions_.end()) {
+    return;
+  }
+  // One sampler per generation, carrying its own generator state from here on.
+  it->second.sampler = std::make_unique<Sampler>(
+      vocab_size_,
+      params.temperature,
+      params.top_p,
+      seed.value_or(nondeterministic_seed()));
+  it->second.sampler->set_topk(params.top_k);
+}
+
+bool ModuleExecutor::execute(const BatchInput& batch, BatchOutput& out) {
+  out.outputs.clear();
+  out.outputs.resize(batch.inputs.size());
+
+  const Result<Step> step =
+      build_step(*ctl_, batch, sessions_, max_session_tokens_);
+  if (!step.ok()) {
+    return false;
+  }
+
+  // A batch wider than the method was traced at runs as several forwards. They
+  // go in order, so a slice attends the cells its predecessors wrote, and each
+  // input's logits row falls in exactly one of them.
+  const int total = static_cast<int>(step->tokens.size());
+  for (int off = 0; off < total; off += max_step_tokens_) {
+    const int n = std::min(max_step_tokens_, total - off);
+    // Placement checks the forward's token count against the declaration, so
+    // each slice declares its own.
+    if (!ctl_->declare_step(std::vector<std::int32_t>(
+            step->seq_ids.begin() + off, step->seq_ids.begin() + off + n))) {
+      ET_LOG(Error, "ModuleExecutor: the cache refused a slice of %d", n);
+      return false;
+    }
+    auto tokens = make_tensor_ptr(
+        {1, n},
+        std::vector<std::int64_t>(
+            step->tokens.begin() + off, step->tokens.begin() + off + n));
+    auto positions = make_tensor_ptr(
+        {n},
+        std::vector<std::int64_t>(
+            step->positions.begin() + off, step->positions.begin() + off + n));
+    auto result = module_->execute(method_, {tokens, positions});
+    if (!result.ok()) {
+      ET_LOG(
+          Error,
+          "ModuleExecutor: %s failed with 0x%x",
+          method_.c_str(),
+          static_cast<unsigned>(result.error()));
+      return false;
+    }
+    if (result->empty() || !result->at(0).isTensor()) {
+      ET_LOG(Error, "ModuleExecutor: %s returned no logits", method_.c_str());
+      return false;
+    }
+    // Non-const: the sampler reduces each row in place. Each is read once.
+    auto logits = result->at(0).toTensor();
+
+    for (std::size_t i = 0; i < batch.inputs.size(); ++i) {
+      const int row = step->logit_indices[i];
+      if (row < off || row >= off + n) {
+        continue; // another slice's row, or a chunk whose prediction is dropped
+      }
+      const SessionId session = batch.inputs[i].sid;
+      const std::optional<Token> token = sample_row(logits, row - off, session);
+      if (!token) {
+        return false;
+      }
+      out.outputs[i] = Output{session, {*token}};
+    }
+  }
+  return true;
+}
+
+std::optional<Token> ModuleExecutor::sample_row(
+    ::executorch::aten::Tensor& logits,
+    int row,
+    SessionId session) {
+  const auto it = sessions_.find(session);
+  if (it == sessions_.end() || it->second.sampler == nullptr) {
+    ET_LOG(
+        Error,
+        "ModuleExecutor: session %" PRId64 " has no sampling policy",
+        session);
+    return std::nullopt;
+  }
+  if (row >= logits.numel() / vocab_size_) {
+    ET_LOG(Error, "ModuleExecutor: logits hold no row %d", row);
+    return std::nullopt;
+  }
+  // A one-row view over the model's own output: sample_from_logits reduces in
+  // place and reads the last dimension.
+  auto one_row = make_tensor_ptr(
+      {vocab_size_},
+      static_cast<std::uint8_t*>(logits.mutable_data_ptr()) +
+          static_cast<std::size_t>(row) * vocab_size_ *
+              ::executorch::runtime::elementSize(logits.scalar_type()),
+      logits.scalar_type());
+  return static_cast<Token>(sample_from_logits(*one_row, *it->second.sampler));
+}
+
+} // namespace batching
+} // namespace llm
+} // namespace extension
+} // namespace executorch

--- a/extension/llm/batching/module_executor.h
+++ b/extension/llm/batching/module_executor.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// An Executor that runs an ExecuTorch Module over a registered KV cache, built
+// from the layout the program publishes. A session is one cache sequence, a
+// batch is one forward carrying every input's tokens on a single axis, and the
+// cache's mask keeps the sequences apart.
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <executorch/extension/llm/batching/executor.h>
+#include <executorch/extension/llm/cache/cache.h>
+#include <executorch/extension/llm/cache/cache_registry.h>
+#include <executorch/extension/module/module.h>
+#include <executorch/runtime/core/result.h>
+#include <executorch/runtime/platform/compiler.h> // ET_EXPERIMENTAL
+
+namespace executorch {
+namespace extension {
+namespace llm {
+
+class Sampler;
+
+namespace batching {
+
+namespace cache = ::executorch::extension::llm::cache;
+
+// A session's cache sequence and the sampler its generation draws from.
+struct SessionInfo {
+  std::int32_t seq_id;
+  std::unique_ptr<Sampler> sampler;
+};
+
+class ET_EXPERIMENTAL ModuleExecutor : public Executor {
+ public:
+  ~ModuleExecutor() override;
+
+  // Builds the cache from the layout `module` publishes and pairs it with the
+  // backend, which is read from the program -- so the method's attention must
+  // be delegated to just one. The method itself loads in initialize(); the
+  // program must be loaded and its method must not be, since the delegate
+  // resolves the cache while that load runs.
+  //
+  // Capacity is `max_sessions` x `max_session_tokens` cells exactly, and
+  // open_session() holds the count, so exhaustion is unreachable rather than
+  // handled. `kv_dtype` is the ET ScalarType K/V is stored in; a negative
+  // `initial_capacity` leaves the pools to grow from their own default.
+  // `cache_kind` must name a builder that carries batch control -- a cache
+  // serving one sequence cannot back a batch of them.
+  //
+  // nullptr = unusable limits, no published KV layout, a method spanning
+  // several backends, or no such cache for the backend it names. A method that
+  // will not load is reported by initialize().
+  static std::unique_ptr<ModuleExecutor> create(
+      std::unique_ptr<Module> module,
+      int max_sessions,
+      int max_session_tokens,
+      int kv_dtype,
+      int initial_capacity = -1,
+      std::string cache_kind = "cell",
+      std::string method = "forward");
+
+  // The widest step this method takes, from the shape its token input was
+  // traced at. A wider batch is sliced; a narrower one leaves the forward
+  // partly unused.
+  std::size_t preferred_batch_tokens() const override {
+    return static_cast<std::size_t>(max_step_tokens_);
+  }
+
+  // Loads the method here so the delegate that resolves the cache binds on the
+  // thread that runs it.
+  bool initialize() override;
+
+  std::optional<SessionId> open_session() override;
+  void close_session(SessionId session) override;
+  void set_sampling(
+      SessionId session,
+      const SamplingParams& params,
+      std::optional<std::uint64_t> seed) override;
+  bool execute(const BatchInput& batch, BatchOutput& out) override;
+
+ private:
+  ModuleExecutor(
+      std::unique_ptr<Module> module,
+      std::shared_ptr<cache::CacheBase> cache,
+      std::unique_ptr<cache::CacheSession> session,
+      int max_sessions,
+      int max_session_tokens,
+      std::string backend_id,
+      std::string method,
+      std::int32_t vocab_size,
+      int max_step_tokens);
+
+  // Draw the token an input produced from its row of `logits`, which the
+  // session's sampler consumes in place.
+  std::optional<Token>
+  sample_row(::executorch::aten::Tensor& logits, int row, SessionId session);
+
+  // Ordered so the module dies first, releasing the delegate that resolved the
+  // cache before the registry entry naming it goes.
+  std::unique_ptr<cache::CacheSession> session_;
+  std::shared_ptr<cache::CacheBase> cache_;
+  std::unique_ptr<Module> module_;
+  cache::BatchControl* ctl_;
+  int max_sessions_;
+  int max_session_tokens_;
+  std::string backend_id_;
+  std::string method_;
+  // The method's logits width, so a sampler can be built by its policy.
+  std::int32_t vocab_size_;
+  int max_step_tokens_;
+
+  SessionId next_session_ = 1; // never reused, unlike the cache's sequence ids
+  std::unordered_map<SessionId, SessionInfo> sessions_;
+};
+
+} // namespace batching
+} // namespace llm
+} // namespace extension
+} // namespace executorch


### PR DESCRIPTION
### Summary
Implements the Executor seam against an ExecuTorch program. Backend-neutral: it reaches the cache through CacheBuilderRegistry and BatchControl, with the backend id read from the program and the cache kind and cache-key option as configuration, so any backend registering a batch-capable cache is served. A session is one cache sequence, and a batch is one forward carrying every input's tokens end to end on a single axis, with the cache's mask keeping the sequences apart. SessionIds are monotonic and never reissued, mapped onto cache sequence ids that do recycle; the cache frees an id once a sequence's last cell goes, which the seam forbids for a SessionId.

Read build_step first; it holds the reasoning. It flattens a batch into tokens and positions in one pass so entry i of each names the same token, which is how the cache pairs them when placing cells and building the mask. Sequence lengths come from the cache and do not move as inputs are laid down, so a per-sequence cursor carries the batch's own writes.

A batch wider than the method was traced at is split into slices rather than refused, so a scheduler need not know the width; preferred_batch_tokens() reports it for one that wants to pack a single pass anyway. Slices run in order, so each attends the cells its predecessors wrote. 