### PR TITLE
Arm backend: Report CPU time per inference for Ethos-U on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1740,6 +1740,11 @@ if(EXECUTORCH_BUILD_EXECUTOR_RUNNER)
     target_compile_definitions(
       executor_runner PRIVATE EXECUTORCH_BUILD_ARM_ETHOSU_LINUX=1
     )
+    target_sources(
+      executor_runner
+      PRIVATE
+        ${EXECUTORCH_ROOT}/examples/arm/executor_runner/arm_perf_monitor.cpp
+    )
     target_link_libraries(
       executor_runner
       PRIVATE $<LINK_LIBRARY:WHOLE_ARCHIVE,executorch_delegate_ethos_u>

--- a/examples/arm/executor_runner/arm_perf_monitor.cpp
+++ b/examples/arm/executor_runner/arm_perf_monitor.cpp
@@ -339,6 +339,68 @@ void StopMeasurements(int num_inferences) {
 #endif
 }
 
+#elif defined(EXECUTORCH_BUILD_ARM_ETHOSU_LINUX)
+#include <time.h>
+
+#include <executorch/runtime/platform/log.h>
+
+namespace {
+static inline uint64_t arm_cpu_time_ns() {
+  struct timespec ts;
+  clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ull + ts.tv_nsec;
+}
+
+uint32_t ethosu_delegation_count = 0;
+uint64_t ethosu_ArmCpuTimeStart = 0;
+uint64_t ethosu_ArmBackendExecuteCpuTimeStart = 0;
+uint64_t ethosu_ArmBackendExecuteCpuTime = 0;
+} // namespace
+
+extern "C" {
+// Callback invoked at start of EthosUBackend::execute()
+void EthosUBackend_execute_begin() {
+  ethosu_ArmBackendExecuteCpuTimeStart = arm_cpu_time_ns();
+}
+
+// Callback invoked at end of EthosUBackend::execute()
+void EthosUBackend_execute_end() {
+  ethosu_ArmBackendExecuteCpuTime +=
+      arm_cpu_time_ns() - ethosu_ArmBackendExecuteCpuTimeStart;
+  ethosu_delegation_count++;
+}
+}
+
+void StartMeasurements() {
+  ethosu_delegation_count = 0;
+  ethosu_ArmBackendExecuteCpuTime = 0;
+  ethosu_ArmCpuTimeStart = arm_cpu_time_ns();
+}
+
+void StopMeasurements(int num_inferences) {
+  const uint64_t cpu_time = arm_cpu_time_ns() - ethosu_ArmCpuTimeStart;
+
+  ET_LOG(Info, "NPU Inferences : %d", num_inferences);
+  ET_LOG(
+      Info,
+      "NPU delegations: %" PRIu32 " (%.2f per inference)",
+      ethosu_delegation_count,
+      (double)ethosu_delegation_count / num_inferences);
+  ET_LOG(Info, "Profiler report, CPU time per operator:");
+  // CPU time spent in EthosUBackend::execute(), summed over all delegations
+  ET_LOG(
+      Info,
+      "ethos-u : cpu_time : %.3f ms (%.3f ms per inference)",
+      ethosu_ArmBackendExecuteCpuTime / 1e6,
+      ethosu_ArmBackendExecuteCpuTime / 1e6 / num_inferences);
+  // CPU time of the whole measured region, delegated and non-delegated work
+  ET_LOG(
+      Info,
+      "Inference runtime: %.3f ms CPU time total (%.3f ms per inference)",
+      cpu_time / 1e6,
+      cpu_time / 1e6 / num_inferences);
+}
+
 #else
 // cppcheck-suppress unusedFunction
 void StartMeasurements() {}

--- a/examples/portable/executor_runner/executor_runner.cpp
+++ b/examples/portable/executor_runner/executor_runner.cpp
@@ -42,6 +42,9 @@
 #include <executorch/runtime/platform/log.h>
 #include <executorch/runtime/platform/platform.h>
 #include <executorch/runtime/platform/runtime.h>
+#if defined(EXECUTORCH_BUILD_ARM_ETHOSU_LINUX)
+#include <executorch/examples/arm/executor_runner/arm_perf_monitor.h>
+#endif
 #ifdef ET_EVENT_TRACER_ENABLED
 #include <executorch/devtools/etdump/etdump_flatcc.h>
 #endif // ET_EVENT_TRACER_ENABLED
@@ -720,6 +723,9 @@ int main(int argc, char** argv) {
   }
 
   et_timestamp_t time_spent_executing = 0;
+#if defined(EXECUTORCH_BUILD_ARM_ETHOSU_LINUX)
+  StartMeasurements();
+#endif
   // Run the model.
   for (uint32_t i = 0; i < FLAGS_num_executions; i++) {
     // Allocate input tensors and set all of their elements to 1 or to the
@@ -784,6 +790,9 @@ int main(int argc, char** argv) {
         static_cast<double>(iter_elapsed) * iter_tick_ratio.numerator /
             iter_tick_ratio.denominator / 1000000.0);
   }
+#if defined(EXECUTORCH_BUILD_ARM_ETHOSU_LINUX)
+  StopMeasurements(FLAGS_num_executions);
+#endif
   const auto tick_ratio = et_pal_ticks_to_ns_multiplier();
   constexpr auto NANOSECONDS_PER_MILLISECOND = 1000000;
   ET_LOG(


### PR DESCRIPTION
### Summary
`EthosUBackend::execute()` calls the `EthosUBackend_execute_begin()` / `EthosUBackend_execute_end()` hooks around each delegated inference.
- The Cortex-M runner reports the CPU time spent in `EthosUBackend::execute()` per inference.
- The Linux runtime runner does not.

I added a Linux branch to `arm_perf_monitor.cpp` to measure the CPU time saved by a Linux runtime change (#22599)

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani