### PR TITLE
[ET-VK][testing] Reduce host tensor retention

### DIFF
--- a/backends/vulkan/test/custom_ops/targets.bzl
+++ b/backends/vulkan/test/custom_ops/targets.bzl
@@ -1,4 +1,4 @@
-load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID")
+load("@fbsource//tools/build_defs:platform_defs.bzl", "ANDROID", "CXX")
 load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 load(
     "@fbsource//xplat/executorch/backends/vulkan:targets.bzl",
@@ -83,6 +83,19 @@ def define_common_targets(is_fbcode = False):
         ],
         visibility = ["PUBLIC"],
         link_whole = True,
+    )
+
+    runtime.cxx_test(
+        name = "utils_test",
+        srcs = [
+            "utils_test.cpp",
+        ],
+        contacts = ["oncall+ai_infra_mobile_platform@xmail.facebook.com"],
+        platforms = [CXX],
+        deps = [
+            ":prototyping_utils",
+            "//third-party/googletest:gtest_main",
+        ],
     )
 
     define_custom_op_test_binary("test_add")

--- a/backends/vulkan/test/custom_ops/utils.cpp
+++ b/backends/vulkan/test/custom_ops/utils.cpp
@@ -172,10 +172,29 @@ void set_debugging(bool enable_debugging) {
 }
 
 // ValueSpec implementation
-void ValueSpec::generate_tensor_data(int seed) {
+void ValueSpec::ensure_unique_data() const {
+  if (data_.use_count() != 1) {
+    data_ = std::make_shared<TensorData>(*data_);
+  }
+}
+
+void ValueSpec::ensure_unique_reference_data() const {
+  if (reference_data_.use_count() != 1) {
+    reference_data_ = std::make_shared<TensorData>(*reference_data_);
+  }
+}
+
+void ValueSpec::generate_tensor_data(int seed) const {
   if (spec_type != SpecType::Tensor) {
     return;
   }
+
+  ensure_unique_data();
+  auto& float_data = data_->float_data;
+  auto& int32_data = data_->int32_data;
+  auto& half_data = data_->half_data;
+  auto& int8_data = data_->int8_data;
+  auto& uint8_data = data_->uint8_data;
 
   int64_t num_elements = numel();
 
@@ -498,81 +517,95 @@ std::string ValueSpec::to_string() const {
 
 // Additional ValueSpec methods
 void ValueSpec::resize_data(size_t new_size) {
+  // Generate first so a deferred tensor keeps its data-gen pattern (resized,
+  // not pinned to zeros by the data_generated_ flag set below).
+  ensure_data_generated();
+  ensure_unique_data();
   switch (dtype) {
     case vkapi::kFloat:
-      float_data.resize(new_size);
+      data_->float_data.resize(new_size);
       break;
     case vkapi::kHalf:
-      half_data.resize(new_size);
+      data_->half_data.resize(new_size);
       break;
     case vkapi::kInt:
-      int32_data.resize(new_size);
+      data_->int32_data.resize(new_size);
       break;
     case vkapi::kChar:
-      int8_data.resize(new_size);
+      data_->int8_data.resize(new_size);
       break;
     case vkapi::kByte:
-      uint8_data.resize(new_size);
+      data_->uint8_data.resize(new_size);
       break;
     default:
-      float_data.resize(new_size);
+      data_->float_data.resize(new_size);
       break;
   }
+  data_generated_ = true;
 }
 
 void* ValueSpec::get_mutable_data_ptr() {
+  ensure_data_generated();
+  ensure_unique_data();
   switch (dtype) {
     case vkapi::kFloat:
-      return float_data.data();
+      return data_->float_data.data();
     case vkapi::kHalf:
-      return half_data.data();
+      return data_->half_data.data();
     case vkapi::kInt:
-      return int32_data.data();
+      return data_->int32_data.data();
     case vkapi::kChar:
-      return int8_data.data();
+      return data_->int8_data.data();
     case vkapi::kByte:
-      return uint8_data.data();
+      return data_->uint8_data.data();
     default:
-      return float_data.data();
+      return data_->float_data.data();
   }
 }
 
 float ValueSpec::get_element(size_t index) const {
+  ensure_data_generated();
   if (index >= static_cast<size_t>(numel())) {
     return 0.0f;
   }
 
   switch (dtype) {
     case vkapi::kFloat:
-      return index < float_data.size() ? float_data[index] : 0.0f;
+      return index < data_->float_data.size() ? data_->float_data[index] : 0.0f;
     case vkapi::kHalf:
-      return index < half_data.size() ? half_to_float(half_data[index]) : 0.0f;
+      return index < data_->half_data.size()
+          ? half_to_float(data_->half_data[index])
+          : 0.0f;
     case vkapi::kInt:
-      return index < int32_data.size() ? static_cast<float>(int32_data[index])
-                                       : 0.0f;
+      return index < data_->int32_data.size()
+          ? static_cast<float>(data_->int32_data[index])
+          : 0.0f;
     case vkapi::kChar:
-      return index < int8_data.size() ? static_cast<float>(int8_data[index])
-                                      : 0.0f;
+      return index < data_->int8_data.size()
+          ? static_cast<float>(data_->int8_data[index])
+          : 0.0f;
     case vkapi::kByte:
-      return index < uint8_data.size() ? static_cast<float>(uint8_data[index])
-                                       : 0.0f;
+      return index < data_->uint8_data.size()
+          ? static_cast<float>(data_->uint8_data[index])
+          : 0.0f;
     default:
       return 0.0f;
   }
 }
 
 const void* ValueSpec::get_data_ptr() const {
+  ensure_data_generated();
   switch (dtype) {
     case vkapi::kFloat:
-      return float_data.data();
+      return data_->float_data.data();
     case vkapi::kHalf:
-      return half_data.data();
+      return data_->half_data.data();
     case vkapi::kInt:
-      return int32_data.data();
+      return data_->int32_data.data();
     case vkapi::kChar:
-      return int8_data.data();
+      return data_->int8_data.data();
     case vkapi::kByte:
-      return uint8_data.data();
+      return data_->uint8_data.data();
     default:
       throw std::runtime_error("Unsupported data type for get_data_ptr");
   }
@@ -801,7 +834,7 @@ bool ValueSpec::validate_against_reference(
 }
 
 // Ensure data is generated for this ValueSpec
-void ValueSpec::ensure_data_generated(int seed) {
+void ValueSpec::ensure_data_generated(int seed) const {
   if (data_generated_) {
     return;
   }
@@ -809,18 +842,22 @@ void ValueSpec::ensure_data_generated(int seed) {
   data_generated_ = true;
 }
 
-// Copy input data from another ValueSpec
-void ValueSpec::copy_data_from(const ValueSpec& other) {
+void ValueSpec::share_data_from(const ValueSpec& other) {
   if (!is_tensor() || !other.is_tensor()) {
     return;
   }
-  // Copy raw data based on dtype
-  float_data = other.float_data;
-  int32_data = other.int32_data;
-  half_data = other.half_data;
-  int8_data = other.int8_data;
-  uint8_data = other.uint8_data;
-  data_generated_ = other.data_generated_;
+  // Materialize the source first: sharing an ungenerated payload would let a
+  // later access materialize each spec independently under different seeds.
+  other.ensure_data_generated();
+  data_ = other.data_;
+  data_generated_ = true;
+}
+
+void ValueSpec::share_reference_from(const ValueSpec& other) {
+  if (!is_tensor() || !other.is_tensor()) {
+    return;
+  }
+  reference_data_ = other.reference_data_;
 }
 
 // ReferenceKey implementation
@@ -1743,17 +1780,11 @@ TestResult execute_test_cases(
 
     // Compute reference once for prototype
     bool ref_computed = false;
-    std::vector<std::vector<float>> ref_data;
     if (reference_compute_func) {
       try {
         reference_compute_func(prototype);
         ref_computed = true;
-
-        // Cache the reference output for this group
-        for (const auto& output : prototype.outputs()) {
-          ref_data.push_back(output.get_ref_float_data());
-        }
-      } catch (const std::invalid_argument& _) {
+      } catch (const std::invalid_argument&) {
         // Reference computation skipped for this group
       }
     }
@@ -1771,15 +1802,21 @@ TestResult execute_test_cases(
         const auto& src = prototype.inputs()[j];
         if (dest.is_tensor() && src.is_tensor() && dest.sizes == src.sizes &&
             dest.dtype == src.dtype) {
-          dest.copy_data_from(src);
+          dest.share_data_from(src);
         }
       }
 
       // Copy reference output data if available
       if (ref_computed) {
-        for (size_t j = 0; j < tc.outputs().size() && j < ref_data.size();
+        for (size_t j = 0;
+             j < tc.outputs().size() && j < prototype.outputs().size();
              ++j) {
-          tc.outputs()[j].get_ref_float_data() = ref_data[j];
+          const auto& src = prototype.outputs()[j];
+          auto& dest = tc.outputs()[j];
+          if (dest.is_tensor() && src.is_tensor() && dest.sizes == src.sizes &&
+              dest.dtype == src.dtype) {
+            dest.share_reference_from(src);
+          }
         }
       }
     }
@@ -1924,6 +1961,8 @@ TestResult execute_test_cases(
 
       // Add result to collection
       results.add_result(std::move(result));
+
+      test_case.clear();
     }
   }
 

--- a/backends/vulkan/test/custom_ops/utils.h
+++ b/backends/vulkan/test/custom_ops/utils.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -220,20 +221,7 @@ struct ValueSpec {
   bool is_constant_tensor;
   bool is_none_flag;
   bool is_int4_tensor;
-  bool data_generated_ = false;
-
-  std::vector<float> float_data;
-  std::vector<int32_t> int32_data;
-  std::vector<uint16_t> half_data; // Using uint16_t as substitute for half
-  std::vector<int8_t> int8_data; // For kChar (signed 8-bit)
-  std::vector<uint8_t> uint8_data; // For kByte (unsigned 8-bit)
   std::string string_data;
-
-  std::vector<float> ref_float_data;
-  std::vector<int32_t> ref_int32_data;
-  std::vector<uint16_t> ref_half_data;
-  std::vector<int8_t> ref_int8_data;
-  std::vector<uint8_t> ref_uint8_data;
 
   ValueSpec(
       const std::vector<int64_t>& sizes,
@@ -250,7 +238,8 @@ struct ValueSpec {
         is_none_flag(false),
         is_int4_tensor(false),
         data_generated_(false) {
-    // Data generation is deferred until ensure_data_generated() is called
+    // Data generation is deferred until first access (any data getter or
+    // ensure_data_generated() triggers it).
   }
 
   // Constructor for tensor with custom data generation type
@@ -270,7 +259,8 @@ struct ValueSpec {
         is_none_flag(false),
         is_int4_tensor(false),
         data_generated_(false) {
-    // Data generation is deferred until ensure_data_generated() is called
+    // Data generation is deferred until first access (any data getter or
+    // ensure_data_generated() triggers it).
   }
 
   // Constructor for single int
@@ -285,7 +275,7 @@ struct ValueSpec {
         is_none_flag(false),
         is_int4_tensor(false),
         data_generated_(true) {
-    int32_data.push_back(value);
+    data_->int32_data.push_back(value);
   }
 
   // Constructor for single float
@@ -300,7 +290,7 @@ struct ValueSpec {
         is_none_flag(false),
         is_int4_tensor(false),
         data_generated_(true) {
-    float_data.push_back(value);
+    data_->float_data.push_back(value);
   }
 
   // Constructor for single bool
@@ -315,7 +305,7 @@ struct ValueSpec {
         is_none_flag(false),
         is_int4_tensor(false),
         data_generated_(true) {
-    int32_data.push_back(value ? 1 : 0);
+    data_->int32_data.push_back(value ? 1 : 0);
   }
 
   // Constructor for int list
@@ -329,8 +319,9 @@ struct ValueSpec {
         is_constant_tensor(false),
         is_none_flag(false),
         is_int4_tensor(false),
-        data_generated_(true),
-        int32_data(values) {}
+        data_generated_(true) {
+    data_->int32_data = values;
+  }
 
   // Factory method for string (avoids ambiguity with vector constructor)
   static ValueSpec make_string(const std::string& value) {
@@ -385,98 +376,136 @@ struct ValueSpec {
   }
 
   int32_t get_int_value() const {
-    return int32_data.empty() ? 0 : int32_data[0];
+    ensure_data_generated();
+    return data_->int32_data.empty() ? 0 : data_->int32_data[0];
   }
   float get_float_value() const {
-    return float_data.empty() ? 0.0f : float_data[0];
+    ensure_data_generated();
+    return data_->float_data.empty() ? 0.0f : data_->float_data[0];
   }
   bool get_bool_value() const {
-    return int32_data.empty() ? false : (int32_data[0] != 0);
+    ensure_data_generated();
+    return data_->int32_data.empty() ? false : (data_->int32_data[0] != 0);
   }
   const std::string& get_string_value() const {
     return string_data;
   }
   const std::vector<int32_t>& get_int_list() const {
-    return int32_data;
+    ensure_data_generated();
+    return data_->int32_data;
   }
   const std::vector<int64_t>& get_tensor_sizes() const {
     return sizes;
   }
 
+  // References and pointers into tensor data must not be held across any other
+  // access to the same spec: a mutable access may detach the shared payload,
+  // leaving a previously returned reference bound to the old payload. Consume
+  // immediately.
   const std::vector<float>& get_float_data() const {
-    return float_data;
+    ensure_data_generated();
+    return data_->float_data;
   }
   const std::vector<int32_t>& get_int32_data() const {
-    return int32_data;
+    ensure_data_generated();
+    return data_->int32_data;
   }
   const std::vector<uint16_t>& get_half_data() const {
-    return half_data;
+    ensure_data_generated();
+    return data_->half_data;
   }
   const std::vector<int8_t>& get_int8_data() const {
-    return int8_data;
+    ensure_data_generated();
+    return data_->int8_data;
   }
   const std::vector<uint8_t>& get_uint8_data() const {
-    return uint8_data;
+    ensure_data_generated();
+    return data_->uint8_data;
   }
 
   std::vector<float>& get_float_data() {
-    return float_data;
+    ensure_data_generated();
+    ensure_unique_data();
+    return data_->float_data;
   }
   std::vector<int32_t>& get_int32_data() {
-    return int32_data;
+    ensure_data_generated();
+    ensure_unique_data();
+    return data_->int32_data;
   }
   std::vector<uint16_t>& get_half_data() {
-    return half_data;
+    ensure_data_generated();
+    ensure_unique_data();
+    return data_->half_data;
   }
   std::vector<int8_t>& get_int8_data() {
-    return int8_data;
+    ensure_data_generated();
+    ensure_unique_data();
+    return data_->int8_data;
   }
   std::vector<uint8_t>& get_uint8_data() {
-    return uint8_data;
+    ensure_data_generated();
+    ensure_unique_data();
+    return data_->uint8_data;
   }
 
   const std::vector<float>& get_ref_float_data() const {
-    return ref_float_data;
+    return reference_data_->float_data;
   }
   const std::vector<int32_t>& get_ref_int32_data() const {
-    return ref_int32_data;
+    return reference_data_->int32_data;
   }
   const std::vector<uint16_t>& get_ref_half_data() const {
-    return ref_half_data;
+    return reference_data_->half_data;
   }
   const std::vector<int8_t>& get_ref_int8_data() const {
-    return ref_int8_data;
+    return reference_data_->int8_data;
   }
   const std::vector<uint8_t>& get_ref_uint8_data() const {
-    return ref_uint8_data;
+    return reference_data_->uint8_data;
   }
 
   std::vector<float>& get_ref_float_data() {
-    return ref_float_data;
+    ensure_unique_reference_data();
+    return reference_data_->float_data;
   }
   std::vector<int32_t>& get_ref_int32_data() {
-    return ref_int32_data;
+    ensure_unique_reference_data();
+    return reference_data_->int32_data;
   }
   std::vector<uint16_t>& get_ref_half_data() {
-    return ref_half_data;
+    ensure_unique_reference_data();
+    return reference_data_->half_data;
   }
   std::vector<int8_t>& get_ref_int8_data() {
-    return ref_int8_data;
+    ensure_unique_reference_data();
+    return reference_data_->int8_data;
   }
   std::vector<uint8_t>& get_ref_uint8_data() {
-    return ref_uint8_data;
+    ensure_unique_reference_data();
+    return reference_data_->uint8_data;
   }
 
   void resize_data(size_t new_size);
   void* get_mutable_data_ptr();
   float get_element(size_t index) const;
 
-  // Data generation methods for deferred generation and caching
+  // Data generation methods for deferred generation and caching.
+  //
+  // ValueSpec is not thread-safe: lazy materialization and copy-on-write
+  // detach mutate shared state from const methods. Test cases are built and
+  // executed on a single thread.
+  //
+  // Implicit materialization (any data getter, resize_data) consumes the
+  // global seed counter. Callers needing deterministic data must call
+  // ensure_data_generated(explicit_seed) before any other access; a later
+  // seeded call is a no-op once data is generated.
   bool is_data_generated() const {
     return data_generated_;
   }
-  void ensure_data_generated(int seed = -1);
-  void copy_data_from(const ValueSpec& other);
+  void ensure_data_generated(int seed = -1) const;
+  void share_data_from(const ValueSpec& other);
+  void share_reference_from(const ValueSpec& other);
 
   // Set/get constant flag
   bool is_constant() const {
@@ -484,10 +513,6 @@ struct ValueSpec {
   }
   void set_constant(bool is_constant) {
     is_constant_tensor = is_constant;
-    // Constant tensors need data immediately for test case setup
-    if (is_constant && is_tensor()) {
-      ensure_data_generated();
-    }
   }
 
   // Set/get none flag
@@ -517,7 +542,22 @@ struct ValueSpec {
       float rel_tolerance = 1e-3f) const;
 
  private:
-  void generate_tensor_data(int seed = -1);
+  struct TensorData {
+    std::vector<float> float_data;
+    std::vector<int32_t> int32_data;
+    std::vector<uint16_t> half_data;
+    std::vector<int8_t> int8_data;
+    std::vector<uint8_t> uint8_data;
+  };
+
+  void ensure_unique_data() const;
+  void ensure_unique_reference_data() const;
+  void generate_tensor_data(int seed = -1) const;
+
+  mutable bool data_generated_ = false;
+  mutable std::shared_ptr<TensorData> data_ = std::make_shared<TensorData>();
+  mutable std::shared_ptr<TensorData> reference_data_ =
+      std::make_shared<TensorData>();
 };
 
 //

--- a/backends/vulkan/test/custom_ops/utils_test.cpp
+++ b/backends/vulkan/test/custom_ops/utils_test.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gtest/gtest.h>
+
+#include "utils.h"
+
+namespace executorch::vulkan::prototyping {
+namespace {
+
+TEST(ValueSpecTest, SetConstant_DoesNotMaterializeTensorData) {
+  ValueSpec value(
+      {16},
+      vkcompute::vkapi::kFloat,
+      vkcompute::utils::kBuffer,
+      vkcompute::utils::kWidthPacked,
+      DataGenType::ONES);
+
+  value.set_constant(true);
+
+  EXPECT_FALSE(value.is_data_generated());
+}
+
+TEST(ValueSpecTest, ShareDataFrom_SharesImmutableTensorData) {
+  ValueSpec source(
+      {16},
+      vkcompute::vkapi::kFloat,
+      vkcompute::utils::kBuffer,
+      vkcompute::utils::kWidthPacked,
+      DataGenType::ONES);
+  source.ensure_data_generated();
+
+  ValueSpec copy(
+      {16},
+      vkcompute::vkapi::kFloat,
+      vkcompute::utils::kTexture3D,
+      vkcompute::utils::kChannelsPacked,
+      DataGenType::ONES);
+  copy.share_data_from(source);
+
+  const ValueSpec& const_source = source;
+  const ValueSpec& const_copy = copy;
+  EXPECT_EQ(
+      const_source.get_float_data().data(), const_copy.get_float_data().data());
+}
+
+TEST(ValueSpecTest, MutableDataAccess_DetachesSharedTensorData) {
+  ValueSpec source(
+      {4},
+      vkcompute::vkapi::kFloat,
+      vkcompute::utils::kBuffer,
+      vkcompute::utils::kWidthPacked,
+      DataGenType::ONES);
+  source.ensure_data_generated();
+
+  ValueSpec copy = source;
+  copy.get_float_data()[0] = 7.0f;
+
+  const ValueSpec& const_source = source;
+  const ValueSpec& const_copy = copy;
+  EXPECT_FLOAT_EQ(const_source.get_float_data()[0], 1.0f);
+  EXPECT_FLOAT_EQ(const_copy.get_float_data()[0], 7.0f);
+  EXPECT_NE(
+      const_source.get_float_data().data(), const_copy.get_float_data().data());
+}
+
+TEST(ValueSpecTest, CopyConstruction_SharesImmutableReferenceData) {
+  ValueSpec source(
+      {4},
+      vkcompute::vkapi::kFloat,
+      vkcompute::utils::kBuffer,
+      vkcompute::utils::kWidthPacked,
+      DataGenType::ZEROS);
+  source.get_ref_float_data() = {1.0f, 2.0f, 3.0f, 4.0f};
+
+  ValueSpec copy = source;
+
+  const ValueSpec& const_source = source;
+  const ValueSpec& const_copy = copy;
+  EXPECT_EQ(
+      const_source.get_ref_float_data().data(),
+      const_copy.get_ref_float_data().data());
+}
+
+TEST(ValueSpecTest, MutableReferenceAccess_DetachesSharedReferenceData) {
+  ValueSpec source(
+      {2},
+      vkcompute::vkapi::kFloat,
+      vkcompute::utils::kBuffer,
+      vkcompute::utils::kWidthPacked,
+      DataGenType::ZEROS);
+  source.get_ref_float_data() = {1.0f, 2.0f};
+
+  ValueSpec copy = source;
+  copy.get_ref_float_data()[0] = 9.0f;
+
+  const ValueSpec& const_source = source;
+  const ValueSpec& const_copy = copy;
+  EXPECT_FLOAT_EQ(const_source.get_ref_float_data()[0], 1.0f);
+  EXPECT_FLOAT_EQ(const_copy.get_ref_float_data()[0], 9.0f);
+  EXPECT_NE(
+      const_source.get_ref_float_data().data(),
+      const_copy.get_ref_float_data().data());
+}
+
+TEST(ValueSpecTest, ConstGetter_MaterializesDeferredData) {
+  ValueSpec value(
+      {4},
+      vkcompute::vkapi::kFloat,
+      vkcompute::utils::kBuffer,
+      vkcompute::utils::kWidthPacked,
+      DataGenType::ONES);
+  const ValueSpec& const_value = value;
+  EXPECT_FALSE(const_value.is_data_generated());
+  EXPECT_FLOAT_EQ(const_value.get_float_data()[0], 1.0f);
+  EXPECT_FLOAT_EQ(const_value.get_float_value(), 1.0f);
+  EXPECT_TRUE(const_value.is_data_generated());
+}
+
+TEST(ValueSpecTest, ResizeData_PreservesGeneratedPattern) {
+  ValueSpec value(
+      {4},
+      vkcompute::vkapi::kFloat,
+      vkcompute::utils::kBuffer,
+      vkcompute::utils::kWidthPacked,
+      DataGenType::ONES);
+  value.resize_data(8);
+  const ValueSpec& const_value = value;
+  const std::vector<float> expected(
+      {1.0f, 1.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f});
+  EXPECT_EQ(const_value.get_float_data(), expected);
+}
+
+TEST(ValueSpecTest, MutableDataPtr_DetachesSharedTensorData) {
+  ValueSpec source(
+      {4},
+      vkcompute::vkapi::kFloat,
+      vkcompute::utils::kBuffer,
+      vkcompute::utils::kWidthPacked,
+      DataGenType::ONES);
+  source.ensure_data_generated();
+
+  ValueSpec copy = source;
+  auto* mutable_ptr = static_cast<float*>(copy.get_mutable_data_ptr());
+  ASSERT_NE(mutable_ptr, nullptr);
+  mutable_ptr[0] = 7.0f;
+
+  const ValueSpec& const_source = source;
+  const ValueSpec& const_copy = copy;
+  EXPECT_FLOAT_EQ(const_source.get_float_data()[0], 1.0f);
+  EXPECT_FLOAT_EQ(const_copy.get_float_data()[0], 7.0f);
+}
+
+TEST(ValueSpecTest, ShareReferenceFrom_IgnoresNonTensorSpecs) {
+  ValueSpec scalar(3);
+  ValueSpec tensor(
+      {4},
+      vkcompute::vkapi::kFloat,
+      vkcompute::utils::kBuffer,
+      vkcompute::utils::kWidthPacked,
+      DataGenType::ZEROS);
+  tensor.get_ref_float_data() = {1.0f, 2.0f, 3.0f, 4.0f};
+  const void* before = tensor.get_ref_float_data().data();
+  tensor.share_reference_from(scalar);
+  EXPECT_EQ(tensor.get_ref_float_data().data(), before);
+  const std::vector<float> expected({1.0f, 2.0f, 3.0f, 4.0f});
+  EXPECT_EQ(tensor.get_ref_float_data(), expected);
+}
+
+} // namespace
+} // namespace executorch::vulkan::prototyping


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22625
* __->__ #22624

Store `ValueSpec` tensor and reference payloads in shared copy-on-write storage. Defer constant materialization, share payloads among equivalent variants, and release completed test cases so host memory follows active work instead of accumulating across the suite. Add focused tests for lazy generation, sharing, and copy-on-write behavior.

Differential Revision: [D119237809](https://our.internmc.facebook.com/intern/diff/D119237809/)