### PR TITLE
Arm backend: Stop re-creating Ethos-U driver objects per inference on Linux

### DIFF
--- a/backends/arm/runtime/EthosUBackend.cpp
+++ b/backends/arm/runtime/EthosUBackend.cpp
@@ -138,7 +138,7 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
       return read_status;
     }
 
-    handle->platform_state = platform_init(compile_specs, allocator);
+    handle->platform_state = platform_init(compile_specs, allocator, handle);
 
     // Return the same buffer we were passed - this data will be
     // executed directly

--- a/backends/arm/runtime/EthosUBackend.cpp
+++ b/backends/arm/runtime/EthosUBackend.cpp
@@ -138,7 +138,12 @@ class EthosUBackend final : public ::executorch::runtime::BackendInterface {
       return read_status;
     }
 
-    handle->platform_state = platform_init(compile_specs, allocator, handle);
+    const Error platform_status =
+        platform_init(compile_specs, allocator, handle);
+    if (platform_status != Error::Ok) {
+      delete handle;
+      return platform_status;
+    }
 
     // Return the same buffer we were passed - this data will be
     // executed directly

--- a/backends/arm/runtime/EthosUBackend_Cortex_A.cpp
+++ b/backends/arm/runtime/EthosUBackend_Cortex_A.cpp
@@ -358,21 +358,23 @@ Error create_driver_objects(const VelaHandles& handles, PlatformState* state) {
 
 // Used by EthosUBackend.cpp through EthosUBackend_Internal.h.
 // cppcheck-suppress unusedFunction
-PlatformState* platform_init(
+Error platform_init(
     ArrayRef<CompileSpec> specs,
     MemoryAllocator* allocator,
-    const ExecutionHandle* handle) {
+    ExecutionHandle* handle) {
   (void)allocator;
   PlatformState* state = new (std::nothrow) PlatformState();
   if (state == nullptr) {
-    return nullptr;
+    return Error::MemoryAllocationFailed;
   }
   state->options = parse_linux_options(specs);
-  if (create_driver_objects(handle->handles, state) != Error::Ok) {
+  const Error status = create_driver_objects(handle->handles, state);
+  if (status != Error::Ok) {
     delete state;
-    return nullptr;
+    return status;
   }
-  return state;
+  handle->platform_state = state;
+  return Error::Ok;
 }
 
 // Used by EthosUBackend.cpp through EthosUBackend_Internal.h.

--- a/backends/arm/runtime/EthosUBackend_Cortex_A.cpp
+++ b/backends/arm/runtime/EthosUBackend_Cortex_A.cpp
@@ -49,6 +49,11 @@ struct LinuxDriverOptions {
 
 struct PlatformState {
   LinuxDriverOptions options;
+  std::shared_ptr<EthosU::Network> network;
+  std::shared_ptr<EthosU::Buffer> constant_buffer;
+  std::shared_ptr<EthosU::Buffer> intermediate_buffer;
+  std::vector<std::shared_ptr<EthosU::Buffer>> ifm_buffers;
+  std::vector<std::shared_ptr<EthosU::Buffer>> ofm_buffers;
 };
 
 namespace {
@@ -181,35 +186,9 @@ Error invoke_linux_driver(
     const std::vector<char*>& output_ptrs,
     const std::vector<size_t>& input_copy_sizes,
     const std::vector<size_t>& output_copy_sizes,
-    const LinuxDriverOptions& options) {
-  if (handles.outputs == nullptr) {
-    ET_LOG(Error, "Ethos-U backend missing output metadata");
-    return Error::InvalidProgram;
-  }
+    const PlatformState& state) {
+  const LinuxDriverOptions& options = state.options;
   try {
-    EthosU::Device& device = get_linux_device_cache().get(options.device_path);
-    auto network = std::make_shared<EthosU::Network>(
-        device,
-        reinterpret_cast<const unsigned char*>(handles.cmd_data),
-        handles.cmd_data_size);
-
-    std::shared_ptr<EthosU::Buffer> constant_buffer =
-        std::make_shared<EthosU::Buffer>();
-    if (handles.weight_data_size > 0) {
-      auto constant_buffers = device.createBuffers({handles.weight_data_size});
-      constant_buffer = constant_buffers.front();
-      constant_buffer->write(
-          const_cast<char*>(handles.weight_data), handles.weight_data_size);
-    }
-
-    std::shared_ptr<EthosU::Buffer> intermediate_buffer =
-        std::make_shared<EthosU::Buffer>();
-    if (handles.scratch_data_size > 0) {
-      auto scratch_buffers = device.createBuffers({handles.scratch_data_size});
-      intermediate_buffer = scratch_buffers.front();
-    }
-
-    std::vector<std::shared_ptr<EthosU::Buffer>> ifm_buffers;
     if (handles.inputs != nullptr && handles.inputs->count > 0) {
       if (input_copy_sizes.size() !=
           static_cast<size_t>(handles.inputs->count)) {
@@ -228,7 +207,6 @@ Error invoke_linux_driver(
             input_copy_sizes.size());
         return Error::InvalidState;
       }
-      ifm_buffers = device.createBuffers(input_copy_sizes);
       for (int i = 0; i < handles.inputs->count; ++i) {
         const size_t copy_size = input_copy_sizes[i];
         if (copy_size == 0) {
@@ -239,7 +217,7 @@ Error invoke_linux_driver(
           ET_LOG(Error, "Missing input buffer for index %d", i);
           return Error::InvalidState;
         }
-        ifm_buffers[i]->write(const_cast<char*>(src), copy_size);
+        state.ifm_buffers[i]->write(const_cast<char*>(src), copy_size);
       }
     }
 
@@ -260,16 +238,14 @@ Error invoke_linux_driver(
           output_copy_sizes.size());
       return Error::InvalidState;
     }
-    auto ofm_buffers = device.createBuffers(output_copy_sizes);
-
     auto inference = std::make_unique<EthosU::Inference>(
-        network,
-        ifm_buffers.begin(),
-        ifm_buffers.end(),
-        ofm_buffers.begin(),
-        ofm_buffers.end(),
-        intermediate_buffer,
-        constant_buffer,
+        state.network,
+        state.ifm_buffers.begin(),
+        state.ifm_buffers.end(),
+        state.ofm_buffers.begin(),
+        state.ofm_buffers.end(),
+        state.intermediate_buffer,
+        state.constant_buffer,
         options.pmu_events,
         options.enable_cycle_counter);
 
@@ -311,10 +287,68 @@ Error invoke_linux_driver(
         ET_LOG(Error, "Missing output buffer for index %d", i);
         return Error::InvalidState;
       }
-      ofm_buffers[i]->read(dst, copy_size);
+      state.ofm_buffers[i]->read(dst, copy_size);
     }
   } catch (const std::exception& e) {
     ET_LOG(Error, "Ethos-U Linux driver invocation failed: %s", e.what());
+    return Error::InvalidState;
+  }
+
+  return Error::Ok;
+}
+
+// Get the byte size of an IO tensor from its Vela descriptor.
+size_t vela_io_bytes(const VelaIO& io) {
+  size_t count = 1;
+  for (int i = 0; i < shapeDim; i++) {
+    count *= static_cast<size_t>(io.shape[i]);
+  }
+  return count * static_cast<size_t>(io.elem_size);
+}
+
+// Created once in platform_init(), reused by every invoke_linux_driver().
+Error create_driver_objects(const VelaHandles& handles, PlatformState* state) {
+  if (handles.outputs == nullptr) {
+    ET_LOG(Error, "Ethos-U backend missing output metadata");
+    return Error::InvalidProgram;
+  }
+  const LinuxDriverOptions& options = state->options;
+  try {
+    EthosU::Device& device = get_linux_device_cache().get(options.device_path);
+    state->network = std::make_shared<EthosU::Network>(
+        device,
+        reinterpret_cast<const unsigned char*>(handles.cmd_data),
+        handles.cmd_data_size);
+
+    state->constant_buffer = std::make_shared<EthosU::Buffer>();
+    if (handles.weight_data_size > 0) {
+      auto constant_buffers = device.createBuffers({handles.weight_data_size});
+      state->constant_buffer = constant_buffers.front();
+      state->constant_buffer->write(
+          const_cast<char*>(handles.weight_data), handles.weight_data_size);
+    }
+
+    state->intermediate_buffer = std::make_shared<EthosU::Buffer>();
+    if (handles.scratch_data_size > 0) {
+      auto scratch_buffers = device.createBuffers({handles.scratch_data_size});
+      state->intermediate_buffer = scratch_buffers.front();
+    }
+
+    if (handles.inputs != nullptr && handles.inputs->count > 0) {
+      std::vector<size_t> ifm_sizes;
+      for (int i = 0; i < handles.inputs->count; ++i) {
+        ifm_sizes.push_back(vela_io_bytes(handles.inputs->io[i]));
+      }
+      state->ifm_buffers = device.createBuffers(ifm_sizes);
+    }
+
+    std::vector<size_t> ofm_sizes;
+    for (int i = 0; i < handles.outputs->count; ++i) {
+      ofm_sizes.push_back(vela_io_bytes(handles.outputs->io[i]));
+    }
+    state->ofm_buffers = device.createBuffers(ofm_sizes);
+  } catch (const std::exception& e) {
+    ET_LOG(Error, "Ethos-U Linux driver setup failed: %s", e.what());
     return Error::InvalidState;
   }
 
@@ -326,13 +360,18 @@ Error invoke_linux_driver(
 // cppcheck-suppress unusedFunction
 PlatformState* platform_init(
     ArrayRef<CompileSpec> specs,
-    MemoryAllocator* allocator) {
+    MemoryAllocator* allocator,
+    const ExecutionHandle* handle) {
   (void)allocator;
   PlatformState* state = new (std::nothrow) PlatformState();
   if (state == nullptr) {
     return nullptr;
   }
   state->options = parse_linux_options(specs);
+  if (create_driver_objects(handle->handles, state) != Error::Ok) {
+    delete state;
+    return nullptr;
+  }
   return state;
 }
 
@@ -401,7 +440,7 @@ Error platform_execute(
       linux_output_ptrs,
       input_copy_sizes,
       output_io_bytes,
-      state->options);
+      *state);
   if (status != Error::Ok) {
     return status;
   }

--- a/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
+++ b/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
@@ -54,11 +54,11 @@ namespace arm {
 
 struct PlatformState {};
 
-PlatformState* platform_init(
+executorch::runtime::Error platform_init(
     executorch::runtime::ArrayRef<executorch::runtime::CompileSpec> /*specs*/,
     executorch::runtime::MemoryAllocator* /*allocator*/,
-    const ExecutionHandle* /*handle*/) {
-  return nullptr;
+    ExecutionHandle* /*handle*/) {
+  return executorch::runtime::Error::Ok;
 }
 
 void platform_destroy(PlatformState* state) {

--- a/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
+++ b/backends/arm/runtime/EthosUBackend_Cortex_M.cpp
@@ -56,7 +56,8 @@ struct PlatformState {};
 
 PlatformState* platform_init(
     executorch::runtime::ArrayRef<executorch::runtime::CompileSpec> /*specs*/,
-    executorch::runtime::MemoryAllocator* /*allocator*/) {
+    executorch::runtime::MemoryAllocator* /*allocator*/,
+    const ExecutionHandle* /*handle*/) {
   return nullptr;
 }
 

--- a/backends/arm/runtime/EthosUBackend_Internal.h
+++ b/backends/arm/runtime/EthosUBackend_Internal.h
@@ -84,7 +84,8 @@ extern size_t ethosu_fast_scratch_size;
 
 PlatformState* platform_init(
     executorch::runtime::ArrayRef<executorch::runtime::CompileSpec> specs,
-    executorch::runtime::MemoryAllocator* allocator);
+    executorch::runtime::MemoryAllocator* allocator,
+    const ExecutionHandle* handle);
 
 void platform_destroy(PlatformState* state);
 

--- a/backends/arm/runtime/EthosUBackend_Internal.h
+++ b/backends/arm/runtime/EthosUBackend_Internal.h
@@ -82,10 +82,10 @@ extern unsigned char* ethosu_fast_scratch;
 extern size_t ethosu_fast_scratch_size;
 }
 
-PlatformState* platform_init(
+executorch::runtime::Error platform_init(
     executorch::runtime::ArrayRef<executorch::runtime::CompileSpec> specs,
     executorch::runtime::MemoryAllocator* allocator,
-    const ExecutionHandle* handle);
+    ExecutionHandle* handle);
 
 void platform_destroy(PlatformState* state);
 


### PR DESCRIPTION
## Problem

On the Cortex-A path, the same driver setup is redone on every inference.

```mermaid
sequenceDiagram
    participant ET as EthosUBackend
    participant CA as Cortex-A platform
    participant K as Kernel driver

    ET->>CA: init()
    loop every execute()
        ET->>CA: execute(inputs)
        Note over K: allocated and freed on every inference
        rect rgb(255, 225, 225)
            CA->>K: create network, weight, intermediate, IFM/OFM buffers<br/>(copies command stream and weights)
        end
        CA->>K: write inputs
        CA->>K: run inference
        K-->>CA: outputs
        CA->>K: free all of them
        CA-->>ET: outputs
    end
```

## Changes

```mermaid
sequenceDiagram
    participant ET as EthosUBackend
    participant CA as Cortex-A platform
    participant K as Kernel driver

    ET->>CA: init()
    Note over K: allocated once, freed in destroy()
    rect rgb(225, 245, 225)
        CA->>K: create network, weight, intermediate, IFM/OFM buffers<br/>(copies command stream and weights)
    end
    loop every execute()
        ET->>CA: execute(inputs)
        CA->>K: write inputs
        CA->>K: run inference
        K-->>CA: outputs
        CA-->>ET: outputs
    end
    ET->>CA: destroy()
    CA->>K: free all of them
```

This commit creates the driver objects once in `platform_init()` and keeps them in `PlatformState` for the lifetime of the loaded method.<br>
`invoke_linux_driver()` now only writes the inputs, runs the inference, and reads the outputs.

| Piece | Change |
| --- | --- |
| `PlatformState` | Holds the driver objects: network, weight buffer, intermediate buffer, IFM and OFM buffers |
| `invoke_linux_driver()` | Setup removed; takes `const PlatformState&` and reuses its objects on each inference |
| `create_driver_objects()` | The setup part moved out of `invoke_linux_driver()` |

## Measurement

These results were measured on the Corstone-1000 A320 FVP (Ethos-U85) using the CPU time report from #22596.

| Model | `execute()` CPU time per inference, before -> after | Saved |
| --- | --- | --- |
| ResNet8 | 2.60 -> 0.93 ms | 64% |
| DS-CNN | 1.99 -> 0.93 ms | 53% |
| MobileNetV1 0.25 | 4.35 -> 1.01 ms | 77% |
| DeepAutoEncoder | 3.97 -> 0.93 ms | 77% |

- Outputs byte-identical and NPU cycle counter unchanged for all four models.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani