### PR TITLE
Fix eager eval token ID fallbacks

### DIFF
--- a/examples/models/llama/evaluate/eager_eval.py
+++ b/examples/models/llama/evaluate/eager_eval.py
@@ -44,14 +44,16 @@ class EagerEvalWrapper(eval_wrapper):
         """
         The stories model does not have an EOT token, so we use the EOS token instead.
         """
-        if hasattr(self._tokenizer, "eot_id"):
-            return self._tokenizer.eot_id
+        eot_id = getattr(self._tokenizer, "eot_id", None)
+        if eot_id is not None:
+            return eot_id
         return self._tokenizer.eos_id
 
     @property
     def prefix_token_id(self):
-        if hasattr(self._tokenizer, "bos_id"):
-            return self._tokenizer.bos_id
+        bos_id = getattr(self._tokenizer, "bos_id", None)
+        if bos_id is not None:
+            return bos_id
         return self.eot_token_id
 
     @property

--- a/examples/models/llama/tests/BUCK
+++ b/examples/models/llama/tests/BUCK
@@ -10,6 +10,7 @@ fbcode_target(_kind = python_unittest,
     ],
     deps = [
         "//executorch/examples/models/llama:eval_library",
+        "fbsource//third-party/pypi/pytest:pytest",
     ],
 )
 

--- a/examples/models/llama/tests/BUCK
+++ b/examples/models/llama/tests/BUCK
@@ -4,6 +4,16 @@ load("@fbcode_macros//build_defs:python_unittest.bzl", "python_unittest")
 oncall("executorch")
 
 fbcode_target(_kind = python_unittest,
+    name = "test_eager_eval",
+    srcs = [
+        "test_eager_eval.py",
+    ],
+    deps = [
+        "//executorch/examples/models/llama:eval_library",
+    ],
+)
+
+fbcode_target(_kind = python_unittest,
     name = "test_simple_sdpa",
     srcs = [
         "test_simple_sdpa.py",

--- a/examples/models/llama/tests/test_eager_eval.py
+++ b/examples/models/llama/tests/test_eager_eval.py
@@ -8,7 +8,13 @@ import unittest
 from types import SimpleNamespace
 from typing import Optional
 
-from executorch.examples.models.llama.evaluate import EagerEvalWrapper
+import pytest
+
+pytest.importorskip("lm_eval", reason="requires lm-evaluation-harness")
+
+from executorch.examples.models.llama.evaluate.eager_eval import (  # noqa: E402
+    EagerEvalWrapper,
+)
 
 
 class TestEagerEvalWrapperTokenIds(unittest.TestCase):

--- a/examples/models/llama/tests/test_eager_eval.py
+++ b/examples/models/llama/tests/test_eager_eval.py
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from types import SimpleNamespace
+from typing import Optional
+
+from executorch.examples.models.llama.evaluate import EagerEvalWrapper
+
+
+class TestEagerEvalWrapperTokenIds(unittest.TestCase):
+    @staticmethod
+    def _wrapper(**token_ids: Optional[int]) -> EagerEvalWrapper:
+        # HFLM initialization loads a model and is unrelated to these properties.
+        wrapper = object.__new__(EagerEvalWrapper)
+        wrapper._tokenizer = SimpleNamespace(**token_ids)  # pyre-ignore[8]
+        return wrapper
+
+    def test_token_id_fallbacks(self):
+        cases = (
+            ({"bos_id": 1, "eot_id": 2, "eos_id": 3}, 2, 1),
+            ({"bos_id": None, "eot_id": 2, "eos_id": 3}, 2, 2),
+            ({"bos_id": None, "eot_id": None, "eos_id": 0}, 0, 0),
+            ({"eos_id": 0}, 0, 0),
+        )
+
+        for token_ids, expected_eot, expected_prefix in cases:
+            with self.subTest(token_ids=token_ids):
+                wrapper = self._wrapper(**token_ids)
+                self.assertEqual(wrapper.eot_token_id, expected_eot)
+                self.assertEqual(wrapper.prefix_token_id, expected_prefix)

--- a/examples/models/llama/tests/test_eager_eval.py
+++ b/examples/models/llama/tests/test_eager_eval.py
@@ -22,7 +22,9 @@ class TestEagerEvalWrapperTokenIds(unittest.TestCase):
     def test_token_id_fallbacks(self):
         cases = (
             ({"bos_id": 1, "eot_id": 2, "eos_id": 3}, 2, 1),
+            ({"bos_id": 0, "eot_id": 2, "eos_id": 3}, 2, 0),
             ({"bos_id": None, "eot_id": 2, "eos_id": 3}, 2, 2),
+            ({"bos_id": None, "eot_id": 0, "eos_id": 3}, 0, 0),
             ({"bos_id": None, "eot_id": None, "eos_id": 0}, 0, 0),
             ({"eos_id": 0}, 0, 0),
         )


### PR DESCRIPTION
## Summary

- treat None-valued BOS and EOT token IDs as unavailable
- fall back from BOS to EOT to EOS while preserving valid token ID 0
- add focused regression coverage for present, zero-valued, None-valued, and missing optional IDs

## Test plan

- python3 -m py_compile examples/models/llama/evaluate/eager_eval.py examples/models/llama/tests/test_eager_eval.py
- focused six-case fallback matrix: passed
- git diff --check

Fixes #22518

cc @mergennachin @iseeyuan @lucylq @helunwencser @tarun292 @kimishpatel @jackzhxng @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani