### PR TITLE
[RELEASE-ONLY CHANGES] Pin test-infra workflows to release/2.14

### DIFF
--- a/.github/workflows/_android.yml
+++ b/.github/workflows/_android.yml
@@ -70,7 +70,7 @@ jobs:
       API_LEVEL: 34
     steps:
       - name: Setup SSH (Click me for login details)
-        uses: pytorch/test-infra/.github/actions/setup-ssh@main
+        uses: pytorch/test-infra/.github/actions/setup-ssh@release/2.14
         with:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
           instructions: |

--- a/.github/workflows/_llm_server.yml
+++ b/.github/workflows/_llm_server.yml
@@ -16,7 +16,7 @@ jobs:
 
   linux:
     needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/_test_arduino_library.yml
+++ b/.github/workflows/_test_arduino_library.yml
@@ -20,7 +20,7 @@ jobs:
 
   run:
     needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/_test_backend.yml
+++ b/.github/workflows/_test_backend.yml
@@ -63,7 +63,7 @@ jobs:
         suite: [models, operators]
         exclude: ${{ fromJSON(inputs.exclude) }}
 
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -143,7 +143,7 @@ jobs:
         suite: [models, operators]
         exclude: ${{ fromJSON(inputs.exclude) }}
 
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       ref: ${{ inputs.ref }}

--- a/.github/workflows/_test_cadence.yml
+++ b/.github/workflows/_test_cadence.yml
@@ -35,7 +35,7 @@ jobs:
 
   test-aot:
     needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -59,7 +59,7 @@ jobs:
 
   test-ops:
     needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/_test_cortex_m_e2e.yml
+++ b/.github/workflows/_test_cortex_m_e2e.yml
@@ -29,7 +29,7 @@ jobs:
 
   run:
     needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/_test_cortex_m_ops.yml
+++ b/.github/workflows/_test_cortex_m_ops.yml
@@ -24,7 +24,7 @@ jobs:
 
   run:
     needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/_test_riscv.yml
+++ b/.github/workflows/_test_riscv.yml
@@ -43,7 +43,7 @@ jobs:
 
   run:
     needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/_unittest.yml
+++ b/.github/workflows/_unittest.yml
@@ -36,7 +36,7 @@ jobs:
 
   linux:
     needs: docker-image
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -51,7 +51,7 @@ jobs:
         .ci/scripts/unittest-linux.sh --build-tool "${{ inputs.build-tool }}" --build-mode "${{ inputs.build-mode }}" --editable "${{ inputs.editable }}"
 
   macos:
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       runner: macos-m1-stable
@@ -67,7 +67,7 @@ jobs:
 
   windows:
     if: ${{ inputs.build-tool == 'cmake' }}
-    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@release/2.14
     with:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120

--- a/.github/workflows/_xtensa_build.yml
+++ b/.github/workflows/_xtensa_build.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@release/2.14
         with:
           docker-image-name: ci-image:executorch-ubuntu-22.04-clang12
 

--- a/.github/workflows/_xtensa_test.yml
+++ b/.github/workflows/_xtensa_test.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Calculate docker image
         id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
+        uses: pytorch/test-infra/.github/actions/calculate-docker-image@release/2.14
         with:
           docker-image-name: ci-image:executorch-ubuntu-22.04-clang12
 

--- a/.github/workflows/android-release-artifacts.yml
+++ b/.github/workflows/android-release-artifacts.yml
@@ -73,7 +73,7 @@ jobs:
     name: build-aar
     needs: check-if-aar-exists
     if: ${{ !github.event.pull_request.head.repo.fork && needs.check-if-aar-exists.outputs.should-skip != 'true' }}
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     secrets: inherit
     permissions:
       id-token: write

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -89,7 +89,7 @@ jobs:
     name: build-demo-ios
     # NB: Don't run this on fork PRs because they won't have access to the secret and would fail anyway
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     secrets: inherit
     with:
       default-packages: ""
@@ -160,12 +160,12 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pytorch/test-infra/.github/workflows/mobile_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/mobile_job.yml@release/2.14
     with:
       device-type: ios
       # For iOS testing, the runner just needs to call AWS Device Farm, so there is no need to run this on macOS
       runner: linux.2xlarge
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       # This is the ARN of ExecuTorch project on AWS
       project-arn: arn:aws:devicefarm:us-west-2:308535385114:project:02a2cf0f-6d9b-45ee-ba1a-a086587469e6
       # This is the custom device pool that only includes iOS devices
@@ -178,7 +178,7 @@ jobs:
   build-frameworks-ios:
     name: build-frameworks-ios
     needs: set-version
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       runner: macos-14-xlarge
@@ -397,7 +397,7 @@ jobs:
     name: build-benchmark-app
     # NB: Don't run this on fork PRs because they won't have access to the secret and would fail anyway
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     secrets: inherit
     with:
       default-packages: ""

--- a/.github/workflows/build-cadence-runner.yml
+++ b/.github/workflows/build-cadence-runner.yml
@@ -31,7 +31,7 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository &&
       contains(github.event.pull_request.labels.*.name, 'CLA Signed') && contains(github.event.pull_request.labels.*.name, 'meta-exported'))
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build-cmsis-pack.yml
+++ b/.github/workflows/build-cmsis-pack.yml
@@ -46,7 +46,7 @@ concurrency:
 jobs:
   build-cmsis-pack:
     name: build-cmsis-pack
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build-presets.yml
+++ b/.github/workflows/build-presets.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   apple:
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     strategy:
       fail-fast: false
       matrix:
@@ -34,7 +34,7 @@ jobs:
         ${CONDA_RUN} cmake --build cmake-out -j$(( $(sysctl -n hw.ncpu) - 1 ))
 
   zephyr:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +73,7 @@ jobs:
         cmake --preset ${{ matrix.preset }}
         cmake --build cmake-out -j$(( $(nproc) - 1 ))
   linux:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     strategy:
       fail-fast: false
       matrix:
@@ -106,7 +106,7 @@ jobs:
         cmake --build cmake-out -j$(( $(nproc) - 1 ))
 
   windows:
-    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@release/2.14
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-wheels-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-aarch64-linux.yml
@@ -35,12 +35,12 @@ concurrency:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.14
     with:
       package-type: wheel
       os: linux-aarch64
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       with-cuda: disabled
       with-rocm: disabled
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
@@ -60,12 +60,12 @@ jobs:
             smoke-test-script: .ci/scripts/wheel/test_linux_aarch64.py
             package-name: executorch
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@release/2.14
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       submodules: recursive
       env-var-script: .ci/scripts/wheel/envvar_linux.sh

--- a/.github/workflows/build-wheels-cuda-aarch64-linux.yml
+++ b/.github/workflows/build-wheels-cuda-aarch64-linux.yml
@@ -39,12 +39,12 @@ concurrency:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.14
     with:
       package-type: wheel
       os: linux-aarch64
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       with-cuda: enable
       with-cpu: disable
       with-rocm: disable
@@ -94,12 +94,12 @@ jobs:
             smoke-test-script: .ci/scripts/wheel/test_cuda_linux.py
             package-name: executorch
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@release/2.14
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       submodules: recursive
       env-var-script: .ci/scripts/wheel/envvar_cuda_linux.sh

--- a/.github/workflows/build-wheels-cuda-linux.yml
+++ b/.github/workflows/build-wheels-cuda-linux.yml
@@ -39,12 +39,12 @@ concurrency:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.14
     with:
       package-type: wheel
       os: linux
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       with-cuda: enable
       with-cpu: disable
       with-rocm: disable
@@ -93,12 +93,12 @@ jobs:
             smoke-test-script: .ci/scripts/wheel/test_cuda_linux.py
             package-name: executorch
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@release/2.14
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       build-matrix: ${{ needs.filter-matrix.outputs.matrix }}
       submodules: recursive
       env-var-script: .ci/scripts/wheel/envvar_cuda_linux.sh

--- a/.github/workflows/build-wheels-linux.yml
+++ b/.github/workflows/build-wheels-linux.yml
@@ -35,12 +35,12 @@ concurrency:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.14
     with:
       package-type: wheel
       os: linux
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       with-cuda: disabled
       with-rocm: disabled
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
@@ -60,12 +60,12 @@ jobs:
             smoke-test-script: .ci/scripts/wheel/test_linux.py
             package-name: executorch
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@release/2.14
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       submodules: recursive
       env-var-script: .ci/scripts/wheel/envvar_linux.sh

--- a/.github/workflows/build-wheels-macos.yml
+++ b/.github/workflows/build-wheels-macos.yml
@@ -35,12 +35,12 @@ concurrency:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.14
     with:
       package-type: wheel
       os: macos-arm64
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       with-cuda: disabled
       with-rocm: disabled
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
@@ -60,12 +60,12 @@ jobs:
             smoke-test-script: .ci/scripts/wheel/test_macos.py
             package-name: executorch
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@release/2.14
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       submodules: recursive
       delocate-wheel: false

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -38,12 +38,12 @@ concurrency:
 
 jobs:
   generate-matrix:
-    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@release/2.14
     with:
       package-type: wheel
       os: windows
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       with-cuda: disabled
       with-rocm: disabled
       python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
@@ -61,12 +61,12 @@ jobs:
             smoke-test-script: .ci/scripts/wheel/test_windows.py
             package-name: executorch
     name: ${{ matrix.repository }}
-    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@main
+    uses: pytorch/test-infra/.github/workflows/build_wheels_windows.yml@release/2.14
     with:
       repository: ${{ matrix.repository }}
       ref: ""
       test-infra-repository: pytorch/test-infra
-      test-infra-ref: main
+      test-infra-ref: release/2.14
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ${{ matrix.pre-script }}
       env-script: ${{ matrix.env-script }}

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   claude-code:
-    uses: pytorch/test-infra/.github/workflows/_claude-code.yml@main
+    uses: pytorch/test-infra/.github/workflows/_claude-code.yml@release/2.14
     with:
       setup_script: |
         pip install lintrunner==0.12.7 lintrunner-adapters==0.14.1

--- a/.github/workflows/cuda-perf.yml
+++ b/.github/workflows/cuda-perf.yml
@@ -124,7 +124,7 @@ jobs:
   export-models:
     name: export-models
     needs: set-parameters
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -206,7 +206,7 @@ jobs:
         contains(needs.changed-files.outputs.changed-files, '.ci/scripts/test_model_e2e.sh') ||
         needs.run-decision.outputs.is-full-run == 'true'
       )
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -500,7 +500,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload benchmark results to dashboard
-        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@main
+        uses: pytorch/test-infra/.github/actions/upload-benchmark-results@release/2.14
         with:
           benchmark-results-dir: benchmark-results/v3
           dry-run: false

--- a/.github/workflows/cuda-windows.yml
+++ b/.github/workflows/cuda-windows.yml
@@ -54,7 +54,7 @@ jobs:
         contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda-windows.yml') ||
         needs.run-decision.outputs.is-full-run == 'true'
       )
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -161,7 +161,7 @@ jobs:
         contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda-windows.yml') ||
         needs.run-decision.outputs.is-full-run == 'true'
       )
-    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@release/2.14
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -67,7 +67,7 @@ jobs:
         cuda-version: ["12.6", "13.0"]
 
     name: test-executorch-cuda-build-${{ matrix.cuda-version }}
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -126,7 +126,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.ci/scripts/export_model_artifact.sh') ||
       contains(needs.changed-files.outputs.changed-files, '.ci/scripts/test_model_e2e.sh') ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -167,7 +167,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, 'backends/aoti') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/cuda.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -211,7 +211,7 @@ jobs:
     name: test-cuda-target-smem-cross-arch-a10g
     needs: [export-cuda-target-smem-cross-arch]
     if: needs.export-cuda-target-smem-cross-arch.result == 'success'
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -272,7 +272,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, 'extension/pybindings') ||
       contains(needs.changed-files.outputs.changed-files, 'runtime/__init__.py') ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -352,7 +352,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.ci/scripts/export_model_artifact.sh') ||
       contains(needs.changed-files.outputs.changed-files, '.ci/scripts/test_model_e2e.sh') ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -394,7 +394,7 @@ jobs:
         contains(needs.changed-files.outputs.changed-files, '.ci/scripts/test_model_e2e.sh') ||
         needs.run-decision.outputs.is-full-run == 'true'
       )
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -564,7 +564,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.ci/scripts/test_model_e2e.sh') ||
       contains(needs.changed-files.outputs.changed-files, 'examples/models/muse-glimmer') ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v3.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -639,7 +639,7 @@ jobs:
         contains(needs.changed-files.outputs.changed-files, '.ci/scripts/test_model_e2e.sh') ||
         needs.run-decision.outputs.is-full-run == 'true'
       )
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -98,7 +98,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     secrets: inherit
     with:
       repository: pytorch/executorch

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -126,7 +126,7 @@ jobs:
       # No step timeout: the action retries a cold BuildKit pool for at least two
       # hours, and the job's timeout-minutes is what bounds that.
       - name: Build and push to ECR
-        uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@main
+        uses: pytorch/test-infra/.github/actions/docker-build-remote-buildkit@release/2.14
         with:
           # calculate-docker-image wrapped the build in three retries because it
           # "frequently fails with network error downloading various stuffs".

--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -48,7 +48,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, 'extension/llm/export') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/metal.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       runner: macos-m2-stable
@@ -73,7 +73,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, 'extension/llm/export') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/metal.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       runner: macos-m2-stable
@@ -106,7 +106,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, 'extension/llm/export') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/metal.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       runner: macos-m2-stable
@@ -218,7 +218,7 @@ jobs:
         contains(needs.changed-files.outputs.changed-files, '.github/workflows/metal.yml') ||
         needs.run-decision.outputs.is-full-run == 'true'
       )
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     secrets: inherit
     strategy:
       fail-fast: false
@@ -304,7 +304,7 @@ jobs:
         contains(needs.changed-files.outputs.changed-files, '.github/workflows/metal.yml') ||
         needs.run-decision.outputs.is-full-run == 'true'
       )
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/mlx.yml
+++ b/.github/workflows/mlx.yml
@@ -42,7 +42,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       job-name: test-mlx
@@ -153,7 +153,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       job-name: test-mlx-supertonic
@@ -240,7 +240,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       job-name: test-mlx-qwen35-moe
@@ -322,7 +322,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       job-name: test-mlx-muse-glimmer-build
@@ -369,7 +369,7 @@ jobs:
       fail-fast: false
       matrix:
         suite: [models, operators]
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       job-name: test-mlx-backend-${{ matrix.suite }}
@@ -415,7 +415,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       job-name: test-mlx-parakeet
@@ -476,7 +476,7 @@ jobs:
     if: |
       (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request') &&
       (github.event_name == 'pull_request' || needs.run-decision.outputs.is-full-run == 'true')
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     secrets: inherit
     with:
       default-packages: ""
@@ -540,7 +540,7 @@ jobs:
     if: |
       (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request') &&
       (github.event_name == 'pull_request' || needs.run-decision.outputs.is-full-run == 'true')
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     secrets: inherit
     with:
       default-packages: ""
@@ -621,7 +621,7 @@ jobs:
     if: |
       (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request') &&
       (github.event_name == 'pull_request' || needs.run-decision.outputs.is-full-run == 'true')
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     secrets: inherit
     with:
       default-packages: ""
@@ -676,7 +676,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       job-name: test-mlx-stories110m
@@ -772,7 +772,7 @@ jobs:
             use-custom: false
             qconfig: "4w"
             runner: "macos-15-xlarge"
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     secrets: inherit
     with:
       default-packages: ""
@@ -857,7 +857,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       job-name: test-mlx-dflash
@@ -999,7 +999,7 @@ jobs:
             name: "gemma4-e2b"
             chat: "gemma4"
             runner: "macos-15-xlarge"
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     secrets: inherit
     with:
       default-packages: ""

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,13 +21,13 @@ jobs:
     environment: ${{ (github.event_name == 'schedule') && 'update-commit-hash' || '' }}
     steps:
       - name: update-pytorch-commit-hash
-        uses: pytorch/test-infra/.github/actions/update-commit-hash@main
+        uses: pytorch/test-infra/.github/actions/update-commit-hash@release/2.14
         if: ${{ github.event_name == 'schedule' }}
         with:
           repo-name: pytorch
           branch: main
           pin-folder: .ci/docker/ci_commit_pins
-          test-infra-ref: main
+          test-infra-ref: release/2.14
           updatebot-token: ${{ secrets.UPDATEBOT_TOKEN }}
           pytorchbot-token: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
 
@@ -51,7 +51,7 @@ jobs:
 
   test-static-hf-llm-qnn-linux:
     name: test-static-hf-llm-qnn-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -42,7 +42,7 @@ jobs:
 
   test-models-linux:
     name: test-models-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -36,7 +36,7 @@ jobs:
 
   test-qnn-wheel-packages-linux:
     name: test-qnn-wheel-packages-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -92,7 +92,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, 'setup.py') ||
       contains(needs.changed-files.outputs.changed-files, 'tools/cmake/')
     name: test-minimal-wheel-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -110,7 +110,7 @@ jobs:
 
   test-setup-linux-gcc:
     name: test-setup-linux-gcc
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -135,7 +135,7 @@ jobs:
 
   test-models-linux-basic:
     name: test-models-linux-basic
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -179,7 +179,7 @@ jobs:
 
   test-models-linux:
     name: test-models-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -232,7 +232,7 @@ jobs:
 
   test-parakeet-xnnpack-linux:
     name: test-parakeet-xnnpack-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -265,7 +265,7 @@ jobs:
 
   test-voxtral-realtime-xnnpack-linux:
     name: test-voxtral-realtime-xnnpack-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -302,7 +302,7 @@ jobs:
   test-llama-runner-linux:
     # Test Both linux x86 and linux aarch64
     name: test-llama-runner-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -352,7 +352,7 @@ jobs:
 
   test-llama-runner-linux-android:
     name: test-llama-runner-linux-android
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -377,7 +377,7 @@ jobs:
 
   test-custom-ops-linux:
     name: test-custom-ops-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -401,7 +401,7 @@ jobs:
 
   test-selective-build-linux:
     name: test-selective-build-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -426,7 +426,7 @@ jobs:
   test-multimodal-linux:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     name: test-multimodal-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -464,7 +464,7 @@ jobs:
 
   test-moshi-linux:
     name: test-moshi-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -496,7 +496,7 @@ jobs:
 
   test-quantized-aot-lib-linux:
     name: test-quantized-aot-lib-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -519,7 +519,7 @@ jobs:
 
   test-binary-size-linux-gcc:
     name: test-binary-size-linux-gcc
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -562,7 +562,7 @@ jobs:
 
   test-binary-size-linux:
     name: test-binary-size-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -606,7 +606,7 @@ jobs:
 
   test-arm-cortex-m-size-test:
     name: test-arm-cortex-m-size-test
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -699,7 +699,7 @@ jobs:
 
   test-mcu-cortex-m-backend:
     name: test-mcu-cortex-m-backend
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -766,7 +766,7 @@ jobs:
 
   test-qnn-buck-build-linux:
     name: test-qnn-buck-build-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -800,7 +800,7 @@ jobs:
 
   test-arm-backend-no-driver:
     name: test-arm-backend-no-driver
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -835,7 +835,7 @@ jobs:
 
   test-arm-backend-public-api-backward-compatibility:
     name: test-arm-backend-public-api-backward-compatibility
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -862,7 +862,7 @@ jobs:
 
   test-llama-runner-qnn-linux:
     name: test-llama-runner-qnn-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -901,7 +901,7 @@ jobs:
 
   test-static-llama-qnn-linux:
     name: test-static-llama-qnn-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -935,7 +935,7 @@ jobs:
 
   test-sqnr-static-llm-qnn-linux:
     name: test-sqnr-static-llm-qnn-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -969,7 +969,7 @@ jobs:
 
   test-qnn-models-linux:
     name: test-qnn-models-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -994,7 +994,7 @@ jobs:
 
   test-qnn-direct-build-linux:
     name: test-qnn-direct-build-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1030,7 +1030,7 @@ jobs:
 
   test-qnn-passes-linux:
     name: test-qnn-passes-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1068,7 +1068,7 @@ jobs:
 
   test-qnn-delegate-linux:
     name: test-qnn-delegate-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1106,7 +1106,7 @@ jobs:
 
   test-phi-3-mini-runner-linux:
     name: test-phi-3-mini-runner-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1136,7 +1136,7 @@ jobs:
 
   test-qnn-python-imports-linux:
     name: test-qnn-python-imports-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1184,7 +1184,7 @@ jobs:
 
   test-eval_llama-wikitext-linux:
     name: test-eval_llama-wikitext-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1212,7 +1212,7 @@ jobs:
   # TODO(larryliu0820): Fix this issue before reenabling it: https://gist.github.com/larryliu0820/7377ecd0d79dbc06076cec8d9f2b85d2
   # test-eval_llama-mmlu-linux:
   #   name: test-eval_llama-mmlu-linux
-  #   uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+  #   uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
   #   permissions:
   #     id-token: write
   #     contents: read
@@ -1239,7 +1239,7 @@ jobs:
 
   test-llama_runner_eager-linux:
     name: test-llama_runner_eager-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1266,7 +1266,7 @@ jobs:
 
   test-lora-linux:
     name: test-lora-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1293,7 +1293,7 @@ jobs:
 
   test-lora-multimethod-linux:
     name: test-lora-multimethod-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1320,7 +1320,7 @@ jobs:
 
   test-mediatek-models-linux:
     name: test-mediatek-models-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1347,7 +1347,7 @@ jobs:
 
   test-openvino-linux:
     name: test-openvino-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1369,7 +1369,7 @@ jobs:
 
   test-build-wasm-linux:
     name: test-build-wasm-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1397,7 +1397,7 @@ jobs:
 
   unittest-wasm-bindings:
     name: unittest-wasm-bindings
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1442,7 +1442,7 @@ jobs:
         pnpm test
 
   unittest-nxp-neutron:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1489,7 +1489,7 @@ jobs:
     name: test-samsung-quantmodels-linux
     # Skip this job if the pull request is from a fork (secrets are not available)
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1527,7 +1527,7 @@ jobs:
     name: test-samsung-models-linux
     # Skip this job if the pull request is from a fork (secrets are not available)
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1567,7 +1567,7 @@ jobs:
 
   test-vulkan-models-linux:
     name: test-vulkan-models-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1608,7 +1608,7 @@ jobs:
 
   test-vulkan-operators-linux:
     name: test-vulkan-operators-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1668,7 +1668,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/pull.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
     name: test-coreml-bc-macos (${{ matrix.runner }})
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1700,7 +1700,7 @@ jobs:
 
   nxp-build-test:
     name: nxp-build-test
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -1730,7 +1730,7 @@ jobs:
 
   nxp-mcuxpresso-test:
     name: nxp-mcuxpresso-test
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/qnn-windows-msvc.yml
+++ b/.github/workflows/qnn-windows-msvc.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   build-qnn-windows-msvc:
     name: build-qnn-windows-msvc
-    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@release/2.14
     with:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90

--- a/.github/workflows/rocm.yml
+++ b/.github/workflows/rocm.yml
@@ -170,7 +170,7 @@ jobs:
       fail-fast: false
       matrix:
         rocm-version: ["7.2"]
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -198,7 +198,7 @@ jobs:
       needs.voxtral-run-decision.outputs.run-voxtral == 'true' &&
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -240,7 +240,7 @@ jobs:
     concurrency:
       group: rocm-gfx1100-${{ github.event.pull_request.number || github.ref_name }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test-pico2-build.yml
+++ b/.github/workflows/test-pico2-build.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   test-pico2-fp32-build:
     name: test-pico2-fp32-build
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -90,7 +90,7 @@ jobs:
 
   test-pico2-cmsis-build:
     name: test-pico2-cmsis-nn-build
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test-webgpu-native.yml
+++ b/.github/workflows/test-webgpu-native.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   test-webgpu-native:
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     with:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       runner: linux.4xlarge.memory

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -44,7 +44,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     strategy:
       matrix:
         # Mac runners are expensive and limited, and non reliable.
@@ -82,7 +82,7 @@ jobs:
 
   test-arm-backend-zephyr:
     name: test-arm-backend-zephyr
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job.yml@release/2.14
     strategy:
       matrix:
         include:
@@ -120,7 +120,7 @@ jobs:
 
   test-models-linux-aarch64:
     name: test-models-linux-aarch64
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -174,7 +174,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     strategy:
       matrix:
         include:
@@ -201,7 +201,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     strategy:
       matrix:
         include:
@@ -224,7 +224,7 @@ jobs:
 
   test-demo-backend-delegation:
     name: test-demo-backend-delegation
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -251,7 +251,7 @@ jobs:
 
   test-arm-backend-ethos-u:
     name: test-arm-backend-ethos-u
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -304,7 +304,7 @@ jobs:
 
   test-arm-backend-vkml:
     name: test-arm-backend-vkml
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -355,7 +355,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/trunk.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
     name: test-coreml-delegate
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       runner: macos-14-xlarge
@@ -385,7 +385,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/trunk.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
     name: test-static-llama-ane
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       runner: macos-m1-stable
@@ -412,7 +412,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     with:
       default-packages: ""
       runner: macos-m1-stable
@@ -434,7 +434,7 @@ jobs:
   test-llama-runner-linux:
     # Test Both linux x86 and linux aarch64
     name: test-llama-runner-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -508,7 +508,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/trunk.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
     name: test-llama-runner-mac
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     strategy:
       matrix:
         dtype: [fp32]
@@ -544,7 +544,7 @@ jobs:
 
   test-torchao-huggingface-checkpoints:
     name: test-torchao-huggingface-checkpoints
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -598,7 +598,7 @@ jobs:
         needs.run-decision.outputs.is-full-run == 'true'
       )
     name: test-multimodal-macos
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -638,7 +638,7 @@ jobs:
 
   test-qnn-model:
     name: test-qnn-model
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -664,7 +664,7 @@ jobs:
 
   test-qnn-optimum-model:
     name: test-qnn-optimum-model
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -699,7 +699,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/trunk.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
     name: test-models-macos-coreml
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     strategy:
       matrix:
         model: [dl3, edsr, efficient_sam, emformer_join, emformer_transcribe, ic3, ic4, mobilebert, mv2, mv3, resnet50, vit, w2l]
@@ -743,7 +743,7 @@ jobs:
     # NB: Don't run this on fork PRs because they won't have access to the secret and would fail anyway
     if: ${{ !github.event.pull_request.head.repo.fork }}
     name: test-huggingface-transformers-xnnpack
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -843,7 +843,7 @@ jobs:
         needs.run-decision.outputs.is-full-run == 'true'
       )
     name: test-huggingface-transformers-macos
-    uses: pytorch/test-infra/.github/workflows/macos_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/macos_job.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -906,7 +906,7 @@ jobs:
 
   test-llama-runner-qnn-linux:
     name: test-llama-runner-qnn-linux
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -989,7 +989,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@release/2.14
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Update viable/strict
         id: update
-        uses: pytorch/test-infra/.github/actions/update-viablestrict@main
+        uses: pytorch/test-infra/.github/actions/update-viablestrict@release/2.14
         with:
           repository: pytorch/executorch
           stable-branch: viable/strict

--- a/.github/workflows/vulkan.yml
+++ b/.github/workflows/vulkan.yml
@@ -50,7 +50,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.ci/scripts/setup-vulkan-linux-deps.sh') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/vulkan.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@release/2.14
     permissions:
       id-token: write
       contents: read
@@ -134,7 +134,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/vulkan.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
     name: build-vulkan-windows-msvc
-    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@release/2.14
     with:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 90

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -44,7 +44,7 @@ jobs:
       contains(needs.changed-files.outputs.changed-files, '.ci/scripts/') ||
       contains(needs.changed-files.outputs.changed-files, '.github/workflows/windows-msvc.yml') ||
       needs.run-decision.outputs.is-full-run == 'true'
-    uses: pytorch/test-infra/.github/workflows/windows_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/windows_job.yml@release/2.14
     with:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 60

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ To build the documentation locally:
 1. Clone the ExecuTorch repo to your machine.
 
    ```bash
-   git clone -b viable/strict https://github.com/pytorch/executorch.git && cd executorch
+   git clone -b release/1.5 https://github.com/pytorch/executorch.git && cd executorch
    ```
 
 1. If you don't have it already, start either a Python virtual environment:

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -199,7 +199,7 @@ For a platform the package does not cover, or to change build options, build fro
 CMake is the preferred build system for the ExecuTorch C++ runtime. To use with CMake, clone the ExecuTorch repository as a subdirectory of your project, and use CMake's `add_subdirectory("executorch")` to include the dependency. The `executorch` target, as well as kernel and backend targets will be made available to link against. The runtime can also be built standalone to support diverse toolchains. See [Using ExecuTorch with C++](using-executorch-cpp.md) and [Building from Source](using-executorch-building-from-source.md) for a detailed description of build integration, targets, and cross compilation.
 
 ```
-git clone -b viable/strict https://github.com/pytorch/executorch.git
+git clone -b release/1.5 https://github.com/pytorch/executorch.git
 ```
 ```cmake
 # Set CMAKE_CXX_STANDARD to 17 or above.

--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -50,7 +50,7 @@ portability details.
 ## Environment Setup
  Clone the ExecuTorch repository from GitHub and create a conda environment. Venv can be used in place of conda.
    ```bash
-   git clone -b viable/strict https://github.com/pytorch/executorch.git
+   git clone -b release/1.5 https://github.com/pytorch/executorch.git
    cd executorch
    conda create -yn executorch python=3.10
    conda activate executorch

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -112,7 +112,7 @@ xcode-select --install
 2. Clone ExecuTorch:
 
 ```bash
-git clone -b viable/strict https://github.com/pytorch/executorch.git --depth 1 --recurse-submodules --shallow-submodules && cd executorch
+git clone -b release/1.5 https://github.com/pytorch/executorch.git --depth 1 --recurse-submodules --shallow-submodules && cd executorch
 ```
 
 3. Set up [Python](https://www.python.org/downloads/macos/) 3.10+ and activate a virtual environment:


### PR DESCRIPTION
### Summary

Release-only changes. Do not merge to `main`.

Pins ExecuTorch reusable workflows and actions to `pytorch/test-infra@release/2.14`, and updates release documentation clone commands from `viable/strict` to `release/1.5`, following `scripts/release/apply-release-changes.sh`.

Depends on [pytorch/test-infra#8746](https://github.com/pytorch/test-infra/pull/8746), which backports the remote BuildKit action used by the Docker workflow to `release/2.14`.

### Test plan

- `git diff --check`
- parsed all 72 workflow YAML files
- verified all 17 referenced test-infra actions/workflows: 16 already exist on `release/2.14`, and the remaining remote BuildKit action is supplied by the dependency PR
- verified no mutable `pytorch/test-infra@main` or `test-infra-ref: main` references remain
