### PR TITLE
Move the NXP op alias table out of the test package

### DIFF
--- a/backends/nxp/BUCK
+++ b/backends/nxp/BUCK
@@ -68,7 +68,6 @@ fbcode_target(_kind = runtime.python_library,
         "fbsource//third-party/pypi/neutron_converter:neutron_converter",
         "//caffe2:torch",
         "//executorch/exir:lib",
-        "//executorch/backends/nxp/tests:ops_aliases",
     ],
 )
 

--- a/backends/nxp/backend/edge_helper.py
+++ b/backends/nxp/backend/edge_helper.py
@@ -8,7 +8,7 @@ import operator
 
 import torch
 
-from executorch.backends.nxp.tests.ops_aliases import (
+from executorch.backends.nxp.backend.ops_aliases import (
     AddTensor,
     Amax,
     Amin,

--- a/backends/nxp/backend/node_format_inference.py
+++ b/backends/nxp/backend/node_format_inference.py
@@ -15,7 +15,7 @@ from executorch.backends.nxp.backend.edge_helper import (
     try_get_arg,
 )
 from executorch.backends.nxp.backend.edge_program_converter import functions_converters
-from executorch.backends.nxp.tests.ops_aliases import (
+from executorch.backends.nxp.backend.ops_aliases import (
     AdaptiveAvgPool2D,
     Amax,
     Amin,

--- a/backends/nxp/backend/ops_aliases.py
+++ b/backends/nxp/backend/ops_aliases.py
@@ -3,8 +3,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# This file defines ops aliases for shorter and more readable test description. List is sorted alphabetically.
-# When finding a missing alias, add it at the correct place.
+# This file defines ops aliases for shorter and more readable descriptions of edge operators.
+# List is sorted alphabetically. When finding a missing alias, add it at the correct place.
 
 import operator
 

--- a/backends/nxp/edge_passes/move_auxiliary_operator_into_separate_qdq_cluster_pass.py
+++ b/backends/nxp/edge_passes/move_auxiliary_operator_into_separate_qdq_cluster_pass.py
@@ -6,10 +6,10 @@
 import operator
 
 import torch
+from executorch.backends.nxp.backend.ops_aliases import PermuteCopy
 
 from executorch.backends.nxp.edge_passes.neutron_edge_pass import NeutronEdgePass
 from executorch.backends.nxp.neutron_partitioner import QDQClusterRecognizer
-from executorch.backends.nxp.tests.ops_aliases import PermuteCopy
 
 # noinspection PyProtectedMember
 from executorch.exir.dialects._ops import ops as exir_ops

--- a/backends/nxp/tests/BUCK
+++ b/backends/nxp/tests/BUCK
@@ -5,17 +5,6 @@ load("@fbcode_macros//build_defs:python_pytest.bzl", "python_pytest")
 oncall("executorch")
 
 fbcode_target(_kind = runtime.python_library,
-    name = "ops_aliases",
-    srcs = [
-        "ops_aliases.py",
-    ],
-    deps = [
-        "//caffe2:torch",
-        "//executorch/exir:lib",
-    ],
-)
-
-fbcode_target(_kind = runtime.python_library,
     name = "models",
     srcs = [
         "models.py",

--- a/backends/nxp/tests/generic_tests/test_add_batch_size_for_3d_input_pool_2d_ops.py
+++ b/backends/nxp/tests/generic_tests/test_add_batch_size_for_3d_input_pool_2d_ops.py
@@ -15,6 +15,13 @@ from executorch.backends.nxp.aten_passes.add_batch_size_for_3d_input_pool_2d_ops
 from executorch.backends.nxp.aten_passes.neutron_aten_pass_manager import (
     NeutronAtenPassManager,
 )
+from executorch.backends.nxp.backend.ops_aliases import (
+    AdaptiveAvgPool2D,
+    AvgPool2D,
+    GetItem,
+    MaxPool2DWithIndices,
+    ViewCopy,
+)
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import neutron_target_spec
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
@@ -28,13 +35,6 @@ from executorch.backends.nxp.tests.models import (
     MaxPool2dModule,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AdaptiveAvgPool2D,
-    AvgPool2D,
-    GetItem,
-    MaxPool2DWithIndices,
-    ViewCopy,
-)
 
 
 @pytest.fixture(autouse=True)

--- a/backends/nxp/tests/generic_tests/test_convert_div_to_mul.py
+++ b/backends/nxp/tests/generic_tests/test_convert_div_to_mul.py
@@ -13,6 +13,7 @@ from executorch.backends.nxp.aten_passes.neutron_aten_pass_manager import (
     ConvertDivToMulPass,
     NeutronAtenPassManager,
 )
+from executorch.backends.nxp.backend.ops_aliases import MulTensor
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import neutron_target_spec
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
@@ -22,7 +23,6 @@ from executorch.backends.nxp.tests.models import (
     StaticDivLinearModel,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import MulTensor
 
 
 @pytest.fixture(autouse=True)

--- a/backends/nxp/tests/generic_tests/test_convert_scalar_to_attr.py
+++ b/backends/nxp/tests/generic_tests/test_convert_scalar_to_attr.py
@@ -18,6 +18,7 @@ from executorch.backends.nxp.aten_passes.neutron_aten_pass_manager import (
 from executorch.backends.nxp.backend.edge_helper import (
     try_get_tensor_constant_from_node,
 )
+from executorch.backends.nxp.backend.ops_aliases import AddTensor, MulTensor, SubTensor
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import neutron_target_spec
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
@@ -31,7 +32,6 @@ from executorch.backends.nxp.tests.nsys_testing import (
     AllCloseOutputComparator,
     lower_run_compare,
 )
-from executorch.backends.nxp.tests.ops_aliases import AddTensor, MulTensor, SubTensor
 
 
 @pytest.fixture(autouse=True)

--- a/backends/nxp/tests/generic_tests/test_decompose_split_to_slices.py
+++ b/backends/nxp/tests/generic_tests/test_decompose_split_to_slices.py
@@ -12,6 +12,7 @@ from executorch.backends.nxp.aten_passes.neutron_aten_pass_manager import (
     NeutronAtenPassManager,
     SplitGRUBasedOnNumLayers,
 )
+from executorch.backends.nxp.backend.ops_aliases import SliceCopy
 from executorch.backends.nxp.tests.executorch_pipeline import neutron_target_spec
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
@@ -21,7 +22,6 @@ from executorch.backends.nxp.tests.models import (
     SplitWithSize,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import SliceCopy
 
 
 @pytest.fixture(autouse=True)

--- a/backends/nxp/tests/generic_tests/test_integration.py
+++ b/backends/nxp/tests/generic_tests/test_integration.py
@@ -5,8 +5,8 @@
 
 import executorch.extension.pybindings.portable_lib
 import executorch.kernels.quantized  # noqa F401
+from executorch.backends.nxp.backend.ops_aliases import AddMM, Convolution
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
-from executorch.backends.nxp.tests.ops_aliases import AddMM, Convolution
 from executorch.backends.nxp.tests.use_qat import *  # noqa F401
 
 from executorch.backends.nxp.tests.executorch_pipeline import (

--- a/backends/nxp/tests/generic_tests/test_node_format_inference.py
+++ b/backends/nxp/tests/generic_tests/test_node_format_inference.py
@@ -13,6 +13,10 @@ from executorch.backends.nxp.backend.node_format_inference import (
     NodeFormatInference,
     NXP_NODE_FORMAT,
 )
+from executorch.backends.nxp.backend.ops_aliases import (
+    ExecutorchDelegateCall,
+    MaxPool2DWithIndices,
+)
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 
@@ -20,10 +24,6 @@ from executorch.backends.nxp.tests.models import (
     Conv2dModule,
     MaxPool2dModule,
     SoftmaxModule,
-)
-from executorch.backends.nxp.tests.ops_aliases import (
-    ExecutorchDelegateCall,
-    MaxPool2DWithIndices,
 )
 
 

--- a/backends/nxp/tests/generic_tests/test_quantized_input_data.py
+++ b/backends/nxp/tests/generic_tests/test_quantized_input_data.py
@@ -5,6 +5,7 @@
 
 import executorch.backends.nxp.tests.nsys_testing as nsys_testing
 import torch
+from executorch.backends.nxp.backend.ops_aliases import AvgPool2D, MulTensor
 
 from executorch.backends.nxp.tests.executorch_pipeline import ModelInputSpec
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
@@ -14,7 +15,6 @@ from executorch.backends.nxp.tests.nsys_testing import (
     OUTPUTS_DIR,
     ReferenceModel,
 )
-from executorch.backends.nxp.tests.ops_aliases import AvgPool2D, MulTensor
 
 
 def test__single_quantized_inputs(mocker, request):

--- a/backends/nxp/tests/graph_verifier.py
+++ b/backends/nxp/tests/graph_verifier.py
@@ -10,17 +10,17 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Callable, Union
 
-from executorch.backends.nxp.neutron_partitioner import (
-    NeutronPartitioner,
-    NXP_DELEGATION_TAG,
-)
-from executorch.backends.nxp.tests.ops_aliases import (
+from executorch.backends.nxp.backend.ops_aliases import (
     DequantizePerChannel,
     DequantizePerTensor,
     QuantizePerChannel,
     QuantizePerTensor,
 )
 
+from executorch.backends.nxp.neutron_partitioner import (
+    NeutronPartitioner,
+    NXP_DELEGATION_TAG,
+)
 from executorch.exir.dialects.edge._ops import EdgeOpOverload
 
 from pytest_mock import MockerFixture

--- a/backends/nxp/tests/ir/converter/node_converter/test_abs_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_abs_converter.py
@@ -8,12 +8,12 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import Abs
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.nsys_testing import (
     lower_run_compare,
     RandomDatasetCreator,
 )
-from executorch.backends.nxp.tests.ops_aliases import Abs
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_adaptive_avg_pool2d_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_adaptive_avg_pool2d_converter.py
@@ -8,6 +8,10 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    AdaptiveAvgPool2D,
+    ExecutorchDelegateCall,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
@@ -18,10 +22,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
 )
 from executorch.backends.nxp.tests.models import AdaptiveAvgPool2dModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AdaptiveAvgPool2D,
-    ExecutorchDelegateCall,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_add_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_add_tensor_converter.py
@@ -8,6 +8,12 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddTensor,
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import (
@@ -21,12 +27,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
 )
 from executorch.backends.nxp.tests.models import AddTensorModule, MaxPoolAddTensorModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddTensor,
-    ExecutorchDelegateCall,
-    GetItem,
-    MaxPool2DWithIndices,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_addmm_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_addmm_converter.py
@@ -8,6 +8,13 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddMM,
+    ExecutorchDelegateCall,
+    MM,
+    PermuteCopy,
+    ViewCopy,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
@@ -15,13 +22,6 @@ from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier, Operator
 from executorch.backends.nxp.tests.models import AddmmModule, LinearModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddMM,
-    ExecutorchDelegateCall,
-    MM,
-    PermuteCopy,
-    ViewCopy,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_amax_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_amax_converter.py
@@ -21,6 +21,13 @@ from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.reduce_
 from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.transpose_options import (
     Transpose,
 )
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddTensor,
+    Amax,
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
+)
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
@@ -29,13 +36,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddTensor,
-    Amax,
-    ExecutorchDelegateCall,
-    GetItem,
-    MaxPool2DWithIndices,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_amin_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_amin_converter.py
@@ -21,6 +21,13 @@ from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.reduce_
 from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.transpose_options import (
     Transpose,
 )
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddTensor,
+    Amin,
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
+)
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
@@ -29,13 +36,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddTensor,
-    Amin,
-    ExecutorchDelegateCall,
-    GetItem,
-    MaxPool2DWithIndices,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_avg_pool2d_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_avg_pool2d_converter.py
@@ -8,17 +8,17 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    AvgPool2D,
+    ExecutorchDelegateCall,
+    ViewCopy,
+)
 
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.models import AvgPool2dModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AvgPool2D,
-    ExecutorchDelegateCall,
-    ViewCopy,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_bmm_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_bmm_converter.py
@@ -6,6 +6,11 @@
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    BMM,
+    GetItem,
+    MaxPool2DWithIndices,
+)
 
 from executorch.backends.nxp.edge_passes.move_auxiliary_operator_into_separate_qdq_cluster_pass import (
     ViewCopy,
@@ -21,7 +26,6 @@ from executorch.backends.nxp.tests.models import (
     BatchMatMulModel,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import BMM, GetItem, MaxPool2DWithIndices
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_cat_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_cat_converter.py
@@ -8,6 +8,12 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    Cat,
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
+)
 
 from executorch.backends.nxp.tests.executorch_pipeline import (
     ModelInputSpec,
@@ -16,12 +22,6 @@ from executorch.backends.nxp.tests.executorch_pipeline import (
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    Cat,
-    ExecutorchDelegateCall,
-    GetItem,
-    MaxPool2DWithIndices,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_clamp_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_clamp_converter.py
@@ -18,6 +18,11 @@ from executorch.backends.nxp.backend.ir.converter.builder.aten_model_builder_dir
 from executorch.backends.nxp.backend.ir.lib.tflite.BuiltinOperator import (
     BuiltinOperator as Ops,
 )
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddTensor,
+    Clamp,
+    ExecutorchDelegateCall,
+)
 from executorch.backends.nxp.tests.executorch_pipeline import (
     ModelInputSpec,
     to_quantized_edge_program,
@@ -25,11 +30,6 @@ from executorch.backends.nxp.tests.executorch_pipeline import (
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddTensor,
-    Clamp,
-    ExecutorchDelegateCall,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa: F403 F401
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_constant_pad_nd_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_constant_pad_nd_converter.py
@@ -12,10 +12,10 @@ import torch
 from executorch.backends.nxp.backend.ir.converter.builder.model_builder import (
     ModelBuilder,
 )
+from executorch.backends.nxp.backend.ops_aliases import ConstantPadND, Convolution
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.models import PadConvModule, PadModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import ConstantPadND, Convolution
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_conv_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_conv_converter.py
@@ -6,6 +6,11 @@
 import numpy as np
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    Convolution,
+    ExecutorchDelegateCall,
+    ViewCopy,
+)
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
@@ -15,11 +20,6 @@ from executorch.backends.nxp.tests.nsys_testing import (
     AllCloseOutputComparator,
     lower_run_compare,
     ReferenceModel,
-)
-from executorch.backends.nxp.tests.ops_aliases import (
-    Convolution,
-    ExecutorchDelegateCall,
-    ViewCopy,
 )
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_exp_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_exp_converter.py
@@ -8,10 +8,10 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import Exp
 
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import Exp
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 from executorch.backends.nxp.tests.dataset_creator import (
     LinearRampDatasetCreator,

--- a/backends/nxp/tests/ir/converter/node_converter/test_hardswish_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_hardswish_converter.py
@@ -8,6 +8,13 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddMM,
+    Convolution,
+    Hardswish,
+    PermuteCopy,
+    ViewCopy,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
@@ -20,13 +27,6 @@ from executorch.backends.nxp.tests.models import (
     LinearHardswishModule,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddMM,
-    Convolution,
-    Hardswish,
-    PermuteCopy,
-    ViewCopy,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_hardtanh_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_hardtanh_converter.py
@@ -18,17 +18,17 @@ from executorch.backends.nxp.backend.ir.converter.builder.aten_model_builder_dir
 from executorch.backends.nxp.backend.ir.lib.tflite.BuiltinOperator import (
     BuiltinOperator as Ops,
 )
+from executorch.backends.nxp.backend.ops_aliases import (
+    Convolution,
+    ExecutorchDelegateCall,
+    HardTanh,
+)
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.models import Conv2dWithActivation, HardTanhModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    Convolution,
-    ExecutorchDelegateCall,
-    HardTanh,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_leaky_relu_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_leaky_relu_converter.py
@@ -8,11 +8,11 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import LeakyRelu
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import LeakyRelu
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_log_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_log_converter.py
@@ -8,10 +8,10 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import Log
 
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import Log
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 from executorch.backends.nxp.tests.dataset_creator import (
     LinearRampDatasetCreator,

--- a/backends/nxp/tests/ir/converter/node_converter/test_max_pool_2d_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_max_pool_2d_converter.py
@@ -8,17 +8,17 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
-
-from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
-from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
-from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
-from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
+from executorch.backends.nxp.backend.ops_aliases import (
     ExecutorchDelegateCall,
     GetItem,
     MaxPool2DWithIndices,
     ViewCopy,
 )
+
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
+from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_maximum_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_maximum_converter.py
@@ -8,6 +8,12 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    ExecutorchDelegateCall,
+    GetItem,
+    Maximum,
+    MaxPool2DWithIndices,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import (
@@ -21,12 +27,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
 )
 from executorch.backends.nxp.tests.models import MaximumModule, MaxPoolMaximumModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    ExecutorchDelegateCall,
-    GetItem,
-    Maximum,
-    MaxPool2DWithIndices,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_mean_dim_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_mean_dim_converter.py
@@ -21,6 +21,13 @@ from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.mean_op
 from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.transpose_options import (
     Transpose,
 )
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddTensor,
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
+    MeanDim,
+)
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
@@ -29,13 +36,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddTensor,
-    ExecutorchDelegateCall,
-    GetItem,
-    MaxPool2DWithIndices,
-    MeanDim,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_minimum_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_minimum_converter.py
@@ -8,6 +8,12 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
+    Minimum,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import (
@@ -21,12 +27,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
 )
 from executorch.backends.nxp.tests.models import MaxPoolMinimumModule, MinimumModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    ExecutorchDelegateCall,
-    GetItem,
-    MaxPool2DWithIndices,
-    Minimum,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_mm_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_mm_converter.py
@@ -8,12 +8,12 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import MM, PermuteCopy, ViewCopy
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier, Operator
 from executorch.backends.nxp.tests.models import LinearModule, MmModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import MM, PermuteCopy, ViewCopy
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_mul_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_mul_tensor_converter.py
@@ -8,6 +8,12 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
+    MulTensor,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import (
@@ -21,12 +27,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
 )
 from executorch.backends.nxp.tests.models import MaxPoolMulTensorModule, MulTensorModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    ExecutorchDelegateCall,
-    GetItem,
-    MaxPool2DWithIndices,
-    MulTensor,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_neg_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_neg_converter.py
@@ -8,6 +8,7 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import Convolution, Neg
 
 from executorch.backends.nxp.tests.dataset_creator import (
     LinearRampDatasetCreator,
@@ -15,7 +16,6 @@ from executorch.backends.nxp.tests.dataset_creator import (
 )
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import Convolution, Neg
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_pad_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_pad_converter.py
@@ -10,10 +10,10 @@ import torch
 from executorch.backends.nxp.backend.ir.converter.builder.model_builder import (
     ModelBuilder,
 )
+from executorch.backends.nxp.backend.ops_aliases import Convolution, Pad
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.models import PadConvModule, PadModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import Convolution, Pad
 
 
 @pytest.fixture(autouse=True)

--- a/backends/nxp/tests/ir/converter/node_converter/test_permute_copy_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_permute_copy_converter.py
@@ -9,17 +9,17 @@ import itertools
 import pytest
 import torch
 from _pytest.mark import ParameterSet
-
-from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
-from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
-from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
-from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
+from executorch.backends.nxp.backend.ops_aliases import (
     ExecutorchDelegateCall,
     GetItem,
     MaxPool2DWithIndices,
     PermuteCopy,
 )
+
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
+from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_prelu_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_prelu_converter.py
@@ -11,6 +11,17 @@ import torch
 from executorch.backends.nxp.backend.edge_program_converter import (
     EdgeProgramToIRConverter,
 )
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddMM,
+    Convolution,
+    ExecutorchDelegateCall,
+    GtScalar,
+    MulTensor,
+    PermuteCopy,
+    Prelu,
+    ViewCopy,
+    WhereSelf,
+)
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
@@ -25,17 +36,6 @@ from executorch.backends.nxp.tests.models import (
 )
 
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddMM,
-    Convolution,
-    ExecutorchDelegateCall,
-    GtScalar,
-    MulTensor,
-    PermuteCopy,
-    Prelu,
-    ViewCopy,
-    WhereSelf,
-)
 from torch.export import ExportedProgram
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program

--- a/backends/nxp/tests/ir/converter/node_converter/test_relu_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_relu_converter.py
@@ -7,13 +7,7 @@ import numpy as np
 import pytest
 import torch
 from executorch.backends.nxp.backend.edge_program_converter import exir_ops
-from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
-from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
-from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
-from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
-from executorch.backends.nxp.tests.models import Conv2dModule, LinearModule, ReLUModule
-from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
+from executorch.backends.nxp.backend.ops_aliases import (
     AddMM,
     Convolution,
     DequantizePerChannel,
@@ -23,6 +17,12 @@ from executorch.backends.nxp.tests.ops_aliases import (
     Relu,
     ViewCopy,
 )
+from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
+from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.models import Conv2dModule, LinearModule, ReLUModule
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_rsqrt_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_rsqrt_converter.py
@@ -8,6 +8,7 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import Rsqrt
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
@@ -15,7 +16,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import Rsqrt
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_sigmoid_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_sigmoid_converter.py
@@ -9,6 +9,7 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import Sigmoid
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
@@ -16,7 +17,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import Sigmoid
 from torch import nn
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_slice_copy_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_slice_copy_tensor_converter.py
@@ -8,6 +8,11 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    Convolution,
+    ExecutorchDelegateCall,
+    SliceCopy,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
@@ -21,11 +26,6 @@ from executorch.backends.nxp.tests.models import (
     SliceTensorModule,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    Convolution,
-    ExecutorchDelegateCall,
-    SliceCopy,
-)
 
 
 @pytest.fixture(autouse=True)

--- a/backends/nxp/tests/ir/converter/node_converter/test_softmax_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_softmax_converter.py
@@ -6,6 +6,12 @@
 import numpy as np
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    Convolution,
+    ExecutorchDelegateCall,
+    Softmax,
+    ViewCopy,
+)
 
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
@@ -17,12 +23,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
 )
 from executorch.backends.nxp.tests.models import SoftmaxModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    Convolution,
-    ExecutorchDelegateCall,
-    Softmax,
-    ViewCopy,
-)
 
 
 @pytest.fixture(autouse=True)

--- a/backends/nxp/tests/ir/converter/node_converter/test_sub_tensor_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_sub_tensor_converter.py
@@ -8,6 +8,12 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
+    SubTensor,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import (
@@ -21,12 +27,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
 )
 from executorch.backends.nxp.tests.models import MaxPoolSubTensorModule, SubTensorModule
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    ExecutorchDelegateCall,
-    GetItem,
-    MaxPool2DWithIndices,
-    SubTensor,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_sum_dim_int_list_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_sum_dim_int_list_converter.py
@@ -21,6 +21,13 @@ from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.sum_opt
 from executorch.backends.nxp.backend.ir.tflite_generator.builtin_options.transpose_options import (
     Transpose,
 )
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddTensor,
+    ExecutorchDelegateCall,
+    GetItem,
+    MaxPool2DWithIndices,
+    SumDimIntList,
+)
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
@@ -29,13 +36,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddTensor,
-    ExecutorchDelegateCall,
-    GetItem,
-    MaxPool2DWithIndices,
-    SumDimIntList,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_tanh_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_tanh_converter.py
@@ -7,12 +7,12 @@
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import Convolution, Tanh
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.models import Conv2dWithActivation
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import Convolution, Tanh
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_upsample_bilinear2d.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_upsample_bilinear2d.py
@@ -8,6 +8,11 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddTensor,
+    ExecutorchDelegateCall,
+    UpsampleBilinear2D,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
@@ -17,11 +22,6 @@ from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddTensor,
-    ExecutorchDelegateCall,
-    UpsampleBilinear2D,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_upsample_nearest2d.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_upsample_nearest2d.py
@@ -8,17 +8,17 @@ import numpy as np
 # noinspection PyUnusedImports
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import (
+    AddTensor,
+    ExecutorchDelegateCall,
+    UpsampleNearest2D,
+)
 
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
 from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
-from executorch.backends.nxp.tests.ops_aliases import (
-    AddTensor,
-    ExecutorchDelegateCall,
-    UpsampleNearest2D,
-)
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 
 

--- a/backends/nxp/tests/ir/converter/node_converter/test_view_copy_converter.py
+++ b/backends/nxp/tests/ir/converter/node_converter/test_view_copy_converter.py
@@ -8,16 +8,8 @@ from typing import Sequence
 import numpy as np
 import pytest
 import torch
-from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
-from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
-from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
-from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
-from executorch.backends.nxp.tests.model_output_comparator import (
-    AllCloseOutputComparator,
-)
-from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 
-from executorch.backends.nxp.tests.ops_aliases import (
+from executorch.backends.nxp.backend.ops_aliases import (
     AddMM,
     AddTensor,
     AvgPool2D,
@@ -28,6 +20,14 @@ from executorch.backends.nxp.tests.ops_aliases import (
     Relu,
     ViewCopy,
 )
+from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
+from executorch.backends.nxp.tests.executorch_pipeline import to_quantized_edge_program
+from executorch.backends.nxp.tests.executors import graph_contains_any_of_ops
+from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
+from executorch.backends.nxp.tests.model_output_comparator import (
+    AllCloseOutputComparator,
+)
+from executorch.backends.nxp.tests.nsys_testing import lower_run_compare
 from torch import nn
 from executorch.backends.nxp.tests.use_qat import *  # noqa F403
 

--- a/backends/nxp/tests/ir/edge_passes/test_convert_reshaping_nodes_to_view.py
+++ b/backends/nxp/tests/ir/edge_passes/test_convert_reshaping_nodes_to_view.py
@@ -6,6 +6,7 @@
 import numpy as np
 import pytest
 import torch
+from executorch.backends.nxp.backend.ops_aliases import AddTensor, ViewCopy
 from executorch.backends.nxp.tests.dataset_creator import RandomDatasetCreator
 from executorch.backends.nxp.tests.graph_verifier import DetailedGraphVerifier
 from executorch.backends.nxp.tests.models import SqueezeAddModel, UnsqueezeAddModel
@@ -13,7 +14,6 @@ from executorch.backends.nxp.tests.nsys_testing import (
     AllCloseOutputComparator,
     lower_run_compare,
 )
-from executorch.backends.nxp.tests.ops_aliases import AddTensor, ViewCopy
 
 
 @pytest.fixture(autouse=True)

--- a/backends/nxp/tests/nsys_testing.py
+++ b/backends/nxp/tests/nsys_testing.py
@@ -24,6 +24,7 @@ from executorch.backends.nxp.backend.ir.converter.conversion import translator
 from executorch.backends.nxp.backend.ir.converter.conversion.translator import (
     torch_type_to_numpy_type,
 )
+from executorch.backends.nxp.backend.ops_aliases import ExecutorchDelegateCall
 from executorch.backends.nxp.neutron_partitioner import NeutronPartitioner
 from executorch.backends.nxp.tests.config_importer import test_config
 from executorch.backends.nxp.tests.dataset_creator import (
@@ -44,7 +45,6 @@ from executorch.backends.nxp.tests.graph_verifier import GraphVerifier
 from executorch.backends.nxp.tests.model_output_comparator import (
     AllCloseOutputComparator,
 )
-from executorch.backends.nxp.tests.ops_aliases import ExecutorchDelegateCall
 from executorch.backends.nxp.tests.outputs_dir_importer import outputs_dir
 from executorch.backends.nxp.tests.utils import save_pte_program, store_txt_input_tensor
 


### PR DESCRIPTION
The NXP backend keeps a table of short names for edge operators, for example `AddTensor = exir_ops.edge.aten.add.Tensor`. It lives in the backend's test package, but three modules that ship in the wheel read it at import time:

- `backend/edge_helper.py`
- `backend/node_format_inference.py`
- `edge_passes/move_auxiliary_operator_into_separate_qdq_cluster_pass.py`

Two dozen production files import those modules, so the backend cannot load at all without a test package. The dependency points the wrong way: the tests should depend on the backend, not the backend on the tests.

### What this does

The table has no test logic in it, so it moves to `backend/ops_aliases.py`, next to the code that reads it. That follows the shape the Arm backend already uses for shared operator constants in `backends/arm/constants.py`.

The Buck target that published the table from the test package is removed, since the backend library already globs the directory it moves into.

No behavior changes. The names, values and every importer stay the same, including the roughly fifty tests that use the table.

### Why the diff looks larger than it is

Most of it is one line per file. Every importer switches from `nxp.tests.ops_aliases` to `nxp.backend.ops_aliases`, and because `backend` sorts before `tests`, the import sorter then moves that line to the top of the block. So a one line change shows up as several lines moving in some files. No code changed in any of them.

### Test plan

Imported the moved module and every updated importer from an installed wheel, and confirmed the table exposes the same names bound to the same values as before the move. Compared the alias assignments before and after by parsing both files: 56 aliases, no names added or removed, no values changed.

Checked that every NXP test target can still reach the table, through the backend library that already globs that directory, and that no reference to the old Buck target or the old import path remains anywhere in the tree.

Ran the formatter and linter over all changed files.
