### PR TITLE
Propagate layout permutations through split (#22594)

### DIFF
--- a/backends/transforms/remove_permutes_around_elementwise_ops.py
+++ b/backends/transforms/remove_permutes_around_elementwise_ops.py
@@ -8,6 +8,7 @@
 # pyre-unsafe
 
 from dataclasses import dataclass, field
+from operator import getitem
 from typing import cast
 
 import torch
@@ -98,6 +99,17 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
         exir_ops.edge.aten.view_copy.default,
         exir_ops.edge.aten.view.default,
     )
+
+    _SPLIT_OPS = (exir_ops.edge.aten.split_with_sizes_copy.default,)
+
+    def _split_producer(self, node: torch.fx.Node) -> torch.fx.Node | None:
+        """Return the split feeding ``node`` when it is a getitem off a split."""
+        if node.op != "call_function" or node.target is not getitem:
+            return None
+        src = node.args[0] if node.args else None
+        if isinstance(src, torch.fx.Node) and src.target in self._SPLIT_OPS:
+            return src
+        return None
 
     @staticmethod
     def _concrete_shape(node: torch.fx.Node) -> list[int] | None:
@@ -517,7 +529,11 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
                 if self.get_permutation(inp) != current_start_permute:
                     return False
                 subgraph.edges_in.add((inp, node))
-            elif (inp_val := inp.meta.get("val")) is not None and inp_val.numel() == 1:
+            elif (
+                (inp_val := inp.meta.get("val")) is not None
+                and isinstance(inp_val, torch.Tensor)
+                and inp_val.numel() == 1
+            ):
                 # A numel-1 input (per-tensor quant scale / zero_point, scalar
                 # constant, ...) is layout-invariant: it broadcasts identically
                 # under any permutation, so it needs no compensating permute and
@@ -601,6 +617,11 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
     def is_node_permutable(self, node: torch.fx.Node) -> bool:
         if node.target in self._PAD_OPS and not self._is_constant_pad(node):
             return False
+        # A split and the getitems unpacking it form one rank-preserving unit:
+        # the split's dim is remapped like cat's, and tuple indexing is
+        # layout-invariant.
+        if node.target in self._SPLIT_OPS or self._split_producer(node) is not None:
+            return True
         if node.target in self._permutable_ops:
             if node.target in (
                 exir_ops.edge.aten.mean.dim,
@@ -699,6 +720,8 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
                 self.update_mean_dim(node, node_start_perm)
             elif node.target == exir_ops.edge.aten.slice_copy.Tensor:
                 self.update_slice_copy(node, node_start_perm)
+            elif node.target in self._SPLIT_OPS:
+                self.update_split(node, node_start_perm)
             elif node.target in self._PAD_OPS:
                 self.update_pad(node, node_start_perm)
             elif node.target in self._VIEW_OPS:
@@ -844,6 +867,10 @@ class RemovePermutesAroundElementwiseOps(ExportPass):
         set_arg(node, "dim", [start_permute[d] for d in cast(list[int], dims)])
 
     def update_slice_copy(self, node: torch.fx.Node, start_permute: list[int]) -> None:
+        dim = get_arg(node, "dim", int)
+        set_arg(node, "dim", start_permute[dim])
+
+    def update_split(self, node: torch.fx.Node, start_permute: list[int]) -> None:
         dim = get_arg(node, "dim", int)
         set_arg(node, "dim", start_permute[dim])
 

--- a/backends/transforms/test/test_permute_optimization_passes.py
+++ b/backends/transforms/test/test_permute_optimization_passes.py
@@ -8,6 +8,7 @@
 # pyre-unsafe
 
 import copy
+import operator
 import unittest
 from typing import cast
 
@@ -2391,5 +2392,47 @@ class LayoutPermuteVisibilityTest(unittest.TestCase):
             gm_before,
             gm,
             (torch.randn(1, 2, 3, 4),),
+            "RemovePermutesAroundElementwiseOps",
+        )
+
+    def test_permutes_around_split_and_getitem_are_removed(self) -> None:
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.randn(1, 6, 4))
+        to_nlc = builder.call_operator(
+            op=exir_ops.edge.aten.permute_copy.default, args=(x, [0, 2, 1])
+        )
+        split = builder.call_operator(
+            op=exir_ops.edge.aten.split_with_sizes_copy.default,
+            args=(to_nlc, [2, 4], 2),
+        )
+        lhs = builder.call_operator(op=operator.getitem, args=(split, 0))
+        rhs = builder.call_operator(op=operator.getitem, args=(split, 1))
+        widened = builder.call_operator(
+            op=exir_ops.edge.aten.cat.default, args=([lhs, lhs], 2)
+        )
+        added = builder.call_operator(
+            op=exir_ops.edge.aten.add.Tensor, args=(widened, rhs)
+        )
+        to_ncl = builder.call_operator(
+            op=exir_ops.edge.aten.permute_copy.default, args=(added, [0, 2, 1])
+        )
+        builder.output([to_ncl])
+        original = builder.get_graph_module()
+        gm_before = copy.deepcopy(original)
+
+        result = cast(PassResult, RemovePermutesAroundElementwiseOps()(original))
+        self.assertTrue(result.modified)
+        gm = result.graph_module
+        self.assertEqual(count_node(gm, exir_ops.edge.aten.permute_copy.default), 0)
+        # The split's dim follows the removed permutation, as cat's already did.
+        (split_node,) = gm.graph.find_nodes(
+            op="call_function",
+            target=exir_ops.edge.aten.split_with_sizes_copy.default,
+        )
+        self.assertEqual(split_node.args[2], 1)
+        validate_numerics(
+            gm_before,
+            gm,
+            (torch.randn(1, 6, 4),),
             "RemovePermutesAroundElementwiseOps",
         )


### PR DESCRIPTION
Summary:

Treat a `split_with_sizes_copy` and the `getitem` nodes that unpack it as one rank-preserving unit in `RemovePermutesAroundElementwiseOps`, remapping the split's `dim` under the region's permutation exactly as `cat`'s dim is already remapped. A permutation only reorders axes, so the extent of the split axis is unchanged and `split_sizes` stays valid.

`visit` accepts a region only if every node in its transitive closure is permutable, so a single unrecognised node discards the whole subgraph. `getitem` is a plain `operator.getitem`: it carries no `_op`, so it is not tagged pointwise, it is not in the permutable set, and it is not a view. Any region reaching a split therefore failed, even though tuple indexing is layout-invariant and the split itself only needs its dim remapped.

Guard the numel-one input check with an `isinstance` test. A multi-output op carries a list of fake tensors in `meta["val"]`, and calling `numel()` on that list raises.

Differential Revision: D118743098


