### PR TITLE
Fix renamed compiler test source in `BUCK`

### DIFF
--- a/backends/nxp/tests/BUCK
+++ b/backends/nxp/tests/BUCK
@@ -148,7 +148,7 @@ fbcode_target(_kind = python_pytest,
 fbcode_target(_kind = python_pytest,
     name = "test_neutron_converter_manager",
     srcs = [
-        "generic_tests/test_neutron_converter_manager.py",
+        "generic_tests/test_neutron_compiler_manager.py",
     ],
     deps = [
         "//executorch/backends/nxp:neutron_sdk",


### PR DESCRIPTION
Summary:
D119200814 replaced `test_neutron_converter_manager.py` with `test_neutron_compiler_manager.py` but left the old source path in the mirrored `BUCK` files. This makes `test_neutron_converter_manager` fail to build with a missing-file error.

Update both source paths to the renamed test file, preserving the existing target name.

Authored with Codex.

Differential Revision: D119340967


