### PR TITLE
Qualcomm AI Engine Direct - Add HTP context graph splitting option

### DIFF
--- a/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendFactory.cpp
@@ -60,6 +60,9 @@ std::unique_ptr<BackendConfigParameters> QnnBackendFactory::Create(
         QNN_EXECUTORCH_LOG_INFO(
             "use_weight_sharing in htp_options: %d",
             htp_options->use_weight_sharing());
+        QNN_EXECUTORCH_LOG_INFO(
+            "use_graph_splitting in htp_options: %d",
+            htp_options->use_graph_splitting());
       }
       backend_params->qnn_backend_cache_ptr_ =
           std::make_unique<HtpBackendCache>(

--- a/backends/qualcomm/runtime/backends/htp/host/HtpContextCustomConfig.cpp
+++ b/backends/qualcomm/runtime/backends/htp/host/HtpContextCustomConfig.cpp
@@ -26,6 +26,27 @@ HtpContextCustomConfig::CreateContextCustomConfig() {
     ret.push_back(static_cast<QnnContext_CustomConfig_t>(p_custom_config));
   }
 
+#if (QNN_HTP_API_VERSION_MAJOR >= 5 && QNN_HTP_API_VERSION_MINOR >= 49)
+  if (htp_options_->use_graph_splitting()) {
+    p_custom_config = AllocContextCustomConfig();
+    p_custom_config->option =
+        QNN_HTP_CONTEXT_CONFIG_OPTION_GRAPH_SPLITTING_CONFIGS;
+    QnnHtpContext_GraphSplit_t graph_split_info;
+    graph_split_info.graphSplittingEnabled = true;
+    p_custom_config->graphSplittingConfigs = graph_split_info;
+    ret.push_back(static_cast<QnnContext_CustomConfig_t>(p_custom_config));
+  }
+#else
+  if (htp_options_->use_graph_splitting()) {
+    QNN_EXECUTORCH_LOG_WARN(
+        "use_graph_splitting is enabled but the QNN SDK used for this build "
+        "(API %d.%d) does not support graph splitting, which requires HTP API "
+        "5.49 or newer. The option will be ignored.",
+        QNN_API_VERSION_MAJOR,
+        QNN_API_VERSION_MINOR);
+  }
+#endif
+
   return ret;
 }
 

--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -205,6 +205,10 @@ table QnnExecuTorchHtpBackendOptions {
   /// It will help the by reducing overall bandwith on the use case.
   /// The feature is only supported by specific SOCs.
   use_slc_allocator:bool;
+
+  /// When enabled, the compiled graph is split based on its structure and
+  /// each part is compiled as an independent subgraph.
+  use_graph_splitting:bool;
 }
 
 /// Real-time: Indicates that the model is intended for real-time use cases, where a specific performance threshold must be met.

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -201,6 +201,7 @@ class QnnExecuTorchHtpBackendOptions:
     use_multi_contexts: bool = False
     use_weight_sharing: bool = False
     use_slc_allocator: bool = False
+    use_graph_splitting: bool = False
 
 
 @unique

--- a/backends/qualcomm/tests/rework/htp/feature/v68/test.py
+++ b/backends/qualcomm/tests/rework/htp/feature/v68/test.py
@@ -15,6 +15,16 @@ from executorch.backends.qualcomm.tests.rework.src.feature import *  # noqa: F40
 @pytest.mark.parametrize(
     "kwargs",
     [
+        pytest.param({"expected": Tolerance()}, id="e2e"),
+    ],
+)
+def test_graph_splitting(request, kwargs):
+    GraphSplit.test_graph_splitting(request, kwargs)  # noqa: F405
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
         pytest.param({"expected": nullcontext()}, id="e2e"),
     ],
 )

--- a/backends/qualcomm/tests/rework/src/feature.py
+++ b/backends/qualcomm/tests/rework/src/feature.py
@@ -71,6 +71,75 @@ def get_quantizer(qnn_config: QnnConfig):
     )
 
 
+class GraphSplit:
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def example_inputs(self):
+            return (torch.randn(1, 2, 3, 4),)
+
+        def forward(self, x):
+            return torch.nn.ReLU()(x)
+
+    @staticmethod
+    def _test(qnn_config, compile_specs, expected):
+        def callback(adb: SimpleADB, pattern):
+            def verify(log):
+                msg = log.stdout
+                assert pattern in msg, f"{pattern} in log"
+
+            # QnnExecuTorchLogLevel.kLogLevelVerbose
+            adb.extra_cmds += " --log_level 4"
+            adb.execute(output_callback=verify)
+
+        with expected:
+            # model declaration
+            model = __class__.Model()
+            inputs = model.example_inputs()
+            # perform ptq
+            with calibrate(
+                model, [inputs], make_quantizer(soc_model=qnn_config.soc_model)
+            ) as model:
+                executorch_prog_mgr = to_edge_transform_and_lower_to_qnn(
+                    module=model,
+                    inputs=inputs,
+                    compiler_specs=compile_specs,
+                ).to_executorch()
+                # file for subgraph 0
+                assert os.path.isfile("forward_schematic.bin_sg_0.py")
+                os.remove("forward_schematic.bin_sg_0.py")
+                # remote testing
+                invoke_remote(
+                    qnn_config=qnn_config,
+                    executorch_prog=executorch_prog_mgr,
+                    callback=partial(callback, pattern="Found blob with gpe enabled"),
+                )
+
+    @staticmethod
+    @unpack_fixtures
+    def test_graph_splitting(qnn_config, compile_specs, expected):
+        # extend this for other backends
+        backend_compile_specs = {
+            QnnExecuTorchBackendType.kHtpBackend: compile_specs(
+                tuple(
+                    {
+                        "soc_model": getattr(QcomChipset, qnn_config.soc_model),
+                        "use_graph_splitting": True,
+                        "use_fp16": False,
+                        "profile_level": 3,
+                    }.items()
+                )
+            ),
+        }
+
+        __class__._test(
+            qnn_config=qnn_config,
+            compile_specs=backend_compile_specs[qnn_config.backend],
+            expected=expected,
+        )
+
+
 class Logging:
     class Model(torch.nn.Module):
         def __init__(self):

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -7208,6 +7208,32 @@ class TestQNNFloatingPointUtils(TestQNN):
         exec_prog = edge_prog.to_executorch()
         self.verify_output(module.get_reference_module(), sample_input, exec_prog)
 
+    @unittest.skipIf(
+        is_qnn_sdk_version_less_than("2.49"),
+        "feature is enable after 2.49.",
+    )
+    def test_qnn_backend_graph_splitting(self):
+        backend_options = generate_htp_compiler_spec(
+            use_fp16=True,
+            use_graph_splitting=True,
+        )
+        compiler_spec = generate_qnn_executorch_compiler_spec(
+            soc_model=self.chipset_table[TestQNN.soc_model],
+            backend_options=backend_options,
+            profile_level=3,
+        )
+        sample_input = (torch.randn([2, 5, 1, 3]),)
+        module = Relu()  # noqa: F405
+        edge_prog_mgr = to_edge_transform_and_lower_to_qnn(
+            module, sample_input, compiler_spec
+        ).to_executorch()
+        # file for subgraph 0
+        self.assertTrue(os.path.isfile("forward_schematic.bin_sg_0.py"))
+        os.remove("forward_schematic.bin_sg_0.py")
+        self.verify_output(
+            module=module, sample_inputs=sample_input, executorch_prog=edge_prog_mgr
+        )
+
     def test_qnn_backend_multi_graphs(self):
         if self.enable_x86_64:
             self.skipTest("weight sharing is not supported on host machine")
@@ -8284,6 +8310,35 @@ class TestQNNQuantizedUtils(TestQNN):
         update_spill_fill_size(edge_prog.exported_program())
         exec_prog = edge_prog.to_executorch()
         self.verify_output(module.get_reference_module(), sample_input, exec_prog)
+
+    @unittest.skipIf(
+        is_qnn_sdk_version_less_than("2.49"),
+        "feature is enable after 2.49.",
+    )
+    def test_qnn_backend_graph_splitting(self):
+        backend_options = generate_htp_compiler_spec(
+            use_fp16=False,
+            use_graph_splitting=True,
+        )
+        compiler_spec = generate_qnn_executorch_compiler_spec(
+            soc_model=self.chipset_table[TestQNN.soc_model],
+            backend_options=backend_options,
+            profile_level=3,
+        )
+        sample_input = (torch.randn([2, 5, 1, 3]),)
+        module = Relu()  # noqa: F405
+        module = self.get_qdq_module(
+            module, sample_input, quant_dtype=QuantDtype.use_8a8w
+        )
+        edge_prog_mgr = to_edge_transform_and_lower_to_qnn(
+            module, sample_input, compiler_spec
+        ).to_executorch()
+        # file for subgraph 0
+        self.assertTrue(os.path.isfile("forward_schematic.bin_sg_0.py"))
+        os.remove("forward_schematic.bin_sg_0.py")
+        self.verify_output(
+            module=module, sample_inputs=sample_input, executorch_prog=edge_prog_mgr
+        )
 
     def test_qnn_backend_multi_graphs(self):
         if self.enable_x86_64:

--- a/backends/qualcomm/utils/utils.py
+++ b/backends/qualcomm/utils/utils.py
@@ -1069,6 +1069,7 @@ def generate_htp_compiler_spec(
     use_multi_contexts: bool = False,
     use_weight_sharing: bool = False,
     use_slc_allocator: bool = False,
+    use_graph_splitting: bool = False,
     htp_performance_mode: QnnExecuTorchHtpPerformanceMode = QnnExecuTorchHtpPerformanceMode.kHtpBurst,
 ) -> QnnExecuTorchBackendOptions:
     """
@@ -1088,6 +1089,8 @@ def generate_htp_compiler_spec(
         use_slc_allocator: Allows user to enable the usage of the System Level Cache Allocator for a given graph.
             It will help the by reducing overall bandwith on the use case.
             The feature is only supported by specific SOCs.
+        use_graph_splitting: When enabled, the compiled graph is split based on
+            its structure and each part is compiled as an independent subgraph.
 
     Returns:
         QnnExecuTorchHtpBackendOptions: backend options for QNN HTP.
@@ -1106,6 +1109,7 @@ def generate_htp_compiler_spec(
     htp_options.use_weight_sharing = use_weight_sharing
     htp_options.use_dlbc = use_dlbc
     htp_options.use_slc_allocator = use_slc_allocator
+    htp_options.use_graph_splitting = use_graph_splitting
     return QnnExecuTorchBackendOptions(
         backend_type=QnnExecuTorchBackendType.kHtpBackend,
         htp_options=htp_options,


### PR DESCRIPTION
## Summary
- Exposes QNN's HTP context graph-splitting config (`QNN_HTP_CONTEXT_CONFIG_OPTION_GRAPH_SPLITTING_CONFIGS` / `QnnHtpContext_GraphSplit_t`) via a new `use_graph_splitting` option on `generate_htp_compiler_spec()`, see https://docs.qualcomm.com/doc/80-63442-10/topic/htp_backend.html. This option significantly reduces finalization time at the cost of a slight increase in execution time.

### Misc
- Wired up for the offline-prepare (host/x86 export) path only, since this feature is used in finalize.
- Gated behind `QNN_HTP_API_VERSION_MAJOR >= 5 && QNN_HTP_API_VERSION_MINOR >= 49` since this option doesn't exist in older QNN_HTP_API_VERSION

## Test plan
```
python backends/qualcomm/tests/test_qnn_delegate.py -k "test_qnn_backend_graph_splitting" --device ef5e4029 --host localhost --soc_model SM8850 --build_folder build-android --executorch_root . 
```

LLAMA3.2 3B performance:
| Graph | Graph Preparation Initializing (us) | Graph Optimizations (us) | Post Graph Optimization (us) | Graph Sequencing for Target (us) | VTCM Allocation (us) | Parallelization Optimization (us) | Finalizing Graph Sequence (us) | Completion (us) | QNN (execute) time (us) |
|---|---|---|---|---|---|---|---|---|---|
| kv_forward1_without_gpe | 1146 | 26843138 | 433549 | 6828982 | 449030 | 5929118 | 266695 | 15171 | 9552 |
| kv_forward1_with_gpe | 496 | 2014382 | 26630 | 427743 | 27504 | 246911 | 22066 | 1268 | 9880 |
| kv_forward2_without_gpe | 373 | 27618966 | 1049136 | 10700233 | 313808 | 7947260 | 291464 | 14841 | 9452 |
| kv_forward2_with_gpe | 599 | 2511473 | 34099 | 577162 | 36742 | 353654 | 31248 | 1754 | 9787 |
| kv_forward3_without_gpe | 405 | 30262309 | 541066 | 8523872 | 407082 | 8058194 | 314898 | 16692 | 11136 |
| kv_forward3_with_gpe | 512 | 5575498 | 75421 | 1322133 | 111640 | 1009982 | 51157 | 3371 | 11437 |
| kv_forward4_without_gpe | 1966 | 10304161 | 36241 | 1151113 | 87287 | 749097 | 34706 | 1944 | 6703 |
| kv_forward4_with_gpe | 342 | 8387236 | 41997 | 1104533 | 96270 | 870457 | 31896 | 2245 | 6686 |
| prefill_forward1_without_gpe | 403 | 23425582 | 521963 | 20288202 | 28141820 | 13415019 | 534725 | 19491 | 23283 |
| prefill_forward1_with_gpe | 635 | 2404414 | 42852 | 928676 | 607167 | 368336 | 25194 | 1790 | 20824 |
| prefill_forward2_without_gpe | 354 | 22249865 | 496426 | 16837420 | 24738364 | 9634081 | 464298 | 16200 | 20473 |
| prefill_forward2_with_gpe | 557 | 2521494 | 41107 | 929431 | 765368 | 426039 | 28336 | 1955 | 20764 |
| prefill_forward3_without_gpe | 744 | 31356868 | 553758 | 17889195 | 17232990 | 9485483 | 500217 | 15025 | 21125 |
| prefill_forward3_with_gpe | 1933 | 5689220 | 99188 | 2404130 | 2256161 | 1236475 | 79918 | 6054 | 21835 |
| prefill_forward4_without_gpe | 889 | 10117697 | 43571 | 1450046 | 1323893 | 1062400 | 35717 | 2122 | 9431 |
| prefill_forward4_with_gpe | 331 | 8484639 | 50456 | 1647489 | 1798310 | 1306534 | 45152 | 2760 | 9446 |

This table is created by extracting data from finalization log:
<img width="392" height="351" alt="image" src="https://github.com/user-attachments/assets/76f876f3-5084-4ac3-8be6-54b7971402e8" />


This PR was authored with assistance from Claude Code (Anthropic).


cc @cbilgin @psiddh