### PR TITLE
Resolve the NXP profiler paths on use, not at import

### DIFF
--- a/backends/nxp/tests/config.py
+++ b/backends/nxp/tests/config.py
@@ -7,13 +7,9 @@ import os
 import pathlib
 import shutil
 
-import eiq_neutron_sdk
-
 # The PROJECT_DIR env variable is set by the conftest.py in backends.nxp.tests_models.conftest.
 # It is supposed to point at ExecuTorch Project directory (not install folder) to derive path to artefacts (config files,
 # dataset, model weight) located in the project directory structure, but not installed.
-# TODO(Robert Kalmar) In accordance with the "TODO(dbort): Prune /test[s]/ dirs, /third-party/ dirs" in pyproject.toml,
-#  once the test folders are not installed we can derive the path from current file location: `pathlib.Path(__file__)`
 PROJECT_DIR = os.environ.get("PROJECT_DIR")
 if not PROJECT_DIR:
     # Auto-detect: The PROJECT_DIR env variable is set by the conftest.py in backends.nxp.tests.conftest. But unittests
@@ -25,32 +21,46 @@ assert os.path.exists(
 
 OUTPUTS_DIR = pathlib.Path(os.getcwd()) / ".outputs"
 
-NSYS_PATH = pathlib.Path(shutil.which("nsys"))
-NSYS_CONFIG_PATH = os.path.join(
-    PROJECT_DIR, "backends", "nxp", "tests", "neutron-imxrt700.ini"
-)
-NSYS_FIRMWARE_PATH = os.path.join(
-    os.path.dirname(eiq_neutron_sdk.__file__),
-    "target",
-    "imxrt700",
-    "cmodel",
-    "NeutronFirmware.elf",
-)
 
-# The NXP_RUNNER_PATH env variable is either defined by pytest when using the CLI argument --nxp_executor_path or
-# a standard environment variable.
-NEUTRON_TEST_PATH = os.environ.get("NXP_RUNNER_PATH")
-if not NEUTRON_TEST_PATH:
-    # Auto-detect: The NXP_RUNNER_PATH env variable is set by the conftest.py in backends.nxp.tests.conftest. But
-    #               unittests don't use the conftest, so this variable is not set -> set it manually here in that case.
-    NEUTRON_TEST_PATH = (
-        pathlib.Path(PROJECT_DIR)
+# The four values below need the profiler and the Neutron SDK, which only the machine running the
+# hardware tests has. Resolved on call rather than at import, so importing this module does not
+# require them: the wheel ships this file but not the SDK, so a module level lookup made every
+# importer of the surrounding test helpers fail.
+def nsys_path() -> pathlib.Path:
+    found = shutil.which("nsys")
+    assert found, "nsys not found on PATH."
+    return pathlib.Path(found)
+
+
+def nsys_config_path() -> str:
+    return os.path.join(PROJECT_DIR, "backends", "nxp", "tests", "neutron-imxrt700.ini")
+
+
+def nsys_firmware_path() -> str:
+    import eiq_neutron_sdk
+
+    return os.path.join(
+        os.path.dirname(eiq_neutron_sdk.__file__),
+        "target",
+        "imxrt700",
+        "cmodel",
+        "NeutronFirmware.elf",
+    )
+
+
+def neutron_test_path() -> pathlib.Path:
+    # The NXP_RUNNER_PATH env variable is either defined by pytest when using the CLI argument
+    # --nxp_executor_path or a standard environment variable.
+    from_env = os.environ.get("NXP_RUNNER_PATH")
+    path = (
+        pathlib.Path(from_env)
+        if from_env
+        else pathlib.Path(PROJECT_DIR)
         / "examples"
         / "nxp"
         / "executor_runner"
         / "build"
         / "nxp_executor_runner"
     )
-assert os.path.exists(
-    NEUTRON_TEST_PATH
-), f"Invalid NXP_RUNNER_PATH env variable: `{NEUTRON_TEST_PATH}`."
+    assert os.path.exists(path), f"Invalid NXP_RUNNER_PATH env variable: `{path}`."
+    return path

--- a/backends/nxp/tests/nsys_testing.py
+++ b/backends/nxp/tests/nsys_testing.py
@@ -59,10 +59,6 @@ from torch.fx import GraphModule
 logger = logging.getLogger(__name__)
 
 OUTPUTS_DIR = outputs_dir.OUTPUTS_DIR
-NSYS_PATH = test_config.NSYS_PATH
-NSYS_CONFIG_PATH = test_config.NSYS_CONFIG_PATH
-NSYS_FIRMWARE_PATH = test_config.NSYS_FIRMWARE_PATH
-NEUTRON_TEST_PATH = test_config.NEUTRON_TEST_PATH
 PROJECT_DIR = test_config.PROJECT_DIR
 
 
@@ -183,8 +179,8 @@ def _run_delegated_executorch_program(
         os.path.join(test_dir, f"{test_name}_delegated.pte")
     )
 
-    delegated_cmd = f"{NEUTRON_TEST_PATH} --model {delegated_model_path} {dataset_cli} {dataset_or_inputs} \
-        --output {npu_results_dir} --firmware {NSYS_FIRMWARE_PATH} --nsys {NSYS_PATH} --nsys_config {NSYS_CONFIG_PATH}"
+    delegated_cmd = f"{test_config.neutron_test_path()} --model {delegated_model_path} {dataset_cli} {dataset_or_inputs} \
+        --output {npu_results_dir} --firmware {test_config.nsys_firmware_path()} --nsys {test_config.nsys_path()} --nsys_config {test_config.nsys_config_path()}"
     execute_cmd(delegated_cmd)
 
     return exported_program, testing_dataset_dir
@@ -227,8 +223,8 @@ def _run_non_delegated_executorch_program(
         os.path.join(test_dir, f"{test_name}_non_delegated.pte")
     )
 
-    non_delegated_cmd = f"{NEUTRON_TEST_PATH} --model {non_delegated_model_path} {dataset_cli} {dataset_or_inputs} \
-        --output {cpu_results_dir} --firmware {NSYS_FIRMWARE_PATH} --nsys {NSYS_PATH} --nsys_config {NSYS_CONFIG_PATH}"
+    non_delegated_cmd = f"{test_config.neutron_test_path()} --model {non_delegated_model_path} {dataset_cli} {dataset_or_inputs} \
+        --output {cpu_results_dir} --firmware {test_config.nsys_firmware_path()} --nsys {test_config.nsys_path()} --nsys_config {test_config.nsys_config_path()}"
     execute_cmd(non_delegated_cmd)
 
     return non_delegated_program.exported_program()
@@ -421,9 +417,9 @@ def _run_python_program(
 
 
 def assert_NSYS():
-    assert os.path.exists(NSYS_PATH)
-    assert os.path.exists(NSYS_CONFIG_PATH)
-    assert os.path.exists(NSYS_FIRMWARE_PATH)
+    assert os.path.exists(test_config.nsys_path())
+    assert os.path.exists(test_config.nsys_config_path())
+    assert os.path.exists(test_config.nsys_firmware_path())
 
 
 def lower_run_compare(
@@ -739,7 +735,7 @@ def get_test_name(request):
 
 def execute_cmd(cmd, cwd="."):
     env = environ.copy()  # Copy the current environment
-    env["LD_LIBRARY_PATH"] = str(NSYS_PATH.parent)
+    env["LD_LIBRARY_PATH"] = str(test_config.nsys_path().parent)
     logger.debug(f"Running command: {cmd}")
 
     with subprocess.Popen(
@@ -812,7 +808,7 @@ def dump_debug_test_summary(test_name: str, test_dir: str):
     # During development, the NSYS in virtual env is not used.
     nsys_version = (
         "Internal build from executorch-integration"
-        if NSYS_PATH is not None
+        if shutil.which("nsys") is not None
         else version("eiq_nsys")
     )
     summary = {

--- a/backends/nxp/tests/tester/tester.py
+++ b/backends/nxp/tests/tester/tester.py
@@ -397,9 +397,9 @@ def _resolve_nsys_paths():
     from executorch.backends.nxp.tests.config_importer import test_config
 
     return (
-        str(test_config.NSYS_PATH),
-        str(test_config.NSYS_CONFIG_PATH),
-        str(test_config.NSYS_FIRMWARE_PATH),
+        str(test_config.nsys_path()),
+        str(test_config.nsys_config_path()),
+        str(test_config.nsys_firmware_path()),
     )
 
 
@@ -413,7 +413,7 @@ def _resolve_runner_path() -> Optional[str]:
     """
     from executorch.backends.nxp.tests.config_importer import test_config
 
-    runner = str(test_config.NEUTRON_TEST_PATH)
+    runner = str(test_config.neutron_test_path())
     if os.path.isfile(runner):
         return runner
     return None


### PR DESCRIPTION
A small config file in the NXP test support code refuses to load on any machine that
does not have NXP's hardware tools installed. That matters because it is not only
used by the hardware tests. Shared test helpers import it, and the wheel ships those
helpers, so importing one of them from an installed wheel failed outright.

Two things caused it, both running the moment the file loads rather than when a value
is needed. It imports the eIQ Neutron SDK (the vendor toolkit that talks to the
hardware), which is not installed on an ordinary machine. It also builds a path from
`shutil.which("nsys")`, and `which` returns None when the profiler is missing, so
`pathlib.Path` then raises TypeError.

The four values that need the toolchain are now functions, resolved when something
asks for them:

  nsys_path()            the profiler binary
  nsys_config_path()     its ini file
  nsys_firmware_path()   the Neutron firmware, which needs the SDK
  neutron_test_path()    the built executor runner

PROJECT_DIR and OUTPUTS_DIR stay as they were, since neither needs the toolchain.

Both callers now call these instead of reading a constant. One of them only wanted to
know whether the profiler exists, not where it is, so that check asks `shutil` directly
and still tolerates a missing profiler rather than failing.

Nothing changes on a machine that has the toolchain: the same paths are computed
from the same inputs, with the same assertions, only later. On a machine without it,
the failure moves from import time to the first call that actually needs a path, and
says which piece is missing.

### Test plan

Installed the wheel into a clean environment with no vendor toolkit and no profiler,
then imported the file. Before this change it failed with ModuleNotFoundError. After
it, the import succeeds and the project directory still resolves. Each of the four
functions still raises there, naming what is absent.

Confirmed no module level statement in config.py needs the toolchain any more, by
walking the parsed file and looking for one.

Note the shared helpers still do not import from a wheel, for a different reason
that this change does not touch: backends/nxp/backend/neutron_converter_manager.py
requires the SDK deliberately, in production code rather than in test support.

cc @robert-kalmar @JakeStevens @digantdesai @rascani