### PR TITLE
[ET-VK][q8ta] Route pointwise convolution through unsigned dot

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/pack_q8_conv2d_weights.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/pack_q8_conv2d_weights.glsl
@@ -9,6 +9,7 @@
 #version 450 core
 
 #define PRECISION ${PRECISION}
+#define ADD_UNSIGNED_OFFSET ${ADD_UNSIGNED_OFFSET}
 
 ${define_active_storage_type(STORAGE)}
 
@@ -69,7 +70,11 @@ void main() {
           weight_vals[col] = (t_int8_weight[word_idx >> 2][word_idx & 3] >> (byte_pos * 8)) & 0xFF;
         }
       }
-      packed_block[row] = pack_into_int32(weight_vals);
+      int packed = pack_into_int32(weight_vals);
+#if ADD_UNSIGNED_OFFSET == 1
+      packed = int(uint(packed) ^ 0x80808080u);
+#endif
+      packed_block[row] = packed;
     }
     buf_idx += oc_stride;
   }

--- a/backends/vulkan/runtime/graph/ops/glsl/pack_q8_conv2d_weights.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/pack_q8_conv2d_weights.yaml
@@ -7,9 +7,12 @@
 pack_q8_conv2d_weights:
   parameter_names_with_default_values:
     STORAGE: buffer
+    ADD_UNSIGNED_OFFSET: 0
   generate_variant_forall:
     STORAGE:
       - VALUE: buffer
       - VALUE: texture2d
   shader_variants:
     - NAME: pack_q8_conv2d_weights
+    - NAME: pack_q8_conv2d_weights_unsigned
+      ADD_UNSIGNED_OFFSET: 1

--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.glsl
@@ -11,6 +11,7 @@
 ${define_required_extensions("buffer", DTYPE)}
 
 #define USE_INT8_DOT_PRODUCT_EXT ${USE_INT8_DOT_PRODUCT_EXT}
+#define USE_UNSIGNED_DOT_PRODUCT ${USE_UNSIGNED_DOT_PRODUCT}
 
 #extension GL_EXT_control_flow_attributes : require
 $if USE_INT8_DOT_PRODUCT_EXT == 1:
@@ -126,10 +127,19 @@ void main() {
   const int inp_n_stride = int(inp.strides[0][3]);
 
   // Initialize int32 accumulator
+#if USE_UNSIGNED_DOT_PRODUCT == 1
+  uvec4 out_accum[TILE_M][TILE_N4];
+  uvec4 input_sums = uvec4(0u);
+#else
   ivec4 out_accum[TILE_M][TILE_N4];
+#endif
   [[unroll]] for (int m = 0; m < TILE_M; ++m) {
     [[unroll]] for (int n4 = 0; n4 < TILE_N4; ++n4) {
+#if USE_UNSIGNED_DOT_PRODUCT == 1
+      out_accum[m][n4] = uvec4(0u);
+#else
       out_accum[m][n4] = ivec4(0);
+#endif
     }
   }
 
@@ -149,6 +159,10 @@ void main() {
     // Load the packed int8 input tile for the current width and K sub-block.
     // Each int contains 4 packed int8s (one per width position in the tile)
     ivec4 int8_input_tile = t_packed_int8_input[input_idx];
+#if USE_UNSIGNED_DOT_PRODUCT == 1
+    const uvec4 uint8_input_tile =
+        uvec4(int8_input_tile) ^ uvec4(0x80808080u);
+#endif
 
     // Load the int8 weight tile for the current K and output-channel sub-block.
     ivec4 int8_weight_tile[TILE_N4];
@@ -158,17 +172,34 @@ void main() {
           ivec2(oc_block_idx + n4, k4),
           0);
     }
+#if USE_UNSIGNED_DOT_PRODUCT == 1
+    uvec4 uint8_weight_tile[TILE_N4];
+    [[unroll]] for (int n4 = 0; n4 < TILE_N4; ++n4) {
+      uint8_weight_tile[n4] = uvec4(int8_weight_tile[n4]);
+    }
+#endif
 
     // Accumulate using int8 dot product
     // Input tile indexed as input[m] where m is the width index within tile
     // Weight tile indexed as weight[n4][n4i] where n4i is the channel index within block
     [[unroll]] for (int m = 0; m < TILE_M; ++m) {
+#if USE_UNSIGNED_DOT_PRODUCT == 1
+      input_sums[m] = dotPacked4x8AccSatEXT(
+          uint8_input_tile[m], 0x01010101u, input_sums[m]);
+#endif
       [[unroll]] for (int n4 = 0; n4 < TILE_N4; ++n4) {
         [[unroll]] for (int n4i = 0; n4i < 4; ++n4i) {
+#if USE_UNSIGNED_DOT_PRODUCT == 1
+          out_accum[m][n4][n4i] = dotPacked4x8AccSatEXT(
+              uint8_input_tile[m],
+              uint8_weight_tile[n4][n4i],
+              out_accum[m][n4][n4i]);
+#else
           out_accum[m][n4][n4i] = dotPacked4x8AccSat(
               int8_input_tile[m],
               int8_weight_tile[n4][n4i],
               out_accum[m][n4][n4i]);
+#endif
         }
       }
     }
@@ -188,6 +219,14 @@ void main() {
     weight_sums[n4] = ivec4(t_weight_sums[oc_block_idx + n4]);
   }
 
+#if USE_UNSIGNED_DOT_PRODUCT == 1
+  ivec4 unsigned_weight_correction[TILE_N4];
+  [[unroll]] for (int n4 = 0; n4 < TILE_N4; ++n4) {
+    unsigned_weight_correction[n4] =
+        (128 + input_zp) * weight_sums[n4];
+  }
+#endif
+
   // Initialize int8 output tile
   ivec4 int8_out_tile[TILE_M4][TILE_N4];
   [[unroll]] for (int m4 = 0; m4 < TILE_M4; ++m4) {
@@ -197,7 +236,9 @@ void main() {
   }
 
   // Compute int8 output tile from int32 accumulator
+#if USE_UNSIGNED_DOT_PRODUCT == 0
   ivec4 input_zp_vec = ivec4(-input_zp);
+#endif
 
   if (apply_bias > 0) {
     // Load bias tile
@@ -211,8 +252,14 @@ void main() {
         [[unroll]] for (int n4 = 0; n4 < TILE_N4; ++n4) {
           const int m = mul_4(m4) + m4i;
           // Compute floating point output values
+#if USE_UNSIGNED_DOT_PRODUCT == 1
+          ivec4 accum_adjusted = ivec4(out_accum[m][n4])
+              - ivec4(int(input_sums[m]) * 128)
+              - unsigned_weight_correction[n4];
+#else
           ivec4 accum_adjusted =
               input_zp_vec * weight_sums[n4] + out_accum[m][n4];
+#endif
           vec4 float_out_texel =
               fma(vec4(accum_adjusted),
                   vec4(weight_scales[n4]) * input_scale,
@@ -236,8 +283,14 @@ void main() {
         [[unroll]] for (int n4 = 0; n4 < TILE_N4; ++n4) {
           const int m = mul_4(m4) + m4i;
           // Compute floating point output values
+#if USE_UNSIGNED_DOT_PRODUCT == 1
+          ivec4 accum_adjusted = ivec4(out_accum[m][n4])
+              - ivec4(int(input_sums[m]) * 128)
+              - unsigned_weight_correction[n4];
+#else
           ivec4 accum_adjusted =
               input_zp_vec * weight_sums[n4] + out_accum[m][n4];
+#endif
           vec4 float_out_texel =
               vec4(accum_adjusted) * vec4(weight_scales[n4] * input_scale);
           // Apply ReLU if enabled

--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.yaml
@@ -8,10 +8,13 @@ q8ta_conv2d_pw:
   parameter_names_with_default_values:
     DTYPE: float
     USE_INT8_DOT_PRODUCT_EXT: 1
+    USE_UNSIGNED_DOT_PRODUCT: 0
   generate_variant_forall:
     DTYPE:
       - VALUE: float
   shader_variants:
     - NAME: q8ta_conv2d_pw
+    - NAME: q8ta_conv2d_pw_unsigned
+      USE_UNSIGNED_DOT_PRODUCT: 1
     - NAME: q8ta_conv2d_pw_fallback
       USE_INT8_DOT_PRODUCT_EXT: 0

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h
@@ -111,6 +111,7 @@ void add_q8ta_conv2d_node(
 
 void add_q8ta_conv2d_pw_node(
     ComputeGraph& graph,
+    const bool use_unsigned_dot,
     const ValueRef packed_int8_input,
     const ValueRef input_scale,
     const ValueRef input_zp,
@@ -129,6 +130,15 @@ void add_q8ta_conv2d_pw_node(
     const ValueRef stride = kDummyValueRef,
     const ValueRef padding = kDummyValueRef,
     const ValueRef dilation = kDummyValueRef);
+
+bool can_use_unsigned_pw_dot(const vkapi::Adapter& adapter);
+
+void q8ta_conv2d_pw_impl(
+    ComputeGraph& graph,
+    bool use_unsigned_dot,
+    const std::vector<ValueRef>& args);
+
+void q8ta_conv2d_pw(ComputeGraph& graph, const std::vector<ValueRef>& args);
 
 std::vector<int64_t> calculate_q8ta_im2col_sizes(
     ComputeGraph* graph,

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dIm2Col.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dIm2Col.cpp
@@ -318,6 +318,7 @@ void q8ta_conv2d_im2col(
 
   add_q8ta_conv2d_pw_node(
       graph,
+      /*use_unsigned_dot=*/false,
       packed_int8_im2col,
       input_scale,
       input_zp,

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dPW.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dPW.cpp
@@ -118,7 +118,8 @@ ValueRef prepack_quantized_conv2d_pw_weight(
     const QuantizationConfig& weight_quant_config,
     const ValueRef weight_data,
     const ValueRef input,
-    const ValueRef output) {
+    const ValueRef output,
+    const bool use_unsigned_dot) {
   VK_CHECK_COND(weight_quant_config.nbits == 8);
   VK_CHECK_COND(weight_quant_config.is_symmetric);
 
@@ -149,7 +150,8 @@ ValueRef prepack_quantized_conv2d_pw_weight(
   std::vector<int64_t> packed_weight_sizes{output_height, output_width};
 
   utils::StorageType storage_type = utils::kTexture2D;
-  uint32_t max_extent = graph.context()->adapter_ptr()->max_texture2d_dim();
+  const uint32_t max_extent =
+      graph.context()->adapter_ptr()->max_texture2d_dim();
   if (output_width > max_extent * 4 || output_height > max_extent) {
     storage_type = utils::kBuffer;
   }
@@ -166,7 +168,8 @@ ValueRef prepack_quantized_conv2d_pw_weight(
        1u},
       kTiledWorkGrid);
 
-  std::string kernel_name = "pack_q8_conv2d_weights";
+  std::string kernel_name = use_unsigned_dot ? "pack_q8_conv2d_weights_unsigned"
+                                             : "pack_q8_conv2d_weights";
   add_storage_type_suffix(kernel_name, storage_type);
 
   graph.prepack_nodes().emplace_back(new PrepackNode(
@@ -257,6 +260,7 @@ void resize_q8ta_conv2d_pw_im2col_node(
 
 void add_q8ta_conv2d_pw_node(
     ComputeGraph& graph,
+    const bool use_unsigned_dot,
     const ValueRef packed_int8_input,
     const ValueRef input_scale,
     const ValueRef input_zp,
@@ -311,8 +315,15 @@ void add_q8ta_conv2d_pw_node(
 
   const bool use_hw_dot =
       graph.context()->adapter_ptr()->supports_int8_dot_product();
-  std::string kernel_name =
-      use_hw_dot ? "q8ta_conv2d_pw" : "q8ta_conv2d_pw_fallback";
+  std::string kernel_name;
+  if (use_unsigned_dot) {
+    VK_CHECK_COND(
+        use_hw_dot,
+        "Unsigned q8ta pointwise convolution requires integer dot product");
+    kernel_name = "q8ta_conv2d_pw_unsigned";
+  } else {
+    kernel_name = use_hw_dot ? "q8ta_conv2d_pw" : "q8ta_conv2d_pw_fallback";
+  }
   add_dtype_suffix(kernel_name, graph.dtype_of(packed_weight_scales));
 
   vkapi::ParamsBindList param_buffers = {
@@ -364,7 +375,15 @@ void add_q8ta_conv2d_pw_node(
 // High level operator impl
 //
 
-void q8ta_conv2d_pw(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+bool can_use_unsigned_pw_dot(const vkapi::Adapter& adapter) {
+  return adapter.accelerates_unsigned_packed4x8_dot() &&
+      !adapter.accelerates_signed_packed4x8_dot();
+}
+
+void q8ta_conv2d_pw_impl(
+    ComputeGraph& graph,
+    const bool use_unsigned_dot,
+    const std::vector<ValueRef>& args) {
   int32_t idx = 0;
   const ValueRef packed_int8_input = args.at(idx++);
   const ValueRef input_scale = args.at(idx++);
@@ -396,7 +415,8 @@ void q8ta_conv2d_pw(ComputeGraph& graph, const std::vector<ValueRef>& args) {
       weight_quant_config,
       weight_data,
       packed_int8_input,
-      packed_int8_output);
+      packed_int8_output,
+      use_unsigned_dot);
 
   ValueRef packed_weight_sums = prepack_standard(
       graph, weight_sums_data, utils::kBuffer, utils::kWidthPacked);
@@ -422,6 +442,7 @@ void q8ta_conv2d_pw(ComputeGraph& graph, const std::vector<ValueRef>& args) {
 
   add_q8ta_conv2d_pw_node(
       graph,
+      use_unsigned_dot,
       packed_int8_input,
       input_scale,
       input_zp,
@@ -434,6 +455,12 @@ void q8ta_conv2d_pw(ComputeGraph& graph, const std::vector<ValueRef>& args) {
       packed_bias,
       activation_type_val,
       packed_int8_output);
+}
+
+void q8ta_conv2d_pw(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  const vkapi::Adapter* const adapter = graph.context()->adapter_ptr();
+  const bool use_unsigned_dot = can_use_unsigned_pw_dot(*adapter);
+  q8ta_conv2d_pw_impl(graph, use_unsigned_dot, args);
 }
 
 REGISTER_OPERATORS {

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -231,13 +231,41 @@ class Adapter final {
 #endif /* VK_KHR_shader_float16_int8 */
   }
 
-  inline bool supports_int8_dot_product() {
+  inline bool supports_int8_dot_product() const {
 #ifdef ETVK_FORCE_NO_EXTENSIONS
     return false;
 #endif
 #ifdef VK_KHR_shader_integer_dot_product
     return physical_device_.shader_int_dot_product_features
                .shaderIntegerDotProduct == VK_TRUE;
+#else
+    return false;
+#endif /* VK_KHR_shader_integer_dot_product */
+  }
+
+  inline bool accelerates_signed_packed4x8_dot() const {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
+#ifdef VK_KHR_shader_integer_dot_product
+    return supports_int8_dot_product() &&
+        physical_device_.shader_int_dot_product_properties
+            .integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated ==
+        VK_TRUE;
+#else
+    return false;
+#endif /* VK_KHR_shader_integer_dot_product */
+  }
+
+  inline bool accelerates_unsigned_packed4x8_dot() const {
+#ifdef ETVK_FORCE_NO_EXTENSIONS
+    return false;
+#endif
+#ifdef VK_KHR_shader_integer_dot_product
+    return supports_int8_dot_product() &&
+        physical_device_.shader_int_dot_product_properties
+            .integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated ==
+        VK_TRUE;
 #else
     return false;
 #endif /* VK_KHR_shader_integer_dot_product */

--- a/backends/vulkan/test/custom_ops/impl/TestQ8taConv2d.cpp
+++ b/backends/vulkan/test/custom_ops/impl/TestQ8taConv2d.cpp
@@ -14,6 +14,71 @@
 
 namespace vkcompute {
 
+namespace {
+
+void assert_pw_kernel_selection(
+    ComputeGraph& graph,
+    const bool expect_unsigned,
+    const bool expect_buffer_weights) {
+  const vkapi::Adapter* const adapter = graph.context()->adapter_ptr();
+  std::string expected_execute;
+  std::string expected_prepack;
+  if (expect_unsigned) {
+    expected_execute = expect_buffer_weights
+        ? "q8ta_conv2d_pw_unsigned_buffer_float"
+        : "q8ta_conv2d_pw_unsigned_float";
+    expected_prepack = expect_buffer_weights
+        ? "pack_q8_conv2d_weights_unsigned_buffer"
+        : "pack_q8_conv2d_weights_unsigned_texture2d";
+  } else {
+    VK_CHECK_COND(!expect_buffer_weights);
+    expected_execute = adapter->supports_int8_dot_product()
+        ? "q8ta_conv2d_pw_float"
+        : "q8ta_conv2d_pw_fallback_float";
+    expected_prepack = "pack_q8_conv2d_weights_texture2d";
+  }
+
+  int32_t execute_matches = 0;
+  std::string execute_names;
+  for (const auto& node : graph.execute_nodes()) {
+    const ExecuteNode* const node_ptr = node.get();
+    VK_CHECK_COND(node_ptr != nullptr);
+    const std::string& node_name = node_ptr->name();
+    execute_names += node_name + " ";
+    if (node_name.find("q8ta_conv2d_pw") == 0) {
+      VK_CHECK_COND(
+          node_name == expected_execute,
+          "Expected ",
+          expected_execute,
+          " but selected execute kernel ",
+          node_name);
+      ++execute_matches;
+    }
+  }
+  VK_CHECK_COND(execute_matches > 0, "Execute kernels: ", execute_names);
+
+  int32_t prepack_matches = 0;
+  std::string prepack_names;
+  for (const auto& node : graph.prepack_nodes()) {
+    const PrepackNode* const node_ptr = node.get();
+    VK_CHECK_COND(node_ptr != nullptr);
+    const std::string& node_name = node_ptr->name();
+    prepack_names += node_name + " ";
+    if (node_name.find("pack_q8_conv2d_weights") == 0) {
+      VK_CHECK_COND(
+          node_name == expected_prepack,
+          "Expected ",
+          expected_prepack,
+          " but selected prepack kernel ",
+          node_name);
+      ++prepack_matches;
+    }
+  }
+  VK_CHECK_COND(prepack_matches > 0, "Prepack kernels: ", prepack_names);
+}
+
+} // namespace
+
 void test_q8ta_conv2d_dw(
     ComputeGraph& graph,
     const std::vector<ValueRef>& args) {
@@ -287,7 +352,28 @@ void test_q8ta_conv2d_pw(
         groups,
         activation,
         packed_int8_output};
-    VK_GET_OP_FN("et_vk.q8ta_conv2d_pw.default")(graph, conv_args);
+    if (impl_selector == "pw_signed" || impl_selector == "pw_unsigned" ||
+        impl_selector == "pw_auto") {
+      const vkapi::Adapter* const adapter = graph.context()->adapter_ptr();
+      bool expect_unsigned = impl_selector == "pw_unsigned";
+      if (impl_selector == "pw_auto") {
+        VK_GET_OP_FN("et_vk.q8ta_conv2d_pw.default")(graph, conv_args);
+        expect_unsigned = can_use_unsigned_pw_dot(*adapter);
+      } else {
+        q8ta_conv2d_pw_impl(graph, expect_unsigned, conv_args);
+      }
+      const int64_t packed_height =
+          utils::div_up_4(graph.size_at<int64_t>(-1, weight_data));
+      const int64_t packed_width =
+          utils::div_up_4(graph.size_at<int64_t>(-2, weight_data)) * 4;
+      const int64_t max_texture_extent = adapter->max_texture2d_dim();
+      const bool expect_buffer_weights =
+          packed_width > max_texture_extent * 4 ||
+          packed_height > max_texture_extent;
+      assert_pw_kernel_selection(graph, expect_unsigned, expect_buffer_weights);
+    } else {
+      VK_GET_OP_FN("et_vk.q8ta_conv2d_pw.default")(graph, conv_args);
+    }
   }
 
   // Dequantize packed int8 output to floating point

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d_pw.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d_pw.cpp
@@ -4,10 +4,12 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <algorithm>
 #include <iostream>
 #include <vector>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
@@ -109,6 +111,15 @@ static TestCase create_test_case_from_config(
       utils::kWidthPacked,
       DataGenType::RANDINT8);
   quantized_weight.set_constant(true);
+  std::vector<int8_t>& weight_data = quantized_weight.get_int8_data();
+  for (int64_t out_channel = 0; out_channel < config.channels.out;
+       ++out_channel) {
+    const auto padding_begin =
+        weight_data.begin() + out_channel * in_features + in_channels_per_group;
+    const auto padding_end =
+        weight_data.begin() + (out_channel + 1) * in_features;
+    std::fill(padding_begin, padding_end, 0);
+  }
 
   if (debugging()) {
     print_valuespec_data(quantized_weight, "weight_tensor");
@@ -215,8 +226,12 @@ static TestCase create_test_case_from_config(
   return test_case;
 }
 
-// Generate test cases for quantized pointwise conv2d operation
-static std::vector<TestCase> generate_quantized_conv2d_pw_test_cases() {
+// Generate test cases for quantized pointwise conv2d operation. When
+// pw_selector is non-empty ("pw_signed", "pw_unsigned", "pw_auto"), every
+// non-legacy case carries that selector so the test graph builder can force or
+// verify the unsigned-dot routing instead of using the default automatic path.
+static std::vector<TestCase> generate_quantized_conv2d_pw_test_cases(
+    const std::string& pw_selector = "") {
   std::vector<TestCase> test_cases;
   if (!vkcompute::api::context()->adapter_ptr()->supports_int8_dot_product()) {
     return test_cases;
@@ -342,7 +357,11 @@ static std::vector<TestCase> generate_quantized_conv2d_pw_test_cases() {
         config.test_case_name = make_test_case_name(
             config, is_performance, fp_storage_type, utils::kBuffer);
         test_cases.push_back(create_test_case_from_config(
-            config, vkapi::kFloat, fp_storage_type, int8_memory_layout));
+            config,
+            vkapi::kFloat,
+            fp_storage_type,
+            int8_memory_layout,
+            pw_selector));
 
         // For 4W4C layout, also test the legacy implementation
         if (int8_memory_layout == utils::kPackedInt8_4W4C) {
@@ -390,10 +409,18 @@ static std::vector<TestCase> generate_quantized_conv2d_pw_test_cases() {
     config.test_case_name = make_test_case_name(
         config, is_performance, utils::kTexture3D, utils::kBuffer);
     test_cases.push_back(create_test_case_from_config(
-        config, vkapi::kFloat, utils::kTexture3D, utils::kPackedInt8_4C1W));
+        config,
+        vkapi::kFloat,
+        utils::kTexture3D,
+        utils::kPackedInt8_4C1W,
+        pw_selector));
     if (config.batch == 2) {
       test_cases.push_back(create_test_case_from_config(
-          config, vkapi::kFloat, utils::kTexture3D, utils::kPackedInt8_4W4C));
+          config,
+          vkapi::kFloat,
+          utils::kTexture3D,
+          utils::kPackedInt8_4W4C,
+          pw_selector));
     }
   }
 
@@ -498,7 +525,7 @@ static void conv2d_q8ta_q8csw_q8to_reference_impl(TestCase& test_case) {
   auto& ref_data = output_spec.get_ref_float_data();
   ref_data.resize(num_output_elements);
 
-  const int in_features = utils::align_up_4(C_in_per_group * K_h * K_w);
+  const int64_t in_features = utils::align_up_4(C_in_per_group * K_h * K_w);
 
   // Perform activation, weight, and output quantized conv2d operation
   for (int64_t n = 0; n < N; ++n) {
@@ -635,6 +662,26 @@ static int64_t quantized_conv2d_flop_calculator(const TestCase& test_case) {
 }
 
 int main(int argc, char* argv[]) {
+  const vkapi::Adapter& adapter = *vkcompute::api::context()->adapter_ptr();
+  const bool prefers_unsigned_dot =
+      adapter.accelerates_unsigned_packed4x8_dot() &&
+      !adapter.accelerates_signed_packed4x8_dot();
+  VK_CHECK_COND(can_use_unsigned_pw_dot(adapter) == prefers_unsigned_dot);
+
+  std::string pw_impl_selector;
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg(argv[i]);
+    if (arg == "--pw-path=signed") {
+      pw_impl_selector = "pw_signed";
+    } else if (arg == "--pw-path=unsigned") {
+      pw_impl_selector = "pw_unsigned";
+    } else if (arg == "--pw-path=auto") {
+      pw_impl_selector = "pw_auto";
+    } else {
+      std::cerr << "Unknown argument: " << arg << std::endl;
+      return 2;
+    }
+  }
   set_debugging(false);
   set_print_output(false);
 #ifdef DEBUG_MODE
@@ -653,12 +700,11 @@ int main(int argc, char* argv[]) {
   ReferenceComputeFunc ref_fn = reference_impl;
 
   // Execute test cases using the new framework with custom FLOP calculator
+  const auto test_case_generator = [pw_impl_selector]() {
+    return generate_quantized_conv2d_pw_test_cases(pw_impl_selector);
+  };
   auto results = execute_test_cases(
-#ifdef DEBUG_MODE
-      generate_quantized_conv2d_pw_test_cases,
-#else
-      generate_quantized_conv2d_pw_test_cases,
-#endif
+      test_case_generator,
       quantized_conv2d_flop_calculator,
       "QuantizedConv2dPW",
       /*warmup_runs = */ 1,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22540
* __->__ #22539
* #22538

Use unsigned accumulating-saturating packed dot when Vulkan accelerates unsigned packed dot but not signed packed dot. Keep weight prepack and execution routing consistent while preserving signed routing elsewhere. Authored with Codex.

Differential Revision: [D118585646](https://our.internmc.facebook.com/intern/diff/D118585646/)