### PR TITLE
Declare dynamic quantization transform dependency in test harness

### DIFF
--- a/backends/test/harness/BUCK
+++ b/backends/test/harness/BUCK
@@ -8,6 +8,7 @@ fbcode_target(_kind = runtime.python_library,
     srcs = native.glob(["*.py", "stages/*.py"]),
     visibility = ["PUBLIC"],
     deps = [
+        "//executorch/backends/transforms:duplicate_dynamic_quant_chain",
         "//executorch/exir:graph_module",
     ],
 )


### PR DESCRIPTION
The //executorch/backends/test/harness:tester target includes stages/quantize.py, which imports duplicate_dynamic_quant_chain, but did not declare its Buck dependency.

Existing consumers supplied the dependency transitively, masking the omission. The new Cortex-M explicit-layout test exposed it during test collection. Declare the dependency on the harness target that owns the importing source.

Test plan: git diff --check; GitHub and internal CI.

AI-assisted: Codex.