### PR TITLE
Arm backend: Add tests for Stable Diffusion 3.5 Large model

### DIFF
--- a/backends/arm/test/models/stable_diffusion_3_5_large/test_CLIPTextModelWithProjection_sd35_large.py
+++ b/backends/arm/test/models/stable_diffusion_3_5_large/test_CLIPTextModelWithProjection_sd35_large.py
@@ -1,0 +1,228 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import pytest
+import torch
+from executorch.backends.arm._passes import (
+    ConvertInt64ConstOpsToInt32Pass,
+    ConvertInt64OutputOpsToInt32Pass,
+    InsertInt32CastsAfterInt64PlaceholdersPass,
+)
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.models.stable_diffusion_3_5_large.test_configs_sd35_large import (
+    get_tiny_sd35_large_text_encoder_2_config,
+    get_tiny_sd35_large_text_encoder_config,
+)
+from executorch.backends.arm.test.tester.test_pipeline import (
+    TosaPipelineFP,
+    TosaPipelineINT,
+    VgfPipeline,
+)
+from executorch.examples.models.stable_diffusion_3_5_large.model import (
+    SD3CLIPTextEncoderWrapper,
+)
+from transformers import CLIPTextModelWithProjection
+
+input_t = Tuple[torch.Tensor]
+
+_INT64_TO_INT32_PASSES = [
+    ConvertInt64ConstOpsToInt32Pass(),
+    ConvertInt64OutputOpsToInt32Pass(),
+    InsertInt32CastsAfterInt64PlaceholdersPass(),
+]
+
+
+class TestCLIPTextModelWithProjection:
+    """Test helper for SD3.5 Large CLIPTextModelWithProjection configs."""
+
+    ops_after_partitioner_FP = {
+        "executorch_exir_dialects_edge__ops_aten_argmax_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_slice_copy_Tensor": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 2,
+        "torch.ops.higher_order.executorch_call_delegate": 2,
+    }
+
+    ops_after_partitioner_vgf_no_quantize = {
+        "executorch_exir_dialects_edge__ops_aten_argmax_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 2,
+        "torch.ops.higher_order.executorch_call_delegate": 2,
+    }
+    ops_after_partitioner_vgf_quantize = {
+        "executorch_exir_dialects_edge__ops_aten_argmax_default": 1,
+        "executorch_exir_dialects_edge__ops_aten_view_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 2,
+        "torch.ops.higher_order.executorch_call_delegate": 1,
+    }
+
+    def create_dummy_inputs(
+        self,
+        config,
+        batch_size: int = 1,
+        seq_length: int = 2,
+        dtype: torch.dtype = torch.long,
+    ) -> tuple[torch.Tensor]:
+        """Create dummy inputs for the CLIPTextModelWithProjection tests."""
+        # SD3.5 Large uses (batch_size, seq_length) = (1, 77) for both CLIP-L
+        # and CLIP-bigG. Keep this unit-test default smaller for TOSA runtime.
+        return (
+            torch.randint(
+                low=0,
+                high=config.vocab_size,
+                size=(batch_size, seq_length),
+                dtype=dtype,
+            ),
+        )
+
+    def create_model(
+        self,
+        config,
+    ) -> SD3CLIPTextEncoderWrapper:
+        """Instantiate wrapped CLIPTextModelWithProjection for tests."""
+        return SD3CLIPTextEncoderWrapper(
+            CLIPTextModelWithProjection(config).to(dtype=config.dtype)  # type: ignore[call-arg]
+        ).eval()
+
+    @staticmethod
+    def ops_after_partitioner_INT(config) -> dict[str, int]:
+        if config.num_hidden_layers == 2:
+            return {
+                "executorch_exir_dialects_edge__ops_aten_add_Tensor": 2,
+                "executorch_exir_dialects_edge__ops_aten_argmax_default": 1,
+                "executorch_exir_dialects_edge__ops_aten_where_self": 2,
+                "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 12,
+                "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 18,
+                "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 12,
+                "torch.ops.higher_order.executorch_call_delegate": 7,
+            }
+
+        raise ValueError(
+            f"Unexpected CLIP config: hidden_act={config.hidden_act}, "
+            f"num_hidden_layers={config.num_hidden_layers}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("config_factory", "atol"),
+    (
+        (get_tiny_sd35_large_text_encoder_config, 1e-2),  # FP atol
+        (get_tiny_sd35_large_text_encoder_2_config, 1.5e-2),  # FP atol
+    ),
+    ids=("text_encoder", "text_encoder_2"),
+)
+def test_clip_text_model_with_projection_tosa_FP(config_factory, atol):
+    """Run the CLIPTextModelWithProjection TOSA FP test for a given config."""
+    test_helper = TestCLIPTextModelWithProjection()
+    config = config_factory()
+
+    with torch.no_grad():
+        pipeline = TosaPipelineFP[input_t](
+            test_helper.create_model(config),
+            test_helper.create_dummy_inputs(config),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            atol=atol,
+            transform_passes=_INT64_TO_INT32_PASSES,
+        )
+        pipeline.change_args(
+            "check_count.exir", TestCLIPTextModelWithProjection.ops_after_partitioner_FP
+        )
+        pipeline.run()
+
+
+@pytest.mark.parametrize(
+    ("config_factory", "atol"),
+    (
+        (get_tiny_sd35_large_text_encoder_config, 5.5e-2),  # INT atol
+        (get_tiny_sd35_large_text_encoder_2_config, 6e-2),  # INT atol
+    ),
+    ids=("text_encoder", "text_encoder_2"),
+)
+def test_clip_text_model_with_projection_tosa_INT(config_factory, atol):
+    """Run the CLIPTextModelWithProjection TOSA INT test for a given config."""
+    test_helper = TestCLIPTextModelWithProjection()
+    config = config_factory()
+
+    with torch.no_grad():
+        pipeline = TosaPipelineINT[input_t](
+            test_helper.create_model(config),
+            test_helper.create_dummy_inputs(config),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            atol=atol,
+            frobenius_threshold=None,
+            cosine_threshold=None,
+        )
+        pipeline.change_args(
+            "check_count.exir",
+            TestCLIPTextModelWithProjection.ops_after_partitioner_INT(config),
+        )
+        pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+@pytest.mark.parametrize(
+    ("config_factory",),
+    (
+        (get_tiny_sd35_large_text_encoder_config,),
+        (get_tiny_sd35_large_text_encoder_2_config,),
+    ),
+    ids=("text_encoder", "text_encoder_2"),
+)
+def test_clip_text_model_with_projection_vgf_no_quant(config_factory):
+    """Run the CLIPTextModelWithProjection VGF no-quant test."""
+    test_helper = TestCLIPTextModelWithProjection()
+    config = config_factory()
+
+    with torch.no_grad():
+        pipeline = VgfPipeline[input_t](
+            test_helper.create_model(config),
+            test_helper.create_dummy_inputs(config),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            atol=5e-3,
+            transform_passes=_INT64_TO_INT32_PASSES,
+            quantize=False,
+        )
+        pipeline.change_args(
+            "check_count.exir",
+            TestCLIPTextModelWithProjection.ops_after_partitioner_vgf_no_quantize,
+        )
+        pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+@pytest.mark.parametrize(
+    ("config_factory", "atol"),
+    (
+        (get_tiny_sd35_large_text_encoder_config, 5.5e-2),
+        (get_tiny_sd35_large_text_encoder_2_config, 6e-2),
+    ),
+    ids=("text_encoder", "text_encoder_2"),
+)
+def test_clip_text_model_with_projection_vgf_quant(config_factory, atol):
+    """Run the CLIPTextModelWithProjection VGF quant test."""
+    test_helper = TestCLIPTextModelWithProjection()
+    config = config_factory()
+
+    with torch.no_grad():
+        pipeline = VgfPipeline[input_t](
+            test_helper.create_model(config),
+            test_helper.create_dummy_inputs(config),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            atol=atol,
+            quantize=True,
+        )
+        pipeline.change_args(
+            "check_count.exir",
+            TestCLIPTextModelWithProjection.ops_after_partitioner_vgf_quantize,
+        )
+        pipeline.run()

--- a/backends/arm/test/models/stable_diffusion_3_5_large/test_CLIPTextModelWithProjection_sd35_large.py
+++ b/backends/arm/test/models/stable_diffusion_3_5_large/test_CLIPTextModelWithProjection_sd35_large.py
@@ -7,13 +7,9 @@ from typing import Tuple
 
 import pytest
 import torch
-from executorch.backends.arm._passes import (
-    ConvertInt64ConstOpsToInt32Pass,
-    ConvertInt64OutputOpsToInt32Pass,
-    InsertInt32CastsAfterInt64PlaceholdersPass,
-)
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.models.stable_diffusion_3_5_large.test_configs_sd35_large import (
+    get_int64_to_int32_passes,
     get_tiny_sd35_large_text_encoder_2_config,
     get_tiny_sd35_large_text_encoder_config,
 )
@@ -28,12 +24,6 @@ from executorch.examples.models.stable_diffusion_3_5_large.model import (
 from transformers import CLIPTextModelWithProjection
 
 input_t = Tuple[torch.Tensor]
-
-_INT64_TO_INT32_PASSES = [
-    ConvertInt64ConstOpsToInt32Pass(),
-    ConvertInt64OutputOpsToInt32Pass(),
-    InsertInt32CastsAfterInt64PlaceholdersPass(),
-]
 
 
 class TestCLIPTextModelWithProjection:
@@ -126,7 +116,7 @@ def test_clip_text_model_with_projection_tosa_FP(config_factory, atol):
             exir_op=[],
             use_to_edge_transform_and_lower=True,
             atol=atol,
-            transform_passes=_INT64_TO_INT32_PASSES,
+            transform_passes=get_int64_to_int32_passes(),
         )
         pipeline.change_args(
             "check_count.exir", TestCLIPTextModelWithProjection.ops_after_partitioner_FP
@@ -187,7 +177,7 @@ def test_clip_text_model_with_projection_vgf_no_quant(config_factory):
             exir_op=[],
             use_to_edge_transform_and_lower=True,
             atol=5e-3,
-            transform_passes=_INT64_TO_INT32_PASSES,
+            transform_passes=get_int64_to_int32_passes(),
             quantize=False,
         )
         pipeline.change_args(

--- a/backends/arm/test/models/stable_diffusion_3_5_large/test_SD3Transformer2DModel_sd35_large.py
+++ b/backends/arm/test/models/stable_diffusion_3_5_large/test_SD3Transformer2DModel_sd35_large.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import pytest
+import torch
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.models.stable_diffusion_3_5_large.test_configs_sd35_large import (
+    get_tiny_sd35_large_transformer_config,
+)
+from executorch.backends.arm.test.tester.test_pipeline import (
+    TosaPipelineFP,
+    TosaPipelineINT,
+    VgfPipeline,
+)
+from executorch.examples.models.stable_diffusion_3_5_large.model import (
+    SD3TransformerWrapper,
+)
+
+input_t4 = Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
+
+
+class TestSD3Transformer2DModel:
+    """Test helper for SD3.5 Large SD3Transformer2DModel config."""
+
+    ops_after_partitioner_FP = {
+        "executorch_exir_dialects_edge__ops_aten_unsqueeze_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 1,
+        "torch.ops.higher_order.executorch_call_delegate": 1,
+    }
+
+    ops_after_partitioner_INT = {
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 3,
+        "torch.ops.higher_order.executorch_call_delegate": 1,
+    }
+
+    ops_after_partitioner_vgf_quantize = {
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 1,
+        "torch.ops.higher_order.executorch_call_delegate": 1,
+    }
+    ops_after_partitioner_vgf_no_quantize = ops_after_partitioner_FP
+
+    def create_config(self):
+        """Create a tiny SD3.5 Large-like MMDiT config for tests."""
+        return get_tiny_sd35_large_transformer_config()
+
+    def create_dummy_inputs(
+        self,
+        batch_size: int = 2,
+        latent_channels: int = 4,
+        latent_size: int = 32,
+        seq_length: int = 77,
+        joint_attention_dim: int = 16,
+        pooled_projection_dim: int = 32,
+        max_timestep: int = 1000,
+        dtype: torch.dtype = torch.float32,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Create dummy inputs for the SD3Transformer2DModel tests."""
+        # SD3.5 Large uses latent channels=16, latent size=128, T5 seq length=256,
+        # joint_attention_dim=4096, and pooled_projection_dim=2048. Keep this
+        # unit-test default smaller for TOSA runtime and VGF memory limits.
+        return (
+            torch.randn(
+                batch_size,
+                latent_channels,
+                latent_size,
+                latent_size,
+                dtype=dtype,
+            ),
+            torch.randint(low=0, high=max_timestep, size=(batch_size,)),
+            torch.randn(
+                batch_size,
+                seq_length,
+                joint_attention_dim,
+                dtype=dtype,
+            ),
+            torch.randn(batch_size, pooled_projection_dim, dtype=dtype),
+        )
+
+    def create_model(self) -> SD3TransformerWrapper:
+        """Instantiate wrapped SD3Transformer2DModel for tests."""
+        SD3Transformer2DModel = pytest.importorskip(
+            "diffusers.models.transformers"
+        ).SD3Transformer2DModel
+        return SD3TransformerWrapper(
+            SD3Transformer2DModel(**self.create_config())
+        ).eval()
+
+
+def test_sd3_transformer_tosa_FP():
+    """Run the SD3Transformer2DModel TOSA FP test."""
+    test_helper = TestSD3Transformer2DModel()
+
+    with torch.no_grad():
+        pipeline = TosaPipelineFP[input_t4](
+            test_helper.create_model(),
+            test_helper.create_dummy_inputs(),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+        )
+        pipeline.change_args(
+            "check_count.exir", TestSD3Transformer2DModel.ops_after_partitioner_FP
+        )
+        pipeline.run()
+
+
+def test_sd3_transformer_tosa_INT():
+    """Run the SD3Transformer2DModel TOSA INT test."""
+    test_helper = TestSD3Transformer2DModel()
+
+    with torch.no_grad():
+        pipeline = TosaPipelineINT[input_t4](
+            test_helper.create_model(),
+            test_helper.create_dummy_inputs(),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            frobenius_threshold=None,
+            cosine_threshold=None,
+        )
+        pipeline.change_args(
+            "check_count.exir", TestSD3Transformer2DModel.ops_after_partitioner_INT
+        )
+        pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_sd3_transformer_vgf_no_quant():
+    """Run the SD3Transformer2DModel VGF no-quant test."""
+    test_helper = TestSD3Transformer2DModel()
+
+    with torch.no_grad():
+        pipeline = VgfPipeline[input_t4](
+            test_helper.create_model(),
+            test_helper.create_dummy_inputs(),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            quantize=False,
+        )
+        pipeline.change_args(
+            "check_count.exir",
+            TestSD3Transformer2DModel.ops_after_partitioner_vgf_no_quantize,
+        )
+        pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_sd3_transformer_vgf_quant():
+    """Run the SD3Transformer2DModel VGF quant test."""
+    test_helper = TestSD3Transformer2DModel()
+
+    with torch.no_grad():
+        pipeline = VgfPipeline[input_t4](
+            test_helper.create_model(),
+            test_helper.create_dummy_inputs(),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            quantize=True,
+        )
+        pipeline.change_args(
+            "check_count.exir",
+            TestSD3Transformer2DModel.ops_after_partitioner_vgf_quantize,
+        )
+        pipeline.run()

--- a/backends/arm/test/models/stable_diffusion_3_5_large/test_T5EncoderModel_sd35_large.py
+++ b/backends/arm/test/models/stable_diffusion_3_5_large/test_T5EncoderModel_sd35_large.py
@@ -6,13 +6,9 @@
 from typing import Tuple
 
 import torch
-from executorch.backends.arm._passes import (
-    ConvertInt64ConstOpsToInt32Pass,
-    ConvertInt64OutputOpsToInt32Pass,
-    InsertInt32CastsAfterInt64PlaceholdersPass,
-)
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.models.stable_diffusion_3_5_large.test_configs_sd35_large import (
+    get_int64_to_int32_passes,
     get_tiny_sd35_large_t5_config,
 )
 from executorch.backends.arm.test.tester.test_pipeline import (
@@ -26,12 +22,6 @@ from executorch.examples.models.stable_diffusion_3_5_large.model import (
 from transformers import T5EncoderModel
 
 input_t = Tuple[torch.Tensor]
-
-_INT64_TO_INT32_PASSES = [
-    ConvertInt64ConstOpsToInt32Pass(),
-    ConvertInt64OutputOpsToInt32Pass(),
-    InsertInt32CastsAfterInt64PlaceholdersPass(),
-]
 
 
 class TestT5EncoderModel:
@@ -106,10 +96,9 @@ def test_t5_encoder_tosa_FP():
             test_helper.create_dummy_inputs(config),
             aten_op=[],
             exir_op=[],
-            run_on_tosa_ref_model=False,
             use_to_edge_transform_and_lower=True,
             atol=2e-2,
-            transform_passes=_INT64_TO_INT32_PASSES,
+            transform_passes=get_int64_to_int32_passes(),
         )
         pipeline.change_args(
             "check_count.exir", TestT5EncoderModel.ops_after_partitioner_FP
@@ -153,7 +142,7 @@ def test_t5_encoder_vgf_no_quant():
             exir_op=[],
             use_to_edge_transform_and_lower=True,
             atol=8e-3,
-            transform_passes=_INT64_TO_INT32_PASSES,
+            transform_passes=get_int64_to_int32_passes(),
             quantize=False,
         )
         pipeline.change_args(

--- a/backends/arm/test/models/stable_diffusion_3_5_large/test_T5EncoderModel_sd35_large.py
+++ b/backends/arm/test/models/stable_diffusion_3_5_large/test_T5EncoderModel_sd35_large.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import torch
+from executorch.backends.arm._passes import (
+    ConvertInt64ConstOpsToInt32Pass,
+    ConvertInt64OutputOpsToInt32Pass,
+    InsertInt32CastsAfterInt64PlaceholdersPass,
+)
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.models.stable_diffusion_3_5_large.test_configs_sd35_large import (
+    get_tiny_sd35_large_t5_config,
+)
+from executorch.backends.arm.test.tester.test_pipeline import (
+    TosaPipelineFP,
+    TosaPipelineINT,
+    VgfPipeline,
+)
+from executorch.examples.models.stable_diffusion_3_5_large.model import (
+    SD3T5TextEncoderWrapper,
+)
+from transformers import T5EncoderModel
+
+input_t = Tuple[torch.Tensor]
+
+_INT64_TO_INT32_PASSES = [
+    ConvertInt64ConstOpsToInt32Pass(),
+    ConvertInt64OutputOpsToInt32Pass(),
+    InsertInt32CastsAfterInt64PlaceholdersPass(),
+]
+
+
+class TestT5EncoderModel:
+    """Test helper for SD3.5 Large T5EncoderModel config."""
+
+    ops_after_partitioner_FP = {
+        "executorch_exir_dialects_edge__ops_aten_clamp_Tensor": 4,
+        "executorch_exir_dialects_edge__ops_aten_isinf_default": 4,
+        "executorch_exir_dialects_edge__ops_aten_where_self": 1,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 2,
+        "torch.ops.higher_order.executorch_call_delegate": 10,
+    }
+
+    ops_after_partitioner_INT = {
+        "executorch_exir_dialects_edge__ops_aten_isinf_default": 4,
+        "executorch_exir_dialects_edge__ops_aten_mul_Tensor": 5,
+        "executorch_exir_dialects_edge__ops_aten_where_self": 5,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 21,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 30,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 24,
+        "aten.scalar_tensor.default": 9,
+        "torch.ops.higher_order.executorch_call_delegate": 24,
+    }
+
+    ops_after_partitioner_vgf_quantize = {
+        "executorch_exir_dialects_edge__ops_aten_clamp_Tensor": 4,
+        "executorch_exir_dialects_edge__ops_aten_isinf_default": 4,
+        "executorch_exir_dialects_edge__ops_dim_order_ops__to_dim_order_copy_default": 1,
+        "torch.ops.higher_order.executorch_call_delegate": 9,
+    }
+
+    ops_after_partitioner_vgf_no_quantize = ops_after_partitioner_vgf_quantize
+
+    def create_dummy_inputs(
+        self,
+        config,
+        batch_size: int = 1,
+        seq_length: int = 2,
+        dtype: torch.dtype = torch.long,
+    ) -> tuple[torch.Tensor]:
+        """Create dummy inputs for the T5EncoderModel tests."""
+        # SD3.5 Large uses (batch_size, seq_length) = (1, 256) for T5.
+        # Keep this unit-test default smaller for TOSA runtime.
+        return (
+            torch.randint(
+                low=0,
+                high=config.vocab_size,
+                size=(batch_size, seq_length),
+                dtype=dtype,
+            ),
+        )
+
+    def create_config(self):
+        """Create a tiny SD3.5 Large-like T5 config for tests."""
+        return get_tiny_sd35_large_t5_config()
+
+    def create_model(self, config) -> SD3T5TextEncoderWrapper:
+        """Instantiate wrapped T5EncoderModel for tests."""
+        return SD3T5TextEncoderWrapper(
+            T5EncoderModel(config).to(dtype=config.dtype)  # type: ignore[call-arg]
+        ).eval()
+
+
+def test_t5_encoder_tosa_FP():
+    """Run the T5EncoderModel TOSA FP test."""
+    test_helper = TestT5EncoderModel()
+    config = test_helper.create_config()
+
+    with torch.no_grad():
+        pipeline = TosaPipelineFP[input_t](
+            test_helper.create_model(config),
+            test_helper.create_dummy_inputs(config),
+            aten_op=[],
+            exir_op=[],
+            run_on_tosa_ref_model=False,
+            use_to_edge_transform_and_lower=True,
+            atol=2e-2,
+            transform_passes=_INT64_TO_INT32_PASSES,
+        )
+        pipeline.change_args(
+            "check_count.exir", TestT5EncoderModel.ops_after_partitioner_FP
+        )
+        pipeline.run()
+
+
+def test_t5_encoder_tosa_INT():
+    """Run the T5EncoderModel TOSA INT test."""
+    test_helper = TestT5EncoderModel()
+    config = test_helper.create_config()
+
+    with torch.no_grad():
+        pipeline = TosaPipelineINT[input_t](
+            test_helper.create_model(config),
+            test_helper.create_dummy_inputs(config),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            atol=3e-2,
+            frobenius_threshold=None,
+            cosine_threshold=None,
+        )
+        pipeline.change_args(
+            "check_count.exir", TestT5EncoderModel.ops_after_partitioner_INT
+        )
+        pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_t5_encoder_vgf_no_quant():
+    """Run the T5EncoderModel VGF no-quant test."""
+    test_helper = TestT5EncoderModel()
+    config = test_helper.create_config()
+
+    with torch.no_grad():
+        pipeline = VgfPipeline[input_t](
+            test_helper.create_model(config),
+            test_helper.create_dummy_inputs(config),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            atol=8e-3,
+            transform_passes=_INT64_TO_INT32_PASSES,
+            quantize=False,
+        )
+        pipeline.change_args(
+            "check_count.exir",
+            TestT5EncoderModel.ops_after_partitioner_vgf_no_quantize,
+        )
+        pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_t5_encoder_vgf_quant():
+    """Run the T5EncoderModel VGF quant test."""
+    test_helper = TestT5EncoderModel()
+    config = test_helper.create_config()
+
+    with torch.no_grad():
+        pipeline = VgfPipeline[input_t](
+            test_helper.create_model(config),
+            test_helper.create_dummy_inputs(config),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            atol=1.2e-2,
+            quantize=True,
+        )
+        pipeline.change_args(
+            "check_count.exir",
+            TestT5EncoderModel.ops_after_partitioner_vgf_quantize,
+        )
+        pipeline.run()

--- a/backends/arm/test/models/stable_diffusion_3_5_large/test_configs_sd35_large.py
+++ b/backends/arm/test/models/stable_diffusion_3_5_large/test_configs_sd35_large.py
@@ -10,6 +10,12 @@ import warnings
 from pathlib import Path
 from typing import Any
 
+from executorch.backends.arm._passes import (
+    ArmPass,
+    ConvertInt64ConstOpsToInt32Pass,
+    ConvertInt64OutputOpsToInt32Pass,
+    InsertInt32CastsAfterInt64PlaceholdersPass,
+)
 from transformers import CLIPTextConfig, T5Config
 
 
@@ -151,6 +157,14 @@ def _warn_if_sd35_large_config_differs_from_upstream(
             RuntimeWarning,
             stacklevel=2,
         )
+
+
+def get_int64_to_int32_passes() -> list[ArmPass]:
+    return [
+        ConvertInt64ConstOpsToInt32Pass(),
+        ConvertInt64OutputOpsToInt32Pass(),
+        InsertInt32CastsAfterInt64PlaceholdersPass(),
+    ]
 
 
 def get_tiny_sd35_large_text_encoder_config() -> CLIPTextConfig:

--- a/backends/arm/test/models/stable_diffusion_3_5_large/test_configs_sd35_large.py
+++ b/backends/arm/test/models/stable_diffusion_3_5_large/test_configs_sd35_large.py
@@ -1,0 +1,297 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import hashlib
+import json
+import os
+import warnings
+from pathlib import Path
+from typing import Any
+
+from transformers import CLIPTextConfig, T5Config
+
+
+_EXECUTORCH_SD35_UPSTREAM_SYNC_ENV_VAR = "EXECUTORCH_SD35_UPSTREAM_SYNC"
+_sd35_large_upstream_checked: set[str] = set()
+
+_SD35_LARGE_UPSTREAM_FINGERPRINTS: dict[str, tuple[tuple[str, ...], str]] = {
+    "text_encoder": (
+        (
+            "hidden_act",
+            "hidden_size",
+            "intermediate_size",
+            "max_position_embeddings",
+            "num_attention_heads",
+            "num_hidden_layers",
+            "projection_dim",
+            "vocab_size",
+        ),
+        "0cb164627ea428c39166d8ecf70462f7ddba34a57071d383a1116603e114bf50",
+    ),
+    "text_encoder_2": (
+        (
+            "hidden_act",
+            "hidden_size",
+            "intermediate_size",
+            "max_position_embeddings",
+            "num_attention_heads",
+            "num_hidden_layers",
+            "projection_dim",
+            "vocab_size",
+        ),
+        "4c082c890625573879240ef700b1dbe18e2a263ad8e76d222cba759553176e1e",
+    ),
+    "text_encoder_3": (
+        (
+            "d_ff",
+            "d_kv",
+            "d_model",
+            "dense_act_fn",
+            "feed_forward_proj",
+            "num_heads",
+            "num_layers",
+            "relative_attention_num_buckets",
+            "vocab_size",
+        ),
+        "da069a817a2fe4eb347fc5aefd7690bf97f8661d33dbe689058977809651023d",
+    ),
+    "transformer": (
+        (
+            "sample_size",
+            "patch_size",
+            "in_channels",
+            "num_layers",
+            "attention_head_dim",
+            "num_attention_heads",
+            "caption_projection_dim",
+            "joint_attention_dim",
+            "pooled_projection_dim",
+            "out_channels",
+            "pos_embed_max_size",
+            "qk_norm",
+        ),
+        "bc87c7eefb80f7bc6e80479f5bd2af929fd14c2331a19ddb4e27a989546ebfb0",
+    ),
+    "vae": (
+        (
+            "sample_size",
+            "in_channels",
+            "out_channels",
+            "down_block_types",
+            "up_block_types",
+            "block_out_channels",
+            "layers_per_block",
+            "latent_channels",
+            "norm_num_groups",
+            "act_fn",
+            "mid_block_add_attention",
+            "force_upcast",
+            "use_quant_conv",
+            "use_post_quant_conv",
+            "scaling_factor",
+            "shift_factor",
+        ),
+        "8019be48e6681895b9b7c54c0f2f48c3ddc9975d7b6c7ef2061b7743f8d55b71",
+    ),
+}
+
+
+def _load_upstream_sd35_large_config(subfolder: str) -> dict[str, Any]:
+    from executorch.examples.models.stable_diffusion_3_5_large.model import MODEL_ID
+    from huggingface_hub import hf_hub_download
+
+    config_path = hf_hub_download(  # nosec B615
+        repo_id=MODEL_ID,
+        filename="config.json",
+        subfolder=subfolder,
+        token=os.environ.get("HF_TOKEN"),
+        etag_timeout=1.0,
+    )
+    return json.loads(Path(config_path).read_text())
+
+
+def _fingerprint_sd35_large_config(
+    config: dict[str, Any], fields: tuple[str, ...]
+) -> str:
+    selected_config = {field: config[field] for field in fields}
+    serialized_config = json.dumps(
+        selected_config,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(serialized_config.encode()).hexdigest()
+
+
+def _warn_if_sd35_large_config_differs_from_upstream(
+    subfolder: str, warning_name: str
+) -> None:
+    if os.environ.get(_EXECUTORCH_SD35_UPSTREAM_SYNC_ENV_VAR, "0") != "1":
+        return
+    if subfolder in _sd35_large_upstream_checked:
+        return
+
+    _sd35_large_upstream_checked.add(subfolder)
+    try:
+        upstream_config = _load_upstream_sd35_large_config(subfolder)
+        fields, expected_fingerprint = _SD35_LARGE_UPSTREAM_FINGERPRINTS[subfolder]
+        upstream_fingerprint = _fingerprint_sd35_large_config(upstream_config, fields)
+    except Exception as exc:
+        warnings.warn(
+            f"Unable to validate {warning_name} against upstream metadata: {exc}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return
+
+    if upstream_fingerprint != expected_fingerprint:
+        warnings.warn(
+            f"Upstream {warning_name} architecture changed; review the tiny test config",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+def get_tiny_sd35_large_text_encoder_config() -> CLIPTextConfig:
+    """Create a tiny SD3.5 Large-like CLIP-L text encoder config for tests."""
+    _warn_if_sd35_large_config_differs_from_upstream(
+        "text_encoder", "SD3.5 Large CLIP text encoder"
+    )
+    return CLIPTextConfig(  # type: ignore[call-arg]
+        architectures=["CLIPTextModelWithProjection"],
+        attention_dropout=0.0,
+        bos_token_id=0,
+        dropout=0.0,
+        eos_token_id=2,
+        hidden_act="quick_gelu",
+        hidden_size=32,
+        initializer_factor=1.0,
+        initializer_range=0.02,
+        intermediate_size=128,
+        layer_norm_eps=1e-5,
+        max_position_embeddings=16,
+        num_attention_heads=4,
+        num_hidden_layers=2,
+        pad_token_id=1,
+        projection_dim=32,
+        dtype="float16",
+        vocab_size=256,
+    )
+
+
+def get_tiny_sd35_large_text_encoder_2_config() -> CLIPTextConfig:
+    """Create a tiny SD3.5 Large-like CLIP-bigG text encoder config for
+    tests.
+    """
+    _warn_if_sd35_large_config_differs_from_upstream(
+        "text_encoder_2", "SD3.5 Large CLIP text encoder 2"
+    )
+    return CLIPTextConfig(  # type: ignore[call-arg]
+        architectures=["CLIPTextModelWithProjection"],
+        attention_dropout=0.0,
+        bos_token_id=0,
+        dropout=0.0,
+        eos_token_id=2,
+        hidden_act="gelu",
+        hidden_size=48,
+        initializer_factor=1.0,
+        initializer_range=0.02,
+        intermediate_size=192,
+        layer_norm_eps=1e-5,
+        max_position_embeddings=16,
+        num_attention_heads=6,
+        num_hidden_layers=2,
+        pad_token_id=1,
+        projection_dim=48,
+        dtype="float16",
+        vocab_size=256,
+    )
+
+
+def get_tiny_sd35_large_t5_config() -> T5Config:
+    """Create a tiny SD3.5 Large-like T5 config for tests."""
+    _warn_if_sd35_large_config_differs_from_upstream(
+        "text_encoder_3", "SD3.5 Large T5 text encoder"
+    )
+    return T5Config(  # type: ignore[call-arg]
+        architectures=["T5EncoderModel"],
+        classifier_dropout=0.0,
+        d_ff=64,
+        d_kv=8,
+        d_model=32,
+        decoder_start_token_id=0,
+        dense_act_fn="gelu_new",
+        dropout_rate=0.1,
+        eos_token_id=1,
+        feed_forward_proj="gated-gelu",
+        initializer_factor=1.0,
+        is_encoder_decoder=True,
+        is_gated_act=True,
+        layer_norm_epsilon=1e-6,
+        num_decoder_layers=2,
+        num_heads=4,
+        num_layers=2,
+        output_past=True,
+        pad_token_id=0,
+        relative_attention_max_distance=128,
+        relative_attention_num_buckets=8,
+        tie_word_embeddings=False,
+        dtype="float16",
+        vocab_size=256,
+        use_cache=True,
+    )
+
+
+def get_tiny_sd35_large_transformer_config() -> dict[str, Any]:
+    """Create a tiny SD3.5 Large-like MMDiT config for tests."""
+    _warn_if_sd35_large_config_differs_from_upstream(
+        "transformer", "SD3.5 Large transformer"
+    )
+    return {
+        "sample_size": 32,
+        "patch_size": 2,
+        "in_channels": 4,
+        "num_layers": 2,
+        "attention_head_dim": 8,
+        "num_attention_heads": 2,
+        "caption_projection_dim": 16,
+        "joint_attention_dim": 16,
+        "pooled_projection_dim": 32,
+        "out_channels": 4,
+        "pos_embed_max_size": 32,
+        "qk_norm": "rms_norm",
+    }
+
+
+def get_tiny_sd35_large_vae_config() -> dict[str, Any]:
+    """Create a tiny SD3.5 Large-like VAE config for tests."""
+    _warn_if_sd35_large_config_differs_from_upstream("vae", "SD3.5 Large VAE")
+    return {
+        "sample_size": 32,
+        "in_channels": 3,
+        "out_channels": 3,
+        "down_block_types": (
+            "DownEncoderBlock2D",
+            "DownEncoderBlock2D",
+            "DownEncoderBlock2D",
+            "DownEncoderBlock2D",
+        ),
+        "up_block_types": (
+            "UpDecoderBlock2D",
+            "UpDecoderBlock2D",
+            "UpDecoderBlock2D",
+            "UpDecoderBlock2D",
+        ),
+        "block_out_channels": (4, 8, 8, 8),
+        "layers_per_block": 1,
+        "latent_channels": 16,
+        "norm_num_groups": 1,
+        "act_fn": "silu",
+        "mid_block_add_attention": True,
+        "force_upcast": False,
+        "use_quant_conv": False,
+        "use_post_quant_conv": False,
+        "scaling_factor": 1.5305,
+        "shift_factor": 0.0609,
+    }

--- a/backends/arm/test/models/stable_diffusion_3_5_large/test_model_sd35_large.py
+++ b/backends/arm/test/models/stable_diffusion_3_5_large/test_model_sd35_large.py
@@ -1,0 +1,369 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from executorch.backends.arm.test.models.stable_diffusion_3_5_large.test_configs_sd35_large import (
+    get_tiny_sd35_large_t5_config,
+    get_tiny_sd35_large_text_encoder_2_config,
+    get_tiny_sd35_large_text_encoder_config,
+    get_tiny_sd35_large_transformer_config,
+    get_tiny_sd35_large_vae_config,
+)
+from executorch.examples.models.stable_diffusion_3_5_large import (
+    model as sd35_large_model,
+)
+from transformers import CLIPTextModelWithProjection, T5EncoderModel
+
+
+@pytest.mark.parametrize(
+    ("clip_skip", "hidden_state_index"),
+    (
+        pytest.param(None, -2, id="default_clip_skip"),
+        pytest.param(1, -3, id="clip_skip_1"),
+    ),
+)
+def test_clip_text_encoder_wrapper_returns_selected_hidden_state_and_pooled_projection(
+    clip_skip, hidden_state_index
+):
+    """Verify CLIP wrapper outputs."""
+    config = get_tiny_sd35_large_text_encoder_config()
+    config.num_hidden_layers = 3  # Set to 3 layers to test clip_skip=1 behavior
+    text_encoder = CLIPTextModelWithProjection(config).to(dtype=config.dtype)
+    text_encoder.eval()
+    wrapper = sd35_large_model.SD3CLIPTextEncoderWrapper(
+        text_encoder, clip_skip=clip_skip
+    )
+    input_ids = torch.randint(0, config.vocab_size, (2, 7))
+
+    with torch.no_grad():
+        hidden_states, pooled_projection = wrapper(input_ids)
+        expected = text_encoder(input_ids, output_hidden_states=True, return_dict=True)
+
+    torch.testing.assert_close(
+        hidden_states, expected.hidden_states[hidden_state_index]
+    )
+    torch.testing.assert_close(pooled_projection, expected[0])
+
+
+def test_t5_text_encoder_wrapper_returns_last_hidden_state():
+    """Verify T5 text encoder wrapper returns last hidden state."""
+    config = get_tiny_sd35_large_t5_config()
+    text_encoder = T5EncoderModel(config)
+    text_encoder.eval()
+    wrapper = sd35_large_model.SD3T5TextEncoderWrapper(text_encoder)
+    input_ids = torch.randint(0, config.vocab_size, (2, 7))
+
+    with torch.no_grad():
+        hidden_states = wrapper(input_ids)
+        expected = text_encoder(input_ids, return_dict=True)
+
+    torch.testing.assert_close(hidden_states, expected.last_hidden_state)
+
+
+def test_transformer_wrapper_returns_sample_tensor():
+    """Verify transformer wrapper returns the sample tensor."""
+    SD3Transformer2DModel = pytest.importorskip(
+        "diffusers.models.transformers"
+    ).SD3Transformer2DModel
+    transformer = SD3Transformer2DModel(**get_tiny_sd35_large_transformer_config())
+    transformer.eval()
+    wrapper = sd35_large_model.SD3TransformerWrapper(transformer)
+    batch_size = 2
+    latents = torch.randn(batch_size, 4, 32, 32)
+    timestep = torch.randint(0, 1000, (batch_size,))
+    encoder_hidden_states = torch.randn(batch_size, 154, 16)
+    pooled_projections = torch.randn(batch_size, 32)
+
+    with torch.no_grad():
+        sample = wrapper(
+            latents,
+            timestep,
+            encoder_hidden_states,
+            pooled_projections,
+        )
+        expected = transformer(
+            hidden_states=latents,
+            timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states,
+            pooled_projections=pooled_projections,
+            return_dict=True,
+        )
+
+    torch.testing.assert_close(sample, expected.sample)
+
+
+def test_vae_decoder_wrapper_scales_shifts_decodes_and_clamps():
+    """Verify VAE decoder wrapper scales, shifts, decodes, and clamps."""
+    AutoencoderKL = pytest.importorskip("diffusers.models.autoencoders").AutoencoderKL
+    vae_config = get_tiny_sd35_large_vae_config()
+    vae = AutoencoderKL(**vae_config)
+    vae.eval()
+    wrapper = sd35_large_model.SD3VAEDecoderWrapper(vae)
+    latents = torch.randn(1, vae_config["latent_channels"], 4, 4)
+
+    with torch.no_grad():
+        image = wrapper(latents)
+        expected_latents = latents / vae.config.scaling_factor + vae.config.shift_factor
+        expected = vae.decode(expected_latents, return_dict=True).sample
+        # Normalize decoder output from [-1, 1] to image range [0, 1].
+        expected = (expected / 2 + 0.5).clamp(0, 1)
+
+    torch.testing.assert_close(image, expected)
+    assert torch.all(image >= 0)
+    assert torch.all(image <= 1)
+
+
+@pytest.mark.parametrize(
+    "getter_name",
+    (
+        "get_text_encoder_wrapper",
+        "get_text_encoder_2_wrapper",
+        "get_text_encoder_3_wrapper",
+        "get_transformer_wrapper",
+        "get_vae_decoder_wrapper",
+    ),
+)
+def test_model_loader_getters_require_loaded_components(getter_name):
+    """Verify model loader getters require loaded components."""
+    loader = sd35_large_model.StableDiffusion3ModelLoader(dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="Models not loaded"):
+        getattr(loader, getter_name)()
+
+
+def test_model_loader_text_encoder_getters_wrap_loaded_components():
+    """Verify model loader text encoder getters wrap loaded components."""
+    loader = sd35_large_model.StableDiffusion3ModelLoader(dtype=torch.float32)
+    loader.text_encoder = CLIPTextModelWithProjection(
+        get_tiny_sd35_large_text_encoder_config()
+    )
+    loader.text_encoder_2 = CLIPTextModelWithProjection(
+        get_tiny_sd35_large_text_encoder_2_config()
+    )
+    loader.text_encoder_3 = T5EncoderModel(get_tiny_sd35_large_t5_config())
+
+    assert loader.get_text_encoder_wrapper().text_encoder is loader.text_encoder
+    assert loader.get_text_encoder_2_wrapper().text_encoder is loader.text_encoder_2
+    assert loader.get_text_encoder_3_wrapper().text_encoder is loader.text_encoder_3
+
+
+def test_model_loader_transformer_getter_wraps_loaded_component():
+    """Verify model loader transformer getter wraps loaded component."""
+    SD3Transformer2DModel = pytest.importorskip(
+        "diffusers.models.transformers"
+    ).SD3Transformer2DModel
+    loader = sd35_large_model.StableDiffusion3ModelLoader(dtype=torch.float32)
+    loader.transformer = SD3Transformer2DModel(
+        **get_tiny_sd35_large_transformer_config()
+    )
+
+    assert loader.get_transformer_wrapper().transformer is loader.transformer
+
+
+def test_model_loader_vae_getter_wraps_loaded_component():
+    """Verify model loader VAE getter wraps loaded component."""
+    AutoencoderKL = pytest.importorskip("diffusers.models.autoencoders").AutoencoderKL
+    loader = sd35_large_model.StableDiffusion3ModelLoader(dtype=torch.float32)
+    loader.vae = AutoencoderKL(**get_tiny_sd35_large_vae_config())
+
+    assert loader.get_vae_decoder_wrapper().vae is loader.vae
+
+
+def _patch_model_loaders(monkeypatch):
+    """Patch model loaders and return call records."""
+
+    class FakeModel:
+        def __init__(self):
+            self.eval_called = False
+
+        def to(self, dtype):
+            return self
+
+        def eval(self):
+            self.eval_called = True
+            return self
+
+    calls = SimpleNamespace(
+        tokenizer=[],
+        text_encoder=[],
+        t5=[],
+        transformer=[],
+        vae=[],
+    )
+
+    class FakeTokenizer:
+        @staticmethod
+        def from_pretrained(model_id, **kwargs):
+            calls.tokenizer.append((model_id, kwargs))
+            return SimpleNamespace(model_max_length=77)
+
+    class FakeTextEncoder:
+        @staticmethod
+        def from_pretrained(model_id, **kwargs):
+            calls.text_encoder.append((model_id, kwargs))
+            return FakeModel()
+
+    class FakeT5:
+        @staticmethod
+        def from_pretrained(model_id, **kwargs):
+            calls.t5.append((model_id, kwargs))
+            return FakeModel()
+
+    class FakeTransformer:
+        @staticmethod
+        def from_pretrained(model_id, **kwargs):
+            calls.transformer.append((model_id, kwargs))
+            return FakeModel()
+
+    class FakeVAE:
+        @staticmethod
+        def from_pretrained(model_id, **kwargs):
+            calls.vae.append((model_id, kwargs))
+            return FakeModel()
+
+    monkeypatch.setattr(sd35_large_model, "CLIPTokenizer", FakeTokenizer)
+    monkeypatch.setattr(
+        sd35_large_model, "CLIPTextModelWithProjection", FakeTextEncoder
+    )
+    monkeypatch.setattr(sd35_large_model, "T5EncoderModel", FakeT5)
+    monkeypatch.setattr(sd35_large_model, "SD3Transformer2DModel", FakeTransformer)
+    monkeypatch.setattr(sd35_large_model, "AutoencoderKL", FakeVAE)
+
+    return calls
+
+
+def test_load_models_uses_component_subfolders(monkeypatch):
+    """Verify model loading uses the expected component subfolders."""
+    calls = _patch_model_loaders(monkeypatch)
+
+    loader = sd35_large_model.StableDiffusion3ModelLoader(
+        model_id="test/sd3",
+        dtype=torch.float32,
+    )
+
+    assert loader.load_models()
+    assert calls.tokenizer == [
+        ("test/sd3", {"subfolder": "tokenizer"}),
+        ("test/sd3", {"subfolder": "tokenizer_2"}),
+    ]
+    assert calls.text_encoder == [
+        ("test/sd3", {"subfolder": "text_encoder", "torch_dtype": torch.float32}),
+        ("test/sd3", {"subfolder": "text_encoder_2", "torch_dtype": torch.float32}),
+    ]
+    assert calls.t5 == [
+        ("test/sd3", {"subfolder": "text_encoder_3", "torch_dtype": torch.float32})
+    ]
+    assert calls.transformer == [
+        ("test/sd3", {"subfolder": "transformer", "torch_dtype": torch.float32})
+    ]
+    assert calls.vae == [
+        ("test/sd3", {"subfolder": "vae", "torch_dtype": torch.float32})
+    ]
+    assert loader.text_encoder.eval_called
+    assert loader.text_encoder_2.eval_called
+    assert loader.text_encoder_3.eval_called
+    assert loader.transformer.eval_called
+    assert loader.vae.eval_called
+
+
+def test_load_models_loads_only_requested_component(monkeypatch):
+    """Verify model loading can load only requested components."""
+    calls = _patch_model_loaders(monkeypatch)
+
+    loader = sd35_large_model.StableDiffusion3ModelLoader(
+        model_id="test/sd3",
+        dtype=torch.float32,
+    )
+
+    assert loader.load_models(
+        [sd35_large_model.StableDiffusionComponent.TEXT_ENCODER_3]
+    )
+    assert calls.tokenizer == []
+    assert calls.text_encoder == []
+    assert calls.t5 == [
+        ("test/sd3", {"subfolder": "text_encoder_3", "torch_dtype": torch.float32})
+    ]
+    assert calls.transformer == []
+    assert calls.vae == []
+    assert loader.text_encoder is None
+    assert loader.text_encoder_2 is None
+    assert loader.text_encoder_3 is not None
+    assert loader.transformer is None
+    assert loader.vae is None
+
+
+@pytest.mark.parametrize(
+    ("latent_size", "expected_latent_size"),
+    (
+        pytest.param(None, 32, id="default_latent_size"),
+        pytest.param(16, 16, id="override_latent_size"),
+    ),
+)
+def test_get_dummy_inputs_builds_expected_component_inputs(
+    latent_size, expected_latent_size
+):
+    """Verify dummy inputs have expected component shapes."""
+    loader = sd35_large_model.StableDiffusion3ModelLoader(dtype=torch.float32)
+    loader.tokenizer = SimpleNamespace(model_max_length=77)
+    loader.text_encoder = object()
+    loader.text_encoder_2 = object()
+    loader.text_encoder_3 = object()
+    loader.transformer = SimpleNamespace(
+        config=SimpleNamespace(
+            in_channels=4,
+            sample_size=32,
+            joint_attention_dim=16,
+            pooled_projection_dim=32,
+        )
+    )
+    loader.vae = SimpleNamespace(config=SimpleNamespace(latent_channels=16))
+
+    dummy_inputs = loader.get_dummy_inputs(
+        max_sequence_length=256,
+        latent_size=latent_size,
+    )
+
+    assert set(dummy_inputs) == {
+        sd35_large_model.StableDiffusionComponent.TEXT_ENCODER,
+        sd35_large_model.StableDiffusionComponent.TEXT_ENCODER_2,
+        sd35_large_model.StableDiffusionComponent.TEXT_ENCODER_3,
+        sd35_large_model.StableDiffusionComponent.TRANSFORMER,
+        sd35_large_model.StableDiffusionComponent.VAE_DECODER,
+    }
+    assert dummy_inputs[sd35_large_model.StableDiffusionComponent.TEXT_ENCODER][
+        0
+    ].shape == (1, 77)
+    assert (
+        dummy_inputs[sd35_large_model.StableDiffusionComponent.TEXT_ENCODER][0].dtype
+        == torch.long
+    )
+    assert dummy_inputs[sd35_large_model.StableDiffusionComponent.TEXT_ENCODER_2][
+        0
+    ].shape == (1, 77)
+    assert dummy_inputs[sd35_large_model.StableDiffusionComponent.TEXT_ENCODER_3][
+        0
+    ].shape == (1, 256)
+
+    transformer_inputs = dummy_inputs[
+        sd35_large_model.StableDiffusionComponent.TRANSFORMER
+    ]
+    assert transformer_inputs[0].shape == (
+        1,
+        4,
+        expected_latent_size,
+        expected_latent_size,
+    )
+    assert transformer_inputs[0].dtype == torch.float32
+    assert transformer_inputs[1].shape == (1,)
+    assert transformer_inputs[1].dtype == torch.float32
+    assert transformer_inputs[2].shape == (1, 333, 16)
+    assert transformer_inputs[3].shape == (1, 32)
+
+    assert dummy_inputs[sd35_large_model.StableDiffusionComponent.VAE_DECODER][
+        0
+    ].shape == (1, 16, expected_latent_size, expected_latent_size)

--- a/backends/arm/test/models/stable_diffusion_3_5_large/test_vae_AutoencoderKL_sd35_large.py
+++ b/backends/arm/test/models/stable_diffusion_3_5_large/test_vae_AutoencoderKL_sd35_large.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Tuple
+
+import pytest
+import torch
+from executorch.backends.arm.test import common
+from executorch.backends.arm.test.models.stable_diffusion_3_5_large.test_configs_sd35_large import (
+    get_tiny_sd35_large_vae_config,
+)
+from executorch.backends.arm.test.tester.test_pipeline import (
+    TosaPipelineFP,
+    TosaPipelineINT,
+    VgfPipeline,
+)
+from executorch.examples.models.stable_diffusion_3_5_large.model import (
+    SD3VAEDecoderWrapper,
+)
+
+input_t = Tuple[torch.Tensor]
+
+
+class TestAutoencoderKL:
+    """Test helper for SD3.5 Large AutoencoderKL config."""
+
+    ops_after_partitioner_FP = {
+        "torch.ops.higher_order.executorch_call_delegate": 1,
+    }
+
+    ops_after_partitioner_INT = {
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_dequantize_per_tensor_default": 1,
+        "executorch_exir_dialects_edge__ops_quantized_decomposed_quantize_per_tensor_default": 1,
+        "torch.ops.higher_order.executorch_call_delegate": 1,
+    }
+
+    ops_after_partitioner_vgf_quantize = ops_after_partitioner_FP
+    ops_after_partitioner_vgf_no_quantize = ops_after_partitioner_FP
+
+    def create_config(self):
+        """Create a tiny SD3.5 Large-like AutoencoderKL config for tests."""
+        return get_tiny_sd35_large_vae_config()
+
+    def create_dummy_inputs(
+        self,
+        batch_size: int = 1,
+        latent_channels: int = 16,
+        latent_size: int = 4,
+        dtype: torch.dtype = torch.float32,
+    ) -> tuple[torch.Tensor]:
+        """Create dummy inputs for the SD3 VAE decoder tests."""
+        # SD3.5 Large uses VAE decoder latent channels=16 and latent size=128.
+        # Keep this unit-test default spatial size smaller for TOSA runtime.
+        return (
+            torch.randn(
+                batch_size,
+                latent_channels,
+                latent_size,
+                latent_size,
+                dtype=dtype,
+            ),
+        )
+
+    def create_model(self) -> SD3VAEDecoderWrapper:
+        """Instantiate wrapped AutoencoderKL decoder for tests."""
+        diffusers_autoencoders = pytest.importorskip("diffusers.models.autoencoders")
+        AutoencoderKL = diffusers_autoencoders.AutoencoderKL
+        return SD3VAEDecoderWrapper(AutoencoderKL(**self.create_config())).eval()
+
+
+def test_vae_tosa_FP():
+    """Run the AutoencoderKL TOSA FP test."""
+    test_helper = TestAutoencoderKL()
+
+    with torch.no_grad():
+        pipeline = TosaPipelineFP[input_t](
+            test_helper.create_model(),
+            test_helper.create_dummy_inputs(),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+        )
+        pipeline.change_args(
+            "check_count.exir", TestAutoencoderKL.ops_after_partitioner_FP
+        )
+        pipeline.run()
+
+
+def test_vae_tosa_INT():
+    """Run the AutoencoderKL TOSA INT test."""
+    test_helper = TestAutoencoderKL()
+
+    with torch.no_grad():
+        pipeline = TosaPipelineINT[input_t](
+            test_helper.create_model(),
+            test_helper.create_dummy_inputs(),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            atol=9e-2,
+            frobenius_threshold=None,
+            cosine_threshold=None,
+        )
+        pipeline.change_args(
+            "check_count.exir", TestAutoencoderKL.ops_after_partitioner_INT
+        )
+        pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_vae_vgf_no_quant():
+    """Run the AutoencoderKL VGF no-quant test."""
+    test_helper = TestAutoencoderKL()
+
+    with torch.no_grad():
+        pipeline = VgfPipeline[input_t](
+            test_helper.create_model(),
+            test_helper.create_dummy_inputs(),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            quantize=False,
+        )
+        pipeline.change_args(
+            "check_count.exir",
+            TestAutoencoderKL.ops_after_partitioner_vgf_no_quantize,
+        )
+        pipeline.run()
+
+
+@common.SkipIfNoModelConverter
+def test_vae_vgf_quant():
+    """Run the AutoencoderKL VGF quant test."""
+    test_helper = TestAutoencoderKL()
+
+    with torch.no_grad():
+        pipeline = VgfPipeline[input_t](
+            test_helper.create_model(),
+            test_helper.create_dummy_inputs(),
+            aten_op=[],
+            exir_op=[],
+            use_to_edge_transform_and_lower=True,
+            quantize=True,
+        )
+        pipeline.change_args(
+            "check_count.exir",
+            TestAutoencoderKL.ops_after_partitioner_vgf_quantize,
+        )
+        pipeline.run()

--- a/backends/arm/test/models/stable_diffusion_3_5_large/test_vae_AutoencoderKL_sd35_large.py
+++ b/backends/arm/test/models/stable_diffusion_3_5_large/test_vae_AutoencoderKL_sd35_large.py
@@ -143,6 +143,7 @@ def test_vae_vgf_quant():
             exir_op=[],
             use_to_edge_transform_and_lower=True,
             quantize=True,
+            qtol=2,
         )
         pipeline.change_args(
             "check_count.exir",


### PR DESCRIPTION
- Add SD3.5 Large test configs for CLIP text encoders, T5 text encoder, MMDiT transformer, and VAE decoder, with optional upstream-sync validation.
- Add Arm backend lowering tests for CLIP-L, CLIP-bigG, T5, transformer, and VAE decoder components across TOSA and VGF pipelines.
- Add wrapper and model-loader unit tests covering wrapper output signatures, component subfolder loading, selective component loading, and dummy input shape generation.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani