### PR TITLE
Arm backend: Relax DeepSeek VGF BF16 abs tolerance

### DIFF
--- a/backends/arm/test/models/DeepSeek_R1_Distill_Qwen/test_deepseek_r1_distill_qwen_model.py
+++ b/backends/arm/test/models/DeepSeek_R1_Distill_Qwen/test_deepseek_r1_distill_qwen_model.py
@@ -197,7 +197,7 @@ CHECKPOINT_VGF_NO_QUANT_BF16_XLARGE_TEST_CASES: dict[
     "base_model": DeepSeekR1DistillQwenModelTestCase(
         model_cls=BaseModelWrapper,
         config_factory=_make_deepseek_r1_distill_qwen_1_5b_model_config,
-        atol=0.1,
+        atol=0.17,
         rtol=0.1,
         tosa_spec="TOSA-1.0+FP+bf16",
     ),


### PR DESCRIPTION
The xlarge DeepSeek VGF BF16 test is numerically stable in its mean error but exceeds the existing 0.1 absolute tolerance across platforms and random seeds.

| Platform  | Seed | Result | Max |Δ|  | Mean |Δ| | |-----------|------|--------|----------|----------|
| Ubuntu x86| 0    | Fail   | 0.140625 | 0.026189 |
| Ubuntu x86| 1    | Fail   | 0.150391 | 0.026114 |
| Ubuntu x86| 2    | Fail   | 0.134766 | 0.025801 |
| macOS     | 0    | Fail   | 0.156250 | 0.025820 |
| macOS     | 1    | Fail   | 0.153320 | 0.025708 |
| macOS     | 2    | Pass   | —        | —        |

Raise atol from 0.1 to 0.17, providing modest headroom above the largest observed difference while retaining rtol=0.1.

The exact test passes on Ubuntu x86 with seeds 0, 1, and 2 after this change.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani