### PR TITLE
[ET-VK][ops] Bound q8ta im2col scratch memory

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.glsl
@@ -11,6 +11,7 @@
 ${define_required_extensions("buffer", DTYPE)}
 
 #define USE_INT8_DOT_PRODUCT_EXT ${USE_INT8_DOT_PRODUCT_EXT}
+#define STREAMING_IM2COL ${STREAMING_IM2COL}
 
 #extension GL_EXT_control_flow_attributes : require
 $if USE_INT8_DOT_PRODUCT_EXT == 1:
@@ -59,6 +60,8 @@ layout(push_constant) uniform restrict Block {
   int output_zp;
   int K4_per_group;
   int OC4_per_group;
+$if STREAMING_IM2COL == 1:
+  int stream_row_offset;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -103,9 +106,25 @@ void main() {
   const int W4 = div_up_4(int(outp.sizes[0][0]));
   const int H = int(outp.sizes[0][1]);
   const int OC4 = div_up_4(int(outp.sizes[0][2]));
-  const int hn = int(gl_GlobalInvocationID.z);
-  const int n = hn / H;
-  const int oh = hn % H;
+  const int local_row_idx = int(gl_GlobalInvocationID.z);
+#if STREAMING_IM2COL == 1
+  if (local_row_idx >= int(inp.sizes[0][1])) {
+    return;
+  }
+  const int global_row_idx = stream_row_offset + local_row_idx;
+  if (global_row_idx >= int(outp.sizes[0][3]) * H) {
+    return;
+  }
+  const int n = global_row_idx / H;
+  const int oh = global_row_idx % H;
+  const int input_n = 0;
+  const int input_h = local_row_idx;
+#else
+  const int n = local_row_idx / H;
+  const int oh = local_row_idx % H;
+  const int input_n = n;
+  const int input_h = oh;
+#endif
 
   // Bounds check in block space
   if (ow_block_idx >= W4 ||
@@ -139,8 +158,8 @@ void main() {
   // Compute initial input tile index with group offset
   // For grouped im2col, each group's K range starts at group_idx * K4_per_group
   // For non-grouped (groups=1), group_idx is always 0 so offset is 0
-  int input_idx = n * inp_n_stride
-                + oh * inp_h_stride
+  int input_idx = input_n * inp_n_stride
+                + input_h * inp_h_stride
                 + ow_block_idx * inp_w_stride
                 + group_idx * K4_per_group;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.yaml
@@ -8,6 +8,7 @@ q8ta_conv2d_pw:
   parameter_names_with_default_values:
     DTYPE: float
     USE_INT8_DOT_PRODUCT_EXT: 1
+    STREAMING_IM2COL: 0
   generate_variant_forall:
     DTYPE:
       - VALUE: float
@@ -15,3 +16,8 @@ q8ta_conv2d_pw:
     - NAME: q8ta_conv2d_pw
     - NAME: q8ta_conv2d_pw_fallback
       USE_INT8_DOT_PRODUCT_EXT: 0
+    - NAME: q8ta_conv2d_pw_streaming
+      STREAMING_IM2COL: 1
+    - NAME: q8ta_conv2d_pw_streaming_fallback
+      USE_INT8_DOT_PRODUCT_EXT: 0
+      STREAMING_IM2COL: 1

--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_im2col.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_im2col.glsl
@@ -9,6 +9,7 @@
 #version 450 core
 
 #define PRECISION ${PRECISION}
+#define STREAMING_IM2COL ${STREAMING_IM2COL}
 
 #define PACKED_INT8_OUTPUT_BUFFER
 
@@ -33,6 +34,8 @@ ${layout_declare_spec_const(C, "int", "inp_layout", "CONTIG_LAYOUT_INT")}
 
 layout(push_constant) uniform restrict Block {
   int zp;
+$if STREAMING_IM2COL == 1:
+  int stream_row_offset;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -50,24 +53,45 @@ void main() {
   const int im2col_W4 = div_up_4(im2col_sizes.x);
   const int im2col_H = im2col_sizes.y;
   const int im2col_Z4 = div_up_4(im2col_sizes.z);
-  const int im2col_N = im2col_sizes.w;
+  $if STREAMING_IM2COL == 0:
+    const int im2col_N = im2col_sizes.w;
 
   // im2col block index from linear output buffer index
   const int c4_idx = out_buf_idx % im2col_Z4;
   const int row = out_buf_idx / im2col_Z4;
   const int w4_idx = row % im2col_W4;
   const int hn_idx = row / im2col_W4;
-  const int h_idx = hn_idx % im2col_H;
-  const int n_idx = hn_idx / im2col_H;
+  $if STREAMING_IM2COL == 1:
+    const int local_row_idx = hn_idx;
+    const int h_idx = hn_idx % im2col_H;
+    const int output_H =
+        (input_sizes.y + 2 * conv2d_params.padding.y -
+         conv2d_params.dilation.y * (conv2d_params.kernel_size.y - 1) - 1) /
+            conv2d_params.stride.y +
+        1;
+    const int global_row_idx = stream_row_offset + local_row_idx;
+    const int n_idx = global_row_idx / output_H;
+  $else:
+    const int h_idx = hn_idx % im2col_H;
+    const int n_idx = hn_idx / im2col_H;
 
   // out of bounds check
-  if (w4_idx >= im2col_W4 || h_idx >= im2col_H ||
-      c4_idx >= im2col_Z4 || n_idx >= im2col_N) {
-    return;
-  }
+  $if STREAMING_IM2COL == 1:
+    if (w4_idx >= im2col_W4 || local_row_idx >= im2col_H ||
+        c4_idx >= im2col_Z4 || n_idx >= input_sizes.w) {
+      return;
+    }
+  $else:
+    if (w4_idx >= im2col_W4 || h_idx >= im2col_H ||
+        c4_idx >= im2col_Z4 || n_idx >= im2col_N) {
+      return;
+    }
 
   const int im2col_w = mul_4(w4_idx);
-  const int im2col_h = h_idx;
+  $if STREAMING_IM2COL == 1:
+    const int im2col_h = global_row_idx % output_H;
+  $else:
+    const int im2col_h = h_idx;
   const int im2col_k = mul_4(c4_idx);
 
   const int group_idx = im2col_k / conv2d_params.K_per_group;
@@ -128,10 +152,15 @@ void main() {
   }
 
   // store_packed_int8_output_tile (with TILE_M4=1, TILE_N4=1)
-  const int buffer_idx = n_idx * int(im2col_outp.strides[0][3])
-                         + h_idx * int(im2col_outp.strides[0][1])
-                         + w4_idx * int(im2col_outp.strides[0][0])
-                         + c4_idx;
+  $if STREAMING_IM2COL == 1:
+    const int buffer_idx = h_idx * int(im2col_outp.strides[0][1])
+                           + w4_idx * int(im2col_outp.strides[0][0])
+                           + c4_idx;
+  $else:
+    const int buffer_idx = n_idx * int(im2col_outp.strides[0][3])
+                           + h_idx * int(im2col_outp.strides[0][1])
+                           + w4_idx * int(im2col_outp.strides[0][0])
+                           + c4_idx;
 
   if (w4_idx < im2col_W4 && c4_idx < im2col_Z4) {
     t_packed_int8_output[buffer_idx] = im2col_block;

--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_im2col.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_im2col.yaml
@@ -7,5 +7,8 @@
 q8ta_im2col:
   parameter_names_with_default_values:
     DTYPE: float
+    STREAMING_IM2COL: 0
   shader_variants:
     - NAME: q8ta_im2col
+    - NAME: q8ta_im2col_streaming
+      STREAMING_IM2COL: 1

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h
@@ -14,9 +14,43 @@
 
 namespace vkcompute {
 
+inline constexpr int64_t kQ8taConv2dIm2ColScratchBudgetBytes =
+    16 * 1024 * 1024;
+
+struct Q8taConv2dStreamPlan final {
+  int64_t aligned_out_width;
+  int64_t rows_per_tile;
+  int64_t num_tiles;
+  int64_t scratch_bytes;
+  bool feasible;
+};
+
+Q8taConv2dStreamPlan make_q8ta_conv2d_stream_plan(
+    int64_t batch,
+    int64_t flattened_kernel_size,
+    int64_t out_height,
+    int64_t out_width,
+    int64_t scratch_budget_bytes);
+
 enum class ActivationType : uint32_t {
   kNone = 0,
   kRelu = 1,
+};
+
+enum class Q8taConv2dPwMode : uint8_t {
+  kStandalone,
+  kIm2Col,
+  kStreamingIm2Col,
+};
+
+enum class Q8taIm2ColMode : uint8_t {
+  kFull,
+  kStreaming,
+};
+
+enum class Q8taConv2dPwKernel : uint8_t {
+  kAuto,
+  kFallback,
 };
 
 ActivationType activation_type_from_string(const std::string& activation);
@@ -124,11 +158,14 @@ void add_q8ta_conv2d_pw_node(
     const uint32_t activation_type,
     const ValueRef packed_int8_output,
     const int32_t groups = 1,
+    const Q8taConv2dPwMode mode = Q8taConv2dPwMode::kStandalone,
+    const Q8taConv2dPwKernel kernel = Q8taConv2dPwKernel::kAuto,
     const ValueRef conv_input = kDummyValueRef,
     const ValueRef kernel_size = kDummyValueRef,
     const ValueRef stride = kDummyValueRef,
     const ValueRef padding = kDummyValueRef,
-    const ValueRef dilation = kDummyValueRef);
+    const ValueRef dilation = kDummyValueRef,
+    const int32_t stream_row_offset = 0);
 
 std::vector<int64_t> calculate_q8ta_im2col_sizes(
     ComputeGraph* graph,
@@ -147,9 +184,18 @@ void add_q8ta_im2col_node(
     const ValueRef groups,
     const ValueRef packed_int8_output,
     const ValueRef packed_int8_im2col,
-    const int32_t zp);
+    const int32_t zp,
+    Q8taIm2ColMode mode,
+    const int32_t stream_row_offset);
 
 void q8ta_conv2d_im2col(ComputeGraph& graph, const std::vector<ValueRef>& args);
+
+void q8ta_conv2d_im2col_with_kernel(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args,
+    Q8taConv2dPwKernel kernel);
+
+void q8ta_conv2d_general(ComputeGraph& graph, const std::vector<ValueRef>& args);
 
 // Transposed convolution
 

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dIm2Col.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dIm2Col.cpp
@@ -16,33 +16,121 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
+#include <algorithm>
+#include <limits>
+
 namespace vkcompute {
+
+Q8taConv2dStreamPlan make_q8ta_conv2d_stream_plan(
+    const int64_t batch,
+    const int64_t flattened_kernel_size,
+    const int64_t out_height,
+    const int64_t out_width,
+    const int64_t scratch_budget_bytes) {
+  Q8taConv2dStreamPlan plan{};
+  if (batch <= 0 || flattened_kernel_size <= 0 || out_height <= 0 ||
+      out_width <= 0 || scratch_budget_bytes <= 0) {
+    return plan;
+  }
+
+  constexpr int64_t kAlignment = 4;
+  if (out_width >
+      std::numeric_limits<int64_t>::max() - (kAlignment - 1)) {
+    return plan;
+  }
+  plan.aligned_out_width =
+      (out_width + kAlignment - 1) / kAlignment * kAlignment;
+  if (flattened_kernel_size >
+      std::numeric_limits<int64_t>::max() / plan.aligned_out_width) {
+    return plan;
+  }
+  const int64_t bytes_per_row =
+      flattened_kernel_size * plan.aligned_out_width;
+  if (bytes_per_row > scratch_budget_bytes ||
+      batch > std::numeric_limits<int64_t>::max() / out_height) {
+    return plan;
+  }
+
+  const int64_t total_rows = batch * out_height;
+  if (total_rows > std::numeric_limits<int32_t>::max()) {
+    return plan;
+  }
+  const int64_t max_rows_per_tile =
+      std::min(total_rows, scratch_budget_bytes / bytes_per_row);
+  plan.num_tiles = total_rows / max_rows_per_tile +
+      static_cast<int64_t>(total_rows % max_rows_per_tile != 0);
+  plan.rows_per_tile = total_rows / plan.num_tiles +
+      static_cast<int64_t>(total_rows % plan.num_tiles != 0);
+  plan.scratch_bytes = plan.rows_per_tile * bytes_per_row;
+  plan.feasible = true;
+  return plan;
+}
 
 //
 // Shader dispatch utilities
 //
 
-GlobalWorkGrid pick_q8ta_im2col_gwg(
+GlobalWorkGrid pick_q8ta_im2col_full_gwg(
     ComputeGraph* graph,
     const vkapi::ShaderInfo& shader,
     const std::vector<ArgGroup>& args,
     const std::vector<ValueRef>& resize_args) {
   (void)shader;
   (void)resize_args;
+  VK_CHECK_COND(graph != nullptr);
+  const ValueRef output = args.at(0).refs.at(0);
+  const uint32_t K4 = utils::div_up_4(graph->size_at<uint32_t>(-3, output));
+  const uint32_t H = graph->size_at<uint32_t>(-2, output);
+  const uint32_t W4 = utils::div_up_4(graph->size_at<uint32_t>(-1, output));
+  const uint32_t N = graph->size_at<uint32_t>(-4, output);
+  return graph->create_linear_gwg(utils::safe_downcast<uint32_t>(
+      static_cast<uint64_t>(K4) * H * W4 * N));
+}
 
+GlobalWorkGrid pick_q8ta_im2col_streaming_gwg(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)shader;
+  VK_CHECK_COND(graph != nullptr);
   const ValueRef im2col_output = args.at(0).refs.at(0);
-
-  const uint32_t N = graph->size_at<uint32_t>(-4, im2col_output);
   const uint32_t K = graph->size_at<uint32_t>(-3, im2col_output);
-  const uint32_t H = graph->size_at<uint32_t>(-2, im2col_output);
+  const uint32_t rows_per_tile =
+      graph->size_at<uint32_t>(-2, im2col_output);
   const uint32_t W = graph->size_at<uint32_t>(-1, im2col_output);
+
+  const ValueRef input = resize_args.at(0);
+  const ValueRef kernel_size = resize_args.at(1);
+  const ValueRef stride = resize_args.at(2);
+  const ValueRef padding = resize_args.at(3);
+  const ValueRef dilation = resize_args.at(4);
+  const int64_t row_offset =
+      graph->extract_scalar<int64_t>(resize_args.at(6));
+
+  const std::vector<int64_t> input_sizes = graph->sizes_of(input);
+  const int64_t batch = utils::val_at(-4, input_sizes);
+  const std::vector<int64_t> out_hw = calc_out_sizes_hw(
+      *graph,
+      input_sizes,
+      kernel_size,
+      /*kernel_size_only=*/true,
+      {stride, padding, dilation, dilation},
+      /*transposed=*/false);
+  const int64_t total_rows = batch * out_hw.at(0);
+  if (row_offset >= total_rows) {
+    return graph->create_linear_gwg(0u);
+  }
+  const uint32_t live_rows = utils::safe_downcast<uint32_t>(
+      std::min<int64_t>(rows_per_tile, total_rows - row_offset));
 
   const uint32_t K4 = utils::div_up_4(K);
   const uint32_t W4 = utils::div_up_4(W);
 
   // Each thread handles one 4x4 block in the output
   return graph->create_linear_gwg(
-      utils::safe_downcast<uint32_t>(static_cast<uint64_t>(K4) * W4 * H * N));
+      utils::safe_downcast<uint32_t>(
+          static_cast<uint64_t>(K4) * W4 * live_rows));
 }
 
 LocalWorkGroup pick_q8ta_im2col_lwg(
@@ -102,19 +190,16 @@ std::vector<int64_t> calculate_q8ta_im2col_sizes(
 // Resize
 //
 
-// resize_args = { input, kernel_size, stride, padding, dilation, groups }
+// resize_args = { input, kernel_size, stride, padding, dilation, groups,
+//                 row_offset }
 //
-// The im2col scratch tensor is [N, K, H_out, align_up_4(W_out)] where K (the
-// flattened conv window, channel/kernel-derived) is shape-independent and
-// H_out/W_out are the conv output spatial dims. The downstream PW GEMM that
-// consumes this scratch is resized separately (it preserves H/W). Without this,
-// the scratch freezes at the build-time upper bound and feeds garbage rows into
-// the GEMM. Recompute H_out/W_out from the CURRENT input (NOT the conv output
-// tensor, which may itself still be frozen at this point in the resize order).
+// The streaming scratch tensor is [1, K, rows_per_tile, align_up_4(W_out)].
+// K and rows_per_tile are fixed; only W_out tracks the current input shape.
 void resize_q8ta_im2col_node(
     ComputeGraph* graph,
     const std::vector<ArgGroup>& args,
     const std::vector<ValueRef>& resize_args) {
+  VK_CHECK_COND(graph != nullptr);
   const ValueRef im2col_out = args.at(0).refs.at(0);
   const ValueRef in = resize_args.at(0);
   const ValueRef kernel_size = resize_args.at(1);
@@ -124,9 +209,7 @@ void resize_q8ta_im2col_node(
   const ValueRef groups = resize_args.at(5);
 
   const std::vector<int64_t> in_sizes = graph->sizes_of(in);
-  const int64_t batch = utils::val_at(-4, in_sizes);
-
-  // Conv output H/W from the current input.
+  // Conv output width from the current input.
   const std::vector<int64_t> out_hw = calc_out_sizes_hw(
       *graph,
       in_sizes,
@@ -134,7 +217,6 @@ void resize_q8ta_im2col_node(
       /*kernel_size_only=*/true,
       {stride, padding, dilation, dilation},
       /*transposed=*/false);
-  const int64_t out_height = out_hw.at(0);
   const int64_t out_width = out_hw.at(1);
 
   // K (flattened conv window) is shape-independent — recompute from channels +
@@ -149,7 +231,47 @@ void resize_q8ta_im2col_node(
   const int64_t K = flattened_kernel_len * groups_val;
   const int64_t W = utils::align_up_4(out_width);
 
-  graph->virtual_resize(im2col_out, {batch, K, out_height, W});
+  const int64_t rows_per_tile = graph->size_at<int64_t>(-2, im2col_out);
+
+  graph->virtual_resize(im2col_out, {1, K, rows_per_tile, W});
+}
+
+void resize_q8ta_im2col_full_node(
+    ComputeGraph* graph,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  VK_CHECK_COND(graph != nullptr);
+  const ValueRef im2col_out = args.at(0).refs.at(0);
+  const ValueRef in = resize_args.at(0);
+  const ValueRef kernel_size = resize_args.at(1);
+  const ValueRef stride = resize_args.at(2);
+  const ValueRef padding = resize_args.at(3);
+  const ValueRef dilation = resize_args.at(4);
+  const ValueRef groups = resize_args.at(5);
+
+  const std::vector<int64_t> in_sizes = graph->sizes_of(in);
+  const std::vector<int64_t> out_hw = calc_out_sizes_hw(
+      *graph,
+      in_sizes,
+      kernel_size,
+      /*kernel_size_only=*/true,
+      {stride, padding, dilation, dilation},
+      /*transposed=*/false);
+  const int64_t in_channels = utils::val_at(-3, in_sizes);
+  const int64_t groups_val = graph->extract_scalar<int64_t>(groups);
+  const int64_t in_channels_per_group = in_channels / groups_val;
+  const auto kernel_size_list = graph->get_int_list(kernel_size);
+  const int64_t flattened_kernel_len = utils::align_up_4(
+      in_channels_per_group * kernel_size_list->at(0) *
+      kernel_size_list->at(1));
+  const int64_t K = flattened_kernel_len * groups_val;
+
+  graph->virtual_resize(
+      im2col_out,
+      {utils::val_at(-4, in_sizes),
+       K,
+       out_hw.at(0),
+       utils::align_up_4(out_hw.at(1))});
 }
 
 //
@@ -166,7 +288,9 @@ void add_q8ta_im2col_node(
     const ValueRef groups,
     const ValueRef packed_int8_output,
     const ValueRef packed_int8_im2col,
-    const int32_t zp) {
+    const int32_t zp,
+    const Q8taIm2ColMode mode,
+    const int32_t stream_row_offset) {
   // Validate packed dim info for input and output tensors
   VK_CHECK_COND(q8ta_conv2d_check_packed_dim_info(
       graph.packed_dim_info_of(packed_int8_input)));
@@ -188,7 +312,9 @@ void add_q8ta_im2col_node(
   // 4
   VK_CHECK_COND(conv_params.in_channels_per_group % 4 == 0);
 
-  std::string kernel_name = "q8ta_im2col";
+  const bool is_streaming = mode == Q8taIm2ColMode::kStreaming;
+  std::string kernel_name =
+      is_streaming ? "q8ta_im2col_streaming" : "q8ta_im2col";
 
   vkapi::ParamsBindList param_buffers = {
       graph.buffer_meta_ubo(packed_int8_im2col),
@@ -198,6 +324,10 @@ void add_q8ta_im2col_node(
   std::vector<PushConstantDataInfo> push_constants = {
       PushConstantDataInfo(&zp, sizeof(zp)),
   };
+  if (is_streaming) {
+    push_constants.emplace_back(
+        &stream_row_offset, sizeof(stream_row_offset));
+  }
 
   // Build spec constants: apply_bias + layout constants (for generic shader)
   vkapi::SpecVarList spec_constants = {
@@ -212,10 +342,21 @@ void add_q8ta_im2col_node(
   //   spec_constants.append(graph.hashed_layout_of(packed_int8_im2col));
   // }
 
+  std::vector<ValueRef> resize_args = {
+      packed_int8_input, kernel_size, stride, padding, dilation, groups};
+  if (is_streaming) {
+    resize_args.push_back(graph.add_scalar<int64_t>(stream_row_offset));
+  }
+
+  const auto pick_gwg = is_streaming ? pick_q8ta_im2col_streaming_gwg
+                                     : pick_q8ta_im2col_full_gwg;
+  const auto resize_fn = is_streaming ? resize_q8ta_im2col_node
+                                      : resize_q8ta_im2col_full_node;
+
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
       VK_KERNEL_FROM_STR(kernel_name),
-      pick_q8ta_im2col_gwg,
+      pick_gwg,
       pick_q8ta_im2col_lwg,
       // Inputs and Outputs
       {{packed_int8_im2col, vkapi::kWrite}, {packed_int8_input, vkapi::kRead}},
@@ -225,20 +366,18 @@ void add_q8ta_im2col_node(
       push_constants,
       // Specialization Constants
       spec_constants,
-      // Resize args: { input, kernel_size, stride, padding, dilation, groups }
-      {packed_int8_input, kernel_size, stride, padding, dilation, groups},
-      // Resizing Logic: recompute the im2col scratch dims from the current
-      // input
-      resize_q8ta_im2col_node));
+      resize_args,
+      resize_fn));
 }
 
 //
 // High level operator impl
 //
 
-void q8ta_conv2d_im2col(
+void q8ta_conv2d_im2col_with_kernel(
     ComputeGraph& graph,
-    const std::vector<ValueRef>& args) {
+    const std::vector<ValueRef>& args,
+    const Q8taConv2dPwKernel kernel) {
   int32_t idx = 0;
   const ValueRef packed_int8_input = args.at(idx++);
   const ValueRef input_scale = args.at(idx++);
@@ -256,6 +395,19 @@ void q8ta_conv2d_im2col(
   const ValueRef groups = args.at(idx++);
   const ValueRef activation = args.at(idx++);
   const ValueRef packed_int8_output = args.at(idx++);
+
+  const std::vector<int64_t> full_im2col_sizes = calculate_q8ta_im2col_sizes(
+      &graph, packed_int8_input, packed_int8_output, kernel_size, groups);
+  const Q8taConv2dStreamPlan stream_plan = make_q8ta_conv2d_stream_plan(
+      full_im2col_sizes.at(0),
+      full_im2col_sizes.at(1),
+      full_im2col_sizes.at(2),
+      full_im2col_sizes.at(3),
+      kQ8taConv2dIm2ColScratchBudgetBytes);
+  if (!stream_plan.feasible) {
+    q8ta_conv2d_general(graph, args);
+    return;
+  }
 
   QuantizationConfig weight_quant_config(8, kPerChannel, {});
 
@@ -286,11 +438,15 @@ void q8ta_conv2d_im2col(
   uint32_t activation_type_val = static_cast<uint32_t>(
       activation_type_from_string(graph.extract_string(activation)));
 
-  // Calculate im2col output sizes
-  std::vector<int64_t> im2col_sizes = calculate_q8ta_im2col_sizes(
-      &graph, packed_int8_input, packed_int8_output, kernel_size, groups);
+  const bool is_streaming = stream_plan.num_tiles > 1;
+  const std::vector<int64_t> im2col_sizes = is_streaming
+      ? std::vector<int64_t>{
+            1,
+            full_im2col_sizes.at(1),
+            stream_plan.rows_per_tile,
+            stream_plan.aligned_out_width}
+      : full_im2col_sizes;
 
-  // Create temporary tensor for im2col output (4W4C layout)
   TmpTensor packed_int8_im2col(
       &graph,
       im2col_sizes,
@@ -299,45 +455,100 @@ void q8ta_conv2d_im2col(
       utils::kPackedInt8_4W4C);
 
   int32_t zp = graph.extract_scalar<int32_t>(input_zp);
-
-  // Step 1: Perform im2col transformation
-  add_q8ta_im2col_node(
-      graph,
-      packed_int8_input,
-      kernel_size,
-      stride,
-      padding,
-      dilation,
-      groups,
-      packed_int8_output,
-      packed_int8_im2col,
-      zp);
-
-  // Step 2: Perform pointwise convolution on the im2col result
   const int32_t groups_val = graph.extract_scalar<int32_t>(groups);
 
-  add_q8ta_conv2d_pw_node(
-      graph,
-      packed_int8_im2col,
-      input_scale,
-      input_zp,
-      packed_weight,
-      packed_weight_sums,
-      packed_weight_scales,
-      output_scale,
-      output_zp,
-      bias_data,
-      packed_bias,
-      activation_type_val,
-      packed_int8_output,
-      groups_val,
-      // Original activation + conv geometry so the PW output H/W is recomputed
-      // from the true conv result, not the width-padded im2col scratch.
-      packed_int8_input,
-      kernel_size,
-      stride,
-      padding,
-      dilation);
+  if (!is_streaming) {
+    add_q8ta_im2col_node(
+        graph,
+        packed_int8_input,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        groups,
+        packed_int8_output,
+        packed_int8_im2col,
+        zp,
+        Q8taIm2ColMode::kFull,
+        /*stream_row_offset=*/0);
+
+    add_q8ta_conv2d_pw_node(
+        graph,
+        packed_int8_im2col,
+        input_scale,
+        input_zp,
+        packed_weight,
+        packed_weight_sums,
+        packed_weight_scales,
+        output_scale,
+        output_zp,
+        bias_data,
+        packed_bias,
+        activation_type_val,
+        packed_int8_output,
+        groups_val,
+        Q8taConv2dPwMode::kIm2Col,
+        kernel,
+        packed_int8_input,
+        kernel_size,
+        stride,
+        padding,
+        dilation);
+    return;
+  }
+
+  // Reuse one fixed-size scratch buffer across all row tiles. Interleaved
+  // write/read dispatches insert the barrier before the next tile overwrites
+  // it.
+  for (int64_t tile = 0; tile < stream_plan.num_tiles; ++tile) {
+    const int32_t row_offset = utils::safe_downcast<int32_t>(
+        tile * stream_plan.rows_per_tile);
+
+    add_q8ta_im2col_node(
+        graph,
+        packed_int8_input,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        groups,
+        packed_int8_output,
+        packed_int8_im2col,
+        zp,
+        Q8taIm2ColMode::kStreaming,
+        row_offset);
+
+    add_q8ta_conv2d_pw_node(
+        graph,
+        packed_int8_im2col,
+        input_scale,
+        input_zp,
+        packed_weight,
+        packed_weight_sums,
+        packed_weight_scales,
+        output_scale,
+        output_zp,
+        bias_data,
+        packed_bias,
+        activation_type_val,
+        packed_int8_output,
+        groups_val,
+        Q8taConv2dPwMode::kStreamingIm2Col,
+        kernel,
+        packed_int8_input,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        row_offset);
+  }
+}
+
+void q8ta_conv2d_im2col(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args) {
+  q8ta_conv2d_im2col_with_kernel(
+      graph, args, Q8taConv2dPwKernel::kAuto);
 }
 
 REGISTER_OPERATORS {

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dPW.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dPW.cpp
@@ -14,6 +14,8 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
+#include <algorithm>
+
 namespace vkcompute {
 
 //
@@ -52,6 +54,34 @@ GlobalWorkGrid pick_q8ta_conv2d_pw_gwg(
        utils::div_up(W4, TILE_M4),
        utils::safe_downcast<uint32_t>(static_cast<uint64_t>(H) * N)},
       kTiledWorkGrid);
+}
+
+GlobalWorkGrid pick_q8ta_conv2d_pw_streaming_gwg(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)shader;
+  VK_CHECK_COND(graph != nullptr);
+
+  const ValueRef output = args.at(0).refs.at(0);
+  const ValueRef input = args.at(1).refs.at(0);
+  const uint32_t W = graph->size_at<uint32_t>(-1, output);
+  const uint32_t H = graph->size_at<uint32_t>(-2, output);
+  const uint32_t C = graph->size_at<uint32_t>(-3, output);
+  const uint32_t N = graph->size_at<uint32_t>(-4, output);
+  const uint32_t rows_per_tile = graph->size_at<uint32_t>(-2, input);
+  const int64_t row_offset =
+      graph->extract_scalar<int64_t>(resize_args.at(5));
+  const int64_t total_rows = static_cast<int64_t>(N) * H;
+  if (row_offset >= total_rows) {
+    return GlobalWorkGrid({0u, 0u, 0u}, kTiledWorkGrid);
+  }
+
+  const uint32_t live_rows = utils::safe_downcast<uint32_t>(
+      std::min<int64_t>(rows_per_tile, total_rows - row_offset));
+  return GlobalWorkGrid(
+      {utils::div_up_4(C), utils::div_up_4(W), live_rows}, kTiledWorkGrid);
 }
 
 LocalWorkGroup pick_q8ta_conv2d_pw_lwg(
@@ -220,9 +250,8 @@ void resize_q8ta_conv2d_pw_node(
 // im2col-path PW conv. Here the PW node's bound input is the im2col scratch
 // tensor sized {K, H_out, align_up_4(W_out)} — its width is rounded up to a
 // multiple of 4 for texel alignment, so it must NOT be used to size the output.
-// Recompute the TRUE conv H_out/W_out from the ORIGINAL activation + conv
-// geometry, exactly as resize_q8ta_conv2d_node does. N/C are shape-independent
-// and stay as currently allocated.
+// Recompute the true conv N/H_out/W_out from the original activation + conv
+// geometry, exactly as resize_q8ta_conv2d_node does. C is shape-independent.
 void resize_q8ta_conv2d_pw_im2col_node(
     ComputeGraph* graph,
     const std::vector<ArgGroup>& args,
@@ -246,6 +275,7 @@ void resize_q8ta_conv2d_pw_im2col_node(
 
   std::vector<int64_t> new_sizes = graph->sizes_of(out);
   const size_t ndim = new_sizes.size();
+  new_sizes.at(ndim - 4) = utils::val_at(-4, in_sizes);
   new_sizes.at(ndim - 2) = out_hw.at(0);
   new_sizes.at(ndim - 1) = out_hw.at(1);
   graph->virtual_resize(out, new_sizes);
@@ -270,11 +300,14 @@ void add_q8ta_conv2d_pw_node(
     const uint32_t activation_type,
     const ValueRef packed_int8_output,
     const int32_t groups,
+    const Q8taConv2dPwMode mode,
+    const Q8taConv2dPwKernel kernel,
     const ValueRef conv_input,
     const ValueRef kernel_size,
     const ValueRef stride,
     const ValueRef padding,
-    const ValueRef dilation) {
+    const ValueRef dilation,
+    const int32_t stream_row_offset) {
   VK_CHECK_COND(q8ta_conv2d_check_4w4c_packed_dim_info(
       graph.packed_dim_info_of(packed_int8_input)));
   VK_CHECK_COND(q8ta_conv2d_check_packed_dim_info(
@@ -309,10 +342,22 @@ void add_q8ta_conv2d_pw_node(
       PushConstantDataInfo(&OC4_per_group, sizeof(OC4_per_group)),
   };
 
-  const bool use_hw_dot =
+  const bool is_im2col = mode != Q8taConv2dPwMode::kStandalone;
+  const bool is_streaming = mode == Q8taConv2dPwMode::kStreamingIm2Col;
+  if (is_streaming) {
+    push_constants.emplace_back(&stream_row_offset, sizeof(stream_row_offset));
+  }
+
+  const bool use_hw_dot = kernel == Q8taConv2dPwKernel::kAuto &&
       graph.context()->adapter_ptr()->supports_int8_dot_product();
-  std::string kernel_name =
-      use_hw_dot ? "q8ta_conv2d_pw" : "q8ta_conv2d_pw_fallback";
+  std::string kernel_name;
+  if (is_streaming) {
+    kernel_name = use_hw_dot ? "q8ta_conv2d_pw_streaming"
+                             : "q8ta_conv2d_pw_streaming_fallback";
+  } else {
+    kernel_name =
+        use_hw_dot ? "q8ta_conv2d_pw" : "q8ta_conv2d_pw_fallback";
+  }
   add_dtype_suffix(kernel_name, graph.dtype_of(packed_weight_scales));
 
   vkapi::ParamsBindList param_buffers = {
@@ -333,18 +378,25 @@ void add_q8ta_conv2d_pw_node(
   // output matches directly.
   std::vector<ValueRef> resize_args;
   ExecuteNode::ResizeFunction resize_fn;
-  if (conv_input == kDummyValueRef) {
+  if (!is_im2col) {
     resize_args = {packed_int8_input};
     resize_fn = resize_q8ta_conv2d_pw_node;
   } else {
-    resize_args = {conv_input, kernel_size, stride, padding, dilation};
+    resize_args = {
+        conv_input, kernel_size, stride, padding, dilation};
+    if (is_streaming) {
+      resize_args.push_back(graph.add_scalar<int64_t>(stream_row_offset));
+    }
     resize_fn = resize_q8ta_conv2d_pw_im2col_node;
   }
+
+  const auto pick_gwg = is_streaming ? pick_q8ta_conv2d_pw_streaming_gwg
+                                     : pick_q8ta_conv2d_pw_gwg;
 
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
       VK_KERNEL_FROM_STR(kernel_name),
-      pick_q8ta_conv2d_pw_gwg,
+      pick_gwg,
       pick_q8ta_conv2d_pw_lwg,
       {{packed_int8_output, vkapi::kWrite},
        {{packed_int8_input,

--- a/backends/vulkan/test/custom_ops/impl/TestQ8taConv2d.cpp
+++ b/backends/vulkan/test/custom_ops/impl/TestQ8taConv2d.cpp
@@ -10,6 +10,7 @@
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taClone.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taQuantizeDequantize.h>
 
 namespace vkcompute {
@@ -188,6 +189,9 @@ void test_q8ta_conv2d(ComputeGraph& graph, const std::vector<ValueRef>& args) {
         packed_int8_output};
     if (impl_selector == "im2col") {
       VK_GET_OP_FN("et_vk.q8ta_conv2d_im2col.default")(graph, conv_args);
+    } else if (impl_selector == "im2col_fallback") {
+      q8ta_conv2d_im2col_with_kernel(
+          graph, conv_args, Q8taConv2dPwKernel::kFallback);
     } else if (impl_selector == "general") {
       VK_GET_OP_FN("et_vk.q8ta_conv2d_general.default")(graph, conv_args);
     } else {

--- a/backends/vulkan/test/custom_ops/q8ta_conv2d_stream_plan_test.cpp
+++ b/backends/vulkan/test/custom_ops/q8ta_conv2d_stream_plan_test.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+namespace vkcompute {
+namespace {
+
+constexpr int64_t kEightMiB = 8 * 1024 * 1024;
+constexpr int64_t kSixteenMiB = 16 * 1024 * 1024;
+
+TEST(Q8taConv2dStreamPlanTest, SplitsFirstSceneXConvolution) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/60,
+      /*flattened_kernel_size=*/576,
+      /*out_height=*/20,
+      /*out_width=*/26,
+      kEightMiB);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.aligned_out_width, 28);
+  EXPECT_EQ(plan.rows_per_tile, 400);
+  EXPECT_EQ(plan.num_tiles, 3);
+  EXPECT_EQ(plan.scratch_bytes, 6451200);
+}
+
+TEST(Q8taConv2dStreamPlanTest, SplitsSecondSceneXConvolution) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/60,
+      /*flattened_kernel_size=*/1152,
+      /*out_height=*/10,
+      /*out_width=*/13,
+      kEightMiB);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.aligned_out_width, 16);
+  EXPECT_EQ(plan.rows_per_tile, 300);
+  EXPECT_EQ(plan.num_tiles, 2);
+  EXPECT_EQ(plan.scratch_bytes, 5529600);
+}
+
+TEST(Q8taConv2dStreamPlanTest, UsesOneTileWhenFullScratchFits) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/2,
+      /*flattened_kernel_size=*/288,
+      /*out_height=*/7,
+      /*out_width=*/7,
+      kEightMiB);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.rows_per_tile, 14);
+  EXPECT_EQ(plan.num_tiles, 1);
+  EXPECT_EQ(plan.scratch_bytes, 32256);
+}
+
+TEST(Q8taConv2dStreamPlanTest, SelectsFullFitBelowProductionBudget) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/10,
+      /*flattened_kernel_size=*/288,
+      /*out_height=*/30,
+      /*out_width=*/99,
+      kSixteenMiB);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.rows_per_tile, 300);
+  EXPECT_EQ(plan.num_tiles, 1);
+  EXPECT_EQ(plan.scratch_bytes, 8640000);
+}
+
+TEST(Q8taConv2dStreamPlanTest, SelectsStreamingAboveProductionBudget) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/10,
+      /*flattened_kernel_size=*/576,
+      /*out_height=*/30,
+      /*out_width=*/99,
+      kSixteenMiB);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.rows_per_tile, 150);
+  EXPECT_EQ(plan.num_tiles, 2);
+  EXPECT_EQ(plan.scratch_bytes, 8640000);
+}
+
+TEST(Q8taConv2dStreamPlanTest, RejectsOneRowLargerThanBudget) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/1,
+      /*flattened_kernel_size=*/16384,
+      /*out_height=*/1,
+      /*out_width=*/513,
+      kEightMiB);
+
+  EXPECT_FALSE(plan.feasible);
+  EXPECT_EQ(plan.rows_per_tile, 0);
+  EXPECT_EQ(plan.num_tiles, 0);
+  EXPECT_EQ(plan.scratch_bytes, 0);
+}
+
+TEST(Q8taConv2dStreamPlanTest, RejectsOutputWidthAlignmentOverflow) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/1,
+      /*flattened_kernel_size=*/1,
+      /*out_height=*/1,
+      /*out_width=*/std::numeric_limits<int64_t>::max(),
+      std::numeric_limits<int64_t>::max());
+
+  EXPECT_FALSE(plan.feasible);
+}
+
+TEST(Q8taConv2dStreamPlanTest, HandlesTileCountCeilDivisionAtShaderLimit) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/std::numeric_limits<int32_t>::max(),
+      /*flattened_kernel_size=*/1,
+      /*out_height=*/1,
+      /*out_width=*/1,
+      /*scratch_budget_bytes=*/8);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.rows_per_tile, 2);
+  EXPECT_EQ(plan.num_tiles, 1073741824);
+  EXPECT_EQ(plan.scratch_bytes, 8);
+}
+
+TEST(Q8taConv2dStreamPlanTest, RejectsRowOffsetBeyondShaderIndexRange) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/std::numeric_limits<int64_t>::max(),
+      /*flattened_kernel_size=*/1,
+      /*out_height=*/1,
+      /*out_width=*/1,
+      std::numeric_limits<int64_t>::max());
+
+  EXPECT_FALSE(plan.feasible);
+}
+
+} // namespace
+} // namespace vkcompute

--- a/backends/vulkan/test/custom_ops/targets.bzl
+++ b/backends/vulkan/test/custom_ops/targets.bzl
@@ -85,6 +85,16 @@ def define_common_targets(is_fbcode = False):
         link_whole = True,
     )
 
+    runtime.cxx_test(
+        name = "q8ta_conv2d_stream_plan_test",
+        srcs = ["q8ta_conv2d_stream_plan_test.cpp"],
+        platforms = get_platforms(),
+        deps = [
+            "//third-party/googletest:gtest_main",
+            "//executorch/backends/vulkan:vulkan_graph_runtime",
+        ],
+    )
+
     define_custom_op_test_binary("test_add")
     define_custom_op_test_binary("test_q8csw_linear")
     define_custom_op_test_binary("test_q8csw_conv2d")

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
@@ -30,7 +31,9 @@ static TestCase create_test_case_from_config(
     vkapi::ScalarType input_dtype,
     utils::StorageType fp_storage_type,
     utils::GPUMemoryLayout int8_memory_layout,
-    const std::string& impl_selector = "") {
+    const std::string& impl_selector = "",
+    const float input_scale_val = 0.008123f,
+    const DataGenType input_data_gen = DataGenType::RANDOM) {
   TestCase test_case;
 
   // Calculate output dimensions
@@ -78,18 +81,12 @@ static TestCase create_test_case_from_config(
       input_dtype,
       fp_storage_type,
       fp_memory_layout,
-#ifdef DEBUG_MODE
-      DataGenType::RANDOM
-#else
-      DataGenType::RANDOM
-#endif
-  );
+      input_data_gen);
 
   if (debugging()) {
     print_valuespec_data(input_tensor, "input_tensor");
   }
 
-  float input_scale_val = 0.008123;
   ValueSpec input_scale(input_scale_val);
 
   int32_t input_zero_point_val = 2;
@@ -303,6 +300,113 @@ std::vector<TestCase> generate_quantized_conv2d_easy_cases() {
     }
   }
 
+  return test_cases;
+}
+
+static std::vector<TestCase> generate_streaming_im2col_test_cases() {
+  std::vector<TestCase> test_cases;
+  if (!vkcompute::api::context()->adapter_ptr()->supports_int8_dot_product()) {
+    return test_cases;
+  }
+
+  Conv2dConfig full_fit_config = {
+      OutInChannels(4, 32),
+      InputSize2D(30, 99),
+      KernelSize(3, 3),
+      Stride(1, 1),
+      Padding(1, 1),
+      Dilation(1, 1),
+      1,
+      10};
+  full_fit_config.op_name = "conv2d_q8ta_q8csw_q8to";
+  full_fit_config.test_case_name = make_test_case_name(
+      full_fit_config, false, utils::kTexture3D, utils::kBuffer);
+
+  for (const utils::GPUMemoryLayout layout :
+       {utils::kPackedInt8_4C1W, utils::kPackedInt8_4W4C}) {
+    test_cases.push_back(create_test_case_from_config(
+        full_fit_config,
+        vkapi::kFloat,
+        utils::kTexture3D,
+        layout,
+        /*impl_selector=*/"im2col",
+        /*input_scale_val=*/1.0f,
+        /*input_data_gen=*/DataGenType::RANDINT));
+  }
+  test_cases.push_back(create_test_case_from_config(
+      full_fit_config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4W4C,
+      /*impl_selector=*/"im2col_fallback",
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT));
+
+  Conv2dConfig streaming_config = full_fit_config;
+  streaming_config.channels.in = 64;
+  streaming_config.test_case_name = make_test_case_name(
+      streaming_config, false, utils::kTexture3D, utils::kBuffer);
+  test_cases.push_back(create_test_case_from_config(
+      streaming_config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4C1W,
+      /*impl_selector=*/"im2col",
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT));
+  test_cases.push_back(create_test_case_from_config(
+      streaming_config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4W4C,
+      /*impl_selector=*/"im2col_fallback",
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT));
+
+  Conv2dConfig grouped_config = {
+      OutInChannels(16, 32),
+      InputSize2D(30, 99),
+      KernelSize(3, 3),
+      Stride(1, 1),
+      Padding(1, 1),
+      Dilation(1, 1),
+      2,
+      20};
+  grouped_config.op_name = "conv2d_q8ta_q8csw_q8to";
+  grouped_config.test_case_name = make_test_case_name(
+      grouped_config, false, utils::kTexture3D, utils::kBuffer);
+  test_cases.push_back(create_test_case_from_config(
+      grouped_config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4W4C,
+      /*impl_selector=*/"im2col",
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT));
+
+  Conv2dConfig output_channel_tail_config = {
+      OutInChannels(10, 32),
+      InputSize2D(30, 99),
+      KernelSize(3, 3),
+      Stride(1, 1),
+      Padding(1, 1),
+      Dilation(1, 1),
+      1,
+      20};
+  output_channel_tail_config.op_name = "conv2d_q8ta_q8csw_q8to";
+  output_channel_tail_config.test_case_name = make_test_case_name(
+      output_channel_tail_config,
+      false,
+      utils::kTexture3D,
+      utils::kBuffer);
+  test_cases.push_back(create_test_case_from_config(
+      output_channel_tail_config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4W4C,
+      /*impl_selector=*/"im2col",
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT));
   return test_cases;
 }
 
@@ -583,6 +687,10 @@ static std::vector<TestCase> generate_quantized_conv2d_test_cases() {
       narrow_workgroup_cases.begin(),
       narrow_workgroup_cases.end());
 
+  auto streaming_cases = generate_streaming_im2col_test_cases();
+  test_cases.insert(
+      test_cases.end(), streaming_cases.begin(), streaming_cases.end());
+
   return test_cases;
 }
 
@@ -820,6 +928,99 @@ static int64_t quantized_conv2d_flop_calculator(const TestCase& test_case) {
   return flop;
 }
 
+static void execute_streaming_dynamic_shrink_test() {
+  Conv2dConfig config = {
+      OutInChannels(4, 64),
+      InputSize2D(30, 99),
+      KernelSize(3, 3),
+      Stride(1, 1),
+      Padding(1, 1),
+      Dilation(1, 1),
+      1,
+      10};
+  config.op_name = "conv2d_q8ta_q8csw_q8to";
+  config.test_case_name = make_test_case_name(
+      config, false, utils::kTexture3D, utils::kBuffer);
+  TestCase test_case = create_test_case_from_config(
+      config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4W4C,
+      /*impl_selector=*/"im2col",
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT);
+  for (ValueSpec& input : test_case.inputs()) {
+    input.ensure_data_generated(/*seed=*/0);
+  }
+
+  ComputeGraph graph = setup_compute_graph(
+      test_case, test_case.operator_name(), /*op_invocations_per_execute=*/1);
+  graph.prepare();
+  graph.prepack();
+
+  const std::vector<int64_t> upper_input_sizes =
+      test_case.inputs().at(0).sizes;
+  const std::vector<int64_t> shrunk_input_sizes = {1, 64, 20, 51};
+  const std::vector<int64_t> shrunk_output_sizes = {1, 4, 20, 51};
+  TestCase shrunk_case = test_case;
+  shrunk_case.inputs().at(0).sizes = shrunk_input_sizes;
+  shrunk_case.inputs().at(0).resize_data(1 * 64 * 20 * 51);
+  shrunk_case.outputs().at(0).sizes = shrunk_output_sizes;
+  shrunk_case.outputs().at(0).resize_data(1 * 4 * 20 * 51);
+  reference_impl(shrunk_case);
+
+  constexpr int kRepetitions = 4;
+  for (int repetition = 0; repetition < kRepetitions; ++repetition) {
+    graph.resize_input(0, upper_input_sizes);
+    graph.propagate_resize();
+    graph.maybe_cast_and_copy_into_staging(
+        graph.inputs().at(0).staging,
+        test_case.inputs().at(0).get_data_ptr(),
+        test_case.inputs().at(0).numel(),
+        vkapi::kFloat);
+    graph.execute();
+
+    graph.resize_input(0, shrunk_input_sizes);
+    graph.propagate_resize();
+    if (graph.sizes_of(graph.outputs().at(0).value) != shrunk_output_sizes) {
+      throw std::runtime_error("streaming im2col output did not shrink");
+    }
+    graph.maybe_cast_and_copy_into_staging(
+        graph.inputs().at(0).staging,
+        shrunk_case.inputs().at(0).get_data_ptr(),
+        shrunk_case.inputs().at(0).numel(),
+        vkapi::kFloat);
+    graph.execute();
+    graph.maybe_cast_and_copy_from_staging(
+        graph.outputs().at(0).staging,
+        shrunk_case.outputs().at(0).get_mutable_data_ptr(),
+        shrunk_case.outputs().at(0).numel(),
+        vkapi::kFloat);
+    if (!shrunk_case.outputs().at(0).validate_against_reference(
+            shrunk_case.get_abs_tolerance(),
+            shrunk_case.get_rel_tolerance())) {
+      throw std::runtime_error("streaming im2col shrink output was stale");
+    }
+  }
+
+  const Q8taConv2dStreamPlan upper_plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/10,
+      /*flattened_kernel_size=*/576,
+      /*out_height=*/30,
+      /*out_width=*/99,
+      kQ8taConv2dIm2ColScratchBudgetBytes);
+  if (!upper_plan.feasible || upper_plan.num_tiles != 2 ||
+      upper_plan.rows_per_tile <= 20) {
+    throw std::runtime_error("dynamic shrink test did not create dead tiles");
+  }
+  const int64_t resized_scratch_bytes =
+      576 * upper_plan.rows_per_tile * utils::align_up_4(51);
+  if (resized_scratch_bytes > kQ8taConv2dIm2ColScratchBudgetBytes) {
+    throw std::runtime_error("streaming im2col scratch exceeded its cap");
+  }
+  std::cout << "Streaming im2col dynamic shrink PASSED" << std::endl;
+}
+
 int main(int argc, char* argv[]) {
   set_debugging(false);
   set_print_output(false);
@@ -840,6 +1041,14 @@ int main(int argc, char* argv[]) {
 
   const bool narrow_workgroups_only =
       argc == 2 && std::string(argv[1]) == "--narrow-workgroups-only";
+  const bool streaming_im2col_only =
+      argc == 2 && std::string(argv[1]) == "--streaming-im2col-only";
+  const bool streaming_dynamic_shrink_only =
+      argc == 2 && std::string(argv[1]) == "--streaming-dynamic-shrink-only";
+  if (streaming_dynamic_shrink_only) {
+    execute_streaming_dynamic_shrink_test();
+    return 0;
+  }
 #ifdef DEBUG_MODE
   std::function<std::vector<TestCase>()> test_case_generator =
       generate_quantized_conv2d_easy_cases;
@@ -849,6 +1058,8 @@ int main(int argc, char* argv[]) {
 #endif
   if (narrow_workgroups_only) {
     test_case_generator = generate_narrow_workgroup_test_cases;
+  } else if (streaming_im2col_only) {
+    test_case_generator = generate_streaming_im2col_test_cases;
   }
 
   auto results = execute_test_cases(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #22536
* #22535

Large or batched q8ta convolutions materialize the complete im2col tensor,
which can require hundreds of MiB. Stream flattened batch/output-height rows
through one reusable 16 MiB scratch buffer. Preserve the original one-dispatch
path when full scratch fits, and fall back to direct convolution when one row
cannot fit.

The cap was selected from 4/8/16/32 MiB device sweeps. 16 MiB is the smallest
cap without extra tiling for the representative 8.6 MiB operator and cuts
Edits Saliency uint8 VMA allocation by at least 129 MiB.

Authored with Codex.

Differential Revision: [D118709587](https://our.internmc.facebook.com/intern/diff/D118709587/)