### PR TITLE
Read a single tensor element as the type the caller asked for

### DIFF
--- a/backends/cuda/runtime/shims/memory.cpp
+++ b/backends/cuda/runtime/shims/memory.cpp
@@ -6,7 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <c10/util/overflows.h>
 #include <executorch/backends/cuda/runtime/shims/memory.h>
+#include <type_traits>
 
 #include <executorch/backends/aoti/slim/factory/empty.h>
 #include <executorch/backends/aoti/slim/factory/from_blob.h>
@@ -31,10 +33,63 @@ const PalInitializer kPalInitializer{};
 } // namespace
 
 namespace c10 = executorch::backends::aoti::slim::c10;
+
 using c10::Device;
 using c10::DeviceIndex;
 using c10::DeviceType;
 using c10::ScalarType;
+
+namespace {
+
+// Reads the one element as T. Dispatch on the dtype the tensor actually holds:
+// item<T>() copies sizeof(T) bytes and does not check, so asking for the wrong
+// width reads past a one-element allocation.
+//
+// The dtype in each entry point's name is the type the caller wants back, not
+// the type the tensor holds. Generated code reads a boolean branch selector
+// through the int64 entry point, for instance. So convert, and refuse only when
+// the value does not fit, which is what the reference implementation does.
+template <typename To, typename From>
+AOTITorchError narrow_to(From value, To* ret_value) {
+  // Anything at all converts to a boolean, so there is nothing to check there.
+  if (!std::is_same_v<To, bool> && ::c10::overflows<To, From>(value)) {
+    ET_CHECK_OR_RETURN_ERROR(
+        false, InvalidArgument, "reading a single element: value does not fit");
+  }
+  *ret_value = static_cast<To>(value);
+  return Error::Ok;
+}
+
+template <typename T>
+AOTITorchError read_one_element(const SlimTensor* tensor, T* ret_value) {
+  switch (tensor->dtype()) {
+    case ScalarType::Byte:
+      return narrow_to(tensor->item<uint8_t>(), ret_value);
+    case ScalarType::Char:
+      return narrow_to(tensor->item<int8_t>(), ret_value);
+    case ScalarType::Short:
+      return narrow_to(tensor->item<int16_t>(), ret_value);
+    case ScalarType::Int:
+      return narrow_to(tensor->item<int32_t>(), ret_value);
+    case ScalarType::Long:
+      return narrow_to(tensor->item<int64_t>(), ret_value);
+    case ScalarType::Float:
+      return narrow_to(tensor->item<float>(), ret_value);
+    case ScalarType::BFloat16:
+      return narrow_to(
+          static_cast<float>(tensor->item<c10::BFloat16>()), ret_value);
+    case ScalarType::Bool:
+      return narrow_to(tensor->item<bool>(), ret_value);
+    default:
+      ET_CHECK_OR_RETURN_ERROR(
+          false,
+          InvalidArgument,
+          "reading a single element: dtype %d is not supported",
+          static_cast<int>(tensor->dtype()));
+  }
+}
+
+} // namespace
 using executorch::backends::aoti::slim::empty_strided;
 using executorch::backends::aoti::slim::from_blob;
 using executorch::backends::aoti::slim::IntArrayRef;
@@ -347,34 +402,36 @@ aoti_torch_copy_(SlimTensor* self, SlimTensor* src, int32_t non_blocking) {
   return Error::Ok;
 }
 
-AOTITorchError aoti_torch_item_bool(SlimTensor* tensor, bool* ret_value) {
-  ET_CHECK_OR_RETURN_ERROR(
-      tensor != nullptr,
-      InvalidArgument,
-      "aoti_torch_item_bool: tensor is null");
+#define ET_CUDA_DEFINE_ITEM_SHIM(SUFFIX, CTYPE)            \
+  AOTITorchError aoti_torch_item_##SUFFIX(                 \
+      SlimTensor* tensor, CTYPE* ret_value) {              \
+    ET_CHECK_OR_RETURN_ERROR(                              \
+        tensor != nullptr,                                 \
+        InvalidArgument,                                   \
+        "aoti_torch_item_" #SUFFIX ": tensor is null");    \
+    ET_CHECK_OR_RETURN_ERROR(                              \
+        ret_value != nullptr,                              \
+        InvalidArgument,                                   \
+        "aoti_torch_item_" #SUFFIX ": ret_value is null"); \
+    ET_CHECK_OR_RETURN_ERROR(                              \
+        tensor->numel() == 1,                              \
+        InvalidArgument,                                   \
+        "aoti_torch_item_" #SUFFIX                         \
+        ": tensor must have exactly 1 element, got %zu",   \
+        tensor->numel());                                  \
+    return read_one_element<CTYPE>(tensor, ret_value);     \
+  }
 
-  ET_CHECK_OR_RETURN_ERROR(
-      ret_value != nullptr,
-      InvalidArgument,
-      "aoti_torch_item_bool: ret_value is null");
+ET_CUDA_DEFINE_ITEM_SHIM(uint8, uint8_t)
+ET_CUDA_DEFINE_ITEM_SHIM(int8, int8_t)
+ET_CUDA_DEFINE_ITEM_SHIM(int16, int16_t)
+ET_CUDA_DEFINE_ITEM_SHIM(int32, int32_t)
+ET_CUDA_DEFINE_ITEM_SHIM(int64, int64_t)
+ET_CUDA_DEFINE_ITEM_SHIM(float32, float)
+ET_CUDA_DEFINE_ITEM_SHIM(bfloat16, c10::BFloat16)
+ET_CUDA_DEFINE_ITEM_SHIM(bool, bool)
 
-  ET_CHECK_OR_RETURN_ERROR(
-      tensor->numel() == 1,
-      InvalidArgument,
-      "aoti_torch_item_bool: tensor must have exactly 1 element, got %zu",
-      tensor->numel());
-
-  ET_CHECK_OR_RETURN_ERROR(
-      tensor->dtype() == ScalarType::Bool,
-      InvalidArgument,
-      "aoti_torch_item_bool: tensor dtype must be Bool");
-
-  // SlimTensor::item<T>() handles both CPU and CUDA tensors.
-  // For CUDA tensors, it copies the value to CPU automatically.
-  *ret_value = tensor->item<bool>();
-
-  return Error::Ok;
-}
+#undef ET_CUDA_DEFINE_ITEM_SHIM
 
 AOTITorchError aoti_torch_assign_tensors_out(
     SlimTensor* src,

--- a/backends/cuda/runtime/shims/memory.h
+++ b/backends/cuda/runtime/shims/memory.h
@@ -195,18 +195,49 @@ AOTI_SHIM_EXPORT AOTITorchError aoti_torch__reinterpret_tensor(
 AOTI_SHIM_EXPORT AOTITorchError
 aoti_torch_copy_(SlimTensor* self, SlimTensor* src, int32_t non_blocking);
 
+/// See aoti_torch_item_uint8.
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_item_bool(SlimTensor* tensor, bool* ret_value);
+
 /**
- * Extracts a boolean scalar value from a single-element tensor.
+ * Extracts a scalar value from a single-element tensor.
  *
- * The tensor must contain exactly one element and have Bool dtype.
- * For CUDA tensors, this will synchronize to copy the value to CPU.
+ * The type in the name is the type returned, not the tensor's dtype: generated
+ * code reads a boolean branch selector through the int64 entry point. The value
+ * is converted, and rejected only when it does not fit. The tensor must contain
+ * exactly one element. For CUDA tensors, this will synchronize to copy the
+ * value to CPU.
  *
- * @param tensor Single-element boolean tensor (must not be null)
- * @param ret_value Output parameter for the extracted boolean value
+ * @param tensor Single-element tensor (must not be null)
+ * @param ret_value Output parameter for the extracted value
  * @return AOTITorchError error code (Error::Ok on success)
  */
 AOTI_SHIM_EXPORT AOTITorchError
-aoti_torch_item_bool(SlimTensor* tensor, bool* ret_value);
+aoti_torch_item_uint8(SlimTensor* tensor, uint8_t* ret_value);
+
+/// See aoti_torch_item_uint8.
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_item_int8(SlimTensor* tensor, int8_t* ret_value);
+
+/// See aoti_torch_item_uint8.
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_item_int16(SlimTensor* tensor, int16_t* ret_value);
+
+/// See aoti_torch_item_uint8.
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_item_int32(SlimTensor* tensor, int32_t* ret_value);
+
+/// See aoti_torch_item_uint8.
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_item_int64(SlimTensor* tensor, int64_t* ret_value);
+
+/// See aoti_torch_item_uint8.
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_item_float32(SlimTensor* tensor, float* ret_value);
+
+/// See aoti_torch_item_uint8.
+AOTI_SHIM_EXPORT AOTITorchError
+aoti_torch_item_bfloat16(SlimTensor* tensor, c10::BFloat16* ret_value);
 
 /**
  * Moves a tensor into a new handle and assigns it to the output parameter.

--- a/backends/cuda/runtime/shims/tests/test_aoti_torch_item_bool.cpp
+++ b/backends/cuda/runtime/shims/tests/test_aoti_torch_item_bool.cpp
@@ -155,6 +155,53 @@ TEST_F(AOTITorchItemBoolSlimTest, NullReturnValue) {
   EXPECT_EQ(aoti_torch_delete_tensor_object(tensor), Error::Ok);
 }
 
+TEST_F(AOTITorchItemBoolSlimTest, ConvertsFromLong) {
+  // Generated code reads a value through whichever entry point matches the type
+  // it wants back, not the type the tensor holds.
+  std::vector<int64_t> sizes = {1};
+  Tensor* tensor = createTestTensor(
+      sizes,
+      static_cast<int32_t>(slim_c10::ScalarType::Long),
+      static_cast<int32_t>(slim_c10::DeviceType::CPU),
+      0);
+  ASSERT_NE(tensor, nullptr);
+  *static_cast<int64_t*>(tensor->data_ptr()) = 1;
+
+  bool result = false;
+  EXPECT_EQ(aoti_torch_item_bool(tensor, &result), Error::Ok);
+  EXPECT_TRUE(result);
+
+  EXPECT_EQ(aoti_torch_delete_tensor_object(tensor), Error::Ok);
+}
+
+TEST_F(AOTITorchItemBoolSlimTest, BoolReadAsInt64) {
+  Tensor* tensor = createScalarBoolTensor(
+      true, static_cast<int32_t>(slim_c10::DeviceType::CPU), 0);
+  ASSERT_NE(tensor, nullptr);
+
+  int64_t result = -1;
+  EXPECT_EQ(aoti_torch_item_int64(tensor, &result), Error::Ok);
+  EXPECT_EQ(result, 1);
+
+  EXPECT_EQ(aoti_torch_delete_tensor_object(tensor), Error::Ok);
+}
+
+TEST_F(AOTITorchItemBoolSlimTest, RejectsValueThatDoesNotFit) {
+  std::vector<int64_t> sizes = {1};
+  Tensor* tensor = createTestTensor(
+      sizes,
+      static_cast<int32_t>(slim_c10::ScalarType::Long),
+      static_cast<int32_t>(slim_c10::DeviceType::CPU),
+      0);
+  ASSERT_NE(tensor, nullptr);
+  *static_cast<int64_t*>(tensor->data_ptr()) = 300;
+
+  uint8_t result = 0;
+  EXPECT_EQ(aoti_torch_item_uint8(tensor, &result), Error::InvalidArgument);
+
+  EXPECT_EQ(aoti_torch_delete_tensor_object(tensor), Error::Ok);
+}
+
 TEST_F(AOTITorchItemBoolSlimTest, MultiElementTensor) {
   std::vector<int64_t> sizes = {2, 3};
   Tensor* tensor = createTestTensor(
@@ -164,40 +211,6 @@ TEST_F(AOTITorchItemBoolSlimTest, MultiElementTensor) {
       0);
   ASSERT_NE(tensor, nullptr);
   EXPECT_GT(tensor->numel(), 1);
-
-  bool result = false;
-  AOTITorchError error = aoti_torch_item_bool(tensor, &result);
-
-  EXPECT_EQ(error, Error::InvalidArgument);
-
-  EXPECT_EQ(aoti_torch_delete_tensor_object(tensor), Error::Ok);
-}
-
-TEST_F(AOTITorchItemBoolSlimTest, WrongDtype_Float) {
-  std::vector<int64_t> sizes = {1};
-  Tensor* tensor = createTestTensor(
-      sizes,
-      static_cast<int32_t>(slim_c10::ScalarType::Float),
-      static_cast<int32_t>(slim_c10::DeviceType::CPU),
-      0);
-  ASSERT_NE(tensor, nullptr);
-
-  bool result = false;
-  AOTITorchError error = aoti_torch_item_bool(tensor, &result);
-
-  EXPECT_EQ(error, Error::InvalidArgument);
-
-  EXPECT_EQ(aoti_torch_delete_tensor_object(tensor), Error::Ok);
-}
-
-TEST_F(AOTITorchItemBoolSlimTest, WrongDtype_Long) {
-  std::vector<int64_t> sizes = {1};
-  Tensor* tensor = createTestTensor(
-      sizes,
-      static_cast<int32_t>(slim_c10::ScalarType::Long),
-      static_cast<int32_t>(slim_c10::DeviceType::CPU),
-      0);
-  ASSERT_NE(tensor, nullptr);
 
   bool result = false;
   AOTITorchError error = aoti_torch_item_bool(tensor, &result);
@@ -262,27 +275,6 @@ TEST_F(AOTITorchItemBoolSlimTest, MultiElementTensor_CUDA) {
       0);
   ASSERT_NE(tensor, nullptr);
   EXPECT_TRUE(tensor->is_cuda());
-
-  bool result = false;
-  AOTITorchError error = aoti_torch_item_bool(tensor, &result);
-
-  EXPECT_EQ(error, Error::InvalidArgument);
-
-  EXPECT_EQ(aoti_torch_delete_tensor_object(tensor), Error::Ok);
-}
-
-TEST_F(AOTITorchItemBoolSlimTest, WrongDtype_Float_CUDA) {
-  if (!isCudaAvailable()) {
-    GTEST_SKIP() << "CUDA not available";
-  }
-
-  std::vector<int64_t> sizes = {1};
-  Tensor* tensor = createTestTensor(
-      sizes,
-      static_cast<int32_t>(slim_c10::ScalarType::Float),
-      static_cast<int32_t>(slim_c10::DeviceType::CUDA),
-      0);
-  ASSERT_NE(tensor, nullptr);
 
   bool result = false;
   AOTITorchError error = aoti_torch_item_bool(tensor, &result);


### PR DESCRIPTION
## Summary

Running a model on the CUDA backend can fail the moment it loads:

```
symbol lookup error: executorch_cuda_0.so: undefined symbol: aoti_torch_item_int64
```

The compiler that produces the shared library emits a call to read one element out of a
tensor, and there are fourteen of those calls, one per type. This runtime defined a
single one, for booleans, so a model reading an integer or a float referred to something
that was never there. Nothing catches it when the library is built, because that name is
resolved when the library loads.

## The type in the name is the return type

A branch selector is stored as a boolean and read through the integer call, because the
generated branch table compares integers. So these calls convert. The one that was
already here insisted on an exact match, which is wrong for the same reason; it had not
caused trouble only because nothing had reached it with anything else yet.

Two things follow. The element is read as whatever the tensor actually holds, because
reading it as the wrong width would copy more bytes than the tensor owns. And the value
is refused only when it does not fit, which is what the reference implementation does and
what this project already does elsewhere when narrowing a number.

## Test plan

Compiled the file and read the exported names out of the object file. Before, one name.
After, eight:

```
aoti_torch_item_bool     aoti_torch_item_int8      aoti_torch_item_int16
aoti_torch_item_int32    aoti_torch_item_int64     aoti_torch_item_uint8
aoti_torch_item_float32  aoti_torch_item_bfloat16
```

That check fails on the previous version.

Two tests asserted that a mismatched type is refused. That is the normal case, not an
error, so they are replaced with tests of what the generated code actually does: a
boolean read as an integer returns one, an integer read as a boolean returns true, and an
integer too large for a byte is refused. The first two fail on the previous version. The
third fails on a version that converts without checking, where three hundred silently
becomes forty four.

Those conversions were measured, not assumed, including the two that must keep working: a
boolean widened to an integer, and a fraction read as a boolean, which the reference
implementation allows deliberately.

The remaining calls upstream declares need types this runtime does not have, so a model
cannot ask for them.
