### PR TITLE
Arm backend: bounds-check the Ethos-U vela_bin_stream parser

### DIFF
--- a/backends/arm/runtime/EthosUBackend.cpp
+++ b/backends/arm/runtime/EthosUBackend.cpp
@@ -179,6 +179,21 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
     const int input_count = handles.inputs ? handles.inputs->count : 0;
     const int output_count = handles.outputs ? handles.outputs->count : 0;
 
+    // input_count/output_count originate from the (potentially malformed)
+    // delegate blob and index into args below (args[i] and args[input_count +
+    // i]); reject anything that would read past the args span.
+    if (input_count < 0 || output_count < 0 ||
+        static_cast<size_t>(input_count) + static_cast<size_t>(output_count) >
+            args.size()) {
+      ET_LOG(
+          Error,
+          "Ethos-U IO count (%d in + %d out) exceeds args span size %zu",
+          input_count,
+          output_count,
+          args.size());
+      return Error::InvalidProgram;
+    }
+
     char* ethosu_scratch = nullptr;
     if (needs_scratch_allocation()) {
       MemoryAllocator* temp_allocator = context.get_temp_allocator();
@@ -249,8 +264,22 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
       }
 
       if (needs_scratch_allocation()) {
-        char* scratch_addr = ethosu_scratch + handles.inputs->io[i].offset;
-
+        // The offset comes from the (potentially malformed) delegate blob and
+        // is used as a memcpy destination; reject anything that would write
+        // outside the scratch buffer.
+        const int io_offset = handles.inputs->io[i].offset;
+        if (io_offset < 0 ||
+            static_cast<size_t>(io_offset) + tensor_in.nbytes() >
+                handles.scratch_data_size) {
+          ET_LOG(
+              Error,
+              "Input %d scratch offset %d + size %zu out of range for scratch size %zu",
+              i,
+              io_offset,
+              tensor_in.nbytes(),
+              handles.scratch_data_size);
+          return Error::InvalidProgram;
+        }
         // Select a compatible copy routine including checking for input layouts
         // which require permutation.
         bool both_int = tensor_in.scalar_type() == ScalarType::Int &&
@@ -264,6 +293,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
             (handles.inputs->io[i].elem_size == 1);
 
         if (both_char || both_int || both_short || both_bool) {
+          char* scratch_addr = ethosu_scratch + io_offset;
           EXECUTORCH_PROF_SCOPE(
               event_tracer, "+EthosUBackend::execute()handles.input.memcpy()");
           // Sizes match and elt size matches so memcpy.

--- a/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
+++ b/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
@@ -131,7 +131,10 @@ Error platform_execute(
   // Write outputs from scratch into EValue pointers
   for (int i = 0; i < output_count; i++) {
     int tensor_count = 1, io_count = 1;
-    const char* output_addr = ethosu_scratch + handles.outputs->io[i].offset;
+    // The offset comes from the (potentially malformed) delegate blob and is
+    // used as the source of a copy out of the scratch buffer; reject anything
+    // that would read outside it.
+    const int out_offset = handles.outputs->io[i].offset;
     // Process input EValue into scratch
     // Outputs are in the index immediately after inputs
     auto tensor_out = args[input_count + i]->toTensor();
@@ -140,6 +143,19 @@ Error platform_execute(
         tensor_out, &handles.outputs->io[i], &tensor_count, &io_count);
 
     size_t tensor_bytes = tensor_out.nbytes();
+    if (out_offset < 0 ||
+        static_cast<size_t>(out_offset) + tensor_bytes >
+            handles.scratch_data_size) {
+      ET_LOG(
+          Error,
+          "Output %d scratch offset %d + size %zu out of range for scratch size %zu",
+          i,
+          out_offset,
+          tensor_bytes,
+          handles.scratch_data_size);
+      return Error::InvalidProgram;
+    }
+    const char* output_addr = ethosu_scratch + out_offset;
     size_t io_bytes = static_cast<size_t>(io_count) *
         static_cast<size_t>(handles.outputs->io[i].elem_size);
 

--- a/backends/arm/runtime/VelaBinStream.cpp
+++ b/backends/arm/runtime/VelaBinStream.cpp
@@ -62,9 +62,44 @@ Error resolve_external_block(
   return Error::Ok;
 }
 
+// Reinterpret a block payload as a VelaIOs descriptor, but only after checking
+// that the payload is large enough to hold the `count` field and the full
+// `io[count]` array. Without this a malformed stream could point `count` past
+// the buffer, and every subsequent `io[i]` access (including the scratch
+// offsets used for memcpy at execute time) would read out of bounds.
+Error bind_io_block(const VelaBlockPayload& payload, VelaIOs** out) {
+  if (payload.size < sizeof(VelaIOs)) {
+    ET_LOG(Error, "Vela IO block too small for count field");
+    return Error::InvalidProgram;
+  }
+  VelaIOs* ios = reinterpret_cast<VelaIOs*>(const_cast<char*>(payload.data));
+  if (ios->count < 0) {
+    ET_LOG(Error, "Negative Vela IO count %d", ios->count);
+    return Error::InvalidProgram;
+  }
+  const size_t io_bytes = payload.size - sizeof(VelaIOs);
+  if (static_cast<size_t>(ios->count) > io_bytes / sizeof(VelaIO)) {
+    ET_LOG(
+        Error,
+        "Vela IO count %d overruns %zu payload bytes",
+        ios->count,
+        payload.size);
+    return Error::InvalidProgram;
+  }
+  *out = ios;
+  return Error::Ok;
+}
+
 } // namespace
 
 bool vela_bin_validate(const char* data, int size) {
+  // A single block header must fit before computing the footer pointer;
+  // otherwise foot = data + size - sizeof(VelaBinBlock) underflows below data
+  // and the strncmp below reads out of bounds.
+  if (size < static_cast<int>(sizeof(VelaBinBlock))) {
+    ET_LOG(Error, "Vela binary too small: %d bytes", size);
+    return false;
+  }
   const char* foot = data + size - sizeof(VelaBinBlock);
 
   // Check 16 byte alignment
@@ -96,10 +131,46 @@ Error vela_bin_read(
     const NamedDataMap* named_data_map,
     VelaHandles* handles) {
   const char* ptr = data;
+  const size_t total = size < 0 ? 0 : static_cast<size_t>(size);
 
-  while (ptr - data < size) {
+  while (static_cast<size_t>(ptr - data) < total) {
+    // A full block header must be present before any of its fields (size,
+    // name, external) are read. The stream is attacker-controllable when the
+    // delegate blob comes from a malformed .pte, so never dereference past the
+    // buffer.
+    const size_t remaining = total - static_cast<size_t>(ptr - data);
+    if (remaining < sizeof(VelaBinBlock)) {
+      ET_LOG(Error, "Truncated vela block header");
+      return Error::InvalidProgram;
+    }
     VelaBinBlock* b = reinterpret_cast<VelaBinBlock*>(const_cast<char*>(ptr));
-    ptr += sizeof(VelaBinBlock) + next_mul_16(b->size);
+    // The block's inline payload (padded to 16 bytes) must fit within the
+    // bytes remaining after its header; otherwise b->data + b->size, and the
+    // ptr advance below, would run off the end of the buffer.
+    const size_t avail = remaining - sizeof(VelaBinBlock);
+    // Check the raw size against the buffer first, in size_t, before padding.
+    // next_mul_16() is computed in uintptr_t and wraps to 0 for b->size near
+    // UINT32_MAX on 32-bit targets (i.e. Cortex-M), which would otherwise let a
+    // ~4GB payload slip past a padded-only check.
+    if (b->size > avail) {
+      ET_LOG(
+          Error,
+          "Vela block size %u overruns %zu remaining payload bytes",
+          static_cast<unsigned>(b->size),
+          avail);
+      return Error::InvalidProgram;
+    }
+    const size_t padded =
+        (static_cast<size_t>(b->size) + 15) & ~static_cast<size_t>(15);
+    if (padded > avail) {
+      ET_LOG(
+          Error,
+          "Padded vela block size %zu overruns %zu remaining payload bytes",
+          padded,
+          avail);
+      return Error::InvalidProgram;
+    }
+    ptr += sizeof(VelaBinBlock) + padded;
 
     VelaBlockPayload payload{b->data, b->size};
     if (b->external == kVelaExternalBlockReference) {
@@ -118,6 +189,9 @@ Error vela_bin_read(
         return Error::InvalidProgram;
     } else if (!strncmp(b->name, "cmd_data", strlen("cmd_data"))) {
       // This driver magic header confirms a valid command stream in binary
+      if (payload.size < strlen("COP1")) {
+        return Error::InvalidProgram;
+      }
       if (strncmp(payload.data, "COP1", strlen("COP1")) &&
           strncmp(payload.data, "COP2", strlen("COP2"))) {
         return Error::InvalidProgram;
@@ -128,15 +202,23 @@ Error vela_bin_read(
       handles->weight_data = payload.data;
       handles->weight_data_size = payload.size;
     } else if (!strncmp(b->name, "scratch_size", strlen("scratch_size"))) {
+      if (payload.size < sizeof(uint32_t)) {
+        ET_LOG(Error, "Malformed scratch_size block");
+        return Error::InvalidProgram;
+      }
       const uint32_t* scratch_size_ptr =
           reinterpret_cast<const uint32_t*>(payload.data);
       handles->scratch_data_size = *scratch_size_ptr;
     } else if (!strncmp(b->name, "inputs", strlen("inputs"))) {
-      handles->inputs =
-          reinterpret_cast<VelaIOs*>(const_cast<char*>(payload.data));
+      const Error status = bind_io_block(payload, &handles->inputs);
+      if (status != Error::Ok) {
+        return status;
+      }
     } else if (!strncmp(b->name, "outputs", strlen("outputs"))) {
-      handles->outputs =
-          reinterpret_cast<VelaIOs*>(const_cast<char*>(payload.data));
+      const Error status = bind_io_block(payload, &handles->outputs);
+      if (status != Error::Ok) {
+        return status;
+      }
     } else if (!strncmp(
                    b->name, "vela_end_stream", strlen("vela_end_stream"))) {
       // expect vela_end_stream last

--- a/backends/arm/test/vela_external_blocks_test.cpp
+++ b/backends/arm/test/vela_external_blocks_test.cpp
@@ -26,6 +26,7 @@
 using executorch::backends::arm::kVelaExternalBlockReference;
 using executorch::backends::arm::vela_bin_read;
 using executorch::backends::arm::VelaHandles;
+using executorch::backends::arm::VelaIO;
 using executorch::backends::arm::VelaIOs;
 using executorch::runtime::Error;
 using executorch::runtime::FreeableBuffer;
@@ -261,8 +262,14 @@ TEST(VelaExternalBlocksTest, ResolvesEveryExternalBlockType) {
 }
 
 TEST(VelaExternalBlocksTest, ResolvesMultipleExternalBlocksIndependently) {
-  alignas(16) std::array<uint8_t, 4> inputs_data{1, 0, 0, 0};
-  alignas(16) std::array<uint8_t, 4> outputs_data{2, 0, 0, 0};
+  // The payload must be large enough to hold `count` VelaIO entries, otherwise
+  // vela_bin_read rejects it. count is the first int of the buffer.
+  alignas(16) std::array<uint8_t, sizeof(VelaIOs) + sizeof(VelaIO)>
+      inputs_data{};
+  inputs_data[0] = 1; // count = 1
+  alignas(16) std::array<uint8_t, sizeof(VelaIOs) + 2 * sizeof(VelaIO)>
+      outputs_data{};
+  outputs_data[0] = 2; // count = 2
   std::vector<uint8_t> stream;
   append_block(stream, "vela_bin_stream");
   append_block(
@@ -308,6 +315,65 @@ TEST(VelaExternalBlocksTest, RejectsUnknownExternalBlock) {
           reinterpret_cast<const char*>(stream.data()),
           stream.size(),
           &data_map,
+          &handles),
+      Error::InvalidProgram);
+}
+
+// A block header that is truncated by the end of the buffer must be rejected
+// instead of being read out of bounds.
+TEST(VelaExternalBlocksTest, RejectsTruncatedBlockHeader) {
+  std::vector<uint8_t> stream;
+  append_block(stream, "vela_bin_stream");
+  // Fewer than sizeof(VelaBinBlock) trailing bytes: not a full header.
+  stream.insert(stream.end(), 8, 0);
+  VelaHandles handles{};
+
+  EXPECT_EQ(
+      vela_bin_read(
+          reinterpret_cast<const char*>(stream.data()),
+          stream.size(),
+          nullptr,
+          &handles),
+      Error::InvalidProgram);
+}
+
+// A block whose declared size field exceeds the bytes remaining in the buffer
+// must be rejected before its payload (or the cursor advance) runs off the end.
+TEST(VelaExternalBlocksTest, RejectsBlockSizeLargerThanBuffer) {
+  std::vector<uint8_t> stream;
+  append_block(stream, "vela_bin_stream");
+  // Hand-write a header claiming a 4096-byte payload but supply only one byte.
+  append_fixed_string(stream, "weight_data", 16);
+  append_u32(stream, 4096u);
+  stream.push_back(0); // external
+  stream.resize(stream.size() + 11, 0); // reserved
+  stream.push_back(0xAA); // single real payload byte
+  VelaHandles handles{};
+
+  EXPECT_EQ(
+      vela_bin_read(
+          reinterpret_cast<const char*>(stream.data()),
+          stream.size(),
+          nullptr,
+          &handles),
+      Error::InvalidProgram);
+}
+
+// An inputs/outputs block whose declared count is larger than the payload can
+// hold must be rejected, so that io[i] is never read out of bounds at execute.
+TEST(VelaExternalBlocksTest, RejectsIoCountExceedingPayload) {
+  std::vector<uint8_t> stream;
+  append_block(stream, "vela_bin_stream");
+  // count = 1 but no VelaIO entry follows (only the 4-byte count field).
+  append_block(stream, "inputs", std::vector<uint8_t>{1, 0, 0, 0});
+  append_block(stream, "vela_end_stream");
+  VelaHandles handles{};
+
+  EXPECT_EQ(
+      vela_bin_read(
+          reinterpret_cast<const char*>(stream.data()),
+          stream.size(),
+          nullptr,
           &handles),
       Error::InvalidProgram);
 }


### PR DESCRIPTION
# Arm backend: bounds-check the Ethos-U vela_bin_stream parser

### Summary

`vela_bin_read()` trusted the per-block `size` field and the `inputs`/`outputs`
descriptor sizes from the Ethos-U delegate blob without validating them against
the buffer, so a malformed or corrupt blob could read or write out of bounds
while parsing at load time and while copying into the scratch buffer at execute
time. This adds the missing bounds validation, matching the untrusted-delegate-blob
hardening already present in the XNNPACK, Vulkan and Qualcomm backends.

### What changed (suggested review order)

1. `backends/arm/runtime/VelaBinStream.cpp`
   - Require a full `VelaBinBlock` header to remain before reading a block, and
     reject a block whose payload does not fit in the remaining buffer. The raw
     `size` is checked in `size_t` **before** the 16-byte padding, because
     `next_mul_16()` is computed in `uintptr_t` and wraps to 0 for sizes near
     `UINT32_MAX` on 32-bit targets (Cortex-M).
   - `bind_io_block()`: validate that an `inputs`/`outputs` payload holds its
     declared `count` of `VelaIO` entries (and `count >= 0`) before the
     `reinterpret_cast`.
   - Size-check the `scratch_size` and `cmd_data` payloads before reading them.
   - `vela_bin_validate()`: reject a blob smaller than one block header before
     computing `foot = data + size - sizeof(VelaBinBlock)` (which otherwise
     underflows below `data`).
2. `backends/arm/runtime/EthosUBackend.cpp` — reject `input_count`/`output_count`
   that overrun the `args` span, and bound the input scratch `offset + nbytes`
   against `scratch_data_size` before the copy.
3. `backends/arm/runtime/EthosUBackend_Cortex_M.cpp` — bound the output scratch
   `offset + tensor_bytes` against `scratch_data_size` before the copy.
4. `backends/arm/test/vela_external_blocks_test.cpp` — add negative tests
   (truncated header, block size larger than buffer, IO count exceeding payload)
   and size the existing IO-block test payloads to hold their declared `count`.

### Testing

- Added the negative parser tests above; existing `VelaExternalBlocks` tests
  still pass by construction (the IO-block payloads were resized to match the new
  validation).
- Note: I was unable to build/run the suite in my environment (no local C++
  toolchain for the Arm runtime); relying on CI. Please run the
  `backends/arm` runtime tests.

Fixes #22579

---

This PR was authored with assistance from Claude Code.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani