### PR TITLE
[ET-VK][q8ta] Route im2col convolution through unsigned dot

### DIFF
--- a/backends/vulkan/runtime/graph/ops/PrepackNode.h
+++ b/backends/vulkan/runtime/graph/ops/PrepackNode.h
@@ -50,6 +50,10 @@ class PrepackNode final {
     node_id_ = node_id;
   }
 
+  inline const std::string& name() const {
+    return shader_.kernel_name;
+  }
+
  protected:
   uint32_t node_id_;
   const vkapi::ShaderInfo shader_;

--- a/backends/vulkan/runtime/graph/ops/glsl/pack_q8_linear_weight.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/pack_q8_linear_weight.glsl
@@ -9,6 +9,7 @@
 #version 450 core
 
 #define PRECISION ${PRECISION}
+#define ADD_UNSIGNED_OFFSET ${ADD_UNSIGNED_OFFSET}
 
 ${define_active_storage_type(STORAGE)}
 
@@ -52,6 +53,10 @@ void main() {
   } else {
     load_block_data_with_checks(block , k4, n, K4, N);
   }
+
+#if ADD_UNSIGNED_OFFSET == 1
+  block.data = ivec4(uvec4(block.data) ^ uvec4(0x80808080u));
+#endif
 
   // The weight blocks are stored in a tranposed manner, such that weight blocks
   // are indexed like packed_weight[k4][n4]. This is to optimize memory

--- a/backends/vulkan/runtime/graph/ops/glsl/pack_q8_linear_weight.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/pack_q8_linear_weight.yaml
@@ -7,8 +7,15 @@
 pack_q8_linear_weight:
   parameter_names_with_default_values:
     STORAGE: buffer
+    ADD_UNSIGNED_OFFSET: 0
   shader_variants:
     - NAME: pack_q8_linear_weight_buffer
       STORAGE: buffer
     - NAME: pack_q8_linear_weight_texture2d
       STORAGE: texture2d
+    - NAME: pack_q8_linear_weight_unsigned_buffer
+      STORAGE: buffer
+      ADD_UNSIGNED_OFFSET: 1
+    - NAME: pack_q8_linear_weight_unsigned_texture2d
+      STORAGE: texture2d
+      ADD_UNSIGNED_OFFSET: 1

--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.glsl
@@ -13,6 +13,9 @@ ${define_required_extensions("buffer", DTYPE)}
 #define USE_INT8_DOT_PRODUCT_EXT ${USE_INT8_DOT_PRODUCT_EXT}
 #define USE_UNSIGNED_DOT_PRODUCT ${USE_UNSIGNED_DOT_PRODUCT}
 
+$if WEIGHT_STORAGE == "buffer":
+  #define WEIGHT_BUFFER
+
 #extension GL_EXT_control_flow_attributes : require
 $if USE_INT8_DOT_PRODUCT_EXT == 1:
   #extension GL_EXT_integer_dot_product : require
@@ -44,7 +47,7 @@ layout(std430) buffer;
 
 ${layout_declare_tensor(B, "w", "t_packed_int8_output", "int", "buffer", is_scalar_array=True)}
 ${layout_declare_tensor(B, "r", "t_packed_int8_input", "int", "buffer", is_scalar_array=False)}
-${layout_declare_tensor(B, "r", "t_packed_int8_weight", "int", "texture2d", is_scalar_array=False)}
+${layout_declare_tensor(B, "r", "t_packed_int8_weight", "int", WEIGHT_STORAGE, is_scalar_array=False)}
 ${layout_declare_tensor(B, "r", "t_weight_sums", "int", "buffer", is_scalar_array=False)}
 ${layout_declare_tensor(B, "r", "t_weight_scales", DTYPE, "buffer", is_scalar_array=False)}
 ${layout_declare_tensor(B, "r", "t_bias", DTYPE, "buffer", is_scalar_array=False)}
@@ -167,10 +170,15 @@ void main() {
     // Load the int8 weight tile for the current K and output-channel sub-block.
     ivec4 int8_weight_tile[TILE_N4];
     [[unroll]] for (int n4 = 0; n4 < TILE_N4; ++n4) {
+#ifdef WEIGHT_BUFFER
+      int8_weight_tile[n4] = t_packed_int8_weight[
+          k4 * OC4 + oc_block_idx + n4];
+#else
       int8_weight_tile[n4] = texelFetch(
           t_packed_int8_weight,
           ivec2(oc_block_idx + n4, k4),
           0);
+#endif
     }
 #if USE_UNSIGNED_DOT_PRODUCT == 1
     uvec4 uint8_weight_tile[TILE_N4];

--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.yaml
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.yaml
@@ -9,6 +9,7 @@ q8ta_conv2d_pw:
     DTYPE: float
     USE_INT8_DOT_PRODUCT_EXT: 1
     USE_UNSIGNED_DOT_PRODUCT: 0
+    WEIGHT_STORAGE: texture2d
   generate_variant_forall:
     DTYPE:
       - VALUE: float
@@ -16,5 +17,8 @@ q8ta_conv2d_pw:
     - NAME: q8ta_conv2d_pw
     - NAME: q8ta_conv2d_pw_unsigned
       USE_UNSIGNED_DOT_PRODUCT: 1
+    - NAME: q8ta_conv2d_pw_unsigned_buffer
+      USE_UNSIGNED_DOT_PRODUCT: 1
+      WEIGHT_STORAGE: buffer
     - NAME: q8ta_conv2d_pw_fallback
       USE_INT8_DOT_PRODUCT_EXT: 0

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h
@@ -161,6 +161,13 @@ void add_q8ta_im2col_node(
 
 void q8ta_conv2d_im2col(ComputeGraph& graph, const std::vector<ValueRef>& args);
 
+bool can_use_unsigned_dot(const vkapi::Adapter& adapter, int64_t k_per_group);
+
+void q8ta_conv2d_im2col_impl(
+    ComputeGraph& graph,
+    bool use_unsigned_dot,
+    const std::vector<ValueRef>& args);
+
 // Transposed convolution
 
 void q8ta_conv2d_transposed(

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dIm2Col.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dIm2Col.cpp
@@ -236,8 +236,27 @@ void add_q8ta_im2col_node(
 // High level operator impl
 //
 
-void q8ta_conv2d_im2col(
+namespace {
+
+constexpr int64_t kMaxUnsignedAccumulatorBytes = 33025;
+
+bool unsigned_q8ta_im2col_accumulator_is_safe(const int64_t k_per_group) {
+  return k_per_group <= kMaxUnsignedAccumulatorBytes;
+}
+
+} // namespace
+
+bool can_use_unsigned_dot(
+    const vkapi::Adapter& adapter,
+    const int64_t k_per_group) {
+  return adapter.accelerates_unsigned_packed4x8_dot() &&
+      !adapter.accelerates_signed_packed4x8_dot() &&
+      unsigned_q8ta_im2col_accumulator_is_safe(k_per_group);
+}
+
+void q8ta_conv2d_im2col_impl(
     ComputeGraph& graph,
+    const bool use_unsigned_dot,
     const std::vector<ValueRef>& args) {
   int32_t idx = 0;
   const ValueRef packed_int8_input = args.at(idx++);
@@ -260,8 +279,8 @@ void q8ta_conv2d_im2col(
   QuantizationConfig weight_quant_config(8, kPerChannel, {});
 
   // Prepack weight using linear weight packing (for im2col approach)
-  ValueRef packed_weight =
-      prepack_quantized_linear_weight(graph, weight_quant_config, weight_data);
+  ValueRef packed_weight = prepack_quantized_linear_weight(
+      graph, weight_quant_config, weight_data, use_unsigned_dot);
 
   ValueRef packed_weight_sums = prepack_standard(
       graph, weight_sums_data, utils::kBuffer, utils::kWidthPacked);
@@ -315,10 +334,15 @@ void q8ta_conv2d_im2col(
 
   // Step 2: Perform pointwise convolution on the im2col result
   const int32_t groups_val = graph.extract_scalar<int32_t>(groups);
+  VK_CHECK_COND(
+      !use_unsigned_dot ||
+          unsigned_q8ta_im2col_accumulator_is_safe(
+              graph.size_at<int64_t>(-1, weight_data)),
+      "Unsigned q8ta im2col convolution exceeds the accumulator bound");
 
   add_q8ta_conv2d_pw_node(
       graph,
-      /*use_unsigned_dot=*/false,
+      use_unsigned_dot,
       packed_int8_im2col,
       input_scale,
       input_zp,
@@ -339,6 +363,16 @@ void q8ta_conv2d_im2col(
       stride,
       padding,
       dilation);
+}
+
+void q8ta_conv2d_im2col(
+    ComputeGraph& graph,
+    const std::vector<ValueRef>& args) {
+  const vkapi::Adapter* const adapter = graph.context()->adapter_ptr();
+  const ValueRef weight_data = args.at(3);
+  const int64_t k_per_group = graph.size_at<int64_t>(-1, weight_data);
+  const bool use_unsigned_dot = can_use_unsigned_dot(*adapter, k_per_group);
+  q8ta_conv2d_im2col_impl(graph, use_unsigned_dot, args);
 }
 
 REGISTER_OPERATORS {

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dPW.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dPW.cpp
@@ -321,6 +321,9 @@ void add_q8ta_conv2d_pw_node(
         use_hw_dot,
         "Unsigned q8ta pointwise convolution requires integer dot product");
     kernel_name = "q8ta_conv2d_pw_unsigned";
+    if (graph.storage_type_of(packed_weight) == utils::kBuffer) {
+      kernel_name += "_buffer";
+    }
   } else {
     kernel_name = use_hw_dot ? "q8ta_conv2d_pw" : "q8ta_conv2d_pw_fallback";
   }

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.cpp
@@ -331,9 +331,11 @@ vkapi::ShaderInfo pick_linear_dqa_qw_shader(
 ValueRef prepack_quantized_linear_weight(
     ComputeGraph& graph,
     const QuantizationConfig& weight_quant_config,
-    const ValueRef qmat2_data) {
+    const ValueRef qmat2_data,
+    const bool use_unsigned_dot) {
   VK_CHECK_COND(
       weight_quant_config.nbits == 8 || weight_quant_config.nbits == 4);
+  VK_CHECK_COND(!use_unsigned_dot || weight_quant_config.nbits == 8);
 
   std::vector<int64_t> qmat2_orig_sizes = graph.sizes_of(qmat2_data);
   const int64_t ndim = graph.dim_of(qmat2_data);
@@ -410,10 +412,13 @@ ValueRef prepack_quantized_linear_weight(
   if (output_width > max_extent * 4 || output_height > max_extent) {
     storage_type = utils::kBuffer;
   }
-
-  std::string kernel_name = weight_quant_config.nbits == 4
-      ? "pack_q4_linear_weight"
-      : "pack_q8_linear_weight";
+  std::string kernel_name;
+  if (weight_quant_config.nbits == 4) {
+    kernel_name = "pack_q4_linear_weight";
+  } else {
+    kernel_name = use_unsigned_dot ? "pack_q8_linear_weight_unsigned"
+                                   : "pack_q8_linear_weight";
+  }
   add_storage_type_suffix(kernel_name, storage_type);
 
   // Check prepack cache before creating a new prepack node. This avoids

--- a/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.h
+++ b/backends/vulkan/runtime/graph/ops/impl/QuantizedLinear.h
@@ -24,6 +24,7 @@ LocalWorkGroup quantized_linear_lwg(
 ValueRef prepack_quantized_linear_weight(
     ComputeGraph& graph,
     const QuantizationConfig& weight_quant_config,
-    const ValueRef qmat2_data);
+    const ValueRef qmat2_data,
+    const bool use_unsigned_dot = false);
 
 } // namespace vkcompute

--- a/backends/vulkan/test/custom_ops/impl/TestQ8taConv2d.cpp
+++ b/backends/vulkan/test/custom_ops/impl/TestQ8taConv2d.cpp
@@ -10,11 +10,73 @@
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taClone.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taQuantizeDequantize.h>
 
 namespace vkcompute {
 
 namespace {
+
+void assert_im2col_kernel_selection(
+    ComputeGraph& graph,
+    const bool expect_unsigned,
+    const bool expect_buffer_weights) {
+  const vkapi::Adapter* const adapter = graph.context()->adapter_ptr();
+  std::string expected_execute;
+  std::string expected_prepack;
+  if (expect_unsigned) {
+    expected_execute = expect_buffer_weights
+        ? "q8ta_conv2d_pw_unsigned_buffer_float"
+        : "q8ta_conv2d_pw_unsigned_float";
+    expected_prepack = expect_buffer_weights
+        ? "pack_q8_linear_weight_unsigned_buffer"
+        : "pack_q8_linear_weight_unsigned_texture2d";
+  } else {
+    VK_CHECK_COND(!expect_buffer_weights);
+    expected_execute = adapter->supports_int8_dot_product()
+        ? "q8ta_conv2d_pw_float"
+        : "q8ta_conv2d_pw_fallback_float";
+    expected_prepack = "pack_q8_linear_weight_texture2d";
+  }
+
+  int32_t execute_matches = 0;
+  std::string execute_names;
+  for (const auto& node : graph.execute_nodes()) {
+    const ExecuteNode* const node_ptr = node.get();
+    VK_CHECK_COND(node_ptr != nullptr);
+    const std::string& node_name = node_ptr->name();
+    execute_names += node_name + " ";
+    if (node_name.find("q8ta_conv2d_pw") == 0) {
+      VK_CHECK_COND(
+          node_name == expected_execute,
+          "Expected ",
+          expected_execute,
+          " but selected execute kernel ",
+          node_name);
+      ++execute_matches;
+    }
+  }
+  VK_CHECK_COND(execute_matches > 0, "Execute kernels: ", execute_names);
+
+  int32_t prepack_matches = 0;
+  std::string prepack_names;
+  for (const auto& node : graph.prepack_nodes()) {
+    const PrepackNode* const node_ptr = node.get();
+    VK_CHECK_COND(node_ptr != nullptr);
+    const std::string& node_name = node_ptr->name();
+    prepack_names += node_name + " ";
+    if (node_name.find("pack_q8_linear_weight") == 0) {
+      VK_CHECK_COND(
+          node_name == expected_prepack,
+          "Expected ",
+          expected_prepack,
+          " but selected prepack kernel ",
+          node_name);
+      ++prepack_matches;
+    }
+  }
+  VK_CHECK_COND(prepack_matches > 0, "Prepack kernels: ", prepack_names);
+}
 
 void assert_pw_kernel_selection(
     ComputeGraph& graph,
@@ -251,8 +313,27 @@ void test_q8ta_conv2d(ComputeGraph& graph, const std::vector<ValueRef>& args) {
         groups,
         activation,
         packed_int8_output};
-    if (impl_selector == "im2col") {
-      VK_GET_OP_FN("et_vk.q8ta_conv2d_im2col.default")(graph, conv_args);
+    if (impl_selector == "im2col" || impl_selector == "im2col_unsigned" ||
+        impl_selector == "im2col_auto") {
+      const vkapi::Adapter* const adapter = graph.context()->adapter_ptr();
+      bool expect_unsigned = impl_selector == "im2col_unsigned";
+      if (impl_selector == "im2col_auto") {
+        VK_GET_OP_FN("et_vk.q8ta_conv2d_im2col.default")(graph, conv_args);
+        expect_unsigned = can_use_unsigned_dot(
+            *adapter, graph.size_at<int64_t>(-1, weight_data));
+      } else {
+        q8ta_conv2d_im2col_impl(graph, expect_unsigned, conv_args);
+      }
+      const int64_t packed_height =
+          utils::div_up_4(graph.size_at<int64_t>(-1, weight_data));
+      const int64_t packed_width =
+          utils::div_up_4(graph.size_at<int64_t>(-2, weight_data)) * 4;
+      const int64_t max_texture_extent = adapter->max_texture2d_dim();
+      const bool expect_buffer_weights =
+          packed_width > max_texture_extent * 4 ||
+          packed_height > max_texture_extent;
+      assert_im2col_kernel_selection(
+          graph, expect_unsigned, expect_buffer_weights);
     } else if (impl_selector == "general") {
       VK_GET_OP_FN("et_vk.q8ta_conv2d_general.default")(graph, conv_args);
     } else {

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
@@ -4,10 +4,14 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <algorithm>
+#include <array>
 #include <iostream>
+#include <utility>
 #include <vector>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Common.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Staging.h>
@@ -22,6 +26,17 @@ using namespace executorch::vulkan::prototyping;
 using namespace vkcompute;
 
 static constexpr int64_t kRefDimSizeLimit = 100;
+static constexpr int64_t kRefOperationLimit = 2 * 1024 * 1024;
+
+struct Im2colUnsignedTestOptions {
+  int32_t input_zero_point = 2;
+  int32_t output_zero_point = -1;
+  bool use_extreme_values = false;
+  bool use_accumulator_limit_values = false;
+  bool has_bias = true;
+  const char* activation = "none";
+  float weight_scale = 1.0f / 256.0f;
+};
 
 // Utility function to create a test case from a Conv2dConfig
 static TestCase create_test_case_from_config(
@@ -29,7 +44,8 @@ static TestCase create_test_case_from_config(
     vkapi::ScalarType input_dtype,
     utils::StorageType fp_storage_type,
     utils::GPUMemoryLayout int8_memory_layout,
-    const std::string& impl_selector = "") {
+    const std::string& impl_selector = "",
+    const Im2colUnsignedTestOptions* im2col_options = nullptr) {
   TestCase test_case;
 
   // Calculate output dimensions
@@ -91,8 +107,27 @@ static TestCase create_test_case_from_config(
   float input_scale_val = 0.008123;
   ValueSpec input_scale(input_scale_val);
 
-  int32_t input_zero_point_val = 2;
+  const int32_t input_zero_point_val =
+      im2col_options == nullptr ? 2 : im2col_options->input_zero_point;
   ValueSpec input_zero_point(input_zero_point_val);
+
+  if (im2col_options != nullptr &&
+      im2col_options->use_accumulator_limit_values) {
+    input_tensor.ensure_data_generated(2401);
+    std::fill(
+        input_tensor.get_float_data().begin(),
+        input_tensor.get_float_data().end(),
+        (127.0f - input_zero_point_val) * input_scale_val);
+  } else if (im2col_options != nullptr && im2col_options->use_extreme_values) {
+    input_tensor.ensure_data_generated(2401);
+    constexpr std::array<int8_t, 5> values = {-128, -1, 0, 1, 127};
+    std::vector<float>& input_data = input_tensor.get_float_data();
+    for (size_t i = 0; i < input_data.size(); ++i) {
+      input_data.at(i) = (static_cast<float>(values.at(i % values.size())) -
+                          input_zero_point_val) *
+          input_scale_val;
+    }
+  }
 
   // Quantized weight tensor (int8) - [C_out, C_in_per_group * K_h * K_w]
   // Memory layout: height, width, then channels - in_c is innermost (stride 1)
@@ -109,6 +144,22 @@ static TestCase create_test_case_from_config(
       DataGenType::RANDINT8);
   quantized_weight.set_constant(true);
 
+  if (im2col_options != nullptr &&
+      im2col_options->use_accumulator_limit_values) {
+    quantized_weight.ensure_data_generated(2402);
+    std::fill(
+        quantized_weight.get_int8_data().begin(),
+        quantized_weight.get_int8_data().end(),
+        127);
+  } else if (im2col_options != nullptr && im2col_options->use_extreme_values) {
+    quantized_weight.ensure_data_generated(2402);
+    constexpr std::array<int8_t, 5> values = {-128, -1, 0, 1, 127};
+    std::vector<int8_t>& weight_data = quantized_weight.get_int8_data();
+    for (size_t i = 0; i < weight_data.size(); ++i) {
+      weight_data.at(i) = values.at((i * 3 + 1) % values.size());
+    }
+  }
+
   if (debugging()) {
     print_valuespec_data(quantized_weight, "weight_tensor");
   }
@@ -123,6 +174,13 @@ static TestCase create_test_case_from_config(
       utils::kWidthPacked,
       DataGenType::RANDOM_SCALES);
   weight_scales.set_constant(true);
+  if (im2col_options != nullptr) {
+    weight_scales.ensure_data_generated(2403);
+    std::fill(
+        weight_scales.get_float_data().begin(),
+        weight_scales.get_float_data().end(),
+        im2col_options->weight_scale);
+  }
 
   ValueSpec weight_sums(
       {aligned_out_channels}, // Per output channel
@@ -144,12 +202,16 @@ static TestCase create_test_case_from_config(
       utils::kWidthPacked,
       DataGenType::ZEROS);
   bias.set_constant(true);
+  if (im2col_options != nullptr && !im2col_options->has_bias) {
+    bias.set_none(true);
+  }
 
   // Output quantization parameters
   float output_scale_val = 0.05314;
   ValueSpec output_scale(output_scale_val);
 
-  int32_t output_zero_point_val = -1;
+  const int32_t output_zero_point_val =
+      im2col_options == nullptr ? -1 : im2col_options->output_zero_point;
   ValueSpec output_zero_point(output_zero_point_val);
 
   // Stride and padding parameters
@@ -188,7 +250,8 @@ static TestCase create_test_case_from_config(
   test_case.add_input_spec(groups);
 
   // Activation (none = no activation)
-  ValueSpec activation = ValueSpec::make_string("none");
+  ValueSpec activation = ValueSpec::make_string(
+      im2col_options == nullptr ? "none" : im2col_options->activation);
   test_case.add_input_spec(activation);
 
   // Add memory layout parameter for the quantized tensors
@@ -201,7 +264,9 @@ static TestCase create_test_case_from_config(
 
   test_case.add_output_spec(output);
 
-  test_case.set_abs_tolerance(output_scale_val + 1e-4f);
+  test_case.set_abs_tolerance(
+      im2col_options == nullptr ? output_scale_val + 1e-4f
+                                : output_scale_val * 0.25f);
 
   // Filter out quantize/dequantize shaders from timing measurements
   test_case.set_shader_filter({
@@ -271,10 +336,21 @@ std::vector<TestCase> generate_quantized_conv2d_easy_cases() {
   return test_cases;
 }
 
+static std::vector<TestCase> generate_im2col_unsigned_test_cases(
+    const std::string& impl_selector);
+
 // Generate test cases for quantized conv2d operation
 static std::vector<TestCase> generate_quantized_conv2d_test_cases() {
   std::vector<TestCase> test_cases;
-  if (!vkcompute::api::context()->adapter_ptr()->supports_int8_dot_product()) {
+  api::Context* const context = vkcompute::api::context();
+  if (!context->adapter_ptr()->supports_int8_dot_product()) {
+    for (const std::string& impl_selector : {"im2col", "im2col_auto"}) {
+      std::vector<TestCase> im2col_cases =
+          generate_im2col_unsigned_test_cases(impl_selector);
+      for (TestCase& test_case : im2col_cases) {
+        test_cases.push_back(std::move(test_case));
+      }
+    }
     return test_cases;
   }
 
@@ -542,6 +618,118 @@ static std::vector<TestCase> generate_quantized_conv2d_test_cases() {
     }
   }
 
+  for (const std::string& impl_selector :
+       {"im2col", "im2col_unsigned", "im2col_auto"}) {
+    std::vector<TestCase> im2col_cases =
+        generate_im2col_unsigned_test_cases(impl_selector);
+    for (TestCase& test_case : im2col_cases) {
+      test_cases.push_back(std::move(test_case));
+    }
+  }
+
+  return test_cases;
+}
+
+static std::vector<TestCase> generate_im2col_unsigned_test_cases(
+    const std::string& impl_selector) {
+  api::Context* const context = vkcompute::api::context();
+  if (impl_selector == "im2col_unsigned" &&
+      !context->adapter_ptr()->supports_int8_dot_product()) {
+    return {};
+  }
+
+  std::vector<std::pair<Conv2dConfig, Im2colUnsignedTestOptions>> configs = {
+      {{OutInChannels(5, 4),
+        InputSize2D(5, 5),
+        KernelSize(3, 3),
+        Stride(1, 1),
+        Padding(0, 0),
+        Dilation(1, 1),
+        1},
+       {2, -1, true, false, true, "none"}},
+      {{OutInChannels(8, 8),
+        InputSize2D(5, 5),
+        KernelSize(3, 3),
+        Stride(1, 1),
+        Padding(1, 1),
+        Dilation(1, 1),
+        1},
+       {-7, 3, true, false, false, "none"}},
+      {{OutInChannels(12, 8),
+        InputSize2D(7, 7),
+        KernelSize(3, 3),
+        Stride(2, 2),
+        Padding(1, 1),
+        Dilation(1, 1),
+        1},
+       {127, -5, true, false, true, "relu"}},
+      {{OutInChannels(12, 8),
+        InputSize2D(9, 9),
+        KernelSize(3, 3),
+        Stride(1, 1),
+        Padding(2, 2),
+        Dilation(2, 2),
+        1},
+       {-128, 5, true, false, false, "none"}},
+      {{OutInChannels(8, 8),
+        InputSize2D(6, 7),
+        KernelSize(3, 3),
+        Stride(1, 1),
+        Padding(1, 1),
+        Dilation(1, 1),
+        2},
+       {11, -3, true, false, true, "relu"}},
+      {{OutInChannels(1, 4),
+        InputSize2D(90, 91),
+        KernelSize(90, 91),
+        Stride(1, 1),
+        Padding(0, 0),
+        Dilation(1, 1),
+        1},
+       {0, -1, false, true, true, "none", 1.0f / 1000000.0f}},
+  };
+
+  std::vector<TestCase> test_cases;
+  test_cases.reserve(configs.size());
+  for (auto& [config, options] : configs) {
+    config.op_name = "conv2d_q8ta_q8csw_q8to";
+    config.test_case_name =
+        make_test_case_name(config, false, utils::kTexture3D, utils::kBuffer);
+    test_cases.push_back(create_test_case_from_config(
+        config,
+        vkapi::kFloat,
+        utils::kTexture3D,
+        utils::kPackedInt8_4W4C,
+        impl_selector,
+        &options));
+  }
+
+  const vkapi::Adapter& adapter = *context->adapter_ptr();
+  if (impl_selector == "im2col_unsigned" ||
+      (impl_selector == "im2col_auto" && can_use_unsigned_dot(adapter, 4))) {
+    const int32_t buffer_output_channels = utils::safe_downcast<int32_t>(
+        static_cast<int64_t>(adapter.max_texture2d_dim()) * 4 + 1);
+    Conv2dConfig config{
+        OutInChannels(buffer_output_channels, 4),
+        InputSize2D(1, 1),
+        KernelSize(1, 1),
+        Stride(1, 1),
+        Padding(0, 0),
+        Dilation(1, 1),
+        1};
+    Im2colUnsignedTestOptions options;
+    config.op_name = "conv2d_q8ta_q8csw_q8to";
+    config.test_case_name =
+        make_test_case_name(config, false, utils::kBuffer, utils::kBuffer);
+    test_cases.push_back(create_test_case_from_config(
+        config,
+        vkapi::kFloat,
+        utils::kBuffer,
+        utils::kPackedInt8_4W4C,
+        impl_selector,
+        &options));
+  }
+
   return test_cases;
 }
 
@@ -565,7 +753,6 @@ static void conv2d_q8ta_q8csw_q8to_reference_impl(TestCase& test_case) {
   const ValueSpec& dilation_spec = test_case.inputs()[idx++];
   const ValueSpec& groups_spec = test_case.inputs()[idx++];
   const ValueSpec& activation_spec = test_case.inputs()[idx++];
-  (void)activation_spec; // Not used in reference implementation
   const ValueSpec& layout_spec = test_case.inputs()[idx++];
   (void)layout_spec; // Not used in reference implementation
   const ValueSpec& impl_selector_spec = test_case.inputs()[idx++];
@@ -606,10 +793,12 @@ static void conv2d_q8ta_q8csw_q8to_reference_impl(TestCase& test_case) {
   int64_t dilation_w = dilation_data[1];
   int64_t groups = groups_spec.get_int_value();
 
-  // Skip for large tensors since computation time will be extremely slow
-  if (N > kRefDimSizeLimit || C_in > kRefDimSizeLimit ||
-      H_in > kRefDimSizeLimit || W_in > kRefDimSizeLimit ||
-      C_out > kRefDimSizeLimit) {
+  const int64_t reference_operations =
+      N * C_out * H_out * W_out * (C_in / groups) * K_h * K_w;
+  const bool has_large_dimension = N > kRefDimSizeLimit ||
+      C_in > kRefDimSizeLimit || H_in > kRefDimSizeLimit ||
+      W_in > kRefDimSizeLimit || C_out > kRefDimSizeLimit;
+  if (has_large_dimension && reference_operations > kRefOperationLimit) {
     throw std::invalid_argument(
         "One or more dimensions exceed the allowed limit for reference implementation.");
     std::cout
@@ -643,7 +832,7 @@ static void conv2d_q8ta_q8csw_q8to_reference_impl(TestCase& test_case) {
   auto& ref_data = output_spec.get_ref_float_data();
   ref_data.resize(num_output_elements);
 
-  const int in_features = utils::align_up_4(C_in_per_group * K_h * K_w);
+  const int64_t in_features = utils::align_up_4(C_in_per_group * K_h * K_w);
 
   // Perform activation, weight, and output quantized conv2d operation
   for (int64_t n = 0; n < N; ++n) {
@@ -722,8 +911,12 @@ static void conv2d_q8ta_q8csw_q8to_reference_impl(TestCase& test_case) {
           float float_result =
               accum_adjusted * input_scale * weight_scales_data[out_c];
 
-          // Add bias and store result
-          float_result += bias_data[out_c];
+          if (!bias_spec.is_none()) {
+            float_result += bias_data[out_c];
+          }
+          if (activation_spec.get_string_value() == "relu") {
+            float_result = std::max(float_result, 0.0f);
+          }
 
           // Quantize the output to int8
           float quant_output_f =
@@ -780,6 +973,27 @@ static int64_t quantized_conv2d_flop_calculator(const TestCase& test_case) {
 }
 
 int main(int argc, char* argv[]) {
+  const vkapi::Adapter& adapter = *vkcompute::api::context()->adapter_ptr();
+  const bool prefers_unsigned_dot =
+      adapter.accelerates_unsigned_packed4x8_dot() &&
+      !adapter.accelerates_signed_packed4x8_dot();
+  VK_CHECK_COND(can_use_unsigned_dot(adapter, 33025) == prefers_unsigned_dot);
+  VK_CHECK_COND(!can_use_unsigned_dot(adapter, 33026));
+
+  std::string im2col_impl_selector;
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg(argv[i]);
+    if (arg == "--im2col-path=signed") {
+      im2col_impl_selector = "im2col";
+    } else if (arg == "--im2col-path=unsigned") {
+      im2col_impl_selector = "im2col_unsigned";
+    } else if (arg == "--im2col-path=auto") {
+      im2col_impl_selector = "im2col_auto";
+    } else {
+      std::cerr << "Unknown argument: " << arg << std::endl;
+      return 2;
+    }
+  }
   set_debugging(false);
   set_print_output(false);
 #ifdef DEBUG_MODE
@@ -798,11 +1012,16 @@ int main(int argc, char* argv[]) {
   ReferenceComputeFunc ref_fn = reference_impl;
 
   // Execute test cases using the new framework with custom FLOP calculator
+  const auto test_case_generator = [im2col_impl_selector]() {
+    return im2col_impl_selector.empty()
+        ? generate_quantized_conv2d_test_cases()
+        : generate_im2col_unsigned_test_cases(im2col_impl_selector);
+  };
   auto results = execute_test_cases(
 #ifdef DEBUG_MODE
       generate_quantized_conv2d_easy_cases,
 #else
-      generate_quantized_conv2d_test_cases,
+      test_case_generator,
 #endif
       quantized_conv2d_flop_calculator,
       "QuantizedConv2dQ8ToQ8To",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #22540
* #22539
* #22538

Use corrected unsigned accumulating-saturating packed dot for im2col convolution when the adapter accelerates unsigned but not signed packed dot and the accumulator bound is safe. Support both texture- and buffer-backed packed weights. Preserve signed routing elsewhere. Authored with Codex.

Differential Revision: [D118585647](https://our.internmc.facebook.com/intern/diff/D118585647/)