### PR TITLE
[ET-VK][testing] Reuse allocations in chained benchmarks

### DIFF
--- a/backends/vulkan/test/custom_ops/utils.cpp
+++ b/backends/vulkan/test/custom_ops/utils.cpp
@@ -31,6 +31,46 @@ constexpr float kMinProbeTimeUs = 1.0f;
 
 } // namespace
 
+// Benchmark graphs are immutable after input upload, so their execute nodes can
+// be recorded repeatedly without triggering ComputeGraph resize bookkeeping
+// (neither the old replay loop nor this executor invokes it).
+RepeatedGraphExecutor::RepeatedGraphExecutor(
+    ComputeGraph& graph,
+    int repetitions)
+    : graph_(graph) {
+  VK_CHECK_COND(repetitions > 0);
+
+  api::Context* const context = graph_.context();
+  context->flush();
+  context->set_cmd(/*reusable=*/true);
+  context->cmd_reset_querypool();
+
+  for (int i = 0; i < repetitions; ++i) {
+    for (std::unique_ptr<ExecuteNode>& node : graph_.execute_nodes()) {
+      node->encode(&graph_);
+    }
+  }
+
+  command_ =
+      std::make_unique<vkapi::CommandBuffer>(std::move(context->extract_cmd()));
+}
+
+void RepeatedGraphExecutor::execute() {
+  api::Context* const context = graph_.context();
+  command_->end();
+
+  // Intentionally bypasses Context::submit_cmd_to_gpu(): its submit-count
+  // bookkeeping and threshold-split path only serve submit_compute_job
+  // recording, which benchmarks don't use.
+  vkapi::VulkanFence fence = context->fences().get_fence();
+  context->adapter_ptr()->submit_cmd(
+      context->queue(),
+      command_->get_submit_handle(/*final_use=*/false),
+      fence.get_submit_handle());
+  fence.wait();
+  context->fences().return_fence(fence);
+}
+
 int get_seed() {
   static int seed = 42;
   return seed++;
@@ -1436,6 +1476,8 @@ ComputeGraph setup_compute_graph(
     int op_invocations_per_execute) {
   GraphConfig config;
   config.enable_querypool = true;
+  config.descriptor_pool_safety_factor *=
+      std::max(1, op_invocations_per_execute);
   // Default-on (opt-out via TestCase::set_force_resize(false)): force every
   // DynamicDispatchNode to run its resize function on each execute(),
   // exercising the op's resize formula even when input shapes are unchanged.
@@ -1518,12 +1560,7 @@ ComputeGraph setup_compute_graph(
   std::vector<ValueRef> op_args = input_values;
   op_args.insert(op_args.end(), output_values.begin(), output_values.end());
 
-  // Invoke the op op_invocations_per_execute times to stack dispatches per
-  // graph.execute(). The output set_output_value() calls below still happen
-  // exactly once.
-  for (int i = 0; i < op_invocations_per_execute; ++i) {
-    opFn(graph, op_args);
-  }
+  opFn(graph, op_args);
 
   for (size_t i = 0; i < output_values.size(); ++i) {
     graph.set_output_value(output_values[i]);
@@ -1546,9 +1583,8 @@ BenchmarkResult execute_test_case(
     api::context()->initialize_querypool();
   }
 
-  // Build the measurement graph with the requested chained_dispatches factor.
-  // The caller (typically execute_test_cases) decides what it should be —
-  // this function is a pure "run at the given chained_dispatches" primitive.
+  // Build the operator once. Benchmark repetition is encoded separately so
+  // persistent graph allocations are not duplicated.
   ComputeGraph graph = setup_compute_graph(
       test_case, test_case.operator_name(), chained_dispatches);
 
@@ -1602,9 +1638,11 @@ BenchmarkResult execute_test_case(
     ++graph_input_idx;
   }
 
+  RepeatedGraphExecutor graph_executor(graph, chained_dispatches);
+
   // Warmup runs
   for (int run = 0; run < warmup_runs; ++run) {
-    graph.execute();
+    graph_executor.execute();
   }
 
   // Benchmark runs - collect individual iteration timings
@@ -1616,7 +1654,7 @@ BenchmarkResult execute_test_case(
   for (int run = 0; run < benchmark_runs; ++run) {
     // Measure CPU time for each execute() call
     auto cpu_start = std::chrono::high_resolution_clock::now();
-    graph.execute();
+    graph_executor.execute();
     auto cpu_end = std::chrono::high_resolution_clock::now();
 
     auto cpu_duration = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/backends/vulkan/test/custom_ops/utils.cpp
+++ b/backends/vulkan/test/custom_ops/utils.cpp
@@ -31,24 +31,34 @@ constexpr float kMinProbeTimeUs = 1.0f;
 
 } // namespace
 
-// Benchmark graphs are immutable after input upload, so their execute nodes can
-// be recorded repeatedly without triggering ComputeGraph resize bookkeeping
-// (neither the old replay loop nor this executor invokes it).
+// Benchmark graphs are immutable after input upload, so the operator nodes can
+// be recorded repeatedly. Staging uploads/downloads are encoded once:
+// repeating them would redo host-visible copies on every repetition and bias
+// per-invocation timings.
 RepeatedGraphExecutor::RepeatedGraphExecutor(
     ComputeGraph& graph,
-    int repetitions)
+    int repetitions,
+    OpNodeRange op_nodes)
     : graph_(graph) {
   VK_CHECK_COND(repetitions > 0);
+  VK_CHECK_COND(op_nodes.begin <= op_nodes.end);
+  VK_CHECK_COND(op_nodes.end <= graph_.execute_nodes().size());
 
   api::Context* const context = graph_.context();
   context->flush();
   context->set_cmd(/*reusable=*/true);
   context->cmd_reset_querypool();
 
+  for (size_t i = 0; i < op_nodes.begin; ++i) {
+    graph_.execute_nodes()[i]->encode(&graph_);
+  }
   for (int i = 0; i < repetitions; ++i) {
-    for (std::unique_ptr<ExecuteNode>& node : graph_.execute_nodes()) {
-      node->encode(&graph_);
+    for (size_t j = op_nodes.begin; j < op_nodes.end; ++j) {
+      graph_.execute_nodes()[j]->encode(&graph_);
     }
+  }
+  for (size_t i = op_nodes.end; i < graph_.execute_nodes().size(); ++i) {
+    graph_.execute_nodes()[i]->encode(&graph_);
   }
 
   command_ =
@@ -1473,17 +1483,21 @@ int64_t default_flop_calculator(const TestCase& test_case) {
   return total_elements;
 }
 
-ComputeGraph setup_compute_graph(
+BenchmarkGraph setup_compute_graph(
     TestCase& test_case,
     std::string op_name,
     int op_invocations_per_execute) {
   GraphConfig config;
   config.enable_querypool = true;
+  // Pool sizing takes max(execute, prepack) * factor, so scaling the factor
+  // also over-reserves the prepack side (encoded once). Accepted: precise
+  // execute-only sizing would need runtime changes.
   config.descriptor_pool_safety_factor *=
       std::max(1, op_invocations_per_execute);
   // Default-on (opt-out via TestCase::set_force_resize(false)): force every
-  // DynamicDispatchNode to run its resize function on each execute(),
-  // exercising the op's resize formula even when input shapes are unchanged.
+  // DynamicDispatchNode to run its resize function when execute_test_case
+  // runs propagate_resize() after prepack, exercising the op's resize formula
+  // even when input shapes are unchanged.
   config.force_resize = test_case.get_force_resize();
   ComputeGraph graph(config);
 
@@ -1563,12 +1577,16 @@ ComputeGraph setup_compute_graph(
   std::vector<ValueRef> op_args = input_values;
   op_args.insert(op_args.end(), output_values.begin(), output_values.end());
 
+  // Nodes added before the op are staging uploads; nodes added after are
+  // staging downloads. Only the op's own nodes are repeated by benchmarks.
+  const size_t op_begin = graph.execute_nodes().size();
   opFn(graph, op_args);
+  const size_t op_end = graph.execute_nodes().size();
 
   for (size_t i = 0; i < output_values.size(); ++i) {
     graph.set_output_value(output_values[i]);
   }
-  return graph;
+  return {std::move(graph), {op_begin, op_end}};
 }
 
 // Test execution utilities
@@ -1588,12 +1606,17 @@ BenchmarkResult execute_test_case(
 
   // Build the operator once. Benchmark repetition is encoded separately so
   // persistent graph allocations are not duplicated.
-  ComputeGraph graph = setup_compute_graph(
+  BenchmarkGraph benchmark = setup_compute_graph(
       test_case, test_case.operator_name(), chained_dispatches);
+  ComputeGraph& graph = benchmark.graph;
 
   // Prepare the graph
   graph.prepare();
   graph.prepack();
+
+  // Run resize functions once so force_resize exercises resize formulas even
+  // though the record/replay path below never calls propagate_resize().
+  graph.propagate_resize();
 
   // Copy input data into the graph's staging buffers
   size_t graph_input_idx = 0;
@@ -1641,7 +1664,8 @@ BenchmarkResult execute_test_case(
     ++graph_input_idx;
   }
 
-  RepeatedGraphExecutor graph_executor(graph, chained_dispatches);
+  RepeatedGraphExecutor graph_executor(
+      graph, chained_dispatches, benchmark.op_nodes);
 
   // Warmup runs
   for (int run = 0; run < warmup_runs; ++run) {

--- a/backends/vulkan/test/custom_ops/utils.h
+++ b/backends/vulkan/test/custom_ops/utils.h
@@ -608,9 +608,9 @@ class TestCase {
     return shader_filter_;
   }
 
-  // Manual override for the number of times the op is dispatched per
-  // graph.execute() (a.k.a. chained_dispatches). If > 0, the framework uses
-  // this directly and skips the probe phase. 0 (the default) means adaptive
+  // Manual override for the number of chained dispatches per measurement
+  // iteration (a.k.a. chained_dispatches). If > 0, the framework uses this
+  // directly and skips the probe phase. 0 (the default) means adaptive
   // (probe-then-scale).
   void set_op_invocations_per_execute(int n) {
     op_invocations_per_execute_ = n;
@@ -927,9 +927,33 @@ int64_t default_flop_calculator(const TestCase& test_case);
 
 using ReferenceComputeFunc = std::function<void(TestCase&)>;
 
-// Runs a measurement at the given chained_dispatches factor (how many times
-// the op is stacked inside one graph.execute()). This is a primitive; the
-// probe-then-scale orchestration lives in execute_test_cases().
+// Benchmark-only executor that records a graph's execute nodes N times into a
+// single reusable command buffer, then replays it on every execute().
+// Production ComputeGraph::execute() behavior is unchanged.
+//
+// Notes for interpreting benchmark numbers:
+// - Submit granularity differs from stacking N distinct nodes: all N encodings
+//   live in one command buffer with one submit per iteration (the old path
+//   could split across command buffers at the node-count threshold), so
+//   per-dispatch times may shift systematically against older data.
+// - No resize is triggered on the benchmark path in either design; resize
+//   coverage comes from the probe pass via graph.execute().
+// - Repeated encodings share one node/dispatch id, so per-repetition
+//   querypool attribution is unavailable (aggregation keys on kernel name).
+class RepeatedGraphExecutor final {
+ public:
+  RepeatedGraphExecutor(ComputeGraph& graph, int repetitions);
+  void execute();
+
+ private:
+  ComputeGraph& graph_;
+  std::unique_ptr<vkapi::CommandBuffer> command_;
+};
+
+// Runs a measurement at the given chained_dispatches factor. The operator is
+// built once, then its execute nodes are encoded that many times into a
+// benchmark-only reusable command buffer. The probe-then-scale orchestration
+// lives in execute_test_cases().
 //
 // write_outputs controls whether the graph's staging output buffers are copied
 // back into test_case.outputs() at the end of the run. The probe path needs
@@ -1007,10 +1031,9 @@ void compute_weight_sums_4bit_grouped(
 uint16_t float_to_half(float value);
 float half_to_float(uint16_t half_val);
 
-// Setup compute graph based on TestCase and operation name. The op function
-// is invoked op_invocations_per_execute times so that one graph.execute()
-// dispatches the op that many times (Google Benchmark-style stacking). The
-// output set_output_value() calls still happen once at the end.
+// Setup compute graph based on TestCase and operation name. The op function is
+// invoked once. op_invocations_per_execute is used only to reserve enough
+// descriptor capacity for benchmark-only repeated command encoding.
 ComputeGraph setup_compute_graph(
     TestCase& test_case,
     std::string op_name,

--- a/backends/vulkan/test/custom_ops/utils.h
+++ b/backends/vulkan/test/custom_ops/utils.h
@@ -645,13 +645,15 @@ class TestCase {
 
   // When true, the ComputeGraph built for this test case sets
   // GraphConfig::force_resize, so every DynamicDispatchNode runs its resize
-  // function on each execute() even when no input shape changed. Because the
-  // output is already allocated at the swept shape, the resize must recompute
-  // the same shape from the current input — a wrong resize formula resizes the
-  // output to a mismatched shape and surfaces as a test failure. Default true
-  // (opt-out): every custom_ops test exercises its resize formulas across the
-  // swept shapes. Call set_force_resize(false) for the rare op whose resize fn
-  // is intentionally not shape-preserving under a fixed output allocation.
+  // function once during measurement setup (execute_test_case runs
+  // propagate_resize() after prepack) even when no input shape changed.
+  // Because the output is already allocated at the swept shape, the resize
+  // must recompute the same shape from the current input — a wrong resize
+  // formula resizes the output to a mismatched shape and surfaces as a test
+  // failure. Default true (opt-out): every custom_ops test exercises its
+  // resize formulas across the swept shapes. Call set_force_resize(false) for
+  // the rare op whose resize fn is intentionally not shape-preserving under a
+  // fixed output allocation.
   void set_force_resize(bool force_resize) {
     force_resize_ = force_resize;
   }
@@ -940,22 +942,42 @@ int64_t default_flop_calculator(const TestCase& test_case);
 
 using ReferenceComputeFunc = std::function<void(TestCase&)>;
 
-// Benchmark-only executor that records a graph's execute nodes N times into a
-// single reusable command buffer, then replays it on every execute().
-// Production ComputeGraph::execute() behavior is unchanged.
+// Half-open index range of the operator's own dispatch nodes within a
+// benchmark graph's execute_nodes(). Staging upload nodes precede it, staging
+// download nodes follow it.
+struct OpNodeRange {
+  size_t begin = 0;
+  size_t end = 0;
+};
+
+// A benchmark graph plus the location of its repeatable operator nodes.
+struct BenchmarkGraph {
+  ComputeGraph graph;
+  OpNodeRange op_nodes;
+};
+
+// Benchmark-only executor that records a graph's execute nodes into a single
+// reusable command buffer, then replays it on every execute(). Staging uploads
+// are encoded once, operator nodes N times, staging downloads once, so each
+// iteration performs the same work as the old stacked-nodes layout (1 upload +
+// N ops + 1 download) and the per-invocation divisor is unchanged. Production
+// ComputeGraph::execute() behavior is unchanged.
 //
 // Notes for interpreting benchmark numbers:
-// - Submit granularity differs from stacking N distinct nodes: all N encodings
+// - Submit granularity differs from stacking N distinct nodes: all encodings
 //   live in one command buffer with one submit per iteration (the old path
 //   could split across command buffers at the node-count threshold), so
 //   per-dispatch times may shift systematically against older data.
-// - No resize is triggered on the benchmark path in either design; resize
-//   coverage comes from the probe pass via graph.execute().
+// - Resize functions run once via propagate_resize() in execute_test_case
+//   before recording; replay itself never re-triggers resize.
 // - Repeated encodings share one node/dispatch id, so per-repetition
 //   querypool attribution is unavailable (aggregation keys on kernel name).
 class RepeatedGraphExecutor final {
  public:
-  RepeatedGraphExecutor(ComputeGraph& graph, int repetitions);
+  RepeatedGraphExecutor(
+      ComputeGraph& graph,
+      int repetitions,
+      OpNodeRange op_nodes);
   void execute();
 
  private:
@@ -1046,8 +1068,9 @@ float half_to_float(uint16_t half_val);
 
 // Setup compute graph based on TestCase and operation name. The op function is
 // invoked once. op_invocations_per_execute is used only to reserve enough
-// descriptor capacity for benchmark-only repeated command encoding.
-ComputeGraph setup_compute_graph(
+// descriptor capacity for benchmark-only repeated command encoding. Returns
+// the graph plus the range of the operator's own nodes for repeated encoding.
+BenchmarkGraph setup_compute_graph(
     TestCase& test_case,
     std::string op_name,
     int op_invocations_per_execute = 1);

--- a/backends/vulkan/test/custom_ops/utils_test.cpp
+++ b/backends/vulkan/test/custom_ops/utils_test.cpp
@@ -12,11 +12,25 @@ namespace executorch::vulkan::prototyping {
 namespace {
 
 int operator_build_count = 0;
+int encode_count = 0;
+
+class CountingEncodeNode final : public ExecuteNode {
+ public:
+  explicit CountingEncodeNode(int& count) : count_(count) {}
+  void encode(ComputeGraph* graph) override {
+    (void)graph;
+    ++count_;
+  }
+
+ private:
+  int& count_;
+};
 
 void counting_operator(ComputeGraph& graph, const std::vector<ValueRef>& args) {
   (void)args;
   ++operator_build_count;
-  graph.execute_nodes().emplace_back(std::make_unique<ExecuteNode>());
+  graph.execute_nodes().emplace_back(
+      std::make_unique<CountingEncodeNode>(encode_count));
 }
 
 REGISTER_OPERATORS {
@@ -189,17 +203,23 @@ TEST(BenchmarkGraphTest, ChainedDispatchesBuildOperatorOnce) {
 
   TestCase test_case;
   operator_build_count = 0;
+  encode_count = 0;
 
-  ComputeGraph graph = setup_compute_graph(
+  BenchmarkGraph benchmark = setup_compute_graph(
       test_case,
       "test_etvk.counting_operator.default",
       /*op_invocations_per_execute=*/8);
+  ComputeGraph& graph = benchmark.graph;
 
   EXPECT_EQ(operator_build_count, 1);
-  EXPECT_EQ(graph.execute_nodes().size(), 1);
+  ASSERT_EQ(graph.execute_nodes().size(), 1u);
+  EXPECT_EQ(benchmark.op_nodes.begin, 0u);
+  EXPECT_EQ(benchmark.op_nodes.end, 1u);
 
-  // Exercise the benchmark-only record-once/replay path over the built graph.
-  RepeatedGraphExecutor graph_executor(graph, /*repetitions=*/8);
+  // The replay path must encode the operator node once per repetition.
+  RepeatedGraphExecutor graph_executor(
+      graph, /*repetitions=*/8, benchmark.op_nodes);
+  EXPECT_EQ(encode_count, 8);
   graph_executor.execute();
 }
 

--- a/backends/vulkan/test/custom_ops/utils_test.cpp
+++ b/backends/vulkan/test/custom_ops/utils_test.cpp
@@ -11,6 +11,18 @@
 namespace executorch::vulkan::prototyping {
 namespace {
 
+int operator_build_count = 0;
+
+void counting_operator(ComputeGraph& graph, const std::vector<ValueRef>& args) {
+  (void)args;
+  ++operator_build_count;
+  graph.execute_nodes().emplace_back(std::make_unique<ExecuteNode>());
+}
+
+REGISTER_OPERATORS {
+  VK_REGISTER_OP(test_etvk.counting_operator.default, counting_operator);
+}
+
 TEST(ValueSpecTest, SetConstant_DoesNotMaterializeTensorData) {
   ValueSpec value(
       {16},
@@ -166,6 +178,27 @@ TEST(ValueSpecTest, ShareReferenceFrom_IgnoresNonTensorSpecs) {
   const void* before = tensor.get_ref_float_data().data();
   tensor.share_reference_from(scalar);
   EXPECT_EQ(tensor.get_ref_float_data().data(), before);
+}
+
+TEST(BenchmarkGraphTest, ChainedDispatchesBuildOperatorOnce) {
+  if (!vkcompute::api::available()) {
+    return;
+  }
+
+  TestCase test_case;
+  operator_build_count = 0;
+
+  ComputeGraph graph = setup_compute_graph(
+      test_case,
+      "test_etvk.counting_operator.default",
+      /*op_invocations_per_execute=*/8);
+
+  EXPECT_EQ(operator_build_count, 1);
+  EXPECT_EQ(graph.execute_nodes().size(), 1);
+
+  // Exercise the benchmark-only record-once/replay path over the built graph.
+  RepeatedGraphExecutor graph_executor(graph, /*repetitions=*/8);
+  graph_executor.execute();
 }
 
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #22619
* #22618

Build each benchmark operator once and replay its `execute_nodes()` in a benchmark-owned reusable command buffer. This prevents chained timing from multiplying persistent prepack and intermediate GPU allocations while leaving production `ComputeGraph::execute()` behavior unchanged. Authored with Codex.

Differential Revision: [D119219596](https://our.internmc.facebook.com/intern/diff/D119219596/)