### PR TITLE
[executorch][muse-glimmer] Make temperature 0 an exact argmax in the solo sampler

### DIFF
--- a/examples/models/muse-glimmer/runtime/engine/muse_glimmer_engine.cpp
+++ b/examples/models/muse-glimmer/runtime/engine/muse_glimmer_engine.cpp
@@ -911,7 +911,7 @@ class MuseGlimmerSession : public LLMSession,
     if (!valid_temperature(temperature)) {
       return Error::InvalidArgument;
     }
-    temp_val_ = (temperature <= 0.0f) ? 1e-6f : temperature;
+    temp_val_ = temperature;
     if (cudaMemcpy(
             temp_tensor_dev_->mutable_data_ptr(),
             &temp_val_,

--- a/examples/models/muse-glimmer/runtime/runners/solo.cpp
+++ b/examples/models/muse-glimmer/runtime/runners/solo.cpp
@@ -87,7 +87,7 @@ DEFINE_bool(
     tokens_have_bos,
     false,
     "If true the file already includes BOS; else BOS is prepended.");
-DEFINE_double(temperature, 0.8, "Sampling temperature (0 = near-greedy).");
+DEFINE_double(temperature, 0.8, "Sampling temperature (0 = exact greedy).");
 DEFINE_double(
     top_p,
     1.0,
@@ -1697,11 +1697,10 @@ int main(int argc, char** argv) {
 
   stats.inference_start_ms = llm::time_in_ms();
 
-  // On-device Gumbel sampling: temperature input (0 -> ~greedy via clamp).
+  // On-device sampling: exact argmax at temperature 0, Gumbel-max otherwise.
   // Methods return one sampled token; read_token() copies the 4-byte scalar.
   // Unused on the MLX build (kSingleMethod), which samples on the host.
-  [[maybe_unused]] float temp_val =
-      FLAGS_temperature <= 0.0 ? 1e-6f : static_cast<float>(FLAGS_temperature);
+  [[maybe_unused]] float temp_val = static_cast<float>(FLAGS_temperature);
   [[maybe_unused]] auto temp_tensor =
       from_blob(&temp_val, {1}, executorch::aten::ScalarType::Float);
 

--- a/examples/models/muse-glimmer/source_transformations/sampler.py
+++ b/examples/models/muse-glimmer/source_transformations/sampler.py
@@ -23,8 +23,9 @@ def sample(
 
     Args:
         logits: ``[B, V]`` float32 logits (already soft-capped).
-        temperature: 0-D or 1-D float tensor; clamped to >= 1e-6.
-            When ``None``, returns ``logits`` unchanged.
+        temperature: 0-D or 1-D float tensor. Values <= 0 select exact
+            deterministic argmax; positive values use Gumbel-max. When
+            ``None``, returns ``logits`` unchanged.
 
     Returns:
         ``[B, 1]`` float32 token IDs, or unmodified logits when
@@ -36,4 +37,9 @@ def sample(
     logits = logits / temperature.clamp(min=1e-6)
     noise = torch.rand_like(logits)
     gumbel = -torch.log(-torch.log(noise + 1e-20) + 1e-20)
+    # Keep a single argmax consumer of logits. Besides avoiding needless
+    # Gumbel perturbation in greedy mode, this preserves the original CUDA
+    # compilation dataflow instead of materializing logits for a second
+    # reduction branch.
+    gumbel = torch.where(temperature <= 0, torch.zeros_like(gumbel), gumbel)
     return (logits + gumbel).argmax(dim=-1, keepdim=True).float()

--- a/examples/models/muse-glimmer/tests/test_cuda_pipeline.py
+++ b/examples/models/muse-glimmer/tests/test_cuda_pipeline.py
@@ -20,6 +20,7 @@ import os
 import tempfile
 import unittest
 from dataclasses import replace
+from unittest.mock import patch
 
 import executorch.backends.cuda.quantize_op_dispatch as _quantize_op_dispatch  # noqa: F401
 import torch
@@ -43,6 +44,9 @@ from executorch.examples.models.muse_glimmer.source_transformations.cuda import 
     add_on_device_sampler,
     cuda_source_transformations,
 )
+from executorch.examples.models.muse_glimmer.source_transformations.sampler import (
+    sample,
+)
 from executorch.examples.models.muse_glimmer.tests.test_pipeline import (
     build_random_tiny_model,
     DEFAULT_RECIPE,
@@ -56,6 +60,25 @@ from executorch.extension.llm.export.quant import quantize_model
 def _require_cuda(testcase: unittest.TestCase) -> None:
     if not torch.cuda.is_available():
         testcase.skipTest("CUDA required")
+
+
+class TestCudaSamplerTest(unittest.TestCase):
+    def test_zero_temperature_is_exact_argmax_for_tied_logits(self):
+        logits = torch.tensor([[3.0, 3.0, 1.0]])
+        temperature = torch.tensor([0.0])
+        for seed in range(20):
+            torch.manual_seed(seed)
+            self.assertEqual(sample(logits, temperature).item(), 0)
+
+    def test_positive_temperature_retains_gumbel_noise(self):
+        logits = torch.tensor([[1.0, 0.0]])
+        noise = torch.tensor([[0.01, 0.99]])
+        with patch(
+            "executorch.examples.models.muse_glimmer.source_transformations."
+            "sampler.torch.rand_like",
+            return_value=noise,
+        ):
+            self.assertEqual(sample(logits, torch.tensor([1.0])).item(), 1)
 
 
 class TestMutableBufferMetadataTest(unittest.TestCase):
@@ -110,7 +133,7 @@ class TestCudaInferenceTest(unittest.TestCase):
         self.assertGreater(len(out), 0)
 
     def test_generate_greedy(self):
-        """Near-greedy generation (temperature=0) produces valid output."""
+        """Exact-greedy generation (temperature=0) produces valid output."""
         with tempfile.TemporaryDirectory() as tmpdir:
             save_checkpoint(tmpdir)
             model, config = load_prequantized_model(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22492
* __->__ #22631
* #22630
* #22491
* #22490
* #22489
* #22488
* #22487
* #22486
* #22485
* #22484

The in-graph solo sampler implemented greedy decoding as `logits / temperature.clamp(min=1e-6)` plus Gumbel noise, and the CUDA engine clamped a requested temperature of 0 up to 1e-6 before uploading it as a model input. Dividing by 1e-6 makes the noise negligible for well-separated logits, but it does not make the result deterministic: when the top logits are tied or separated by less than the noise scale, the Gumbel term still decides the winner, so temperature 0 could return different tokens across runs.

Zero the Gumbel term when temperature <= 0 so greedy selection is an exact argmax, and stop clamping in set_temperature so the graph actually observes 0. Both halves are needed: without the engine change the new sampler branch is unreachable. Zeroing the noise keeps a single argmax consumer of logits rather than adding a second reduction branch, which preserves the existing CUDA compilation dataflow instead of materializing logits twice.

This only affects the solo path, which is the sole user of add_on_device_sampler and of the temperature model input. DFlash does not embed a sampling method in its .pte and passes temperature directly to the runtime CUDA sampling primitives, which already dispatch temperature <= 0 to argmax_index.

Differential Revision: [D119207258](https://our.internmc.facebook.com/intern/diff/D119207258/)