### PR TITLE
Fix Arm recipe BUCK dependency

### DIFF
--- a/backends/arm/recipes/BUCK
+++ b/backends/arm/recipes/BUCK
@@ -43,7 +43,6 @@ fbcode_target(
         "//executorch/backends/arm/tosa:compile_spec",
         "//executorch/backends/cortex_m/passes:replace_quant_nodes_pass",
         "//executorch/exir:lib",
-        "//executorch/exir/backend:op_backend",
         "//executorch/export:lib",
     ],
 )


### PR DESCRIPTION
## Summary

The Arm recipe provider moved from `OpBackend` to `edge_manager_transform_passes` before merge, but its BUCK target retained a dependency on the unlanded `//executorch/exir/backend:op_backend` target. This causes fbsource target graph analysis to fail for D118843589.

Remove the unused dependency. This does not change source behavior.

## Test plan

`buck2 build fbcode//executorch/backends/arm/recipes:arm_recipe_provider fbcode//executorch/backends/arm/recipes:recipes fbcode//executorch/backends/arm/test:arm_recipes`

`buck2 test fbcode//executorch/backends/arm/test:arm_recipes` (25 passed, 0 failed)

`git diff --check`

Authored with Codex.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell