### PR TITLE
Arm backend: Align static KV-cache tests to extensions/llm

### DIFF
--- a/backends/arm/test/modules/test_static_cache.py
+++ b/backends/arm/test/modules/test_static_cache.py
@@ -12,6 +12,7 @@ from executorch.backends.arm._passes.insert_int32_casts_after_int64_placeholders
     InsertInt32CastsAfterInt64PlaceholdersPass,
 )
 from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.arm_tester import ToExecutorch
 from executorch.backends.arm.test.tester.test_pipeline import (
     EthosU55PipelineINT,
     EthosU85PipelineINT,
@@ -19,6 +20,11 @@ from executorch.backends.arm.test.tester.test_pipeline import (
     TosaPipelineINT,
     VgfPipeline,
 )
+from executorch.examples.models.llama.source_transformation.custom_kv_cache import (
+    StaticQuantizedKVCache,
+)
+from executorch.exir import ExecutorchBackendConfig
+from executorch.exir.passes.init_mutable_pass import InitializedMutableBufferPass
 from torch.export.graph_signature import InputKind, OutputKind
 
 from transformers import LlamaConfig
@@ -41,39 +47,23 @@ EXPECTED_INPUT_COUNTS = {
     InputKind.USER_INPUT: 3,
 }
 
-EXPECTED_STATIC_QUANTIZED_INPUT_COUNTS = {
-    InputKind.BUFFER: 4,
-    InputKind.USER_INPUT: 3,
-}
-
 EXPECTED_OUTPUT_COUNTS = {
     OutputKind.BUFFER_MUTATION: 2,
     OutputKind.USER_OUTPUT: 2,
 }
 
 
-DYNAMIC_KVQ_OPS = [
-    "torch.ops.quantized_decomposed.choose_qparams_per_token_asymmetric.default",
-    "torch.ops.quantized_decomposed.quantize_per_token.default",
-    "torch.ops.quantized_decomposed.dequantize_per_token.default",
-    "torch.ops.llama.update_cache.default",
-    "torch.ops.llama.update_cache_with_indices.default",
-]
-
-
-def _reject_dynamic_kvq_ops(pipeline):
-    pipeline.add_stage_after(
-        "export", pipeline.tester.check_not, DYNAMIC_KVQ_OPS, suffix="dynamic_kvq_ops"
+def _initialize_cache_buffers(pipeline, pattern: list[str]) -> None:
+    pipeline.change_args(
+        "to_executorch",
+        ToExecutorch(
+            ExecutorchBackendConfig(passes=[InitializedMutableBufferPass(pattern)])
+        ),
     )
 
 
 @torch.no_grad()
 class StaticQuantizedCacheModule(torch.nn.Module):
-    key_cache: torch.Tensor
-    value_cache: torch.Tensor
-    key_scale: torch.Tensor
-    value_scale: torch.Tensor
-
     def __init__(
         self,
         config: LlamaConfig,
@@ -90,21 +80,15 @@ class StaticQuantizedCacheModule(torch.nn.Module):
         self.hidden_size = hidden_size
         self.num_attention_heads = num_attention_heads
         self.head_dim = self.hidden_size // self.num_attention_heads
-        cache_shape = (1, self.num_attention_heads, max_cache_len, self.head_dim)
-        scale_shape = (1, 1, 1, self.head_dim)
-
-        self.register_buffer("key_cache", torch.zeros(cache_shape, dtype=torch.int8))
-        self.register_buffer("value_cache", torch.zeros(cache_shape, dtype=torch.int8))
-        self.register_buffer(
-            "key_scale", torch.full(scale_shape, scale, dtype=torch.float32)
+        self.cache = StaticQuantizedKVCache(
+            max_batch_size=1,
+            max_context_length=max_cache_len,
+            n_heads=self.num_attention_heads,
+            head_dim=self.head_dim,
+            scale=scale,
+            use_custom_update_cache_op=False,
+            use_per_channel=False,
         )
-        self.register_buffer(
-            "value_scale", torch.full(scale_shape, scale, dtype=torch.float32)
-        )
-
-    # PT2E activation quantization does not create persistent int8 mutable buffers.
-    def _quantize(self, value: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-        return torch.clamp(torch.round(value / scale), -128, 127).to(torch.int8)
 
     def forward(
         self,
@@ -112,18 +96,7 @@ class StaticQuantizedCacheModule(torch.nn.Module):
         value_states: torch.Tensor,
         cache_position: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        key_q = self._quantize(key_states, self.key_scale)
-        value_q = self._quantize(value_states, self.value_scale)
-
-        self.key_cache[:, :, cache_position] = key_q
-        self.value_cache[:, :, cache_position] = value_q
-
-        key = self.key_cache.to(torch.float32) * self.key_scale
-        value = self.value_cache.to(torch.float32) * self.value_scale
-        key[:, :, cache_position] = key_states
-        value[:, :, cache_position] = value_states
-
-        return key.clone(), value.clone()
+        return self.cache.update(cache_position, key_states, value_states)
 
     def get_inputs(self) -> input_t:
         key_states = torch.randn(
@@ -236,17 +209,18 @@ def test_static_cache_tosa_FP(test_data):
         exir_op=[],
         transform_passes=[InsertInt32CastsAfterInt64PlaceholdersPass()],
     )
+    _initialize_cache_buffers(pipeline, ["cache_layer_"])
     pipeline.count_program_io_kinds(EXPECTED_INPUT_COUNTS, EXPECTED_OUTPUT_COUNTS)
     pipeline.run()
 
 
-@pytest.mark.xfail(reason="BUFFER_MUTATION count mismatch: MLETORCH-1971")
 @common.parametrize("test_data", test_configs)
 def test_static_cache_tosa_INT(test_data):
-    module = StaticCacheModule(test_data).eval()
+    module = StaticQuantizedCacheModule(test_data).eval()
     pipeline = TosaPipelineINT[input_t](
-        module, module.get_inputs(), aten_op=[], exir_op=[], fold_quantize=False
+        module, module.get_inputs(), aten_op=[], exir_op=[]
     )
+    _initialize_cache_buffers(pipeline, ["k_cache", "v_cache"])
     pipeline.count_program_io_kinds(EXPECTED_INPUT_COUNTS, EXPECTED_OUTPUT_COUNTS)
     pipeline.run()
 
@@ -255,41 +229,26 @@ def test_static_cache_tosa_INT(test_data):
 @pytest.mark.xfail(reason="Scatter operator is not supported on U55.")
 @common.parametrize("test_data", test_configs)
 def test_static_cache_u55_INT(test_data):
-    module = StaticCacheModule(test_data).eval()
+    module = StaticQuantizedCacheModule(test_data).eval()
     pipeline = EthosU55PipelineINT[input_t](
         module,
         module.get_inputs(),
         aten_ops=[],
     )
+    _initialize_cache_buffers(pipeline, ["k_cache", "v_cache"])
     pipeline.run()
 
 
-@common.parametrize(
-    "test_data",
-    test_configs,
-    xfails={
-        "multihead_attention": (
-            "BUFFER_MUTATION count mismatch: MLETORCH-1971"
-            "Incorrect numerical behavior: MLBEDSW-11589"
-        ),
-        "grouped_query_attention": (
-            "BUFFER_MUTATION count mismatch: MLETORCH-1971"
-            "Incorrect numerical behavior: MLBEDSW-11589"
-        ),
-        "multi_query_attention": (
-            "BUFFER_MUTATION count mismatch: MLETORCH-1971"
-            "Incorrect numerical behavior: MLBEDSW-11589"
-        ),
-    },
-)
+@common.XfailIfNoCorstone320
+@common.parametrize("test_data", test_configs)
 def test_static_cache_u85_INT(test_data):
-    module = StaticCacheModule(test_data).eval()
+    module = StaticQuantizedCacheModule(test_data).eval()
     pipeline = EthosU85PipelineINT[input_t](
         module,
         module.get_inputs(),
         aten_ops=[],
-        fold_quantize=False,
     )
+    _initialize_cache_buffers(pipeline, ["k_cache", "v_cache"])
     # U85: keep _to_dim_order_copy portable for int64->int32 cast of cache_position (not delegatable).
     pipeline.tester.use_portable_ops = True
     pipeline.count_program_io_kinds(EXPECTED_INPUT_COUNTS, EXPECTED_OUTPUT_COUNTS)
@@ -308,85 +267,23 @@ def test_static_cache_vgf_no_quant(test_data):
         transform_passes=[InsertInt32CastsAfterInt64PlaceholdersPass()],
         quantize=False,
     )
+    _initialize_cache_buffers(pipeline, ["cache_layer_"])
     pipeline.count_program_io_kinds(EXPECTED_INPUT_COUNTS, EXPECTED_OUTPUT_COUNTS)
     pipeline.run()
 
 
 @common.SkipIfNoModelConverter
-@pytest.mark.xfail(reason="BUFFER_MUTATION count mismatch: MLETORCH-1971")
 @common.parametrize("test_data", test_configs)
 def test_static_cache_vgf_quant(test_data):
-    module = StaticCacheModule(test_data).eval()
+    module = StaticQuantizedCacheModule(test_data).eval()
     pipeline = VgfPipeline[input_t](
         module,
         module.get_inputs(),
         aten_op=[],
         exir_op=[],
         quantize=True,
-        fold_quantize=False,
         tosa_spec="TOSA-1.0+INT",
     )
+    _initialize_cache_buffers(pipeline, ["k_cache", "v_cache"])
     pipeline.count_program_io_kinds(EXPECTED_INPUT_COUNTS, EXPECTED_OUTPUT_COUNTS)
-    pipeline.run()
-
-
-@common.parametrize("test_data", test_configs)
-def test_static_quantized_cache_tosa_INT(test_data):
-    module = StaticQuantizedCacheModule(test_data).eval()
-    pipeline = TosaPipelineINT[input_t](
-        module, module.get_inputs(), aten_op=[], exir_op=[], fold_quantize=False
-    )
-    _reject_dynamic_kvq_ops(pipeline)
-    pipeline.change_args(
-        "check_count.exir",
-        {"torch.ops.higher_order.executorch_call_delegate": 2},
-    )
-    pipeline.count_program_io_kinds(
-        EXPECTED_STATIC_QUANTIZED_INPUT_COUNTS, EXPECTED_OUTPUT_COUNTS
-    )
-    pipeline.run()
-
-
-@common.parametrize(
-    "test_data",
-    test_configs,
-    xfails={
-        config: "Incorrect numerical behavior: MLBEDSW-11589" for config in test_configs
-    },
-)
-def test_static_quantized_cache_u85_INT(test_data):
-    module = StaticQuantizedCacheModule(test_data).eval()
-    pipeline = EthosU85PipelineINT[input_t](
-        module, module.get_inputs(), aten_ops=[], fold_quantize=False
-    )
-    _reject_dynamic_kvq_ops(pipeline)
-    pipeline.change_args(
-        "check_count.exir",
-        {"torch.ops.higher_order.executorch_call_delegate": 2},
-    )
-    pipeline.tester.use_portable_ops = True
-    pipeline.count_program_io_kinds(
-        EXPECTED_STATIC_QUANTIZED_INPUT_COUNTS, EXPECTED_OUTPUT_COUNTS
-    )
-    pipeline.run()
-
-
-@common.SkipIfNoModelConverter
-@common.parametrize("test_data", test_configs)
-def test_static_quantized_cache_vgf_quant(test_data):
-    module = StaticQuantizedCacheModule(test_data).eval()
-    pipeline = VgfPipeline[input_t](
-        module,
-        module.get_inputs(),
-        aten_op=[],
-        exir_op=[],
-        quantize=True,
-        fold_quantize=False,
-        tosa_spec="TOSA-1.0+INT",
-        n_expected_delegates=2,
-    )
-    _reject_dynamic_kvq_ops(pipeline)
-    pipeline.count_program_io_kinds(
-        EXPECTED_STATIC_QUANTIZED_INPUT_COUNTS, EXPECTED_OUTPUT_COUNTS
-    )
     pipeline.run()

--- a/examples/models/llama/source_transformation/custom_kv_cache.py
+++ b/examples/models/llama/source_transformation/custom_kv_cache.py
@@ -265,6 +265,7 @@ class StaticQuantizedKVCache(nn.Module):
         scale: float = 1.0 / 127.0,
         use_custom_update_cache_op: bool = True,
         return_float_values: bool = True,
+        use_per_channel: bool = True,
         dtype: torch.dtype = torch.float32,
     ):
         super().__init__()
@@ -276,9 +277,12 @@ class StaticQuantizedKVCache(nn.Module):
         self.quantized_cache_dtype = torch.int8
         self.return_float_values = return_float_values
         self.max_context_length = max_context_length
+        self.use_per_channel = use_per_channel
+        self.k_cache_scale = scale
+        self.v_cache_scale = scale
         self.calibration_enabled = False
         cache_shape = (max_batch_size, max_context_length, n_heads, head_dim)
-        scale_shape = (1, 1, 1, head_dim)
+        scale_shape = (1, 1, 1, head_dim) if use_per_channel else (1,)
         self.register_buffer(
             "k_cache",
             torch.zeros(cache_shape, dtype=self.quantized_cache_dtype),
@@ -324,9 +328,11 @@ class StaticQuantizedKVCache(nn.Module):
         k_scales = self.k_observed_max.to(self.k_cache_scales.dtype) / 127.0
         v_scales = self.v_observed_max.to(self.v_cache_scales.dtype) / 127.0
         if torch.any(k_scales == 0) or torch.any(v_scales == 0):
+            qparam_scope = "channel" if self.use_per_channel else "cache"
             logging.warning(
-                "Static KV cache calibration observed an all-zero K/V channel; "
-                "using the smallest positive scale for that channel."
+                "Static KV cache calibration observed an all-zero K/V %s; "
+                "using the smallest positive scale.",
+                qparam_scope,
             )
         # This floor prevents division by zero; it is not an accuracy threshold.
         self.k_cache_scales.copy_(
@@ -335,6 +341,9 @@ class StaticQuantizedKVCache(nn.Module):
         self.v_cache_scales.copy_(
             v_scales.clamp_min(torch.finfo(self.v_cache_scales.dtype).tiny)
         )
+        if not self.use_per_channel:
+            self.k_cache_scale = self.k_cache_scales.item()
+            self.v_cache_scale = self.v_cache_scales.item()
         self.calibration_enabled = False
         self.k_calibration_cache = None
         self.v_calibration_cache = None
@@ -347,30 +356,54 @@ class StaticQuantizedKVCache(nn.Module):
         self.k_observed_max.copy_(
             torch.maximum(
                 self.k_observed_max,
-                k_val.detach().abs().amax(dim=(0, 1, 2), keepdim=True),
+                (
+                    k_val.detach().abs().amax(dim=(0, 1, 2), keepdim=True)
+                    if self.use_per_channel
+                    else k_val.detach().abs().amax().reshape_as(self.k_observed_max)
+                ),
             )
         )
         self.v_observed_max.copy_(
             torch.maximum(
                 self.v_observed_max,
-                v_val.detach().abs().amax(dim=(0, 1, 2), keepdim=True),
+                (
+                    v_val.detach().abs().amax(dim=(0, 1, 2), keepdim=True)
+                    if self.use_per_channel
+                    else v_val.detach().abs().amax().reshape_as(self.v_observed_max)
+                ),
             )
         )
         self.k_calibration_cache[:, input_pos] = k_val
         self.v_calibration_cache[:, input_pos] = v_val
         return self.k_calibration_cache, self.v_calibration_cache
 
-    def _quantize(self, value, scales):
-        # torchao affine custom ops do not yet have the required Arm/TOSA
-        # lowering and ExecuTorch out-variant runtime support.
-        qmin = torch.iinfo(self.quantized_cache_dtype).min
-        qmax = torch.iinfo(self.quantized_cache_dtype).max
-        return torch.clamp(torch.round(value / scales), qmin, qmax).to(
-            self.quantized_cache_dtype
+    def _quantize(self, value, scale):
+        if self.use_per_channel:
+            qmin = torch.iinfo(self.quantized_cache_dtype).min
+            qmax = torch.iinfo(self.quantized_cache_dtype).max
+            return torch.clamp(torch.round(value / scale), qmin, qmax).to(
+                self.quantized_cache_dtype
+            )
+        return torch.ops.quantized_decomposed.quantize_per_tensor.default(
+            value,
+            scale,
+            0,
+            torch.iinfo(self.quantized_cache_dtype).min,
+            torch.iinfo(self.quantized_cache_dtype).max,
+            self.quantized_cache_dtype,
         )
 
-    def _dequantize(self, value, scales, dtype):
-        return value.to(dtype) * scales.to(dtype)
+    def _dequantize(self, value, scale, dtype):
+        if self.use_per_channel:
+            return value.to(dtype) * scale.to(dtype)
+        return torch.ops.quantized_decomposed.dequantize_per_tensor.default(
+            value,
+            scale,
+            0,
+            torch.iinfo(self.quantized_cache_dtype).min,
+            torch.iinfo(self.quantized_cache_dtype).max,
+            self.quantized_cache_dtype,
+        ).to(dtype)
 
     def _update_cache(self, value, cache, input_pos, indices=None):
         start_pos = input_pos[0].item()
@@ -386,8 +419,10 @@ class StaticQuantizedKVCache(nn.Module):
             cache[:, input_pos] = value
 
     def _quantize_and_update(self, input_pos, k_val, v_val, indices=None):
-        quantized_k_val = self._quantize(k_val, self.k_cache_scales)
-        quantized_v_val = self._quantize(v_val, self.v_cache_scales)
+        k_scale = self.k_cache_scales if self.use_per_channel else self.k_cache_scale
+        v_scale = self.v_cache_scales if self.use_per_channel else self.v_cache_scale
+        quantized_k_val = self._quantize(k_val, k_scale)
+        quantized_v_val = self._quantize(v_val, v_scale)
 
         self._update_cache(quantized_k_val, self.k_cache, input_pos, indices)
         self._update_cache(quantized_v_val, self.v_cache, input_pos, indices)
@@ -395,8 +430,10 @@ class StaticQuantizedKVCache(nn.Module):
     def _update_and_return_float_values(self, input_pos, k_val, v_val, indices=None):
         self._quantize_and_update(input_pos, k_val, v_val, indices)
 
-        k_out = self._dequantize(self.k_cache, self.k_cache_scales, k_val.dtype)
-        v_out = self._dequantize(self.v_cache, self.v_cache_scales, v_val.dtype)
+        k_scale = self.k_cache_scales if self.use_per_channel else self.k_cache_scale
+        v_scale = self.v_cache_scales if self.use_per_channel else self.v_cache_scale
+        k_out = self._dequantize(self.k_cache, k_scale, k_val.dtype)
+        v_out = self._dequantize(self.v_cache, v_scale, v_val.dtype)
 
         self._update_cache(k_val, k_out, input_pos, indices)
         self._update_cache(v_val, v_out, input_pos, indices)
@@ -414,7 +451,7 @@ class StaticQuantizedKVCache(nn.Module):
         """
         k_val, v_val: [B, H, S, D]
         return: [B, H, S, D]
-        Storage is [B, S, H, D], with static per-head-dim qparams.
+        Storage is [B, S, H, D], with static per-head-dim or per-tensor qparams.
         """
 
         k_val = k_val.transpose(1, 2)
@@ -440,6 +477,7 @@ class StaticQuantizedKVCache(nn.Module):
         kv_cache,
         scale: float = 1.0 / 127.0,
         use_custom_update_cache_op: bool = True,
+        use_per_channel: bool = True,
     ):
         if isinstance(kv_cache, CustomKVCache):
             max_batch_size, max_context_length, n_heads, head_dim = (
@@ -456,6 +494,7 @@ class StaticQuantizedKVCache(nn.Module):
             head_dim,
             scale=scale,
             use_custom_update_cache_op=use_custom_update_cache_op,
+            use_per_channel=use_per_channel,
             dtype=kv_cache.k_cache.dtype,
         )
 


### PR DESCRIPTION
* Add per tensor path to StaticQuantizedKVCache to enable delegation
* Rearchitect StaticQuantizedCacheModule to use StaticQuantizedKVCache
* Use StaticCacheModule for FP32 tests only
* Use StaticQuantizedCacheModule for INT tests
* Ensure cache buffers are initialized correctly


Change-Id: I3f39f19ad75c056e10bd9f336b711ad7271d95ff



cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani