### PR TITLE
Arm backend: Reject complex dtypes

### DIFF
--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -352,7 +352,7 @@ def _positive_checks(
 
 
 def _disallowed_dtypes(tosa_spec: TosaSpecification) -> list[torch.dtype]:
-    dtypes = [torch.float64]
+    dtypes = [torch.float64, torch.complex32, torch.complex64, torch.complex128]
     if not tosa_spec.support_extension("bf16"):
         dtypes.append(torch.bfloat16)
     if not (


### PR DESCRIPTION
They are not supported by the backend.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani