### PR TITLE
NXP backend: Add QAT support to Neutron lowering recipes.

### DIFF
--- a/backends/nxp/recipes/nxp_recipe_provider.py
+++ b/backends/nxp/recipes/nxp_recipe_provider.py
@@ -9,6 +9,15 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, cast, Iterable, Optional, Sequence
 
+import torch
+
+from executorch.backends.nxp.aten_passes.fuse_batch_norm_with_linear_pass import (
+    FuseBatchNormWithLinearPass,
+)
+from executorch.backends.nxp.aten_passes.simulated_linear_bn_fusion_passes import (
+    AddSimulatedLinearBatchNormFusionQATPass,
+    RemoveSimulatedLinearBatchNormFusionQATPass,
+)
 from executorch.backends.nxp.backend.custom_delegation_options import (
     CustomDelegationOptions,
 )
@@ -29,12 +38,18 @@ from executorch.backends.nxp.nxp_backend import (
     default_preserve_ops,
     generate_neutron_compile_spec,
 )
+from executorch.backends.nxp.quantizer.utils import (
+    _replace_histogram_observers_for_integer_inputs,
+)
 from executorch.backends.nxp.recipes.nxp_recipe_types import NXP_BACKEND, NXPRecipeType
 from executorch.backends.nxp.tests.executorch_pipeline import (
     get_default_quantizer,
     handle_kernel_selection,
     ModelInputSpec,
     to_model_input_spec,
+)
+from executorch.backends.transforms.quantize_fused_convbn_bias_pass import (
+    QuantizeFusedConvBnBiasAtenPass,
 )
 from executorch.exir import (
     EdgeCompileConfig,
@@ -72,7 +87,7 @@ NEUTRON_RECIPE_CONFIG_KEY = "neutron_recipe_config"
 class NeutronRecipeConfig:
     """Configuration shared by all NXP recipe types.
 
-    Parameters that vary the *type* of export (delegate vs no-delegate)
+    Parameters that vary the *type* of export (delegate vs no-delegate, PTQ vs QAT)
     are expressed by choosing a different NXPRecipeType rather than by flags here.
 
     Attributes:
@@ -95,6 +110,9 @@ class NeutronRecipeConfig:
         dump_kernel_selection_code: Generate kernel-selection files after compilation.
         use_profiling: Enable Neutron execution profiling. IMPORTANT: To also generate an
                        ETRecord, pass generate_etrecord=True to export() separately.
+        train_fn: Training function required for QAT recipe types (INT8_QAT_NEUTRON and
+                  INT8_QAT_NO_DELEGATE). Receives the prepared GraphModule and must
+                  perform the training loop. Ignored for PTQ recipe types.
     """
 
     input_spec: Iterable[ModelInputSpec] | tuple[int, ...] | list[tuple[int, ...]]
@@ -109,6 +127,7 @@ class NeutronRecipeConfig:
     fetch_constants_to_sram: bool = False
     dump_kernel_selection_code: bool = False
     use_profiling: bool = False
+    train_fn: Callable[["torch.fx.GraphModule"], None] | None = None
 
 
 class NXPRecipeProvider(BackendRecipeProvider):
@@ -149,6 +168,10 @@ class NXPRecipeProvider(BackendRecipeProvider):
                 return self._build_recipe(recipe_type, rc, is_qat=False, delegate=True)
             case NXPRecipeType.INT8_PTQ_NO_DELEGATE:
                 return self._build_recipe(recipe_type, rc, is_qat=False, delegate=False)
+            case NXPRecipeType.INT8_QAT_NEUTRON:
+                return self._build_recipe(recipe_type, rc, is_qat=True, delegate=True)
+            case NXPRecipeType.INT8_QAT_NO_DELEGATE:
+                return self._build_recipe(recipe_type, rc, is_qat=True, delegate=False)
             case _:
                 raise NotImplementedError(
                     f"NXP backend: Recipe `{recipe_type}` is not supported."
@@ -162,10 +185,10 @@ class NXPRecipeProvider(BackendRecipeProvider):
         is_qat: bool,
         delegate: bool,
     ) -> ExportRecipe:
-        # is_qat=True is reserved for future QAT support; always False for now.
-        if is_qat:
-            raise NotImplementedError(
-                "NXP recipe with QAT (quantization aware training) is not yet supported."
+        if is_qat and rc.train_fn is None:
+            raise ValueError(
+                f"NXP backend: Recipe `{recipe_type}` requires `train_fn` to be set in "
+                f"NeutronRecipeConfig. Provide a callable that trains the prepared model."
             )
 
         neutron_target_spec = NeutronTargetSpec(rc.target)
@@ -175,7 +198,7 @@ class NXPRecipeProvider(BackendRecipeProvider):
                 get_default_quantizer, neutron_target_spec, is_qat
             )
 
-        quantization_recipe = _build_quantization_recipe(rc)
+        quantization_recipe = _build_quantization_recipe(rc, is_qat)
         compile_spec = generate_neutron_compile_spec(
             rc.target,
             intermediates_dir=rc.intermediates_dir,
@@ -200,22 +223,87 @@ class NXPRecipeProvider(BackendRecipeProvider):
 
 
 # ---------------------------------------------------------------------------
+# Pass wrappers
+# ---------------------------------------------------------------------------
+# ExirPassBase subclasses return a PassResult with a .graph_module attribute,
+# but QuantizeStage._apply_passes expects callable(GraphModule) -> GraphModule.
+# These thin wrappers bridge the two conventions.
+
+
+def _wrap_exir_pass(pass_cls, *args, **kwargs):
+    """Return a callable(GraphModule) -> GraphModule wrapping an ExirPass instance."""
+    _pass_instance = pass_cls(*args, **kwargs)
+
+    def _wrapped(m):
+        return _pass_instance(m).graph_module
+
+    _wrapped.__qualname__ = f"_wrap_exir_pass({pass_cls.__name__})"
+    return _wrapped
+
+
+def _histogram_observer_fix_pass(m):
+    """Callable(GraphModule) -> GraphModule that replaces HistogramObserver for integer inputs."""
+    _replace_histogram_observers_for_integer_inputs(m)
+    return m
+
+
+# ---------------------------------------------------------------------------
 # Module-level builder helpers
 # ---------------------------------------------------------------------------
 
 
-def _build_quantization_recipe(rc: NeutronRecipeConfig) -> QuantizationRecipe:
-    """Build the QuantizationRecipe for PTQ.
+def _build_quantization_recipe(
+    rc: NeutronRecipeConfig, is_qat: bool
+) -> QuantizationRecipe:
+    """Build the QuantizationRecipe for PTQ or QAT.
 
     PTQ uses the standard QuantizeStage flow (prepare_pt2e -> calibrate -> convert_pt2e).
-    The example_inputs passed to the export session are used directly for calibration.
-    Multiple PTQ recipes can be combined with ExportRecipe.combine().
+    QAT uses the QAT flow (prepare_qat_pt2e -> BN-fusion passes -> train_fn -> convert_pt2e).
+
+    The NXP-specific passes are injected via the QuantizationRecipe hook lists so
+    that QuantizeStage executes them in the correct order.
     """
     _quantizer = rc.get_quantizer_fn()
 
-    return QuantizationRecipe(
-        quantizers=[_quantizer],
-    )
+    # post_prepare_passes: always fix HistogramObserver for non-float inputs.
+    # For QAT, also insert the simulated linear-BN fusion before training so
+    # fake-quantize nodes see fused weights during the training loop.
+    post_prepare: list[Callable] = []
+    if is_qat:
+        post_prepare.append(_wrap_exir_pass(AddSimulatedLinearBatchNormFusionQATPass))
+    post_prepare.append(_histogram_observer_fix_pass)
+
+    if is_qat:
+        # pre_convert_passes: tear down the simulated fusion and fold BN into
+        # the linear weights before convert_pt2e.
+        pre_convert: list[Callable] = [
+            _wrap_exir_pass(RemoveSimulatedLinearBatchNormFusionQATPass),
+            _wrap_exir_pass(FuseBatchNormWithLinearPass),
+        ]
+
+        # post_convert_passes: fix up quantization parameters for fused conv+BN
+        # bias nodes after convert_pt2e has inserted the quantize/dequantize ops.
+        post_convert: list[Callable] = [
+            _wrap_exir_pass(
+                QuantizeFusedConvBnBiasAtenPass,
+                default_zero_bias=False,
+                symmetric_quant=True,
+            )
+        ]
+
+        return QuantizationRecipe(
+            quantizers=[_quantizer],
+            is_qat=True,
+            train_fn=rc.train_fn,
+            post_prepare_passes=post_prepare,
+            pre_convert_passes=pre_convert,
+            post_convert_passes=post_convert,
+        )
+    else:
+        return QuantizationRecipe(
+            quantizers=[_quantizer],
+            post_prepare_passes=post_prepare,
+        )
 
 
 def _build_lowering_recipe(

--- a/backends/nxp/recipes/nxp_recipe_types.py
+++ b/backends/nxp/recipes/nxp_recipe_types.py
@@ -15,6 +15,8 @@ class NXPRecipeType(RecipeType):
     Choose the recipe that matches your intended export configuration:
       - INT8_PTQ_NEUTRON: standard post-training quantization, delegates to Neutron NPU.
       - INT8_PTQ_NO_DELEGATE: PTQ without NPU delegation (useful for debugging or CPU-only deployment).
+      - INT8_QAT_NEUTRON: quantization-aware training, delegates to Neutron NPU.
+      - INT8_QAT_NO_DELEGATE: QAT without NPU delegation (useful for accuracy evaluation).
     """
 
     # INT8 static PTQ (weights + activations). Calibration dataset required.
@@ -24,6 +26,14 @@ class NXPRecipeType(RecipeType):
     # INT8 PTQ without NPU delegation. Produces a quantized graph that runs on CPU.
     # Useful for accuracy evaluation or debugging before enabling delegation.
     INT8_PTQ_NO_DELEGATE = "nxp_int8_ptq_no_delegate"
+
+    # INT8 QAT (weights + activations). A train_fn must be provided in NeutronRecipeConfig.
+    # Applicable operators are delegated to the Neutron NPU.
+    INT8_QAT_NEUTRON = "nxp_int8_qat_neutron"
+
+    # INT8 QAT without NPU delegation. Produces a quantized graph that runs on CPU.
+    # Useful for accuracy evaluation or debugging before enabling delegation.
+    INT8_QAT_NO_DELEGATE = "nxp_int8_qat_no_delegate"
 
     @classmethod
     def get_backend_name(cls) -> str:

--- a/backends/nxp/tests/generic_tests/test_recipe_export.py
+++ b/backends/nxp/tests/generic_tests/test_recipe_export.py
@@ -7,15 +7,24 @@ import pytest
 import torch
 import torch.nn
 
+from executorch.backends.nxp.aten_passes.fuse_batch_norm_with_linear_pass import (
+    FuseBatchNormWithLinearPass,
+)
+from executorch.backends.nxp.aten_passes.simulated_linear_bn_fusion_passes import (
+    AddSimulatedLinearBatchNormFusionQATPass,
+    RemoveSimulatedLinearBatchNormFusionQATPass,
+)
 from executorch.backends.nxp.backend.custom_delegation_options import (
     CustomDelegationOptions,
 )
+from executorch.backends.nxp.backend.graph_utils import batch_norm_target_ops
 from executorch.backends.nxp.backend.ops_aliases import ExecutorchDelegateCall
 from executorch.backends.nxp.edge_passes.neutron_edge_pass_manager import (
     NeutronEdgePassManager,
 )
 from executorch.backends.nxp.neutron_partitioner import NeutronPartitioner
 from executorch.backends.nxp.recipes.nxp_recipe_provider import (
+    _histogram_observer_fix_pass,
     NEUTRON_RECIPE_CONFIG_KEY,
     NeutronRecipeConfig,
     NXPRecipeProvider,
@@ -25,6 +34,10 @@ from executorch.backends.nxp.tests.executorch_pipeline import ModelInputSpec
 from executorch.backends.nxp.tests.executors import (
     graph_contains_any,
     graph_contains_any_of_ops,
+)
+from executorch.backends.nxp.tests.models import ConvBatchNormModule
+from executorch.backends.transforms.quantize_fused_convbn_bias_pass import (
+    QuantizeFusedConvBnBiasAtenPass,
 )
 from executorch.export import export
 from executorch.export.recipe import ExportRecipe
@@ -74,7 +87,10 @@ def test_ptq_neutron_basic():
     assert not graph_contains_any(graph, is_cnn_op)
 
     nodes = list(graph.nodes)
-    first_call = next(n for n in nodes if n.op == "call_function" and n.name != "alloc")
+    # Skip alloc nodes (e.g. "alloc", "alloc_1") which also have op == "call_function".
+    first_call = next(
+        n for n in nodes if n.op == "call_function" and not n.name.startswith("alloc")
+    )
     last_call = next(n for n in reversed(nodes) if n.op == "call_function")
     assert first_call.target == quantized_decomposed.quantize_per_tensor.out
     assert last_call.target == quantized_decomposed.dequantize_per_tensor.out
@@ -96,14 +112,6 @@ class TestInt8PTQNoDelegate:
 
         # With no delegation, original ops should be visible in the graph.
         assert graph_contains_any(graph, is_cnn_op)
-
-    def test__recipe_has_empty_partitioners(self):
-        """INT8_PTQ_NO_DELEGATE recipe has an empty partitioner list."""
-        rc = NeutronRecipeConfig(INPUT_SHAPE)
-        recipe = NXPRecipeProvider().create_recipe(
-            NXPRecipeType.INT8_PTQ_NO_DELEGATE, neutron_recipe_config=rc
-        )
-        assert recipe.lowering_recipe.partitioners == []
 
 
 class TestNeutronRecipeConfigFlags:
@@ -413,3 +421,313 @@ class TestEdgeManagerTransformPasses:
         qdq_callable = recipe.lowering_recipe.edge_manager_transform_passes[0]
         result = qdq_callable(mocker.MagicMock())
         assert isinstance(result, NeutronEdgePassManager)
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by QAT tests
+# ---------------------------------------------------------------------------
+
+
+def _noop_train_fn(model: torch.fx.GraphModule) -> None:
+    """A no-op train_fn used by structural/unit tests that only inspect pass shape."""
+    pass
+
+
+def _minimal_train_fn(model: torch.fx.GraphModule, shape=(1, 3, 5, 5)) -> None:
+    """Run a few SGD steps on random data so fake-quant observer statistics are populated.
+    Used by end-to-end tests.
+    """
+    optimizer = torch.optim.SGD(model.parameters(), lr=1e-4)
+    for _ in range(3):
+        optimizer.zero_grad()
+        out = model(torch.randn(shape))
+        loss = out.sum()
+        loss.backward()
+        optimizer.step()
+
+
+def _run_qat_export(model, train_fn=None, recipe_type=NXPRecipeType.INT8_QAT_NEUTRON):
+    if train_fn is None:
+        train_fn = _noop_train_fn
+    rc = NeutronRecipeConfig(INPUT_SHAPE, train_fn=train_fn)
+    return _run_export(model, rc, recipe_type=recipe_type)
+
+
+# ---------------------------------------------------------------------------
+# QAT recipe: end-to-end tests
+# ---------------------------------------------------------------------------
+
+
+# Both QAT recipe types must reject a missing train_fn.
+@pytest.mark.parametrize(
+    "recipe_type",
+    [NXPRecipeType.INT8_QAT_NEUTRON, NXPRecipeType.INT8_QAT_NO_DELEGATE],
+    ids=lambda r: r.value,
+)
+def test__qat_requires_train_fn(recipe_type):
+    """Any QAT recipe raises ValueError when train_fn is absent from NeutronRecipeConfig."""
+    rc = NeutronRecipeConfig(INPUT_SHAPE)  # train_fn=None (default)
+    with pytest.raises(ValueError, match="train_fn"):
+        NXPRecipeProvider().create_recipe(recipe_type, neutron_recipe_config=rc)
+
+
+# Both _NO_DELEGATE recipe types (PTQ and QAT) must produce an empty partitioner list.
+@pytest.mark.parametrize(
+    "recipe_type",
+    [NXPRecipeType.INT8_PTQ_NO_DELEGATE, NXPRecipeType.INT8_QAT_NO_DELEGATE],
+    ids=lambda r: r.value,
+)
+def test__no_delegate_recipe_has_empty_partitioners(recipe_type):
+    """Both NO_DELEGATE recipe types produce an empty partitioner list."""
+    # train_fn is required by QAT recipes; PTQ ignores it, so always pass it.
+    rc = NeutronRecipeConfig(INPUT_SHAPE, train_fn=_noop_train_fn)
+    recipe = NXPRecipeProvider().create_recipe(recipe_type, neutron_recipe_config=rc)
+    assert recipe.lowering_recipe.partitioners == []
+
+
+class TestInt8QATNeutron:
+
+    def test__basic(self):
+        """INT8_QAT_NEUTRON: full export succeeds and the graph contains a delegate call."""
+        model = SimpleCNN()
+        sess = _run_qat_export(model)
+        graph = _get_graph(sess)
+        assert graph_contains_any_of_ops(graph, [ExecutorchDelegateCall])
+
+    def test__train_fn_is_called(self):
+        """train_fn is invoked exactly once during the QAT export pipeline."""
+        model = SimpleCNN()
+        call_count = []
+
+        def counting_train_fn(m):
+            call_count.append(1)
+
+        rc = NeutronRecipeConfig(INPUT_SHAPE, train_fn=counting_train_fn)
+        _run_export(model, rc, recipe_type=NXPRecipeType.INT8_QAT_NEUTRON)
+        assert (
+            len(call_count) == 1
+        ), f"Expected train_fn called once, got {len(call_count)}"
+
+    def test__recipe_name(self):
+        """INT8_QAT_NEUTRON recipe has the expected name."""
+        rc = NeutronRecipeConfig(INPUT_SHAPE, train_fn=_noop_train_fn)
+        recipe = NXPRecipeProvider().create_recipe(
+            NXPRecipeType.INT8_QAT_NEUTRON, neutron_recipe_config=rc
+        )
+        assert recipe.name == NXPRecipeType.INT8_QAT_NEUTRON.value
+
+    def test__recipe_structure(self):
+        """INT8_QAT_NEUTRON recipe has is_qat=True, one quantizer, one partitioner."""
+        rc = NeutronRecipeConfig(INPUT_SHAPE, train_fn=_noop_train_fn)
+        recipe = NXPRecipeProvider().create_recipe(
+            NXPRecipeType.INT8_QAT_NEUTRON, neutron_recipe_config=rc
+        )
+        qr = recipe.quantization_recipe
+        assert qr is not None
+        assert qr.is_qat is True
+        assert qr.train_fn is _noop_train_fn
+        assert len(qr.quantizers) == 1
+        assert recipe.lowering_recipe.partitioners is not None
+        assert len(recipe.lowering_recipe.partitioners) == 1
+
+    def test__io_is_quantized_by_default(self):
+        """QAT export with default settings: IO boundary has quantize/dequantize ops."""
+        model = SimpleCNN()
+        sess = _run_qat_export(model)
+        graph = _get_graph(sess)
+        nodes = list(graph.nodes)
+        # Skip alloc nodes (e.g. "alloc", "alloc_1") which also have op == "call_function".
+        first_call = next(
+            n
+            for n in nodes
+            if n.op == "call_function" and not n.name.startswith("alloc")
+        )
+        last_call = next(n for n in reversed(nodes) if n.op == "call_function")
+        assert first_call.target == quantized_decomposed.quantize_per_tensor.out
+        assert last_call.target == quantized_decomposed.dequantize_per_tensor.out
+
+
+class TestInt8QATNoDelegate:
+
+    def test__basic(self):
+        """INT8_QAT_NO_DELEGATE: export succeeds without any delegate call."""
+        model = SimpleCNN()
+        sess = _run_qat_export(model, recipe_type=NXPRecipeType.INT8_QAT_NO_DELEGATE)
+        graph = _get_graph(sess)
+        assert not graph_contains_any_of_ops(graph, [ExecutorchDelegateCall])
+
+
+# ---------------------------------------------------------------------------
+# QAT recipe: NXP-specific pass structure tests
+# ---------------------------------------------------------------------------
+
+# Both QAT recipe types are built from the same _build_quantization_recipe(is_qat=True)
+# call, so their pass lists must be identical. The parametrization below makes this
+# explicit and catches any accidental divergence.
+_QAT_RECIPE_TYPES = [NXPRecipeType.INT8_QAT_NEUTRON, NXPRecipeType.INT8_QAT_NO_DELEGATE]
+
+
+@pytest.mark.parametrize("recipe_type", _QAT_RECIPE_TYPES, ids=lambda r: r.value)
+class TestQATNXPPasses:
+
+    def _get_qat_recipe(self, recipe_type: NXPRecipeType) -> "ExportRecipe":
+        rc = NeutronRecipeConfig(INPUT_SHAPE, train_fn=_noop_train_fn)
+        return NXPRecipeProvider().create_recipe(recipe_type, neutron_recipe_config=rc)
+
+    def test__post_prepare_passes_start_with_add_bn_fusion(self, recipe_type):
+        """QAT post_prepare_passes: first pass is AddSimulatedLinearBatchNormFusionQATPass wrapper."""
+        recipe = self._get_qat_recipe(recipe_type)
+        qr = recipe.quantization_recipe
+        assert qr.post_prepare_passes is not None
+        # The first post-prepare pass must wrap AddSimulatedLinearBatchNormFusionQATPass.
+        # We verify by inspecting the __qualname__ set by _wrap_exir_pass.
+        first_pass = qr.post_prepare_passes[0]
+        assert (
+            AddSimulatedLinearBatchNormFusionQATPass.__name__ in first_pass.__qualname__
+        )
+
+    def test__post_prepare_passes_end_with_histogram_observer_fix(self, recipe_type):
+        """QAT post_prepare_passes: last pass is _histogram_observer_fix_pass."""
+        recipe = self._get_qat_recipe(recipe_type)
+        qr = recipe.quantization_recipe
+        assert qr.post_prepare_passes is not None
+        last_pass = qr.post_prepare_passes[-1]
+        assert last_pass is _histogram_observer_fix_pass
+
+    def test__pre_convert_passes_include_remove_bn_fusion_and_fold(self, recipe_type):
+        """QAT pre_convert_passes: contains RemoveSimulatedLinearBatchNormFusionQATPass
+        followed by FuseBatchNormWithLinearPass (each applied once)."""
+        recipe = self._get_qat_recipe(recipe_type)
+        qr = recipe.quantization_recipe
+        assert qr.pre_convert_passes is not None
+        assert len(qr.pre_convert_passes) == 2, (
+            "Expected 2 pre_convert passes (remove + fuse), "
+            f"got {len(qr.pre_convert_passes)}"
+        )
+        qualnames = [p.__qualname__ for p in qr.pre_convert_passes]
+        assert (
+            qualnames[0]
+            == f"_wrap_exir_pass({RemoveSimulatedLinearBatchNormFusionQATPass.__name__})"
+        )
+        assert (
+            qualnames[1] == f"_wrap_exir_pass({FuseBatchNormWithLinearPass.__name__})"
+        )
+
+    def test__post_convert_passes_include_quant_fused_conv_bn_bias(self, recipe_type):
+        """QAT post_convert_passes: contains QuantizeFusedConvBnBiasAtenPass wrapper."""
+        recipe = self._get_qat_recipe(recipe_type)
+        qr = recipe.quantization_recipe
+        assert qr.post_convert_passes is not None
+        assert len(qr.post_convert_passes) == 1
+        assert f"_wrap_exir_pass({QuantizeFusedConvBnBiasAtenPass.__name__})" in (
+            qr.post_convert_passes[0].__qualname__
+        )
+
+
+# ---------------------------------------------------------------------------
+# PTQ recipe: pass structure tests (complement to TestQATNXPPasses above)
+# ---------------------------------------------------------------------------
+
+
+class TestPTQNXPPasses:
+    """Verifies the pass structure of INT8_PTQ_NEUTRON recipes.
+
+    These tests are separate from TestQATNXPPasses because the assertions are
+    PTQ-specific and independent of which QAT recipe type is being tested.
+    """
+
+    def _get_ptq_recipe(self) -> "ExportRecipe":
+        rc = NeutronRecipeConfig(INPUT_SHAPE)
+        return NXPRecipeProvider().create_recipe(
+            NXPRecipeType.INT8_PTQ_NEUTRON, neutron_recipe_config=rc
+        )
+
+    def test__no_pre_or_post_convert_passes(self):
+        """PTQ recipe does not set pre_convert_passes or post_convert_passes."""
+        qr = self._get_ptq_recipe().quantization_recipe
+        assert qr.pre_convert_passes is None
+        assert qr.post_convert_passes is None
+
+    def test__post_prepare_passes_include_histogram_observer_fix(self):
+        """PTQ recipe post_prepare_passes contains _histogram_observer_fix_pass."""
+        qr = self._get_ptq_recipe().quantization_recipe
+        assert qr.post_prepare_passes is not None
+        assert _histogram_observer_fix_pass in qr.post_prepare_passes
+
+    def test__post_prepare_passes_do_not_include_add_bn_fusion(self):
+        """PTQ recipe post_prepare_passes must NOT contain AddSimulatedLinearBatchNormFusionQATPass."""
+        qr = self._get_ptq_recipe().quantization_recipe
+        for p in qr.post_prepare_passes or []:
+            assert AddSimulatedLinearBatchNormFusionQATPass.__name__ not in getattr(
+                p, "__qualname__", ""
+            )
+
+
+# ---------------------------------------------------------------------------
+# QAT recipe: e2e test on a real model - equivalent to imperative QAT tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bias", [True, False], ids=lambda b: "bias" if b else "no_bias"
+)
+class TestQATEquivalentToImperative:
+    """Recipe-path QAT tests that mirror the imperative-path tests in test_batch_norm_fusion.py.
+
+    The imperative reference is test_biasless_convbn_fusion_qat (and its bias=True variant).
+    The recipe path must produce an equivalent result: the graph is delegated and the
+    BN is fully fused away by the QAT passes.
+    """
+
+    # Use (1, 3, 5, 5) so that Conv2d(kernel_size=3) produces a (1, 3, 3, 3) feature map,
+    # giving BatchNorm > 1 value per channel in training mode (QAT requires train mode).
+    _CONVBN_INPUT_SHAPE = (1, 3, 5, 5)
+
+    def test__convbn_qat_produces_delegate_call(self, bias):
+        """INT8_QAT_NEUTRON on ConvBatchNormModule produces a delegate call.
+        Equivalent imperative test: test_biasless_convbn_fusion_qat / test_batch_norm_conv_fusing
+        in backends/nxp/tests/generic_tests/test_batch_norm_fusion.py."""
+        model = ConvBatchNormModule(
+            bias=bias,
+            input_rank=len(self._CONVBN_INPUT_SHAPE),
+            num_features=self._CONVBN_INPUT_SHAPE[1],
+        )
+        rc = NeutronRecipeConfig(
+            self._CONVBN_INPUT_SHAPE,
+            train_fn=_minimal_train_fn,
+            use_neutron_for_format_conversion=False,
+        )
+        sess = _run_export(
+            model,
+            rc,
+            recipe_type=NXPRecipeType.INT8_QAT_NEUTRON,
+            input_shape=self._CONVBN_INPUT_SHAPE,
+        )
+        graph = _get_graph(sess)
+
+        # Same assertion as the imperative path: the model is delegated.
+        assert graph_contains_any_of_ops(graph, [ExecutorchDelegateCall])
+
+    def test__convbn_qat_bn_is_fused_away(self, bias):
+        """INT8_QAT_NEUTRON on ConvBatchNormModule: BN is fused away by QAT passes.
+        Equivalent imperative test: test_batch_norm_conv_fusing__full_pipeline__2d
+        in backends/nxp/tests/generic_tests/test_batch_norm_fusion.py."""
+        model = ConvBatchNormModule(
+            bias=bias,
+            input_rank=len(self._CONVBN_INPUT_SHAPE),
+            num_features=self._CONVBN_INPUT_SHAPE[1],
+        )
+        rc = NeutronRecipeConfig(
+            self._CONVBN_INPUT_SHAPE,
+            train_fn=_minimal_train_fn,
+            use_neutron_for_format_conversion=False,
+        )
+        sess = _run_export(
+            model,
+            rc,
+            recipe_type=NXPRecipeType.INT8_QAT_NEUTRON,
+            input_shape=self._CONVBN_INPUT_SHAPE,
+        )
+        # The edge program (before delegation) must not contain any BN ops.
+        edge_graph = sess.get_edge_program_manager().exported_program().graph
+        assert not graph_contains_any_of_ops(edge_graph, batch_norm_target_ops)


### PR DESCRIPTION
### Summary
Add 2 QAT export recipes for the Neutron backend. The `INT8_QAT_NEUTRON` recipe is a direct equivalent to the imperative QAT lowering that was used until now.

### Test plan
`pytest backends/nxp/tests/generic_tests/test_recipe_export.py`

cc @robert-kalmar @JakeStevens @digantdesai @rascani