### PR TITLE
Add a batched-sequence KV cache to the eager reference

### DIFF
--- a/backends/mlx/test/test_ops.py
+++ b/backends/mlx/test/test_ops.py
@@ -8598,14 +8598,14 @@ class UpdateAndAttendTest(OpTestCase):
         # an oracle cache installed for its duration.
         from executorch.extension.llm.cache.reference_cache import (
             CacheConfig,
-            ContiguousReferenceCache,
+            SequenceReferenceCache,
         )
         from executorch.extension.llm.cache.update_and_attend import REGISTRY
 
         key = f"{self.name}-oracle"
         REGISTRY.install(
             key,
-            ContiguousReferenceCache(
+            SequenceReferenceCache(
                 CacheConfig(
                     n_layers=self.n_layers,
                     n_kv_heads=self.n_kv_heads,

--- a/extension/llm/cache/reference_cache.py
+++ b/extension/llm/cache/reference_cache.py
@@ -20,9 +20,10 @@ but is capped, per the design's "grows lazily and bounds hard".
 The cache places K/V and returns the history plus an ``AttendSpec`` (a mask *semantic*). The attend
 mechanism (``attend`` below) is applied by the op/backend from that spec.
 
-Two caches share the op: ``ContiguousReferenceCache`` (one sequence appended in
-place) and ``CellReferenceCache`` (many sequences over a pool of per-token cells,
-with sharing and eviction). Both store float KV.
+Three caches share the op: ``SequenceReferenceCache`` (one sequence),
+``BatchedSequenceReferenceCache`` (many private sequence caches), and
+``CellReferenceCache`` (many sequences over a shared pool of per-token cells,
+with sharing and eviction). All store float KV.
 """
 
 from __future__ import annotations
@@ -50,7 +51,17 @@ class MaskKind(Enum):
 
 @dataclass
 class AttendSpec:
+    """One attention: what to attend over, which queries do it, how to mask it.
+
+    A step is answered with a list of these -- one for a cache holding a single
+    history, one per sequence for a cache holding a private history each. They
+    cover the query axis in order, so ``q_len`` alone places each.
+    """
+
+    k: torch.Tensor  # [B, H_kv, total, head_dim] -- key history
+    v: torch.Tensor  # [B, H_kv, total, v_head_dim] -- value history
     kind: MaskKind
+    q_len: int  # query tokens this spec answers, following the one before it
     mask: Optional[torch.Tensor] = None  # EXPLICIT only: bool, true = attend
 
 
@@ -109,7 +120,7 @@ class CacheConfig:
 @experimental(
     "update_and_attend KV cache is experimental and may change without notice."
 )
-class ContiguousReferenceCache:
+class SequenceReferenceCache:
     """Per-layer contiguous float KV history for a single sequence."""
 
     def __init__(self, config: CacheConfig):
@@ -125,6 +136,36 @@ class ContiguousReferenceCache:
 
     def used(self, layer_id: int) -> int:
         return self._used[layer_id]
+
+    def rewind(self, new_len: int) -> None:
+        """Drop everything from ``new_len`` on, in every layer.
+
+        A windowed layer retains only its last ``window`` positions, so it
+        cannot go back further than that even though this reference keeps the
+        older ones -- the window is applied to the mask here and to the storage
+        in a byte layer, and a rewind past it would attend cells that layer no
+        longer holds.
+        """
+        used = self._used[0]
+        if new_len < 0 or new_len > used:
+            raise ValueError(f"rewind to {new_len}: the history holds {used}")
+        floor = max(
+            (
+                used - self.config.policy_for(layer_id).window
+                for layer_id in range(self.config.n_layers)
+                if self.config.policy_for(layer_id).window > 0
+            ),
+            default=0,
+        )
+        if new_len < floor:
+            raise ValueError(
+                f"rewind to {new_len}: a windowed layer retains only from {floor}"
+            )
+        for layer_id in range(self.config.n_layers):
+            if self.config.sizing == CacheSizing.DYNAMIC:
+                self._k[layer_id] = self._k[layer_id][:, :, :new_len, :]
+                self._v[layer_id] = self._v[layer_id][:, :, :new_len, :]
+            self._used[layer_id] = new_len
 
     def reset(self):
         self._used = [0] * self.config.n_layers
@@ -144,8 +185,10 @@ class ContiguousReferenceCache:
         k: torch.Tensor,
         v: torch.Tensor,
         position: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor, AttendSpec]:
-        """Place this step's K/V and return the full history + mask semantic.
+    ) -> List[AttendSpec]:
+        """Place this step's K/V and return what to attend over.
+
+        One sequence, one history, so the list is always one long.
 
         Per the design, ``position`` is the cache's placement + masking input.
         This contiguous single-sequence cache appends at its used length, so the
@@ -160,9 +203,8 @@ class ContiguousReferenceCache:
             position: ``[q_len, n_dims]`` int -- per-query-token positions.
 
         Returns:
-            ``(k_hist, v_hist, spec)`` -- history ``[B, H_kv, total, head_dim]`` /
-            ``[B, H_kv, total, v_head_dim]`` (``total`` = prior length + q_len) and
-            the AttendSpec mask semantic.
+            one AttendSpec over the whole history, ``total`` = prior length +
+            q_len.
         """
         q_len = k.shape[-2]
         used = self._used[layer_id]
@@ -188,10 +230,14 @@ class ContiguousReferenceCache:
             v_hist = self._v[layer_id]
         self._used[layer_id] = new_used
 
-        return k_hist, v_hist, self._spec(layer_id, q_len, new_used, k.device)
+        return [self._spec(layer_id, k_hist, v_hist, q_len)]
 
     def _spec(
-        self, layer_id: int, q_len: int, total: int, device: torch.device
+        self,
+        layer_id: int,
+        k_hist: torch.Tensor,
+        v_hist: torch.Tensor,
+        q_len: int,
     ) -> AttendSpec:
         """The mask semantic for q_len new cells at the tail of a total window.
 
@@ -200,21 +246,25 @@ class ContiguousReferenceCache:
         ``i + total - q_len - window``. Whichever bound the fused kinds cannot
         express is what makes the step EXPLICIT.
         """
+        total = k_hist.shape[-2]
         window = self.config.policy_for(layer_id).window
         windowed = 0 < window < total
         if q_len == 1 and not windowed:
-            return AttendSpec(kind=MaskKind.NONE)
+            return AttendSpec(k=k_hist, v=v_hist, kind=MaskKind.NONE, q_len=q_len)
         if q_len == total and not windowed:
-            return AttendSpec(kind=MaskKind.CAUSAL)
+            return AttendSpec(k=k_hist, v=v_hist, kind=MaskKind.CAUSAL, q_len=q_len)
         # torch's is_causal is upper-left and expresses no window, so the band
         # is handed back explicitly.
+        device = k_hist.device
         offsets = torch.arange(total, device=device) - torch.arange(
             q_len, device=device
         ).unsqueeze(-1)
         band = offsets <= total - q_len
         if windowed:
             band &= offsets > total - q_len - window
-        return AttendSpec(kind=MaskKind.EXPLICIT, mask=band)
+        return AttendSpec(
+            k=k_hist, v=v_hist, kind=MaskKind.EXPLICIT, q_len=q_len, mask=band
+        )
 
 
 # A cell's owners are a bitset in a torch int64, so bit 63 (the sign bit) is out.
@@ -242,7 +292,7 @@ def flatten_step(
     Returns:
         ``(tokens, positions, seq_ids, logits_indices)`` -- tokens concatenated
         on the token axis and ``positions`` (``[n_tok, 1]``) as model inputs,
-        ``seq_ids`` for ``begin_step``, and ``logits_indices`` selecting each
+        ``seq_ids`` for ``declare_step``, and ``logits_indices`` selecting each
         sequence's last token, the rows worth running the LM head on.
     """
     tokens, positions, seq_ids, logits_indices = [], [], [], []
@@ -257,6 +307,180 @@ def flatten_step(
         seq_ids,
         torch.tensor(logits_indices, dtype=torch.long),
     )
+
+
+@dataclass(frozen=True)
+class _SequenceSpan:
+    seq_id: int
+    start: int
+    length: int
+
+
+@experimental(
+    "update_and_attend KV cache is experimental and may change without notice."
+)
+class BatchedSequenceReferenceCache:
+    """A private ``SequenceReferenceCache`` per sequence in a flat batch.
+
+    Projections share one model forward over the flattened token axis. Attention
+    splits that axis into its declared sequence spans, runs independently over
+    each sequence's private history, then concatenates the outputs in input
+    order. No sequence attends another and no dense cross-sequence mask is built.
+    """
+
+    def __init__(self, config: CacheConfig):
+        if config.batch_size != 1:
+            raise ValueError(
+                "batched sequence cache is flat on the token axis: batch_size must be 1"
+            )
+        self.config = config
+        self._sequences: Dict[int, SequenceReferenceCache] = {}
+        self._spans: List[_SequenceSpan] = []
+        self._served: Set[int] = set()
+        self._declared = False
+
+    def declare_step(self, seq_ids: Sequence[int]) -> None:
+        if not seq_ids:
+            raise ValueError("a step carries at least one token")
+        for seq_id in seq_ids:
+            self._check_seq_id(seq_id)
+
+        spans: List[_SequenceSpan] = []
+        start = 0
+        while start < len(seq_ids):
+            seq_id = seq_ids[start]
+            end = start + 1
+            while end < len(seq_ids) and seq_ids[end] == seq_id:
+                end += 1
+            spans.append(_SequenceSpan(seq_id, start, end - start))
+            start = end
+
+        # capacity bounds the whole cache. Checked before anything is created so a refusal changes
+        # nothing.
+        held = sum(sequence.used(0) for sequence in self._sequences.values())
+        if held + len(seq_ids) > self.config.capacity:
+            raise RuntimeError(
+                f"KV cache overflow: {held + len(seq_ids)} cells exceeds "
+                f"capacity {self.config.capacity}"
+            )
+
+        for span in spans:
+            if span.seq_id not in self._sequences:
+                self._sequences[span.seq_id] = SequenceReferenceCache(self.config)
+
+        self._spans = spans
+        self._served.clear()
+        self._declared = True
+
+    def update_and_fetch(
+        self,
+        layer_id: int,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        position: torch.Tensor,
+    ) -> List[AttendSpec]:
+        """Place each span's K/V in its own sequence and return one spec each.
+
+        The specs follow the declared spans, so they cover the query axis in
+        order and no sequence appears in another's window.
+        """
+        if not self._declared:
+            raise RuntimeError(
+                "no step declared: declare_step must precede every forward"
+            )
+        if layer_id in self._served:
+            raise RuntimeError(
+                f"layer {layer_id} served twice for one step: "
+                "declare_step must precede every forward"
+            )
+        token_count = k.shape[-2]
+        if not position.shape[0] == token_count == v.shape[-2]:
+            raise ValueError("position, k, and v must have the same token count")
+        if token_count != sum(span.length for span in self._spans):
+            raise ValueError("the forward token count must match declare_step")
+        if position.shape[-1] != 1:
+            raise NotImplementedError(
+                "sequence placement needs one position per token, got "
+                f"{position.shape[-1]}"
+            )
+        self._check_positions(layer_id, position.reshape(-1).tolist())
+
+        specs: List[AttendSpec] = []
+        for span in self._spans:
+            end = span.start + span.length
+            sequence = self._sequences[span.seq_id]
+            specs.extend(
+                sequence.update_and_fetch(
+                    layer_id,
+                    k[:, :, span.start : end, :],
+                    v[:, :, span.start : end, :],
+                    position[span.start : end],
+                )
+            )
+
+        self._served.add(layer_id)
+        return specs
+
+    def reset(self) -> None:
+        self._sequences.clear()
+        self._spans.clear()
+        self._served.clear()
+        self._declared = False
+
+    def seq_rm(self, seq_id: int, p0: int = 0, p1: Optional[int] = None) -> None:
+        """Drop seq_id's claim on positions [p0, p1); p1 = None runs to the end.
+
+        A private contiguous history drops its tail but not its middle: it has
+        no per-token position map to reindex what would survive. Bounding
+        history from below is a layer policy, not a verb.
+        """
+        self._check_seq_id(seq_id)
+        if p1 is not None:
+            raise NotImplementedError(
+                "a private history drops only its tail, so [p0, p1) with a "
+                "bounded end has nothing to reindex the remainder against"
+            )
+        sequence = self._sequences.get(seq_id)
+        if sequence is not None:
+            if p0 == 0:
+                del self._sequences[seq_id]
+            else:
+                sequence.rewind(p0)
+        self._spans.clear()
+        self._served.clear()
+        self._declared = False
+
+    def seq_len(self, seq_id: int) -> int:
+        self._check_seq_id(seq_id)
+        sequence = self._sequences.get(seq_id)
+        return sequence.used(0) if sequence is not None else 0
+
+    def _check_positions(self, layer_id: int, positions: List[int]) -> None:
+        """Every span continues its own sequence, from where that sequence ends.
+
+        A private history appends at its used length and never reads
+        ``position``, so a step that declared the wrong one would still place
+        its tokens contiguously -- correct cells under the wrong names, and no
+        later step would notice. A sequence spanned twice in one step continues
+        across both.
+        """
+        ends: Dict[int, int] = {}
+        for span in self._spans:
+            at = ends.get(span.seq_id, self._sequences[span.seq_id].used(layer_id))
+            got = positions[span.start : span.start + span.length]
+            want = list(range(at, at + span.length))
+            if got != want:
+                raise ValueError(
+                    f"sequence {span.seq_id} holds {at} positions on layer "
+                    f"{layer_id}: the step declares {got}, not {want}"
+                )
+            ends[span.seq_id] = at + span.length
+
+    @staticmethod
+    def _check_seq_id(seq_id: int) -> None:
+        # No upper bound: a sequence is a dict entry, not a bit in an owner set.
+        if seq_id < 0:
+            raise ValueError(f"seq_id must be non-negative, got {seq_id}")
 
 
 @dataclass
@@ -296,7 +520,7 @@ class CellReferenceCache:
     that, so the spec is always EXPLICIT.
 
     The batch is flat: tokens from every sequence sit on one axis with B = 1,
-    and sequence identity is supplied out-of-band. ``begin_step`` declares which
+    and sequence identity is supplied out-of-band. ``declare_step`` declares which
     sequence each of the next forward's tokens belongs to; the positions arrive
     with the forward itself, in the op's ``position`` tensor, so cells are
     allocated on the first layer of the step and memoized for the rest of it.
@@ -332,7 +556,7 @@ class CellReferenceCache:
             for _ in range(config.n_layers)
         ]
         self._step_seq_ids: List[int] = []
-        self._declared = False  # set by begin_step, cleared by the step it authorizes
+        self._declared = False  # set by declare_step, cleared by the step it authorizes
         self._plan: Optional[_CellStepPlan] = None
         self._served: Set[int] = set()
 
@@ -354,7 +578,7 @@ class CellReferenceCache:
         bit = 1 << seq_id
         return sum(1 for owners in self._owners if owners & bit)
 
-    def begin_step(self, seq_ids: Sequence[int]) -> None:
+    def declare_step(self, seq_ids: Sequence[int]) -> None:
         """Declare the sequence each of the next forward's tokens belongs to.
 
         Admission is decided here, before the forward: the token count is known
@@ -430,17 +654,19 @@ class CellReferenceCache:
         k: torch.Tensor,
         v: torch.Tensor,
         position: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor, AttendSpec]:
+    ) -> List[AttendSpec]:
         """Scatter this step's K/V into its cells and return the read window.
 
         The first layer of a step allocates; the rest reuse that allocation, so
         the cells and the mask are computed once per forward, not once per
-        layer. Args are as ``ContiguousReferenceCache.update_and_fetch``.
+        layer. Every sequence reads the same window and the mask holds them
+        apart, so the list is always one long. Args are as
+        ``SequenceReferenceCache.update_and_fetch``.
         """
         if layer_id in self._served:
             raise RuntimeError(
                 f"layer {layer_id} served twice for one step: "
-                "begin_step must precede every forward"
+                "declare_step must precede every forward"
             )
         if self._plan is None:
             self._plan = self._allocate(position)
@@ -451,14 +677,15 @@ class CellReferenceCache:
         cells = self._plan.cells
         self._k[layer_id][:, :, cells, :] = k.to(self.config.dtype)
         self._v[layer_id][:, :, cells, :] = v.to(self.config.dtype)
-        return (
-            self._k[layer_id][:, :, :read_len, :],
-            self._v[layer_id][:, :, :read_len, :],
+        return [
             AttendSpec(
+                k=self._k[layer_id][:, :, :read_len, :],
+                v=self._v[layer_id][:, :, :read_len, :],
                 kind=MaskKind.EXPLICIT,
+                q_len=len(cells),
                 mask=self._plan.mask_for(self.config.policy_for(layer_id).window),
-            ),
-        )
+            )
+        ]
 
     # -- internals ----------------------------------------------------------
 
@@ -467,18 +694,17 @@ class CellReferenceCache:
         device = self._k[0].device
         if not self._declared:
             raise RuntimeError(
-                "no step declared: begin_step must precede every forward"
+                "no step declared: declare_step must precede every forward"
             )
         self._declared = False  # one declaration, one attempt at allocating it
         if position.shape[-1] != 1:
             raise NotImplementedError(
-                "cell placement needs one position per token, got "
-                f"{position.shape[-1]}"
+                f"cell placement needs one position per token, got {position.shape[-1]}"
             )
         positions = position.reshape(-1).tolist()
         if len(positions) != len(self._step_seq_ids):
             raise ValueError(
-                f"begin_step declared {len(self._step_seq_ids)} tokens, "
+                f"declare_step declared {len(self._step_seq_ids)} tokens, "
                 f"the forward carries {len(positions)}"
             )
         cells = [
@@ -537,7 +763,7 @@ class CellReferenceCache:
                 self._owners[i] = owners
                 self._used_end = max(self._used_end, i + 1)
                 return i
-        raise RuntimeError("no free cell")  # begin_step admitted the step
+        raise RuntimeError("no free cell")  # declare_step admitted the step
 
     def _shrink(self):
         while self._used_end > 0 and self._pos[self._used_end - 1] < 0:
@@ -546,7 +772,7 @@ class CellReferenceCache:
     def _invalidate_plan(self):
         # A mutated cell table leaves a built plan's cells and mask stale. The
         # step protocol state is deliberately left alone: a mutation must not
-        # disguise a forward that skipped begin_step.
+        # disguise a forward that skipped declare_step.
         self._plan = None
 
     @staticmethod
@@ -563,8 +789,6 @@ class CellReferenceCache:
 
 def attend(
     q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
     spec: AttendSpec,
     scale: float,
     out_dtype: torch.dtype,
@@ -579,17 +803,17 @@ def attend(
     so a cache must declare EXPLICIT for a chunked or multi-turn step.
 
     Args (BHSD):
-        q: ``[B, H_q, q_len, head_dim]`` -- queries (already RoPE-rotated).
-        k: ``[B, H_kv, total, head_dim]`` -- key history.
-        v: ``[B, H_kv, total, v_head_dim]`` -- value history.
-        spec: mask semantic (NONE = attend all; CAUSAL = causal; EXPLICIT = the
-            spec's bool mask).
+        q: ``[B, H_q, q_len, head_dim]`` -- queries (already RoPE-rotated), the
+            ones this spec answers.
+        spec: the K/V history to attend over and its mask semantic (NONE =
+            attend all; CAUSAL = causal; EXPLICIT = the spec's bool mask).
         scale: attention softmax scale.
         out_dtype: output dtype.
 
     Returns:
         ``[B, H_q, q_len, v_head_dim]`` attention output, in ``out_dtype``.
     """
+    k, v = spec.k, spec.v
     n_q_heads = q.shape[1]
     n_kv_heads = k.shape[1]
     if n_q_heads != n_kv_heads:

--- a/extension/llm/cache/test_update_and_attend.py
+++ b/extension/llm/cache/test_update_and_attend.py
@@ -11,15 +11,16 @@ import torch.nn.functional as F
 from executorch.extension.llm.cache.reference_cache import (
     attend,
     AttendSpec,
+    BatchedSequenceReferenceCache,
     CacheConfig,
     CacheSizing,
     CellReferenceCache,
-    ContiguousReferenceCache,
     flatten_step,
     LayerKind,
     LayerPolicy,
     MaskKind,
     MAX_SEQS,
+    SequenceReferenceCache,
 )
 from executorch.extension.llm.cache.update_and_attend import REGISTRY, update_and_attend
 
@@ -175,7 +176,7 @@ class UpdateAndAttendTest(unittest.TestCase):
             (CacheSizing.STATIC, seq_len),
         ]:
             with self.subTest(sizing=sizing):
-                cache = ContiguousReferenceCache(self._config(sizing, cap))
+                cache = SequenceReferenceCache(self._config(sizing, cap))
                 REGISTRY.install(self.cache_key, cache)
                 with REGISTRY.active(self.cache_key):
                     out = ep.module()(x, _positions(0, seq_len), torch.arange(seq_len))
@@ -195,7 +196,7 @@ class UpdateAndAttendTest(unittest.TestCase):
             (CacheSizing.STATIC, total),
         ]:
             with self.subTest(sizing=sizing):
-                cache = ContiguousReferenceCache(self._config(sizing, cap))
+                cache = SequenceReferenceCache(self._config(sizing, cap))
                 REGISTRY.install(self.cache_key, cache)
                 with REGISTRY.active(self.cache_key):
                     ep_prefill.module()(
@@ -221,7 +222,7 @@ class UpdateAndAttendTest(unittest.TestCase):
         ref = self.model.reference_forward(x, torch.arange(total))
 
         ep = self._export(chunk)
-        cache = ContiguousReferenceCache(self._config(CacheSizing.DYNAMIC, total))
+        cache = SequenceReferenceCache(self._config(CacheSizing.DYNAMIC, total))
         REGISTRY.install(self.cache_key, cache)
         with REGISTRY.active(self.cache_key):
             for start in range(0, total, chunk):
@@ -236,12 +237,34 @@ class UpdateAndAttendTest(unittest.TestCase):
 
     def test_static_overflow_raises(self):
         ep = self._export(seq_len=5)
-        cache = ContiguousReferenceCache(self._config(CacheSizing.STATIC, capacity=3))
+        cache = SequenceReferenceCache(self._config(CacheSizing.STATIC, capacity=3))
         REGISTRY.install(self.cache_key, cache)
         with self.assertRaises(RuntimeError), REGISTRY.active(self.cache_key):
             ep.module()(
                 torch.randn(1, 5, self.hidden), _positions(0, 5), torch.arange(5)
             )
+
+    def test_the_specs_must_cover_every_query_token(self):
+        # Each spec's queries are placed by the running total of the ones
+        # before it, so a cache that miscounts would attend the wrong slice
+        # rather than fail. Only this check separates the two.
+        class Miscounting:
+            def __init__(self, q_len):
+                self.q_len = q_len
+
+            def update_and_fetch(self, layer_id, k, v, position):
+                return [AttendSpec(k=k, v=v, kind=MaskKind.NONE, q_len=self.q_len)]
+
+        q = torch.randn(1, self.n_heads, 3, self.head_dim)
+        kv = torch.randn(1, self.n_kv_heads, 3, self.head_dim)
+        for q_len in (2, 4):  # answering too few, and claiming too many
+            with self.subTest(q_len=q_len):
+                REGISTRY.install(self.cache_key, Miscounting(q_len))
+                with self.assertRaisesRegex(ValueError, "of 3 query tokens"):
+                    with REGISTRY.active(self.cache_key):
+                        update_and_attend(
+                            q, kv, kv, _positions(0, 3), 0, 0.125, torch.float32
+                        )
 
     def test_output_shape_uses_value_head_dim(self):
         # The output's last dim comes from v, which may differ from q's head dim
@@ -261,6 +284,295 @@ class UpdateAndAttendTest(unittest.TestCase):
             and n.target is torch.ops.kvcache.update_and_attend.default
         )
         self.assertEqual(tuple(node.meta["val"].shape), (1, 4, 3, 5))
+
+
+class BatchedSequenceCacheTest(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        self.n_layers, self.hidden = 2, 16
+        self.n_heads, self.n_kv_heads, self.head_dim = 4, 2, 8
+        self.model = TinyAttentionModel(
+            self.n_layers,
+            self.hidden,
+            self.n_heads,
+            self.n_kv_heads,
+            self.head_dim,
+            40,
+        ).eval()
+        self.cache_key = "batched-sequences"
+
+    def tearDown(self):
+        REGISTRY.uninstall(self.cache_key)
+
+    def _cache(self, capacity=16, layers=None):
+        cache = BatchedSequenceReferenceCache(
+            CacheConfig(
+                n_layers=self.n_layers,
+                n_kv_heads=self.n_kv_heads,
+                head_dim=self.head_dim,
+                capacity=capacity,
+                layers=[LayerPolicy.flat()] if layers is None else layers,
+            )
+        )
+        REGISTRY.install(self.cache_key, cache)
+        return cache
+
+    def _step(self, cache, x, positions, seq_ids):
+        cache.declare_step(seq_ids)
+        with REGISTRY.active(self.cache_key):
+            return self.model(x, positions, torch.arange(x.shape[1]))
+
+    def _attention_inputs(self, length):
+        return (
+            torch.randn(1, self.n_heads, length, self.head_dim),
+            torch.randn(1, self.n_kv_heads, length, self.head_dim),
+            torch.randn(1, self.n_kv_heads, length, self.head_dim),
+            _positions(0, length),
+        )
+
+    def _attend(self, cache, inputs, layer_id=0):
+        # What the op does: fetch one spec per span, attend each over the query
+        # tokens it answers, rejoin.
+        q, k, v, positions = inputs
+        specs = cache.update_and_fetch(layer_id, k, v, positions)
+        outputs, start = [], 0
+        for spec in specs:
+            end = start + spec.q_len
+            outputs.append(
+                attend(
+                    q[:, :, start:end, :],
+                    spec,
+                    self.head_dim**-0.5,
+                    torch.float32,
+                )
+            )
+            start = end
+        return outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=2)
+
+    def test_single_span_matches_single_sequence(self):
+        x = torch.randn(1, 5, self.hidden)
+        out = self._step(self._cache(), x, _positions(0, 5), [3] * 5)
+        torch.testing.assert_close(
+            out,
+            self.model.reference_forward(x, torch.arange(5)),
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    def test_multiple_sequence_spans_match_separate_runs(self):
+        a = torch.randn(1, 4, self.hidden)
+        b = torch.randn(1, 3, self.hidden)
+        tokens, positions, seq_ids, _ = flatten_step({2: (a, 0), 7: (b, 0)})
+
+        out = self._step(self._cache(), tokens, positions, seq_ids)
+
+        torch.testing.assert_close(
+            out[:, :4],
+            self.model.reference_forward(a, torch.arange(4)),
+            atol=1e-4,
+            rtol=1e-4,
+        )
+        torch.testing.assert_close(
+            out[:, 4:],
+            self.model.reference_forward(b, torch.arange(3)),
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    def test_repeated_sequence_spans_preserve_input_order(self):
+        a = torch.randn(1, 3, self.hidden)
+        b = torch.randn(1, 1, self.hidden)
+        tokens = torch.cat([a[:, :2], b, a[:, 2:]], dim=1)
+        positions = torch.tensor([[0], [1], [0], [2]], dtype=torch.long)
+        out = self._step(self._cache(), tokens, positions, [2, 2, 7, 2])
+
+        a_out = self.model.reference_forward(a, torch.arange(3))
+        b_out = self.model.reference_forward(b, torch.arange(1))
+        torch.testing.assert_close(out[:, [0, 1, 3]], a_out, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(out[:, 2:3], b_out, atol=1e-4, rtol=1e-4)
+
+    def test_decode_continues_each_private_sequence(self):
+        a = torch.randn(1, 4, self.hidden)
+        b = torch.randn(1, 3, self.hidden)
+        cache = self._cache()
+
+        tokens, positions, seq_ids, _ = flatten_step(
+            {2: (a[:, :3], 0), 7: (b[:, :2], 0)}
+        )
+        self._step(cache, tokens, positions, seq_ids)
+
+        tokens, positions, seq_ids, _ = flatten_step(
+            {2: (a[:, 3:], 3), 7: (b[:, 2:], 2)}
+        )
+        out = self._step(cache, tokens, positions, seq_ids)
+
+        torch.testing.assert_close(
+            out[:, 0],
+            self.model.reference_forward(a, torch.arange(4))[:, -1],
+            atol=1e-4,
+            rtol=1e-4,
+        )
+        torch.testing.assert_close(
+            out[:, 1],
+            self.model.reference_forward(b, torch.arange(3))[:, -1],
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    def test_a_span_must_continue_its_own_sequence(self):
+        # A private history appends at its length, so a wrong position would
+        # still land contiguously. Only this check separates the two.
+        cache = self._cache()
+        q, k, v, _ = self._attention_inputs(2)
+        cache.declare_step([5, 5])
+
+        with self.assertRaisesRegex(ValueError, r"declares \[1, 2\], not \[0, 1\]"):
+            self._attend(cache, (q, k, v, _positions(1, 2)))
+        self.assertEqual(cache.seq_len(5), 0)  # a refusal writes nothing
+
+        # Ascending is not enough; a span is a consecutive run.
+        gapped = torch.tensor([[0], [2]], dtype=torch.long)
+        with self.assertRaisesRegex(ValueError, r"declares \[0, 2\], not \[0, 1\]"):
+            self._attend(cache, (q, k, v, gapped))
+        self.assertEqual(cache.seq_len(5), 0)
+
+        # The declaration still stands, so the same layer can be retried.
+        self._attend(cache, (q, k, v, _positions(0, 2)))
+        self.assertEqual(cache.seq_len(5), 2)
+
+    def test_a_sequence_spanned_twice_continues_across_both(self):
+        cache = self._cache()
+        q, k, v, _ = self._attention_inputs(3)
+
+        # Tokens 0 and 2 are seq 4, token 1 is seq 9; seq 4's second span picks
+        # up where its first left off rather than at its prior length.
+        cache.declare_step([4, 9, 4])
+        self._attend(cache, (q, k, v, torch.tensor([[0], [0], [1]])))
+        self.assertEqual(cache.seq_len(4), 2)
+        self.assertEqual(cache.seq_len(9), 1)
+
+        # The bad position is in the last span, so a per-span check would have
+        # written the first two before refusing.
+        cache.declare_step([4, 9, 4])
+        with self.assertRaisesRegex(ValueError, r"holds 3 .*declares \[4\], not \[3\]"):
+            self._attend(cache, (q, k, v, torch.tensor([[2], [1], [4]])))
+        self.assertEqual(cache.seq_len(4), 2)
+        self.assertEqual(cache.seq_len(9), 1)
+
+    def test_requires_one_declared_step_per_forward(self):
+        cache = self._cache()
+        inputs = self._attention_inputs(1)
+
+        with self.assertRaisesRegex(RuntimeError, "no step declared"):
+            self._attend(cache, inputs)
+
+        cache.declare_step([2])
+        self._attend(cache, inputs)
+        with self.assertRaisesRegex(RuntimeError, "served twice"):
+            self._attend(cache, inputs)
+
+    def test_declaration_and_sequence_verbs_validate_ids(self):
+        cache = self._cache()
+        with self.assertRaisesRegex(ValueError, "at least one token"):
+            cache.declare_step([])
+
+        for call in (
+            lambda: cache.declare_step([-1]),
+            lambda: cache.seq_rm(-1),
+            lambda: cache.seq_len(-1),
+        ):
+            with self.subTest(call=call), self.assertRaises(ValueError):
+                call()
+
+        # Private histories are dict entries, so nothing caps the id.
+        cache.declare_step([9999])
+        self.assertEqual(cache.seq_len(9999), 0)
+
+    def test_capacity_is_the_pool_total_and_refusal_changes_nothing(self):
+        cache = self._cache(capacity=4)
+        with self.assertRaisesRegex(RuntimeError, "exceeds capacity"):
+            cache.declare_step([2] * 5)
+        self.assertEqual(cache.seq_len(2), 0)
+
+        # Two sequences share the budget rather than each getting one.
+        a = torch.randn(1, 2, self.hidden)
+        b = torch.randn(1, 2, self.hidden)
+        tokens, positions, seq_ids, _ = flatten_step({2: (a, 0), 7: (b, 0)})
+        self._step(cache, tokens, positions, seq_ids)
+        self.assertEqual(cache.seq_len(2), 2)
+        self.assertEqual(cache.seq_len(7), 2)
+
+        # Either sequence is now blocked by what the other holds.
+        with self.assertRaisesRegex(RuntimeError, "exceeds capacity"):
+            cache.declare_step([2])
+        self.assertEqual(cache.seq_len(2), 2)
+        self.assertEqual(cache.seq_len(7), 2)
+
+    def test_forward_width_must_match_tensors_and_declaration(self):
+        one = self._attention_inputs(1)
+        two = self._attention_inputs(2)
+        cases = (
+            ("position", [2], (one[0], one[1], one[2], two[3]), "same token count"),
+            ("q/k", [2, 2], (two[0], one[1], one[2], two[3]), "same token count"),
+            ("k/v", [2], (one[0], one[1], two[2], one[3]), "same token count"),
+            ("declaration", [2, 2], one, "must match declare_step"),
+        )
+        for name, seq_ids, inputs, message in cases:
+            with self.subTest(name=name):
+                cache = self._cache()
+                cache.declare_step(seq_ids)
+                with self.assertRaisesRegex(ValueError, message):
+                    self._attend(cache, inputs)
+
+    def test_sequence_removal_invalidates_a_declared_step(self):
+        cache = self._cache()
+        cache.declare_step([2])
+        cache.seq_rm(2)
+
+        self.assertEqual(cache.seq_len(2), 0)
+        with self.assertRaisesRegex(RuntimeError, "no step declared"):
+            self._attend(cache, self._attention_inputs(1))
+
+    def test_seq_rm_truncates_or_drops_and_refuses_a_bounded_range(self):
+        cache = self._cache()
+        self._step(cache, torch.randn(1, 4, self.hidden), _positions(0, 4), [1] * 4)
+        self._step(cache, torch.randn(1, 2, self.hidden), _positions(0, 2), [6] * 2)
+
+        with self.assertRaises(NotImplementedError):
+            cache.seq_rm(1, 0, 2)
+        self.assertEqual(cache.seq_len(1), 4)
+
+        cache.seq_rm(1, 2)  # keep positions 0..1
+        self.assertEqual(cache.seq_len(1), 2)
+        self.assertEqual(cache.seq_len(6), 2)  # its neighbour is untouched
+
+        cache.seq_rm(1)  # the whole sequence
+        self.assertEqual(cache.seq_len(1), 0)
+        self.assertEqual(cache.seq_len(6), 2)
+
+    def test_rewinding_then_continuing_matches_an_unbroken_run(self):
+        x = torch.randn(1, 5, self.hidden)
+        ref = self.model.reference_forward(x, torch.arange(5))
+
+        cache = self._cache()
+        self._step(cache, x[:, :4], _positions(0, 4), [3] * 4)
+        cache.seq_rm(3, 2)  # discard positions 2..3
+        out = self._step(cache, x[:, 2:], _positions(2, 3), [3] * 3)
+
+        torch.testing.assert_close(out, ref[:, 2:], atol=1e-4, rtol=1e-4)
+
+    def test_rewind_refuses_to_grow_or_pass_a_window(self):
+        cache = self._cache(layers=[LayerPolicy.ring(2)])
+        self._step(cache, torch.randn(1, 5, self.hidden), _positions(0, 5), [0] * 5)
+
+        with self.assertRaisesRegex(ValueError, "the history holds 5"):
+            cache.seq_rm(0, 6)
+        # A windowed layer keeps only its last two positions, so 3 is the floor
+        # even though this reference still holds the older ones.
+        with self.assertRaisesRegex(ValueError, "retains only from 3"):
+            cache.seq_rm(0, 1)
+        cache.seq_rm(0, 3)
+        self.assertEqual(cache.seq_len(0), 3)
 
 
 class CellCacheTest(unittest.TestCase):
@@ -305,7 +617,7 @@ class CellCacheTest(unittest.TestCase):
 
     def _step(self, cache, x, positions, seqs):
         """One forward carrying `x`, whose tokens have these positions/seqs."""
-        cache.begin_step(seqs)
+        cache.declare_step(seqs)
         pos = torch.tensor(positions, dtype=torch.long).unsqueeze(-1)
         with REGISTRY.active(self.cache_key):
             return self.model(x, pos, torch.arange(x.shape[1]))
@@ -325,7 +637,7 @@ class CellCacheTest(unittest.TestCase):
 
         # {seq_id: (tokens, start_pos)} -> the step's parallel arrays
         tokens, positions, seq_ids, _ = flatten_step({0: (a, 0), 1: (b, 0)})
-        cache.begin_step(seq_ids)
+        cache.declare_step(seq_ids)
         with REGISTRY.active(self.cache_key):
             # every row, not one per sequence: each token is compared below
             out = self.model(tokens, positions, torch.arange(tokens.shape[1]))
@@ -352,14 +664,14 @@ class CellCacheTest(unittest.TestCase):
         tokens, positions, seq_ids, logits_indices = flatten_step(
             {0: (a[:, :3], 0), 1: (b[:, :2], 0)}
         )
-        cache.begin_step(seq_ids)
+        cache.declare_step(seq_ids)
         with REGISTRY.active(self.cache_key):
             self.model(tokens, positions, logits_indices)
 
         tokens, positions, seq_ids, logits_indices = flatten_step(
             {0: (a[:, 3:], 3), 1: (b[:, 2:], 2)}
         )
-        cache.begin_step(seq_ids)
+        cache.declare_step(seq_ids)
         with REGISTRY.active(self.cache_key):
             out = self.model(tokens, positions, logits_indices)
 
@@ -433,18 +745,18 @@ class CellCacheTest(unittest.TestCase):
     def test_freeing_the_tail_shrinks_the_read_window(self):
         cache = self._cache()
         kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
-        cache.begin_step([0] * 4)
-        k, _, _ = cache.update_and_fetch(0, kv, kv, _positions(0, 4))
-        self.assertEqual(k.shape[2], 4)  # four cells held, so a window of four
+        cache.declare_step([0] * 4)
+        spec = cache.update_and_fetch(0, kv, kv, _positions(0, 4))[0]
+        self.assertEqual(spec.k.shape[2], 4)  # four cells held, so a window of four
 
         cache.seq_rm(0)  # frees all four, so used_end walks back to 0
         self.assertEqual(cache.free_cells(), self.CAPACITY)
 
         # one token reclaims cell 0, so the window is its own single cell
         kv = torch.randn(1, self.n_kv_heads, 1, self.head_dim)
-        cache.begin_step([1])
-        k, _, spec = cache.update_and_fetch(0, kv, kv, torch.tensor([[0]]))
-        self.assertEqual(k.shape[2], 1)  # the window length is 1, not the old 4
+        cache.declare_step([1])
+        spec = cache.update_and_fetch(0, kv, kv, torch.tensor([[0]]))[0]
+        self.assertEqual(spec.k.shape[2], 1)  # the window length is 1, not the old 4
         self.assertEqual(spec.mask.shape[-1], 1)
 
     def test_seq_rm_over_a_range_frees_only_that_window(self):
@@ -464,7 +776,7 @@ class CellCacheTest(unittest.TestCase):
         # much later as an overflow while building the mask.
         cache = self._cache()
         for call in (
-            lambda: cache.begin_step([MAX_SEQS]),
+            lambda: cache.declare_step([MAX_SEQS]),
             lambda: cache.seq_cp(0, MAX_SEQS),
             lambda: cache.seq_cp(MAX_SEQS, 0),
             lambda: cache.seq_rm(MAX_SEQS),
@@ -491,8 +803,8 @@ class CellCacheTest(unittest.TestCase):
     def test_window_narrows_each_query_without_crossing_sequences(self):
         cache = self._cache(layers=[LayerPolicy.ring(2)])
         kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
-        cache.begin_step([0] * 4)
-        spec = cache.update_and_fetch(0, kv, kv, _positions(0, 4))[2]
+        cache.declare_step([0] * 4)
+        spec = cache.update_and_fetch(0, kv, kv, _positions(0, 4))[0]
 
         # offsets[i][j] = j - i, so <= 0 is causal and > -2 keeps the newest
         # two: a band whose row 2 drops key 0, which plain causal would keep.
@@ -501,9 +813,9 @@ class CellCacheTest(unittest.TestCase):
 
         # a second sequence is bounded the same way, and still sees none of
         # the first's cells even though they are inside its window
-        cache.begin_step([1, 1])
+        cache.declare_step([1, 1])
         kv = torch.randn(1, self.n_kv_heads, 2, self.head_dim)
-        spec = cache.update_and_fetch(0, kv, kv, _positions(0, 2))[2]
+        spec = cache.update_and_fetch(0, kv, kv, _positions(0, 2))[0]
         expected = torch.zeros(2, 6, dtype=torch.bool)
         expected[0, 4] = expected[1, 4] = expected[1, 5] = True
         torch.testing.assert_close(spec.mask, expected)
@@ -513,10 +825,10 @@ class CellCacheTest(unittest.TestCase):
         # per policy, not per layer, so a mixed model costs one extra mask.
         cache = self._cache(layers=[LayerPolicy.flat(), LayerPolicy.ring(2)])
         kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
-        cache.begin_step([0] * 4)
+        cache.declare_step([0] * 4)
         pos = _positions(0, 4)
-        flat = cache.update_and_fetch(0, kv, kv, pos)[2].mask
-        windowed = cache.update_and_fetch(1, kv, kv, pos)[2].mask
+        flat = cache.update_and_fetch(0, kv, kv, pos)[0].mask
+        windowed = cache.update_and_fetch(1, kv, kv, pos)[0].mask
 
         offsets = torch.arange(4) - torch.arange(4).unsqueeze(-1)
         torch.testing.assert_close(flat, offsets <= 0)
@@ -530,11 +842,11 @@ class CellCacheTest(unittest.TestCase):
             n_layers=3,
         )
         kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
-        cache.begin_step([0] * 4)
+        cache.declare_step([0] * 4)
         pos = _positions(0, 4)
-        flat = cache.update_and_fetch(0, kv, kv, pos)[2].mask
-        first = cache.update_and_fetch(1, kv, kv, pos)[2].mask
-        second = cache.update_and_fetch(2, kv, kv, pos)[2].mask
+        flat = cache.update_and_fetch(0, kv, kv, pos)[0].mask
+        first = cache.update_and_fetch(1, kv, kv, pos)[0].mask
+        second = cache.update_and_fetch(2, kv, kv, pos)[0].mask
 
         self.assertIs(first, second)
         self.assertIsNot(flat, first)
@@ -543,22 +855,25 @@ class CellCacheTest(unittest.TestCase):
         window = 2
         cache = self._cache(layers=[LayerPolicy.ring(window)])
         kv = torch.randn(1, self.n_kv_heads, 4, self.head_dim)
-        cache.begin_step([0] * 4)
+        cache.declare_step([0] * 4)
         cache.update_and_fetch(0, kv, kv, _positions(0, 4))
 
-        cache.begin_step([0])
+        cache.declare_step([0])
         kv = torch.randn(1, self.n_kv_heads, 1, self.head_dim)
-        k, v, spec = cache.update_and_fetch(0, kv, kv, _positions(4, 1))
+        spec = cache.update_and_fetch(0, kv, kv, _positions(4, 1))[0]
 
         q = torch.randn(1, self.n_heads, 1, self.head_dim)
         scale = self.head_dim**-0.5
         torch.testing.assert_close(
-            attend(q, k, v, spec, scale, torch.float32),
+            attend(q, spec, scale, torch.float32),
             attend(  # the last `window` cells of its sequence, unmasked
                 q,
-                k[:, :, -window:, :],
-                v[:, :, -window:, :],
-                AttendSpec(kind=MaskKind.NONE),
+                AttendSpec(
+                    k=spec.k[:, :, -window:, :],
+                    v=spec.v[:, :, -window:, :],
+                    kind=MaskKind.NONE,
+                    q_len=1,
+                ),
                 scale,
                 torch.float32,
             ),
@@ -568,7 +883,7 @@ class CellCacheTest(unittest.TestCase):
         cache = self._cache(capacity=4)
         self.assertFalse(cache.can_extend(5))
         with self.assertRaises(RuntimeError):
-            cache.begin_step([0] * 5)
+            cache.declare_step([0] * 5)
 
     def test_step_protocol_is_enforced(self):
         cache = self._cache()
@@ -576,17 +891,17 @@ class CellCacheTest(unittest.TestCase):
         pos = torch.tensor([[0]])
 
         with self.assertRaises(ValueError):  # a step with no tokens
-            cache.begin_step([])
+            cache.declare_step([])
 
-        cache.begin_step([0, 0])  # declares two tokens, forward carries one
+        cache.declare_step([0, 0])  # declares two tokens, forward carries one
         with self.assertRaises(ValueError):
             cache.update_and_fetch(0, kv, kv, pos)
         with self.assertRaises(RuntimeError):  # the failed attempt still cleared it
             cache.update_and_fetch(0, kv, kv, torch.tensor([[0], [1]]))
 
-        cache.begin_step([0])
+        cache.declare_step([0])
         cache.update_and_fetch(0, kv, kv, pos)
-        with self.assertRaises(RuntimeError):  # a second step, no begin_step
+        with self.assertRaises(RuntimeError):  # a second step, no declare_step
             cache.update_and_fetch(0, kv, kv, pos)
 
     def test_growth_keeps_cell_indices_and_bytes(self):
@@ -595,18 +910,19 @@ class CellCacheTest(unittest.TestCase):
         # move history without anything noticing.
         cache = self._cache()
         first = torch.randn(1, self.n_kv_heads, 2, self.head_dim)
-        cache.begin_step([0, 0])
-        k, _, _ = cache.update_and_fetch(0, first, first, torch.tensor([[0], [1]]))
-        self.assertEqual(k.shape[2], 2)  # a short session reserves a short pool
+        cache.declare_step([0, 0])
+        spec = cache.update_and_fetch(0, first, first, torch.tensor([[0], [1]]))[0]
+        self.assertEqual(spec.k.shape[2], 2)  # a short session reserves a short pool
 
         rest = torch.randn(1, self.n_kv_heads, 6, self.head_dim)
-        cache.begin_step([0] * 6)
-        k, v, _ = cache.update_and_fetch(
+        cache.declare_step([0] * 6)
+        spec = cache.update_and_fetch(
             0, rest, rest, torch.tensor([[p] for p in range(2, 8)])
-        )
-        self.assertEqual(k.shape[2], 8)
-        torch.testing.assert_close(k[:, :, :2, :], first)  # cells 0,1 unmoved
-        torch.testing.assert_close(v[:, :, 2:, :], rest)
+        )[0]
+        self.assertEqual(spec.k.shape[2], 8)
+        # cells 0,1 unmoved
+        torch.testing.assert_close(spec.k[:, :, :2, :], first)
+        torch.testing.assert_close(spec.v[:, :, 2:, :], rest)
 
     def test_sizings_agree(self):
         x = torch.randn(1, 5, self.hidden)
@@ -616,14 +932,14 @@ class CellCacheTest(unittest.TestCase):
         ]
         torch.testing.assert_close(out[0], out[1])
 
-    def test_a_verb_does_not_hide_a_missing_begin_step(self):
+    def test_a_verb_does_not_hide_a_missing_declare_step(self):
         # A sequence verb drops the memoized plan, which must not be mistaken
         # for the start of a step -- that would silently reuse the previous
         # step's sequence assignment for the new tokens.
         cache = self._cache()
         kv = torch.randn(1, self.n_kv_heads, 2, self.head_dim)
         pos = torch.tensor([[0], [0]])
-        cache.begin_step([0, 1])
+        cache.declare_step([0, 1])
         cache.update_and_fetch(0, kv, kv, pos)
 
         cache.seq_rm(2)  # any verb; a no-op here beyond dropping the plan
@@ -633,18 +949,18 @@ class CellCacheTest(unittest.TestCase):
             cache.update_and_fetch(1, kv, kv, pos)
 
 
-class ContiguousSpecTest(unittest.TestCase):
+class SequenceSpecTest(unittest.TestCase):
     # Which mask semantic the cache declares for each shape of step.
 
     def setUp(self):
         torch.manual_seed(0)
-        self.cache = ContiguousReferenceCache(
+        self.cache = SequenceReferenceCache(
             CacheConfig(n_layers=1, n_kv_heads=2, head_dim=4, capacity=8)
         )
 
     def _update(self, start, q_len):
         kv = torch.randn(1, 2, q_len, 4)
-        return self.cache.update_and_fetch(0, kv, kv, _positions(start, q_len))[2]
+        return self.cache.update_and_fetch(0, kv, kv, _positions(start, q_len))[0]
 
     def test_decode_is_unmasked(self):
         self.assertEqual(self._update(0, 1).kind, MaskKind.NONE)
@@ -674,7 +990,7 @@ class WindowedSpecTest(unittest.TestCase):
         self.scale = self.DIM**-0.5
 
     def _cache(self, policy, sizing=CacheSizing.DYNAMIC):
-        return ContiguousReferenceCache(
+        return SequenceReferenceCache(
             CacheConfig(
                 n_layers=1,
                 n_kv_heads=self.HEADS,
@@ -689,50 +1005,51 @@ class WindowedSpecTest(unittest.TestCase):
         kv = torch.randn(1, self.HEADS, n, self.DIM)
         return cache.update_and_fetch(0, kv, kv, _positions(start, n))
 
-    def _attend(self, q, k, v, spec):
-        return attend(q, k, v, spec, self.scale, torch.float32)
+    def _attend(self, q, spec):
+        return attend(q, spec, self.scale, torch.float32)
+
+    def _unmasked(self, q, k, v):
+        # The same queries over a hand-picked window, for the spec to match.
+        spec = AttendSpec(k=k, v=v, kind=MaskKind.NONE, q_len=q.shape[-2])
+        return attend(q, spec, self.scale, torch.float32)
 
     def test_decode_attends_only_the_window(self):
         window = 3
         cache = self._cache(LayerPolicy.ring(window))
         self._update(cache, 5, 0)
-        k, v, spec = self._update(cache, 1, 5)
+        spec = self._update(cache, 1, 5)[0]
 
         q = torch.randn(1, self.HEADS, 1, self.DIM)
         torch.testing.assert_close(
-            self._attend(q, k, v, spec),
-            self._attend(  # the last `window` cells, unmasked
-                q,
-                k[:, :, -window:, :],
-                v[:, :, -window:, :],
-                AttendSpec(kind=MaskKind.NONE),
+            self._attend(q, spec),
+            self._unmasked(  # the last `window` cells, unmasked
+                q, spec.k[:, :, -window:, :], spec.v[:, :, -window:, :]
             ),
         )
 
     def test_each_prefill_query_attends_its_own_window(self):
         window = 2
         cache = self._cache(LayerPolicy.ring(window))
-        k, v, spec = self._update(cache, 4, 0)
+        spec = self._update(cache, 4, 0)[0]
         self.assertEqual(spec.kind, MaskKind.EXPLICIT)
 
         q = torch.randn(1, self.HEADS, 4, self.DIM)
-        out = self._attend(q, k, v, spec)
+        out = self._attend(q, spec)
         for i in range(4):  # query at position i sees (i - window, i]
             lo = max(0, i - window + 1)
             torch.testing.assert_close(
                 out[:, :, i : i + 1, :],
-                self._attend(
+                self._unmasked(
                     q[:, :, i : i + 1, :],
-                    k[:, :, lo : i + 1, :],
-                    v[:, :, lo : i + 1, :],
-                    AttendSpec(kind=MaskKind.NONE),
+                    spec.k[:, :, lo : i + 1, :],
+                    spec.v[:, :, lo : i + 1, :],
                 ),
             )
 
     def test_layers_can_window_independently(self):
         # gemma-style: only some layers are windowed, so one step yields two
         # different semantics from the same cache.
-        cache = ContiguousReferenceCache(
+        cache = SequenceReferenceCache(
             CacheConfig(
                 n_layers=2,
                 n_kv_heads=self.HEADS,
@@ -743,8 +1060,8 @@ class WindowedSpecTest(unittest.TestCase):
         )
         kv = torch.randn(1, self.HEADS, 4, self.DIM)
         pos = _positions(0, 4)
-        flat = cache.update_and_fetch(0, kv, kv, pos)[2]
-        windowed = cache.update_and_fetch(1, kv, kv, pos)[2]
+        flat = cache.update_and_fetch(0, kv, kv, pos)[0]
+        windowed = cache.update_and_fetch(1, kv, kv, pos)[0]
 
         self.assertEqual(flat.kind, MaskKind.CAUSAL)
         self.assertEqual(windowed.kind, MaskKind.EXPLICIT)
@@ -757,7 +1074,7 @@ class WindowedSpecTest(unittest.TestCase):
         window = 2
         cache = self._cache(LayerPolicy.ring(window))
         self._update(cache, 4, 0)
-        _, _, spec = self._update(cache, 3, 4)
+        spec = self._update(cache, 3, 4)[0]
 
         self.assertEqual(spec.kind, MaskKind.EXPLICIT)
         q_len, total = 3, 7
@@ -773,8 +1090,8 @@ class WindowedSpecTest(unittest.TestCase):
         # later the band appears.
         window = 4
         cache = self._cache(LayerPolicy.ring(window))
-        self.assertEqual(self._update(cache, window, 0)[2].kind, MaskKind.CAUSAL)
-        self.assertEqual(self._update(cache, 1, window)[2].kind, MaskKind.EXPLICIT)
+        self.assertEqual(self._update(cache, window, 0)[0].kind, MaskKind.CAUSAL)
+        self.assertEqual(self._update(cache, 1, window)[0].kind, MaskKind.EXPLICIT)
 
     def test_static_sizing_windows_like_dynamic(self):
         # STATIC writes into a preallocated buffer and slices it; the window is
@@ -782,13 +1099,13 @@ class WindowedSpecTest(unittest.TestCase):
         window = 2
         torch.manual_seed(0)
         static = self._cache(LayerPolicy.ring(window), sizing=CacheSizing.STATIC)
-        sk, sv, s_spec = self._update(static, 4, 0)
+        s_spec = self._update(static, 4, 0)[0]
         torch.manual_seed(0)
         dynamic = self._cache(LayerPolicy.ring(window))
-        dk, dv, d_spec = self._update(dynamic, 4, 0)
+        d_spec = self._update(dynamic, 4, 0)[0]
 
-        torch.testing.assert_close(sk, dk)
-        torch.testing.assert_close(sv, dv)
+        torch.testing.assert_close(s_spec.k, d_spec.k)
+        torch.testing.assert_close(s_spec.v, d_spec.v)
         self.assertEqual(s_spec.kind, d_spec.kind)
         torch.testing.assert_close(s_spec.mask, d_spec.mask)
 
@@ -796,8 +1113,8 @@ class WindowedSpecTest(unittest.TestCase):
         # Nothing to bound from below, so the window must not force a mask.
         for policy in (LayerPolicy.flat(), LayerPolicy.ring(64)):
             cache = self._cache(policy)
-            self.assertEqual(self._update(cache, 4, 0)[2].kind, MaskKind.CAUSAL)
-            self.assertEqual(self._update(cache, 1, 4)[2].kind, MaskKind.NONE)
+            self.assertEqual(self._update(cache, 4, 0)[0].kind, MaskKind.CAUSAL)
+            self.assertEqual(self._update(cache, 1, 4)[0].kind, MaskKind.NONE)
 
 
 class AttendExplicitTest(unittest.TestCase):
@@ -812,16 +1129,21 @@ class AttendExplicitTest(unittest.TestCase):
         self.v = torch.randn(1, 2, self.total, self.head_dim)
         self.scale = self.head_dim**-0.5
 
-    def _attend(self, spec, k=None, v=None):
-        k = self.k if k is None else k
-        v = self.v if v is None else v
-        return attend(self.q, k, v, spec, self.scale, torch.float32)
+    def _attend(self, kind, mask=None, k=None, v=None):
+        spec = AttendSpec(
+            k=self.k if k is None else k,
+            v=self.v if v is None else v,
+            kind=kind,
+            q_len=self.q_len,
+            mask=mask,
+        )
+        return attend(self.q, spec, self.scale, torch.float32)
 
     def test_causal_rejects_a_non_square_window(self):
         # torch's is_causal is upper-left, so it cannot serve a continuation;
         # a cache must declare EXPLICIT there rather than CAUSAL.
         with self.assertRaises(ValueError):
-            self._attend(AttendSpec(kind=MaskKind.CAUSAL))
+            self._attend(MaskKind.CAUSAL)
 
     def test_explicit_attends_the_true_cells(self):
         # Polarity: masking to cells {0, 2} must equal attending over just those
@@ -830,11 +1152,11 @@ class AttendExplicitTest(unittest.TestCase):
         mask = torch.zeros(self.q_len, self.total, dtype=torch.bool)
         mask[:, keep] = True
         torch.testing.assert_close(
-            self._attend(AttendSpec(kind=MaskKind.EXPLICIT, mask=mask)),
+            self._attend(MaskKind.EXPLICIT, mask=mask),
             self._attend(
-                AttendSpec(kind=MaskKind.NONE),
-                self.k.index_select(2, keep),
-                self.v.index_select(2, keep),
+                MaskKind.NONE,
+                k=self.k.index_select(2, keep),
+                v=self.v.index_select(2, keep),
             ),
         )
 

--- a/extension/llm/cache/update_and_attend.py
+++ b/extension/llm/cache/update_and_attend.py
@@ -95,8 +95,16 @@ def update_and_attend(
     Returns:
         ``[B, H_q, q_len, v_head_dim]`` attention output, in ``out_dtype``.
     """
-    k_hist, v_hist, spec = REGISTRY.current().update_and_fetch(layer_id, k, v, position)
-    return attend(q, k_hist, v_hist, spec, scale, out_dtype)
+    specs = REGISTRY.current().update_and_fetch(layer_id, k, v, position)
+    outputs = []
+    start = 0
+    for spec in specs:
+        end = start + spec.q_len
+        outputs.append(attend(q[:, :, start:end, :], spec, scale, out_dtype))
+        start = end
+    if start != q.shape[-2]:
+        raise ValueError(f"the cache answered {start} of {q.shape[-2]} query tokens")
+    return outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=2)
 
 
 @update_and_attend.register_fake


### PR DESCRIPTION
### Summary
Adds a third reference layout: a private history per sequence instead of one shared cell table. Attention splits the flat token axis into its declared spans and runs independently over each sequence's own history, so no sequence attends another and no cross-sequence mask is built. 

That means a step can be answered by more than one attention, so update_and_fetch returns a list of AttendSpec and the op attends each over the query tokens it covers. A spec now carries its own K/V and how many queries it answers; the offsets follow from the running total, and the op checks the specs cover the step. The single-history layouts return a one-element list and are behaviourally unchanged; most of the test diff is call sites reshaping around that.

Read reference_cache.py first (AttendSpec, then BatchedSequenceReferenceCache), then update_and_attend.py for the loop, then the tests.