### PR TITLE
NXP backend: Register Neutron backend recipes.

### DIFF
--- a/backends/nxp/recipes/__init__.py
+++ b/backends/nxp/recipes/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2026 NXP
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from executorch.export import recipe_registry
+
+from .nxp_recipe_provider import NeutronRecipeConfig, NXPRecipeProvider
+from .nxp_recipe_types import NXPRecipeType
+
+# Auto-register NXP recipe provider
+recipe_registry.register_backend_recipe_provider(NXPRecipeProvider())
+
+__all__ = [
+    "NeutronRecipeConfig",
+    "NXPRecipeProvider",
+    "NXPRecipeType",
+]


### PR DESCRIPTION
### Summary
Register Neutron backend recipes.

### Test plan
N/A

cc @robert-kalmar @JakeStevens @digantdesai @rascani