### PR TITLE
Erase the cat/slice/select nop ops after memory planning (#22651)

### DIFF
--- a/backends/cadence/aot/memory_planning.py
+++ b/backends/cadence/aot/memory_planning.py
@@ -26,7 +26,11 @@ from executorch.backends.cadence.aot.utils import (
 )
 
 from executorch.exir import ExecutorchProgramManager
-from executorch.exir.memory_planning import collect_specs_from_nodes, Verifier
+from executorch.exir.memory_planning import (
+    collect_specs_from_nodes,
+    update_all_tensors_lifetime,
+    Verifier,
+)
 from executorch.exir.pass_base import PassBase
 from executorch.exir.pass_manager import PassManager
 from executorch.exir.passes import MemoryPlanningPass
@@ -388,6 +392,89 @@ class SimplifyIdmaOpsPass(PassBase):
         return PassResult(graph_module, modified)
 
 
+class RemoveNopOpsPass(PassBase):
+    """Erase the cat/slice/select nop nodes once memory planning is done.
+
+    These ops never touch data. A cat is only rewritten to its nop form once
+    memory planning can place every input at a contiguous offset inside the
+    output, and a slice likewise once its output can be colocated inside its
+    input, so by the time planning has run both hold by construction and the
+    instructions are pure dispatch overhead.
+
+    This has to happen here rather than as its own pass. Before planning the
+    nodes cannot go, because they are what carries the placement constraint;
+    after it nothing may run at all (see the warning in
+    exir/program/_program.py). Running inside the memory planning pass, in the
+    slot SimplifyIdmaOpsPass already occupies, is the one point where the
+    placement is decided but the program is not yet emitted.
+    """
+
+    def __init__(self, graph_signature: Optional[ExportGraphSignature] = None) -> None:
+        self.graph_signature = graph_signature
+
+    def call(self, graph_module: torch.fx.GraphModule) -> Optional[PassResult]:
+        # Every nop target memory_constraints.py can produce. Keep in sync
+        # with compute_cat_contiguity_constraints and
+        # compute_slice_and_select_loc_constraints. Looked up here rather than
+        # at class scope because the schemas come from ops_registrations, which
+        # this module does not import.
+        targets = (
+            torch.ops.aten._cat_nop.out,
+            torch.ops.aten._slice_copy_nop.Tensor_out,
+            torch.ops.aten._select_copy_nop.int_out,
+        )
+        modified = False
+        for target in targets:
+            for node in graph_module.graph.find_nodes(
+                op="call_function", target=target
+            ):
+                out = node.kwargs.get("out")
+                if out is None:
+                    # These ops exist only to carry a placement constraint
+                    # between constraint generation and here. One that cannot
+                    # be erased would reach the runtime, where there is no
+                    # kernel to service it, so fail the build instead.
+                    raise RuntimeError(
+                        f"cannot erase {node.name} ({node.target}): no out "
+                        "kwarg to redirect its consumers to. A nop op must "
+                        "never reach the emitter."
+                    )
+                # Consumers read the output buffer, which the producers have
+                # already written in place. Point them straight at it.
+                node.replace_all_uses_with(out)
+                graph_module.graph.erase_node(node)
+                modified = True
+
+        if not modified:
+            return PassResult(graph_module, False)
+
+        graph_module.recompile()
+        self._refresh_lifetimes(graph_module)
+        return PassResult(graph_module, True)
+
+    def _refresh_lifetimes(self, graph_module: torch.fx.GraphModule) -> None:
+        """Recompute spec lifetimes against the graph we actually emit.
+
+        Lifetimes are node indices, so erasing nodes leaves them pointing past
+        the end of the graph, which trips the peak-memory reporter and the
+        activation profiler.
+
+        update_tensor_lifetime only ever widens a lifetime, so a single
+        recompute leaves the stale upper bounds in place. The first call
+        identifies exactly which specs the recompute reaches (it returns
+        them); those are cleared and the second call then rebuilds them from
+        scratch. Clearing a wider set than that would leave specs the
+        recompute never revisits stuck at None, which reads as "no lifetime"
+        and silently drops them from the memory reports.
+
+        Placement is already decided at this point - only lifetimes change.
+        """
+        specs = update_all_tensors_lifetime(graph_module, self.graph_signature)
+        for spec in specs:
+            spec.lifetime = [None, None]
+        update_all_tensors_lifetime(graph_module, self.graph_signature)
+
+
 ConstraintGenPassType: TypeAlias = Callable[
     [MemConstraints],
     Callable[[torch.fx.GraphModule], Optional[PassResult]],
@@ -465,8 +552,11 @@ class CadenceMemoryPlanning:
         )
         mem_planning.run(graph_module, graph_signature)
 
-        graph_module = PassManager(passes=[SimplifyIdmaOpsPass()])(
-            graph_module
-        ).graph_module
+        graph_module = PassManager(
+            passes=[
+                SimplifyIdmaOpsPass(),
+                RemoveNopOpsPass(graph_signature),
+            ]
+        )(graph_module).graph_module
 
         return PassResult(graph_module, True)

--- a/backends/cadence/aot/tests/test_memory_passes.py
+++ b/backends/cadence/aot/tests/test_memory_passes.py
@@ -42,6 +42,7 @@ from executorch.exir.memory_planning import (
     update_all_tensors_lifetime,
 )
 from executorch.exir.pass_base import PassBase, PassResult
+from executorch.exir.passes import MemoryPlanningPass
 from executorch.exir.passes.spec_prop_pass import SpecPropPass
 from executorch.exir.tests.models import MultiLayerPerceptron
 from parameterized import parameterized
@@ -152,6 +153,14 @@ class TestMemPlanningPasses(unittest.TestCase):
             mem_constraints=None,
         )
         self.assertEqual(peak_usage, 0)
+
+
+def specs_of(node: torch.fx.Node) -> list[object]:
+    """A node's spec meta is a single TensorSpec, or a list for multi-output ops."""
+    spec = node.meta.get("spec")
+    if spec is None:
+        return []
+    return list(spec) if isinstance(spec, (list, tuple)) else [spec]
 
 
 class TestMemTransform(unittest.TestCase):
@@ -272,6 +281,44 @@ class TestMemTransform(unittest.TestCase):
             additional_constraint_gen_passes=additional_constraint_gen_passes,
         )(graph_module).graph_module
 
+    # Runs planning but stops short of the cleanup passes that CadenceMemoryPlanning
+    # runs afterwards, so the nop nodes are still in the graph.
+    #
+    # The nop ops are the only record of which tensors were concatenated or
+    # sliced into which, so they are what the placement assertions below read
+    # the offsets from. RemoveNopOpsPass erases them, and once erased there is
+    # nothing left to walk - verify_nop_memory_alloc would iterate over an
+    # empty set and pass vacuously. Placement is verified here; that the nops
+    # are subsequently erased is verified separately.
+    def run_memory_planning_only(
+        self,
+        original: GraphModule,
+        mode: CompileMode = CompileMode.DEFAULT,
+        mem_algo: int = 1,  # greedy_by_size_for_offset_calculation_with_hierarchy
+        alloc_graph_input: bool = True,
+        alloc_graph_output: bool = True,
+        memory_config: Optional[MemoryConfig] = None,
+        additional_constraint_gen_passes: Optional[Sequence[ConstraintsGenPass]] = None,
+    ) -> GraphModule:
+        if memory_config is None:
+            memory_config = get_default_memory_config()
+        graph_module = SpecPropPass().call(original).graph_module
+        planner = CadenceMemoryPlanning(
+            memory_config,
+            mode=mode,
+            mem_algo=mem_algo,
+            alloc_graph_input=alloc_graph_input,
+            alloc_graph_output=alloc_graph_output,
+            additional_constraint_gen_passes=additional_constraint_gen_passes,
+        )
+        MemoryPlanningPass(
+            planner.algo,
+            allow_lifetime_and_storage_overlap=True,
+            alloc_graph_input=alloc_graph_input,
+            alloc_graph_output=alloc_graph_output,
+        ).run(graph_module, None)
+        return graph_module
+
     @expand(
         [
             [
@@ -312,7 +359,7 @@ class TestMemTransform(unittest.TestCase):
         builder.output([graph_output])
         original = builder.get_graph_module()
 
-        graph_module = self.run_memory_planning(
+        graph_module = self.run_memory_planning_only(
             original, alloc_graph_input=alloc_graph_input
         )
         graph_module.graph.eliminate_dead_code()
@@ -323,6 +370,119 @@ class TestMemTransform(unittest.TestCase):
             self.assertEqual(count_node(graph_module, torch.ops.aten.cat.out), 1)
             self.assertEqual(count_node(graph_module, torch.ops.aten._cat_nop.out), 0)
         self.verify_nop_memory_alloc(graph_module)
+
+    def test_cat_nop_is_erased_after_memory_planning(self) -> None:
+        """The nop op must not survive into the emitted program.
+
+        Placement is asserted elsewhere against the pre-removal graph; this
+        covers the other half, that RemoveNopOpsPass then takes the
+        instruction out entirely rather than leaving a call that does nothing.
+        """
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.ones(3, 6))
+        y = builder.placeholder("y", torch.ones(2, 6))
+        pre_created_output = builder.call_operator(
+            op=exir_ops.edge.aten.full.default,
+            args=([5, 6], 0.0),
+            kwargs={"dtype": torch.float32},
+        )
+        graph_output = builder.call_operator(
+            op=torch.ops.aten.cat.out,
+            args=([x, y],),
+            kwargs={"dim": 0, "out": pre_created_output},
+        )
+        builder.output([graph_output])
+        original = builder.get_graph_module()
+
+        # Planning alone converts the cat to its nop form and leaves it there.
+        planned = self.run_memory_planning_only(original, alloc_graph_input=True)
+        planned.graph.eliminate_dead_code()
+        self.assertEqual(count_node(planned, torch.ops.aten._cat_nop.out), 1)
+
+        # The full pipeline erases it, and does not fall back to a real cat.
+        graph_module = self.run_memory_planning(original, alloc_graph_input=True)
+        graph_module.graph.eliminate_dead_code()
+        self.assertEqual(count_node(graph_module, torch.ops.aten._cat_nop.out), 0)
+        self.assertEqual(count_node(graph_module, torch.ops.aten.cat.out), 0)
+
+    def test_erasing_nops_preserves_placement(self) -> None:
+        """Erasing the nodes must not disturb the offsets planning assigned."""
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.ones(3, 6))
+        y = builder.placeholder("y", torch.ones(2, 6))
+        pre_created_output = builder.call_operator(
+            op=exir_ops.edge.aten.full.default,
+            args=([5, 6], 0.0),
+            kwargs={"dtype": torch.float32},
+        )
+        graph_output = builder.call_operator(
+            op=torch.ops.aten.cat.out,
+            args=([x, y],),
+            kwargs={"dim": 0, "out": pre_created_output},
+        )
+        builder.output([graph_output])
+        original = builder.get_graph_module()
+
+        def offsets(gm: GraphModule) -> dict[str, tuple[int, int]]:
+            out = {}
+            for node in gm.graph.nodes:
+                for i, spec in enumerate(specs_of(node)):
+                    if getattr(spec, "mem_offset", None) is not None:
+                        out[f"{node.name}[{i}]"] = (spec.mem_id, spec.mem_offset)
+            return out
+
+        before = offsets(
+            self.run_memory_planning_only(original, alloc_graph_input=True)
+        )
+        after = offsets(self.run_memory_planning(original, alloc_graph_input=True))
+
+        # The erased node itself is gone; everything still present must be
+        # placed exactly where planning put it.
+        self.assertGreater(len(after), 0, "no spec carried a placement to check")
+        for name, placement in after.items():
+            self.assertIn(name, before)
+            self.assertEqual(placement, before[name], f"{name} moved")
+
+    def test_lifetimes_are_valid_after_erasing_nops(self) -> None:
+        """Lifetimes are node indices, so erasing nodes can leave them dangling.
+
+        The peak-memory reporter and the activation profiler both index a list
+        by lifetime end, and raised IndexError before RemoveNopOpsPass
+        refreshed them.
+        """
+        builder = GraphBuilder()
+        x = builder.placeholder("x", torch.ones(3, 6))
+        y = builder.placeholder("y", torch.ones(2, 6))
+        pre_created_output = builder.call_operator(
+            op=exir_ops.edge.aten.full.default,
+            args=([5, 6], 0.0),
+            kwargs={"dtype": torch.float32},
+        )
+        graph_output = builder.call_operator(
+            op=torch.ops.aten.cat.out,
+            args=([x, y],),
+            kwargs={"dim": 0, "out": pre_created_output},
+        )
+        builder.output([graph_output])
+        original = builder.get_graph_module()
+
+        graph_module = self.run_memory_planning(original, alloc_graph_input=True)
+        num_nodes = len(graph_module.graph.nodes)
+        checked = 0
+        for node in graph_module.graph.nodes:
+            for spec in specs_of(node):
+                if getattr(spec, "lifetime", None) is None or spec.lifetime[0] is None:
+                    continue
+                start, end = spec.lifetime
+                self.assertLess(
+                    end,
+                    num_nodes,
+                    f"{node.name} lifetime {spec.lifetime} runs past the "
+                    f"{num_nodes}-node graph",
+                )
+                self.assertLessEqual(start, end)
+                checked += 1
+        self.assertGreater(checked, 0, "no spec carried a lifetime to check")
 
     # Returns a GraphModule with the following structure:
     # "add_add_cat_model" : cat(x + 123, y + 456)
@@ -414,7 +574,7 @@ class TestMemTransform(unittest.TestCase):
         original = self.get_graph_module(
             "add_add_cat_model", x_shape, y_shape, concated_shape, concat_dim
         )
-        graph_module = self.run_memory_planning(original)
+        graph_module = self.run_memory_planning_only(original)
         graph_module.graph.eliminate_dead_code()
         # Assert that cat op is optimized away
         self.assertEqual(count_node(graph_module, torch.ops.aten.cat.out), 0)
@@ -444,7 +604,7 @@ class TestMemTransform(unittest.TestCase):
         original = self.get_graph_module(
             "add_add_cat_model", x_shape, y_shape, concated_shape, concat_dim
         )
-        graph_module = self.run_memory_planning(original)
+        graph_module = self.run_memory_planning_only(original)
         graph_module.graph.eliminate_dead_code()
         # Assert that cat op is not optimized away, since the concat is not along the outermost dim.
         # The first dimension is 2, but all dims before cat_dim should be == 1.
@@ -483,7 +643,7 @@ class TestMemTransform(unittest.TestCase):
         original = self.get_graph_module(
             "add_add_cat_add_model", x_shape, y_shape, concated_shape, concat_dim
         )
-        graph_module = self.run_memory_planning(original)
+        graph_module = self.run_memory_planning_only(original)
         graph_module.graph.eliminate_dead_code()
 
         # Assert that cat op is optimized away only if its arguments offsets are multiple of 8 bytes.
@@ -534,7 +694,7 @@ class TestMemTransform(unittest.TestCase):
         builder.output([graph_output])
         original = builder.get_graph_module()
 
-        graph_module = self.run_memory_planning(original, alloc_graph_input=False)
+        graph_module = self.run_memory_planning_only(original, alloc_graph_input=False)
         graph_module.graph.eliminate_dead_code()
 
         # Assert that cat op is optimized away.
@@ -605,7 +765,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([cat])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(
+        graph_module = self.run_memory_planning_only(
             original, mode=CompileMode.DEFAULT, alloc_graph_input=alloc_graph_input
         )
         graph_module.graph.eliminate_dead_code()
@@ -653,7 +813,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([slice_result])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(original, alloc_graph_input=False)
+        graph_module = self.run_memory_planning_only(original, alloc_graph_input=False)
         graph_module.graph.eliminate_dead_code()
         self.assertEqual(
             count_node(graph_module, torch.ops.aten._slice_copy_nop.Tensor_out), 1
@@ -692,7 +852,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([slice_result])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(original, alloc_graph_input=False)
+        graph_module = self.run_memory_planning_only(original, alloc_graph_input=False)
         graph_module.graph.eliminate_dead_code()
         self.assertEqual(
             count_node(graph_module, torch.ops.aten._slice_copy_nop.Tensor_out), 1
@@ -722,7 +882,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([slice_result])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(
+        graph_module = self.run_memory_planning_only(
             original, mode=CompileMode.DEFAULT, alloc_graph_input=False
         )
         graph_module.graph.eliminate_dead_code()
@@ -733,7 +893,7 @@ class TestMemTransform(unittest.TestCase):
 
         # When we compile with alloc_graph_input=True, all the slice ops must
         # be optimized, which is available only outside minimal mode.
-        graph_module = self.run_memory_planning(
+        graph_module = self.run_memory_planning_only(
             original, mode=CompileMode.DEFAULT, alloc_graph_input=True
         )
         graph_module.graph.eliminate_dead_code()
@@ -772,7 +932,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([slice_result])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(original, alloc_graph_input=False)
+        graph_module = self.run_memory_planning_only(original, alloc_graph_input=False)
         graph_module.graph.eliminate_dead_code()
         self.assertEqual(
             count_node(graph_module, torch.ops.aten._select_copy_nop.int_out), 1
@@ -809,7 +969,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([slice_result])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(original, alloc_graph_input=False)
+        graph_module = self.run_memory_planning_only(original, alloc_graph_input=False)
         graph_module.graph.eliminate_dead_code()
         self.assertEqual(
             count_node(graph_module, torch.ops.aten._select_copy_nop.int_out), 1
@@ -837,7 +997,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([slice_result])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(
+        graph_module = self.run_memory_planning_only(
             original, mode=CompileMode.DEFAULT, alloc_graph_input=False
         )
         graph_module.graph.eliminate_dead_code()
@@ -848,7 +1008,7 @@ class TestMemTransform(unittest.TestCase):
 
         # When we compile with alloc_graph_input=True, all the slice ops must
         # be optimized, which is available only outside minimal mode.
-        graph_module = self.run_memory_planning(
+        graph_module = self.run_memory_planning_only(
             original, mode=CompileMode.DEFAULT, alloc_graph_input=True
         )
         graph_module.graph.eliminate_dead_code()
@@ -889,7 +1049,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([slice_result])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(original, mode=CompileMode.DEFAULT)
+        graph_module = self.run_memory_planning_only(original, mode=CompileMode.DEFAULT)
         graph_module.graph.eliminate_dead_code()
         self.assertEqual(count_node(graph_module, torch.ops.aten.cat.out), 0)
         self.assertEqual(count_node(graph_module, torch.ops.aten._cat_nop.out), 1)
@@ -937,7 +1097,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([cat2])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(
+        graph_module = self.run_memory_planning_only(
             original, mode=CompileMode.DEFAULT, alloc_graph_input=False
         )
 
@@ -975,7 +1135,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([cat])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(original)
+        graph_module = self.run_memory_planning_only(original)
         graph_module.graph.eliminate_dead_code()
 
         # Assert that cat op is NOT optimized away since the same tensor
@@ -1038,7 +1198,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([graph_output])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(
+        graph_module = self.run_memory_planning_only(
             original, mode=CompileMode.DEFAULT, alloc_graph_input=False
         )
         graph_module.graph.eliminate_dead_code()
@@ -1072,7 +1232,7 @@ class TestMemTransform(unittest.TestCase):
         )
         builder.output([add_x, add_x_y])
         original = builder.get_graph_module()
-        graph_module = self.run_memory_planning(
+        graph_module = self.run_memory_planning_only(
             original, mode=CompileMode.DEFAULT, alloc_graph_output=False
         )
         self.assertEqual(


### PR DESCRIPTION
Summary:

`_cat_nop`, `_slice_copy_nop` and `_select_copy_nop` do nothing at runtime. A
cat is only rewritten to its nop form once memory planning can place every
input at a contiguous offset inside the output, and a slice or select likewise
once its output can be colocated inside its input, so by the time planning has
run they hold by construction. The instructions that remain are pure dispatch
overhead.

This erases them, pointing their consumers at the output buffer the producers
have already written in place. A nop that cannot be erased raises rather than
being skipped: these ops exist only to carry a placement constraint from
constraint generation to here, so one reaching the emitter is a compiler bug.

**Why it has to live inside the memory planning pass.** A standalone pass is
not possible:

- Before planning the nodes cannot go, because the node is what carries the
  placement constraint. Remove it early and the aliasing never happens.
- After planning nothing may run at all:

    # WARNING: DO NOT ADD ANY MORE PASSES AFTER MEMORY PLANNING PASS.
    # THERE ARE A LOT OF ASSUMPTIONS IN THE STACK THAT MEMORY PLANNING IS
    # THE LAST PASS BEFORE THE EMITTER.
    (exir/program/_program.py)

`CadenceMemoryPlanning.run` already mutates the graph after `mem_planning.run`
- `SimplifyIdmaOpsPass` retargets nodes and runs dead code elimination there -
so that slot is the one point where placement is decided but the program is not
yet emitted. This joins it.

**The assumptions that warning refers to are real.** Spec lifetimes are node
indices, so erasing nodes leaves them pointing past the end of the graph. That
trips `find_peak_memory_usage` and, in executorch/util, the activation memory
profiler. `update_all_tensors_lifetime` alone does not fix it, because
`update_tensor_lifetime` only ever widens a lifetime:

    end = node_idx if end is None or end < node_idx else end

so a stale larger bound survives. `_refresh_lifetimes` uses the first call to
identify exactly which specs the recompute reaches, clears those, and rebuilds
them. Clearing a wider set would leave specs the recompute never revisits stuck
at None, which reads as "no lifetime" and silently drops them from the memory
reports. With that, no change is needed outside the Cadence backend - the shared
executorch diagnostics work unmodified.

The nop targets are looked up inside `call` rather than at class scope, because
their schemas come from `ops_registrations` and `memory_planning` does not
import it - resolving at import time breaks any module that imports
`CadenceMemoryPlanning` without having registered the ops first.

**The kernels stay, deliberately.**

Reviewed By: DrJessop

Differential Revision: D118922409


