### PR TITLE
Fix the Samsung MobileBert test setup so it can run

### DIFF
--- a/backends/samsung/test/models/test_mobilebert_finetuning.py
+++ b/backends/samsung/test/models/test_mobilebert_finetuning.py
@@ -12,36 +12,10 @@ from executorch.backends.samsung.serialization.compile_options import (
 )
 from executorch.backends.samsung.test.tester import SamsungTester
 from executorch.backends.samsung.test.utils.utils import TestConfig
-
 from executorch.examples.samsung.scripts.mobilebert_finetune import MobileBertFinetune
-from transformers import AutoTokenizer
-
-
-def patch_mobilebert_finetuning():
-    def _monkeypatch_load_tokenizer(self):
-        tokenizer = AutoTokenizer.from_pretrained(
-            do_lower_case=True,
-        )
-        return tokenizer
-
-    old_func = MobileBertFinetune.load_tokenizer
-    MobileBertFinetune.load_tokenizer = _monkeypatch_load_tokenizer
-    return old_func
-
-
-def recover_mobilebert_finetuning(old_func):
-    MobileBertFinetune.load_tokenizer = old_func
 
 
 class Test_Milestone_MobileBertFinetune(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._old_func = patch_mobilebert_finetuning(cls.model_cache_dir)
-
-    @classmethod
-    def tearDownClass(cls):
-        recover_mobilebert_finetuning(cls._old_func)
-
     def test_mobilebert_finetuning_fp16(self):
         mobilebert_finetune = MobileBertFinetune()
         model, _ = mobilebert_finetune.get_finetune_mobilebert(None)


### PR DESCRIPTION
### Summary

The Samsung model test job runs every test under `backends/samsung/test/models`. One of those tests, the MobileBert fine-tuning test, always errors out before it does any work:

```
ERROR: setUpClass (test_mobilebert_finetuning.Test_Milestone_MobileBertFinetune)
AttributeError: type object 'Test_Milestone_MobileBertFinetune' has no attribute 'model_cache_dir'
```

One error fails the whole job, so the other ten Samsung model tests passing does not help. The job only runs the tests when a Samsung device is available, which is why this looks like it comes and goes.

There were three separate problems stacked in the test setup, and each one was hidden behind the one before it:

1. `setUpClass` read `cls.model_cache_dir`, which is not defined anywhere.
2. It passed that value to `patch_mobilebert_finetuning()`, which takes no arguments. Python only checks the number of arguments when the call happens, so this could not be seen until the first problem was gone.
3. The setup replaced `load_tokenizer` with a copy of itself that left out the model name, so `AutoTokenizer.from_pretrained()` had nothing to load.

The replacement tokenizer loader was the same as the real one except for the missing model name, so it could only ever do less than the real one. Removing the setup that installed it fixes all three problems at once and lets the test use the real loader. The test now has the same shape as the other ten tests in the same directory, which build a model and check it with no extra setup.

### Test plan

Ran the real test collection and setup for this file before and after the change, with the heavy third party dependencies stubbed out so only the setup path was under test.

- Before: reproduces the same `AttributeError` seen in CI, and never reaches the test body.
- After: setup succeeds and the test body is reached.

Also checked that `model_cache_dir`, `setUpClass` and the now unused `AutoTokenizer` import are all gone, and that the file still compiles.
