### PR TITLE
Fine-tune MobileBert on smaller batches in its test

### DIFF
--- a/backends/samsung/test/models/test_mobilebert_finetuning.py
+++ b/backends/samsung/test/models/test_mobilebert_finetuning.py
@@ -18,7 +18,11 @@ from executorch.examples.samsung.scripts.mobilebert_finetune import MobileBertFi
 class Test_Milestone_MobileBertFinetune(unittest.TestCase):
     def test_mobilebert_finetuning_fp16(self):
         mobilebert_finetune = MobileBertFinetune()
-        model, _ = mobilebert_finetune.get_finetune_mobilebert(None)
+        # Smaller batches, because training keeps every intermediate value until
+        # the backward pass is done and a test runner cannot hold them all. The
+        # number of passes is left alone: it is what the example script uses, and
+        # the range this model ends up with does not fall off with fewer of them.
+        model, _ = mobilebert_finetune.get_finetune_mobilebert(None, batch_size=8)
         example_input = mobilebert_finetune.get_example_inputs()
         tester = SamsungTester(
             model, example_input, [gen_samsung_backend_compile_spec(TestConfig.chipset)]

--- a/examples/samsung/scripts/mobilebert_finetune.py
+++ b/examples/samsung/scripts/mobilebert_finetune.py
@@ -117,7 +117,7 @@ class MobileBertFinetune:
 
         return data_loader
 
-    def get_finetune_mobilebert(self, artifacts_dir):
+    def get_finetune_mobilebert(self, artifacts_dir, batch_size=64):
         # Pretrained bert's output ranges in a large scale. It is challenge for enn backend to support directly.
         # Please finetune mobilebert on specific tasks, make sure that bert's output and hidden states are friendly
         # to resource-constraint device.
@@ -138,7 +138,7 @@ class MobileBertFinetune:
         labels_set = train_data.label.unique()
 
         train_data_loader = self.build_loader_from_dataset(
-            train_data, batch_size=64, usage="train"
+            train_data, batch_size=batch_size, usage="train"
         )
 
         val_url = "https://raw.githubusercontent.com/clairett/pytorch-sentiment-classification/refs/heads/master/data/SST2/test.tsv"
@@ -147,7 +147,7 @@ class MobileBertFinetune:
             BytesIO(content), delimiter="\t", header=None, names=["text", "label"]
         )
         val_data_loader = self.build_loader_from_dataset(
-            val_data, batch_size=64, usage="val"
+            val_data, batch_size=batch_size, usage="val"
         )
 
         artifacts_dir = artifacts_dir if artifacts_dir is not None else "./mobilebert"


### PR DESCRIPTION
## Summary

The MobileBert test in the Samsung model suite is killed for using too much memory.
That stops the whole suite, and because the suite is a required check, it stops the
branch nightly builds are cut from moving forward.

The test asks for a fine-tuned model, and fine-tuning means real training: five passes
over a sentiment dataset, sixty four sentences at a time. Training keeps every
intermediate value until the backward pass finishes, and a sentence of a hundred and
twenty eight tokens through twenty four layers produces a lot of them.

Measured on a single training step, same model and sequence length:

```
batch 64   peak memory 7.58 GiB
batch  8   peak memory 1.43 GiB
```

Smaller batches take longer but hold far less at once, and they do not change what the
model learns, only how often it steps. So the batch size becomes an argument, today's
value stays the default, and the test asks for a smaller one.

## What this deliberately does not change

The number of passes is left alone. Cutting it would shorten the test further, but the
output range the model ends up with is not a falling function of it. Measured on a fixed
probe, the largest logit is about two million untuned, about half a million after one
pass, and about two and a half million after two. Fewer passes is therefore not
obviously safer for the backend, so the memory problem is solved without touching it.

## Test plan

Measured the peak memory of one training step at both batch sizes, on Linux, with the
same model and sequence length: 7.58 GiB against 1.43 GiB, a bit over five times less.

Ran the suite's own order in one process to find where the peak comes from. Two vision
models ahead of this one reach half a gigabyte between them, so the training step is the
peak rather than an accumulation across models.

Confirmed the example script is unchanged. It passes only the artifacts directory, so
the batch size falls back to its default and the accuracy it prints is produced exactly
as before.
