### PR TITLE
Arm backend: Allow FP64 operators to decompose

### DIFF
--- a/backends/arm/test/ops/test_arange.py
+++ b/backends/arm/test/ops/test_arange.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -17,6 +17,11 @@ from executorch.backends.arm.test.tester.test_pipeline import (
     TosaPipelineINT,
     VgfPipeline,
 )
+from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
+from executorch.backends.arm.tosa.partitioner import TOSAPartitioner
+from executorch.exir import to_edge_transform_and_lower
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch._subclasses.fake_tensor import FakeTensorMode
 
 input_t = tuple[torch.Tensor]
 test_data_t = tuple[Callable[[], input_t], tuple[float, float, float, torch.dtype]]
@@ -171,6 +176,75 @@ class LinspaceAdd(torch.nn.Module):
         "10": (lambda: (torch.randn(10, 1),), (0.0, 10.0, 100, torch.float32)),
         "15": (lambda: (torch.randn(20),), (0.0, 15.0, 20, torch.float32)),
     }
+
+
+class _LinspaceToFloatAdd(torch.nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        values = torch.linspace(0.0, 1.0, x.shape[0], dtype=torch.float64)
+        return values.to(torch.float32) + x
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected"),
+    ((torch.float32, True), (torch.float64, False)),
+)
+def test_linspace_preservation_depends_on_dtype(
+    dtype: torch.dtype, expected: bool
+) -> None:
+    exported_program = torch.export.export(
+        LinspaceAdd(0.0, 1.0, 10, dtype),
+        (torch.randn(10),),
+    )
+    partitioner = TOSAPartitioner(TosaCompileSpec("TOSA-1.0+FP"))
+    _, filter_fn = partitioner.ops_to_not_decompose(exported_program)
+    linspace = next(
+        node
+        for node in exported_program.graph.nodes
+        if node.target == torch.ops.aten.linspace.default
+    )
+
+    assert filter_fn is not None
+    assert filter_fn(linspace) is expected
+
+
+def test_ops_to_not_decompose_are_not_preserved_for_fp64() -> None:
+    exported_program = torch.export.export(
+        LinspaceAdd(0.0, 1.0, 10, torch.float32),
+        (torch.randn(10),),
+    )
+    partitioner = TOSAPartitioner(TosaCompileSpec("TOSA-1.0+FP"))
+    ops_to_not_decompose, filter_fn = partitioner.ops_to_not_decompose(exported_program)
+    graph = torch.fx.Graph()
+    fake_tensor = FakeTensorMode().from_tensor(torch.empty(1, dtype=torch.float64))
+
+    assert filter_fn is not None
+    for op in ops_to_not_decompose:
+        node = graph.call_function(op)
+        node.meta["val"] = fake_tensor
+        assert not filter_fn(node), f"FP64 {op} should be decomposed"
+
+
+def test_linspace_fp64_decomposes_for_portable_fallback() -> None:
+    inputs = (torch.randn(10),)
+    exported_program = torch.export.export(_LinspaceToFloatAdd(), inputs)
+    partitioner = TOSAPartitioner(TosaCompileSpec("TOSA-1.0+FP"))
+
+    edge_manager = to_edge_transform_and_lower(
+        exported_program,
+        partitioner=[partitioner],
+    )
+    targets = {
+        node.target
+        for node in edge_manager.exported_program().graph.nodes
+        if node.op == "call_function"
+    }
+
+    assert exir_ops.edge.aten.linspace.default not in targets
+    assert exir_ops.edge.aten.arange.start_step in targets
+
+    program = edge_manager.to_executorch().executorch_program
+    operators = {(op.name, op.overload) for op in program.execution_plan[0].operators}
+    assert not any("linspace" in name for name, _ in operators)
 
 
 @common.parametrize("test_data", LinspaceAdd.test_data)

--- a/backends/arm/tosa/partitioner.py
+++ b/backends/arm/tosa/partitioner.py
@@ -787,6 +787,22 @@ class TOSAPartitioner(Partitioner):
             torch.ops.aten.linspace.default,
             torch.ops.aten.silu.default,
         }
+        ops_to_not_decompose = (
+            ops_to_not_decompose_always
+            | ops_to_not_decompose_if_quant_op
+            | ops_to_not_decompose_if_fp
+            | ops_to_not_decompose_if_integer
+        )
+
+        if not self.tosa_spec.is_U55_subset:
+            # Tosa operator "RESIZE" is not supported on U55. Since
+            # upsample_bilinear2d and upsample_nearest2d decompose into that it
+            # will not be possible to delegate those operators on U55. If we
+            # have said here to not decompose them there will be an error saying
+            # the operator was not decomposed. It will not be possible for it
+            # to end up on either CPU or NPU.
+            ops_to_not_decompose.add(torch.ops.aten.upsample_nearest2d.vec)
+            ops_to_not_decompose.add(torch.ops.aten.upsample_bilinear2d.vec)
 
         def filter_fn(node: torch.fx.Node) -> bool:
             """Return True if an op should not be decomposed.
@@ -803,6 +819,11 @@ class TOSAPartitioner(Partitioner):
             """
             if _is_custom_partition_op(self._custom_partition_ops, node.target):
                 return True
+            if (
+                node.target in ops_to_not_decompose
+                and get_first_fake_tensor(node).dtype == torch.float64
+            ):
+                return False
             if (
                 self.tosa_spec.support_float()
                 and node.target in ops_to_not_decompose_if_fp
@@ -873,21 +894,5 @@ class TOSAPartitioner(Partitioner):
                 return True
             return False
 
-        ops_to_not_decompose = list(
-            ops_to_not_decompose_always
-            | ops_to_not_decompose_if_quant_op
-            | ops_to_not_decompose_if_fp
-            | ops_to_not_decompose_if_integer
-        )
-        ops_to_not_decompose.extend(self._custom_partition_ops)
-
-        if not self.tosa_spec.is_U55_subset:
-            # Tosa operator "RESIZE" is not supported on U55. Since upsample_bilinear2d
-            # and upsample_nearest2d decompose into that it will not be possible to
-            # delegate those operators on U55. If we have said here to not decompose
-            # them there will be an error saying the operator was not decomposed. It
-            # will not be possible for it to end up on either CPU or NPU.
-            ops_to_not_decompose.append(torch.ops.aten.upsample_nearest2d.vec)
-            ops_to_not_decompose.append(torch.ops.aten.upsample_bilinear2d.vec)
-
-        return (ops_to_not_decompose, filter_fn)
+        ops_to_not_decompose.update(self._custom_partition_ops)
+        return (list(ops_to_not_decompose), filter_fn)


### PR DESCRIPTION
The TOSA partitioner preserves certain operators when the backend can lower them directly. Since the Arm backend does not support FP64, preserving FP64 variants prevents framework decompositions that may expose supported downstream operations.

Allow FP64 variants of preserved operators to decompose while retaining the existing behavior for explicitly registered custom operators. Add coverage for the general preservation policy and the linspace portable fallback.

cc @digantdesai @freddan80 @per @zingo @mansnils @Sebastian-Larsson @robell @rascani