### PR TITLE
Cortex-M: preserve unsupported transpose ranks

### DIFF
--- a/backends/cortex_m/passes/aten_to_cortex_m_pass.py
+++ b/backends/cortex_m/passes/aten_to_cortex_m_pass.py
@@ -1259,7 +1259,7 @@ def _get_permute_replacement(
 ) -> DialectNodeSpec | None:
     del dialect_pass
     input_tensor = _get_input_tensor_data(node)
-    if input_tensor.dtype != torch.int8:
+    if input_tensor.dtype != torch.int8 or not 1 <= input_tensor.dim() <= 4:
         return None
     return _transpose_spec(node, input_tensor)
 

--- a/backends/cortex_m/test/ops/test_transpose.py
+++ b/backends/cortex_m/test/ops/test_transpose.py
@@ -24,6 +24,12 @@ OPS_AFTER_PASSES = {
     "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
 }
 
+RANK5_OPS_AFTER_PASSES = {
+    "executorch_exir_dialects_edge__ops_cortex_m_quantize_per_tensor_default": 1,
+    "executorch_exir_dialects_edge__ops_aten_permute_copy_default": 1,
+    "executorch_exir_dialects_edge__ops_cortex_m_dequantize_per_tensor_default": 1,
+}
+
 
 class CortexMPermute(torch.nn.Module):
     ops_before_transforms = OPS_BEFORE_PASSES
@@ -94,6 +100,19 @@ def test_dialect_transpose(test_case, cortex_m_target):
     tester.test_dialect(
         test_case.model.ops_before_transforms,
         test_case.model.ops_after_transforms,
+        qtol=1,
+    )
+
+
+def test_dialect_rank5_permute_stays_portable(cortex_m_target):
+    tester = CortexMTester(
+        CortexMPermute((0, 2, 1, 4, 3)),
+        (ramp_tensor(-1.0, 1.0, (1, 2, 3, 4, 5)),),
+        target_config=cortex_m_target,
+    )
+    tester.test_dialect(
+        OPS_BEFORE_PASSES,
+        RANK5_OPS_AFTER_PASSES,
         qtol=1,
     )
 


### PR DESCRIPTION
### Summary

Keep int8 `aten.permute_copy` nodes with ranks outside 1–4 on the portable operator. The Cortex-M transpose kernel only supports ranks 1–4, so lowering a rank-5 permutation produced a program that failed when loaded by the runtime.

The existing supported-rank FVP coverage remains unchanged. A new dialect test verifies that a rank-5 int8 permutation stays as `aten.permute_copy`.

### Test plan

`source examples/arm/arm-scratch/setup_path.sh && python -m pytest --config-file=backends/arm/test/pytest.ini backends/cortex_m/test/ops/test_transpose.py`

`lintrunner -m origin/main`

AI-assisted: Codex.