### PR TITLE
Arm backend: Improve handling of inputting mutable buffers to ref model

### DIFF
--- a/backends/arm/test/tester/arm_tester.py
+++ b/backends/arm/test/tester/arm_tester.py
@@ -232,18 +232,13 @@ class ToEdgeTransformAndLower(BaseStages.ToEdgeTransformAndLower):
 class ToExecutorch(BaseStages.ToExecutorch):
     def run_artifact(self, inputs):
         with TosaReferenceModelDispatch():
-            # Check if the model has mutable buffers. These are not delegated to the backend
-            # and are handled by core ExecuTorch as I/O. In other words, the mutable buffer
-            # is outputted and re-inputted into the model. As we are calling the graph module
-            # directly, we need to ensure we handle these extra mutable inputs.
-            if (
-                len(self.artifact.exported_program().graph_signature.buffers_to_mutate)
-                > 0
-            ):
-                buffers = list(self.artifact.exported_program().buffers())
-                buffers.extend(inputs)
-
-                return self.artifact.exported_program().graph_module(*buffers)
+            program = self.artifact.exported_program()
+            # Mutable inputs and other parameters become inputs to the graph
+            # so we need to input these in the correct order.
+            # Also, execute the raw graph to preserve mutation outputs for comparison.
+            if program.graph_signature.buffers_to_mutate:
+                flat_inputs = program._graph_module_flat_inputs(inputs, {})
+                return program.graph_module(*flat_inputs)
             else:
                 return super().run_artifact(inputs)
 


### PR DESCRIPTION
* Use _graph_module_flat_inputs to get all inputs in correct order

Signed-off-by: Tom Allsop <tom.allsop@arm.com>

Change-Id: I1b22ac2f9af53a120f969ef67bd42fc986eea60e


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani