### PR TITLE
Arm backend: Pass memory mode to Corstone

### DIFF
--- a/backends/arm/cmake/ArmRunnerUtilsInternal.cmake
+++ b/backends/arm/cmake/ArmRunnerUtilsInternal.cmake
@@ -328,8 +328,10 @@ function(arm_runner_configure_ethos_u_platform)
   arm_ensure_ethos_u_content(
     "${ARG_SDK_PATH}" "${EXECUTORCH_ROOT}" ${FETCH_ETHOS_U_CONTENT}
   )
-  add_corstone_subdirectory(${ARG_SYSTEM_CONFIG} ${ARG_SDK_PATH})
-  configure_timing_adapters(${ARG_SYSTEM_CONFIG} ${ARG_MEMORY_MODE})
+  add_corstone_subdirectory(
+    "${ARG_SYSTEM_CONFIG}" "${ARG_SDK_PATH}" "${ARG_MEMORY_MODE}"
+  )
+  configure_timing_adapters("${ARG_SYSTEM_CONFIG}" "${ARG_MEMORY_MODE}")
   foreach(_platform_variable TARGET_BOARD ETHOSU_MODEL ETHOSU_ARENA)
     if(DEFINED ${_platform_variable})
       set(${_platform_variable}

--- a/backends/arm/scripts/corstone_utils.cmake
+++ b/backends/arm/scripts/corstone_utils.cmake
@@ -126,7 +126,7 @@ function(get_corstone_linker_script OUT_VAR SYSTEM_CONFIG)
   )
 endfunction()
 
-function(add_corstone_subdirectory SYSTEM_CONFIG ETHOS_SDK_PATH)
+function(add_corstone_subdirectory SYSTEM_CONFIG ETHOS_SDK_PATH MEMORY_MODE)
   if(MEMORY_MODE MATCHES "^Dedicated_Sram($|_)")
     # Both model and scratch in DRAM.
     set(MEMORY_MODEL dram)

--- a/examples/arm/mobilesam_prompt_segmentation_example_ethos_u/runtime/CMakeLists.txt
+++ b/examples/arm/mobilesam_prompt_segmentation_example_ethos_u/runtime/CMakeLists.txt
@@ -100,8 +100,10 @@ find_package(
   executorch REQUIRED HINTS "${ET_BUILD_DIR_PATH}/lib/cmake/ExecuTorch"
 )
 
-add_corstone_subdirectory(${SYSTEM_CONFIG} ${ETHOS_SDK_PATH})
-configure_timing_adapters(${SYSTEM_CONFIG} ${MEMORY_MODE})
+add_corstone_subdirectory(
+  "${SYSTEM_CONFIG}" "${ETHOS_SDK_PATH}" "${MEMORY_MODE}"
+)
+configure_timing_adapters("${SYSTEM_CONFIG}" "${MEMORY_MODE}")
 
 add_executable(mobilesam_prompt_segmentation_example main.cpp)
 target_sources(


### PR DESCRIPTION
Pass the platform helper's explicit memory mode through to the Corstone configuration instead of relying on an ambient CMake variable. Update the MobileSAM caller to use the same explicit interface.

This commit was authored with Codex.


Change-Id: I5df5f88a1addf41240f3ebebc5a8acfc6face32b


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani