### PR TITLE
Stop the lora teardowns deleting the HF cache

### DIFF
--- a/.ci/scripts/test_lora.sh
+++ b/.ci/scripts/test_lora.sh
@@ -28,11 +28,14 @@ cmake_build_llama_runner() {
 }
 
 cleanup_files() {
-  echo "Deleting downloaded and generated files"
-  rm -rf "${HF_QWEN_PATH}/"
-  rm -rf "${HF_ADAPTER_PATH}/"
-  rm -rf *.pte *.ptd
-  rm result*.txt
+  # Only what this script generated. HF_QWEN_PATH and HF_ADAPTER_PATH point
+  # inside the huggingface_hub cache: on OSDC that is a shared read-only mount,
+  # so removing them failed the job after the tests had already passed, and
+  # anywhere else it discards a cache entry the next job wants. A teardown also
+  # must not fail a run whose tests passed.
+  echo "Deleting generated files"
+  rm -rf ./*.pte ./*.ptd || true
+  rm -f result*.txt || true
 }
 
 matches_base_response_prefix() {

--- a/.ci/scripts/test_lora_multimethod.sh
+++ b/.ci/scripts/test_lora_multimethod.sh
@@ -28,11 +28,14 @@ cmake_build_llama_runner() {
 }
 
 cleanup_files() {
-  echo "Deleting downloaded and generated files"
-  rm -rf "${HF_QWEN_PATH}/"
-  rm -rf "${HF_ADAPTER_PATH}/"
-  rm -rf *.pte
-  rm -f result*.txt
+  # Only what this script generated. HF_QWEN_PATH and HF_ADAPTER_PATH point
+  # inside the huggingface_hub cache: on OSDC that is a shared read-only mount,
+  # so removing them failed the job after the tests had already passed, and
+  # anywhere else it discards a cache entry the next job wants. A teardown also
+  # must not fail a run whose tests passed.
+  echo "Deleting generated files"
+  rm -rf ./*.pte || true
+  rm -f result*.txt || true
 }
 
 matches_base_response_prefix() {


### PR DESCRIPTION
`test_lora.sh` and `test_lora_multimethod.sh` resolve their model paths through `huggingface_hub`, which returns a path *inside* the hub cache:

```bash
HF_QWEN_PATH=$(python -c "... print(snapshot_download('unsloth/Qwen3-0.6B'))")
```

then hand those paths to `rm -rf` on the way out. On OSDC the cache is a shared read-only mount, so the `rm` fails — and under `set -e` that fails the job *after the tests have already passed*:

```
Multimethod tests passed!
+ cleanup_files
+ rm -rf /mnt/hf_cache/hub/models--unsloth--Qwen3-0.6B/snapshots/db4e90b8.../
rm: cannot remove '.../.gitattributes': Read-only file system
##[error]Process completed with exit code 1.
```

Off OSDC it succeeds and is still wrong: it discards a cache entry the next job has to download again.

So the teardown now removes only what these scripts generate, and can't fail a run whose tests passed. `test_llama.sh` and `test_yolo26.sh` share the function name but only ever removed their own files, so they're untouched.

Seen on pytorch/executorch#22632's `test-lora-multimethod-linux`: https://github.com/pytorch/executorch/actions/runs/34326595941/job/102385366170

Authored with Claude Code.
