### PR TITLE
Lower the CMake version floor so 3.26 through 3.28 can build again

### DIFF
--- a/backends/apple/metal/CMakeLists.txt
+++ b/backends/apple/metal/CMakeLists.txt
@@ -14,7 +14,7 @@
 # ~~~
 # It should also be cmake-lint clean.
 #
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.26)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/backends/cuda/CMakeLists.txt
+++ b/backends/cuda/CMakeLists.txt
@@ -14,7 +14,7 @@
 # ~~~
 # It should also be cmake-lint clean.
 #
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.26)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/backends/webgpu/README.md
+++ b/backends/webgpu/README.md
@@ -218,4 +218,4 @@ backends/webgpu/
 - **Linux:** Vulkan-capable GPU and drivers
 - **Browser:** A WebGPU-enabled browser; the benchmark harness uses Chrome
   Canary
-- **Build:** CMake 3.19+ and a Python environment with ExecuTorch installed
+- **Build:** CMake 3.24+ and a Python environment with ExecuTorch installed

--- a/docs/source/backends/webgpu/webgpu-overview.md
+++ b/docs/source/backends/webgpu/webgpu-overview.md
@@ -68,7 +68,7 @@ depend on the selected WebGPU adapter.
 
 ## Development Requirements
 
-- CMake 3.19 or later.
+- CMake 3.24 or later.
 - A Python environment with ExecuTorch installed for model export.
 - Dawn's CMake package for native builds.
 - Emscripten for browser builds.

--- a/docs/source/llm/run-with-c-plus-plus.md
+++ b/docs/source/llm/run-with-c-plus-plus.md
@@ -12,7 +12,7 @@ Before you begin, make sure you have:
    - For HuggingFace tokenizers, this is a JSON file `tokenizer.json`
    - For SentencePiece tokenizers, this is a `tokenizer.model` file and normally lives alongside the weights file
 3. CMake and a C++ compiler installed
-   - CMake version 3.29 or higher
+   - CMake version 3.26 or higher
    - g++ or clang compiler
 
 ## Model Metadata

--- a/docs/source/raspberry_pi_llama_tutorial.md
+++ b/docs/source/raspberry_pi_llama_tutorial.md
@@ -21,7 +21,7 @@ This tutorial demonstrates how to deploy **Llama models on Raspberry Pi 4/5 devi
 
 - **Python 3.10-3.14** (ExecuTorch requirement)
 - **conda** or **venv** for environment management
-- **CMake 3.29.6+**
+- **CMake 3.26+**
 - **Git** for repository cloning
 
 ### Target Device Requirements
@@ -47,7 +47,7 @@ python3 --version  # Should be 3.10-3.14
 # Check required tools
 hash cmake git md5sum 2>/dev/null || echo "Missing required tools"
 
-cmake --version  # Should be 3.29.6+ at minimum
+cmake --version  # Should be 3.26+ at minimum
 
 ## Development Environment Setup
 

--- a/examples/models/phi-3-mini/CMakeLists.txt
+++ b/examples/models/phi-3-mini/CMakeLists.txt
@@ -14,7 +14,11 @@
 #
 
 cmake_minimum_required(VERSION 3.24)
-cmake_policy(SET CMP0144 NEW)
+# CMP0144 arrives in 3.27, and cmake_policy(SET) on a policy the running CMake
+# does not know is a hard error, so the request has to be guarded.
+if(POLICY CMP0144)
+  cmake_policy(SET CMP0144 NEW)
+endif()
 project(phi_3_mini_runner)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/examples/models/supertonic/README.md
+++ b/examples/models/supertonic/README.md
@@ -110,7 +110,7 @@ exit cleanly; closing stdin also exits with status zero.
 ## Platform and model limits
 
 - This workflow requires an Apple silicon Mac, macOS, Xcode command-line
-  tools, CMake 3.24 or newer, and an ExecuTorch Python environment with the MLX
+  tools, CMake 3.26 or newer, and an ExecuTorch Python environment with the MLX
   backend and custom operations available. The native runner supports only
   arm64 Darwin and uses MLX GPU delegation with FP16 activations.
 - Exported programs use dynamic sequence lengths, five flow-matching steps,

--- a/examples/models/whisper/CMakeLists.txt
+++ b/examples/models/whisper/CMakeLists.txt
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.26)
 project(whisper_runner)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/extension/wasm/CMakeLists.txt
+++ b/extension/wasm/CMakeLists.txt
@@ -9,7 +9,7 @@
 # cmake-format -i CMakeLists.txt
 # ~~~
 
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.26)
 
 project(executorch_wasm)
 

--- a/extension/wasm/tokenizers/CMakeLists.txt
+++ b/extension/wasm/tokenizers/CMakeLists.txt
@@ -9,7 +9,7 @@
 # cmake-format -i CMakeLists.txt
 # ~~~
 
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.26)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "cmake>=3.24,<4.0.0",  # For building binary targets in the wheel. 4.0.0 breaks third-party CMake build so temporarily pin the version.
+  "cmake>=3.26,<4.0.0",  # For building binary targets in the wheel. 4.0.0 breaks third-party CMake build so temporarily pin the version.
   "packaging>=24.2", # Lower bound required by setuptools
   "patchelf; sys_platform == 'linux'",  # Writes the runtime search paths that let the shipped libraries find each other.
   "pip>=23",  # For building the pip package.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Pip packages needed to build from source. Mainly for development of ExecuTorch.
 
-cmake>=3.24, <4.0.0  # For building binary targets in the wheel.
+cmake>=3.26, <4.0.0  # For building binary targets in the wheel.
 packaging>=24.2 # Lower bound required by setuptools
 patchelf; sys_platform == 'linux'  # Writes the runtime search paths that let the shipped libraries find each other.
 pip>=23  # For building the pip package.


### PR DESCRIPTION
### Summary

You cannot build ExecuTorch from source unless you have CMake 3.29 or newer.

CMake is the tool that drives the build. Every build file can name the oldest CMake it
accepts, and if yours is older, CMake stops with an error instead of building. Five files
in this repo named 3.29, and none of them uses anything that needs it.

This hurts most on small Arm computers such as developer boards. Those ship CMake 3.28, and
3.28 is also the newest their system offers, so you cannot simply upgrade. You have to go
and install a second, private copy of CMake before you can build at all.

Those five files now name 3.26 instead, so anyone on 3.26 or newer can build. 3.26 rather
than something lower, because `kernels/optimized` uses CMake syntax that only exists from
3.26 on Arm builds. Going lower means rewriting that file, which belongs in its own change.

The docs and requirement files name a CMake version too, and some of those numbers could
never have worked, so they are corrected here: the build requirements said 3.24 and now say
3.26, the WebGPU docs said 3.19 and now say 3.24, and the Supertonic example said 3.24 and
now says 3.26. Installing a prebuilt wheel is untouched and still works on CMake 3.19.

One more file, `examples/models/phi-3-mini`, named 3.24 and then asked CMake to turn on a
behaviour that only exists from 3.27. Asking for a behaviour CMake does not have is a hard
error, so that file could never build on the version it advertised. It now asks only when
the running CMake has it.
