### PR TITLE
Put the arm backend suites back on linux_job_v2

### DIFF
--- a/.github/workflows/_test_backend.yml
+++ b/.github/workflows/_test_backend.yml
@@ -46,16 +46,24 @@ on:
         required: false
         type: string
         default: ci-image:executorch-ubuntu-22.04-clang12
+      use-v2:
+        description: |
+          Run the Linux tests on linux_job_v2 and EC2 instead of linux_job_v3
+          and OSDC. Pass a `runner-linux` from scale-config.yml with it, since
+          the default here is an OSDC label.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   docker-image:
     name: Resolve CI docker image
-    if: ${{ inputs.run-linux }}
+    if: ${{ inputs.run-linux && !inputs.use-v2 }}
     uses: ./.github/workflows/_docker-image.yml
 
   test-backend-linux:
     needs: docker-image
-    if: ${{ inputs.run-linux }}
+    if: ${{ inputs.run-linux && !inputs.use-v2 }}
     strategy:
       fail-fast: false
       matrix:
@@ -79,9 +87,33 @@ jobs:
 
         source .ci/scripts/test_backend.sh "${{ matrix.suite }}" "${{ matrix.flow }}" "${RUNNER_ARTIFACT_DIR}"
 
+  test-backend-linux-v2:
+    if: ${{ inputs.run-linux && inputs.use-v2 }}
+    strategy:
+      fail-fast: false
+      matrix:
+        flow: ${{ fromJSON(inputs.flows) }}
+        suite: [models, operators]
+        exclude: ${{ fromJSON(inputs.exclude) }}
+
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      ref: ${{ inputs.ref }}
+      runner: ${{ inputs.runner-linux }}
+      docker-image: ${{ inputs.docker-image }}
+      submodules: recursive
+      timeout: ${{ inputs.timeout }}
+      upload-artifact: test-report-${{ inputs.backend }}-${{ matrix.flow }}-${{ matrix.suite }}
+      script: |
+        set -eux
+
+        source .ci/scripts/test_backend.sh "${{ matrix.suite }}" "${{ matrix.flow }}" "${RUNNER_ARTIFACT_DIR}"
+
   package-golden-artifacts:
-    if: ${{ inputs.run-linux }}
-    needs: test-backend-linux
+    # Not cancelled rather than success: one of the two Linux jobs above is
+    # always skipped, and a skipped dependency would skip this too.
+    if: ${{ !cancelled() && inputs.run-linux }}
+    needs: [test-backend-linux, test-backend-linux-v2]
     runs-on: linux.2xlarge
     steps:
       - name: Download model test artifacts

--- a/.github/workflows/test-backend-arm.yml
+++ b/.github/workflows/test-backend-arm.yml
@@ -35,6 +35,12 @@ jobs:
       timeout: 120
       run-linux: true
       docker-image: ci-image:executorch-ubuntu-22.04-arm-sdk
+      # The Ethos-U models cells kill their OSDC pod partway through reporting
+      # failures, on every combination of vendor, worker count and memory
+      # tried, while the same suites complete on EC2. Back to v2 until that is
+      # understood. test-arm-vgf stays on v3, it is unaffected.
+      use-v2: true
+      runner-linux: linux.4xlarge.memory
 
   test-arm-vgf:
     uses: ./.github/workflows/_test_backend.yml


### PR DESCRIPTION
**Draft, fallback only.** Experiment C ([33935989761](https://github.com/pytorch/executorch/actions/runs/33935989761)) is testing whether suppressing the captured output fixes this properly. Land this only if that fails.

Since #22246, `arm_ethos_u55 / models` and `arm_ethos_u85 / models` die partway through reporting their failures: `Executing the custom container implementation failed`, no pytest summary. Ruled out by experiment:

| variable | tried | result |
|---|---|---|
| silicon | AMD r7a vs Intel r7i, same size | both fail |
| workers | 8 / 15 / 32 | all fail |
| memory | 116Gi / 256Gi (32GiB per worker) | both fail |
| disk_size | 300 / 400 | both fail |
| EC2 v2, 128Gi, 8 workers | — | **passes** |

Within one run every other cell passes on the same OSDC label — both `operators` cells, all four `vgf` cells, `tosa_fp`, `tosa_int`. The two that fail are the two that run Corstone FVP on large models and emit a few hundred thousand lines of Vela output per failure, which is why output volume is the remaining suspect.

`use-v2` is an input plus a second job rather than a templated `uses:`, which GitHub doesn't allow. Only `test-backend-arm` passes it; the other eight callers are untouched and `test-arm-vgf` stays on v3.

Worth knowing: these cells already reported 10 test failures before the migration, green because `test_backend.sh` exits with the summary generator's status rather than pytest's. This restores that reporting, not a passing suite.

Authored with Claude Code.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani
