### PR TITLE
Qualcomm AI Engine Direct - Enhance Decompose im2col to support case …

### DIFF
--- a/backends/qualcomm/_passes/decompose_col_im.py
+++ b/backends/qualcomm/_passes/decompose_col_im.py
@@ -3,19 +3,27 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+import logging
+
 import torch
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass, PassResult
 from executorch.exir.passes import dead_code_elimination_pass
 
-from .utils import copy_meta
+from .utils import copy_meta, create_const_node
 
 
 class DecomposeColIm(ExportPass):
     """
-    Decompose im2col(unfold) to pixel_unshuffle + view_copy
+    Decompose im2col(unfold) to pad + index_select + space_to_depth + view_copy
     Decompose col2im(fold) to view_copy + pixel_shuffle
     """
+
+    # When stride != kernel_size, the index_select gather in
+    # _extend_for_space_to_depth duplicates elements. Skip decomposition if the
+    # expansion_factor is too large to avoid unbounded memory consumption;
+    # raise the value if a real case would benefit from more overlap.
+    _MAX_GATHER_EXPANSION_FACTOR = 16
 
     def __init__(self):
         super(DecomposeColIm, self).__init__()
@@ -24,6 +32,88 @@ class DecomposeColIm(ExportPass):
         self.pixel_unshuffle_op = exir_ops.edge.aten.pixel_unshuffle.default
         self.pixel_shuffle_op = exir_ops.edge.aten.pixel_shuffle.default
         self.view_copy_op = exir_ops.edge.aten.view_copy.default
+        self.index_select_op = exir_ops.edge.aten.index_select.default
+        self.space_to_depth_op = exir_ops.edge.qnn_custom.space_to_depth.default
+        self.pad_op = exir_ops.edge.aten.constant_pad_nd.default
+
+    def _emit_space_to_depth(
+        self,
+        graph: torch.fx.Graph,
+        meta,
+        input_node: torch.fx.Node,
+        kernel_size: list[int],
+    ):
+        kernel_height, kernel_width = kernel_size
+        input_val = input_node.meta["val"]
+        val = self.space_to_depth_op(input_val, kernel_height, kernel_width)
+        node = graph.create_node(
+            "call_function",
+            self.space_to_depth_op,
+            (input_node, kernel_height, kernel_width),
+        )
+        node.meta = copy_meta(meta)
+        node.meta["val"] = val
+        return node
+
+    def _extend_for_space_to_depth(
+        self,
+        graph_module: torch.fx.GraphModule,
+        node: torch.fx.Node,
+        input_node: torch.fx.Node,
+        kernel_size,
+        stride,
+        padding,
+    ):
+        graph = graph_module.graph
+        if any(p != 0 for p in padding):
+            # aten.im2col zero-pads symmetrically on both sides
+            # of each spatial dim before extracting windows;
+            # constant_pad_nd takes amounts last-dim-first:
+            # [width_left, width_right, height_top, height_bottom].
+            pad_amount = [padding[1], padding[1], padding[0], padding[0]]
+            pad_val = self.pad_op(input_node.meta["val"], pad_amount, 0.0)
+            pad_node = graph.create_node(
+                "call_function", self.pad_op, (input_node, pad_amount, 0.0)
+            )
+            pad_node.meta = copy_meta(node.meta)
+            pad_node.meta["val"] = pad_val
+            input_node = pad_node
+        # im2col with stride != kernel_size: gather each spatial dim (one 1-D
+        # index_select per dim) so the result tiles exactly into
+        # output_block_height*kernel_height by output_block_width*kernel_width -- i.e.
+        # what space_to_depth expects when stride == kernel_size, matching
+        # torch.nn.functional.unfold's output layout:
+        #   x.index_select(2, height_idx).index_select(3, width_idx)
+
+        for kernel_value, stride_value, dim in zip(kernel_size, stride, [2, 3]):
+            input_val = input_node.meta["val"]
+            input_dim_value = input_val.shape[dim]
+            if kernel_value != stride_value:
+                num_output_block = (input_dim_value - kernel_value) // stride_value + 1
+                expand_idx = [
+                    j * stride_value + i
+                    for j in range(num_output_block)
+                    for i in range(kernel_value)
+                ]
+                idx_node = create_const_node(
+                    graph,
+                    graph_module,
+                    f"{node.name}_dim_{dim}_expand_idx",
+                    expand_idx,
+                    input_node,
+                    const_dtype=torch.int32,
+                    static_shapes=True,  # use static or it become symbolic shape
+                )
+                gather_node = graph.create_node(
+                    "call_function", self.index_select_op, (input_node, dim, idx_node)
+                )
+                gather_node.meta = copy_meta(node.meta)
+                gather_node.meta["val"] = input_val.index_select(
+                    dim, idx_node.meta["val"]
+                )
+                input_node = gather_node
+
+        return input_node
 
     def _decompose_im2col(self, graph_module: torch.fx.GraphModule):
         for node in graph_module.graph.nodes:
@@ -33,51 +123,78 @@ class DecomposeColIm(ExportPass):
                 dilation = node.args[2]
                 padding = node.args[3]
                 stride = node.args[4]
-                batch_size = node.meta["val"].shape[0]
-                assert (
-                    stride == kernel_size
-                ), "im2col can only be converted when stride == kernel_size"
-                assert (
-                    input_node.meta["val"].dim() == 4
-                ), "im2col can only be converted when input dims == 4"
-                assert (
-                    kernel_size[0] == kernel_size[1]
-                ), "im2col can only be converted when kernel height == width"
-                assert all(
-                    d == 1 for d in dilation
-                ), "col2im can only be converted when dilation equals to (1, 1)"
-                assert all(
-                    p == 0 for p in padding
-                ), "col2im can only be converted when padding equals to (0, 0)"
+                if input_node.meta["val"].dim() != 4:
+                    logging.warning(
+                        f"{node}: im2col input must be 4-D to be decomposed, got "
+                        f"dim={input_node.meta['val'].dim()}. Skipping decomposition."
+                    )
+                    continue
+                if any(d != 1 for d in dilation):
+                    logging.warning(
+                        f"{node}: im2col can only be decomposed when dilation == "
+                        f"(1, 1), got dilation={dilation}. Skipping decomposition."
+                    )
+                    continue
+
+                # Given a array length L with kernel K and stride S, the
+                # expanded output is |1...K|1+S...K+S|...|1+(N-1)*S...K+(N-1)*S|
+                # the expanded output length is K*N, where N = (L-K)/S+1,
+                # expansion_factor = K*N/L = K*(L-K+S)/(L*S)
+                # e.g., L=9, K=5, S=2, then expanded output is
+                # |1...5|3...7|5...9|, expansion_factor = 5*(9-5+2)/(9*2) = 30/18
+                # Assume L is largely greater than K and S, simplify
+                # expansion_factor to K/S
+                expansion_factor = (
+                    kernel_size[0] / stride[0] * kernel_size[1] / stride[1]
+                )
+                if expansion_factor > self._MAX_GATHER_EXPANSION_FACTOR:
+                    logging.warning(
+                        f"{node}: im2col decomposition would expand the gather "
+                        f"by {expansion_factor}x (kernel_size={kernel_size}, "
+                        f"stride={stride}), exceeding the "
+                        f"{self._MAX_GATHER_EXPANSION_FACTOR}x limit imposed to "
+                        "avoid excessive memory consumption. Skipping "
+                        "decomposition -- raise "
+                        "DecomposeColIm._MAX_GATHER_EXPANSION_FACTOR if a real "
+                        "case would benefit from loosening this threshold."
+                    )
+                    continue
+                graph = graph_module.graph
                 users = list(node.users.keys())
-                with graph_module.graph.inserting_after(input_node):
-                    pixel_unshuffle_node = graph_module.graph.create_node(
+                x = input_node
+                with graph.inserting_before(node):
+                    # given input [1,1,4,4] with kernel=[2,2] and stride=[1,1]
+                    # e.g.,input
+                    # input = [[ 0,  1,  2,  3],
+                    #          [ 4,  5,  6,  7],
+                    #          [ 8,  9, 10, 11],
+                    #          [12, 13, 14, 15]]
+                    # since kernel is not equal to stride
+                    # it will be extend to a input shape with kernel=stride=[2,2]
+                    # e.g.,
+                    # input = [[ 0,  1,  1,  2,  2,  3],
+                    #          [ 4,  5,  5,  6,  6,  7],
+                    #          [ 4,  5,  5,  6,  6,  7],
+                    #          [ 8,  9,  9, 10, 10, 11],
+                    #          [ 8,  9,  9, 10, 10, 11],
+                    #          [12, 13, 13, 14, 14, 15]]
+                    x = self._extend_for_space_to_depth(
+                        graph_module, node, x, kernel_size, stride, padding
+                    )
+
+                    s2d_node = self._emit_space_to_depth(
+                        graph, node.meta, x, kernel_size
+                    )
+
+                    final_view_node = graph.create_node(
                         "call_function",
-                        self.pixel_unshuffle_op,
-                        (input_node, kernel_size[0]),
+                        self.view_copy_op,
+                        (s2d_node, tuple(node.meta["val"].shape)),
                     )
-                    pixel_unshuffle_node.meta = copy_meta(node.meta)
-                    orig_height = input_node.meta["val"].shape[2]
-                    orig_width = input_node.meta["val"].shape[3]
+                    final_view_node.meta = copy_meta(node.meta)
 
-                    pixel_unshuffle_node.meta["val"] = pixel_unshuffle_node.meta[
-                        "val"
-                    ].reshape(
-                        batch_size,
-                        -1,
-                        orig_height // kernel_size[0],
-                        orig_width // kernel_size[1],
-                    )
-
-                    with graph_module.graph.inserting_after(pixel_unshuffle_node):
-                        view_copy_node = graph_module.graph.create_node(
-                            "call_function",
-                            self.view_copy_op,
-                            (pixel_unshuffle_node, tuple(node.meta["val"].shape)),
-                        )
-                        view_copy_node.meta = copy_meta(node.meta)
-                        for user in users:
-                            user.replace_input_with(node, view_copy_node)
+                for user in users:
+                    user.replace_input_with(node, final_view_node)
 
     def _decompose_col2im(self, graph_module: torch.fx.GraphModule):
         for node in graph_module.graph.nodes:
@@ -89,21 +206,38 @@ class DecomposeColIm(ExportPass):
                 padding = node.args[4]
                 stride = node.args[5]
                 batch_size = node.meta["val"].shape[0]
-                assert (
-                    stride == kernel_size
-                ), "col2im can only be converted when stride == kernel_size"
-                assert (
-                    node.meta["val"].dim() == 4
-                ), "col2im can only be converted when output dims == 4"
-                assert (
-                    kernel_size[0] == kernel_size[1]
-                ), "col2im can only be converted when kernel height == width"
-                assert all(
-                    d == 1 for d in dilation
-                ), "col2im can only be converted when dilation equals to (1, 1)"
-                assert all(
-                    p == 0 for p in padding
-                ), "col2im can only be converted when padding equals to (0, 0)"
+                if stride != kernel_size:
+                    logging.warning(
+                        f"{node}: col2im can only be decomposed when stride == "
+                        f"kernel_size, got stride={stride}, kernel_size="
+                        f"{kernel_size}. Skipping decomposition."
+                    )
+                    continue
+                if node.meta["val"].dim() != 4:
+                    logging.warning(
+                        f"{node}: col2im output must be 4-D to be decomposed, got "
+                        f"dim={node.meta['val'].dim()}. Skipping decomposition."
+                    )
+                    continue
+                if kernel_size[0] != kernel_size[1]:
+                    logging.warning(
+                        f"{node}: col2im can only be decomposed when kernel "
+                        f"height == width, got kernel_size={kernel_size}. "
+                        f"Skipping decomposition."
+                    )
+                    continue
+                if any(d != 1 for d in dilation):
+                    logging.warning(
+                        f"{node}: col2im can only be decomposed when dilation == "
+                        f"(1, 1), got dilation={dilation}. Skipping decomposition."
+                    )
+                    continue
+                if any(p != 0 for p in padding):
+                    logging.warning(
+                        f"{node}: col2im can only be decomposed when padding == "
+                        f"(0, 0), got padding={padding}. Skipping decomposition."
+                    )
+                    continue
 
                 users = list(node.users.keys())
                 with graph_module.graph.inserting_after(input_node):

--- a/backends/qualcomm/_passes/layout_transform.py
+++ b/backends/qualcomm/_passes/layout_transform.py
@@ -56,6 +56,7 @@ class LayoutTransform(ExportPass):
         exir_ops.edge.aten.native_group_norm.default,
         exir_ops.edge.aten.pixel_shuffle.default,
         exir_ops.edge.aten.pixel_unshuffle.default,
+        exir_ops.edge.qnn_custom.space_to_depth.default,
         exir_ops.edge.aten.upsample_bicubic2d.default,
         exir_ops.edge.aten.upsample_bicubic2d.vec,
         exir_ops.edge.aten.upsample_bilinear2d.default,

--- a/backends/qualcomm/_passes/utils.py
+++ b/backends/qualcomm/_passes/utils.py
@@ -355,19 +355,25 @@ def create_const_node(
     attr_name: str,
     value,
     source_node: torch.fx.Node,
+    const_dtype: torch.dtype = None,
+    static_shapes: bool = False,
 ) -> torch.fx.Node:
     """
     Register a scalar constant as a named buffer on the graph module and return a get_attr node referencing it.
     Used in edge dialect op decomposition passes where raw scalar arguments are not accepted by QNN op builders which need the inputs to be graph nodes.
     """
     dtype = source_node.meta["val"].dtype
+    if const_dtype is not None:
+        dtype = const_dtype
     tensor = torch.tensor(value, dtype=dtype)
     graph_module.register_buffer(attr_name, tensor)
 
     fake_mode = source_node.meta["val"].fake_mode
     with graph.inserting_before(next(iter(graph.nodes))):
         const_node = graph.get_attr(attr_name)
-        const_node.meta["val"] = fake_mode.from_tensor(tensor)
+        const_node.meta["val"] = fake_mode.from_tensor(
+            tensor, static_shapes=static_shapes
+        )
     return const_node
 
 

--- a/backends/qualcomm/builders/custom_ops.py
+++ b/backends/qualcomm/builders/custom_ops.py
@@ -16,13 +16,19 @@ def _hadamard_matrix(dim: int, device, dtype) -> torch.Tensor:
     return h
 
 
-if not hasattr(torch.ops, "qnn_custom") or not hasattr(
-    torch.ops.qnn_custom, "hadamard_transform"
+if (
+    not hasattr(torch.ops, "qnn_custom")
+    or not hasattr(torch.ops.qnn_custom, "hadamard_transform")
+    or not hasattr(torch.ops.qnn_custom, "space_to_depth")
 ):
-    hadamard_op_lib = Library("qnn_custom", "DEF")
-    hadamard_op_lib.define("hadamard_transform(Tensor input, float scale) -> Tensor")
+    qnn_custom_lib = Library("qnn_custom", "DEF")
+    qnn_custom_lib.define("hadamard_transform(Tensor input, float scale) -> Tensor")
+    qnn_custom_lib.define(
+        "space_to_depth(Tensor input, int block_h, int block_w) -> Tensor"
+    )
 
-    @impl(hadamard_op_lib, "hadamard_transform", "CompositeExplicitAutograd")
+    # Qnn HadamardTransform
+    @impl(qnn_custom_lib, "hadamard_transform", "CompositeExplicitAutograd")
     def hadamard_transform_impl(input: torch.Tensor, scale: float) -> torch.Tensor:
         # Normalized Walsh-Hadamard transform along the last dim, times scale.
         # Matches a linear/matmul whose weight is scipy.linalg.hadamard(dim) * s,
@@ -37,5 +43,27 @@ if not hasattr(torch.ops, "qnn_custom") or not hasattr(
         # Hadamard weight is square, so the transform preserves shape.
         return torch.empty_like(input)
 
+    # Qnn SpaceToDepth
+    @impl(qnn_custom_lib, "space_to_depth", "CompositeExplicitAutograd")
+    def space_to_depth_impl(
+        input: torch.Tensor, block_h: int, block_w: int
+    ) -> torch.Tensor:
+        # Generalizes torch.nn.functional.pixel_unshuffle to independent block
+        # sizes along height/width, matching QNN SpaceToDepth's CRD mode: output
+        # channel c*block_h*block_w + i*block_w + j holds input channel c's
+        # (i, j)'th block element.
+        n, c, h, w = input.shape
+        out_h, out_w = h // block_h, w // block_w
+        x = input.view(n, c, out_h, block_h, out_w, block_w)
+        x = x.permute(0, 1, 3, 5, 2, 4)
+        return x.reshape(n, c * block_h * block_w, out_h, out_w)
+
+    @register_fake("qnn_custom::space_to_depth")
+    def space_to_depth_fake(
+        input: torch.Tensor, block_h: int, block_w: int
+    ) -> torch.Tensor:
+        n, c, h, w = input.shape
+        return input.new_empty(n, c * block_h * block_w, h // block_h, w // block_w)
+
 else:
-    hadamard_op_lib = Library("qnn_custom", "FRAGMENT")
+    qnn_custom_lib = Library("qnn_custom", "FRAGMENT")

--- a/backends/qualcomm/builders/op_space_to_depth.py
+++ b/backends/qualcomm/builders/op_space_to_depth.py
@@ -19,7 +19,10 @@ from .qnn_constants import OpSpaceToDepth, QNN_OP_PACKAGE_NAME_QTI_AISW
 
 @register_node_visitor
 class SpaceToDepthVisitor(NodeVisitor):
-    target = ["aten.pixel_unshuffle.default"]
+    # aten.pixel_unshuffle.default only supports a single (square) block size;
+    # qnn_custom.space_to_depth.default generalizes it to independent
+    # block_h/block_w, e.g. for im2col decomposition with a non-square kernel.
+    target = ["aten.pixel_unshuffle.default", "qnn_custom.space_to_depth.default"]
 
     def __init__(self, *args) -> None:
         super().__init__(*args)
@@ -50,7 +53,9 @@ class SpaceToDepthVisitor(NodeVisitor):
 
         block_size = []
         for index in range(1, 3):
-            block_size.append(input_tensor.shape[index] / output_tensor.shape[index])
+            size = input_tensor.shape[index] / output_tensor.shape[index]
+            assert size.is_integer(), "block size is not integer"
+            block_size.append(size)
         block_size = np.array(block_size, dtype=np.uint32)
         block_size_shape = [2]
 

--- a/backends/qualcomm/quantizer/annotators/htp_rules.py
+++ b/backends/qualcomm/quantizer/annotators/htp_rules.py
@@ -1265,7 +1265,11 @@ class PixelShuffle(GeneralOpDef):
 
 
 @register_annotator(
-    [torch.ops.aten.pixel_unshuffle.default], QnnConstants.OpSpaceToDepth.op_name
+    [
+        torch.ops.aten.pixel_unshuffle.default,
+        torch.ops.qnn_custom.space_to_depth.default,
+    ],
+    QnnConstants.OpSpaceToDepth.op_name,
 )
 class PixelUnshuffle(GeneralOpDef):
     @staticmethod

--- a/backends/qualcomm/tests/models.py
+++ b/backends/qualcomm/tests/models.py
@@ -3016,16 +3016,18 @@ class Unflatten(torch.nn.Module):
 
 
 class Unfold(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, kernel_size, stride, padding=0):
         super().__init__()
-        self.patch_height = 2
-        self.patch_width = 2
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.padding = padding
 
     def forward(self, x):
         unfold = torch.nn.functional.unfold(
             x,
-            kernel_size=(self.patch_height, self.patch_width),
-            stride=(self.patch_height, self.patch_width),
+            kernel_size=self.kernel_size,
+            stride=self.stride,
+            padding=self.padding,
         )
         return unfold
 

--- a/backends/qualcomm/tests/rework/src/op.py
+++ b/backends/qualcomm/tests/rework/src/op.py
@@ -5360,12 +5360,16 @@ class Unfold(torch.nn.Module):
     @staticmethod
     @unpack_fixtures
     def test(subtests, qnn_config, quantizer, compile_spec, expected):
-        inputs = (torch.randn(2, 128, 32, 32),)
+        inputs = (torch.randn(2, 128, 64, 64),)
         configs = [
             {"kernel_size": 2, "stride": 2, "padding": 0, "dilation": 1},
             {"kernel_size": 4, "stride": 4, "padding": 0, "dilation": 1},
             {"kernel_size": (2, 2), "stride": (2, 2), "padding": 0, "dilation": 1},
             {"kernel_size": (4, 4), "stride": (4, 4), "padding": 0, "dilation": 1},
+            {"kernel_size": (2, 2), "stride": (2, 1), "padding": 0, "dilation": 1},
+            {"kernel_size": (4, 4), "stride": (2, 2), "padding": 0, "dilation": 1},
+            {"kernel_size": (4, 2), "stride": (2, 2), "padding": 0, "dilation": 1},
+            {"kernel_size": (2, 2), "stride": (2, 2), "padding": (1, 1), "dilation": 1},
         ]
         for cfg in configs:
             with subtests.test(msg=str(cfg)):
@@ -5382,13 +5386,15 @@ class Unfold(torch.nn.Module):
     @staticmethod
     @unpack_fixtures
     def test_unsupported(subtests, qnn_config, quantizer, compile_spec, expected):
-        # stride != kernel_size is not supported by DecomposeColIm
-        inputs = (torch.randn(2, 128, 32, 32),)
+        # dilation != 1 is not supported by DecomposeColIm
+        inputs = (torch.randn(2, 128, 64, 64),)
         configs = [
-            {"kernel_size": (2, 2), "stride": (2, 1), "padding": 0, "dilation": 1},
-            {"kernel_size": (4, 4), "stride": (2, 2), "padding": 0, "dilation": 1},
-            {"kernel_size": (2, 2), "stride": (2, 2), "dilation": (2, 2)},
-            {"kernel_size": (2, 2), "stride": (2, 2), "padding": (1, 1)},
+            {
+                "kernel_size": (2, 2),
+                "stride": (2, 2),
+                "padding": (0, 0),
+                "dilation": (2, 2),
+            },
         ]
         for cfg in configs:
             with subtests.test(msg=str(cfg)):
@@ -5402,7 +5408,7 @@ class Unfold(torch.nn.Module):
                         metrics=metrics,
                     )
         inputs = (torch.randn(2, 128, 32),)
-        cfg = {"kernel_size": (2, 2), "stride": (2, 2)}
+        cfg = {"kernel_size": (2, 2), "stride": (2, 2), "padding": 0, "dilation": 1}
         with subtests.test(msg="Unsupported input shape"):
             with expected as metrics:
                 export_and_verify(

--- a/backends/qualcomm/tests/rework/src/pattern.py
+++ b/backends/qualcomm/tests/rework/src/pattern.py
@@ -1319,8 +1319,10 @@ class DecomposeColIm:
                 x, output_size=(4, 4), kernel_size=2, stride=2
             )
 
-    # im2col violation models — each breaks exactly one assertion in _decompose_im2col
-    class _Im2ColStrideMismatch(torch.nn.Module):
+    # im2col support models: stride == kernel_size goes straight to
+    # space_to_depth; stride != kernel_size first gathers each spatial dim
+    # with index_select so the result tiles the way space_to_depth expects.
+    class _Im2ColOverlappingWindows(torch.nn.Module):
         def forward(self, x):
             return torch.nn.functional.unfold(x, kernel_size=2, stride=1)
 
@@ -1328,13 +1330,30 @@ class DecomposeColIm:
         def forward(self, x):
             return torch.nn.functional.unfold(x, kernel_size=(2, 3), stride=(2, 3))
 
+    class _Im2ColNonSquareStrideMismatch(torch.nn.Module):
+        def forward(self, x):
+            return torch.nn.functional.unfold(x, kernel_size=(4, 2), stride=(2, 2))
+
+    # im2col violation models — each breaks exactly one remaining assertion
+    # in _decompose_im2col
     class _Im2ColDilation(torch.nn.Module):
         def forward(self, x):
             return torch.nn.functional.unfold(x, kernel_size=2, stride=2, dilation=2)
 
+    # im2col with nonzero padding: constant_pad_nd zero-pads the input on
+    # both sides of each spatial dim before the existing gather/space_to_depth
+    # decomposition runs.
     class _Im2ColPadding(torch.nn.Module):
         def forward(self, x):
             return torch.nn.functional.unfold(x, kernel_size=2, stride=2, padding=1)
+
+    # im2col config whose stride is far smaller than its kernel: the gather
+    # expansion factor (ceil(kernel/stride) per dim) exceeds
+    # DecomposeColIm._MAX_GATHER_EXPANSION_FACTOR, so decomposition is
+    # skipped instead of building an unbounded index_select gather.
+    class _Im2ColExpansionFactorTooLarge(torch.nn.Module):
+        def forward(self, x):
+            return torch.nn.functional.unfold(x, kernel_size=9, stride=2)
 
     # col2im violation models — each breaks exactly one assertion in _decompose_col2im
     class _Col2ImStrideMismatch(torch.nn.Module):
@@ -1371,9 +1390,19 @@ class DecomposeColIm:
         assertions: Assertions,
         pass_pipeline: PassPipeline,
     ):
+        # DecomposeColIm now runs in the to_edge pipeline (see
+        # QnnPassManager.get_default_pass_activations), so node targets are
+        # exir_ops.edge.*, not plain torch.ops.aten.*.
         target_pass = _passes.DecomposeColIm
+        im2col_op = exir_ops.edge.aten.im2col.default
+        col2im_op = exir_ops.edge.aten.col2im.default
+        space_to_depth_op = exir_ops.edge.qnn_custom.space_to_depth.default
+        index_select_op = exir_ops.edge.aten.index_select.default
+        pad_op = exir_ops.edge.aten.constant_pad_nd.default
+        view_copy_op = exir_ops.edge.aten.view_copy.default
+        pixel_shuffle_op = exir_ops.edge.aten.pixel_shuffle.default
 
-        # im2col (unfold): pixel_unshuffle + view_copy
+        # im2col (unfold), stride == kernel_size: space_to_depth + view_copy
         with subtests.test(msg="im2col"):
             gm = pass_pipeline.lower_edge_ep(
                 module=DecomposeColIm._Im2Col(),
@@ -1383,11 +1412,71 @@ class DecomposeColIm:
                 target_pass=target_pass,
                 quantizer=quantizer,
             ).graph_module
-            assertions.assert_no_target(gm, exir_ops.edge.aten.im2col.default)
-            assertions.assert_target_count(
-                gm, exir_ops.edge.aten.pixel_unshuffle.default, 1
-            )
-            assertions.assert_target_count(gm, exir_ops.edge.aten.view_copy.default, 1)
+            assertions.assert_no_target(gm, im2col_op)
+            assertions.assert_no_target(gm, index_select_op)
+            assertions.assert_target_count(gm, space_to_depth_op, 1)
+            assertions.assert_target_count(gm, view_copy_op, 1)
+
+        # im2col, stride != kernel_size: index_select gather (h, w) + space_to_depth + view_copy
+        with subtests.test(msg="im2col_overlapping_windows"):
+            gm = pass_pipeline.lower_edge_ep(
+                module=DecomposeColIm._Im2ColOverlappingWindows(),
+                sample_input=(torch.randn(1, 4, 4, 4),),
+                backend_type=backend_type,
+                compile_spec=compile_spec,
+                target_pass=target_pass,
+                quantizer=quantizer,
+            ).graph_module
+            assertions.assert_no_target(gm, im2col_op)
+            assertions.assert_target_count(gm, index_select_op, 2)
+            assertions.assert_target_count(gm, space_to_depth_op, 1)
+            assertions.assert_target_count(gm, view_copy_op, 1)
+
+        # im2col, non-square kernel, stride == kernel_size
+        with subtests.test(msg="im2col_non_square_kernel"):
+            gm = pass_pipeline.lower_edge_ep(
+                module=DecomposeColIm._Im2ColNonSquareKernel(),
+                sample_input=(torch.randn(1, 4, 4, 6),),
+                backend_type=backend_type,
+                compile_spec=compile_spec,
+                target_pass=target_pass,
+                quantizer=quantizer,
+            ).graph_module
+            assertions.assert_no_target(gm, im2col_op)
+            assertions.assert_no_target(gm, index_select_op)
+            assertions.assert_target_count(gm, space_to_depth_op, 1)
+            assertions.assert_target_count(gm, view_copy_op, 1)
+
+        # im2col, non-square kernel AND stride != kernel_size combined
+        with subtests.test(msg="im2col_non_square_stride_mismatch"):
+            gm = pass_pipeline.lower_edge_ep(
+                module=DecomposeColIm._Im2ColNonSquareStrideMismatch(),
+                sample_input=(torch.randn(1, 4, 8, 6),),
+                backend_type=backend_type,
+                compile_spec=compile_spec,
+                target_pass=target_pass,
+                quantizer=quantizer,
+            ).graph_module
+            assertions.assert_no_target(gm, im2col_op)
+            assertions.assert_target_count(gm, index_select_op, 1)
+            assertions.assert_target_count(gm, space_to_depth_op, 1)
+            assertions.assert_target_count(gm, view_copy_op, 1)
+
+        # im2col with nonzero padding: constant_pad_nd + space_to_depth + view_copy
+        with subtests.test(msg="im2col_padding"):
+            gm = pass_pipeline.lower_edge_ep(
+                module=DecomposeColIm._Im2ColPadding(),
+                sample_input=(torch.randn(1, 4, 4, 4),),
+                backend_type=backend_type,
+                compile_spec=compile_spec,
+                target_pass=target_pass,
+                quantizer=quantizer,
+            ).graph_module
+            assertions.assert_no_target(gm, im2col_op)
+            assertions.assert_no_target(gm, index_select_op)
+            assertions.assert_target_count(gm, pad_op, 1)
+            assertions.assert_target_count(gm, space_to_depth_op, 1)
+            assertions.assert_target_count(gm, view_copy_op, 1)
 
         # col2im (fold): view_copy + pixel_shuffle
         with subtests.test(msg="col2im"):
@@ -1402,51 +1491,43 @@ class DecomposeColIm:
                 target_pass=target_pass,
                 quantizer=quantizer,
             ).graph_module
-            assertions.assert_no_target(gm, exir_ops.edge.aten.col2im.default)
-            assertions.assert_target_count(
-                gm, exir_ops.edge.aten.pixel_shuffle.default, 1
-            )
-            assertions.assert_target_count(gm, exir_ops.edge.aten.view_copy.default, 1)
+            assertions.assert_no_target(gm, col2im_op)
+            assertions.assert_target_count(gm, pixel_shuffle_op, 1)
+            assertions.assert_target_count(gm, view_copy_op, 1)
 
-        # im2col assertion failures
-        im2col_fail_cases = [
-            (
-                "im2col_stride_mismatch",
-                DecomposeColIm._Im2ColStrideMismatch(),
-                (torch.randn(1, 4, 4, 4),),
-            ),
-            (
-                "im2col_non_square_kernel",
-                DecomposeColIm._Im2ColNonSquareKernel(),
-                (torch.randn(1, 4, 4, 6),),
-            ),
+        # im2col configs the decomposition doesn't handle: each hits exactly
+        # one skip condition in _decompose_im2col, so the node is left
+        # undecomposed instead of being replaced.
+        im2col_skip_cases = [
             (
                 "im2col_dilation_not_one",
                 DecomposeColIm._Im2ColDilation(),
                 (torch.randn(1, 4, 8, 8),),
             ),
             (
-                "im2col_nonzero_padding",
-                DecomposeColIm._Im2ColPadding(),
-                (torch.randn(1, 4, 4, 4),),
+                "im2col_expansion_factor_too_large",
+                DecomposeColIm._Im2ColExpansionFactorTooLarge(),
+                (torch.randn(1, 4, 20, 20),),
             ),
         ]
-        for label, module, inputs in im2col_fail_cases:
+        for label, module, inputs in im2col_skip_cases:
             with subtests.test(msg=label):
-                with pytest.raises(  # noqa: B017
-                    Exception, check=check_exception(EXCEPTION_FROM_PASSES)
-                ):
-                    pass_pipeline.lower_edge_ep(
-                        module=module,
-                        sample_input=inputs,
-                        backend_type=backend_type,
-                        compile_spec=compile_spec,
-                        target_pass=target_pass,
-                        quantizer=quantizer,
-                    )
+                gm = pass_pipeline.lower_edge_ep(
+                    module=module,
+                    sample_input=inputs,
+                    backend_type=backend_type,
+                    compile_spec=compile_spec,
+                    target_pass=target_pass,
+                    quantizer=quantizer,
+                ).graph_module
+                assertions.assert_target_count(gm, im2col_op, 1)
+                assertions.assert_no_target(gm, space_to_depth_op)
+                assertions.assert_no_target(gm, index_select_op)
 
-        # col2im assertion failures
-        col2im_fail_cases = [
+        # col2im configs the decomposition doesn't handle: each hits exactly
+        # one skip condition in _decompose_col2im, so the node is left
+        # undecomposed instead of being replaced.
+        col2im_skip_cases = [
             (
                 "col2im_stride_mismatch",
                 DecomposeColIm._Col2ImStrideMismatch(),
@@ -1484,19 +1565,18 @@ class DecomposeColIm:
                 ),
             ),
         ]
-        for label, module, inputs in col2im_fail_cases:
+        for label, module, inputs in col2im_skip_cases:
             with subtests.test(msg=label):
-                with pytest.raises(  # noqa: B017
-                    Exception, check=check_exception(EXCEPTION_FROM_PASSES)
-                ):
-                    pass_pipeline.lower_edge_ep(
-                        module=module,
-                        sample_input=inputs,
-                        backend_type=backend_type,
-                        compile_spec=compile_spec,
-                        target_pass=target_pass,
-                        quantizer=quantizer,
-                    )
+                gm = pass_pipeline.lower_edge_ep(
+                    module=module,
+                    sample_input=inputs,
+                    backend_type=backend_type,
+                    compile_spec=compile_spec,
+                    target_pass=target_pass,
+                    quantizer=quantizer,
+                ).graph_module
+                assertions.assert_target_count(gm, col2im_op, 1)
+                assertions.assert_no_target(gm, pixel_shuffle_op)
 
 
 class DecomposeDiagonal:

--- a/backends/qualcomm/tests/test_passes.py
+++ b/backends/qualcomm/tests/test_passes.py
@@ -6,6 +6,7 @@ from executorch.backends.qualcomm._passes import (
     AnnotateQuantAttrs,
     ConvertBmmToMatmul,
     ConvertMhaToSha,
+    DecomposeColIm,
     ExpandBroadcastTensorShape,
     FoldQDQ,
     InsertIOQDQ,
@@ -33,6 +34,7 @@ from executorch.backends.qualcomm.tests.models import (
     HardSigmoid,
     Reciprocal,
     TopKandIndex,
+    Unfold,
 )
 from executorch.backends.qualcomm.utils.utils import (
     generate_htp_compiler_spec,
@@ -348,6 +350,140 @@ class TestPasses(unittest.TestCase):
                 torch.allclose(out, *ref, rtol=1e-6, atol=1e-6),
                 f"Output {i} mismatch: got {out}, expected {ref}",
             )
+
+    def test_decompose_im2col_matches_unfold(self):
+        """DecomposeColIm's im2col decomposition must produce the exact same
+        values as torch.nn.functional.unfold, across all three decomposition
+        branches:
+          - stride == kernel_size, square kernel -> pixel_unshuffle
+          - stride == kernel_size, non-square kernel -> qnn_custom.space_to_depth
+          - stride != kernel_size -> index_select gather + the tail above
+        """
+        cases = [
+            ((2, 4, 8, 8), (2, 2), (2, 2), (0, 0)),  # stride == kernel_size, square
+            ((2, 4, 9, 6), (3, 2), (3, 2), (0, 0)),  # stride == kernel_size, non-square
+            (
+                (2, 4, 8, 8),
+                (2, 2),
+                (1, 1),
+                (0, 0),
+            ),  # stride != kernel_size, square kernel
+            (
+                (1, 2, 7, 9),
+                (2, 3),
+                (1, 1),
+                (0, 0),
+            ),  # stride != kernel_size, non-square kernel
+            (
+                (1, 3, 10, 10),
+                (3, 3),
+                (2, 2),
+                (0, 0),
+            ),  # stride != kernel_size, overlapping
+            (
+                (2, 4, 6, 6),
+                (2, 2),
+                (2, 2),
+                (1, 1),
+            ),  # nonzero padding, stride == kernel_size
+            (
+                (2, 4, 6, 6),
+                (2, 2),
+                (1, 1),
+                (1, 1),
+            ),  # nonzero padding, stride != kernel_size
+        ]
+        for shape, kernel_size, stride, padding in cases:
+            with self.subTest(
+                shape=shape, kernel_size=kernel_size, stride=stride, padding=padding
+            ):
+
+                x = torch.randn(*shape)
+                module = Unfold(kernel_size, stride, padding).eval()
+                ref = module(x)
+                exported_program = torch.export.export(module, (x,), strict=True)
+                ep = to_edge(
+                    exported_program,
+                    compile_config=EdgeCompileConfig(
+                        preserve_ops=[torch.ops.aten.im2col.default]
+                    ),
+                ).exported_program()
+                self.assertTrue(
+                    any(
+                        n.target == exir_ops.edge.aten.im2col.default
+                        for n in ep.graph_module.graph.nodes
+                    ),
+                    "im2col was decomposed in to_edge",
+                )
+                gm = DecomposeColIm()(ep.graph_module).graph_module
+                gm.recompile()
+
+                # Decomposition must actually have run: no im2col node left.
+                self.assertFalse(
+                    any(
+                        n.target == exir_ops.edge.aten.im2col.default
+                        for n in gm.graph.nodes
+                    ),
+                    "im2col node was not decomposed",
+                )
+
+                out = gm(x)
+                if isinstance(out, (list, tuple)):
+                    out = out[0]
+                self.assertTrue(
+                    torch.allclose(ref, out),
+                    f"unfold decomposition mismatch for kernel_size={kernel_size}, "
+                    f"stride={stride}: got {out}, expected {ref}",
+                )
+
+    def test_decompose_im2col_fallback(self):
+        """When stride < kernel_size, the index_select gather in
+        DecomposeColIm duplicates elements by roughly
+        (kernel_height/stride_height) * (kernel_width/stride_width).
+        Above DecomposeColIm._MAX_GATHER_EXPANSION_FACTOR, the pass must skip
+        decomposition rather than build an unbounded gather. Since QNN has no
+        node visitor for aten.im2col, the un-decomposed node then falls back
+        to CPU when lowered.
+        """
+        cases = [
+            # factor == (8/2)*(8/2) <= MAX_GATHER_EXPANSION_FACTOR: decomposed.
+            ((1, 1, 20, 20), (8, 8), (2, 2), True),
+            # factor == (9/2)*(9/2) > MAX_GATHER_EXPANSION_FACTOR: falls back.
+            ((1, 1, 20, 20), (9, 9), (2, 2), False),
+        ]
+        for shape, kernel_size, stride, should_decompose in cases:
+            with self.subTest(shape=shape, kernel_size=kernel_size, stride=stride):
+
+                x = torch.randn(*shape)
+                module = Unfold(kernel_size, stride).eval()
+
+                exported_program = torch.export.export(module, (x,), strict=True)
+                ep = to_edge(
+                    exported_program,
+                    compile_config=EdgeCompileConfig(
+                        preserve_ops=[torch.ops.aten.im2col.default]
+                    ),
+                ).exported_program()
+                self.assertTrue(
+                    any(
+                        n.target == exir_ops.edge.aten.im2col.default
+                        for n in ep.graph_module.graph.nodes
+                    ),
+                    "im2col was decomposed in to_edge",
+                )
+                gm = DecomposeColIm()(ep.graph_module).graph_module
+                gm.recompile()
+
+                im2col_present = any(
+                    n.target == exir_ops.edge.aten.im2col.default
+                    for n in gm.graph.nodes
+                )
+                self.assertNotEqual(
+                    im2col_present,
+                    should_decompose,
+                    f"im2col {'should' if should_decompose else 'should NOT'} be "
+                    f"decomposed for kernel_size={kernel_size}, stride={stride}",
+                )
 
     def test_resolve_debug_handle(self):
         name_handle_map = {

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -2699,9 +2699,17 @@ class TestQNNFloatingPointOperator(TestQNN):
         self.lower_module_and_test_output(module, sample_input)
 
     def test_qnn_backend_unfold(self):
-        sample_input = (torch.randn(2, 128, 32, 32),)
-        module = Unfold()  # noqa: F405
-        self.lower_module_and_test_output(module, sample_input)
+        sample_input = (torch.randn(2, 128, 64, 64),)
+        modules = [
+            Unfold(kernel_size=(2, 2), stride=(2, 2)),  # noqa: F405
+            Unfold(kernel_size=(2, 2), stride=(1, 1)),  # noqa: F405
+            Unfold(kernel_size=(2, 1), stride=(2, 1)),  # noqa: F405
+            Unfold(kernel_size=(2, 2), stride=(2, 1)),  # noqa: F405
+            Unfold(kernel_size=(2, 2), stride=(2, 2), padding=(1, 1)),  # noqa: F405
+        ]
+        for index, module in enumerate(modules):
+            with self.subTest(i=index):
+                self.lower_module_and_test_output(module, sample_input)
 
     def test_qnn_backend_unsqueeze(self):
         module = Unsqueeze()  # noqa: F405
@@ -6330,10 +6338,18 @@ class TestQNNQuantizedOperator(TestQNN):
         self.lower_module_and_test_output(module, sample_input)
 
     def test_qnn_backend_unfold(self):
-        sample_input = (torch.randn(2, 128, 32, 32),)
-        module = Unfold()  # noqa: F405
-        module = self.get_qdq_module(module, sample_input)
-        self.lower_module_and_test_output(module, sample_input)
+        sample_input = (torch.randn(2, 128, 64, 64),)
+        modules = [
+            Unfold(kernel_size=(2, 2), stride=(2, 2)),  # noqa: F405
+            Unfold(kernel_size=(2, 2), stride=(1, 1)),  # noqa: F405
+            Unfold(kernel_size=(2, 1), stride=(2, 1)),  # noqa: F405
+            Unfold(kernel_size=(2, 2), stride=(2, 1)),  # noqa: F405
+            Unfold(kernel_size=(2, 2), stride=(2, 2), padding=(1, 1)),  # noqa: F405
+        ]
+        for index, module in enumerate(modules):
+            with self.subTest(i=index):
+                qdq_module = self.get_qdq_module(module, sample_input)
+                self.lower_module_and_test_output(qdq_module, sample_input)
 
     def test_qnn_backend_unsqueeze(self):
         module = Unsqueeze()  # noqa: F405


### PR DESCRIPTION
### Summary
To solve the issue mentioned in https://github.com/pytorch/executorch/issues/19690.
The issue requires support for case kernel != stride and padding!=0.
```
dequantize_per_tensor_892: "f32[1, 1, 312, 552][172224, 172224, 552, 1]cuda:0" = torch.ops.quantized_decomposed.dequantize_per_tensor.default(quantize_per_tensor_590, 0.17020832002162933, 0, 0, 255, torch.uint8);  quantize_per_tensor_590 = None
im2col: "f32[1, 9, 172224][1550016, 172224, 1]cuda:0" = torch.ops.aten.im2col.default(dequantize_per_tensor_892, [3, 3], [1, 1], [1, 1], [1, 1]);  dequantize_per_tensor_892 = None
        
```
- Rewrite the pass to support case kernel != stride and padding!=0.
- Replace pixel_unshuffle to qnn custom op since torch pixel_unshuffle op doesn't
  support different block_size.
- Remove assertion error so op not supported by QNN fallback to cpu.

### Test plan
```
python backends/qualcomm/tests/test_qnn_delegate.py -k "test_qnn_backend_unfold" --device ef5e4029 --host localhost --soc_model SM8850 --build_folder build-android --executorch_root . --artifact test_qnn_delegate_artifact

python backends/qualcomm/tests/test_passes.py -k "test_decompose_im2col"

pytest backends/qualcomm/tests/rework/htp/op/v68/test.py --build_folder build-android --soc_model SM8850 --device ef5e4029 -k test_unfold

pytest backends/qualcomm/tests/rework/passes/test.py -k "decompose_col_im"
```

cc @cbilgin @psiddh