### PR TITLE
Restore pull request cancellation in pull.yml

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -6,12 +6,10 @@ on:
     branches:
       - main
       - release/*
-    tags:
-      - ciflow/trunk/*
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' && github.run_id }}-${{ github.event_name == 'schedule' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Two things, one enabling the other.

**`ciflow/trunk/*` on `pull.yml` is a mistake.** It arrived in #18172, which moved the ARM Cortex-M size test from `trunk.yml` to `pull.yml` and carried trunk's tag trigger across with the job. `ciflow/trunk` should run `trunk.yml`; `pull.yml` already runs on every pull request via `pull_request`, so those tag runs were duplicates — on #22549 the tag run had 120 jobs against the pull request run's 121. `trunk.yml` keeps the trigger.

**With no tag push reaching this workflow, the concurrency key can go back to pytorch's.** #21622 added `github.ref_type == 'branch' && github.sha` to stop ciflow tag re-pushes flooding the fleet, but that term is truthy on `pull_request` too, where `github.sha` is the merge commit and changes with every push — so pushes stopped cancelling superseded runs. Before #21622: eight consecutive runs on one branch, seven cancelled. After: three overlapping full runs on `bump-torch-pin-2.14`, none cancelled. The key now matches pytorch's `pull.yml` exactly, `github.run_id` included so two manual dispatches don't cancel each other.

Authored with Claude Code.
