### PR TITLE
Take external tensor pointers untyped so ATen mode works (#22554)

### DIFF
--- a/backends/xnnpack/runtime/XNNExecutor.cpp
+++ b/backends/xnnpack/runtime/XNNExecutor.cpp
@@ -130,7 +130,9 @@ ET_NODISCARD Error XNNExecutor::prepare_args(Span<EValue*> args) {
         static_cast<uint32_t>(args[ext_id]->tag));
 
     Tensor* tensor = &args[ext_id]->toTensor();
-    externals_[i].data = tensor->mutable_data_ptr<float>();
+    // Untyped: externals are void*, and a quantized subgraph's are int8, which
+    // the typed accessor rejects in ATen mode.
+    externals_[i].data = tensor->mutable_data_ptr();
 
     executorch::aten::DimOrderType dim_order[kTensorDimensionLimit];
 
@@ -300,8 +302,11 @@ ET_NODISCARD Error XNNExecutor::convert_outputs(Span<EValue*> args) const {
     // int64. This means that the data was put into this tensor
     // by XNNPACK as int32 and needs to be copied to int64 form
     if (out_tensor->scalar_type() == ScalarType::Long) {
-      int64_t* data_64 = out_tensor->mutable_data_ptr<int64_t>();
-      const int32_t* data_32 = out_tensor->const_data_ptr<int32_t>();
+      // Both views alias one Long buffer, so the int32 one cannot be asked for
+      // by scalar type: ATen mode rejects the mismatch.
+      void* data = out_tensor->mutable_data_ptr();
+      int64_t* data_64 = static_cast<int64_t*>(data);
+      const int32_t* data_32 = static_cast<const int32_t*>(data);
       for (ssize_t j = out_tensor->numel() - 1; j >= 0; --j) {
         data_64[j] = data_32[j];
       }

--- a/backends/xnnpack/test/runtime/test_xnnexecutor.cpp
+++ b/backends/xnnpack/test/runtime/test_xnnexecutor.cpp
@@ -10,6 +10,8 @@
 #include <executorch/runtime/core/exec_aten/testing_util/tensor_factory.h>
 #include <gtest/gtest.h>
 #include <xnnpack.h>
+#include <algorithm>
+#include <vector>
 
 using executorch::aten::Tensor;
 using executorch::backends::xnnpack::delegate::XNNExecutor;
@@ -95,6 +97,96 @@ TEST(XNNExecutorTest, ArgumentWithTooManyDimensions) {
   Span<EValue*> stack_args(args.data(), 2);
   // Check for invalid number of dimensions should fail without stack overflow.
   EXPECT_EQ(executor.prepare_args(stack_args), Error::InvalidArgument);
+}
+
+// A quantized subgraph's externals are int8, so prepare_args must take their
+// address without naming a scalar type.
+TEST(XNNExecutorTest, PrepareArgsAcceptsQuantizedExternals) {
+  XNNExecutor executor({});
+  xnn_runtime_t rt = nullptr;
+  et_pal_init();
+  ASSERT_EQ(xnn_initialize(nullptr), xnn_status_success);
+
+  xnn_subgraph_t subgraph = nullptr;
+  ASSERT_EQ(xnn_create_subgraph(2, 0, &subgraph), xnn_status_success);
+  std::unique_ptr<xnn_subgraph, decltype(&xnn_delete_subgraph)> auto_subgraph(
+      subgraph, xnn_delete_subgraph);
+
+  // 64 so XNNPACK's SIMD reads stay inside the tensors.
+  constexpr int32_t kNumElements = 64;
+  std::vector<size_t> dims = {static_cast<size_t>(kNumElements)};
+  uint32_t input_id = XNN_INVALID_VALUE_ID;
+  uint32_t output_id = XNN_INVALID_VALUE_ID;
+
+  ASSERT_EQ(
+      xnn_status_success,
+      xnn_define_quantized_tensor_value(
+          subgraph,
+          xnn_datatype_qint8,
+          /*zero_point=*/0,
+          /*scale=*/1,
+          dims.size(),
+          dims.data(),
+          nullptr,
+          /*external_id=*/0,
+          XNN_VALUE_FLAG_EXTERNAL_INPUT,
+          &input_id));
+  ASSERT_EQ(
+      xnn_status_success,
+      xnn_define_quantized_tensor_value(
+          subgraph,
+          xnn_datatype_qint8,
+          /*zero_point=*/0,
+          /*scale=*/1,
+          dims.size(),
+          dims.data(),
+          nullptr,
+          /*external_id=*/1,
+          XNN_VALUE_FLAG_EXTERNAL_OUTPUT,
+          &output_id));
+  ASSERT_EQ(
+      xnn_status_success,
+      xnn_define_clamp(
+          subgraph,
+          /*output_min=*/0,
+          /*output_max=*/10,
+          input_id,
+          output_id,
+          0));
+
+  ASSERT_EQ(xnn_create_runtime(subgraph, &rt), xnn_status_success);
+  ASSERT_EQ(executor.initialize(rt, {0}, {1}, {}), Error::Ok);
+
+  TensorFactory<executorch::aten::ScalarType::Char> tf;
+  std::vector<int8_t> input_data(kNumElements);
+  for (int32_t i = 0; i < kNumElements; ++i) {
+    input_data[i] = static_cast<int8_t>(i);
+  }
+  auto input_tensor = tf.make({kNumElements}, input_data);
+  auto output_tensor =
+      tf.make({kNumElements}, std::vector<int8_t>(kNumElements, -1));
+
+  EValue input_ev(input_tensor);
+  EValue output_ev(output_tensor);
+  std::array<EValue*, 2> args = {&input_ev, &output_ev};
+  Span<EValue*> stack_args(args.data(), 2);
+
+  ASSERT_EQ(executor.prepare_args(stack_args), Error::Ok);
+  executorch::ET_RUNTIME_NAMESPACE::BackendExecutionContext context;
+  ASSERT_EQ(executor.forward(context), Error::Ok);
+  ASSERT_EQ(executor.convert_outputs(stack_args), Error::Ok);
+
+  // Holds only if the clamp ran against the tensor's own int8 buffer.
+  Tensor& result = args[1]->toTensor();
+  std::vector<int8_t> expected(kNumElements);
+  for (int32_t i = 0; i < kNumElements; ++i) {
+    expected[i] = static_cast<int8_t>(std::min(i, 10));
+  }
+  EXPECT_EQ(
+      std::vector<int8_t>(
+          result.const_data_ptr<int8_t>(),
+          result.const_data_ptr<int8_t>() + kNumElements),
+      expected);
 }
 
 // Tests that resize_outputs correctly converts int32 indices to int64.

--- a/backends/xnnpack/test/targets.bzl
+++ b/backends/xnnpack/test/targets.bzl
@@ -1,5 +1,5 @@
 load("@fbsource//xplat/executorch/backends/xnnpack/third-party:third_party_libs.bzl", "third_party_dep")
-load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "get_aten_mode_options", "runtime")
 
 def define_common_targets():
     runtime.cxx_test(
@@ -19,17 +19,21 @@ def define_common_targets():
         ],
     )
 
-    runtime.cxx_test(
-        name = "xnnexecutor_test",
-        srcs = ["runtime/test_xnnexecutor.cpp"],
-        deps = [
-            third_party_dep("XNNPACK"),
-            third_party_dep("FP16"),
-            "//executorch/runtime/core/exec_aten/testing_util:tensor_util",
-            "//executorch/runtime/core/exec_aten/util:scalar_type_util",
-            "//executorch/backends/xnnpack:xnnpack_backend",
-        ],
-    )
+    for aten_mode in get_aten_mode_options():
+        aten_suffix = "_aten" if aten_mode else ""
+
+        runtime.cxx_test(
+            name = "xnnexecutor_test" + aten_suffix,
+            srcs = ["runtime/test_xnnexecutor.cpp"],
+            preprocessor_flags = ["-DUSE_ATEN_LIB"] if aten_mode else [],
+            deps = [
+                third_party_dep("XNNPACK"),
+                third_party_dep("FP16"),
+                "//executorch/runtime/core/exec_aten/testing_util:tensor_util" + aten_suffix,
+                "//executorch/runtime/core/exec_aten/util:scalar_type_util",
+                "//executorch/backends/xnnpack:xnnpack_backend" + aten_suffix,
+            ],
+        )
 
     runtime.cxx_test(
         name = "test_xnn_weights_cache",


### PR DESCRIPTION
Summary:

`XNNExecutor` reaches into tensors through typed accessors in two places, and
both explicitly name the scalar type:

- `prepare_args` fills `xnn_external_value.data` (a `void*`) via
  `mutable_data_ptr<float>()`, but a quantized delegate boundary hands XNNPACK
  int8 externals.
- `convert_outputs` widens XNNPACK's int32 argmax indices in place by taking an
  `int64_t*` and an `int32_t*` view of the same Long tensor buffer, so the
  second view asks a Long tensor for `const_data_ptr<int32_t>()`.

In portable mode `torch::executor::Tensor`'s typed accessor is unchecked, so
both slide through. In ATen mode `at::Tensor` validates the requested scalar
type and throws `expected scalar type Float but found Char` at the quantized
boundary, `expected scalar type Int but found Long` in `convert_outputs`.

Both sites only ever wanted the raw address (the XNNPACK field is `void*`; the
int32 view deliberately aliases the int64 buffer), so the scalar type in the
call bought nothing but a check that was wrong. Switched to the untyped
`mutable_data_ptr()` overload.

Reviewed By: JakeStevens

Differential Revision: D117853393


