### PR TITLE
Arm backend: Deduplicate constants emitted during TOSA lowering

### DIFF
--- a/backends/arm/_passes/__init__.py
+++ b/backends/arm/_passes/__init__.py
@@ -122,6 +122,7 @@ from .decompose_unsupported_bilinear_resize_pass import (  # noqa
 from .decompose_var_pass import DecomposeVarPass  # noqa
 from .decompose_where_scalar_other_pass import DecomposeWhereScalarOtherPass  # noqa
 from .decorate_fp32_to_int32_casting_pass import DecorateFp32toInt32CastingPass  # noqa
+from .deduplicate_const_shapes_pass import DeduplicateConstShapesPass  # noqa
 from .deduplicate_get_attr_pass import DeduplicateGetAttrPass  # noqa
 from .ensure_unique_output_nodes_pass import EnsureUniqueOutputNodesPass  # noqa
 from .exir_to_tosa_pass import ExirToTosaPass  # noqa

--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -109,6 +109,7 @@ from executorch.backends.arm._passes import (  # type: ignore[attr-defined]
     DecomposeVarPass,
     DecomposeWhereScalarOtherPass,
     DecorateFp32toInt32CastingPass,
+    DeduplicateConstShapesPass,
     DeduplicateGetAttrPass,
     EnsureUniqueOutputNodesPass,
     ExirToTosaPass,
@@ -725,6 +726,7 @@ class ArmPassManager(ExportedProgramPassManager):
                 # fusing generated RESCALE users can corrupt distinct quantized paths.
                 FuseDuplicateUsersPass(),
                 InsertRescalePass(),
+                DeduplicateConstShapesPass(),
                 EnsureUniqueOutputNodesPass(),
             ]
         )

--- a/backends/arm/_passes/deduplicate_const_shapes_pass.py
+++ b/backends/arm/_passes/deduplicate_const_shapes_pass.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Set, Type
+
+from executorch.backends.arm._passes import ArmPass
+from executorch.exir.dialects._ops import ops as exir_ops
+from executorch.exir.pass_base import ExportPass, PassResult
+from torch.fx import GraphModule, Node
+
+
+class DeduplicateConstShapesPass(ArmPass):
+    """Reuse the first CONST_SHAPE node with identical static values."""
+
+    _passes_required_after: Set[Type[ExportPass]] = set()
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        representatives: dict[tuple[int, ...], Node] = {}
+        modified = False
+
+        for node in list(graph_module.graph.nodes):
+            if node.target != exir_ops.backend.tosa.CONST_SHAPE.default:
+                continue
+
+            values = node.args[0]
+            if not isinstance(values, (list, tuple)) or not all(
+                type(value) is int for value in values
+            ):
+                continue
+
+            key = tuple(values)
+            representative = representatives.get(key)
+            if representative is None:
+                representatives[key] = node
+                continue
+
+            node.replace_all_uses_with(representative)
+            graph_module.graph.erase_node(node)
+            modified = True
+
+        if modified:
+            graph_module.graph.lint()
+            graph_module.recompile()
+
+        return PassResult(graph_module, modified)

--- a/backends/arm/operators/BUCK
+++ b/backends/arm/operators/BUCK
@@ -33,6 +33,7 @@ fbcode_target(
         "fbsource//third-party/tosa_tools:tosa",
         ":node_visitor",
         ":operator_validation_utils",
+        "//executorch/backends/arm/tosa:constant_pool",
         "//executorch/backends/arm/tosa:mapping",
         "//executorch/backends/arm/tosa:utils",
         "//executorch/backends/arm/_passes:passes",

--- a/backends/arm/operators/op_tosa_matmul.py
+++ b/backends/arm/operators/op_tosa_matmul.py
@@ -76,8 +76,12 @@ class MatmulVisitor(NodeVisitor):
 
         input_A_ZP_name = f"{output.name}_A_ZP"
         input_B_ZP_name = f"{output.name}_B_ZP"
-        tosa_graph.addConst([1], inputs[0].dtype, [input0_zp], name=input_A_ZP_name)
-        tosa_graph.addConst([1], inputs[1].dtype, [input1_zp], name=input_B_ZP_name)
+        input_A_ZP = tosa_graph.addConst(
+            [1], inputs[0].dtype, [input0_zp], name=input_A_ZP_name
+        )
+        input_B_ZP = tosa_graph.addConst(
+            [1], inputs[1].dtype, [input1_zp], name=input_B_ZP_name
+        )
 
         # Add the MATMUL to the TOSA graph.
         attr = ts.TosaSerializerAttribute()
@@ -90,8 +94,8 @@ class MatmulVisitor(NodeVisitor):
             [
                 inputs[0].name,
                 inputs[1].name,
-                input_A_ZP_name,
-                input_B_ZP_name,
+                input_A_ZP.name,
+                input_B_ZP.name,
             ],
             [output.name],
             attr,

--- a/backends/arm/operators/op_tosa_mul.py
+++ b/backends/arm/operators/op_tosa_mul.py
@@ -47,14 +47,14 @@ class MulVisitor(NodeVisitor):
             self.tosa_spec,
         )
 
-        tosa_graph.addConst([1], ts.DType.INT8, 0, name=f"{output.name}_shift")
+        shift = tosa_graph.addConst([1], ts.DType.INT8, 0, name=f"{output.name}_shift")
         attr = ts.TosaSerializerAttribute()
         attr.MulAttribute()
         self._serialize_operator(
             node,
             tosa_graph,
             ts.Op.MUL,
-            [inputs[0].name, inputs[1].name, f"{output.name}_shift"],
+            [inputs[0].name, inputs[1].name, shift.name],
             [output.name],
             attr,
         )

--- a/backends/arm/operators/op_tosa_shapes.py
+++ b/backends/arm/operators/op_tosa_shapes.py
@@ -14,6 +14,7 @@ from executorch.backends.arm.operators.node_visitor import (
     register_node_visitor,
 )
 from executorch.backends.arm.tosa import TosaSpecification
+from executorch.backends.arm.tosa.constant_pool import TosaSerializerWithConstantPool
 from executorch.backends.arm.tosa.mapping import TosaArg
 from executorch.backends.arm.tosa.utils import normalize_symint
 
@@ -32,8 +33,10 @@ class TosaConstShapeVisitor(NodeVisitor):
         shape_input = inputs[0].special
         rank = len(shape_input)
         vals = normalize_symint(node.meta["val"])
-        tosa_graph = cast(ts.TosaSerializer, tosa_graph)
-        tosa_graph.addConst(
+        tosa_graph = cast(TosaSerializerWithConstantPool, tosa_graph)
+        # Downstream visitors reference this FX output by name. Pooling it with a
+        # serializer-generated constant could leave output.name undefined.
+        tosa_graph.addUnpooledConst(
             [
                 rank,
             ],

--- a/backends/arm/operators/ops_quant_utils.py
+++ b/backends/arm/operators/ops_quant_utils.py
@@ -25,12 +25,11 @@ def add_input_weight_zp_consts(tosa_graph, node, inputs, output_name):
     input_zp_name = f"{output_name}_input_zp"
     weight_zp_name = f"{output_name}_weight_zp"
 
-    tosa_graph.addConst([1], inputs[0].dtype, [input_zp], name=input_zp_name)
-    tosa_graph.addConst(
-        [1],
-        inputs[1].dtype,
-        weight_zp,
-        name=weight_zp_name,
+    input_zp_tensor = tosa_graph.addConst(
+        [1], inputs[0].dtype, [input_zp], name=input_zp_name
+    )
+    weight_zp_tensor = tosa_graph.addConst(
+        [1], inputs[1].dtype, weight_zp, name=weight_zp_name
     )
 
-    return input_zp_name, weight_zp_name
+    return input_zp_tensor.name, weight_zp_tensor.name

--- a/backends/arm/process_node.py
+++ b/backends/arm/process_node.py
@@ -106,12 +106,18 @@ def _add_const(
     tosa_arg: TosaArg,
     name: str,
 ) -> None:
-    """Add a constant, preserving packed FP4 storage when required."""
+    """Add a graph-owned constant under its exact name.
+
+    Parameters, buffers, and lifted constants are referenced by their FX names,
+    so pooling them could leave those names undefined. Preserve packed FP4
+    storage when required.
+
+    """
     if _is_packed_fp4_const(values, tosa_arg):
         # TOSA FP4 tensors have logical FP4 shape, but constants are stored as
         # packed bytes (two values per byte). Add the raw bytes as INT8 first
         # then set TOSA dtype and shape correctly on the tensor metadata.
-        tosa_graph.addConst(
+        tosa_graph.addUnpooledConst(
             normalize_symint(values.shape),
             ts.DType.INT8,
             values,
@@ -124,7 +130,7 @@ def _add_const(
         return
 
     prepared_values = _prepare_const_values_for_tosa_dtype(values, tosa_arg)
-    tosa_graph.addConst(
+    tosa_graph.addUnpooledConst(
         _get_const_shape(prepared_values, tosa_arg),
         tosa_arg.dtype,
         prepared_values,

--- a/backends/arm/test/misc/test_process_node.py
+++ b/backends/arm/test/misc/test_process_node.py
@@ -10,6 +10,7 @@ import numpy as np
 import torch
 import tosa_serializer as ts
 from executorch.backends.arm.process_node import _add_const, process_placeholder
+from executorch.backends.arm.tosa.constant_pool import TosaSerializerWithConstantPool
 from executorch.backends.arm.tosa.mapping import TosaArg, TosaSpecialDtype
 from executorch.backends.arm.tosa.specification import TosaSpecification
 from executorch.exir import to_edge
@@ -39,7 +40,7 @@ class CapturingTosaGraph:
         self.name = None
         self.serialized_bytes = None
 
-    def addConst(self, shape, dtype, values, name):
+    def addUnpooledConst(self, shape, dtype, values, name):
         self.shape = shape
         self.dtype = dtype
         self.values = np.asarray(values)
@@ -111,7 +112,7 @@ def test_add_const_fp4_in_packed_storage() -> None:
         TosaArg,
         SimpleNamespace(dtype=ts.DType.FP4E2M1, shape=(1, 1, 8)),
     )
-    tosa_graph = ts.TosaSerializer()
+    tosa_graph = TosaSerializerWithConstantPool()
 
     _add_const(tosa_graph, packed_values, tosa_arg, name="fp4_weight")
 
@@ -140,7 +141,7 @@ def _test_add_const_fp6_in_packed_storage(dtype: int) -> None:
         TosaArg,
         SimpleNamespace(dtype=dtype, shape=(1, 1, 32)),
     )
-    tosa_graph = ts.TosaSerializer()
+    tosa_graph = TosaSerializerWithConstantPool()
 
     _add_const(tosa_graph, values, tosa_arg, name="fp6_weight")
 

--- a/backends/arm/test/misc/test_tosa_constant_pool.py
+++ b/backends/arm/test/misc/test_tosa_constant_pool.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import numpy as np
+import pytest
+import tosa_serializer as ts
+from executorch.backends.arm.tosa.constant_pool import TosaSerializerWithConstantPool
+
+
+def _serializer(path_prefix=""):
+    return TosaSerializerWithConstantPool(
+        path_prefix,
+        targetMajor=1,
+        targetMinor=0,
+        targetPatch=0,
+        targetDraft=False,
+    )
+
+
+def test_identical_constants_are_reused():
+    serializer = _serializer()
+
+    first = serializer.addConst([1], ts.DType.INT8, [0], name="first")
+    second = serializer.addConst([1], ts.DType.INT8, [0], name="second")
+
+    assert isinstance(serializer, ts.TosaSerializer)
+    assert second is first
+    assert first.name == "first"
+    assert len(serializer.currRegion.currBasicBlock.operators) == 1
+    assert list(serializer.currRegion.currBasicBlock.tensors.keys()) == ["first"]
+
+
+def test_unpooled_constants_are_not_reused():
+    serializer = _serializer()
+
+    first = serializer.addUnpooledConst([1], ts.DType.INT8, [0], name="first")
+    second = serializer.addUnpooledConst([1], ts.DType.INT8, [0], name="second")
+
+    assert second is not first
+    assert len(serializer.currRegion.currBasicBlock.operators) == 2
+    assert list(serializer.currRegion.currBasicBlock.tensors.keys()) == [
+        "first",
+        "second",
+    ]
+
+
+def test_unnamed_constant_uses_serializer_generated_name():
+    serializer = _serializer()
+
+    constant = serializer.addConst([1], ts.DType.INT8, [0])
+
+    assert constant.name
+
+
+@pytest.mark.parametrize(
+    "first,second",
+    [
+        (([1], ts.DType.INT8, [0]), ([1], ts.DType.INT16, [0])),
+        (([1], ts.DType.INT8, [0]), ([2], ts.DType.INT8, [0, 0])),
+        (([1], ts.DType.INT8, [0]), ([1], ts.DType.INT8, [1])),
+    ],
+)
+def test_constants_with_different_keys_remain_separate(first, second):
+    serializer = _serializer()
+
+    first_const = serializer.addConst(*first, name="first")
+    second_const = serializer.addConst(*second, name="second")
+
+    assert second_const is not first_const
+    assert len(serializer.currRegion.currBasicBlock.operators) == 2
+
+
+def test_float_constants_use_exact_serialized_values():
+    serializer = _serializer()
+
+    positive_zero = serializer.addConst(
+        [1], ts.DType.FP32, np.array([0.0]), name="positive_zero"
+    )
+    negative_zero = serializer.addConst(
+        [1], ts.DType.FP32, np.array([-0.0]), name="negative_zero"
+    )
+    repeated_negative_zero = serializer.addConst(
+        [1],
+        ts.DType.FP32,
+        np.array([-0.0]),
+        name="repeated_negative_zero",
+    )
+
+    assert negative_zero is not positive_zero
+    assert repeated_negative_zero is negative_zero
+    assert len(serializer.currRegion.currBasicBlock.operators) == 2
+
+
+def test_constants_are_scoped_to_basic_blocks():
+    serializer = _serializer()
+    first = serializer.addConst([1], ts.DType.INT8, [0], name="first")
+
+    serializer.startRegion("main")
+    serializer.currRegion.addBasicBlock("main")
+    second = serializer.addConst([1], ts.DType.INT8, [0], name="second")
+
+    assert second is not first
+    assert second.name == "second"
+
+
+def test_start_region_preserves_path_prefix():
+    serializer = _serializer("artifacts")
+
+    serializer.startRegion("other")
+
+    assert serializer.currRegion.pathPrefix == "artifacts"
+
+
+def test_constant_pool_serialization_is_deterministic():
+    def serialize():
+        serializer = _serializer()
+        serializer.addConst([1], ts.DType.INT8, [0], name="first")
+        serializer.addConst([1], ts.DType.INT8, [0], name="duplicate")
+        serializer.addConst([1], ts.DType.INT8, [1], name="second")
+        return bytes(serializer.serialize())
+
+    assert serialize() == serialize()

--- a/backends/arm/test/misc/test_tosa_constant_pool.py
+++ b/backends/arm/test/misc/test_tosa_constant_pool.py
@@ -3,6 +3,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import gc
+import weakref
+
 import numpy as np
 import pytest
 import tosa_serializer as ts
@@ -19,17 +22,34 @@ def _serializer(path_prefix=""):
     )
 
 
-def test_identical_constants_are_reused():
+@pytest.mark.parametrize("dtype", [ts.DType.INT8, ts.DType.SHAPE])
+def test_identical_constants_are_reused(dtype):
     serializer = _serializer()
 
-    first = serializer.addConst([1], ts.DType.INT8, [0], name="first")
-    second = serializer.addConst([1], ts.DType.INT8, [0], name="second")
+    first = serializer.addConst([1], dtype, [0], name="first")
+    second = serializer.addConst([1], dtype, [0], name="second")
 
     assert isinstance(serializer, ts.TosaSerializer)
     assert second is first
     assert first.name == "first"
-    assert len(serializer.currRegion.currBasicBlock.operators) == 1
-    assert list(serializer.currRegion.currBasicBlock.tensors.keys()) == ["first"]
+    block = serializer.currRegion.currBasicBlock
+    assert len(block.operators) == 1
+    constants = block.shapes if dtype == ts.DType.SHAPE else block.tensors
+    assert list(constants.keys()) == ["first"]
+
+
+@pytest.mark.parametrize("dtype", [ts.DType.INT8, ts.DType.SHAPE])
+def test_constant_pool_does_not_keep_serializer_alive(dtype):
+    serializer = _serializer()
+    serializer.addConst([1], dtype, [0], name="first")
+    serializer.addConst([1], dtype, [0], name="duplicate")
+    serializer.serialize()
+    serializer_ref = weakref.ref(serializer)
+
+    del serializer
+    gc.collect()
+
+    assert serializer_ref() is None
 
 
 def test_unpooled_constants_are_not_reused():

--- a/backends/arm/test/misc/tosa_dialect/test_tosa_shape_node_visitors.py
+++ b/backends/arm/test/misc/tosa_dialect/test_tosa_shape_node_visitors.py
@@ -17,6 +17,7 @@ from executorch.backends.arm.operators.node_visitor import (
     NodeVisitor,
 )
 from executorch.backends.arm.test.runner_utils import TosaReferenceModelDispatch
+from executorch.backends.arm.tosa.constant_pool import TosaSerializerWithConstantPool
 from executorch.backends.arm.tosa.mapping import TosaArg
 from executorch.backends.arm.tosa.specification import TosaSpecification
 from torch.fx import Node
@@ -75,7 +76,7 @@ def _shape_spec() -> TosaSpecification:
 
 
 def _serializer() -> ts.TosaSerializer:
-    return ts.TosaSerializer(
+    return TosaSerializerWithConstantPool(
         "",
         targetMajor=1,
         targetMinor=1,
@@ -287,6 +288,22 @@ def test_const_shape_node_visitor_serializes_const_operator() -> None:
     )
 
     assert _serialized_op_codes(tosa_graph) == [ts.Op.CONST_SHAPE]
+
+
+def test_const_shape_node_visitor_preserves_output_name() -> None:
+    visitor = get_node_visitors(_shape_spec())["tosa.CONST_SHAPE.default"]
+    tosa_graph = _serializer()
+    tosa_graph.addConst([2], ts.DType.SHAPE, [2, 3], name="helper")
+
+    _define_node(
+        visitor,
+        SimpleNamespace(name="node", meta={"val": [2, 3]}, kwargs={}),
+        tosa_graph,
+        [SimpleNamespace(special=[2, 3])],
+        SimpleNamespace(name="output", shape=(2,)),
+    )
+
+    assert list(tosa_graph.currRegion.currBasicBlock.shapes) == ["helper", "output"]
 
 
 def test_dim_shape_node_visitor_serializes_operator() -> None:

--- a/backends/arm/test/ops/test_conv2d.py
+++ b/backends/arm/test/ops/test_conv2d.py
@@ -566,7 +566,8 @@ def _get_dtype_count(model: torch.nn.Module):
     # Set nbr_conv to be the amount of groups set if necessary.
     nbr_convs: int = model.nbr_convs if model.groups is None else model.groups  # noqa
     return {
-        "CONST": {"INT4": nbr_convs * 2},  # One for the weight, one for the zp.
+        # Each convolution has a distinct weight and shares the symmetric zero point.
+        "CONST": {"INT4": nbr_convs + 1},
         "CONV2D": {"INT32": nbr_convs},
         "RESCALE": {"INT8": nbr_convs},
     }

--- a/backends/arm/test/ops/test_conv3d.py
+++ b/backends/arm/test/ops/test_conv3d.py
@@ -585,7 +585,8 @@ test_data_INT16 = {
 def _get_dtype_count(model: torch.nn.Module):
     nbr_convs: int = model.nbr_convs  # noqa
     return {
-        "CONST": {"INT4": nbr_convs * 2},
+        # Each convolution has a distinct weight and shares the symmetric zero point.
+        "CONST": {"INT4": nbr_convs + 1},
         "CONV3D": {"INT32": nbr_convs},
         "RESCALE": {"INT8": nbr_convs},
     }

--- a/backends/arm/test/ops/test_depthwise_conv.py
+++ b/backends/arm/test/ops/test_depthwise_conv.py
@@ -264,7 +264,8 @@ test_data_conv1d_INT = {
 def _get_dtype_count(model: torch.nn.Module):
     nbr_convs: int = model.nbr_convs  # noqa
     return {
-        "CONST": {"INT4": nbr_convs * 2},
+        # Each convolution has a distinct weight and shares the symmetric zero point.
+        "CONST": {"INT4": nbr_convs + 1},
         "DEPTHWISE_CONV2D": {"INT32": nbr_convs},
         "RESCALE": {"INT8": nbr_convs},
     }

--- a/backends/arm/test/passes/test_deduplicate_const_shapes_pass.py
+++ b/backends/arm/test/passes/test_deduplicate_const_shapes_pass.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from executorch.backends.arm._passes import DeduplicateConstShapesPass
+from executorch.exir.dialects._ops import ops as exir_ops
+from torch.fx import Graph, GraphModule
+
+
+def _const_shape(graph: Graph, name: str, values: list[int]):
+    node = graph.call_function(
+        exir_ops.backend.tosa.CONST_SHAPE.default,
+        (values,),
+    )
+    node.name = name
+    node.meta["val"] = values
+    return node
+
+
+def test_deduplicate_identical_const_shapes():
+    graph = Graph()
+    first = _const_shape(graph, "first", [2, 3])
+    second = _const_shape(graph, "second", [2, 3])
+    graph.output((first, second))
+    graph_module = GraphModule(torch.nn.Module(), graph)
+
+    result = DeduplicateConstShapesPass()(graph_module)
+
+    assert result is not None
+    assert result.modified
+    const_shapes = [
+        node
+        for node in graph_module.graph.nodes
+        if node.target == exir_ops.backend.tosa.CONST_SHAPE.default
+    ]
+    assert [node.name for node in const_shapes] == ["first"]
+    assert graph_module.graph.output_node().args[0] == (first, first)
+
+
+def test_keep_const_shapes_with_different_values():
+    graph = Graph()
+    first = _const_shape(graph, "first", [2, 3])
+    second = _const_shape(graph, "second", [3, 2])
+    graph.output((first, second))
+    graph_module = GraphModule(torch.nn.Module(), graph)
+
+    result = DeduplicateConstShapesPass()(graph_module)
+
+    assert result is not None
+    assert not result.modified
+    const_shapes = [
+        node
+        for node in graph_module.graph.nodes
+        if node.target == exir_ops.backend.tosa.CONST_SHAPE.default
+    ]
+    assert const_shapes == [first, second]

--- a/backends/arm/test/passes/test_fuse_duplicate_users_pass.py
+++ b/backends/arm/test/passes/test_fuse_duplicate_users_pass.py
@@ -8,6 +8,7 @@ from typing import Dict, Tuple
 import executorch.backends.arm.tosa.dialect  # noqa: F401
 import torch
 from executorch.backends.arm._passes import (
+    DeduplicateConstShapesPass,
     EnsureUniqueOutputNodesPass,
     FuseDuplicateUsersPass,
     InsertRescalePass,
@@ -222,8 +223,9 @@ def test_fuse_duplicate_users_runs_after_tosa_transformations():
         for index, pass_type in enumerate(pass_types)
         if pass_type is RemoveNoopPass
     )
-    assert pass_types[post_noop_index + 1 : post_noop_index + 4] == [
+    assert pass_types[post_noop_index + 1 : post_noop_index + 5] == [
         FuseDuplicateUsersPass,
         InsertRescalePass,
+        DeduplicateConstShapesPass,
         EnsureUniqueOutputNodesPass,
     ]

--- a/backends/arm/test/passes/test_remove_data_layout_noops.py
+++ b/backends/arm/test/passes/test_remove_data_layout_noops.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from executorch.backends.arm._passes import (
     CanonicalizeViewCopyPermutePass,
+    DeduplicateConstShapesPass,
     EnsureUniqueOutputNodesPass,
     ExirToTosaPass,
     FuseDuplicateUsersPass,
@@ -499,4 +500,5 @@ def test_data_layout_noop_cleanup_pipeline_order():
     assert pass_types[pre_tosa_cleanup + 1] is CanonicalizeViewCopyPermutePass
     assert pass_types[post_tosa_cleanup + 1] is FuseDuplicateUsersPass
     assert pass_types[post_tosa_cleanup + 2] is InsertRescalePass
-    assert pass_types[post_tosa_cleanup + 3] is EnsureUniqueOutputNodesPass
+    assert pass_types[post_tosa_cleanup + 3] is DeduplicateConstShapesPass
+    assert pass_types[post_tosa_cleanup + 4] is EnsureUniqueOutputNodesPass

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -66,6 +66,7 @@ def define_arm_tests():
         "misc/test_external_vela_blocks.py",
         # "misc/test_evaluate_model.py",
         "misc/test_pass_pipeline_config.py",
+        "misc/test_tosa_constant_pool.py",
         "misc/tosa_dialect/test_tosa_dialect_cast_to_block_scaled.py",
         "misc/tosa_dialect/test_tosa_dialect_mxfp_conv2d.py",
         "misc/tosa_dialect/test_tosa_dialect_mxfp_linear.py",

--- a/backends/arm/tosa/BUCK
+++ b/backends/arm/tosa/BUCK
@@ -24,6 +24,16 @@ fbcode_target(_kind = runtime.python_library,
 )
 
 fbcode_target(_kind = runtime.python_library,
+    name = "constant_pool",
+    srcs = [
+        "constant_pool.py",
+    ],
+    deps = [
+        "fbsource//third-party/tosa_tools:serializer",
+    ],
+)
+
+fbcode_target(_kind = runtime.python_library,
     name = "mapping",
     srcs = [
         "mapping.py",
@@ -95,6 +105,7 @@ fbcode_target(_kind = runtime.python_library,
     ],
     deps = [
         ":compile_spec",
+        ":constant_pool",
         "//executorch/backends/arm:constants",
         "//executorch/backends/arm:process_node",
         "//executorch/backends/arm/debug:schema",

--- a/backends/arm/tosa/backend.py
+++ b/backends/arm/tosa/backend.py
@@ -31,6 +31,7 @@ from executorch.backends.arm.process_node import (
     process_placeholder,
 )
 from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
+from executorch.backends.arm.tosa.constant_pool import TosaSerializerWithConstantPool
 from executorch.backends.arm.tosa.mapping import (
     TOSA_CONTROL_FLOW_REGION_NAME_META,
     TOSA_CONTROL_FLOW_SOURCE_NODE_META,
@@ -152,7 +153,7 @@ class TOSABackend(BackendDetails):
             artifact_path = ""
 
         version = tosa_spec.version
-        tosa_graph = ts.TosaSerializer(
+        tosa_graph = TosaSerializerWithConstantPool(
             artifact_path,
             targetMajor=version.major,
             targetMinor=version.minor,
@@ -251,7 +252,7 @@ class TOSABackend(BackendDetails):
         graph_module: GraphModule,
         edge_program: ExportedProgram,
         compile_spec: TosaCompileSpec,
-        tosa_graph: ts.TosaSerializer,
+        tosa_graph: TosaSerializerWithConstantPool,
         debug_hook: DebugHook | None,
         submodule_name: str | None = None,
         containing_graph_module: GraphModule | None = None,
@@ -262,9 +263,12 @@ class TOSABackend(BackendDetails):
             graph_module (GraphModule): Module to lower recursively.
             edge_program (ExportedProgram): Original exported program.
             compile_spec (TosaCompileSpec): Backend options with TOSA settings.
-            tosa_graph (ts.TosaSerializer): Serializer receiving operators.
+            tosa_graph (TosaSerializerWithConstantPool): Serializer receiving
+                operators.
             debug_hook (DebugHook | None): Optional debug instrumentation.
             submodule_name (str | None): Name used when visiting nested blocks.
+            containing_graph_module (GraphModule | None): Parent graph module for
+                nested control flow.
 
         Raises:
             RuntimeError: If an FX node with an unsupported op kind is found.

--- a/backends/arm/tosa/constant_pool.py
+++ b/backends/arm/tosa/constant_pool.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any
+
+import tosa_serializer as ts
+
+
+_ConstantKey = tuple[Any, tuple[int, ...], bytes | None]
+
+
+def _constant_key(shape, dtype, values) -> _ConstantKey:
+    if dtype == ts.DType.SHAPE:
+        if len(shape) > 1:
+            raise ValueError(f"CONST_SHAPE expects rank metadata, got {shape}")
+        rank = 0 if len(shape) == 0 else shape[0]
+        constant = ts.TosaSerializerShape("", rank, values)
+    else:
+        constant = ts.TosaSerializerTensor("", shape, dtype, values)
+
+    data = None if constant.data is None else bytes(constant.data)
+    return constant.dtype, tuple(constant.shape), data
+
+
+class TosaSerializerWithConstantPool(ts.TosaSerializer):
+    """Pool generated constants independently within each TOSA basic block."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._block_pools: dict[Any, dict[_ConstantKey, Any]] = {}
+
+    def addConst(self, shape, dtype, vals=None, name=""):
+        """Return a matching constant in the current block or add a new one."""
+        block = self.currRegion.currBasicBlock
+        pool = self._block_pools.setdefault(block, {})
+        key = _constant_key(shape, dtype, vals)
+        if key not in pool:
+            pool[key] = super().addConst(shape, dtype, vals, name)
+        return pool[key]
+
+    def addUnpooledConst(self, shape, dtype, vals=None, name=""):
+        """Add a constant without pooling so its requested name remains
+        addressable.
+        """
+        return super().addConst(shape, dtype, vals, name)

--- a/backends/arm/tosa/constant_pool.py
+++ b/backends/arm/tosa/constant_pool.py
@@ -29,7 +29,9 @@ class TosaSerializerWithConstantPool(ts.TosaSerializer):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._block_pools: dict[Any, dict[_ConstantKey, Any]] = {}
+        # Native tensor wrappers retain their serializer. Cache names to avoid
+        # an ownership cycle that Python's garbage collector cannot release.
+        self._block_pools: dict[Any, dict[_ConstantKey, str]] = {}
 
     def addConst(self, shape, dtype, vals=None, name=""):
         """Return a matching constant in the current block or add a new one."""
@@ -37,8 +39,18 @@ class TosaSerializerWithConstantPool(ts.TosaSerializer):
         pool = self._block_pools.setdefault(block, {})
         key = _constant_key(shape, dtype, vals)
         if key not in pool:
-            pool[key] = super().addConst(shape, dtype, vals, name)
-        return pool[key]
+            constant = super().addConst(shape, dtype, vals, name)
+            pool[key] = constant.name
+            return constant
+
+        # Resolve the cached name to the object expected by callers. TOSA stores
+        # shape constants separately from tensor constants.
+        cached_name = pool[key]
+        if dtype == ts.DType.SHAPE:
+            constant = block.getShapeByName(cached_name)
+        else:
+            constant = block.getTensorByName(cached_name)
+        return constant
 
     def addUnpooledConst(self, shape, dtype, vals=None, name=""):
         """Add a constant without pooling so its requested name remains


### PR DESCRIPTION
Pool backend-generated helper constants per TOSA basic block using dtype, shape, and exact serialized bytes as the key. Implement the pool in a TosaSerializer subclass. Helper operands use the tensor returned by addConst, making reuse safe.

Keep graph-owned constants unpooled because later lowering refers to their FX names. This covers model parameters, buffers, lifted constants, and CONST_SHAPE outputs, while preserving packed FP4 serialization.

Deduplicate identical static CONST_SHAPE nodes in FX, where their uses can safely be rewritten to the first occurrence.

Representative TOSA-FP operator comparisons:

| Model       | Before | After | Reduction   | Bytes saved |
|-------------|-------:|------:|------------:|------------:|
| SD3         |  1,518 | 1,038 | 480 (31.6%) |      89,068 |
| InceptionV3 |    673 |   456 | 217 (32.2%) |      42,092 |
| Conformer   |    488 |   365 | 123 (25.2%) |      22,852 |

This change was authored with assistance from Codex.

Change-Id: I4de44b034aff33cbf2888801238cc48df5a9124d

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani