### PR TITLE
Cortex-M: expose explicit-layout AOT

### DIFF
--- a/backends/arm/scripts/aot_arm_compiler.py
+++ b/backends/arm/scripts/aot_arm_compiler.py
@@ -626,6 +626,14 @@ def _get_args():
         choices=TARGETS,
         help=f"Target backend. For delegated models: Ethos-U/VGF/TOSA variants. For non-delegated: cortex-m<variant> (CMSIS-NN portable kernels). Valid targets: {TARGETS}",
     )
+    parser.add_argument(
+        "--cortex-m-explicit-layout",
+        action="store_true",
+        help=(
+            "Use explicit NCHW/NHWC permutes for Cortex-M instead of dim-order "
+            "operators. This is an experimental Cortex-M-only option."
+        ),
+    )
     # TODO: Remove --evaluate and --evaluate_config completely after a suitable time.
     # They are deprecated and no longer functional in this script.
     parser.add_argument(
@@ -923,8 +931,15 @@ def _to_edge_cortex_m(
     """Cortex-M/CMSIS-NN compilation path with no delegation."""
     logging.info(
         f"Using Cortex-M/CMSIS-NN compilation path for cpu={target_config.cpu.name} "
-        f"backend={target_config.backend.name}"
+        f"backend={target_config.backend.name} "
+        f"layout={'explicit' if args.cortex_m_explicit_layout else 'dim-order'}"
     )
+
+    if args.cortex_m_explicit_layout and not args.quantize:
+        raise RuntimeError(
+            "--cortex-m-explicit-layout requires --quantize; explicit layout "
+            "does not fall back to portable float spatial operators."
+        )
 
     def _to_channels_last(x):
         if isinstance(x, torch.Tensor):
@@ -949,17 +964,26 @@ def _to_edge_cortex_m(
         )
         model_quant = None
     else:
-        model = model.to(memory_format=torch.channels_last)  # type: ignore[call-overload]
-        example_inputs = tuple(_to_channels_last(x) for x in example_inputs)
+        if not args.cortex_m_explicit_layout:
+            model = model.to(memory_format=torch.channels_last)  # type: ignore[call-overload]
+            example_inputs = tuple(_to_channels_last(x) for x in example_inputs)
+            # Refresh fake-tensor strides after changing the captured module's
+            # memory format so the legacy quantizer sees channels-last inputs.
+            model = torch.export.export(
+                model, example_inputs, strict=args.strict_export
+            ).module()
 
-        quantizer = CortexMQuantizer()
+        quantizer = CortexMQuantizer(use_explicit_layout=args.cortex_m_explicit_layout)
+
         prepared = prepare_pt2e(model, quantizer)
 
         if calibration_samples is None:
             calibration_samples = [example_inputs]
 
         for sample in calibration_samples:
-            prepared(*tuple(_to_channels_last(x) for x in sample))
+            if not args.cortex_m_explicit_layout:
+                sample = tuple(_to_channels_last(x) for x in sample)
+            prepared(*sample)
 
         model_quant = convert_pt2e(prepared)
 
@@ -973,7 +997,9 @@ def _to_edge_cortex_m(
     )
 
     pass_manager = CortexMPassManager(
-        edge.exported_program(), target_config=target_config
+        edge.exported_program(),
+        target_config=target_config,
+        use_explicit_layout=args.cortex_m_explicit_layout,
     )
     edge._edge_programs["forward"] = pass_manager.transform()
 

--- a/backends/cortex_m/README.md
+++ b/backends/cortex_m/README.md
@@ -5,7 +5,17 @@
 
 ## Overview
 
-The Cortex-M backend is implemented as an operator dialect/library based on [CMSIS-NN](https://github.com/ARM-software/CMSIS-NN), together with the `CortexMQuantizer` which targets supported ops, and the `CortexMPassManager` which modifies the exported program to use Cortex-M operators where possible. It is intended for use with **channels-last input**  since this is what the accelerated kernels are using.
+The Cortex-M backend is implemented as an operator dialect/library based on [CMSIS-NN](https://github.com/ARM-software/CMSIS-NN), together with the `CortexMQuantizer` which targets supported ops, and the `CortexMPassManager` which modifies the exported program to use Cortex-M operators where possible.
+
+The default AOT path retains the established channels-last input and dim-order contract. An experimental explicit-layout path accepts ordinary contiguous inputs, inserts graph-visible NHWC copies, and lowers spatial kernels to the `cortex_m::*_nhwc` operator family. Enable it with `--cortex-m-explicit-layout`; the two modes do not fall back to or mix with each other. Explicit-layout compilation fails when a spatial operator is not eligible for NHWC lowering, so models using unsupported configurations must use the legacy mode.
+
+### Explicit-layout migration
+
+The `use_explicit_layout=True` modes on `CortexMQuantizer` and `CortexMPassManager` are temporary staging APIs. They keep the experimental path isolated while the default modes and `CortexMTester` continue to exercise the legacy path.
+
+When explicit layout becomes the default, its support table and pass list will become the defaults in `CortexMQuantizer` and `CortexMPassManager`. The existing legacy support table and pass list will remain temporarily behind an opt-out AOT flag. This keeps the public Python entry points stable and switches `CortexMTester` to explicit layout without changing its callers. The direct NHWC kernel tests and explicit-only model tests will then be folded into the normal operator and model suites.
+
+After the legacy AOT compatibility period, the legacy support table, pass list, input conversion, opt-out flag, and remaining dual-mode tests will be removed. Legacy runtime operators will remain registered so programs serialized by the old AOT path continue to load.
 
 For a detailed example of the full lowering flow, see `examples/arm/cortex_m_mv2_example.ipynb`.
 

--- a/backends/cortex_m/test/build_test_runner.sh
+++ b/backends/cortex_m/test/build_test_runner.sh
@@ -52,6 +52,7 @@ ops_list=(
     aten::full.out
     aten::ge.Tensor_out
     aten::unsqueeze_copy.out
+    aten::squeeze_copy.dim_out
     aten::select_copy.int_out
     aten::amax.out
     cortex_m::quantize_per_tensor.out

--- a/backends/cortex_m/test/test_explicit_layout.py
+++ b/backends/cortex_m/test/test_explicit_layout.py
@@ -1,0 +1,180 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from executorch.backends.cortex_m.target_config import CortexM, CortexMTargetConfig
+from executorch.backends.cortex_m.test.tester import CortexMSerialize
+from executorch.exir.dialects._ops import ops as exir_ops
+
+
+_LEGACY_SPATIAL_OPS = {
+    exir_ops.edge.cortex_m.quantized_conv2d.default,
+    exir_ops.edge.cortex_m.quantized_depthwise_conv2d.default,
+    exir_ops.edge.cortex_m.quantized_transpose_conv2d.default,
+    exir_ops.edge.cortex_m.quantized_avg_pool2d.default,
+    exir_ops.edge.cortex_m.quantized_max_pool2d.default,
+}
+
+# Temporary dual-mode acceptance coverage; see "Explicit-layout migration" in
+# the Cortex-M README.
+
+
+class Conv2d(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv2d(3, 4, 3, padding=1)
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+class Conv1d(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv = torch.nn.Conv1d(2, 4, 3, padding=1)
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+def _compile(module, inputs, *, explicit_layout: bool, quantize: bool = True):
+    from executorch.backends.arm.scripts.aot_arm_compiler import _to_edge_cortex_m
+
+    exported_program = torch.export.export(module, inputs, strict=True)
+    return _to_edge_cortex_m(
+        exported_program,
+        SimpleNamespace(
+            cortex_m_explicit_layout=explicit_layout,
+            quantize=quantize,
+            strict_export=True,
+        ),
+        exported_program.module(),
+        inputs,
+        None,
+        CortexMTargetConfig(cpu=CortexM.M55),
+    )
+
+
+def _count(exported_program, target) -> int:
+    return sum(node.target == target for node in exported_program.graph.nodes)
+
+
+@pytest.mark.parametrize(
+    "explicit_layout,expected,unexpected",
+    [
+        (
+            False,
+            exir_ops.edge.cortex_m.quantized_conv2d.default,
+            exir_ops.edge.cortex_m.quantized_conv2d_nhwc.default,
+        ),
+        (
+            True,
+            exir_ops.edge.cortex_m.quantized_conv2d_nhwc.default,
+            exir_ops.edge.cortex_m.quantized_conv2d.default,
+        ),
+    ],
+)
+def test_aot_layout_mode_selects_operator_family(explicit_layout, expected, unexpected):
+    _, edge, _ = _compile(
+        Conv2d().eval(),
+        (torch.randn(1, 3, 8, 8),),
+        explicit_layout=explicit_layout,
+    )
+    program = edge.exported_program()
+
+    assert _count(program, expected) == 1
+    assert _count(program, unexpected) == 0
+
+
+def test_aot_explicit_layout_requires_quantization():
+    with pytest.raises(RuntimeError, match="requires --quantize"):
+        _compile(
+            Conv2d().eval(),
+            (torch.randn(1, 3, 8, 8),),
+            explicit_layout=True,
+            quantize=False,
+        )
+
+
+def _assert_explicit_copy_ceiling(module, inputs, ceiling):
+    _, edge, _ = _compile(module, inputs, explicit_layout=True)
+    program = edge.exported_program()
+    copies = [
+        node
+        for node in program.graph.nodes
+        if node.target
+        in {
+            exir_ops.edge.cortex_m.transpose.default,
+            exir_ops.edge.aten.view_copy.default,
+        }
+    ]
+
+    assert len(copies) <= ceiling
+    assert all(
+        node.args[0].meta["val"].dtype == torch.int8
+        for node in copies
+        if node.target == exir_ops.edge.cortex_m.transpose.default
+    )
+    assert not any(node.target in _LEGACY_SPATIAL_OPS for node in program.graph.nodes)
+    assert not any(
+        getattr(node.target, "namespace", None) == "channels_last"
+        for node in program.graph.nodes
+    )
+
+
+def test_mobilenet_v2_explicit_copy_ceiling():
+    torchvision = pytest.importorskip("torchvision")
+    _assert_explicit_copy_ceiling(
+        torchvision.models.mobilenet_v2(weights=None).eval(),
+        (torch.randn(1, 3, 224, 224),),
+        ceiling=2,
+    )
+
+
+def test_resnet8_explicit_copy_ceiling():
+    from executorch.examples.models.mlperf_tiny.resnet8 import ResNet8
+
+    _assert_explicit_copy_ceiling(
+        ResNet8().eval(),
+        (torch.rand(1, 3, 32, 32) * 2 - 1,),
+        ceiling=2,
+    )
+
+
+def test_silero_explicit_copy_ceiling():
+    from executorch.examples.models.silero_vad.export_silero_vad import (
+        CONTEXT_SIZE,
+        HIDDEN_DIM,
+        SileroVAD16k,
+        WINDOW_SIZE,
+    )
+
+    _assert_explicit_copy_ceiling(
+        SileroVAD16k().eval(),
+        (
+            torch.randn(1, CONTEXT_SIZE + WINDOW_SIZE),
+            torch.zeros(2, 1, HIDDEN_DIM),
+        ),
+        ceiling=12,
+    )
+
+
+def test_explicit_conv1d_runs_on_fvp():
+    inputs = (torch.linspace(-5, 5, steps=16).reshape(1, 2, 8),)
+    model_quant, edge, runtime_inputs = _compile(
+        Conv1d().eval(), inputs, explicit_layout=True
+    )
+    program = edge.exported_program()
+    assert _count(program, exir_ops.edge.cortex_m.quantized_conv2d_nhwc.default) == 1
+
+    serialized = CortexMSerialize(CortexMTargetConfig(cpu=CortexM.M55))
+    serialized.run(edge.to_executorch())
+    [actual] = serialized.run_artifact(runtime_inputs)
+    expected = model_quant(*runtime_inputs)
+    torch.testing.assert_close(actual, expected, atol=0.05, rtol=1e-3)

--- a/docs/source/backends/arm-cortex-m/arm-cortex-m-overview.md
+++ b/docs/source/backends/arm-cortex-m/arm-cortex-m-overview.md
@@ -6,6 +6,8 @@ This backend is in **beta**. It has been validated with a set of small models (e
 
 The Arm&reg; Cortex&reg;-M backend accelerates quantized model execution on Arm Cortex-M CPUs using [CMSIS-NN](https://arm-software.github.io/CMSIS-NN/latest/) optimized kernels. Unlike delegate-based backends, it operates as an operator library: quantized subgraphs are replaced with CMSIS-NN accelerated kernels during the pass-lowering stage, while unsupported operators fall back to portable fp32 kernels.
 
+The default AOT flow uses channels-last inputs and the existing dim-order representation. The experimental explicit-layout flow uses ordinary contiguous inputs, represents NCHW/NHWC conversions as graph operators, and selects the experimental `cortex_m::*_nhwc` kernels. Enable it with `--cortex-m-explicit-layout`. Layout modes are selected independently of the Cortex-M CPU target and never mix operator families.
+
 ## Target Support
 
 The backend targets Arm Cortex-M CPUs via CMSIS-NN, which provides optimized kernel implementations for three instruction set variants:


### PR DESCRIPTION
### Summary

Expose the experimental explicit-layout Cortex-M pipeline through `--cortex-m-explicit-layout`.

Explicit mode keeps model inputs contiguous and selects the matching quantizer mode and blessed pass sequence. Legacy mode remains the default and continues converting inputs to channels-last before quantization. Explicit mode requires quantization and never falls back to legacy spatial operators.

The tests cover mode-specific operator selection, removal of intermediate channels-last dialect nodes, int8 layout-copy boundaries, copy ceilings for MobileNetV2, ResNet8, and Silero VAD, and serialized Conv1d execution on the M55 FVP. The documentation also records how the explicit mode becomes the default and how legacy AOT generation is subsequently removed without removing legacy runtime operators.

### Test plan

`source examples/arm/arm-scratch/setup_path.sh && python -m pytest --config-file=backends/arm/test/pytest.ini backends/cortex_m/test/test_explicit_layout.py`

`lintrunner -m origin/main`

AI-assisted: Codex.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>