### PR TITLE
[docs] Refresh README, runtime APIs, and success stories

### DIFF
--- a/README-wheel.md
+++ b/README-wheel.md
@@ -4,9 +4,8 @@ standard on-device iOS and Android mobile deployments. One of the main goals for
 ExecuTorch is to enable wider customization and deployment capabilities of the
 PyTorch programs.
 
-The `executorch` pip package is in beta.
 * Supported python versions: 3.10, 3.11, 3.12, 3.13, 3.14
-* Compatible systems: Linux x86_64, Linux aarch64, macOS aarch64
+* Compatible systems: Linux x86_64, Linux aarch64, macOS aarch64, Windows x86_64
 
 Backend export tools can require optional Python dependencies. For example,
 install the dependencies needed for Ethos-U ahead-of-time (AOT) export with:
@@ -25,8 +24,9 @@ serialization, but omits runtime pybindings, kernels, backend packages, headers,
 examples, and devtools. It also declares only the Python dependencies the export
 path needs (no `coremltools`, `pandas`, `scikit-learn`, `hydra-core`, or
 `omegaconf`), so a normal install stays small. Like the full wheel it does not
-bundle PyTorch, so install a compatible `torch` separately. The wheel is still
-platform specific because it ships `flatc`.
+bundle PyTorch. Published stable wheels declare a compatible `torch` dependency;
+install `torch` explicitly when building from source or choosing a specific
+PyTorch channel. The wheel is still platform specific because it ships `flatc`.
 
 The prebuilt `executorch.runtime` module included in this package provides a way
 to run ExecuTorch `.pte` files, with some restrictions:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="docs/source/_static/img/et-logo.png" alt="ExecuTorch logo mark" width="200">
   <h1>ExecuTorch</h1>
-  <p><strong>On-device AI inference powered by PyTorch</strong></p>
+  <p><strong>PyTorch-native AI inference from phones and laptops to microcontrollers</strong></p>
 </div>
 
 <div align="center">
@@ -12,238 +12,225 @@
   <a href="https://docs.pytorch.org/executorch/main/index.html"><img src="https://img.shields.io/badge/Documentation-blue?logo=googledocs&logoColor=white&style=for-the-badge" alt="Documentation"></a>
 </div>
 
-**ExecuTorch** is PyTorch's unified solution for deploying AI models on-device—from smartphones to microcontrollers—built for privacy, performance, and portability. It powers Meta's on-device AI across **Instagram, WhatsApp, Quest 3, Ray-Ban Meta Smart Glasses**, and [more](https://docs.pytorch.org/executorch/main/success-stories.html).
+**ExecuTorch** is PyTorch's open source stack for running AI locally on phones,
+wearables, laptops, browsers, embedded systems, and microcontrollers. Start with
+a PyTorch model, capture it with `torch.export`, optimize it for target hardware,
+and run it through C++, Python, Swift/Objective-C, Kotlin/Java, or JavaScript
+APIs.
 
-Deploy **LLMs, vision, speech, and multimodal models** with the same PyTorch APIs you already know—accelerating research to production with seamless model export, optimization, and deployment. No manual C++ rewrites. No format conversions. No vendor lock-in.
+ExecuTorch powers on-device experiences across **Instagram, WhatsApp, Facebook,
+and Messenger**, serving billions of people. It also runs AI features on
+**Meta Quest and Ray-Ban Meta devices**.
+[See where ExecuTorch is shipping.](https://docs.pytorch.org/executorch/main/success-stories.html)
 
-<details>
-  <summary><strong>📘 Table of Contents</strong></summary>
+> [!IMPORTANT]
+> **Release channels:** use the
+> [latest release](https://github.com/pytorch/executorch/releases/latest) with
+> the [stable documentation](https://docs.pytorch.org/executorch/stable/).
+> This README tracks `main`; features labeled **Main / nightly** may change
+> before release. Use the [main documentation](https://docs.pytorch.org/executorch/main/)
+> with a source checkout or nightly package.
 
-- [Why ExecuTorch?](#why-executorch)
-- [How It Works](#how-it-works)
-- [Quick Start](#quick-start)
-  - [Installation](#installation)
-  - [Export and Deploy in 3 Steps](#export-and-deploy-in-3-steps)
-  - [Run on Device](#run-on-device)
-  - [LLM Example: Llama](#llm-example-llama)
-- [Platform & Hardware Support](#platform--hardware-support)
-- [Production Deployments](#production-deployments)
-- [Examples & Models](#examples--models)
-- [Key Features](#key-features)
-- [Documentation](#documentation)
-- [Community & Contributing](#community--contributing)
-- [License](#license)
+## Built for current edge workloads
 
-</details>
+| Workload | Representative capabilities | Start here |
+|---|---|---|
+| **Local LLM and agent building blocks** | Quantized text models, long context, tool calling, speculative decoding, multi-session execution, and an experimental OpenAI-compatible local server | [Muse Glimmer](examples/models/muse-glimmer/README.md) · [LLM guide](https://docs.pytorch.org/executorch/main/llm/working-with-llms.html) · [LLM server](examples/llm_server/README.md) |
+| **Voice** | Streaming and offline speech recognition, speech synthesis, voice activity detection, and speaker diarization | [Voxtral Realtime](examples/models/voxtral_realtime/README.md) · [Parakeet](examples/models/parakeet/README.md) · [Sortformer diarization](examples/models/sortformer/README.md) · [Voxtral TTS](examples/models/voxtral_tts/README.md) |
+| **Multimodal** | Text, image, and audio runners; mobile vision-language models | [Gemma 4](examples/models/gemma4/README.md) · [Multimodal runner](extension/llm/runner/README.md) |
+| **Computer vision** | Image classification, object detection, semantic segmentation, and promptable segmentation | [MobileNet V2](docs/source/getting-started.md#preparing-the-model) · [YOLO26](examples/models/yolo26/README.md) · [DeepLabV3](https://github.com/meta-pytorch/executorch-examples/tree/main/dl3/android/DeepLabV3Demo) · [EfficientSAM](examples/models/efficient_sam/README.md) |
+| **Embedded AI** | Cortex-M CPU kernels, Ethos-U and NXP NPUs, Cadence DSPs, Zephyr, Arduino, and Raspberry Pi Pico workflows | [Embedded guide](https://docs.pytorch.org/executorch/main/embedded-section.html) · [Cortex-M](https://docs.pytorch.org/executorch/main/backends/arm-cortex-m/arm-cortex-m-overview.html) · [Arduino](examples/arduino/README.md) |
 
-## Why ExecuTorch?
+These are starting points, not a compatibility list. A model does not need to
+appear here to run with ExecuTorch: use the
+[standard export guide](https://docs.pytorch.org/executorch/main/using-executorch-export.html)
+or adapt the closest [model example](examples/models/). Deployment depends on
+`torch.export` capture plus operator, runtime, and selected-backend coverage;
+validate numerical accuracy, memory use, and performance on the target. For a
+new language-model architecture, see the
+[custom LLM guide](https://docs.pytorch.org/executorch/main/llm/export-custom-llm.html).
 
-- **🔒 Native PyTorch Export** — Direct export from PyTorch. No .onnx, .tflite, or intermediate format conversions. Preserve model semantics.
-- **⚡ Production-Proven** — Powers billions of users at [Meta with real-time on-device inference](https://engineering.fb.com/2025/07/28/android/executorch-on-device-ml-meta-family-of-apps/).
-- **💾 Tiny Runtime** — 50KB base footprint. Runs on microcontrollers to high-end smartphones.
-- **🚀 [12+ Hardware Backends](https://docs.pytorch.org/executorch/main/backends-overview.html)** — Open-source acceleration for Apple, Samsung, Qualcomm, ARM, MediaTek, Vulkan, and more.
-- **🎯 One Export, Multiple Backends** — Switch hardware targets with a single line change. Deploy the same model everywhere.
+## Why ExecuTorch
 
-## How It Works
+- **PyTorch-native workflow:** work directly from `torch.export`, with PyTorch
+  program metadata and source mappings available to export and debugging tools.
+- **Partitioned hardware acceleration:** delegate supported graph regions to
+  CPU, GPU, NPU, or DSP backends while retaining portable CPU kernels for
+  fallback.
+- **One source model, explicit targets:** reuse the PyTorch model and export
+  flow, while producing a backend-specific `.pte` for each target that needs
+  hardware specialization.
+- **A runtime you can right-size:** link only the operators, kernels, and
+  delegates a deployment needs;
+  [selective build](https://docs.pytorch.org/executorch/main/kernel-library-selective-build.html)
+  keeps only the required operator kernels.
+- **Inspect, profile, and extend:** use
+  [ETDump](https://docs.pytorch.org/executorch/main/etdump.html),
+  [ETRecord](https://docs.pytorch.org/executorch/main/etrecord.html), and
+  [numeric debugging](https://docs.pytorch.org/executorch/main/model-debugging.html),
+  or add custom operators and backends.
+- **Versioned deployment contract:** a `.pte` created with stable APIs is
+  guaranteed to load and execute for at least one following non-patch runtime
+  release; see the
+  [runtime compatibility](runtime/COMPATIBILITY.md) and
+  [API lifecycle](docs/source/api-life-cycle.md) policies.
 
-ExecuTorch uses **ahead-of-time (AOT) compilation** to prepare PyTorch models for edge deployment:
+## Install
 
-1. **🧩 Export** — Capture your PyTorch model graph with `torch.export()`
-2. **⚙️ Compile** — Quantize, optimize, and partition to hardware backends → `.pte`
-3. **🚀 Execute** — Load `.pte` on-device via lightweight C++ runtime
-
-Models use a standardized [Core ATen operator set](https://docs.pytorch.org/executorch/main/compiler-ir-advanced.html#intermediate-representation). [Partitioners](https://docs.pytorch.org/executorch/main/compiler-delegate-and-partitioner.html) delegate subgraphs to specialized hardware (NPU/GPU) with CPU fallback.
-
-Learn more: [How ExecuTorch Works](https://docs.pytorch.org/executorch/main/intro-how-it-works.html) • [Architecture Guide](https://docs.pytorch.org/executorch/main/getting-started-architecture.html)
-
-## Quick Start
-
-### Installation
+Install the latest stable Python package in a Python 3.10–3.14 environment:
 
 ```bash
 pip install executorch
 ```
 
+Install a nightly built from `main` to use the newest features:
+
+```bash
+pip install --pre executorch torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+```
+
+`torch` is explicit because nightly ExecuTorch wheels do not declare it as a
+dependency. This command installs a CPU-only PyTorch nightly. For an NVIDIA GPU,
+select the nightly command matching your CUDA version in the
+[PyTorch installation selector](https://pytorch.org/get-started/locally/) and
+use its `nightly/cu*` index instead; otherwise, pip can replace a CUDA-enabled
+PyTorch installation with the CPU build.
+
 Backend export tools can require optional dependencies. For example, use
 `pip install 'executorch[ethos_u]'` for Ethos-U AOT export. Embedded
 toolchains, simulators, and target runtimes are installed separately.
 
-For platform-specific setup (Android, iOS, embedded systems), see the [Quick Start](https://docs.pytorch.org/executorch/main/quick-start-section.html) documentation for additional info.
+For platform-specific setup (Android, iOS, embedded systems), see the
+[Quick Start](https://docs.pytorch.org/executorch/main/quick-start-section.html)
+documentation for additional information.
 
-### Export and Deploy in 3 Steps
+The prebuilt Python wheel is published for Linux x86-64, Linux AArch64, macOS
+arm64, and Windows x86-64. Build from source for other hosts or custom
+configurations. Native integration is also available through:
+
+- [Prebuilt C++ libraries, headers, and CMake package in current main/nightly Linux and macOS wheels](https://docs.pytorch.org/executorch/main/using-executorch-cpp.html#using-the-prebuilt-libraries-from-the-pip-package)
+- [Android AAR from Maven Central](https://docs.pytorch.org/executorch/main/using-executorch-android.html)
+- [Apple frameworks through Swift Package Manager](https://docs.pytorch.org/executorch/main/using-executorch-ios.html)
+- [Source builds and cross-compilation](https://docs.pytorch.org/executorch/main/using-executorch-building-from-source.html)
+
+## Five-minute export and run
+
+This complete example, from the
+[quick-start pathway](https://docs.pytorch.org/executorch/main/pathway-quickstart.html),
+exports a small model and lowers it to XNNPACK:
 
 ```python
 import torch
 from executorch.exir import to_edge_transform_and_lower
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+from executorch.runtime import Runtime
 
-# 1. Export your PyTorch model
-model = MyModel().eval()
-example_inputs = (torch.randn(1, 3, 224, 224),)
-exported_program = torch.export.export(model, example_inputs)
+# Define a simple model
+class Add(torch.nn.Module):
+    def forward(self, x, y):
+        return x + y
 
-# 2. Optimize for target hardware (switch backends with one line)
-program = to_edge_transform_and_lower(
-    exported_program,
-    partitioner=[XnnpackPartitioner()]  # CPU | CoreMLPartitioner() for iOS | QnnPartitioner() for Qualcomm
+model = Add().eval()
+sample_inputs = (torch.ones(1), torch.ones(1))
+
+et_program = to_edge_transform_and_lower(
+    torch.export.export(model, sample_inputs),
+    partitioner=[XnnpackPartitioner()]
 ).to_executorch()
 
-# 3. Save for deployment
-with open("model.pte", "wb") as f:
-    f.write(program.buffer)
+with open("add.pte", "wb") as f:
+    f.write(et_program.buffer)
 
-# Test locally via ExecuTorch runtime's pybind API (optional)
-from executorch.runtime import Runtime
 runtime = Runtime.get()
-method = runtime.load_program("model.pte").load_method("forward")
-outputs = method.execute([torch.randn(1, 3, 224, 224)])
+runtime_program = runtime.load_program("add.pte")
+method = runtime_program.load_method("forward")
+output = method.execute(sample_inputs)[0]
+
+torch.testing.assert_close(output, model(*sample_inputs))
+print("Output:", output)
 ```
 
-### Run on Device
+Expected output: `Output: tensor([2.])`. This verifies export, XNNPACK lowering,
+serialization, loading, and execution on the host; measure performance again on
+the target device.
 
-**[C++](https://docs.pytorch.org/executorch/main/using-executorch-cpp.html)**
-```cpp
-#include <executorch/extension/module/module.h>
-#include <executorch/extension/tensor/tensor.h>
+The resulting `add.pte` is specialized for the selected backend. Targeting
+Core ML, Qualcomm, or another accelerator requires that backend's dependencies,
+configuration, and a separate export, not a blind partitioner substitution.
+Continue with the [Python runtime](https://docs.pytorch.org/executorch/main/getting-started.html#testing-the-model),
+[C++ Module API](https://docs.pytorch.org/executorch/main/using-executorch-cpp.html),
+[Android](https://docs.pytorch.org/executorch/main/android-section.html), or
+[iOS](https://docs.pytorch.org/executorch/main/ios-section.html).
 
-Module module("model.pte");
-auto tensor = make_tensor_ptr({2, 2}, {1.0f, 2.0f, 3.0f, 4.0f});
-auto outputs = module.forward(tensor);
-```
+### Choose an export path
 
-**[Swift (iOS)](https://docs.pytorch.org/executorch/main/ios-section.html)**
-```swift
-import ExecuTorch
+| Starting point | Recommended path | Scope |
+|---|---|---|
+| PyTorch `nn.Module` | [Standard export and lowering](https://docs.pytorch.org/executorch/main/using-executorch-export.html) | Full backend choice; some models need decompositions or custom operators |
+| Hugging Face `PreTrainedModel` | [Transformers ExecuTorch exporter](https://huggingface.co/docs/transformers/en/exporters) | Experimental programmatic XNNPACK/CUDA export; generation components require application orchestration |
+| Optimized text or multimodal generation | [`export_llm`](https://docs.pytorch.org/executorch/main/llm/export-llm.html) or [Optimum ExecuTorch](https://huggingface.co/docs/optimum-executorch/) | Tested recipes, quantization, tokenizers, and runner-specific metadata |
 
-let module = Module(filePath: "model.pte")
-let input = Tensor<Float>([1.0, 2.0, 3.0, 4.0], shape: [2, 2])
-let outputs = try module.forward(input)
-```
+Already have a compatible `.pte`? Browse the
+[ExecuTorch Community](https://huggingface.co/executorch-community),
+[Arm AI model catalog filtered to ExecuTorch](https://developer.arm.com/ai/models?runtime=executorch),
+or, where available, the linked model pages above. Match the model
+configuration, precision, backend, and runtime; a `.pte` built for one hardware
+delegate is not a universal model file.
 
-**[Kotlin (Android)](https://docs.pytorch.org/executorch/main/android-section.html)**
-```kotlin
-val module = Module.load("model.pte")
-val inputTensor = Tensor.fromBlob(floatArrayOf(1.0f, 2.0f, 3.0f, 4.0f), longArrayOf(2, 2))
-val outputs = module.forward(EValue.from(inputTensor))
-```
+## Runtime and LLM APIs
 
-### LLM Example: Llama
+All language APIs load target-specific `.pte` programs. See the
+[API lifecycle policy](docs/source/api-life-cycle.md) for stability guarantees.
 
-Export Llama models using the [`export_llm`](https://docs.pytorch.org/executorch/main/llm/export-llm.html) script or [Optimum-ExecuTorch](https://github.com/huggingface/optimum-executorch):
+| Language / platform | General `.pte` execution | Text and multimodal generation |
+|---|---|---|
+| C++ | [`Module`](docs/source/extension-module.md) and lower-level [`Program` / `Method`](docs/source/running-a-model-cpp-tutorial.md) | [`TextLLMRunner`](docs/source/llm/run-with-c-plus-plus.md) and [`MultimodalRunner`](extension/llm/runner/README.md#multimodalrunner) |
+| Python | [`Runtime` / `Program` / `Method`](docs/source/runtime-python-api-reference.rst) for desktop and host validation | [Runner bindings](extension/llm/runner/README.md#python-api), depending on the installed package or source build |
+| Android, Java / Kotlin | [`Module`, `Tensor`, and `EValue`](docs/source/using-executorch-android.md) | [`LlmModule`](docs/source/llm/run-on-android.md) |
+| Apple, Swift / Objective-C | [`Module`, `Tensor`, and `Value`](docs/source/using-executorch-ios.md) | [`TextRunner` and `MultimodalRunner`](docs/source/llm/run-on-ios.md) |
+| JavaScript / WebAssembly | [`Module` and `Tensor`](extension/wasm/README.md), built from source | No high-level LLM API |
 
-```bash
-# Using export_llm
-python -m executorch.extension.llm.export.export_llm --model llama3_2 --output llama.pte
+## Platforms and hardware backends
 
-# Using Optimum-ExecuTorch
-optimum-cli export executorch \
-  --model meta-llama/Llama-3.2-1B \
-  --task text-generation \
-  --recipe xnnpack \
-  --output_dir llama_model
-```
+Choose a backend based on target hardware, operator coverage, and deployment
+constraints. The linked guides document setup, supported hardware, and known
+limitations. These are representative paths; the
+[backend documentation](https://docs.pytorch.org/executorch/main/backends-overview.html)
+is authoritative.
 
-Run on-device with the LLM runner API:
-
-**[C++](https://docs.pytorch.org/executorch/main/llm/run-with-c-plus-plus.html)**
-```cpp
-#include <executorch/extension/llm/runner/text_llm_runner.h>
-
-auto runner = create_llama_runner("llama.pte", "tiktoken.bin");
-executorch::extension::llm::GenerationConfig config{
-    .seq_len = 128, .temperature = 0.8f};
-runner->generate("Hello, how are you?", config);
-```
-
-**[Swift (iOS)](https://docs.pytorch.org/executorch/main/llm/run-on-ios.html)**
-```swift
-import ExecuTorchLLM
-
-let runner = TextRunner(modelPath: "llama.pte", tokenizerPath: "tiktoken.bin")
-try runner.generate("Hello, how are you?", Config {
-    $0.sequenceLength = 128
-}) { token in
-    print(token, terminator: "")
-}
-```
-
-**Kotlin (Android)** — [API Docs](https://docs.pytorch.org/executorch/main/javadoc/org/pytorch/executorch/extension/llm/package-summary.html) • [Demo App](https://github.com/meta-pytorch/executorch-examples/tree/main/llm/android/LlamaDemo)
-```kotlin
-val llmModule = LlmModule("llama.pte", "tiktoken.bin", 0.8f)
-llmModule.load()
-llmModule.generate("Hello, how are you?", 128, object : LlmCallback {
-    override fun onResult(result: String) { print(result) }
-    override fun onStats(stats: String) { }
-})
-```
-
-For multimodal models (vision, audio), use the [MultiModal runner API](extension/llm/runner) which extends the LLM runner to handle image and audio inputs alongside text. See [Llava](examples/models/llava/README.md) and [Voxtral](examples/models/voxtral/README.md) examples.
-
-See [examples/models/llama](examples/models/llama/README.md) for complete workflow including quantization, mobile deployment, and advanced options.
-
-**Next Steps:**
-- 📖 [Step-by-step tutorial](https://docs.pytorch.org/executorch/main/getting-started.html) — Complete walkthrough for your first model
-- ⚡ [Colab notebook](https://colab.research.google.com/drive/1qpxrXC3YdJQzly3mRg-4ayYiOjC6rue3?usp=sharing) — Try ExecuTorch instantly in your browser
-- 🤖 [Deploy Llama models](examples/models/llama/README.md) — LLM workflow with quantization and mobile demos
-
-## Platform & Hardware Support
-
-| **Platform**     | **Supported Backends**                                   |
-|------------------|----------------------------------------------------------|
-| Android          | XNNPACK, Vulkan, Qualcomm, MediaTek, Samsung Exynos      |
-| iOS              | XNNPACK, CoreML (Neural Engine)                          |
-| Linux / Windows  | XNNPACK, OpenVINO, CUDA *(experimental)*                 |
-| macOS            | XNNPACK, Metal *(experimental)*, MLX *(experimental)*    |
-| Embedded / MCU   | XNNPACK, ARM Ethos-U, NXP, Cadence DSP                   |
-
-See [Backend Documentation](https://docs.pytorch.org/executorch/main/backends-overview.html) for detailed hardware requirements and optimization guides. For desktop/laptop GPU inference with CUDA and Metal, see the [Desktop Guide](desktop/README.md). For Zephyr RTOS integration, see the [Zephyr Guide](zephyr/README.md).
-
-## Production Deployments
-
-ExecuTorch powers on-device AI at scale across Meta's family of apps, VR/AR devices, and partner deployments. [View success stories →](https://docs.pytorch.org/executorch/main/success-stories.html)
-
-## Examples & Models
-
-**LLMs:** [Llama 3.2/3.1/3](examples/models/llama/README.md), [Qwen 3](examples/models/qwen3/README.md), [Phi-4-mini](examples/models/phi_4_mini/README.md), [LiquidAI LFM2](examples/models/lfm2/README.md)
-
-**Multimodal:** [Llava](examples/models/llava/README.md) (vision-language), [Voxtral](examples/models/voxtral/README.md) (audio-language), [Gemma](examples/models/gemma3) (vision-language)
-
-**Vision/Speech:** [MobileNetV2](https://github.com/meta-pytorch/executorch-examples/tree/main/mv2), [DeepLabV3](https://github.com/meta-pytorch/executorch-examples/tree/main/dl3), [YOLO26](examples/models/yolo26/README.md), [Whisper](examples/models/whisper/README.md), [Supertonic](examples/models/supertonic/README.md) <!-- @lint-ignore -->
-
-**Resources:** [`examples/`](examples/) directory • [executorch-examples](https://github.com/meta-pytorch/executorch-examples) out-of-tree demos • [Optimum-ExecuTorch](https://github.com/huggingface/optimum-executorch) for HuggingFace models • [Unsloth](https://docs.unsloth.ai/new/deploy-llms-phone) for fine-tuned LLM deployment <!-- @lint-ignore -->
-
-## Key Features
-
-ExecuTorch provides advanced capabilities for production deployment:
-
-- **Quantization** — Built-in support via [torchao](https://docs.pytorch.org/ao) for 8-bit, 4-bit, and dynamic quantization
-- **Memory Planning** — Optimize memory usage with ahead-of-time allocation strategies
-- **Developer Tools** — ETDump profiler, ETRecord inspector, and model debugger
-- **Selective Build** — Strip unused operators to minimize binary size
-- **Custom Operators** — Extend with domain-specific kernels
-- **Dynamic Shapes** — Support variable input sizes with bounded ranges
-
-See [Advanced Topics](https://docs.pytorch.org/executorch/main/advanced-topics-section.html) for quantization techniques, custom backends, and compiler passes.
+| Target | Backends and integrations |
+|---|---|
+| Android | [XNNPACK](docs/source/backends/xnnpack/xnnpack-overview.md) CPU; [Vulkan](docs/source/backends/vulkan/vulkan-overview.md) GPU; [Qualcomm](docs/source/backends-qualcomm.md), [MediaTek](docs/source/backends-mediatek.md), [Arm VGF](docs/source/backends/arm-vgf/arm-vgf-overview.md), and [Samsung Exynos](docs/source/backends/samsung/samsung-overview.md) accelerators |
+| iOS / iPadOS | [XNNPACK](docs/source/backends/xnnpack/xnnpack-overview.md) CPU; [Core ML](docs/source/backends/coreml/coreml-overview.md); [MLX](docs/source/backends/mlx/mlx-overview.md) on physical devices *(experimental)* |
+| macOS | [XNNPACK](docs/source/backends/xnnpack/xnnpack-overview.md); [Core ML](docs/source/backends/coreml/coreml-overview.md); experimental [MLX](docs/source/backends/mlx/mlx-overview.md), [Metal/AOTInductor](backends/apple/metal/README.md), and [WebGPU](docs/source/backends/webgpu/webgpu-overview.md) paths |
+| Linux | [XNNPACK](docs/source/backends/xnnpack/xnnpack-overview.md); [OpenVINO](docs/source/build-run-openvino.md); experimental [CUDA/AOTInductor](docs/source/backends/cuda/cuda-overview.md), [Vulkan](docs/source/backends/vulkan/vulkan-overview.md), and [WebGPU](docs/source/backends/webgpu/webgpu-overview.md) desktop paths |
+| Windows | [XNNPACK](docs/source/backends/xnnpack/xnnpack-overview.md); experimental [CUDA/AOTInductor](docs/source/backends/cuda/cuda-overview.md) and [Vulkan](docs/source/backends/vulkan/vulkan-overview.md) desktop paths |
+| Browser / WebAssembly | [Portable WebAssembly runtime](extension/wasm/README.md) and [WebGPU](docs/source/backends/webgpu/webgpu-overview.md) *(both experimental)* |
+| Embedded / MCU | [Arm Cortex-M with CMSIS-NN](docs/source/backends/arm-cortex-m/arm-cortex-m-overview.md) *(beta)*; [Arm Ethos-U](docs/source/backends/arm-ethos-u/arm-ethos-u-overview.md); [NXP eIQ Neutron](docs/source/backends/nxp/nxp-overview.md); [Cadence DSP](docs/source/backends-cadence.md); [Zephyr](zephyr/README.md) and [Arduino](examples/arduino/README.md) integrations |
 
 ## Documentation
 
-- [**Documentation Home**](https://docs.pytorch.org/executorch/main/index.html) — Complete guides and tutorials
-- [**API Reference**](https://docs.pytorch.org/executorch/main/api-section.html) — Python, C++, Java/Kotlin APIs
-- [**Backend Integration**](https://docs.pytorch.org/executorch/main/backend-delegates-integration.html) — Build custom hardware backends
-- [**Troubleshooting**](https://docs.pytorch.org/executorch/main/support-section.html) — Common issues and solutions
+- [Get started](https://docs.pytorch.org/executorch/main/getting-started.html)
+- [Choose a platform](https://docs.pytorch.org/executorch/main/edge-platforms-section.html)
+- [Choose a backend](https://docs.pytorch.org/executorch/main/backends-overview.html)
+- [Export and lower a model](https://docs.pytorch.org/executorch/main/using-executorch-export.html)
+- [Work with LLMs](https://docs.pytorch.org/executorch/main/llm/working-with-llms.html)
+- [Profile and debug](https://docs.pytorch.org/executorch/main/tools-section.html)
+- [Runtime and LLM APIs](https://docs.pytorch.org/executorch/main/api-section.html)
+- [PTE/runtime compatibility policy](runtime/COMPATIBILITY.md)
+- [LLM benchmark dashboard](https://hud.pytorch.org/benchmark/llms?repoName=pytorch%2Fexecutorch) <!-- @lint-ignore -->
+- [Troubleshooting](https://docs.pytorch.org/executorch/main/support-section.html)
 
-## Community & Contributing
+## Community and contributing
 
-We welcome contributions from the community!
-
-- 💬 [**GitHub Discussions**](https://github.com/pytorch/executorch/discussions) — Ask questions and share ideas
-- 🎮 [**Discord**](https://discord.gg/Dh43CKSAdc) — Chat with the team and community
-- 🐛 [**Issues**](https://github.com/pytorch/executorch/issues) — Report bugs or request features
-- 🤝 [**Contributing Guide**](CONTRIBUTING.md) — Guidelines and codebase structure
+- [GitHub Discussions](https://github.com/pytorch/executorch/discussions): ask questions and share ideas
+- [Discord](https://discord.gg/Dh43CKSAdc): chat with maintainers and the community
+- [Issues](https://github.com/pytorch/executorch/issues): report bugs or request features
+- [Contributing guide](CONTRIBUTING.md): development setup, testing, and review guidelines
 
 ## Citing ExecuTorch
 
-If you found ExecuTorch helpful in your research and would like to acknowledge it, please cite us using the following BibTeX:
+If you use ExecuTorch in research, please cite:
 
 ```bibtex
 @article{executorch2026,
@@ -251,16 +238,14 @@ If you found ExecuTorch helpful in your research and would like to acknowledge i
     author={Nachin, Mergen and Desai, Digant and Jia, Sicheng Stephen and Lai, Chen and Liu, Mengwei and Szwejbka, Jacob and Alvarez, Raziel and Ascani, RJ and Bort, Dave and Candales, Manuel and
   others},
     journal={arXiv preprint arXiv:2605.08195},
-    url={https://github.com/pytorch/executorch},
+    url={https://arxiv.org/abs/2605.08195},
     year={2026}
   }
 ```
 
 ## License
 
-ExecuTorch is BSD licensed, as found in the [LICENSE](LICENSE) file.
-
-<br><br>
+ExecuTorch is BSD licensed. See [LICENSE](LICENSE).
 
 ---
 

--- a/backends/mlx/README.md
+++ b/backends/mlx/README.md
@@ -14,23 +14,24 @@ The MLX delegate compiles PyTorch models to run on Apple Silicon GPUs via the
 
 ## Getting Started
 
-The MLX delegate requires **Apple Silicon** (M1 or later) and the **Metal
-compiler**, which ships with Xcode (not the standalone Command Line Tools).
+The MLX delegate requires **Apple Silicon** (M1 or later), the full **Xcode**
+application (not just Command Line Tools), and the separately installed **Metal
+Toolchain** component.
 
 **Check if Metal is available:**
 
 ```bash
-xcrun -sdk macosx --find metal
+xcrun -sdk macosx metal --version
 ```
 
-If this prints a path (e.g. `/Applications/Xcode.app/.../metal`), you're set.
-If it errors, you either need to install Xcode from the
+If this prints version information, you're set. If it errors, install Xcode from the
 [App Store](https://apps.apple.com/us/app/xcode/id497799835) or
-<https://developer.apple.com/xcode/>, or — if Xcode is already installed but the
-command line developer directory points at Command Line Tools — switch it:
+<https://developer.apple.com/xcode/>, select it as the active developer
+directory, and download the Metal Toolchain:
 
 ```bash
 sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+xcodebuild -downloadComponent MetalToolchain
 ```
 
 ### Python (pybindings)

--- a/docs/source/api-section.md
+++ b/docs/source/api-section.md
@@ -1,13 +1,68 @@
 (api-section)=
 # API
 
-In this section, find complete API documentation for ExecuTorch's export, runtime, and extension interfaces. Includes comprehensive references for Python, C++, and Java APIs across all supported platforms.
+ExecuTorch has two runtime layers:
+
+- The **core runtime** loads and executes methods in a compatible `.pte`
+  program. Use it when your application owns preprocessing, postprocessing,
+  and task orchestration.
+- The **LLM runner** builds on the core runtime with tokenization, prefill and
+  decode orchestration, sampling, and streaming generation for text and
+  multimodal models.
+
+The table below is the entry point for choosing a language binding. Maturity
+follows the {doc}`api-life-cycle`: an API is stable unless it is explicitly
+marked experimental or deprecated. An annotation on an individual API takes
+precedence over this summary.
+
+```{list-table} Runtime and LLM APIs by language
+:header-rows: 1
+:widths: 18 33 33 16
+
+* - **Language / platform**
+  - **Core runtime**
+  - **LLM runner**
+  - **Maturity**
+* - C++
+  - {doc}`extension-module` for the high-level `Module` API, or
+    {doc}`executorch-runtime-api-reference` for `Program` and `Method`
+  - {doc}`llm/run-with-c-plus-plus` for `TextLLMRunner` and
+    `MultimodalRunner`
+  - Core: **stable**; LLM: **experimental**
+* - Python
+  - {doc}`runtime-python-api-reference` for host-side loading, execution, and
+    validation
+  - [Python LLM runner bindings](https://github.com/pytorch/executorch/blob/main/extension/llm/runner/README.md#python-api),
+    whose availability depends on the installed package or source build
+  - Core: **stable**; LLM: **experimental**
+* - Android: Java / Kotlin
+  - {doc}`using-executorch-android` and the
+    [Javadoc](https://pytorch.org/executorch/main/javadoc/) for `Module`,
+    `Tensor`, and `EValue`
+  - {doc}`llm/run-on-android` for `LlmModule`
+  - Core: **experimental**; LLM: **experimental**
+* - Apple: Swift / Objective-C
+  - {doc}`using-executorch-ios` for `Module`, `Tensor`, and `Value`
+  - {doc}`llm/run-on-ios` for `TextRunner` and `MultimodalRunner`
+  - Core: **experimental**; LLM: **experimental**
+* - Browser: JavaScript / WebAssembly
+  - [WebAssembly `Module` and `Tensor`](https://github.com/pytorch/executorch/blob/main/extension/wasm/README.md),
+    currently built from source
+  - No high-level LLM runner API
+  - Core: **experimental**
+```
+
+Use the core runtime for any compatible exported model, including vision,
+audio, and custom workloads. Use an LLM runner only when the exported program
+and tokenizer satisfy that runner's model metadata and packaging requirements.
+
+## Export and reference documentation
 
 - {doc}`export-to-executorch-api-reference` — Export to ExecuTorch API Reference
 - {doc}`executorch-runtime-api-reference` — ExecuTorch Runtime API Reference
 - {doc}`runtime-python-api-reference` — Runtime Python API Reference
 - {doc}`api-life-cycle` — API Life Cycle
-- [Android doc →](https://pytorch.org/executorch/main/javadoc/) — Android API Documentation
+- [Android API reference](https://pytorch.org/executorch/main/javadoc/): Java/Kotlin API documentation
 - {doc}`extension-module` — Extension Module
 - {doc}`extension-tensor` — Extension Tensor
 - {doc}`running-a-model-cpp-tutorial` — Detailed C++ Runtime APIs Tutorial

--- a/docs/source/backends/mlx/mlx-overview.md
+++ b/docs/source/backends/mlx/mlx-overview.md
@@ -28,18 +28,23 @@ One of:
 ## Development Requirements
 
 - [macOS](https://developer.apple.com/macos) on Apple Silicon (M1 or later)
-- [Xcode](https://developer.apple.com/xcode/) (full installation, not just Command Line Tools — the Metal compiler is required)
+- [Xcode](https://developer.apple.com/xcode/) (full installation, not just Command Line Tools)
+- The Metal Toolchain component, installed separately with
+  `xcodebuild -downloadComponent MetalToolchain`
 
 Verify the Metal compiler is available:
 
 ```bash
-xcrun -sdk macosx --find metal
+xcrun -sdk macosx metal --version
 ```
 
-If this prints a path (e.g., `/Applications/Xcode.app/.../metal`), you're set. If it errors, install Xcode from [developer.apple.com](https://developer.apple.com/xcode/), then switch the active developer directory:
+If this prints version information, you're set. If it errors, install Xcode from
+[developer.apple.com](https://developer.apple.com/xcode/), select it as the active
+developer directory, and download the Metal Toolchain:
 
 ```bash
 sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+xcodebuild -downloadComponent MetalToolchain
 ```
 
 ----
@@ -54,7 +59,7 @@ import torchvision.models as models
 from torchvision.models.mobilenetv2 import MobileNet_V2_Weights
 from executorch.backends.mlx import MLXPartitioner
 from executorch.backends.mlx.passes import get_default_passes
-from executorch.exir import to_edge_transform_and_lower
+from executorch.exir import EdgeCompileConfig, to_edge_transform_and_lower
 
 mobilenet_v2 = models.mobilenetv2.mobilenet_v2(weights=MobileNet_V2_Weights.DEFAULT).eval()
 sample_inputs = (torch.randn(1, 3, 224, 224), )
@@ -63,6 +68,10 @@ et_program = to_edge_transform_and_lower(
     torch.export.export(mobilenet_v2, sample_inputs),
     transform_passes=get_default_passes(),
     partitioner=[MLXPartitioner()],
+    compile_config=EdgeCompileConfig(
+        _check_ir_validity=False,
+        _skip_dim_order=True,
+    ),
 ).to_executorch()
 
 with open("mv2_mlx.pte", "wb") as file:
@@ -70,6 +79,9 @@ with open("mv2_mlx.pte", "wb") as file:
 ```
 
 `get_default_passes()` includes RMSNorm fusion, consecutive view/permute/dtype-cast collapsing, no-op removal, and common subexpression elimination. These are recommended for all models and required for optimal LLM performance.
+The accompanying `EdgeCompileConfig` disables generic edge IR validation and
+dimension-order conversion because the MLX reinplace pass introduces
+backend-specific in-place operators after export.
 
 ::::{note}
 The MLX backend is primarily designed for LLM and generative AI workloads on Apple Silicon. The MobileNet V2 example above is shown for simplicity, but in practice you would use this backend for models like Llama, Whisper, and other transformer-based architectures. See [LLM example](https://github.com/pytorch/executorch/tree/main/backends/mlx/examples/llm) for a more representative use case.

--- a/docs/source/backends/mlx/mlx-troubleshooting.md
+++ b/docs/source/backends/mlx/mlx-troubleshooting.md
@@ -92,13 +92,18 @@ python -m executorch.backends.mlx.pte_inspector model.pte --extract-delegate mlx
 
 ### Metal compiler not found
 
-**Error:** `xcrun -sdk macosx --find metal` fails.
+**Error:** `xcrun -sdk macosx metal --version` fails.
 
-**Solution:** Install the full Xcode application (not just Command Line Tools). The Metal compiler ships with Xcode. If Xcode is installed but not selected:
+**Solution:** Install the full Xcode application (not just Command Line Tools),
+select it as the active developer directory, and download the separately
+installed Metal Toolchain component:
 
 ```bash
 sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+xcodebuild -downloadComponent MetalToolchain
 ```
+
+Then rerun `xcrun -sdk macosx metal --version` to verify the compiler.
 
 ### `MLXPartitioner must be used with to_edge_transform_and_lower()`
 

--- a/docs/source/backends/vulkan/tutorials/etvk-llama-tutorial.md
+++ b/docs/source/backends/vulkan/tutorials/etvk-llama-tutorial.md
@@ -44,14 +44,14 @@ export CONTEXT_LENGTH=2048
 ```
 
 Then, export the Llama 3.2 1B/3B Instruct model to ExecuTorch Vulkan. Note that
-that `--vulkan-force-fp16` flag is set, which will improve model inference
+the `--vulkan-force-fp16` flag is set, which will improve model inference
 latency at the cost of model accuracy. Feel free to remove this flag.
 
 ```shell
 python -m examples.models.llama.export_llama \
     -c $HOME/.llama/checkpoints/${LLM_NAME}-${LLM_SIZE}${LLM_SUFFIX}/consolidated.00.pth \
     -p $HOME/.llama/checkpoints/${LLM_NAME}-${LLM_SIZE}${LLM_SUFFIX}/params.json \
-    -d fp32 --${BACKEND} \
+    -d fp32 --${BACKEND} --vulkan-force-fp16 \
     -qmode ${QUANT} -G ${GROUP_SIZE} \
     --max_seq_length ${CONTEXT_LENGTH} \
     --max_context_length ${CONTEXT_LENGTH} \
@@ -136,7 +136,6 @@ adb shell /data/local/tmp/etvk/llama_main \
 Here is some sample output captured from a Galaxy S24:
 
 ```shell
-E tokenizers:hf_tokenizer.cpp:60] Error parsing json file: [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - invalid literal; last read: 'I'
 <|begin_of_text|><|start_header_id|>system<|end_header_id|>Write me a short poem.<|eot_id|><|start_header_id|>assistant<|end_header_id|>
 
 Here is a short poem I came up with:

--- a/docs/source/backends/vulkan/vulkan-overview.md
+++ b/docs/source/backends/vulkan/vulkan-overview.md
@@ -25,10 +25,10 @@ modes is on the way.
 
 ## Development Requirements
 
-To contribute to the Vulkan delegate, the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home#android)
-must be installed on the development system. After installation, the `glslc` binary must
-be found in your `PATH` in order to compile Vulkan shaders. This can be checked by
-running
+To build the Vulkan delegate, install the
+[Vulkan SDK](https://vulkan.lunarg.com/sdk/home) 1.4.341.1 or newer.
+After installation, the `glslc` binary must be found in your `PATH` in order
+to compile Vulkan shaders. This can be checked by running
 
 ```sh
 glslc --version
@@ -47,8 +47,9 @@ or alternatively,
 python install_vulkan.py
 ```
 
-The [Android NDK](https://developer.android.com/ndk/downloads) must also be installed.
-Any NDK version past NDK r17c should suffice.
+To target Android, also install a current
+[Android NDK](https://developer.android.com/ndk/downloads). ExecuTorch CI uses
+NDK r28c.
 
 ----
 
@@ -85,7 +86,7 @@ with open("mv2_vulkan.pte", "wb") as file:
     etvk_program.write_to_file(file)
 ```
 
-See [Partitioner API](vulkan-partitioner.md)
+See {doc}`/backends/vulkan/vulkan-partitioner`
 for a reference on available partitioner options.
 
 ----
@@ -93,7 +94,7 @@ for a reference on available partitioner options.
 ## Quantization
 
 The Vulkan delegate currently supports execution of quantized linear layers.
-See [Vulkan Quantization](vulkan-quantization.md)
+See {doc}`/backends/vulkan/vulkan-quantization`
 for more information on available quantization schemes and APIs.
 
 ----
@@ -110,33 +111,19 @@ When building from source, pass `-DEXECUTORCH_BUILD_VULKAN=ON` when configuring
 the CMake build to compile the Vulkan backend. See [Running on Device](/getting-started.md#running-on-device)
 for more information.
 
-To link against the backend, add the `executorch_backends` CMake target as a
-build dependency, or link directly against `libvulkan_backend`. Due to the use
-of static initialization to register available compute shaders and operators,
-it is required to ensure that the library is linked with `--whole-archive`.
+To link against the backend, use the `vulkan_backend` CMake target. The target
+propagates the platform-specific linker options needed to retain the static
+initializers that register Vulkan compute shaders and operators.
 
 ```cmake
 # CMakeLists.txt
-find_package(executorch CONFIG REQUIRED COMPONENTS vulkan_backend executorch_backends)
+find_package(executorch CONFIG REQUIRED COMPONENTS vulkan_backend)
 
-...
 target_link_libraries(
     my_target
     PRIVATE
     executorch
-    executorch_backends
-    ...
-)
-
-# Ensure that unused code is not discarded. The required linker options may be
-# different depending on the target platform. Typically, the
-# executorch_target_link_options_shared_lib function from
-# executorch/tools/cmake/Utils.cmake can be used to set the required linker
-# options.
-target_link_options(
-    executorch_backends INTERFACE "SHELL:LINKER:--whole-archive \
-    $<TARGET_FILE:${target_name}> \
-    LINKER:--no-whole-archive"
+    vulkan_backend
 )
 ```
 
@@ -156,9 +143,9 @@ Any Vulkan-delegated .pte file will automatically run on the registered backend.
 :hidden:
 :caption: Vulkan Backend
 
-vulkan-partitioner
-vulkan-quantization
-vulkan-op-support
-vulkan-troubleshooting
+/backends/vulkan/vulkan-partitioner
+/backends/vulkan/vulkan-quantization
+/backends/vulkan/vulkan-op-support
+/backends/vulkan/vulkan-troubleshooting
 
-tutorials/vulkan-tutorials
+/backends/vulkan/tutorials/vulkan-tutorials

--- a/docs/source/backends/vulkan/vulkan-partitioner.md
+++ b/docs/source/backends/vulkan/vulkan-partitioner.md
@@ -38,7 +38,7 @@ etvk_program = to_edge_transform_and_lower(
 ### `require_dynamic_shapes`
 
 If a model is expected to use dynamic shapes, then it is recommended to set the
-`"required_dynamic_shapes"` key in `compile_options`.
+`"require_dynamic_shapes"` key in `compile_options`.
 
 Not all operators in Vulkan support dynamic shapes at the moment, although the
 majority do. This flag will prevent operators that don't support dynamic shapes

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -28,8 +28,11 @@ build instead. Nightly wheels are built from the `main` branch every day, so a
 change that has landed but is not yet in a stable release is available there first.
 
 ```
-pip install executorch --pre --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+pip install --pre executorch torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 ```
+
+`torch` is explicit because nightly ExecuTorch wheels do not declare it as a
+dependency.
 
 To build the framework from source, see [Building From Source](using-executorch-building-from-source.md). Backend delegates may require additional dependencies. See the appropriate backend documentation for more information.
 
@@ -38,7 +41,12 @@ To build the framework from source, see [Building From Source](using-executorch-
 <hr/>
 
 ## Preparing the Model
-Exporting is the process of taking a PyTorch model and converting it to the .pte file format used by the ExecuTorch runtime. This is done using Python APIs. PTE files for common models, such as Llama 3.2, can be found on HuggingFace under [ExecuTorch Community](https://huggingface.co/executorch-community). These models have been exported and lowered for ExecuTorch, and can be directly deployed without needing to go through the lowering process.
+Exporting is the process of taking a PyTorch model and converting it to the
+`.pte` format used by the ExecuTorch runtime. This is done using Python APIs.
+Selected pre-exported artifacts are published by the
+[ExecuTorch Community on Hugging Face](https://huggingface.co/executorch-community).
+Use one only when its model configuration, precision, and target backend match
+the runtime your application links.
 
 A complete example of exporting, lowering, and verifying MobileNet V2 is available as a [Colab notebook](https://colab.research.google.com/drive/1qpxrXC3YdJQzly3mRg-4ayYiOjC6rue3?usp=sharing).
 
@@ -53,8 +61,7 @@ ExecuTorch provides hardware acceleration for a wide variety of hardware. The mo
 For mobile use cases, consider using XNNPACK for Android and Core ML or XNNPACK for iOS as a first step. See [Hardware Backends](backends-overview.md) for more information.
 
 ### Exporting
-Exporting is done using Python APIs. ExecuTorch provides a high degree of customization during the export process, but the typical flow is as follows. This example uses the MobileNet V2 image classification model implementation in torchvision, but the process supports any [export-compliant](https://pytorch.org/docs/stable/export.html) PyTorch model. For Hugging Face models,
-you can find a list of supported models in the [*huggingface/optimum-executorch*](https://github.com/huggingface/optimum-executorch) repo.
+Exporting is done using Python APIs. ExecuTorch provides a high degree of customization during the export process, but the typical flow is as follows. This example uses the MobileNet V2 image classification model implementation in torchvision. Other models can follow the same flow when they are [export-compliant](https://pytorch.org/docs/stable/export.html) and their operators are available in the ExecuTorch runtime or selected backend. For Hugging Face `PreTrainedModel` architectures, choose between the [experimental Transformers ExecuTorch exporter](https://huggingface.co/docs/transformers/en/exporters) for broad programmatic XNNPACK or CUDA export and [Optimum ExecuTorch](llm/export-llm-optimum.md) for higher-level, tested task workflows.
 
 ```python
 import torch
@@ -114,12 +121,18 @@ print(torch.allclose(output[0], eager_reference_output, rtol=1e-3, atol=1e-5))
 
 For complete examples of exporting and running the model, please refer to our [examples GitHub repository](https://github.com/meta-pytorch/executorch-examples/tree/main/mv2/python).
 
-Additionally, for Hugging Face models, the [*huggingface/optimum-executorch*](https://github.com/huggingface/optimum-executorch) library simplifies running these models end-to-end with ExecuTorch using familiar Hugging Face APIs. Visit the repository for specific examples and supported models.
+For generative models, Transformers' `export_for_generation` produces independent
+`.pte` graph components; applications still need the appropriate preprocessing,
+tokenization, generation loop, and runtime integration. Optimum ExecuTorch
+supplies more of that task-level integration for its tested model paths.
 
 <hr/>
 
 ## Running on Device
-ExecuTorch provides runtime APIs in Java, Objective-C, and C++.
+ExecuTorch provides a stable C++ runtime API and experimental managed-language
+`Module` APIs for Java/Kotlin on Android and Objective-C/Swift on Apple
+platforms. The experimental APIs may change without notice; see the
+[API lifecycle policy](api-life-cycle.md).
 
 Quick Links:
 - [Android](#android)
@@ -132,17 +145,20 @@ Quick Links:
 ExecuTorch provides Java bindings for Android usage, which can be consumed from both Java and Kotlin.
 To add the library to your app, add the following dependency to gradle build rule.
 
-```
-# app/build.gradle.kts
-dependencies {
-  implementation("org.pytorch:executorch-android:${executorch_version}")
-}
+```kotlin
+// app/build.gradle.kts
+val executorchVersion = "X.Y.Z" // Replace with a version from Maven Central.
 
-# See latest available versions in https://mvnrepository.com/artifact/org.pytorch/executorch-android
+dependencies {
+  implementation("org.pytorch:executorch-android:$executorchVersion")
+}
 ```
+
+[Choose an available version on Maven Central](https://central.sonatype.com/artifact/org.pytorch/executorch-android).
 
 #### Runtime APIs
-Models can be loaded and run from Java or Kotlin using the `Module` class.
+Models can be loaded and run from Java or Kotlin using the experimental
+`Module` class. For a stable native API on Android, use the C++ runtime.
 ```java
 import org.pytorch.executorch.EValue;
 import org.pytorch.executorch.Module;
@@ -166,12 +182,23 @@ For a full example of running a model on Android, see the [DeepLabV3AndroidDemo]
 ### iOS
 
 #### Installation
-ExecuTorch supports both iOS and macOS via C++, as well as hardware backends for CoreML and CPU. The iOS runtime library is provided as a collection of .xcframework targets and are made available as a Swift PM package.
+ExecuTorch supports iOS and macOS through C++ and through experimental
+Objective-C APIs that bridge to Swift. Core ML and XNNPACK provide accelerated
+execution paths on Apple platforms. The runtime libraries are distributed as
+`.xcframework` targets through a Swift Package Manager package.
 
-To get started with Xcode, go to File > Add Package Dependencies. Paste the URL of the ExecuTorch repo into the search bar and select it. Make sure to change the branch name to the desired ExecuTorch version in format “swiftpm-”, (e.g. “swiftpm-0.6.0”).  The ExecuTorch dependency can also be added to the package file manually. See [Using ExecuTorch on iOS](using-executorch-ios.md) for more information.
+To get started with Xcode, go to File > Add Package Dependencies and paste the
+ExecuTorch repository URL into the search bar. For Dependency Rule, select
+**Branch** and enter the `swiftpm-X.Y.Z` branch that matches the ExecuTorch
+release used to export the model, for example `swiftpm-1.4.1`. The dependency
+can also be added to `Package.swift`; see
+[Using ExecuTorch on iOS](using-executorch-ios.md) for details.
 
 #### Runtime APIs
-Models can be loaded and run from Objective-C using the C++ APIs.
+Models can be loaded and run through the experimental Objective-C/Swift
+`Module`, `Tensor`, and `Value` APIs, or through the stable C++ runtime from
+Objective-C++. The managed APIs wrap the C++ `Module` and tensor extensions and
+are subject to change.
 
 For more information on iOS integration, including an API reference, logging setup, and building from source, see [Using ExecuTorch on iOS](using-executorch-ios.md).
 
@@ -179,11 +206,11 @@ For more information on iOS integration, including an API reference, logging set
 ExecuTorch provides C++ APIs, which can be used to target embedded or mobile devices. The C++ APIs provide a greater level of control compared to other language bindings, allowing for advanced memory management, data loading, and platform integration.
 
 #### Installation
-On Linux and macOS the quickest route is the pip package, which ships the runtime as prebuilt
+On Linux and macOS, current main/nightly wheels ship the runtime as prebuilt
 libraries with headers and a CMake package, so there is nothing to build:
 
 ```
-pip install executorch
+pip install --pre executorch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 ```
 
 ```cmake

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,239 +1,166 @@
 (home)=
 # Welcome to the ExecuTorch Documentation
 
-**ExecuTorch** is PyTorch's solution for efficient AI inference on edge devices — from mobile phones to embedded systems.
+**ExecuTorch** is PyTorch's open source export and runtime stack for running AI
+locally on phones, wearables, laptops, browsers, embedded systems, and
+microcontrollers.
 
-## Key Value Propositions
+```{note}
+Match the documentation version to your installed ExecuTorch release using the
+version selector. Examples on the `main` site may require a nightly package or
+a source checkout.
+```
 
-- **Portability:** Run on diverse platforms, from high-end mobile to constrained microcontrollers
-- **Performance:** Lightweight runtime with full hardware acceleration (CPU, GPU, NPU, DSP)
-- **Productivity:** Use familiar PyTorch tools from authoring to deployment
+## Start here
 
----
-
-## 🗺️ Find Your Path
-
-Not sure where to start? Use the guided pathways to navigate ExecuTorch based on your experience level, goal, and target platform.
-
-::::{grid} 3
+::::{grid} 1 2 2 2
 :gutter: 3
 
-:::{grid-item-card} 🟢 New to ExecuTorch
-:class-header: bg-success text-white
-:link: pathway-beginner
+:::{grid-item-card} Run your first model
+:link: getting-started
 :link-type: doc
 
-Step-by-step learning sequence from installation to your first on-device deployment. Includes concept explanations and worked examples.
+Install ExecuTorch, export MobileNet V2 to XNNPACK, and execute the resulting
+`.pte` program on the host.
 
 +++
-**Beginner Pathway →**
+**Open the tutorial →**
 :::
 
-:::{grid-item-card} 🟡 Get Running Fast
-:class-header: bg-warning text-dark
-:link: pathway-quickstart
-:link-type: doc
-
-Skip the theory — get a model running in 15 minutes. Includes export cheat sheets, backend selection tables, and platform quick starts.
-
-+++
-**Quick Start Pathway →**
-:::
-
-:::{grid-item-card} 🔴 Production & Advanced
-:class-header: bg-danger text-white
-:link: pathway-advanced
-:link-type: doc
-
-Quantization, custom backends, C++ runtime, LLM deployment, and compiler internals for production-grade systems.
-
-+++
-**Advanced Pathway →**
-:::
-
-::::
-
-::::{grid} 1
-
-:::{grid-item-card} 🔀 Decision Matrix — Route by Goal, Platform & Model
+:::{grid-item-card} Choose a path
 :link: user-pathways
 :link-type: doc
 
-Not sure which pathway fits? The decision matrix routes you by experience level, target platform, model status, and developer role to the exact documentation you need.
+Route to the right guide by model, workload, target platform, experience level,
+or role.
 
 +++
-**View Decision Matrix →**
+**Open the decision guide →**
 :::
 
 ::::
 
+## Why ExecuTorch
+
+- **PyTorch-native deployment:** Capture models with `torch.export`, lower them
+  for a chosen target, and retain PyTorch program metadata for debugging.
+- **Target-specific acceleration:** Delegate supported graph regions to CPU,
+  GPU, NPU, and DSP backends; unpartitioned regions run with the kernels
+  included in the runtime.
+- **A portable, right-sized runtime:** Integrate `.pte` programs through C++,
+  Python, Java/Kotlin, Objective-C/Swift, or JavaScript, and include only the
+  operators and backends the application needs.
+
 ---
 
-## 🎯 Wins & Success Stories
+## Proven on real products
 
-::::{grid} 1
+::::{grid} 1 1 3 3
+:gutter: 2
 :class-container: success-showcase
-:::{grid-item-card}
+
+:::{grid-item-card} **Billions of people**
 :class-header: bg-primary text-white
 :class-body: text-center
-[View All Success Stories →](success-stories)
+
+Production features across Instagram, WhatsApp, Messenger, and Facebook run
+on-device with ExecuTorch.
+
+[Read the Meta engineering story →](https://engineering.fb.com/2025/07/28/android/executorch-on-device-ml-meta-family-of-apps/)
+:::
+
+:::{grid-item-card} **Shipping voice transcription**
+:class-header: bg-primary text-white
+:class-body: text-center
+
+LM Studio uses ExecuTorch and Parakeet TDT for local transcription on macOS and
+Windows.
+
+[Read the production case study →](https://pytorch.org/blog/building-voice-agents-with-executorch-a-cross-platform-foundation-for-on-device-audio/)
+:::
+
+:::{grid-item-card} **Up to 2× CPU throughput**
+:class-header: bg-primary text-white
+:class-body: text-center
+
+Liquid AI reports the gain against selected similarly sized models, plus lower
+memory use, on its tested laptop and mobile CPUs.
+
+[Read Liquid AI's case study →](https://www.liquid.ai/blog/how-liquid-ai-uses-executorch-to-power-efficient-flexible-on-device-intelligence)
 :::
 ::::
 
----
-
-## Quick Navigation
-
-::::{grid} 2
-
-:::{grid-item-card} **Get Started**
-:link: quick-start-section
-:link-type: doc
-
-New to ExecuTorch? Start here for installation and your first model deployment.
-:::
-
-:::{grid-item-card} **Deploy on Edge Platforms**
-:link: edge-platforms-section
-:link-type: doc
-
-Deploy on Android, iOS, Laptops / Desktops and embedded platforms with optimized backends.
-:::
-
-:::{grid-item-card} **Work with LLMs**
-:link: llm/working-with-llms
-:link-type: doc
-
-Export, optimize, and deploy Large Language Models on edge devices.
-:::
-
-:::{grid-item-card} 🔧 **Developer Tools**
-:link: tools-section
-:link-type: doc
-
-Profile, debug, and inspect your models with comprehensive tooling.
-:::
-
-::::
+{doc}`Explore all deployments, integrations, and showcases → <success-stories>`
 
 ---
 
-## Explore Documentation
+## Browse documentation
 
-::::{grid} 1
-:::{grid-item-card} **Intro**
+::::{grid} 1 2 3 3
+:gutter: 2
+
+:::{grid-item-card} Core concepts
 :link: intro-section
 :link-type: doc
 
-**Overview, architecture, and core concepts** — Understand how ExecuTorch works and its benefits
+Architecture, export and runtime concepts, and the `.pte` program format.
 :::
-::::
 
-::::{grid} 1
-:::{grid-item-card} **Quick Start**
-:link: quick-start-section
+:::{grid-item-card} Export a model
+:link: using-executorch-export
 :link-type: doc
 
-**Get started with ExecuTorch** — Install, export your first model, and run inference
+Capture, lower, quantize, and validate a PyTorch model for a chosen target.
 :::
-::::
 
-::::{grid} 1
-:::{grid-item-card} **Edge**
-:link: edge-platforms-section
-:link-type: doc
-
-**Android, iOS, Desktop, Embedded** — Platform-specific deployment guides and examples
-:::
-::::
-
-::::{grid} 1
-:::{grid-item-card} **Backends**
-:link: backends-section
-:link-type: doc
-
-**CPU, GPU, NPU/Accelerator backends** — Hardware acceleration and backend selection
-:::
-::::
-
-::::{grid} 1
-:::{grid-item-card} **LLMs**
-:link: llm/working-with-llms
-:link-type: doc
-
-**LLM export, optimization, and deployment** — Complete LLM workflow for edge devices
-:::
-::::
-
-::::{grid} 1
-:::{grid-item-card} **Advanced**
+:::{grid-item-card} Advanced optimization
 :link: advanced-topics-section
 :link-type: doc
 
-**Quantization, memory planning, custom passes** — Deep customization and optimization
+Quantization, memory planning, custom operators, passes, and backends.
 :::
-::::
 
-::::{grid} 1
-:::{grid-item-card} **Tools**
-:link: tools-section
+:::{grid-item-card} Deploy by platform
+:link: edge-platforms-section
 :link-type: doc
 
-**Developer tools, profiling, debugging** — Comprehensive development and debugging suite
+Android, iOS, desktop, and embedded integration guides.
 :::
-::::
 
-::::{grid} 1
-:::{grid-item-card} **API**
+:::{grid-item-card} Choose a backend
+:link: backends-section
+:link-type: doc
+
+Compare CPU, GPU, NPU, and DSP acceleration paths for target hardware.
+:::
+
+:::{grid-item-card} Work with LLMs
+:link: llm/working-with-llms
+:link-type: doc
+
+Export, optimize, and deploy text and multimodal generation models.
+:::
+
+:::{grid-item-card} Runtime and LLM APIs
 :link: api-section
 :link-type: doc
 
-**API Reference Usages & Examples** — Detailed Python, C++, and Java API references
+Find C++, Python, Java/Kotlin, Objective-C/Swift, and JavaScript APIs.
 :::
-::::
 
-::::{grid} 1
-:::{grid-item-card} **💬 Support**
+:::{grid-item-card} Optimize and debug
+:link: tools-section
+:link-type: doc
+
+Profile execution and inspect programs with ETDump, ETRecord, and numeric
+debugging.
+:::
+
+:::{grid-item-card} Get help and contribute
 :link: support-section
 :link-type: doc
 
-**FAQ, troubleshooting, contributing** — Get help and contribute to the project
-:::
-::::
-
----
-
-## What's Supported
-
-::::{grid} 3
-
-:::{grid-item}
-**Model Types**
-
-- Large Language Models (LLMs)
-- Computer Vision (CV)
-- Speech Recognition (ASR)
-- Text-to-Speech (TTS)
-- More ...
-:::
-
-:::{grid-item}
-**Platforms**
-
-- Android & iOS
-- Linux, macOS, Windows
-- Embedded & MCUs
-- Go **→ {doc}`edge-platforms-section`**
-:::
-
-:::{grid-item}
-**Rich Acceleration**
-
-- CPU
-- GPU
-- NPU
-- DSP
-- Go **→ {doc}`backends-section`**
+Troubleshooting, FAQs, issue reporting, and contribution guidance.
 :::
 
 ::::
@@ -245,6 +172,7 @@ Profile, debug, and inspect your models with comprehensive tooling.
 intro-section
 quick-start-section
 user-pathways
+success-stories
 edge-platforms-section
 backends-section
 llm/working-with-llms
@@ -252,3 +180,4 @@ advanced-topics-section
 tools-section
 api-section
 support-section
+```

--- a/docs/source/llm/export-custom-llm.md
+++ b/docs/source/llm/export-custom-llm.md
@@ -513,7 +513,8 @@ lowered graph():
 
 ### Further Model Analysis and Debugging
 
-Through the [ExecuTorch's Developer Tools](getting-started.md#performance-analysis), users are able to profile model execution, giving timing information for each operator in the model, doing model numeric debugging, etc.
+Use [ExecuTorch's Developer Tools](../devtools-overview.md) to profile model
+execution, inspect per-operator timing, and debug numerical differences.
 
 An ETRecord is an artifact generated at the time of export that contains model graphs and source-level metadata linking the ExecuTorch program to the original PyTorch model. You can view all profiling events without an ETRecord, though with an ETRecord, you will also be able to link each event to the types of operators being executed, module hierarchy, and stack traces of the original PyTorch source code. For more information, see [the ETRecord docs](../etrecord.rst).
 

--- a/docs/source/llm/export-llm-optimum.md
+++ b/docs/source/llm/export-llm-optimum.md
@@ -1,6 +1,13 @@
-# Exporting LLMs with HuggingFace's Optimum ExecuTorch
+# Exporting LLMs with Hugging Face's Optimum ExecuTorch
 
 [Optimum ExecuTorch](https://github.com/huggingface/optimum-executorch) provides a streamlined way to export Hugging Face transformer models to ExecuTorch format. It offers seamless integration with the Hugging Face ecosystem, making it easy to export models directly from the Hugging Face Hub.
+
+Transformers also includes an
+[experimental ExecuTorch exporter](https://huggingface.co/docs/transformers/en/exporters)
+for broad programmatic export of `PreTrainedModel` architectures to XNNPACK and
+CUDA. Its generative path returns independent graph components that the caller
+must orchestrate. Use Optimum ExecuTorch when you want its CLI, quantization,
+model wrappers, and tested task-level workflows.
 
 ## Overview
 
@@ -23,7 +30,13 @@ See [Exporting LLMs](export-llm.md) for details on using the native `export_llm`
 
 ### Installation
 
-First, clone and install Optimum ExecuTorch from source:
+Install the released package from PyPI:
+
+```bash
+pip install optimum-executorch
+```
+
+To work from the latest source instead, use an isolated environment and run:
 
 ```bash
 git clone https://github.com/huggingface/optimum-executorch.git
@@ -31,13 +44,15 @@ cd optimum-executorch
 pip install '.[dev]'
 ```
 
-For access to the latest features and optimizations, install dependencies in dev mode:
+For nightly or source builds of the underlying projects, run:
 
 ```bash
 python install_dev.py
 ```
 
-This installs `executorch`, `torch`, `torchao`, `transformers`, and other dependencies from nightly builds or source.
+This may replace `executorch`, `torch`, `torchao`, `transformers`, and other
+dependencies with nightly or source builds, which is why a separate environment
+is recommended. It is not required for the released package workflow below.
 
 ## Supported Models
 
@@ -111,7 +126,12 @@ optimum-cli export executorch \
 
 ### Backend Support
 
-Supported backends: `xnnpack` (CPU), `coreml` (Apple GPU), `portable` (baseline), `cuda` (NVIDIA GPU). Specify with `--recipe`.
+The `xnnpack` recipe is the CPU path used in this guide. The current package
+also registers `portable`, `cuda`, `cuda-windows`, `metal`, and
+precision/compute-unit-specific Core ML recipes such as `coreml_fp16`.
+Applicability depends on the model, task, host, and installed dependencies; use
+the exact recipe documented by Optimum ExecuTorch for your target. A bare
+`coreml` recipe is not registered.
 
 ## Exporting Different Model Types
 

--- a/docs/source/llm/export-llm.md
+++ b/docs/source/llm/export-llm.md
@@ -20,14 +20,18 @@ As of this doc, the list of supported LLMs include the following:
 
 The up-to-date list of supported LLMs can be found in the code [here](https://github.com/pytorch/executorch/blob/main/extension/llm/export/config/llm_config.py#L32).
 
-**Note:** If you need to export models that are not on this list or other model architectures (such as Gemma, Mistral, BERT, T5, Whisper, etc.), see [Exporting LLMs with Optimum](export-llm-optimum.md) which supports a much wider variety of models from Hugging Face Hub.
+**Note:** For a Hugging Face architecture not covered here, use the
+[experimental Transformers ExecuTorch exporter](https://huggingface.co/docs/transformers/en/exporters)
+for broad programmatic graph export, or [Optimum ExecuTorch](export-llm-optimum.md)
+for its tested task-level recipes, quantization, and higher-level APIs. Architectures
+that need model-specific changes can start with [Exporting custom LLMs](export-custom-llm.md).
 
 ## The export_llm API
 `export_llm` is ExecuTorch's high-level export API for LLMs. In this tutorial, we will focus on exporting Llama 3.2 1B using this API. `export_llm`'s arguments are specified either through CLI args or through a yaml configuration whose fields are defined in [`LlmConfig`](https://github.com/pytorch/executorch/blob/main/extension/llm/export/config/llm_config.py). To call `export_llm`:
 
 ```
-python -m executorch.extension.llm.export.export_llm
-  --config <path-to-config-yaml>
+python -m executorch.extension.llm.export.export_llm \
+  --config <path-to-config-yaml> \
   +base.<additional-CLI-overrides>
 ```
 
@@ -35,7 +39,7 @@ python -m executorch.extension.llm.export.export_llm
 
 To perform a basic export of Llama3.2, we will first need to download the checkpoint file (`consolidated.00.pth`) and params file (`params.json`). You can find these from the [Llama website](https://www.llama.com/llama-downloads/) or [Hugging Face](https://huggingface.co/meta-llama/Llama-3.2-1B/tree/main/original).
 
-Then, we specify the `model_class`, `checkpoint` (path to checkpoint file), and `params` (path to params file) as arguments. Additionally, later when we run the exported .pte with our runner APIs, the runner will need to know about the bos and eos ids for this model to know when to terminate. These are exposed through bos and eos getter methods in the .pte, which we can add by specifying bos and eos ids in a `metadata` argument. The values for these tokens can usually be found in the model's `tokenizer_config.json` on HuggingFace.
+Then, we specify the `model_class`, `checkpoint` (path to checkpoint file), and `params` (path to params file) as arguments. Additionally, later when we run the exported .pte with our runner APIs, the runner will need to know about the bos and eos ids for this model to know when to terminate. These are exposed through bos and eos getter methods in the .pte, which we can add by specifying bos and eos ids in a `metadata` argument. The values for these tokens can usually be found in the model's `tokenizer_config.json` on Hugging Face.
 
 ```
 # path/to/config.yaml
@@ -52,7 +56,7 @@ python -m extension.llm.export.export_llm \
 
 We only require manually specifying a checkpoint path for the Llama model family, since it is our most optimized model and we have more advanced optimizations such as [SpinQuant](https://github.com/pytorch/executorch/blob/main/examples/models/llama/README.md#spinquant) that require custom checkpoints.
 
-For the other supported LLMs, the checkpoint will be downloaded from HuggingFace automatically, and the param files can be found in their respective directories under `executorch/examples/models`, for instance `executorch/examples/models/qwen3/config/0_6b_config.json`.
+For the other supported LLMs, the checkpoint will be downloaded from Hugging Face automatically, and the param files can be found in their respective directories under `executorch/examples/models`, for instance `executorch/examples/models/qwen3/config/0_6b_config.json`.
 
 ## Export settings
 [ExportConfig](https://github.com/pytorch/executorch/blob/main/extension/llm/export/config/llm_config.py) contains settings for the exported `.pte`, such as `max_seq_length` (max length of the prompt) and `max_context_length` (max length of the model's memory/cache).
@@ -207,7 +211,7 @@ Number of non-delegated nodes: 2513 <br/>
 </details>
 <br/>
 
-To do further performance analysis, you can may opt to use [ExecuTorch's Developer Tools](getting-started.md#performance-analysis) to do things such as trace individual operator performance back to source code, view memory planning, and debug intermediate activations. To generate the ETRecord to link back `.pte` program to source code, you can use:
+For further performance analysis, use [ExecuTorch's Developer Tools](../devtools-overview.md) to trace individual operator performance back to source code, inspect memory planning, and debug intermediate activations. To generate an ETRecord that links the `.pte` program back to source code, use:
 
 ```
 # path/to/config.yaml
@@ -223,8 +227,7 @@ python -m extension.llm.export.export_llm \
 
 Other debug and profiling options can be found in [DebugConfig](https://github.com/pytorch/executorch/blob/main/extension/llm/export/config/llm_config.py#L228).
 
-A few examples ones:
-- `profile_memory`: Used to generate activation memory profile in chrome trace format. It allows one to visualize the lifetimes of different intermediate tensors of a model, how their lifetimes overlap, where these tensors come from, and how they impact the  memory footprint of the model during its execution. Click [here](https://github.com/pytorch/executorch/blob/dd4488d720d676a1227450e8ea0c0c97beed900c/docs/source/memory-planning-inspection.md?plain=1#L19) for more details on memory profiling.
-- `profile_path`: Used to generate time profile of various components of export_llm. Such components include `torch.export`, quantization, `to_edge`, delegation via to_backend APIs etc. This option generate a .html file that gives you time profile in flamegraph/icicle format. It is helpful to understand what part of `export_llm` takes the most time. Largely useful for developers and contributors of ExecuTorch. For more details on flamegraph one can checkout https://www.parca.dev/docs/icicle-graph-anatomy/
+For example:
 
-To learn more about ExecuTorch's Developer Tools, see the [Introduction to the ExecuTorch Developer Tools](../devtools-overview.md).
+- `profile_memory`: Generates an activation memory profile in Chrome trace format. Use it to visualize tensor lifetimes, overlap, provenance, and their effect on runtime memory use. See [Inspecting Memory Planning](../memory-planning-inspection.md) for details.
+- `profile_path`: Generates an HTML time profile of `export_llm` components such as `torch.export`, quantization, `to_edge`, and `to_backend` delegation. The flame graph or icicle view helps ExecuTorch developers identify expensive export stages. For background, see [Icicle graph anatomy](https://www.parca.dev/docs/icicle-graph-anatomy/).

--- a/docs/source/llm/getting-started.md
+++ b/docs/source/llm/getting-started.md
@@ -20,7 +20,8 @@ Deploying LLMs to ExecuTorch can be boiled down to a two-step process: (1) expor
 
 ### Exporting
 - [Exporting LLMs](export-llm.md) - Export using ExecuTorch's native `export_llm` API with advanced optimizations
-- [Exporting LLMs with Optimum](export-llm-optimum.md) - Export Hugging Face models with broader architecture support
+- [Transformers exporters](https://huggingface.co/docs/transformers/en/exporters) - Experimental, broad programmatic export of Hugging Face models
+- [Exporting LLMs with Optimum](export-llm-optimum.md) - Tested Hugging Face recipes, quantization, and higher-level APIs
 - [Exporting custom LLMs](export-custom-llm.md)
 
 ### Running

--- a/docs/source/llm/run-on-ios.md
+++ b/docs/source/llm/run-on-ios.md
@@ -1,6 +1,7 @@
 # Running LLMs on iOS
 
-ExecuTorch’s LLM-specific runtime components provide an experimental Objective-C and Swift components around the core C++ LLM runtime.
+ExecuTorch's LLM-specific runtime provides experimental Objective-C and Swift
+components around the C++ LLM runner.
 
 ## Prerequisites
 
@@ -22,9 +23,9 @@ Swift:
 import ExecuTorchLLM
 ```
 
-### TextLLMRunner
+### TextRunner
 
-The `ExecuTorchLLMTextRunner` class (bridged to Swift as `TextLLMRunner`) provides a simple Objective-C/Swift interface for loading a text-generation model, configuring its tokenizer with custom special tokens, generating token streams, and stopping execution.
+The `ExecuTorchLLMTextRunner` class (bridged to Swift as `TextRunner`) provides a simple Objective-C/Swift interface for loading a text-generation model, configuring its tokenizer with custom special tokens, generating token streams, and stopping execution.
 This API is experimental and subject to change.
 
 #### Initialization
@@ -49,7 +50,7 @@ let modelPath     = Bundle.main.path(forResource: "llama-3.2-instruct", ofType: 
 let tokenizerPath = Bundle.main.path(forResource: "tokenizer", ofType: "model")!
 let specialTokens = ["<|bos|>", "<|eos|>"]
 
-let runner = TextLLMRunner(
+let runner = TextRunner(
   modelPath: modelPath,
   tokenizerPath: tokenizerPath,
   specialTokens: specialTokens

--- a/docs/source/llm/run-with-c-plus-plus.md
+++ b/docs/source/llm/run-with-c-plus-plus.md
@@ -2,6 +2,11 @@
 
 This guide explains how to use ExecuTorch's C++ runner library to run LLM models that have been exported to the `.pte` format. The runner library provides a high-level API for text generation with LLMs, handling tokenization, inference, and token generation.
 
+```{warning}
+The C++ LLM runner APIs are experimental and may change or be removed without
+notice.
+```
+
 ## Prerequisites
 
 Before you begin, make sure you have:
@@ -9,7 +14,7 @@ Before you begin, make sure you have:
 1. A model exported to `.pte` format using the `export_llm` API as described in [Exporting popular LLMs out of the box](export-llm.md) or [Exporting custom LLMs](export-custom-llm.md).
    - Please also see [Model Metadata](#model-metadata) section for important metadata to be serialized into `.pte`.
 2. A tokenizer file compatible with your model
-   - For HuggingFace tokenizers, this is a JSON file `tokenizer.json`
+   - For Hugging Face tokenizers, this is a JSON file `tokenizer.json`
    - For SentencePiece tokenizers, this is a `tokenizer.model` file and normally lives alongside the weights file
 3. CMake and a C++ compiler installed
    - CMake version 3.26 or higher
@@ -23,8 +28,8 @@ The metadata includes several important configuration parameters to be included 
 2. **`max_seq_len`**: Maximum sequence length the model can handle
 3. **`max_context_len`**: Maximum context length for KV cache
 4. **`use_kv_cache`**: Whether the model uses KV cache for efficient generation
-6. **`get_bos_id`**: Beginning-of-sequence token ID
-7. **`get_eos_ids`**: End-of-sequence token IDs
+5. **`get_bos_id`**: Beginning-of-sequence token ID
+6. **`get_eos_ids`**: End-of-sequence token IDs
 
 ### Adding Metadata During Export
 
@@ -36,6 +41,7 @@ python -m extension.llm.export.export_llm \
   --config path/to/config.yaml \
   +base.metadata='{"get_bos_id":128000, "get_eos_ids":[128009, 128001], "get_max_context_len":4096}'
 ```
+
 ## Building the Runner Library
 
 The ExecuTorch LLM runner library can be built using CMake. To integrate it into your project:
@@ -70,6 +76,9 @@ Please note that this runner library is not limited to Llama models and can be u
 Here's a simplified example of using the runner:
 
 ```cpp
+#include <iostream>
+
+#include <executorch/extension/llm/runner/llm_runner_helper.h>
 #include <executorch/extension/llm/runner/text_llm_runner.h>
 
 using namespace executorch::extension::llm;
@@ -105,14 +114,18 @@ The ExecuTorch LLM runner library is designed with a modular architecture that s
 The `IRunner` interface (`irunner.h`) defines the core functionality for LLM text generation. This interface serves as the primary abstraction for interacting with LLM models:
 
 ```cpp
-class IRunner {
-public:
+class ET_EXPERIMENTAL IRunner {
+ public:
   virtual ~IRunner() = default;
   virtual bool is_loaded() const = 0;
   virtual runtime::Error load() = 0;
   virtual runtime::Error generate(...) = 0;
-  virtual runtime::Error generate_from_pos(...) = 0;
+  virtual runtime::Result<uint64_t> prefill(
+      const std::vector<MultimodalInput>& inputs,
+      int32_t num_bos = 0,
+      int32_t num_eos = 0);
   virtual void stop() = 0;
+  virtual void reset() = 0;
 };
 ```
 
@@ -152,15 +165,16 @@ The primary method for text generation. It takes:
 The token callback is called for each token as it's generated, allowing for streaming output. The stats callback provides detailed performance metrics after generation completes.
 
 ```c++
-runtime::Error generate_from_pos(
-   const std::string& prompt,
-   int64_t start_pos,
-   const GenerationConfig& config,
-   std::function<void(const std::string&)> token_callback,
-   std::function<void(const Stats&)> stats_callback)
+runtime::Result<uint64_t> prefill(
+    const std::vector<MultimodalInput>& inputs,
+    int32_t num_bos = 0,
+    int32_t num_eos = 0)
 ```
 
-An advanced version of `generate()` that allows starting generation from a specific position in the KV cache. This is useful for continuing generation from a previous state.
+Prefills supported text, token, image, preprocessed-audio, or raw-audio inputs
+into the KV cache without running the generation loop. It returns the next
+predicted token. The default `IRunner` implementation returns
+`Error::NotSupported`; concrete runners expose the combinations they support.
 
 ```c++
 void stop()
@@ -168,24 +182,39 @@ void stop()
 
 Immediately stops the generation loop. This is typically called from another thread to interrupt a long-running generation.
 
+```c++
+void reset()
+```
+
+Clears the runner's prefilled tokens and resets its KV-cache position.
+
 ### GenerationConfig Structure
 
 The `GenerationConfig` struct controls various aspects of the generation process:
 
 ```cpp
 struct GenerationConfig {
-  bool echo = true;                // Whether to echo the input prompt in the output
-  int32_t max_new_tokens = -1;     // Maximum number of new tokens to generate
-  bool warming = false;            // Whether this is a warmup run
-  int32_t seq_len = -1;            // Maximum number of total tokens
-  float temperature = 0.8f;        // Temperature for sampling
-  int32_t num_bos = 0;             // Number of BOS tokens to add
-  int32_t num_eos = 0;             // Number of EOS tokens to add
+  bool echo = true;
+  std::string grammar;
+  std::string grammar_type;
+  bool ignore_eos = false;
+  int32_t max_new_tokens = -1;
+  bool warming = false;
+  int32_t seq_len = -1;
+  float temperature = 0.8f;
+  int32_t num_bos = 0;
+  int32_t num_eos = 0;
 
-  // Helper method to resolve the actual max_new_tokens based on constraints
-  int32_t resolve_max_new_tokens(int64_t max_context_len, int64_t num_tokens_occupied) const;
+  int32_t resolve_max_new_tokens(
+      int64_t max_context_len,
+      int64_t num_tokens_occupied) const;
 };
 ```
+
+`grammar` and `grammar_type` carry an optional constrained-decoding
+specification in `json_schema`, `regex`, `lark`, or `gbnf` format; support is
+runner-dependent. Setting `ignore_eos` continues generation past EOS until
+another limit is reached.
 
 The `resolve_max_new_tokens` method handles the logic of determining how many tokens can be generated based on:
 - The model's maximum context length
@@ -246,7 +275,7 @@ std::unique_ptr<tokenizers::Tokenizer> tokenizer = load_tokenizer(
 
 Supported tokenizer formats include:
 
-1. **HuggingFace Tokenizers**: JSON format tokenizers
+1. **Hugging Face Tokenizers**: JSON format tokenizers
 2. **SentencePiece**: `.model` format tokenizers
 3. **TikToken**: BPE tokenizers
 4. **Llama2c**: BPE tokenizers in the Llama2.c format

--- a/docs/source/pathway-quickstart.md
+++ b/docs/source/pathway-quickstart.md
@@ -31,21 +31,25 @@ Select the scenario that most closely matches what you are trying to accomplish 
 
 **Fastest path: Download → Run**
 
-Pre-exported `.pte` files for Llama 3.2, MobileNet, and other models are available on [HuggingFace ExecuTorch Community](https://huggingface.co/executorch-community).
+Selected target-specific `.pte` files are available from the
+[ExecuTorch Community on Hugging Face](https://huggingface.co/executorch-community).
+Match the artifact's model configuration, precision, and backend to the runtime
+your application links.
 
 Skip export entirely and go directly to the runtime section of {doc}`getting-started`.
 
 **Time:** ~10 min
 :::
 
-:::{grid-item-card} 🤗 I have a HuggingFace model
+:::{grid-item-card} 🤗 I have a Hugging Face model
 :class-header: bg-primary text-white
 
-**Fastest path: Optimum ExecuTorch**
+**Fastest path: Choose an exporter**
 
-Use the `optimum-executorch` CLI for a one-command export of HuggingFace models.
-
-See {doc}`llm/export-llm-optimum` for installation and usage.
+Use the [experimental Transformers exporter](https://huggingface.co/docs/transformers/en/exporters)
+for programmatic XNNPACK or CUDA graph export. Use
+{doc}`llm/export-llm-optimum` for tested task workflows, quantization, and
+higher-level model wrappers.
 
 **Time:** ~20 min
 :::
@@ -72,19 +76,20 @@ If you have not yet installed ExecuTorch, run the following in a Python 3.10–3
 pip install executorch
 ```
 
-Then verify the installation with a minimal export:
+Then verify export, XNNPACK lowering, serialization, and host execution:
 
 ```python
 import torch
-from executorch.exir import to_edge_transform_and_lower
 from executorch.backends.xnnpack.partition.xnnpack_partitioner import XnnpackPartitioner
+from executorch.exir import to_edge_transform_and_lower
+from executorch.runtime import Runtime
 
 # Define a simple model
 class Add(torch.nn.Module):
     def forward(self, x, y):
         return x + y
 
-model = Add()
+model = Add().eval()
 sample_inputs = (torch.ones(1), torch.ones(1))
 
 et_program = to_edge_transform_and_lower(
@@ -95,10 +100,21 @@ et_program = to_edge_transform_and_lower(
 with open("add.pte", "wb") as f:
     f.write(et_program.buffer)
 
-print("Export successful: add.pte created")
+runtime = Runtime.get()
+runtime_program = runtime.load_program("add.pte")
+method = runtime_program.load_method("forward")
+output = method.execute(sample_inputs)[0]
+
+torch.testing.assert_close(output, model(*sample_inputs))
+print("Output:", output)
 ```
 
-If this runs without error, your environment is correctly configured.
+Expected output: `Output: tensor([2.])`.
+
+This check runs through the host wheel's XNNPACK backend. It verifies the
+exported program's result, but it does not measure performance or prove that a
+different backend is available on the target device. Repeat accuracy and
+performance validation in the target application.
 
 ---
 
@@ -115,15 +131,17 @@ If this runs without error, your environment is correctly configured.
 * - Export with XNNPACK (mobile CPU)
   - `to_edge_transform_and_lower(torch.export.export(model, inputs), partitioner=[XnnpackPartitioner()])`
 * - Export with Core ML (iOS)
-  - Replace `XnnpackPartitioner` with `CoreMLPartitioner` — see {doc}`ios-coreml`
+  - Replace `XnnpackPartitioner` with `CoreMLPartitioner`; see {doc}`ios-coreml`
 * - Export with Qualcomm (Android NPU)
   - See {doc}`android-qualcomm` for QNN SDK setup and partitioner usage
 * - Run from Python
-  - `Runtime.get().load_program("model.pte").load_method("forward").execute([input])`
+  - Load a `Program`, retain it while its `Method` is in use, then call
+    `method.execute(inputs)` with one sequence containing all method inputs
 * - Run from C++
   - See {doc}`extension-module` for the high-level `Module` API
 * - Export an LLM
-  - `python -m executorch.examples.models.llama.export_llm ...` — see {doc}`llm/export-llm`
+  - `python -m extension.llm.export.export_llm --config path/to/config.yaml`;
+    see {doc}`llm/export-llm`
 ```
 
 ---
@@ -139,14 +157,16 @@ Jump directly to the platform-specific setup guide for your target.
 :link: android-section
 :link-type: doc
 
-Gradle dependency, Java `Module` API, and XNNPACK / Vulkan / Qualcomm backend selection for Android.
+Gradle dependency, experimental Java/Kotlin `Module` API, and XNNPACK / Vulkan /
+Qualcomm backend selection for Android.
 :::
 
 :::{grid-item-card} iOS Quick Start
 :link: ios-section
 :link-type: doc
 
-Swift Package Manager setup, Objective-C runtime API, and Core ML / XNNPACK backend selection for iOS.
+Swift Package Manager setup, experimental Swift/Objective-C `Module` APIs, C++,
+and Core ML / XNNPACK backend selection for iOS.
 :::
 
 :::{grid-item-card} Desktop / Linux / macOS

--- a/docs/source/success-stories.md
+++ b/docs/source/success-stories.md
@@ -2,162 +2,279 @@
 
 # Success Stories
 
-Discover how organizations are leveraging ExecuTorch to deploy AI models at scale on edge devices.
+See where ExecuTorch is shipping today, how organizations integrate it, and
+what current reference implementations demonstrate. Labels on this page are
+intentional: production claims link to primary sources, while prototypes and
+experimental backends are identified as such.
 
 ---
 
-## Featured Success Stories
+## Production Deployments
 
-::::{grid} 1
+::::{grid} 1 1 2 2
 :gutter: 3
 
 :::{grid-item-card} **Meta's Family of Apps**
 :class-header: bg-primary text-white
 
-**Industry:** Social Media & Messaging
-**Hardware:** Android & iOS Devices
-**Impact:** Billions of users, latency reduction
+- **Status:** Production
+- **Platforms:** Android and iOS
+- **Scale:** Features serving billions of people
 
-Powers Instagram, WhatsApp, Facebook, and Messenger with real-time on-device AI for content ranking, recommendations, and privacy-preserving features at scale.
+ExecuTorch runs on-device models behind Instagram Cutouts, WhatsApp bandwidth
+estimation, Messenger language identification and encrypted experiences, and
+Facebook Stories music recommendations.
 
-[Read Blog →](https://engineering.fb.com/2025/07/28/android/executorch-on-device-ml-meta-family-of-apps/)
+[Read the engineering story →](https://engineering.fb.com/2025/07/28/android/executorch-on-device-ml-meta-family-of-apps/)
 :::
 
-:::{grid-item-card} **Meta Quest & Ray-Ban Smart Glasses**
-:class-header: bg-success text-white
+:::{grid-item-card} **Meta Reality Labs**
+:class-header: bg-primary text-white
 
-**Industry:** AR/VR & Wearables
-**Hardware:** Quest 3, Ray-Ban Meta Smart Glasses, Meta Ray-Ban Display
+- **Status:** Production
+- **Devices:** Meta Quest 3 and 3S; Ray-Ban Meta, Oakley Meta Vanguard, and Meta
+  Ray-Ban Display glasses
 
-Enables real-time computer vision, hand tracking, voice commands, and translation on power-constrained wearable devices.
-[Read Blog →](https://ai.meta.com/blog/executorch-reality-labs-on-device-ai/)
+ExecuTorch powers capabilities including hand and controller tracking,
+persistent room memory, live translation, visual captions, and on-device OCR.
+
+[Read the product story →](https://ai.meta.com/blog/executorch-reality-labs-on-device-ai/)
 :::
 
-:::{grid-item-card} **Liquid AI: Efficient, Flexible On-Device Intelligence**
-:class-header: bg-info text-white
+:::{grid-item-card} **LM Studio Voice Transcription**
+:class-header: bg-primary text-white
 
-**Industry:** Artificial Intelligence / Edge Computing
-**Hardware:** CPU via PyTorch ExecuTorch
-**Impact:** 2× faster inference, lower latency, seamless multimodal deployment
+- **Status:** Production
+- **Platforms:** macOS and Windows
+- **Model:** NVIDIA Parakeet TDT
 
-Liquid AI builds foundation models that make AI work where the cloud can't. In its LFM2 series, the team uses PyTorch ExecuTorch within the LEAP Edge SDK to deploy high-performance multimodal models efficiently across devices. ExecuTorch provides the flexibility to support custom architectures and processing pipelines while reducing inference latency through graph optimization and caching. Together, they enable faster, more efficient, privacy-preserving AI that runs entirely on the edge.
+LM Studio ships local voice transcription powered by ExecuTorch. The same model
+and application layer target Apple GPUs on macOS and NVIDIA GPUs on Windows.
 
-[Read Blog →](https://www.liquid.ai/blog/how-liquid-ai-uses-executorch-to-power-efficient-flexible-on-device-intelligence) <!-- @lint-ignore -->
-:::
-
-:::{grid-item-card} **PrivateMind: Complete Privacy with On-Device AI**
-:class-header: bg-warning text-white
-
-**Industry:** Privacy & Personal Computing
-**Hardware:** iOS & Android Devices
-**Impact:** 100% on-device processing
-
-PrivateMind delivers a fully private AI assistant using ExecuTorch's .pte format. Built with React Native ExecuTorch, it supports LLaMA, Qwen, Phi-4, and custom models with offline speech-to-text and PDF chat capabilities.
-
-[Visit →](https://privatemind.swmansion.com)
-:::
-
-:::{grid-item-card} **NimbleEdge: On-Device Agentic AI Platform**
-:class-header: bg-danger text-white
-
-**Industry:** AI Infrastructure
-**Hardware:** iOS & Android Devices
-**Impact:** 30% higher TPS on iOS, faster time-to-market with Qwen/Gemma models
-
-NimbleEdge successfully integrated ExecuTorch with its open-source DeliteAI platform to enable agentic workflows orchestrated in Python on mobile devices. The extensible ExecuTorch ecosystem allowed implementation of on-device optimization techniques leveraging contextual sparsity. ExecuTorch significantly accelerated the release of "NimbleEdge AI" for iOS, enabling models like Qwen 2.5 with tool calling support and achieving up to 30% higher transactions per second.
-
-[Visit →](https://nimbleedge.com) • [Blog →](https://www.nimbleedge.com/blog/meet-nimbleedge-ai-the-first-truly-private-on-device-assistant)
+[Read the case study →](https://pytorch.org/blog/building-voice-agents-with-executorch-a-cross-platform-foundation-for-on-device-audio/)
 :::
 
 ::::
 
 ---
 
-## Featured Ecosystem Integrations and Interoperability
+## Customer and Product Case Studies
 
-::::{grid} 2 2 3 3
+::::{grid} 1 1 2 2
+:gutter: 3
+
+:::{grid-item-card} **Liquid AI: Hybrid Models on the Edge**
+:class-header: bg-info text-white
+
+- **Status:** Published customer case study
+- **Hardware tested:** AMD Ryzen AI 9 HX 370 and Samsung Galaxy S24 CPUs
+- **Reported result:** Up to 2× higher CPU throughput than selected similarly
+  sized models, with reduced memory use
+
+Liquid AI adopted ExecuTorch for LFM2 models from 350M to 4B parameters. Its
+case study highlights support for hybrid attention and recurrent architectures,
+portable model packaging, and integration with the LEAP platform.
+
+[Read Liquid AI's case study →](https://www.liquid.ai/blog/how-liquid-ai-uses-executorch-to-power-efficient-flexible-on-device-intelligence) <!-- @lint-ignore -->
+:::
+
+:::{grid-item-card} **Private Mind: A Fully Local AI Assistant**
+:class-header: bg-info text-white
+
+- **Status:** Shipping and open source
+- **Platforms:** iOS and Android
+- **Workloads:** Chat, document retrieval, images, and speech input
+
+Software Mansion built Private Mind with React Native ExecuTorch. After models
+are downloaded, conversations, retrieval, embeddings, and inference stay on the
+device.
+
+[Source →](https://github.com/software-mansion-labs/private-mind) •
+[App Store →](https://apps.apple.com/us/app/private-mind-local-ai/id6746713439) •
+[Google Play →](https://play.google.com/store/apps/details?id=com.swmansion.privatemind)
+:::
+
+::::
+
+---
+
+## Ecosystem Integrations
+
+::::{grid} 1 2 3 3
 :gutter: 2
 
-:::{grid-item-card} **Hugging Face Transformers**
+:::{grid-item-card} **Hugging Face and torchao**
 :class-header: bg-secondary text-white
 
-Popular models from Hugging Face easily export to ExecuTorch format for on-device deployment.
+Transformers includes an experimental generic ExecuTorch exporter, Optimum
+ExecuTorch adds tested task-level recipes and model wrappers, and torchao supplies
+PyTorch-native quantization recipes and kernels used throughout ExecuTorch.
 
-[Learn More →](https://github.com/huggingface/optimum-executorch/)
+[Transformers exporters →](https://huggingface.co/docs/transformers/en/exporters) •
+[Optimum ExecuTorch →](https://huggingface.co/docs/optimum-executorch/en/index) •
+[torchao →](https://docs.pytorch.org/ao/)
 :::
 
 :::{grid-item-card} **React Native ExecuTorch**
 :class-header: bg-secondary text-white
 
-Declarative toolkit for running AI models and LLMs in React Native apps with privacy-first, on-device execution.
+A React Native library with task-level APIs, a pre-exported model catalog, and
+XNNPACK, Core ML, MLX, and Vulkan acceleration.
 
-[Explore →](https://docs.swmansion.com/react-native-executorch/) • [Blog →](https://expo.dev/blog/how-to-run-ai-models-with-react-native-executorch)
-:::
-
-:::{grid-item-card} **torchao**
-:class-header: bg-secondary text-white
-
-PyTorch-native quantization and optimization library for preparing efficient models for ExecuTorch deployment.
-
-[Blog →](https://pytorch.org/blog/torchao-quantized-models-and-quantization-recipes-now-available-on-huggingface-hub/) • [Qwen Example →](https://huggingface.co/pytorch/Qwen3-4B-INT8-INT4) • [Phi Example →](https://huggingface.co/pytorch/Phi-4-mini-instruct-INT8-INT4) 
-:::
-
-:::{grid-item-card} **Unsloth**
-:class-header: bg-secondary text-white
-
-Optimize LLM fine-tuning with faster training and reduced VRAM usage, then deploy efficiently with ExecuTorch.
-
-[Example Model →](https://huggingface.co/metascroy/Qwen3-4B-int8-int4-unsloth) • [Blog →](https://docs.unsloth.ai/new/quantization-aware-training-qat) • [Doc →](https://docs.unsloth.ai/new/deploy-llms-phone)
+[Documentation →](https://executorch.swmansion.com/) •
+[Gallery →](https://github.com/software-mansion-labs/react-native-executorch-gallery)
 :::
 
 :::{grid-item-card} **Ultralytics**
 :class-header: bg-secondary text-white
 
-Deploy on-device inference for Ultralytics YOLO models using ExecuTorch.
+Ultralytics provides a first-class ExecuTorch export path for YOLO26 across its
+seven vision tasks, targeting mobile and edge applications.
 
-[Explore →](https://docs.ultralytics.com/integrations/executorch/) • [Blog →](https://www.ultralytics.com/blog/deploy-ultralytics-yolo-models-using-the-executorch-integration)
+[Integration guide →](https://docs.ultralytics.com/integrations/executorch/)
 :::
 
-:::{grid-item-card} **Arm ML Embedded Evaluation Kit**
+:::{grid-item-card} **NimbleEdge DeliteAI**
 :class-header: bg-secondary text-white
 
-Build and deploy ML applications on Arm Cortex-M (M55, M85) and Ethos-U NPUs (U55, U65, U85) using ExecuTorch.
+The open-source DeliteAI SDK offers ExecuTorch as one of its model runtimes for
+Python-orchestrated agent workflows in Android and iOS applications.
 
-[Explore →](https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit)
+[Source →](https://github.com/NimbleEdge/deliteAI)
 :::
 
-:::{grid-item-card} **Alif Semiconductor Ensemble**
+:::{grid-item-card} **Arm, Alif, and Arduino**
 :class-header: bg-secondary text-white
 
-Run generative AI on Ensemble E4/E6/E8 MCUs with Arm Ethos-U85 NPU acceleration.
+The Arm ML Embedded Evaluation Kit supports Cortex-M and Ethos-U targets. Alif
+has demonstrated generative AI and real-time speech-to-text on its Ensemble E8,
+and the ExecuTorch Arduino library is hardware-verified on Arduino UNO Q.
 
-[Learn More →](https://alifsemi.com/press-release/alif-semiconductor-elevates-generative-ai-with-support-for-executorch-runtime/)
+[Arm kit →](https://gitlab.arm.com/artificial-intelligence/ethos-u/ml-embedded-evaluation-kit) •
+[Alif demonstration →](https://alifsemi.com/press-release/alif-semiconductor-elevates-generative-ai-with-support-for-executorch-runtime/) •
+[Arduino library →](https://github.com/meta-pytorch/executorch-arduino)
 :::
 
-:::{grid-item-card} **Digica AI SDK**
+:::{grid-item-card} **OpenVINO from Intel**
 :class-header: bg-secondary text-white
 
-Automate PyTorch model deployment to iOS, Android, and edge devices with ExecuTorch-powered SDK.
+The OpenVINO delegate supports Intel CPU, GPU, and NPU deployment, with
+end-to-end examples for YOLO26, Llama, and Stable Diffusion.
 
-[Blog →](https://www.digica.com/blog/effortless-edge-deployment-of-ai-models-with-digicas-ai-sdk-feat-executorch.html)
+[Examples →](https://github.com/pytorch/executorch/tree/main/examples/openvino) •
+[Intel guide →](https://www.intel.com/content/www/us/en/developer/articles/community/optimizing-executorch-on-ai-pcs.html)
 :::
 
 ::::
 
 ---
 
-## Featured Demos
+## Technical Showcases
 
-- **Text and Multimodal LLM demo mobile apps** - Text (Llama, Qwen3, Phi-4) and multimodal (Gemma3, Voxtral) mobile demo apps. [Try →](https://github.com/meta-pytorch/executorch-examples/tree/main/llm)
+These are reference implementations, not claims of production deployment.
+Performance figures apply only to the linked model, device, and measurement
+setup.
 
-- **Voxtral** - Deploy audio-text-input LLM on CPU (via XNNPACK) and on CUDA. [Try →](https://github.com/pytorch/executorch/blob/main/examples/models/voxtral/README.md)
+[Browse representative model examples →](https://github.com/pytorch/executorch/tree/main/examples/models)
 
-- **Whisper** - Deploy OpenAI's Whisper speech recognition model on CUDA and Metal backends. [Try →](https://github.com/pytorch/executorch/blob/main/examples/models/whisper/README.md) <!-- @lint-ignore -->
+::::{grid} 1 1 2 2
+:gutter: 3
 
-- **LoRA adapter** - Export two LoRA adapters that share a single foundation weight file, saving memory and disk space. [Try →](https://github.com/meta-pytorch/executorch-examples/tree/main/program-data-separation/cpp/lora_example)
+:::{grid-item-card} **Muse Glimmer 30B Agentic AI**
+:class-header: bg-success text-white
 
-- **OpenVINO from Intel** - Deploy [Yolo26](https://github.com/pytorch/executorch/tree/main/examples/models/yolo26), [Llama](https://github.com/pytorch/executorch/tree/main/examples/openvino/llama), and [Stable Diffusion](https://github.com/pytorch/executorch/tree/main/examples/openvino/stable_diffusion) on [OpenVINO from Intel](https://www.intel.com/content/www/us/en/developer/articles/community/optimizing-executorch-on-ai-pcs.html).
+- **Maturity:** Reference implementation
+- **Platforms:** NVIDIA CUDA and Apple silicon through MLX
 
-- **Audio Generation** - Generate audio from text prompts using Stable Audio Open Small on Arm CPUs with XNNPACK and KleidiAI. [Try →](https://github.com/Arm-Examples/ML-examples/tree/main/kleidiai-examples/audiogen-et) • [Video →](https://www.youtube.com/watch?v=q2P0ESVxhAY) <!-- @lint-ignore -->
+Run text and image input, 128K-token context, OpenAI-compatible serving, GGUF
+K-quant weights, and DFlash speculative decoding. The published M5 Pro test
+improved decode from 21.6 to 33.0 tokens/s (52.8%) without quality regression.
 
-*Want to showcase your demo? [Submit here →](https://github.com/pytorch/executorch/issues)*
+[Try it →](https://github.com/pytorch/executorch/tree/main/examples/models/muse-glimmer) •
+[Read the benchmark →](https://pytorch.org/blog/fast-ondevice-agentic-ai-with-executorch/)
+:::
+
+:::{grid-item-card} **Gemma 4 Multimodal on Mobile**
+:class-header: bg-success text-white
+
+- **Maturity:** Reference implementation
+- **Device measured:** Samsung Galaxy S25
+
+Gemma 4 E2B and E4B examples combine audio transcription, translation, image
+understanding, and text generation. The E2B 4-bit audio configuration reports a
+0.71 real-time factor, 6 tokens/s generation, and 2,251 MB peak memory on the
+documented 23-second sample.
+
+[Try it and see the measurement setup →](https://github.com/pytorch/executorch/tree/main/examples/models/gemma4)
+:::
+
+:::{grid-item-card} **Voice Agent Building Blocks**
+:class-header: bg-success text-white
+
+**Maturity:** Reference implementations; one production adopter
+
+Build transcription, streaming ASR, diarization, and voice activity detection
+with Parakeet TDT, Voxtral Realtime, Whisper, Sortformer, and Silero VAD across
+CPU, GPU, and NPU backends.
+
+[Read the overview →](https://pytorch.org/blog/building-voice-agents-with-executorch-a-cross-platform-foundation-for-on-device-audio/) •
+[Explore the models →](https://github.com/pytorch/executorch/tree/main/examples/models)
+:::
+
+:::{grid-item-card} **Current Text-to-Speech Models**
+:class-header: bg-success text-white
+
+**Maturity:** Reference implementations
+
+Voxtral TTS 2603 supports CPU and CUDA; its documented RTX 5080 configuration
+runs at 0.31× real-time factor, more than 3× real time. Its model weights and
+voice embeddings are CC BY-NC 4.0. Supertonic 3 adds a dynamic FP16
+text-to-speech path for the experimental MLX delegate.
+
+[Voxtral TTS →](https://github.com/pytorch/executorch/tree/main/examples/models/voxtral_tts) •
+[Supertonic 3 →](https://github.com/pytorch/executorch/tree/main/examples/models/supertonic)
+:::
+
+:::{grid-item-card} **Qwen 3.5**
+:class-header: bg-success text-white
+
+**Maturity:** Early model support
+
+The dense 0.8B, 2B, and 4B path currently targets FP32 static-shape XNNPACK.
+The 35B-A3B mixture-of-experts reference adds INT4 export, CUDA and MLX runners,
+and OpenAI-compatible serving. Review each example's limitations before use.
+
+[Dense models →](https://github.com/pytorch/executorch/tree/main/examples/models/qwen3_5) •
+[Mixture of experts →](https://github.com/pytorch/executorch/tree/main/examples/models/qwen3_5_moe)
+:::
+
+:::{grid-item-card} **WebGPU in the Browser**
+:class-header: bg-success text-white
+
+**Maturity:** Experimental
+
+The WebGPU backend demonstrates language, vision, retrieval, audio, and
+on-device training workflows. A July 2026 M4 Pro measurement reports 188.3
+decode tokens/s for a 4-bit Llama 3.2 1B artifact at 128-token context.
+
+[See the benchmark and workflows →](https://github.com/pytorch/executorch/tree/main/backends/webgpu#performance)
+:::
+
+::::
+
+---
+
+## Community Showcase
+
+At the June 2026 ExecuTorch Hackathon, more than 100 participants across over 20
+teams built on-device prototypes on Snapdragon-powered Samsung Galaxy S25 Ultra
+phones. The winning prototypes explored real-time visual safety, haptic
+navigation for blind and low-vision users, and private gait analysis. These are
+community prototypes, not production deployments.
+
+[See the hackathon projects →](https://pytorch.org/blog/building-the-future-of-on-device-ai-at-the-executorch-hackathon/)
+
+Want your project considered for this page? [Submit a success story](https://github.com/pytorch/executorch/issues/new?title=%5BSuccess%20story%5D%20)
+with its deployment status, model, device and backend, reproducible measurements
+and baseline, a public primary source, and permission to use any supplied logo or
+image.

--- a/docs/source/user-pathways.md
+++ b/docs/source/user-pathways.md
@@ -166,7 +166,8 @@ You target microcontrollers, DSPs, or other resource-constrained hardware where 
 
 ## Step 4: What is your model's status?
 
-The right workflow depends on whether you are starting from scratch, using a supported model, or working with a custom architecture.
+The right workflow depends on whether you are starting from scratch, using an
+existing export recipe, or working with a custom architecture.
 
 ```{list-table} Model Status Routing
 :header-rows: 1
@@ -174,10 +175,10 @@ The right workflow depends on whether you are starting from scratch, using a sup
 
 * - **Model Status**
   - **Recommended Path**
-* - Using a supported LLM (Llama, Phi, Qwen, SmolLM)
-  - Use the {doc}`llm/export-llm` script for a streamlined export with quantization and optimization built in. Pre-exported models are also available on `HuggingFace ExecuTorch Community <https://huggingface.co/executorch-community>`_.
-* - Using a HuggingFace model
-  - Use {doc}`llm/export-llm-optimum` (Optimum ExecuTorch) for broad HuggingFace model support with familiar APIs.
+* - Using an LLM covered by an `export_llm` recipe
+  - Use the {doc}`llm/export-llm` script for a streamlined export with quantization and optimization built in. Pre-exported models are also available from the [ExecuTorch Community on Hugging Face](https://huggingface.co/executorch-community).
+* - Using a Hugging Face model
+  - Use the [experimental Transformers exporter](https://huggingface.co/docs/transformers/en/exporters) for broad programmatic XNNPACK or CUDA export, or {doc}`llm/export-llm-optimum` for tested task-level recipes and higher-level APIs.
 * - Using a custom PyTorch model
   - Follow {doc}`getting-started` for the standard export flow, then consult {doc}`using-executorch-export` for advanced lowering options.
 * - Model requires dynamic shapes

--- a/docs/source/using-executorch-android.md
+++ b/docs/source/using-executorch-android.md
@@ -3,8 +3,15 @@
 
 🚀 Quick Start: __New to ExecuTorch__ ? Jump to [Using AAR from Maven Central](#using-aar-from-maven-central) for the fastest setup, then see the [Runtime Integration](#runtime-integration) example.
 
-To use from Android, ExecuTorch provides Java/Kotlin API bindings and Android platform integration, available as an AAR file.
-Note: This page covers Android app integration through the AAR library. The ExecuTorch C++ APIs can also be used from Android native, and the documentation can be found on this page about cross compilation.
+For Android applications, ExecuTorch provides Java/Kotlin bindings and platform
+integration in an AAR. You can instead use the C++ APIs from Android native
+code; see [Cross-Compiling for Android](using-executorch-building-from-source.md#cross-compiling-for-android).
+
+```{warning}
+The Java/Kotlin `Module` and task-level APIs are experimental and may change or
+be removed without notice. Android applications can use the stable C++ runtime
+through native code when API stability is required.
+```
 
 ## Installation
 
@@ -14,7 +21,9 @@ __Choose your installation method:__
 - __[Direct AAR file](#using-aar-file-directly)__: For specific versions or offline development
 - __[Build from source](#building-from-source)__: For custom backends or contributions
 
-All ExecuTorch Android libraries are packaged into an Android library (AAR), executorch.aar for both generic (image/audio processing) and LLM (LLaMA) use case. In each release, prebuilt AAR artifacts are uploaded to Maven and S3. Users can also build the AAR from source.
+ExecuTorch Android libraries are packaged into an Android library (AAR),
+`executorch.aar`, for generic and task-level use cases. Prebuilt artifacts are
+published to Maven Central and S3. Users can also build the AAR from source.
 
 ### Contents of library
 
@@ -29,24 +38,31 @@ The AAR artifact contains the Java library for users to integrate with their Jav
   - Optimized kernels
   - Quantized kernels
   - LLaMa-specific Custom ops library.
-- Comes with two ABI variants, arm64-v8a and x86_64.
+- The default XNNPACK AAR comes with `arm64-v8a` and `x86_64` variants.
 
-The AAR library can be used for generic Android device with arm64-v8a or x86_64 architecture. It can be used across form factors, including phones, tablets, tv boxes, etc, as it does not contain any UI components.
+The AAR library can be used across form factors, including phones, tablets,
+and TV boxes, because it does not contain UI components. Backend-specific
+packages may support fewer ABIs; for example, the QNN release AAR is
+`arm64-v8a` only.
 
 ## Using AAR from Maven Central
 
 ✅ Recommended for most developers
 ExecuTorch is available on Maven Central.
-Simply add the target org.pytorch:executorch-android:${executorch_version} to your Android app dependency (build.gradle), and build your app. For example:
+Add `org.pytorch:executorch-android` to your app's Gradle dependencies. Replace
+`X.Y.Z` with a version from Maven Central that matches the ExecuTorch release
+used to export the model:
 
 ```kotlin
-app/build.gradle.kts
+// app/build.gradle.kts
+val executorchVersion = "X.Y.Z"
+
 dependencies {
-implementation("org.pytorch:executorch-android:${executorch_version}")
+    implementation("org.pytorch:executorch-android:$executorchVersion")
 }
 ```
 
-Note: If you want to use release v1.0.0, please use dependency org.pytorch:executorch-android:1.0.0.
+[Choose a version on Maven Central](https://central.sonatype.com/artifact/org.pytorch/executorch-android).
 Click the screenshot below to watch the demo video on how to add the package and run a simple ExecuTorch model with Android Studio.
 <a href="_static/img/android_studio.mp4">
 <img src="_static/img/android_studio.jpeg" width="800" alt="Integrating and Running ExecuTorch on Android">
@@ -54,27 +70,19 @@ Click the screenshot below to watch the demo video on how to add the package and
 
 ## Using AAR file directly
 
-You can also directly specify an AAR file in the app. We upload pre-built AAR to S3 during each release, or as a snapshot.
+You can also add an AAR file directly. Stable release AARs are
+backend-specific. Set `executorch_version` to the release used for export and
+`executorch_backend` to `xnnpack`, `qnn`, or `vulkan`, then download both the
+artifact and its checksum:
 
-### Latest Released versions (Recommended)
-
-Starting from [v1.0.0](https://github.com/pytorch/executorch/releases/tag/v1.0.0), there are respective executorch.aar library available by backends
-
-| AAR | SHASUMS | Backend |
-| ------- | --- | ------- |
-| [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/1.0.0-xnnpack/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/1.0.0-xnnpack/executorch.aar.sha256sums) | [XNNPACK](backends/xnnpack/xnnpack-overview.md) |
-| [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/1.0.0-qnn/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/1.0.0-qnn/executorch.aar.sha256sums) | [Qualcomm AI Engine](backends-qualcomm.md) |
-| [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/1.0.0-vulkan/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/1.0.0-vulkan/executorch.aar.sha256sums) | [Vulkan](backends/vulkan/vulkan-overview.md) |
-
-### Older Released versions
-
-Download the older released version
-
-| Version | AAR | SHASUMS |
-| ------- | --- | ------- |
-| [v0.7.0](https://github.com/pytorch/executorch/releases/tag/v0.7.0) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.7.0/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.7.0/executorch.aar.sha256sums) |
-| [v0.6.0](https://github.com/pytorch/executorch/releases/tag/v0.6.0) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.6.0/executorch.aar.sha256sums) |
-| [v0.5.0](https://github.com/pytorch/executorch/releases/tag/v0.5.0) | [executorch.aar](https://ossci-android.s3.amazonaws.com/executorch/release/v0.5.0-rc3/executorch.aar) | [executorch.aar.sha256sums](https://ossci-android.s3.amazonaws.com/executorch/release/v0.5.0-rc3/executorch.aar.sha256sums) |
+```sh
+# For release tag v1.4.1, omit the leading "v" from the artifact path.
+executorch_version=1.4.1
+executorch_backend=xnnpack
+curl -fLO "https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version}-${executorch_backend}/executorch.aar"
+curl -fLO "https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version}-${executorch_backend}/executorch.aar.sha256sums"
+shasum -a 256 -c executorch.aar.sha256sums
+```
 
 ### Snapshots from main branch
 
@@ -88,8 +96,9 @@ Starting from 2025-04-12, you can download nightly `main` branch snapshots:
 For example:
 
 ```sh
-curl -O https://ossci-android.s3.amazonaws.com/executorch/release/snapshot-20250412/executorch.aar
-curl -O https://ossci-android.s3.amazonaws.com/executorch/release/snapshot-20250412/executorch.aar.sha256sums
+curl -fLO https://ossci-android.s3.amazonaws.com/executorch/release/snapshot-20250412/executorch.aar
+curl -fLO https://ossci-android.s3.amazonaws.com/executorch/release/snapshot-20250412/executorch.aar.sha256sums
+shasum -a 256 -c executorch.aar.sha256sums
 ```
 
 We aim to make every daily snapshot available and usable. However, for best stability, please use releases, not snapshots.
@@ -99,30 +108,35 @@ We aim to make every daily snapshot available and usable. However, for best stab
 To add the AAR file to your app:
 Download the AAR.
 Add it to your gradle build rule as a file path.
-An AAR file itself does not contain dependency info, unlike the Maven one which bundled with pom.xml. The Java package requires fbjni and soloader, and currently requires users to explicitly declare the dependency. Therefore, two more dependencies in gradle rule is required:
+An AAR file does not carry the dependency metadata that Maven resolves. Declare
+the dependencies used by the published package explicitly:
 
 ```kotlin
-implementation("com.facebook.soloader:soloader:0.10.5")
 implementation("com.facebook.fbjni:fbjni:0.7.0")
+implementation("com.facebook.soloader:nativeloader:0.10.5")
+implementation("androidx.core:core-ktx:1.13.1")
+implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.23")
 ```
 
 ### Example usage
 
-In your app working directory, such as executorch-examples/llm/android/LlamaDemo,
+In your app working directory, such as `executorch-examples/llm/android/LlamaDemo`,
 
 ```sh
 mkdir -p app/libs
-curl https://ossci-android.s3.amazonaws.com/executorch/release/${executorch_version}/executorch.aar -o app/libs/executorch.aar
+cp /path/to/executorch.aar app/libs/executorch.aar
 ```
 
 And include it in gradle:
 
 ```kotlin
-app/build.gradle.kts
+// app/build.gradle.kts
 dependencies {
-implementation(files("libs/executorch.aar"))
-implementation("com.facebook.soloader:soloader:0.10.5")
-implementation("com.facebook.fbjni:fbjni:0.7.0")
+    implementation(files("libs/executorch.aar"))
+    implementation("com.facebook.fbjni:fbjni:0.7.0")
+    implementation("com.facebook.soloader:nativeloader:0.10.5")
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.23")
 }
 ```
 
@@ -131,19 +145,22 @@ Now you can compile your app with the ExecuTorch Android library.
 ## Building from Source
 
 ```text
-scripts/build_android_library.sh
+./scripts/build_android_library.sh
 ```
 
-is a helper script to build the Java library (into .jar), native library (into .so), and the packaged AAR file.
-You need Android SDK and NDK to use it.
-Current NDK version used in ExecuTorch CI: r28c.
-You need to set ANDROID_HOME to Android SDK home and ANDROID_NDK to the correct NDK root (containing NOTICE file).
+is a helper script to build the Java library, native library, and packaged AAR.
+Install JDK 17, Android SDK Platform 34, and Android NDK r28c (the version used
+in ExecuTorch CI). Set `ANDROID_HOME` or `ANDROID_SDK_ROOT` to the SDK and
+`ANDROID_NDK` to the NDK root (the directory containing `NOTICE`).
 
 ```sh
-export ANDROID_HOME=/path/to/sdk
-export ANDROID_NDK=/path/to/ndk
-sh scripts/build_android_library.sh
+export ANDROID_HOME=/path/to/android/sdk
+export ANDROID_NDK=/path/to/android/sdk/ndk/28.2.13676358
+./scripts/build_android_library.sh
 ```
+
+The build script also accepts `ANDROID_SDK` for backward compatibility; it
+takes precedence when more than one SDK variable is set.
 
 NOTE: Currently, XNNPACK backend is always built with the script.
 
@@ -165,10 +182,10 @@ export ANDROID_ABIS=arm64-v8a
 export ANDROID_ABIS=x86_64
 ```
 
-And then run the script.
+Then run the script.
 
 ```sh
-sh scripts/build_android_library.sh
+./scripts/build_android_library.sh
 ```
 
 - __EXECUTORCH_CMAKE_BUILD_TYPE__
@@ -196,44 +213,55 @@ The following backends are available for Android:
 | [XNNPACK](https://github.com/google/XNNPACK) | CPU | [Doc](backends/xnnpack/xnnpack-overview.md) |
 | [MediaTek NeuroPilot](https://neuropilot.mediatek.com/) | NPU | [Doc](backends-mediatek.md) |
 | [Qualcomm AI Engine](https://www.qualcomm.com/developer/software/qualcomm-ai-engine-direct-sdk) | NPU | [Doc](backends-qualcomm.md) |
+| Arm VGF | GPU | [Doc](backends/arm-vgf/arm-vgf-overview.md) |
+| Samsung Exynos | NPU / DSP | [Doc](backends/samsung/samsung-overview.md) |
 | [Vulkan](https://www.vulkan.org/) | GPU | [Doc](backends/vulkan/vulkan-overview.md) |
 
 Start with XNNPACK (CPU backend) for maximum compatibility, then add hardware-specific backends for optimization.
 
 ## Runtime Integration
 
-Here is an example code sample in Java that demonstrates how to integrate ExecuTorch into an Android app:
-
-```java
-import org.pytorch.executorch.EValue;
-import org.pytorch.executorch.Module;
-import org.pytorch.executorch.Tensor;
-public class MainActivity extends Activity {
-private Module module;
-
-@Override
-protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    // Load the ExecuTorch module
-    Module module = Module.load("/data/local/tmp/add.pte");
-
-    Tensor tensor1 = Tensor.fromBlob(new float[] {1.0f}, new long[] {1});
-    Tensor tensor2 = Tensor.fromBlob(new float[] {20.0f}, new long[] {1});
-
-    EValue eValue1 = EValue.from(tensor1);
-    EValue eValue2 = EValue.from(tensor2);
-
-    float result = module.forward(eValue1, eValue2)[0].toTensor().getDataAsFloatArray()[0];
-}
-```
-
-Push the corresponding pte file to your Android device:
+First export the test model into your app's assets from an ExecuTorch source
+checkout with its Python package installed:
 
 ```sh
-adb push extension/module/test/resources/add.pte /data/local/tmp/
+mkdir -p /path/to/app/src/main/assets
+python -m test.models.export_program --modules ModuleAdd \
+  --outdir /path/to/app/src/main/assets
 ```
 
-This example loads an ExecuTorch module, prepares input data, runs inference, and processes the output data.
+Android applications cannot normally read files pushed to `/data/local/tmp`.
+Copy the asset to app-private storage before loading it:
+
+```kotlin
+import android.app.Activity
+import android.os.Bundle
+import java.io.File
+import org.pytorch.executorch.EValue
+import org.pytorch.executorch.Module
+import org.pytorch.executorch.Tensor
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val modelFile = File(filesDir, "ModuleAdd.pte")
+        assets.open("ModuleAdd.pte").use { input ->
+            modelFile.outputStream().use { output -> input.copyTo(output) }
+        }
+
+        val x = Tensor.fromBlob(floatArrayOf(1f, 2f, 3f, 4f), longArrayOf(2, 2))
+        val y = Tensor.fromBlob(floatArrayOf(5f, 6f, 7f, 8f), longArrayOf(2, 2))
+
+        Module.load(modelFile.absolutePath).use { module ->
+            val outputs = module.forward(EValue.from(x), EValue.from(y), EValue.from(1.0))
+            check(outputs[0].toTensor().dataAsFloatArray.contentEquals(
+                floatArrayOf(6f, 8f, 10f, 12f)
+            ))
+        }
+    }
+}
+```
 
 Please use [DeepLabV3AndroidDemo](https://github.com/meta-pytorch/executorch-examples/tree/main/dl3/android/DeepLabV3Demo)
 and [LlamaDemo](https://github.com/meta-pytorch/executorch-examples/tree/main/llm/android/LlamaDemo) for the code examples

--- a/docs/source/using-executorch-building-from-source.md
+++ b/docs/source/using-executorch-building-from-source.md
@@ -1,11 +1,12 @@
 # Building from Source
 
-On Linux and macOS you may not need to build at all. `pip install executorch` ships the
-runtime as prebuilt libraries with headers and a CMake package, so a C++ program can link
-it directly. See [Using the prebuilt libraries from the pip package](using-executorch-cpp.md#using-the-prebuilt-libraries-from-the-pip-package),
-including the CUDA packages for running on a GPU. Build from source when you need a
-platform the package does not cover, a build option it does not enable, or your own
-changes to the runtime.
+On Linux and macOS you may not need to build at all. Current main/nightly wheels
+ship the runtime as prebuilt libraries with headers and a CMake package, so a
+C++ program can link it directly. See
+[Using the prebuilt libraries from the pip package](using-executorch-cpp.md#using-the-prebuilt-libraries-from-the-pip-package),
+including the CUDA packages for running on a GPU. Build from source when you
+need a platform the package does not cover, a build option it does not enable,
+or your own changes to the runtime.
 
 ExecuTorch uses [CMake](https://cmake.org/) as the primary build system.
 Even if you don't use CMake directly, CMake can emit scripts for other format
@@ -36,9 +37,13 @@ ExecuTorch is tested on the following systems, although it should also work in s
 * `g++` version 7 or higher, `clang++` version 5 or higher, or another
   C++17-compatible toolchain.
 * `python` version 3.10-3.14
+* `cmake` version 3.26 or higher
 * `ccache` (optional) - A compiler cache that speeds up recompilation
 * **macOS**
-  - `Xcode Command Line Tools`
+  - Xcode for the Apple platform presets, or Xcode Command Line Tools when
+    using another CMake generator
+  - To build the MLX backend, install the Metal toolchain with
+    `xcodebuild -downloadComponent MetalToolchain`
 * **Windows**
   - `Visual Studio Clang Tools` - See [Clang/LLVM support in Visual Studio](https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170).
 
@@ -50,7 +55,7 @@ portability details.
 ## Environment Setup
  Clone the ExecuTorch repository from GitHub and create a conda environment. Venv can be used in place of conda.
    ```bash
-   git clone -b viable/strict https://github.com/pytorch/executorch.git
+   git clone --recurse-submodules https://github.com/pytorch/executorch.git
    cd executorch
    conda create -yn executorch python=3.10
    conda activate executorch
@@ -104,7 +109,9 @@ portability details.
 
   For Intel-based macOS systems, use `--use-pt-pinned-commit --minimal`. As PyTorch does not provide pre-built binaries for Intel Mac, installation requires building PyTorch from source. Instructions can be found in [PyTorch Installation](https://github.com/pytorch/pytorch#installation).
 
-  Note that only the XNNPACK and CoreML backends are built by default. Additional backends can be enabled or disabled by setting the corresponding CMake flags:
+  XNNPACK and Core ML are built by default. On Apple silicon, MLX is also built
+  when the Metal compiler is installed. Additional backends can be enabled or
+  disabled by setting the corresponding CMake flags:
 
   ```bash
   # Enable the Vulkan backend
@@ -158,9 +165,9 @@ When user code is not using CMake, the runtime can be built standalone and linke
 | :------------------------- | :--------------------------------------------------------------------------------- |
 | C++ with user CMake        | Use CMake `add_subdirectory`.                                                      |
 | C++ without user CMake     | Build ExecuTorch standalone with CMake. Link libraries with user build.            |
-| Android with Java/Kotlin   | Use [scripts/build_android_libraries.sh](#cross-compiling-for-android).            |
+| Android with Java/Kotlin   | Use [scripts/build_android_library.sh](#cross-compiling-for-android).             |
 | Android with C++           | Follow C++ build steps, [cross-compile for Android](#cross-compiling-for-android). |
-| iOS                        | Use [scripts/build_ios_frameworks.sh](#cross-compiling-for-ios).                   |
+| iOS                        | Use [scripts/build_apple_frameworks.sh](#cross-compiling-for-ios).                 |
 
 ### Configuring
 
@@ -170,8 +177,8 @@ When building as a submodule as part of a user CMake build, ExecuTorch CMake opt
 
 CMake configuration for standalone runtime build:
 ```bash
-cmake -B cmake-out --preset [preset] [options]
-cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
+cmake -B cmake-out --preset [preset] -DCMAKE_BUILD_TYPE=Release [options]
+cmake --build cmake-out --config Release -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ```
 
 #### Build Presets
@@ -294,7 +301,7 @@ cd executorch
 # building, and tends to speed up the build significantly. It's typical to use
 # "core count + 1" as the `-j` value; the command below derives that
 # dynamically (`nproc` on Linux, `sysctl -n hw.ncpu` on macOS).
-cmake --build cmake-out -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
+cmake --build cmake-out --config Release -j$(( $(nproc 2>/dev/null || sysctl -n hw.ncpu) + 1 ))
 ```
 
 > **_TIP:_** For faster rebuilds, consider installing ccache (see [Compiler Cache section](#compiler-cache-ccache) below). On first builds, ccache populates its cache. Subsequent builds with the same compiler flags can be significantly faster.
@@ -333,9 +340,13 @@ Backends typically introduce additional targets. See backend-specific documentat
 
 To verify the build, ExecuTorch optionally compiles a simple, stand-alone model runner to run PTE files with all-one input tensors. It is not enabled by default in most presets, but can be enabled by configuring with `-DEXECUTORCH_BUILD_EXECUTOR_RUNNER=ON -DEXECUTORCH_BUILD_EXTENSION_EVALUE_UTIL=ON`.
 
-Once compiled, invoke the runner with a sample PTE (such as the one generated by [verifying the Python build](#verify-the-build)).
+Once compiled, invoke the runner with a sample PTE (such as the one generated by [verifying the Python build](#verify-the-build)). Single-configuration generators such as Ninja and Make place it directly in `cmake-out`; multi-configuration generators such as Xcode and Visual Studio place it under the selected configuration.
 ```bash
+# Ninja or Make
 cmake-out/executor_runner --model_path=mv2_xnnpack_fp32.pte
+
+# Xcode or Visual Studio
+cmake-out/Release/executor_runner --model_path=mv2_xnnpack_fp32.pte
 ```
 
 If the runner runs successfully, you should see output similar to the following:
@@ -355,8 +366,9 @@ OutputX 0: tensor(sizes=[1, 1000], [
 
 ### Pre-requisites
 - Set up a Python environment and clone the ExecuTorch repository, as described in [Environment Setup](#environment-setup).
-- Install the [Android SDK](https://developer.android.com/studio). Android Studio is recommended.
-- Install the [Android NDK](https://developer.android.com/ndk).
+- Install JDK 17. The Android Gradle plugin used by ExecuTorch requires it.
+- Install the [Android SDK](https://developer.android.com/studio), including SDK Platform 34. Android Studio is recommended.
+- Install Android NDK r28c, the version used in ExecuTorch CI.
   - Option 1: Install via [Android Studio](https://developer.android.com/studio/projects/install-ndk).
   - Option 2: Download from [NDK Downloads](https://developer.android.com/ndk/downloads).
 
@@ -365,11 +377,18 @@ OutputX 0: tensor(sizes=[1, 1000], [
 With the NDK installed, the `build_android_library.sh` script will build the ExecuTorch Java AAR, which contains ExecuTorch Java bindings. See [Using the AAR File](using-executorch-android.md#using-aar-file) for usage.
 
 ```bash
+export ANDROID_HOME=/path/to/android/sdk
+export ANDROID_NDK=/path/to/android/sdk/ndk/28.2.13676358
 export ANDROID_ABIS=arm64-v8a
 export BUILD_AAR_DIR=aar-out
-mkdir -p $BUILD_AAR_DIR
-sh scripts/build_android_library.sh
+mkdir -p "$BUILD_AAR_DIR"
+./scripts/build_android_library.sh
 ```
+
+`ANDROID_SDK_ROOT` can be used instead of `ANDROID_HOME`. The build script also
+accepts `ANDROID_SDK` for backward compatibility; it takes precedence when
+more than one SDK variable is set. The resulting AAR is
+`aar-out/executorch.aar`.
 
 ### Android Native
 

--- a/docs/source/using-executorch-cpp.md
+++ b/docs/source/using-executorch-cpp.md
@@ -40,16 +40,17 @@ Running a model using the low-level runtime APIs allows for a high-degree of con
 
 ## Building with CMake
 
-There are two ways to get the C++ runtime. Linking the prebuilt libraries from the pip
-package needs no source checkout and is the quicker option. Building from source gives
-you every option the project has, and is what you need for a platform the wheel does not
+There are two ways to get the C++ runtime. Current main/nightly wheels include
+prebuilt libraries and need no source checkout. Building from source gives you
+every option the project has and is required for a platform the wheel does not
 cover.
 
 ### Using the prebuilt libraries from the pip package
 
-On Linux and macOS, `pip install executorch` ships the runtime as prebuilt shared libraries together
-with the headers and a CMake package. So a C++ program can use ExecuTorch without building it from
-source, and without knowing much CMake.
+On Linux and macOS, current main/nightly wheels ship the runtime as prebuilt
+shared libraries together with the headers and a CMake package. Stable releases
+from before this packaging was introduced do not contain the namespaced CMake
+targets used below; use the documentation for your installed release.
 
 #### Run your first model in four steps
 
@@ -58,12 +59,12 @@ Copy these three files into an empty folder and follow along. No prior CMake kno
 **1. Install, and make a model file.**
 
 ```
-pip install executorch torch --extra-index-url https://download.pytorch.org/whl/cpu
+pip install --pre executorch torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 ```
 
-`torch` is named explicitly because the wheel does not depend on it, so you bring your own torch and
-keep the version under your control. You need it only to create a model file in step 1, not to run
-the C++ program.
+`torch` is installed explicitly because nightly ExecuTorch wheels do not declare
+it as a dependency. Python and PyTorch are needed to create the model file in
+step 1, but not to run the compiled C++ program.
 
 A C++ program loads a `.pte` file, which is a model that has already been exported. C++ cannot
 create one, so make it in Python first:
@@ -79,7 +80,7 @@ class Add(torch.nn.Module):
 
 example = (torch.ones(2, 2), torch.ones(2, 2))
 program = to_edge_transform_and_lower(
-    torch.export.export(Add(), example)
+    torch.export.export(Add().eval(), example)
 ).to_executorch()
 open("model.pte", "wb").write(program.buffer)
 ```
@@ -94,6 +95,8 @@ python export.py
 // main.cpp
 #include <executorch/extension/module/module.h>
 #include <executorch/extension/tensor/tensor.h>
+
+#include <array>
 #include <cstdio>
 
 using namespace executorch::extension;

--- a/docs/source/using-executorch-export.md
+++ b/docs/source/using-executorch-export.md
@@ -4,7 +4,7 @@ The section describes the process of taking a PyTorch model and converting to th
 
 ## Prerequisites
 
-Exporting requires the ExecuTorch python libraries to be installed, typically by running `pip install executorch`. See [Installation](getting-started.md#Installation) for more information. This process assumes you have a PyTorch model, can instantiate it from Python, and can provide example input tensors to run the model.
+Exporting requires the ExecuTorch python libraries to be installed, typically by running `pip install executorch`. See [Installation](getting-started.md#installation) for more information. This process assumes you have a PyTorch model, can instantiate it from Python, and can provide example input tensors to run the model.
 
 ## The Export and Lowering Process
 
@@ -42,10 +42,23 @@ Commonly used hardware backends are listed below. For mobile, consider using XNN
 
 ## Model Preparation
 
-The export process takes in a standard PyTorch model, typically a `torch.nn.Module`. This can be an custom model definition, or a model from an existing source, such as TorchVision or HuggingFace. See [Getting Started with ExecuTorch](getting-started.md) for an example of lowering a TorchVision model.
+The export process takes in a standard PyTorch model, typically a
+`torch.nn.Module`. This can be a custom model definition or a model from an
+existing source, such as TorchVision or Hugging Face. See
+[Getting Started with ExecuTorch](getting-started.md) for an example of lowering
+a TorchVision model.
 
 :::{tip}
-Exporting a model from the [Hugging Face Hub](https://huggingface.co/models)? Use the [Optimum ExecuTorch](llm/export-llm-optimum.md) integration. It wraps the export and lowering steps below in a single CLI invocation and supports a wide range of decoder, encoder, multimodal, and seq2seq architectures out of the box.
+Exporting a `PreTrainedModel` from the [Hugging Face Hub](https://huggingface.co/models)?
+The [Transformers ExecuTorch exporter](https://huggingface.co/docs/transformers/en/exporters)
+is a broad, experimental programmatic path for XNNPACK and CUDA. Pin the versions
+tested by Transformers, and expect to supply application-side orchestration for
+the independent graphs returned by `export_for_generation`.
+
+Use [Optimum ExecuTorch](llm/export-llm-optimum.md) when you want its tested
+task-level recipes, CLI, quantization, and higher-level model wrappers.
+If an architecture needs exporter changes, see Transformers'
+[extension guide](https://huggingface.co/docs/transformers/en/exporters_extend).
 :::
 
 Model export is done from Python. This is commonly done through a Python script or from an interactive Python notebook, such as Jupyter or Colab. The example below shows instantiation and inputs for a simple PyTorch model. The inputs are prepared as a tuple of torch.Tensors, and the model can run with these inputs.
@@ -107,7 +120,7 @@ class Model(torch.nn.Module):
         y = self.linear(y)
         return y
 
-model = Model()
+model = Model().eval()
 inputs = (torch.randn(1,1,16,16),)
 dynamic_shapes = {
     "x": {
@@ -160,7 +173,10 @@ The PyTorch export process uses the example inputs provided to trace through the
 
 Many models require support for varying input sizes. To support this, export takes a `dynamic_shapes` parameter, which informs the compiler of which dimensions can vary and their bounds. This takes the form of a nested dictionary, where keys correspond to input names and values specify the bounds for each input.
 
-In the example model, inputs are provided as 4-dimensions tensors following the standard convention of batch, channels, height, and width (NCHW). An input with the shape `[1, 3, 16, 16]` indicates 1 batch, 3 channels, and a height and width of 16.
+In the example model, inputs are provided as four-dimensional tensors following
+the standard convention of batch, channels, height, and width (NCHW). The input
+shape `[1, 1, 16, 16]` indicates one batch, one channel, and a height and width
+of 16.
 
 Suppose your model supports images with sizes between 16x16 and 1024x1024. The shape bounds can be specified as follows:
 
@@ -191,7 +207,7 @@ from executorch.runtime import Runtime
 
 runtime = Runtime.get()
 
-input_tensor = torch.randn(1, 3, 32, 32)
+input_tensor = torch.randn(1, 1, 32, 32)
 program = runtime.load_program("model.pte")
 method = program.load_method("forward")
 outputs = method.execute([input_tensor])
@@ -202,7 +218,7 @@ To run a model with program and data separated, please use the [ExecuTorch Modul
 import torch
 from executorch.extension.pybindings import portable_lib
 
-input_tensor = torch.randn(1, 3, 32, 32)
+input_tensor = torch.randn(1, 1, 32, 32)
 module = portable_lib._load_for_executorch("model.pte", "model.ptd")
 outputs = module.forward([input_tensor])
 ```

--- a/docs/source/using-executorch-ios.md
+++ b/docs/source/using-executorch-ios.md
@@ -19,9 +19,9 @@ The ExecuTorch Runtime for iOS and macOS (ARM64) is distributed as a collection 
 
 Link your binary with the ExecuTorch runtime and any backends or kernels used by the exported ML model. It is recommended to link the core runtime to the components that use ExecuTorch directly, and link kernels and backends against the main app target.
 
-**Note:** You may need to add some extra linker flags for the build settings of the components that links against ExecuTorch backends or kernels to let them register properly at the app startup. See the [Linkage](#Linkage) section for more details.
+**Note:** You may need to add some extra linker flags for the build settings of the components that links against ExecuTorch backends or kernels to let them register properly at the app startup. See the [Linkage](#linkage) section for more details.
 
-**Note:** To access logs, link against the Debug build of the ExecuTorch runtime, i.e., the `executorch_debug` framework. For optimal performance, always link against the Release version of the deliverables (those without the `_debug` suffix), which have all logging overhead removed. See the [Logging](#Logging) section for more details.
+**Note:** To access logs, link against the Debug build of the ExecuTorch runtime, i.e., the `executorch_debug` framework. For optimal performance, always link against the Release version of the deliverables (those without the `_debug` suffix), which have all logging overhead removed. See the [Logging](#logging) section for more details.
 
 **Note:** The MLX backend links and registers on the iOS simulator, so an app builds for both destinations, but it reports itself unavailable there because the simulator has no Metal device it can use. A model delegated to MLX will not load on the simulator. Use a real device or a Mac to run one.
 
@@ -31,7 +31,14 @@ The prebuilt ExecuTorch runtime, backend, and kernels are available as a [Swift 
 
 #### Xcode
 
-In Xcode, go to `File > Add Package Dependencies`. Paste the URL of the [ExecuTorch repo](https://github.com/pytorch/executorch) into the search bar and select it. Make sure to change the branch name to the desired ExecuTorch version in format "swiftpm-<version>", (e.g. "swiftpm-1.0.0"), or a branch name in format "swiftpm-<version>.<year_month_date>" (e.g. "swiftpm-1.1.0-20251101") for a [nightly build](https://ossci-ios.s3.amazonaws.com/list.html) on a specific date.
+In Xcode, go to `File > Add Package Dependencies`. Paste the URL of the
+[ExecuTorch repo](https://github.com/pytorch/executorch) into the search bar and
+select it. For Dependency Rule, select **Branch** and enter
+`swiftpm-<version>` for a stable release (for example, `swiftpm-1.4.1`), or
+`swiftpm-<version>.<YYYYMMDD>` for a
+[nightly build](https://ossci-ios.s3.amazonaws.com/list.html) on a specific date
+(for example, `swiftpm-1.5.0.20260909`). Match this version to the one used to
+export the model.
 
 ![](_static/img/swiftpm_xcode1.png)
 
@@ -53,6 +60,8 @@ Add a package and target dependencies on ExecuTorch to your package file like th
 // swift-tools-version:5.9
 import PackageDescription
 
+let executorchVersion = "1.4.1" // Match the release used to export the model.
+
 let package = Package(
   name: "YourPackageName",
   platforms: [
@@ -63,8 +72,11 @@ let package = Package(
     .library(name: "YourPackageName", targets: ["YourTargetName"]),
   ],
   dependencies: [
-    // Use "swiftpm-<version>.<year_month_day>" branch name for a nightly build.
-    .package(url: "https://github.com/pytorch/executorch.git", branch: "swiftpm-1.0.0")
+    // Append ".<YYYYMMDD>" to the version for a nightly branch.
+    .package(
+      url: "https://github.com/pytorch/executorch.git",
+      branch: "swiftpm-\(executorchVersion)"
+    )
   ],
   targets: [
     .target(
@@ -74,11 +86,12 @@ let package = Package(
         .product(name: "backend_xnnpack", package: "executorch"),
         .product(name: "kernels_optimized", package: "executorch"),
         // Add other backends and kernels as needed.
-      ]),
+      ],
       linkerSettings: [
-         // Force load all symbols from static libraries to trigger backends and kernels registration
-         .unsafeFlags(["-Wl,-all_load"])
+        // Force-load static initializers that register backends and kernels.
+        .unsafeFlags(["-Xlinker", "-all_load"])
       ]
+    )
   ]
 )
 ```
@@ -257,7 +270,7 @@ try module.load("forward")
 let imageBuffer: UnsafeMutableRawPointer = ... // Existing image buffer
 
 // Create an input tensor referencing the buffer and assuming the given shape and data type.
-let inputTensor = Tensor<Float>(&imageBuffer, shape: [1, 3, 224, 224])
+let inputTensor = Tensor<Float>(bytesNoCopy: imageBuffer, shape: [1, 3, 224, 224])
 
 // Execute the 'forward' method with the given input tensor and get an output tensor back.
 let outputTensor = try Tensor<Float>(module.forward(inputTensor))
@@ -278,7 +291,9 @@ ExecuTorch offers `ExecuTorchTensor` class in Objective-C and two tensor types i
 
 - `Tensor<T: Scalar>`: A generic, type-safe wrapper around AnyTensor. This is the recommended type for most use cases in Swift. It ensures the element type (e.g., `Float`, `Int`) is known at compile time, providing type-safe access to tensor data and catching type mismatches early.
 
-You can convert between them using `tensor.anyTensor` (to get the underlying `AnyTensor`) and `anyTensor.asTensor()` (to convert to a typed `Tensor<T>` if the data types match).
+You can convert between them using `tensor.anyTensor` (to get the underlying
+`AnyTensor`) and `anyTensor.asTensor()` (which returns an optional typed
+`Tensor<T>` that you must unwrap if the data types match).
 
 #### Key Properties:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,86 +1,66 @@
-# Examples
+# ExecuTorch examples
 
+Use this directory to find an end-to-end workflow for a task or hardware
+target. The model entries below are representative starting points, not a
+compatibility list. A model does not need a dedicated example: adapt the
+closest workflow, then validate `torch.export` capture, ExecuTorch runtime and
+operator coverage, and the selected backend.
 
-The series of demos featured in this directory exemplify a broad spectrum of workflows for deploying ML models on edge devices using ExecuTorch. These demos offer practical insights into key processes such as model exporting, quantization, backend delegation, module composition, memory planning, program saving and  loading for inference on ExecuTorch runtime.
+## Start here
 
-ExecuTorch's extensive support spans from simple modules like "Add" to comprehensive models like `MobileNet V3`, `Wav2Letter`, `Llama 2`, and more, showcasing its versatility in enabling the deployment of a wide spectrum of models across various edge AI applications.
+| Goal | Example |
+|---|---|
+| Learn the export-to-runtime flow | [Portable runtime](portable/) |
+| Export your own PyTorch model | [Export guide](../docs/source/using-executorch-export.md) |
+| Export a Hugging Face model | [Transformers exporter](https://huggingface.co/docs/transformers/en/exporters) *(experimental)* or [Optimum ExecuTorch](../docs/source/llm/export-llm-optimum.md) |
+| Understand an LLM runner end to end | [Minimal LLM](llm_manual/) |
+| Profile and debug a program | [Developer tools](devtools/) |
+| Reduce runtime size | [Selective build](selective_build/) |
+| Find a nearby model pattern | [Model implementations](models/) |
 
+## Find an example by task
 
-## Directory structure
-```
-examples
-├── llm_manual                        # A storage place for the files that [LLM Maunal](https://pytorch.org/executorch/main/llm/getting-started) needs
-├── models                            # Contains a set of popular and representative PyTorch models
-├── portable                          # Contains end-to-end demos for ExecuTorch in portable mode
-├── selective_build                   # Contains demos of selective build for optimizing the binary size of the ExecuTorch runtime
-├── devtools                          # Contains demos of BundledProgram and ETDump
-├── demo-apps                         # Contains demo apps for Android and iOS
-├── xnnpack                           # Contains end-to-end ExecuTorch demos with first-party optimization using XNNPACK
-├── apple
-|   └── coreml                        # Contains demos of Apple's Core ML backend
-├── arm                               # Contains demos of the Arm TOSA and Ethos-U NPU flows
-├── qualcomm                          # Contains demos of Qualcomm QNN backend
-�├── samsung                          # Contains demos of Samsung Exynos backend
-├── cadence                           # Contains demos of exporting and running a simple model on Xtensa DSPs
-├── third-party                       # Third-party libraries required for working on the demos
-└── README.md                         # This file
-```
+These are representative entry points, not an exhaustive compatibility list.
+“Released” means the example appeared in a stable ExecuTorch release; it does
+not imply that every backend or configuration is supported.
 
+| Task | Representative examples | Availability |
+|---|---|---|
+| Text generation | [Llama](models/llama/), [Qwen3.5](models/qwen3_5/), [Qwen3.5 MoE](models/qwen3_5_moe/), [Gemma 4 31B](models/gemma4_31b/) | Released; consult each backend matrix |
+| Multimodal generation | [Gemma 4](models/gemma4/), [Voxtral](models/voxtral/) | Released |
+| Streaming speech recognition | [Voxtral Realtime](models/voxtral_realtime/), [Parakeet](models/parakeet/) | Released |
+| Speaker and speech detection | [Sortformer](models/sortformer/), [Silero VAD](models/silero_vad/) | Released |
+| Text-to-speech | [Voxtral TTS](models/voxtral_tts/), [Supertonic](models/supertonic/) | Voxtral TTS released; Supertonic is on main/nightly |
+| Computer vision | [DINOv2](models/dinov2/), [EfficientSAM](models/efficient_sam/), [YOLO26](models/yolo26/) | Model-specific |
+| On-device adaptation | [PTE fine-tuning](llm_pte_finetuning/) | Experimental workflow |
+| Local OpenAI-compatible serving | [LLM server](llm_server/) | Experimental workflow |
 
-## Using the examples
+## Find an example by platform or backend
 
-A user's journey may commence by exploring the demos located in the [`portable/`](portable) directory. Here, you will gain insights into the fundamental end-to-end workflow to generate a binary file from a ML model in [portable mode](../docs/source/concepts.md##portable-mode-lean-mode) and run it on the ExecuTorch runtime.
+| Target | Examples | Maturity notes |
+|---|---|---|
+| Portable CPU | [Portable](portable/), [XNNPACK](xnnpack/) | General-purpose starting points |
+| Android GPU and NPU | [Vulkan](vulkan/), [Qualcomm](qualcomm/), [MediaTek](mediatek/), [Samsung](samsung/) | Hardware and SDK requirements vary |
+| Apple devices | [Core ML](apple/coreml/), [MLX LLM](../backends/mlx/examples/llm/) | MLX is experimental |
+| Desktop acceleration | [CUDA](cuda/), [Vulkan](vulkan/), [OpenVINO](openvino/) | CUDA and Vulkan are experimental; OpenVINO setup is Linux-only |
+| Browser and WebAssembly | [WebAssembly](wasm/), [WebGPU guide](../docs/source/backends/webgpu/webgpu-overview.md) | WebGPU is experimental |
+| Arm microcontrollers | [Arm](arm/), [Arduino](arduino/), [Raspberry Pi Pico 2](raspberry_pi/pico2/), [Zephyr/Alif](../docs/source/zephyr_alif_tutorial.md) | Cortex-M backend is beta |
+| Embedded and edge SoCs | [NXP](nxp/), [Cadence](cadence/), [Espressif](espressif/), [RISC-V](riscv/) | Backend-specific toolchains required |
 
-## Demos Apps
+For complete mobile applications, see
+[executorch-examples](https://github.com/meta-pytorch/executorch-examples/tree/main)
+and the local [demo apps](demo-apps/).
 
-Explore mobile apps with ExecuTorch models integrated and deployable on [Android](https://github.com/meta-pytorch/executorch-examples/tree/main/llm/android) and [iOS](https://github.com/meta-pytorch/executorch-examples/tree/main/llm/apple). This provides end-to-end instructions on how to export Llama models, load on device, build the app, and run it on device.
+## Before running an example
 
-For specific details related to models and backend, you can explore the various subsections.
+- Follow the example's own README; dependencies, model assets, quantization,
+  and build steps differ by target.
+- Start with `pip install executorch` for supported host platforms. Use the
+  [build-from-source guide](../docs/source/using-executorch-building-from-source.md)
+  when an example requires a custom backend or build option.
+- Treat downloaded model weights and generated `.pte`/`.ptd` files as trusted
+  inputs. Third-party model licenses and terms still apply.
 
-### Llama Models
-
-[This page](models/llama/README.md) demonstrates how to run Llama 3.2 (1B, 3B), Llama 3.1 (8B), Llama 3 (8B), and Llama 2 7B models on mobile via ExecuTorch. We use XNNPACK, QNNPACK, and MediaTek to accelerate the performance and 4-bit groupwise PTQ quantization to fit the model on Android and iOS mobile phones.
-
-### Llava1.5 7B
-
-[This page](models/llava/README.md) demonstrates how to run [Llava 1.5 7B](https://github.com/haotian-liu/LLaVA) model on mobile via ExecuTorch. We use XNNPACK to accelerate the performance and 4-bit groupwise PTQ quantization to fit the model on Android and iOS mobile phones.
-
-### Selective Build
-
-To understand how to deploy the ExecuTorch runtime with optimization for binary size, explore the demos available in the [`selective_build`](selective_build) directory. These demos are specifically designed to illustrate the [Selective Build](../docs/source/kernel-library-selective-build.md), offering insights into reducing the binary size while maintaining efficiency.
-
-### Developer Tools
-
-You will find demos of [ExecuTorch Developer Tools](devtools) in the [`devtools`](devtools) directory. The examples focuses on exporting and executing BundledProgram for ExecuTorch model verification and ETDump for collecting profiling and debug data.
-
-### XNNPACK delegation
-
-The demos in the [`xnnpack/`](xnnpack) directory provide valuable insights into the process of lowering and executing an ExecuTorch model with built-in performance enhancements. These demos specifically showcase the workflow involving [XNNPACK backend](https://github.com/pytorch/executorch/tree/main/backends/xnnpack) delegation and quantization.
-
-### Apple Backend
-
-You will find demos of [ExecuTorch Core ML Backend](apple/coreml/) in the [`apple/coreml`](apple/coreml) directory.
-
-### ARM Cortex-M55 + Ethos-U55 Backend
-
-The [`arm`](arm) directory contains scripts to help you run a PyTorch model on a ARM Corstone-300 platform via ExecuTorch.
-
-### QNN Backend
-
-You will find demos of [ExecuTorch QNN Backend](qualcomm) in the [`qualcomm`](qualcomm) directory.
-
-###  Exynos Backend
-
-You will find demos of [ExecuTorch Exynos Backend](samsung) in the [`samsung`](samsung) directory.
-
-### Cadence HiFi4 DSP
-
-The [`Cadence`](cadence) directory hosts a demo that showcases the process of exporting and executing a model on Xtensa Hifi4 DSP. You can utilize [this tutorial](../docs/source/backends-cadence.md) to guide you in configuring the demo and running it.
-
-## Dependencies
-
-Various models and workflows listed in this directory have dependencies on some other packages. You need to follow the setup guide in [Setting up ExecuTorch from GitHub](https://pytorch.org/executorch/main/getting-started-setup) to have appropriate packages installed.
-
-# Disclaimer
+## Disclaimer
 
 The ExecuTorch Repository Content is provided without any guarantees about performance or compatibility. In particular, ExecuTorch makes available model architectures written in Python for PyTorch that may not perform in the same manner or meet the same standards as the original versions of those models. When using the ExecuTorch Repository Content, including any model architectures, you are solely responsible for determining the appropriateness of using or redistributing the ExecuTorch Repository Content and assume any risks associated with your use of the ExecuTorch Repository Content or any models, outputs, or results, both alone and in combination with any other technologies. Additionally, you may have other legal obligations that govern your use of other content, such as the terms of service for third-party models, weights, data, or other technologies, and you are solely responsible for complying with all such obligations.

--- a/examples/models/lfm2/README.md
+++ b/examples/models/lfm2/README.md
@@ -85,11 +85,17 @@ easiest local path is:
 ```
 conda activate et-mlx
 python install_executorch.py
-xcrun -sdk macosx --find metal
+xcrun -sdk macosx metal --version
 ```
 
-The `metal` command must resolve to an Xcode path, not fail under standalone
-Command Line Tools.
+The command must print Metal compiler version information. If it fails, select
+the full Xcode installation and download the separately installed Metal
+Toolchain component:
+
+```bash
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+xcodebuild -downloadComponent MetalToolchain
+```
 
 With ExecuTorch pybindings:
 ```

--- a/examples/models/qwen3/README.md
+++ b/examples/models/qwen3/README.md
@@ -1,5 +1,5 @@
 ## Summary
-Qwen 3 is the latest iteration of the Qwen series of large language models (LLMs) developed by Alibaba. Edge-sized Qwen3 model variations (0.6B, 1.7B, and 4B) are currently supported .
+Qwen 3 is a family of large language models (LLMs) developed by Alibaba. Edge-sized Qwen 3 variants (0.6B, 1.7B, and 4B) are supported by this example.
 
 ## Instructions
 
@@ -8,7 +8,7 @@ Qwen 3 uses the same example code as our optimized Llama model, while the checkp
 All commands for exporting and running Llama on various backends should also be applicable to Qwen 3, by swapping the following args:
 ```
 base.model_class=[qwen3_0_6b,qwen3_1_7b,qwen3_4b]
-base.params=[examples/models/qwen3/config/0_6b_config.json,examples/models/qwen3/config/1_7b_config.json,examples/models/config/qwen3/4b_config.json]
+base.params=[examples/models/qwen3/config/0_6b_config.json,examples/models/qwen3/config/1_7b_config.json,examples/models/qwen3/config/4b_config.json]
 ```
 
 ### Example export

--- a/examples/models/yolo26/README.md
+++ b/examples/models/yolo26/README.md
@@ -21,7 +21,7 @@ To install ExecuTorch, follow this [guide](https://pytorch.org/executorch/stable
 python -m pip install --pre openvino==2026.1.0.dev20260131 --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
 ```
 
-- [XNNPACK backend installation guilde](https://pytorch.org/executorch/stable/tutorial-xnnpack-delegate-lowering.html#running-the-xnnpack-model-with-cmake)
+- [XNNPACK backend installation guide](https://pytorch.org/executorch/stable/tutorial-xnnpack-delegate-lowering.html#running-the-xnnpack-model-with-cmake)
 
 ### Step 3: Install the demo requirements
 
@@ -37,19 +37,32 @@ python -m pip install --upgrade-strategy only-if-needed --extra-index-url https:
 OpenVINO:
 
 ```bash
-python export_and_validate.py --model_name yolo26s --input_dims=[1920,1080]  --backend openvino --device CPU
+python export_and_validate.py \
+  --model_name yolo26s \
+  --input_dims='[1920,1080]' \
+  --backend openvino \
+  --device CPU
 ```
 
 OpenVINO quantized model:
 
 ```bash
-python export_and_validate.py --model_name yolo26s --input_dims=[1920,1080]  --backend openvino --quantize --video_path /path/to/calibration/video --device CPU
+python export_and_validate.py \
+  --model_name yolo26s \
+  --input_dims='[1920,1080]' \
+  --backend openvino \
+  --quantize \
+  --video_path /path/to/calibration/video \
+  --device CPU
 ```
 
 XNNPACK:
 
 ```bash
-python export_and_validate.py --model_name yolo26s --input_dims=[1920,1080] --backend xnnpack
+python export_and_validate.py \
+  --model_name yolo26s \
+  --input_dims='[1920,1080]' \
+  --backend xnnpack
 ```
 
 Exported model could be validated using the `--validate` key:

--- a/examples/vulkan/README.md
+++ b/examples/vulkan/README.md
@@ -81,4 +81,6 @@ INFO:root:✓ Model test PASSED - outputs match reference within tolerance
 
 ### Quantization support
 
-Support for quantization is under active development and will be added soon!
+The Vulkan backend supports 4-bit and 8-bit quantized linear layers. See the
+[Vulkan quantization guide](../../docs/source/backends/vulkan/vulkan-quantization.md)
+for supported schemes and export examples.

--- a/extension/llm/runner/README.md
+++ b/extension/llm/runner/README.md
@@ -2,6 +2,10 @@
 
 This directory contains the LLM Runner framework for ExecuTorch, providing high-level C++ APIs for running Large Language Models with both text-only and multimodal capabilities.
 
+> [!WARNING]
+> The C++ and Python LLM runner APIs are experimental and may change or be
+> removed without notice.
+
 ## Overview
 
 The LLM Runner framework provides two main runner classes:
@@ -216,7 +220,7 @@ runner = MultimodalRunner(
 inputs = []
 inputs.append(make_text_input("What do you see in this image?"))
 
-# Add image from torch tensor (supports both CHW and HWC formats)
+# Add an image from a channels-first CHW tensor
 image_tensor = torch.randint(0, 255, (3, 224, 224), dtype=torch.uint8)  # CHW format
 inputs.append(make_image_input(image_tensor))
 
@@ -261,9 +265,9 @@ token_ids = [1, 15043, 445, 2420]  # Example token IDs
 token_input = make_token_input(token_ids)
 
 # 3. Image input from torch tensor
-# Supports multiple formats: (H,W,C), (C,H,W), (1,H,W,C), (1,C,H,W)
-image_hwc = torch.randint(0, 255, (224, 224, 3), dtype=torch.uint8)  # HWC
-image_input = make_image_input(image_hwc)
+# Supports channels-first (C,H,W), or (1,C,H,W) with batch size 1
+image_chw = torch.randint(0, 255, (3, 224, 224), dtype=torch.uint8)
+image_input = make_image_input(image_chw)
 
 # Float tensors also supported for normalized images
 image_float = torch.rand(3, 224, 224, dtype=torch.float32)  # CHW, normalized
@@ -364,6 +368,10 @@ chat.reset_conversation()
 ### Python API Classes
 
 #### GenerationConfig
+
+The Python binding currently exposes the fields shown below. The C++-only
+constrained-decoding fields are documented in the later C++ API section.
+
 ```python
 from executorch.extension.llm.runner import GenerationConfig
 
@@ -374,10 +382,11 @@ config = GenerationConfig()
 config = GenerationConfig(
     max_new_tokens=100,    # Maximum tokens to generate (-1 = auto)
     temperature=0.8,       # Sampling temperature (0.0 = deterministic)
-    echo=True,            # Echo input prompt in output
-    seq_len=2048,         # Maximum sequence length (-1 = auto)
-    num_bos=0,            # Number of BOS tokens
-    num_eos=0             # Number of EOS tokens
+    echo=True,             # Echo input prompt in output
+    warming=False,         # Whether this is a warmup run
+    seq_len=2048,          # Maximum sequence length (-1 = auto)
+    num_bos=0,             # Number of BOS tokens
+    num_eos=0,             # Number of EOS tokens
 )
 
 # Modify after creation
@@ -388,8 +397,8 @@ config.max_new_tokens = 50
 #### MultimodalInput Types
 ```python
 from executorch.extension.llm.runner import (
-    MultimodalInput, make_text_input, make_token_input, 
-    make_image_input, make_audio_input
+    MultimodalInput, make_text_input, make_token_input,
+    make_image_input, make_audio_input, make_raw_audio_input
 )
 
 # Text input
@@ -404,11 +413,19 @@ print(token_input.get_tokens())  # [1, 2, 3, 4]
 
 # Image input from torch tensor
 import torch
-image_tensor = torch.randint(0, 255, (224, 224, 3), dtype=torch.uint8)
+image_tensor = torch.randint(0, 255, (3, 224, 224), dtype=torch.uint8)
 image_input = make_image_input(image_tensor)
 print(image_input.is_image())  # True
 image = image_input.get_image()
 print(f"Image: {image.width}x{image.height}x{image.channels}")
+
+# Preprocessed and raw audio inputs
+audio_input = make_audio_input(torch.rand(1, 80, 100, dtype=torch.float32))
+raw_audio_input = make_raw_audio_input(
+    torch.randint(0, 255, (1, 1, 16000), dtype=torch.uint8)
+)
+print(audio_input.is_audio())          # True
+print(raw_audio_input.is_raw_audio())  # True
 
 # Check input types safely
 if text_input.is_text():
@@ -461,7 +478,7 @@ try:
     runner = MultimodalRunner("model.pte", "tokenizer.bin")
     
     # Invalid image tensor will raise RuntimeError
-    invalid_image = torch.rand(2, 224, 224, 3)  # Wrong number of dimensions
+    invalid_image = torch.rand(1, 2, 224, 224)  # Wrong channel count
     inputs = [make_image_input(invalid_image)]
     
     config = GenerationConfig(max_new_tokens=50)
@@ -642,13 +659,16 @@ int64_t num_tokens = text_token_generator->generate(
 **Key Parameters**:
 ```cpp
 struct GenerationConfig {
-    int32_t max_new_tokens = -1;    // Max tokens to generate (-1 = use available)
-    int32_t seq_len = 1024;         // Total sequence length
-    float temperature = 0.8f;       // Sampling temperature
-    bool echo = true;               // Echo input prompt
-    int8_t num_bos = 1;            // Number of BOS tokens
-    int8_t num_eos = 1;            // Number of EOS tokens
-    bool warming = false;           // Warmup run flag
+    bool echo = true;
+    std::string grammar;
+    std::string grammar_type;
+    bool ignore_eos = false;
+    int32_t max_new_tokens = -1;
+    bool warming = false;
+    int32_t seq_len = -1;
+    float temperature = 0.8f;
+    int32_t num_bos = 0;
+    int32_t num_eos = 0;
 };
 ```
 
@@ -656,7 +676,7 @@ struct GenerationConfig {
 **Purpose**: Type-safe wrapper for mixed input types
 
 **Key Features**:
-- `std::variant<std::string, Image>` internally
+- `std::variant<std::string, std::vector<uint64_t>, Image, Audio, RawAudio>` internally
 - Type-safe access methods
 - Exception-based and safe access patterns
 - Move semantics for efficiency
@@ -665,19 +685,33 @@ struct GenerationConfig {
 ```cpp
 // Type checking
 bool is_text() const;
+bool is_tokens() const;
 bool is_image() const;
+bool is_audio() const;
+bool is_raw_audio() const;
+MultimodalInput::Type get_type() const;
+const char* type_name() const;
 
 // Direct access (throws on type mismatch)
 const std::string& get_text() const;
+const std::vector<uint64_t>& get_tokens() const;
 const Image& get_image() const;
+const Audio& get_audio() const;
+const RawAudio& get_raw_audio() const;
 
 // Safe access (returns nullptr on type mismatch)
 const std::string* try_get_text() const;
+const std::vector<uint64_t>* try_get_tokens() const;
 const Image* try_get_image() const;
+const Audio* try_get_audio() const;
+const RawAudio* try_get_raw_audio() const;
 
 // Factory functions
 MultimodalInput make_text_input(const std::string& text);
+MultimodalInput make_token_input(const std::vector<uint64_t>& tokens);
 MultimodalInput make_image_input(Image&& image);
+MultimodalInput make_audio_input(Audio&& audio);
+MultimodalInput make_raw_audio_input(RawAudio&& raw_audio);
 ```
 
 ## Helper Functions
@@ -729,13 +763,18 @@ std::unordered_map<std::string, int64_t> get_llm_metadata(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `max_new_tokens` | `int32_t` | `-1` | Maximum new tokens to generate (-1 = use available context) |
-| `seq_len` | `int32_t` | `1024` | Total sequence length including prompt |
-| `temperature` | `float` | `0.8f` | Sampling temperature in [0.0, 1.0] (0.0 = deterministic) |
 | `echo` | `bool` | `true` | Whether to echo the input prompt |
-| `num_bos` | `int8_t` | `1` | Number of beginning-of-sequence tokens |
-| `num_eos` | `int8_t` | `1` | Number of end-of-sequence tokens |
+| `grammar` | `std::string` | empty | Grammar for constrained decoding |
+| `grammar_type` | `std::string` | empty | Grammar format: `json_schema`, `regex`, `lark`, or `gbnf` |
+| `ignore_eos` | `bool` | `false` | Continue generation after an EOS token |
+| `max_new_tokens` | `int32_t` | `-1` | Maximum new tokens to generate (-1 = use available context) |
 | `warming` | `bool` | `false` | Whether this is a warmup run |
+| `seq_len` | `int32_t` | `-1` | Maximum total sequence length (-1 = use model metadata) |
+| `temperature` | `float` | `0.8f` | Sampling temperature |
+| `num_bos` | `int32_t` | `0` | Number of beginning-of-sequence tokens |
+| `num_eos` | `int32_t` | `0` | Number of end-of-sequence tokens |
+
+Support for constrained decoding is runner-dependent.
 
 ### Performance Tuning
 

--- a/extension/wasm/README.md
+++ b/extension/wasm/README.md
@@ -2,6 +2,10 @@
 
 This directory contains the source code for the ExecuTorch Wasm extension. The extension is a C++ library that provides a JavaScript API for ExecuTorch models. The extension is compiled to WebAssembly and can be used in JavaScript applications.
 
+> [!WARNING]
+> The JavaScript/WebAssembly API is experimental and may change or be removed
+> without notice.
+
 ## Installing Emscripten
 
 [Emscripten](https://emscripten.org/index.html) is necessary to compile ExecuTorch for Wasm. You can install Emscripten with these commands:
@@ -81,14 +85,14 @@ The output `my_project.js` should contain both the emitted JS code and the conte
 - `static load(data)`: Load a model from a file or a buffer.
 - `getMethods()`: Returns the list of methods in the model.
 - `loadMethod(methodName)`: Load a method from the model.
-- `getMethodMetadata(methodName)`: Get the metadata of a method.
+- `getMethodMeta(methodName)`: Get the metadata of a method.
 - `etdump()`: If enabled, flushes the etdump buffer and return the results.
 - `execute(methodName, inputs)`: Execute a method with the given inputs.
 - `forward(inputs)`: Execute the forward method with the given inputs.
 - `delete()`: Delete the model from memory.
 
 ### Tensor
-- `static zeroes(shape, dtype=ScalarType.Float)`: Create a tensor of zeros with the given shape and dtype.
+- `static zeros(shape, dtype=ScalarType.Float)`: Create a tensor of zeros with the given shape and dtype.
 - `static ones(shape, dtype=ScalarType.Float)`: Create a tensor of ones with the given shape and dtype.
 - `static full(shape, value, dtype=ScalarType.Float)`: Create a tensor of the given value with the given shape and dtype
 - `static fromArray(shape, array, dtype=ScalarType.Float, dimOrder=[], strides=[])`: Create a tensor from a JavaScript array.
@@ -115,7 +119,7 @@ The output `my_project.js` should contain both the emitted JS code and the conte
 - `dimOrder`: The dimension order of the tensor.
 - `scalarType`: The scalar type of the tensor.
 - `isMemoryPlanned`: Whether the tensor is memory planned.
-- `nBytes`: The number of bytes in the tensor.
+- `nbytes`: The number of bytes in the tensor.
 - `name`: The name of the tensor.
 - These are value types and do not need to be manually deleted.
 
@@ -132,4 +136,4 @@ The output `my_project.js` should contain both the emitted JS code and the conte
 - `value`: The int constant value of the enum.
 - `name`: The `Tag` as a string.
 
-Emscripten's JavaScript API is also avaiable, which you can find more information about it in their [API Reference](https://emscripten.org/docs/api_reference/index.html).
+Emscripten's JavaScript API is also available; see its [API Reference](https://emscripten.org/docs/api_reference/index.html) for more information.


### PR DESCRIPTION
> Updated to `be40b66f45` after merging upstream `main` at `f5e136973d`. The review fixes are pushed, the PR diff remains documentation-only, and fresh CI is in progress.

### Summary

Refreshes the README, documentation homepage, examples index, and success
stories around the current ExecuTorch feature set. The new structure leads with
current workloads, a runnable export-to-runtime path, language APIs, hardware
backends, and evidence-backed production use.

The model section is intentionally representative rather than exhaustive. It
shows credible text, multimodal, speech, vision, and embedded workflows, then
explains how developers can adapt those patterns to another PyTorch model and
validate export, operator, backend, numerical, memory, and performance coverage
for their own target.

The getting-started path now continues through serialization, Python runtime
loading, execution, and an eager-output assertion. Export guidance distinguishes
standard PyTorch export, the experimental Transformers ExecuTorch exporter,
Optimum ExecuTorch, and native `export_llm` workflows. Runtime documentation maps
general `.pte` execution and high-level generation APIs across C++, Python,
Android, Apple platforms, and WebAssembly.

Production claims cite primary sources and are separated from published case
studies, integrations, technical showcases, and community prototypes.

Additional ecosystem stories cover NVIDIA FLARE, Unsloth, and Digica. NoemaAI
appears near the bottom as a community app explicitly marked as not yet vetted
by the ExecuTorch team, not as a production deployment.

Follow-up review corrections align both Android build guides with the helper's
current `ANDROID_SDK` behavior, make nightly installation commands upgrade
existing packages, fix the installed LLM exporter module path, and distinguish
streaming Voxtral Realtime from offline Parakeet speech recognition.

This PR intentionally contains documentation content only. Runtime, build,
package-manifest, and repository-configuration findings from validation are
tracked in follow-up issues below. The standalone `website/` is unchanged from
`origin/main`; its visual redesign will be handled separately.

This includes release-facing documentation: `README-wheel.md` is the published
PyPI description, removes the old beta notice, and advertises Windows x86-64
wheels. API, backend, and model availability/maturity labels and the Vulkan
quantization description are also part of this review. These are documentation
claims to review against the lifecycle policy, source, and published artifacts;
no packaging code or API lifecycle implementation is changed.

For review, start with `README.md`, then `docs/source/index.md`,
`docs/source/pathway-quickstart.md`, and `docs/source/success-stories.md`. The
platform details are in the Android, iOS, build-from-source, Vulkan, MLX, LLM,
and runtime API pages.

Authored with Codex (OpenAI).

### Review follow-up

`10c02b87b9` corrects the Android release/snapshot paths and legacy download
links, documents the separate QNN runtime dependency, and restores the
`viable/strict` source-build pin used by the release script. It fixes all seven
checkout-only LLM exporter commands and corrects metadata names and Hydra JSON
quoting. It separates YAML from shell commands, and documents Python custom/quantized operator
registration and the currently ignored grammar fields. It also corrects artifact
trust guidance, Apple lifecycle wording, the Gradle variable, and the MLX
configuration explanation, and restores the LoRA/audio-generation showcase links.

`d6700c5538` keeps the language API table on the API page, fixes the separate
text/multimodal runner links, and points README documentation links at rendered
pages. The README retains its backend table, restores the desktop guide link,
and scopes CUDA wheel guidance to Linux. Read the instruction-fix commit first,
then this navigation cleanup. Wider cross-page consolidation remains separate.
Both commits modify Markdown only; the full PR still changes 32 Markdown files.

### Validation

#### After upstream synchronization

Merged current `main` (`f5e136973d`) in `be40b66f45`, incorporating the existing
MLX batched-runner and LoRA shared-cache cleanup fixes from #22627 and #22632.
All 13 review-fix files were preserved unchanged; the C++ guide also retains
main's clarification that `kernels_torchao` supports Linux and macOS on aarch64.
GitHub and local comparison against the new base both show 32 Markdown files,
with no website, runtime implementation, build-system, or configuration changes
in the PR diff.

The configured pre-commit hook passed before the merge. After the merge,
lintrunner, URL/xref/file-size lints against `origin/main`, diff checks, and
rendered-HTML/anchor checks passed. URL lint checked 166 links without warnings.
`make -C docs html-noplot` completed with exit 0, but logged 131 warnings and
one CRITICAL missing-include diagnostic in `llm/llama-demo-ios.md`. The same
missing iOS demo README include exists on `main` and in the pre-merge log; it
is not changed by this PR. Tutorial execution was disabled, and this is not a
clean Sphinx build. The earlier end-to-end checks below were not rerun as part
of this synchronization, and local validation does not establish full CI success.

#### Review follow-up validation

The configured pre-commit hook ran successfully for both local commits without
bypassing it. Lintrunner, URL/xref/file-size lints over the full PR range, and diff
checks passed at `d6700c5538`. No runtime, workflow, or build-system changes are
included in these commits.

Before committing, the exact README and quickstart Add/XNNPACK blocks ran outside
the checkout with the published macOS arm64 `executorch-1.6.0.dev20260915` wheel;
both exported, serialized, loaded, executed, compared against eager, and printed
`Output: tensor([2.])`. Six tiny random-weight Llama exports passed, including
KV-cache/SDPA, quantization, XNNPACK, and ETRecord; basic Runtime execution and
optimized/delegated TextLLMRunner generation also passed. The six YAML snippets,
corrected Hydra metadata command, and operator-registration snippet were checked;
nine runner Python blocks compiled, and the generated ETRecord parsed.

The initial optimized-runner missing-operator errors were resolved by explicitly
registering the custom and quantized kernels. The wheel ships them; this is now
documented, not reported as a missing-artifact runtime defect. The test venv
reused existing dependencies via `--system-site-packages`, so this is not a
pristine dependency-installation test. Tiny random models and a synthetic
tokenizer validate the path, not pretrained-model quality or performance.

Seven Android AAR/checksum pairs downloaded and verified: 1.4.1 XNNPACK/QNN/Vulkan,
the 2026-09-14 XNNPACK snapshot, and the three restored legacy releases. Both
documented download blocks ran verbatim; artifact inspection confirmed the
separate Qualcomm runtime requirement. No new Android build, Gradle sync, or
physical-device execution was performed in this follow-up.

Rendered README destinations and actual section anchors were checked, including
19 live documentation URLs and all 45 README main-docs URLs against local HTML.
`make -C docs html-noplot` succeeded with 138 reported diagnostics on the first rebuild and
126 on the final incremental build; tutorial execution was disabled. This is
not a warning-free build or a claim that every documented snippet ran end to end.

#### Earlier validation

For the success-stories follow-up `c0c34676f7`, the configured pre-commit hook,
URL/xref/file-size lints, and diff checks passed. All six new source links return
HTTP 200. `make -C docs html-noplot` passed with 126 reported diagnostics elsewhere in the
docs and none for `success-stories.md`; tutorial execution was disabled. These
checks validate the documentation and sources, not the external vendor
workflows.

Checks rerun for review follow-up `b3f1cfb1d2`:

```text
.githooks/pre-commit
lintrunner -m 01cc07564183
scripts/lint_urls.sh 01cc07564183 HEAD
scripts/lint_xrefs.sh 01cc07564183 HEAD
bash scripts/lint_file_size.sh 01cc07564183 HEAD
make -C docs html-noplot
git diff --check 01cc07564183...HEAD
```

All passed. The configured pre-commit hook also ran during `git commit`,
without bypassing it. Sphinx completed with 224 reported diagnostics; tutorial execution
was disabled for this documentation-only follow-up. A full
`make -C docs clean html` was run during the earlier validation.

Executed end to end on Apple silicon/macOS while developing the documentation:

- Stable 1.4.1 and nightly 1.5.dev wheel installs; the README Add/XNNPACK flow;
  MobileNet V2 export and runtime comparison; dynamic-shape export; and separate
  `.pte`/`.ptd` loading.
- The nightly C++ wheel walkthrough through export, CMake configuration,
  compilation, linking, loading, and execution, including the XNNPACK component.
- Core ML export and execution with eager comparison. MLX MobileNet export
  produced one delegate, and 82 MLX export/unit tests passed. MLX GPU execution
  was unavailable because this host blocks the Metal JIT cache.
- Portable, float XNNPACK, and quantized XNNPACK MobileNet; Wav2Letter, MLPerf
  Tiny DS-CNN, Silero VAD, Whisper preprocessing, and scaled YOLO26 export and
  runtime comparisons.
- Native tiny-Llama export plus Python and C++ generation; 13 Python LLM binding
  tests and 117 runnable C++ runner tests. Transformers exporters were exercised
  with tiny BERT and Llama models through `.pte` execution.
- Fresh `optimum-executorch==1.1.0` basic and optimized SmolLM2-135M exports,
  reload, and generation; plus tiny XNNPACK and portable Llama paths.
- Published stable and nightly Apple xcframeworks through Swift and Objective-C
  execution, 130 Swift tests, simulator builds for both channels, a nightly iOS
  device build, and compile validation of `TextRunner`.
- The documented Android 1.4.1 XNNPACK AAR download and SHA-256 verification;
  Maven/release artifact contents, ABIs, and Java/Kotlin API symbols; ModuleAdd
  export and host execution.
- Vulkan MobileNet, dynamic-shape, bundled-program, FP16 Inception V3, 4-bit,
  and 8-bit exports, plus 119 non-runtime Vulkan tests.

Large Llama, Qwen, Gemma, Parakeet, and Voxtral weights were not downloaded in
full; their CLI/configuration surfaces were checked and smaller models exercised
the same exporters and runners. CUDA, QNN, MediaTek, Samsung, Arm accelerator,
and physical-device execution require hardware or toolchains unavailable on this
host. Repository CI remains the cross-platform gate.

### CI status

Fresh checks are attached to the published head `be40b66f45`, not inherited from
the previous head. [Lint](https://github.com/pytorch/executorch/actions/runs/35006697462),
[documentation build](https://github.com/pytorch/executorch/actions/runs/35006697815),
and [MLX](https://github.com/pytorch/executorch/actions/runs/35006698009), together
with the [pull tests](https://github.com/pytorch/executorch/actions/runs/35006698583)
including LoRA and QNN, are running or queued. Results were pending at publication;
this is not a claim that CI is fully green.

The upstream fixes for the three MLX offgraph failures (#22627) and two LoRA
cleanup failures (#22632) observed at `dd042e5537` are now incorporated. The old
DFlash/QNN failures occurred during dependency downloads. Fresh runs of all
seven previously failing jobs have been scheduled and must complete before
those failures can be considered cleared. See the [current PR checks](https://github.com/pytorch/executorch/pull/22620/checks).

### Follow-up implementation issues

- #22681: correct the deprecated llama `seq_len` CLI help
- #22682: honor standard Android SDK environment variables
- #22683: probe the usable Metal compiler in Apple CMake presets
- #22684: avoid unnecessary portable-kernel linkage from Core ML
- #22685: align the LLM image tensor layout contract with runtime behavior
- #22686: declare SwiftPM system-framework dependencies
- #22687: add the structured deployment-story issue form

