### PR TITLE
Stop uploading Voxtral checkpoints and partial exports when CI exports fail

### DIFF
--- a/.ci/scripts/export_model_artifact.sh
+++ b/.ci/scripts/export_model_artifact.sh
@@ -294,6 +294,26 @@ if [ "$MODEL_NAME" = "muse_glimmer" ]; then
   fi
 fi
 
+# Downloads and compiler caches go in scratch dirs outside OUTPUT_DIR because the CI job
+# templates upload OUTPUT_DIR even when the job fails. A failed export also empties
+# OUTPUT_DIR, but only if it started out empty, so a local run with output_dir=. cannot
+# delete the checkout. Scratch goes under RUNNER_TEMP, which the runner wipes between
+# jobs, with a fallback for containers where RUNNER_TEMP is not writable.
+LOCAL_MODEL_DIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/model_XXXXXX" 2>/dev/null || mktemp -d)
+SCRATCH_DIRS=("$LOCAL_MODEL_DIR")
+OUTPUT_DIR_WAS_EMPTY=0
+[ -n "$(ls -A -- "$OUTPUT_DIR" 2>/dev/null)" ] || OUTPUT_DIR_WAS_EMPTY=1
+cleanup() {
+  local rc=$?
+  set +e
+  rm -rf "${SCRATCH_DIRS[@]}"
+  if [ "$rc" -ne 0 ] && [ "$OUTPUT_DIR_WAS_EMPTY" = 1 ] && [ -d "$OUTPUT_DIR" ]; then
+    echo "Export failed with exit code $rc; removing partial output from ${OUTPUT_DIR}"
+    (cd -- "$OUTPUT_DIR" && find . -mindepth 1 -delete)
+  fi
+}
+trap cleanup EXIT
+
 echo "::group::Export $MODEL_NAME"
 
 if [ -n "$EXTRA_PIP" ]; then
@@ -386,8 +406,7 @@ fi
 if [ "$MODEL_NAME" = "voxtral_realtime" ]; then
   pip install safetensors huggingface_hub
 
-  # Download model weights from HuggingFace (requires HF_TOKEN for gated model)
-  LOCAL_MODEL_DIR="${OUTPUT_DIR}/model_weights"
+  # Download model weights outside OUTPUT_DIR to avoid uploading on failure (requires HF_TOKEN for gated model)
   python -c "from huggingface_hub import snapshot_download; snapshot_download('${HF_MODEL}', local_dir='${LOCAL_MODEL_DIR}')"
 
   # Per-component quantization flags
@@ -437,7 +456,6 @@ if [ "$MODEL_NAME" = "voxtral_realtime" ]; then
   fi
   # Copy tokenizer from downloaded model weights
   cp "$LOCAL_MODEL_DIR/tekken.json" "${OUTPUT_DIR}/tekken.json"
-  rm -rf "$LOCAL_MODEL_DIR"
   ls -al "${OUTPUT_DIR}"
   echo "::endgroup::"
   exit 0
@@ -448,12 +466,11 @@ if [ "$MODEL_NAME" = "qwen3_5_moe" ]; then
   pip install safetensors huggingface_hub
   pip install -r examples/models/qwen3_5_moe/requirements.txt
 
-  # Download prequantized model outside OUTPUT_DIR to avoid uploading on failure
-  LOCAL_MODEL_DIR=$(mktemp -d)
   INDUCTOR_CACHE=$(mktemp -d "${RUNNER_TEMP:-/tmp}/inductor_cache_XXXXXX")
   INDUCTOR_TMPDIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/tmpdir_XXXXXX")
-  trap 'rm -rf "$LOCAL_MODEL_DIR" "$INDUCTOR_CACHE" "$INDUCTOR_TMPDIR"' EXIT
+  SCRATCH_DIRS+=("$INDUCTOR_CACHE" "$INDUCTOR_TMPDIR")
 
+  # Download prequantized model outside OUTPUT_DIR to avoid uploading on failure
   python -c "from huggingface_hub import snapshot_download; snapshot_download('${HF_MODEL}', local_dir='${LOCAL_MODEL_DIR}')"
 
   # Sanity check: run inference on the prequantized model
@@ -521,10 +538,9 @@ fi
 if [ "$MODEL_NAME" = "muse_glimmer" ]; then
   pip install safetensors huggingface_hub gguf
 
-  LOCAL_MODEL_DIR=$(mktemp -d)
   INDUCTOR_CACHE=$(mktemp -d "${RUNNER_TEMP:-/tmp}/inductor_cache_XXXXXX")
   INDUCTOR_TMPDIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/tmpdir_XXXXXX")
-  trap 'rm -rf "$LOCAL_MODEL_DIR" "$INDUCTOR_CACHE" "$INDUCTOR_TMPDIR"' EXIT
+  SCRATCH_DIRS+=("$INDUCTOR_CACHE" "$INDUCTOR_TMPDIR")
 
   case "$QUANT_NAME" in
     kquant-17gb)
@@ -588,14 +604,13 @@ fi
 if [ "$MODEL_NAME" = "gemma4_31b" ]; then
   pip install safetensors huggingface_hub gguf
 
+  INDUCTOR_CACHE=$(mktemp -d "${RUNNER_TEMP:-/tmp}/inductor_cache_XXXXXX")
+  INDUCTOR_TMPDIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/tmpdir_XXXXXX")
+  SCRATCH_DIRS+=("$INDUCTOR_CACHE" "$INDUCTOR_TMPDIR")
+
   # Download GGUF + tokenizer outside OUTPUT_DIR to avoid uploading on failure.
   # The unsloth GGUF repo ships the .gguf but no tokenizer.json, so the tokenizer
   # is fetched from the (non-GGUF) unsloth/gemma-4-31B-it repo.
-  LOCAL_MODEL_DIR=$(mktemp -d)
-  INDUCTOR_CACHE=$(mktemp -d "${RUNNER_TEMP:-/tmp}/inductor_cache_XXXXXX")
-  INDUCTOR_TMPDIR=$(mktemp -d "${RUNNER_TEMP:-/tmp}/tmpdir_XXXXXX")
-  trap 'rm -rf "$LOCAL_MODEL_DIR" "$INDUCTOR_CACHE" "$INDUCTOR_TMPDIR"' EXIT
-
   GGUF_FILE="gemma-4-31B-it-Q4_K_M.gguf"
   python -c "from huggingface_hub import hf_hub_download; hf_hub_download('unsloth/gemma-4-31B-it-GGUF', '${GGUF_FILE}', local_dir='${LOCAL_MODEL_DIR}')"
   python -c "from huggingface_hub import hf_hub_download; hf_hub_download('unsloth/gemma-4-31B-it', 'tokenizer.json', local_dir='${LOCAL_MODEL_DIR}')"


### PR DESCRIPTION
### Summary

Internal context: https://docs.google.com/document/d/1CnGfiP5SU0PG0IdJWn9Ca43LS8bGlEMi3l2gjgC7k48/edit

When a job fails, the output dir is uploaded to GHA storage. This causes a significant increase in storage for Voxtral  models: up to 0.7 TB/day. Like [Qwen3.5](https://github.com/pytorch/executorch/blob/9b3f660b4a74afa87726fbbb4480196d02fcb9e9/.ci/scripts/export_model_artifact.sh#L452-L455) and [Muse Glimmer](https://github.com/pytorch/executorch/blob/9b3f660b4a74afa87726fbbb4480196d02fcb9e9/.ci/scripts/export_model_artifact.sh#L524-L527), let's upload the Voxtral models to a temporary directory instead. 

In this PR we generalize the download location and cleanup for the models.

### Test plan
CI