### PR TITLE
NXP backend: Keep `test_cifarnet` in the wheel for internal testing.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -346,6 +346,7 @@ _CI_ENTRY_POINTS = (
     "executorch.examples.models.muse_glimmer.tests.test_mlx_pipeline",
     "executorch.examples.models.muse_glimmer.tests.test_prompt_tokens",
     "executorch.extension.pybindings.test.test_pybindings",
+    "executorch.backends.nxp.tests.generic_tests.test_cifarnet",
 )
 
 # Directories whose test modules are reached without any import statement naming them, so no scan


### PR DESCRIPTION
### Summary
A [recent PR](https://github.com/pytorch/executorch/pull/22584) prevented unreferenced modules from being included in the wheel. The `test_cifarnet` module is however referenced in the NXP internal testing infrastructure, so the internal CI was broken.

This PR adds an exception, ensuring the `test_cifarnet` is included in the wheel.

### Test plan
N/A


cc @robert-kalmar @JakeStevens @digantdesai @rascani