### PR TITLE
Qualcomm AI Engine Direct - Fix a QNN crash on AMD Hosts

### DIFF
--- a/backends/qualcomm/utils/qnn_sdk_setup.py
+++ b/backends/qualcomm/utils/qnn_sdk_setup.py
@@ -166,7 +166,8 @@ def disable_mkldnn_on_amd() -> None:
 
     import torch
 
-    torch.backends.mkldnn.enabled = False
+    if not torch.backends.flags_frozen():
+        torch.backends.mkldnn.enabled = False
 
 
 def _host_is_amd() -> bool:


### PR DESCRIPTION
### Summary

Fixed a crash on AMD hosts when PyTorch's global backend flags are frozen.

`QnnQuantizer.__init__` calls `disable_mkldnn_on_amd()`, which assigns `torch.backends.mkldnn.enabled = False`. PyTorch forbids that assignment once `disable_global_flags()` has been called, which happens whenever `torch.testing._internal.common_utils` is imported — as the Qualcomm test suite does. The result is that constructing a quantizer on an AMD host fails with:

```
RuntimeError: not allowed to set torch.backends.mkldnn flags after disable_global_flags;
please use flags() context manager instead
```

The assignment is now guarded, so a frozen-flags environment leaves the existing MKLDNN setting in place instead of raising. Disabling MKLDNN is a workaround for AMD-host crashes, not a correctness requirement, so skipping it when the flag is locked is safe.

Note that this is a temporary workaround for an issue introduced in a previous [pr](https://github.com/pytorch/executorch/pull/22395), not a root-cause fix, I haven't validated that this change has not broken anything else.

### Test plan

Ran the tests mentioned in the test plan section of https://github.com/pytorch/executorch/pull/22542.
