### PR TITLE
[ET-VK][ops] Optimize narrow q8ta convolution workgroups

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.cpp
@@ -111,6 +111,7 @@ GlobalWorkGrid pick_q8ta_conv2d_gwg(
   (void)shader;
   (void)resize_args;
 
+  VK_CHECK_COND(graph != nullptr);
   const ValueRef output = args.at(0).refs.at(0);
 
   const uint32_t W = graph->size_at<uint32_t>(-1, output);
@@ -133,6 +134,7 @@ GlobalWorkGrid pick_q8ta_conv2d_gwg(
  * tensor dimensions. Uses experimentation results:
  *   - {4, 2, 8} for medium tensors: +57% improvement on 81x81
  *   - {8, 1, 8} for very large tensors: best baseline performance
+ *   - {2, 1, 32} or {4, 1, 16} for narrow output widths
  *   - {64, 1, 1} for narrow channel dimensions: minimize inactive invocations
  */
 LocalWorkGroup pick_q8ta_conv2d_lwg(
@@ -144,14 +146,13 @@ LocalWorkGroup pick_q8ta_conv2d_lwg(
   (void)shader;
   (void)resize_args;
 
+  VK_CHECK_COND(graph != nullptr);
   const ValueRef output = args.at(0).refs.at(0);
-
-  // Get actual tensor dimensions for adaptive sizing
-  const uint32_t H = graph->size_at<uint32_t>(-2, output);
+  const uint32_t output_height = graph->size_at<uint32_t>(-2, output);
 
   // For very large tensors (H >= 100 and large x/z), use {8, 1, 8}
   // This configuration performed best for 128x128 tensors in experiments
-  if (H >= 100 && gwg[0u] >= 24 && gwg[2u] >= 24) {
+  if (output_height >= 100 && gwg[0u] >= 24 && gwg[2u] >= 24) {
     return LocalWorkGroup(8u, 1u, 8u);
   }
 
@@ -159,6 +160,14 @@ LocalWorkGroup pick_q8ta_conv2d_lwg(
   // This configuration showed +57% improvement on 81x81 tensors
   if (gwg[0u] >= 4 && gwg[1u] >= 2 && gwg[2u] >= 8) {
     return LocalWorkGroup(4u, 2u, 8u);
+  }
+
+  if (gwg[0u] == 2u && gwg[2u] >= 32u) {
+    return LocalWorkGroup(2u, 1u, 32u);
+  }
+
+  if (gwg[0u] == 3u && gwg[2u] >= 16u) {
+    return LocalWorkGroup(4u, 1u, 16u);
   }
 
   // For tensors with sufficient x and z dimensions, use square configuration

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dDW.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dDW.cpp
@@ -57,6 +57,14 @@ LocalWorkGroup pick_q8ta_conv2d_dw_lwg(
   (void)args;
   (void)resize_args;
 
+  if (gwg[0u] == 2u && gwg[2u] >= 32u) {
+    return LocalWorkGroup(2u, 1u, 32u);
+  }
+
+  if (gwg[0u] >= 3u && gwg[0u] <= 4u && gwg[2u] >= 16u) {
+    return LocalWorkGroup(4u, 1u, 16u);
+  }
+
   // Some inactive invocations are okay; set 6 as the threshold to use the
   // a square wg size.
   if (gwg[0u] >= 6 && gwg[2u] >= 6) {

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
@@ -4,6 +4,7 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <functional>
 #include <iostream>
 #include <vector>
 
@@ -212,6 +213,40 @@ static TestCase create_test_case_from_config(
   });
 
   return test_case;
+}
+
+static std::vector<TestCase> generate_narrow_workgroup_test_cases() {
+  std::vector<TestCase> test_cases;
+  std::vector<Conv2dConfig> configs = {
+      {OutInChannels(64, 32),
+       InputSize2D(9, 9),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       1},
+      {OutInChannels(128, 32),
+       InputSize2D(7, 7),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       1},
+  };
+
+  for (auto& config : configs) {
+    const bool is_performance = config.channels.out > kRefDimSizeLimit;
+    config.op_name = "conv2d_q8ta_q8csw_q8to";
+    config.test_case_name = make_test_case_name(
+        config, is_performance, utils::kTexture3D, utils::kBuffer);
+    test_cases.push_back(create_test_case_from_config(
+        config,
+        vkapi::kFloat,
+        utils::kTexture3D,
+        utils::kPackedInt8_4C,
+        /*impl_selector=*/"general"));
+  }
+  return test_cases;
 }
 
 // Generate easy test cases for quantized conv2d operation (for debugging)
@@ -542,6 +577,12 @@ static std::vector<TestCase> generate_quantized_conv2d_test_cases() {
     }
   }
 
+  auto narrow_workgroup_cases = generate_narrow_workgroup_test_cases();
+  test_cases.insert(
+      test_cases.end(),
+      narrow_workgroup_cases.begin(),
+      narrow_workgroup_cases.end());
+
   return test_cases;
 }
 
@@ -797,13 +838,21 @@ int main(int argc, char* argv[]) {
 
   ReferenceComputeFunc ref_fn = reference_impl;
 
-  // Execute test cases using the new framework with custom FLOP calculator
-  auto results = execute_test_cases(
+  const bool narrow_workgroups_only =
+      argc == 2 && std::string(argv[1]) == "--narrow-workgroups-only";
 #ifdef DEBUG_MODE
-      generate_quantized_conv2d_easy_cases,
+  std::function<std::vector<TestCase>()> test_case_generator =
+      generate_quantized_conv2d_easy_cases;
 #else
-      generate_quantized_conv2d_test_cases,
+  std::function<std::vector<TestCase>()> test_case_generator =
+      generate_quantized_conv2d_test_cases;
 #endif
+  if (narrow_workgroups_only) {
+    test_case_generator = generate_narrow_workgroup_test_cases;
+  }
+
+  auto results = execute_test_cases(
+      test_case_generator,
       quantized_conv2d_flop_calculator,
       "QuantizedConv2dQ8ToQ8To",
       /*warmup_runs = */ 1,

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d_dw.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d_dw.cpp
@@ -271,6 +271,43 @@ std::vector<TestCase> generate_quantized_conv2d_dw_easy_cases() {
   return test_cases;
 }
 
+std::vector<TestCase> generate_quantized_conv2d_dw_narrow_workgroup_cases() {
+  std::vector<TestCase> test_cases;
+  std::vector<Conv2dConfig> configs = {
+      {OutInChannels(128, 128),
+       InputSize2D(7, 7),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       128},
+      {OutInChannels(64, 64),
+       InputSize2D(9, 9),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       64},
+      {OutInChannels(64, 64),
+       InputSize2D(13, 13),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       64},
+  };
+
+  for (auto& config : configs) {
+    const bool is_performance = config.channels.out > kRefDimSizeLimit;
+    config.op_name = "conv2d_q8ta_q8csw_q8to";
+    config.test_case_name = make_test_case_name(
+        config, is_performance, utils::kTexture3D, utils::kBuffer);
+    test_cases.push_back(create_test_case_from_config(
+        config, vkapi::kFloat, utils::kTexture3D, utils::kPackedInt8_4C));
+  }
+  return test_cases;
+}
+
 // Generate test cases for quantized depthwise conv2d operation
 std::vector<TestCase> generate_quantized_conv2d_dw_test_cases() {
   std::vector<TestCase> test_cases;
@@ -438,6 +475,13 @@ std::vector<TestCase> generate_quantized_conv2d_dw_test_cases() {
           config, vkapi::kFloat, utils::kTexture3D, utils::kPackedInt8_4W4C));
     }
   }
+
+  auto narrow_workgroup_cases =
+      generate_quantized_conv2d_dw_narrow_workgroup_cases();
+  test_cases.insert(
+      test_cases.end(),
+      narrow_workgroup_cases.begin(),
+      narrow_workgroup_cases.end());
 
   return test_cases;
 }
@@ -680,13 +724,19 @@ int main(int argc, char* argv[]) {
 
   ReferenceComputeFunc ref_fn = reference_impl;
 
-  // Execute test cases using the new framework with custom FLOP calculator
-  auto results = execute_test_cases(
+  const bool narrow_workgroups_only =
+      argc == 2 && std::string(argv[1]) == "--narrow-workgroups-only";
 #ifdef DEBUG_MODE
-      generate_quantized_conv2d_dw_easy_cases,
+  auto test_case_generator = generate_quantized_conv2d_dw_easy_cases;
 #else
-      generate_quantized_conv2d_dw_test_cases,
+  auto test_case_generator = generate_quantized_conv2d_dw_test_cases;
 #endif
+  if (narrow_workgroups_only) {
+    test_case_generator = generate_quantized_conv2d_dw_narrow_workgroup_cases;
+  }
+
+  auto results = execute_test_cases(
+      test_case_generator,
       quantized_conv2d_dw_flop_calculator,
       "QuantizedDepthwiseInt8Conv2d",
       /*warmup_runs = */ 1,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22536
* __->__ #22535

Use narrow local workgroups for regular and depthwise q8ta convolutions whose output width underfills existing workgroups. This reduces inactive invocations in SceneX small-spatial layers. Authored with Codex.

Differential Revision: [D118709586](https://our.internmc.facebook.com/intern/diff/D118709586/)