### PR TITLE
Hold the Ethos-U backend suites at 8 pytest workers

### DIFF
--- a/.github/workflows/_test_backend.yml
+++ b/.github/workflows/_test_backend.yml
@@ -46,6 +46,14 @@ on:
         required: false
         type: string
         default: ci-image:executorch-ubuntu-22.04-clang12
+      pytest-workers:
+        description: |
+          pytest-xdist worker count. Defaults to the pod's CPU allowance, which
+          is right unless a suite needs more memory per worker than the label's
+          8GiB per core.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   docker-image:
@@ -76,6 +84,10 @@ jobs:
       upload-artifact: test-report-${{ inputs.backend }}-${{ matrix.flow }}-${{ matrix.suite }}
       script: |
         set -eux
+
+        if [[ -n "${{ inputs.pytest-workers }}" ]]; then
+          export PYTEST_XDIST_AUTO_NUM_WORKERS="${{ inputs.pytest-workers }}"
+        fi
 
         source .ci/scripts/test_backend.sh "${{ matrix.suite }}" "${{ matrix.flow }}" "${RUNNER_ARTIFACT_DIR}"
 

--- a/.github/workflows/test-backend-arm.yml
+++ b/.github/workflows/test-backend-arm.yml
@@ -35,6 +35,12 @@ jobs:
       timeout: 120
       run-linux: true
       docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
+      # The Ethos-U flows run a Corstone FVP per worker and the failures each
+      # emit a Vela dump of a few hundred thousand lines, which killed the pod
+      # once `auto` stopped discounting hyperthreads: linux.4xlarge.memory gave
+      # 8 workers 16GiB each, the OSDC label gives 15 workers 7.7GiB each. 8
+      # keeps what the suite had.
+      pytest-workers: 8
 
   test-arm-vgf:
     uses: ./.github/workflows/_test_backend.yml


### PR DESCRIPTION
`test-arm`'s `arm_ethos_u85 / models` cell has killed its pod on every main run since #22246 landed: `Executing the custom container implementation failed`, no pytest summary, always while reporting `test_alexnet`. Examples: [f624c34665](https://github.com/pytorch/executorch/actions/runs/33915736773/job/101181371488), [bf88c643ce](https://github.com/pytorch/executorch/actions/runs/33916981377/job/101166348194).

It's memory, not the runner or the log volume: `arm_ethos_u55` passes on the same label with a *larger* log (768k lines vs 457k), and the suite completed on `linux.4xlarge.memory`.

`linux.4xlarge.memory` is r5.4xlarge, 16 vCPU / 128GiB, and r5 is hyperthreaded — so `-n auto` counted 8 physical cores and each worker got 16GiB. OSDC pods run with SMT off, so the cpuset is all physical cores and the worker cap follows it: 15 workers at 7.7GiB. Every Ethos-U failure emits a few hundred thousand lines of Vela output, and 15 of those in flight exceeds the pod. No label fixes this — the fleet is ~8GiB/vCPU throughout — so worker count is the only lever.

An input rather than a change to `pytest-parallelism.sh`: a memory-derived cap would also cut the arm no-driver job on the `8-64` label from 8 workers to 4, and that one is fine. The other eight callers of `_test_backend.yml` keep the default.

**Test plan.** `arm_ethos_u85` only runs on push, so dispatched on this branch (dispatch takes the non-`pull_request` branch of the `flows` expression and runs all four flows): https://github.com/pytorch/executorch/actions/runs/33931026107

Authored with Claude Code.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani
