### PR TITLE
Put the backend test suites back on linux_job_v2

### DIFF
--- a/.github/workflows/_test_backend.yml
+++ b/.github/workflows/_test_backend.yml
@@ -40,21 +40,15 @@ on:
         description: 'Runner type for Linux jobs'
         required: false
         type: string
-        default: mt-l-x86iavx512-16-128
+        default: linux.4xlarge.memory
       docker-image:
-        description: 'Name of the docker image to use, without registry or tag suffix'
+        description: 'Docker image for Linux jobs'
         required: false
         type: string
         default: ci-image:executorch-ubuntu-22.04-clang12
 
 jobs:
-  docker-image:
-    name: Resolve CI docker image
-    if: ${{ inputs.run-linux }}
-    uses: ./.github/workflows/_docker-image.yml
-
   test-backend-linux:
-    needs: docker-image
     if: ${{ inputs.run-linux }}
     strategy:
       fail-fast: false
@@ -63,14 +57,11 @@ jobs:
         suite: [models, operators]
         exclude: ${{ fromJSON(inputs.exclude) }}
 
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
-    permissions:
-      id-token: write
-      contents: read
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       ref: ${{ inputs.ref }}
       runner: ${{ inputs.runner-linux }}
-      docker-image: ${{ needs.docker-image.outputs.docker-registry }}/${{ inputs.docker-image }}-${{ needs.docker-image.outputs.ci-docker-hash }}
+      docker-image: ${{ inputs.docker-image }}
       submodules: recursive
       timeout: ${{ inputs.timeout }}
       upload-artifact: test-report-${{ inputs.backend }}-${{ matrix.flow }}-${{ matrix.suite }}

--- a/.github/workflows/test-backend-arm.yml
+++ b/.github/workflows/test-backend-arm.yml
@@ -19,9 +19,6 @@ concurrency:
 jobs:
   test-arm:
     uses: ./.github/workflows/_test_backend.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       backend: arm
       flows: >-
@@ -38,9 +35,6 @@ jobs:
 
   test-arm-vgf:
     uses: ./.github/workflows/_test_backend.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       backend: arm-vgf
       flows: >-

--- a/.github/workflows/test-backend-coreml.yml
+++ b/.github/workflows/test-backend-coreml.yml
@@ -36,9 +36,6 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/test-backend-coreml.yml') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/_test_backend.yml')
     uses: ./.github/workflows/_test_backend.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       backend: coreml
       # The heavier coreml_static_int8 macOS matrix saturates the shared

--- a/.github/workflows/test-backend-cortex-m.yml
+++ b/.github/workflows/test-backend-cortex-m.yml
@@ -49,9 +49,6 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/test-backend-cortex-m.yml') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/_test_backend.yml')
     uses: ./.github/workflows/_test_backend.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       backend: cortex_m
       flows: '["cortex_m"]'

--- a/.github/workflows/test-backend-nxp.yml
+++ b/.github/workflows/test-backend-nxp.yml
@@ -39,9 +39,6 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/test-backend-nxp.yml') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/_test_backend.yml')
     uses: ./.github/workflows/_test_backend.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       backend: nxp
       flows: '["nxp_neutron_imxrt700_int8_ptq"]'

--- a/.github/workflows/test-backend-openvino.yml
+++ b/.github/workflows/test-backend-openvino.yml
@@ -21,9 +21,6 @@ concurrency:
 jobs:
   test-openvino:
     uses: ./.github/workflows/_test_backend.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       backend: openvino
       flows: '["openvino"]'

--- a/.github/workflows/test-backend-qnn.yml
+++ b/.github/workflows/test-backend-qnn.yml
@@ -19,9 +19,6 @@ concurrency:
 jobs:
   test-qnn:
     uses: ./.github/workflows/_test_backend.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       backend: qnn
       flows: >-
@@ -31,4 +28,4 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-linux: true
-      runner-linux: mt-l-x86iavx512-32-256
+      runner-linux: linux.8xlarge.memory

--- a/.github/workflows/test-backend-vulkan.yml
+++ b/.github/workflows/test-backend-vulkan.yml
@@ -21,9 +21,6 @@ jobs:
   # runners. Runs on every PR and nightly.
   test-vulkan:
     uses: ./.github/workflows/_test_backend.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       backend: vulkan
       flows: >-

--- a/.github/workflows/test-backend-webgpu.yml
+++ b/.github/workflows/test-backend-webgpu.yml
@@ -19,9 +19,6 @@ concurrency:
 jobs:
   test-webgpu:
     uses: ./.github/workflows/_test_backend.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       backend: webgpu
       flows: '["webgpu"]'

--- a/.github/workflows/test-backend-xnnpack.yml
+++ b/.github/workflows/test-backend-xnnpack.yml
@@ -19,9 +19,6 @@ concurrency:
 jobs:
   test-xnnpack:
     uses: ./.github/workflows/_test_backend.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       backend: xnnpack
       flows: >-


### PR DESCRIPTION
**Draft, fallback only.** Experiment C ([33935989761](https://github.com/pytorch/executorch/actions/runs/33935989761)) is testing whether suppressing the captured output fixes this properly. Land this only if that fails.

Reverts `_test_backend.yml` and its nine callers to their state before #22246.

Since that landed, `arm_ethos_u55 / models` and `arm_ethos_u85 / models` die partway through reporting their failures: `Executing the custom container implementation failed`, no pytest summary. Ruled out by experiment:

| variable | tried | result |
|---|---|---|
| silicon | AMD r7a vs Intel r7i, same size | both fail |
| workers | 8 / 15 / 32 | all fail |
| memory | 116Gi / 256Gi (32GiB per worker) | both fail |
| disk_size | 300 / 400 | both fail |
| EC2 v2, 128Gi, 8 workers | — | **passes** |

Every other cell in the same run passes on the OSDC label — both `operators` cells, all four `vgf` cells, `tosa_fp`, `tosa_int`. The two that fail are the two that run Corstone FVP on large models and emit a few hundred thousand lines of Vela output per failure, which is why output volume is the remaining suspect.

Reverting the family rather than adding a per-caller escape hatch: `uses:` can't take an expression, so the alternative was a duplicate job and an input, which was worse to read than this. `_docker-image.yml` stays — seven other workflows resolve their image through it.

Worth migrating again once the pod deaths are understood.

Authored with Claude Code.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani
