### PR TITLE
Let Buck tests inherit the platform C++ standard

### DIFF
--- a/.ci/scripts/tests/test_is_aten_target.py
+++ b/.ci/scripts/tests/test_is_aten_target.py
@@ -27,20 +27,33 @@ MACROS = (
     REPO_ROOT / "shim_et" / "xplat" / "executorch" / "build" / "runtime_wrapper.bzl"
 )
 
-# What the open source dependency map resolves these names to. Kept here rather than
-# imported so the test states the mapping it depends on.
+
+class _Select:
+    __slots__ = ("values",)
+
+    def __init__(self, values: dict[str, list[str]]) -> None:
+        self.values = values
+
+
+# Representative dependency-map results, including platform-specific values and
+# aliases shared by ATen and non-ATen dependency names.
 RESOLVED = {
-    "c10": ["//third-party:libtorch"],
+    "c10": _Select(
+        {
+            "ovr_config//os:android": ["fbsource//xplat/caffe2/c10:c10"],
+            "DEFAULT": ["fbsource//xplat/caffe2/c10:c10_ovrsource"],
+        }
+    ),
     "libtorch": ["//third-party:libtorch"],
     "libtorch_python": ["//third-party:libtorch_python"],
     "torch-core-cpp": ["//third-party:libtorch"],
-    "gtest_aten": ["//third-party:gtest_aten"],
-    "gmock_aten": ["//third-party:gmock_aten"],
+    "gtest_aten": ["fbsource//third-party/googletest:gtest"],
+    "gmock_aten": ["fbsource//third-party/googletest:gmock"],
 }
 FALLTHROUGH = "@fallthrough@"
 
 
-def _load_is_aten_target():
+def _load_macro_function(name: str):
     """Execute the real macro text, with the little of Starlark it uses shimmed."""
     text = MACROS.read_text()
     start = text.index("def _has_pytorch_dep")
@@ -53,6 +66,8 @@ def _load_is_aten_target():
 
     def _apply(obj, function):
         """Stand-in for selects.apply: run over each list the object holds."""
+        if isinstance(obj, _Select):
+            return _Select({key: function(value) for key, value in obj.values.items()})
         if isinstance(obj, dict):
             return {key: function(value) for key, value in obj.items()}
         return function(obj)
@@ -64,7 +79,11 @@ def _load_is_aten_target():
         "selects": types.SimpleNamespace(apply=_apply),
     }
     exec(compile(text[start:end], str(MACROS), "exec"), namespace)
-    return namespace["_is_aten_target"]
+    return namespace[name]
+
+
+def _load_is_aten_target():
+    return _load_macro_function("_is_aten_target")
 
 
 class TestIsAtenTarget(unittest.TestCase):
@@ -93,6 +112,16 @@ class TestIsAtenTarget(unittest.TestCase):
             )
         )
 
+    def test_resolved_label_returned_inside_a_select(self) -> None:
+        for dep in [
+            "fbsource//xplat/caffe2/c10:c10",
+            "fbsource//xplat/caffe2/c10:c10_ovrsource",
+        ]:
+            with self.subTest(dep=dep):
+                self.assertTrue(
+                    self.is_aten_target({"name": "some_lib", "deps": [dep]})
+                )
+
     def test_short_name_in_external_deps(self) -> None:
         for name in RESOLVED:
             with self.subTest(name=name):
@@ -101,7 +130,6 @@ class TestIsAtenTarget(unittest.TestCase):
                 )
 
     def test_plain_target_is_not_aten(self) -> None:
-        """The embedded builds rely on these staying at the older standard."""
         self.assertFalse(
             self.is_aten_target(
                 {
@@ -110,6 +138,16 @@ class TestIsAtenTarget(unittest.TestCase):
                         "//executorch/runtime/core:core",
                         "//third-party/googletest:gtest_main",
                     ],
+                }
+            )
+        )
+
+    def test_plain_gtest_target_is_not_aten(self) -> None:
+        self.assertFalse(
+            self.is_aten_target(
+                {
+                    "name": "some_test",
+                    "deps": ["fbsource//third-party/googletest:gtest"],
                 }
             )
         )
@@ -145,6 +183,26 @@ class TestIsAtenTarget(unittest.TestCase):
                 }
             )
         )
+
+
+class TestPatchTestCompilerFlags(unittest.TestCase):
+    def test_inherits_platform_standard(self) -> None:
+        patch_test_compiler_flags = _load_macro_function("_patch_test_compiler_flags")
+        for name in ["some_test", "some_aten_test"]:
+            with self.subTest(name=name):
+                kwargs = {
+                    "name": name,
+                    "compiler_flags": ["-DTEST"],
+                    "fbobjc_compiler_flags": ["-DAPPLE_TEST"],
+                }
+
+                result = patch_test_compiler_flags(kwargs)
+
+                self.assertFalse(
+                    any(flag.startswith("-std=") for flag in result["compiler_flags"])
+                )
+                self.assertEqual(["-DAPPLE_TEST"], result["fbobjc_compiler_flags"])
+                self.assertIn("-Wno-error", result["compiler_flags"])
 
 
 if __name__ == "__main__":

--- a/shim_et/xplat/executorch/build/runtime_wrapper.bzl
+++ b/shim_et/xplat/executorch/build/runtime_wrapper.bzl
@@ -207,32 +207,9 @@ def _is_aten_target(kwargs):
             return True
     return False
 
-def _patch_test_compiler_flags(kwargs, aten_mode = False):
+def _patch_test_compiler_flags(kwargs):
     if "compiler_flags" not in kwargs:
         kwargs["compiler_flags"] = []
-
-    # A test that compiles against ATen needs C++20, which PyTorch's headers
-    # require. Other tests stay at C++17 for embedded builds, but Apple plugin
-    # generation also requires C++20.
-    name = kwargs.get("name", "")
-    is_aten_test = (
-        aten_mode or
-        "_aten" in name or
-        "aten_" in name
-    )
-    if is_aten_test:
-        kwargs["compiler_flags"] += [
-            "-std=c++20",
-        ]
-    else:
-        kwargs["compiler_flags"] += [
-            "-std=c++17",
-        ]
-        if env.is_xplat():
-            kwargs["fbobjc_compiler_flags"] = kwargs.get(
-                "fbobjc_compiler_flags",
-                [],
-            ) + ["-std=c++20"]
 
     # Relaxing some constraints for tests
     kwargs["compiler_flags"] += [
@@ -391,12 +368,10 @@ def _cxx_test(*args, **kwargs):
         kwargs["deps"] = []
     kwargs["deps"].append("//executorch/test/utils:utils")
 
-    # Before _patch_kwargs_cxx, which consumes external_deps.
-    aten_mode = _is_aten_target(kwargs)
     _patch_kwargs_cxx(kwargs)
     env.patch_headers(kwargs)
     _patch_build_mode_flags(kwargs)
-    _patch_test_compiler_flags(kwargs, aten_mode)
+    _patch_test_compiler_flags(kwargs)
 
     env.patch_platform_build_mode_flags(kwargs)
     env.cxx_test(*args, **kwargs)


### PR DESCRIPTION
### Summary

Let `cxx_test` targets inherit the C++ language standard selected by their platform toolchain. Forcing C++17 on tests can break builds against Folly headers that require C++20; the wrapper should not override the toolchain's choice. ATen detection and standard selection for other target types remain unchanged.

The macro tests now cover dependencies resolved through selects, shared googletest aliases, and test compiler flag patching without an injected language standard. The port maps the mirrored internal files to their OSS paths and applies Python formatting plus `__slots__` to satisfy the OSS linter.

Authored with AI assistance using Codex.

### Test plan

All 10 macro tests pass. Black, Flake8, and whitespace checks pass:

```bash
python3 .ci/scripts/tests/test_is_aten_target.py -v
black --check .ci/scripts/tests/test_is_aten_target.py
flake8 .ci/scripts/tests/test_is_aten_target.py
git diff --check
```

Also checked that the previous macro injects a standard for ATen tests, and that the updated macro initializes missing flags and preserves an explicitly supplied standard.

The internal Buck integration target from the original diff was not rerun in this OSS worktree. Full lintrunner was unavailable locally.
