### PR TITLE
Use a portable job count for -j in the Arm build docs and notebooks

### DIFF
--- a/backends/arm/cmsis_pack/README.md
+++ b/backends/arm/cmsis_pack/README.md
@@ -64,7 +64,7 @@ cmake \
   -DEXECUTORCH_BUILD_KERNELS_QUANTIZED=ON \
   -DEXECUTORCH_BUILD_FLATC=ON \
   -Bcmake-out-arm .
-cmake --build cmake-out-arm --config Release -j$(nproc)
+cmake --build cmake-out-arm --config Release -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 
 # 2. Build the pack. --output-dir is where the .pack archive lands
 #    (created if absent); each invocation rewrites this directory.

--- a/backends/arm/scripts/docgen/ethos-u/ethos-u-getting-started-tutorial.md.in
+++ b/backends/arm/scripts/docgen/ethos-u/ethos-u-getting-started-tutorial.md.in
@@ -91,7 +91,7 @@ cmake -S examples/arm/executor_runner/standalone \
       -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128 \
       -DMEMORY_MODE=Shared_Sram \
       -DSYSTEM_CONFIG=Ethos_U55_High_End_Embedded
-cmake --build ethos_u_minimal_example -j$(nproc) -- arm_executor_runner
+cmake --build ethos_u_minimal_example -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -- arm_executor_runner
 ```
 
 ```{tip}

--- a/docs/source/backends/arm-cortex-m/arm-cortex-m-overview.md
+++ b/docs/source/backends/arm-cortex-m/arm-cortex-m-overview.md
@@ -144,7 +144,7 @@ cmake --preset arm-baremetal \
   -DCMAKE_BUILD_TYPE=Release \
   -DEXECUTORCH_BUILD_DEVTOOLS=ON \
   -Bcmake-out-arm
-cmake --build cmake-out-arm --target install -j$(nproc)
+cmake --build cmake-out-arm --target install -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 
 # Build the executor runner, linking the .pte into the binary
 cmake -DCMAKE_TOOLCHAIN_FILE=$(pwd)/examples/arm/ethos-u-setup/arm-none-eabi-gcc.cmake \
@@ -153,7 +153,7 @@ cmake -DCMAKE_TOOLCHAIN_FILE=$(pwd)/examples/arm/ethos-u-setup/arm-none-eabi-gcc
       -DTARGET_CPU=cortex-m55 \
       -Bbuild \
       examples/arm/executor_runner
-cmake --build build -j$(nproc) -- arm_executor_runner
+cmake --build build -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -- arm_executor_runner
 ```
 
 Run on a simulated Cortex-M target:

--- a/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
+++ b/docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md
@@ -164,7 +164,7 @@ cmake -S examples/arm/executor_runner/standalone \
       -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128 \
       -DMEMORY_MODE=Shared_Sram \
       -DSYSTEM_CONFIG=Ethos_U55_High_End_Embedded
-cmake --build ethos_u_minimal_example -j$(nproc) -- arm_executor_runner
+cmake --build ethos_u_minimal_example -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -- arm_executor_runner
 ```
 
 ```{tip}

--- a/examples/arm/cortex_m_mv2_example.ipynb
+++ b/examples/arm/cortex_m_mv2_example.ipynb
@@ -129,14 +129,14 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%bash\n\n# Build executorch libraries cross-compiled for arm baremetal to executorch/cmake-out-arm\ncmake --preset arm-baremetal \\\n-DCMAKE_BUILD_TYPE=Release \\\n-DEXECUTORCH_BUILD_DEVTOOLS=ON \\\n-B../../cmake-out-arm ../..\ncmake --build ../../cmake-out-arm --target install -j$(nproc) \n"
+   "source": "%%bash\n\n# Build executorch libraries cross-compiled for arm baremetal to executorch/cmake-out-arm\ncmake --preset arm-baremetal \\\n-DCMAKE_BUILD_TYPE=Release \\\n-DEXECUTORCH_BUILD_DEVTOOLS=ON \\\n-B../../cmake-out-arm ../..\ncmake --build ../../cmake-out-arm --target install -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) \n"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%%bash \n# Build example executor runner application to examples/arm/cortex_m_mv2_example\n# Note that this is the same runner as used in the Ethos-U example, creating some overlap in the config even though the Ethos-U is not used.\ncmake -DCMAKE_TOOLCHAIN_FILE=$(pwd)/ethos-u-setup/arm-none-eabi-gcc.cmake \\\n      -DCMAKE_BUILD_TYPE=Release \\\n      -DET_PTE_FILE_PATH=cortex_m_mv2_example.bpte \\\n      -DTARGET_CPU=cortex-m55 \\\n      -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128 \\\n      -DMEMORY_MODE=Shared_Sram \\\n      -DET_BUNDLE_IO=ON \\\n      -DSYSTEM_CONFIG=Ethos_U55_High_End_Embedded \\\n      -Bcortex_m_mv2_example \\\n      -S executor_runner/standalone\ncmake --build cortex_m_mv2_example -j$(nproc) -- arm_executor_runner"
+   "source": "%%bash \n# Build example executor runner application to examples/arm/cortex_m_mv2_example\n# Note that this is the same runner as used in the Ethos-U example, creating some overlap in the config even though the Ethos-U is not used.\ncmake -DCMAKE_TOOLCHAIN_FILE=$(pwd)/ethos-u-setup/arm-none-eabi-gcc.cmake \\\n      -DCMAKE_BUILD_TYPE=Release \\\n      -DET_PTE_FILE_PATH=cortex_m_mv2_example.bpte \\\n      -DTARGET_CPU=cortex-m55 \\\n      -DETHOSU_TARGET_NPU_CONFIG=ethos-u55-128 \\\n      -DMEMORY_MODE=Shared_Sram \\\n      -DET_BUNDLE_IO=ON \\\n      -DSYSTEM_CONFIG=Ethos_U55_High_End_Embedded \\\n      -Bcortex_m_mv2_example \\\n      -S executor_runner/standalone\ncmake --build cortex_m_mv2_example -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -- arm_executor_runner"
   },
   {
    "cell_type": "markdown",

--- a/examples/arm/ethos_u_cmsis_nn_fallback_example.ipynb
+++ b/examples/arm/ethos_u_cmsis_nn_fallback_example.ipynb
@@ -206,7 +206,7 @@
     "      -DSYSTEM_CONFIG=Ethos_U55_High_End_Embedded \\\n",
     "      -Bethos_u_cmsis_nn_fallback_example \\\n",
     "      -S executor_runner/standalone\n",
-    "cmake --build ethos_u_cmsis_nn_fallback_example -j$(nproc) -- arm_executor_runner"
+    "cmake --build ethos_u_cmsis_nn_fallback_example -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -- arm_executor_runner"
    ]
   },
   {

--- a/examples/arm/ethos_u_minimal_example.ipynb
+++ b/examples/arm/ethos_u_minimal_example.ipynb
@@ -196,7 +196,7 @@
     "      -DSYSTEM_CONFIG=Ethos_U55_High_End_Embedded \\\n",
     "      -Bethos_u_minimal_example \\\n",
     "      -S executor_runner/standalone\n",
-    "cmake --build ethos_u_minimal_example -j$(nproc) -- arm_executor_runner"
+    "cmake --build ethos_u_minimal_example -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -- arm_executor_runner"
    ]
   },
   {

--- a/examples/arm/image_classification_example_ethos_u/runtime/README.md
+++ b/examples/arm/image_classification_example_ethos_u/runtime/README.md
@@ -8,7 +8,7 @@
 $ cmake --preset arm-baremetal \
 -DCMAKE_BUILD_TYPE=Release \
 -B../../cmake-out-arm ../..
-cmake --build ../../cmake-out-arm --target install -j$(nproc)
+cmake --build ../../cmake-out-arm --target install -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ```
 
 3. Set up the build system. You need to provide path to the DEiT-Tiny pte generated in the
@@ -21,7 +21,7 @@ $ cmake -DCMAKE_TOOLCHAIN_FILE=$(pwd)/ethos-u-setup/arm-none-eabi-gcc.cmake -DET
 4. Compile the application.
 
 ```
-$ cmake --build simple_app_deit_tiny -j$(nproc) -- img_class_example
+$ cmake --build simple_app_deit_tiny -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -- img_class_example
 ```
 
 5. Deploy the application on the Corstone-320 Fixed Virtual Platform. Assuming you have the Corstone-320 installed on your path, do the following command to deploy the application.

--- a/examples/arm/mobilesam_prompt_segmentation_example_ethos_u/runtime/README.md
+++ b/examples/arm/mobilesam_prompt_segmentation_example_ethos_u/runtime/README.md
@@ -19,7 +19,7 @@ Build and install the Arm bare-metal ExecuTorch libraries from
 cmake --preset arm-baremetal \
   -DCMAKE_BUILD_TYPE=Release \
   -B../../cmake-out-arm ../..
-cmake --build ../../cmake-out-arm --target install -j$(nproc)
+cmake --build ../../cmake-out-arm --target install -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ```
 
 The Arm bare-metal preset installs into the build directory. If you use a
@@ -67,7 +67,7 @@ can inspect and retune post-processing without re-exporting the graph.
 ## Compile
 
 ```bash
-cmake --build mobilesam_point_runtime -j$(nproc) -- mobilesam_prompt_segmentation_example
+cmake --build mobilesam_point_runtime -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -- mobilesam_prompt_segmentation_example
 ```
 
 ## Run on Corstone-320 FVP

--- a/examples/arm/pruning_minimal_example.ipynb
+++ b/examples/arm/pruning_minimal_example.ipynb
@@ -432,7 +432,7 @@
     "cmake --preset arm-baremetal \\\n",
     "-DCMAKE_BUILD_TYPE=Release \\\n",
     "-B../../cmake-out-arm ../..\n",
-    "cmake --build ../../cmake-out-arm --target install -j$(nproc) "
+    "cmake --build ../../cmake-out-arm --target install -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) "
    ]
   },
   {
@@ -454,7 +454,7 @@
     "      -DSYSTEM_CONFIG=Ethos_U85_SYS_DRAM_Mid \\\n",
     "      -Bethos_u_original_model \\\n",
     "      -S executor_runner/standalone\n",
-    "cmake --build ethos_u_original_model -j$(nproc) -- arm_executor_runner"
+    "cmake --build ethos_u_original_model -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -- arm_executor_runner"
    ]
   },
   {
@@ -500,7 +500,7 @@
     "      -DSYSTEM_CONFIG=Ethos_U85_SYS_DRAM_Mid \\\n",
     "      -Bethos_u_pruned_model \\\n",
     "      -S executor_runner/standalone\n",
-    "cmake --build ethos_u_pruned_model -j$(nproc) -- arm_executor_runner"
+    "cmake --build ethos_u_pruned_model -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 )) -- arm_executor_runner"
    ]
   },
   {


### PR DESCRIPTION
### Summary

The Arm flow is supported on macOS, but every build command in its docs and notebooks uses `-j$(nproc)`, which does not exist there.

macOS support is not incidental to this flow. The Ethos-U getting-started tutorial states it under Prerequisites — *"a Linux machine with aarch64 or x86_64 processor architecture, or a macOS™ machine with Apple® Silicon"* — `backends/arm/scripts/utils.sh:186` rejects anything but Linux and Darwin on arm64, and `backends/arm/scripts/toolchain_utils.sh:31` downloads a `darwin-arm64` bare-metal toolchain.

On macOS the documented command loses its `-j` argument entirely:

```
$ cmake --build ethos_u_minimal_example -j$(nproc) -- arm_executor_runner
sh: nproc: command not found
# runs as: cmake --build ethos_u_minimal_example -j -- arm_executor_runner
```

That is a bare `-j`, so the build runs unbounded rather than at the intended core count.

This replaces those 16 sites with the portable form already established in the tree by #20436:

```
-j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
```

Scope is deliberately limited to the Arm flow, where macOS is a documented host. The remaining bare `-j$(nproc)` sites live in backends with no stated macOS support (QNN, CUDA, Samsung, OpenVINO, Espressif) and are left alone.

Follow-up to #21455, which converted the hardcoded `-jN` sites; @synath raised this pattern in review there and I said it would be a separate PR. Partial fix for #10887.

The Ethos-U tutorial is generated, so `backends/arm/scripts/docgen/ethos-u/ethos-u-getting-started-tutorial.md.in` and its output `docs/source/backends/arm-ethos-u/tutorials/ethos-u-getting-started.md` are both updated; the edited line is in the template's static text, not the `$MINIMAL_EXAMPLE` substitution, so re-running `docgen.py` reproduces the committed file.

### Test plan

Docs and notebooks only — no build or runtime code changes.

Verified the replacement expression on both branches. With `nproc` available (16 cores):

```
$ echo "jobs = $(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))"
jobs = 17
```

With `nproc` absent and `sysctl -n hw.ncpu` reporting 8, as on macOS:

```
$ env -i PATH="$stub" sh -c 'echo "jobs = $(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))"'
jobs = 9
```

Confirmed no bare `-j$(nproc)` remains in the touched files, that the four notebooks still parse as JSON, and that the generated tutorial still matches its template with the placeholder substituted.

This PR was authored with AI assistance (Claude Code).


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani