### PR TITLE
Cortex-M: preserve calibration input layout

### DIFF
--- a/backends/arm/scripts/aot_arm_compiler.py
+++ b/backends/arm/scripts/aot_arm_compiler.py
@@ -981,8 +981,6 @@ def _to_edge_cortex_m(
             calibration_samples = [example_inputs]
 
         for sample in calibration_samples:
-            if not args.cortex_m_explicit_layout:
-                sample = tuple(_to_channels_last(x) for x in sample)
             prepared(*sample)
 
         model_quant = convert_pt2e(prepared)

--- a/backends/cortex_m/test/models/test_mobilenet_v2.py
+++ b/backends/cortex_m/test/models/test_mobilenet_v2.py
@@ -37,10 +37,7 @@ ops_after_transforms: dict[str, int] = {
 }
 
 # Use larger sample set for calibration to get better quantization
-calibration_samples = [
-    (torch.randn(1, 3, 224, 224).to(memory_format=torch.channels_last),)
-    for _ in range(100)
-]
+calibration_samples = [(torch.randn(1, 3, 224, 224),) for _ in range(100)]
 
 test_cases = {
     "mobilenet_v2": McuTestCase(

--- a/backends/cortex_m/test/models/test_mobilenet_v3.py
+++ b/backends/cortex_m/test/models/test_mobilenet_v3.py
@@ -39,10 +39,7 @@ ops_after_transforms: dict[str, int] = {
 }
 
 # Use bigger sample set for calibration.
-calibration_samples = [
-    (torch.randn(1, 3, 232, 232).to(memory_format=torch.channels_last),)
-    for i in (range(100))
-]
+calibration_samples = [(torch.randn(1, 3, 232, 232),) for _ in range(100)]
 
 test_cases = {
     "mobilenet_v3_small": McuTestCase(

--- a/docs/source/backends/arm-cortex-m/arm-cortex-m-overview.md
+++ b/docs/source/backends/arm-cortex-m/arm-cortex-m-overview.md
@@ -100,6 +100,9 @@ quantized = convert_pt2e(prepared)
 quantized_exported_program = torch.export.export(quantized, (example_input,))
 ```
 
+Calibration observes logical tensor values, so calibration inputs do not need
+to use the same memory format as the export example.
+
 ### 2. Lower to edge and apply Cortex-M passes
 
 Lower to the edge dialect with the backend's `EdgeCompileConfig`, then run the `CortexMPassManager` to replace quantized subgraphs with CMSIS-NN operator implementations:


### PR DESCRIPTION
### Summary
Calibration observers use logical tensor values, so avoid converting calibration samples to channels-last. Cover the behavior in the MobileNet tests and clarify the documentation.

Authored with Codex.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell