### PR TITLE
Publish the CUDA trains PyTorch still offers, skip the ones it drops

### DIFF
--- a/.ci/scripts/tests/test_filter_cuda_matrix.py
+++ b/.ci/scripts/tests/test_filter_cuda_matrix.py
@@ -191,18 +191,14 @@ class TestGates(unittest.TestCase):
                 FILTER.main(argv)
         self.assertNotEqual(raised.exception.code, 0)
 
-    def test_absent_train_exits_nonzero(self):
-        # A supported train the generator offers nothing for would publish no wheel at all.
+    def test_absent_train_is_skipped_not_fatal(self):
+        # A supported train the generator offers nothing for is one PyTorch stopped shipping. The
+        # release skips it and publishes the rest, so one dropped train cannot take the others down.
         #
-        # Patching the supported list rather than deleting rows, because deleting every row for one
-        # train also creates missing combinations, so both gates fire and the test cannot tell which
-        # one it exercised. Adding an extra supported train makes it absent while every offered
-        # combination stays complete.
-        # These two gates cannot be separated by input: any matrix leaving a train absent also
-        # leaves every combination for that train missing, so the later gate always catches what the
-        # earlier one would. Measured. So each gate gets its own case, and the case asserts on the
-        # message rather than only on a nonzero exit, which is the only way to tell them apart.
+        # Offering every train but the last leaves that train absent while every offered combination
+        # stays complete, which is exactly the shape of an upstream drop.
         offered = FILTER.SUPPORTED_CUDA_VERSIONS[:-1]
+        dropped = FILTER.SUPPORTED_CUDA_VERSIONS[-1]
         matrix = {
             "include": [
                 {"python_version": python, "desired_cuda": cuda}
@@ -210,14 +206,43 @@ class TestGates(unittest.TestCase):
                 for cuda in offered
             ]
         }
-        message = self._exit_message(matrix)
-        self.assertIn("publish no wheel for that CUDA version", message)
+        emitted = _emitted(_run(matrix))
+        published = sorted({row["desired_cuda"] for row in emitted["include"]})
+        self.assertEqual(published, sorted(offered))
+        self.assertNotIn(dropped, published)
+
+    def test_dropped_train_still_publishes_the_others(self):
+        # The exact upstream drop this resilience is for: PyTorch stops shipping cu126, the generator
+        # offers only cu130 and cu132, and the release must still publish those two rather than fail
+        # because cu126 is gone. Skips the case cleanly if the policy no longer lists cu126.
+        if "cu126" not in FILTER.SUPPORTED_CUDA_VERSIONS:
+            self.skipTest("cu126 is not a published train")
+        survivors = [c for c in FILTER.SUPPORTED_CUDA_VERSIONS if c != "cu126"]
+        matrix = {
+            "include": [
+                {"python_version": python, "desired_cuda": cuda}
+                for python in FILTER.SUPPORTED_PYTHON_VERSIONS
+                for cuda in survivors
+            ]
+        }
+        emitted = _emitted(_run(matrix))
+        published = sorted({row["desired_cuda"] for row in emitted["include"]})
+        self.assertEqual(published, sorted(survivors))
+        self.assertNotIn("cu126", published)
+        # Every survivor keeps all its pythons, so what publishes is complete, just narrower.
+        self.assertEqual(
+            len(emitted["include"]),
+            len(survivors) * len(FILTER.SUPPORTED_PYTHON_VERSIONS),
+        )
 
     def test_missing_combination_exits_nonzero(self):
+        # A train that IS offered but missing one python is a real break, not an upstream drop: the
+        # release would ship that train incomplete. Deleting one row from a full matrix leaves its
+        # train present, so this exercises the incomplete-train gate rather than the skip above.
         matrix = _full_matrix()
         del matrix["include"][0]
         message = self._exit_message(matrix)
-        self.assertIn("combination(s) produced no row", message)
+        self.assertIn("incomplete train", message)
 
     def test_jetpack_not_published_exits_nonzero(self):
         # Refused explicitly rather than allowed to fall through to an empty result, so the reason a

--- a/.github/scripts/filter_cuda_matrix.py
+++ b/.github/scripts/filter_cuda_matrix.py
@@ -39,7 +39,7 @@ from typing import Any, Dict, List
 # not on that list is rejected whether or not it appears here.
 DISABLED_PYTHON_VERSIONS: List[str] = ["3.13t", "3.14t", "3.15", "3.15t"]
 
-# CUDA versions to publish.
+# CUDA versions to publish, when the generator offers them.
 #
 # Chosen so that every consumer row can find a matching wheel rather than by what is
 # convenient to verify. A delegate built against one of these has to be able to depend on an
@@ -49,6 +49,12 @@ DISABLED_PYTHON_VERSIONS: List[str] = ["3.13t", "3.14t", "3.15", "3.15t"]
 #   cu126   the floor, and what Jetson devices are limited to
 #   cu130   the generator's stable choice, and the default for accelerator consumers
 #   cu132   the newest, which consumers building against a current TensorRT need
+#
+# A version listed here is published only when the shared generator still offers it. When
+# PyTorch stops shipping a CUDA train, its rows simply do not appear and the release skips it,
+# rather than failing the whole build. So a train PyTorch drops (as it did with cu126) costs
+# only that train, and a train PyTorch restores returns here with no edit. The release still
+# fails if a train that IS offered comes through incomplete, which is a real build break.
 #
 # cu132 is included because omitting it would leave a published consumer row with no
 # ExecuTorch wheel to pair with. It is executable on a device one minor behind, since CUDA
@@ -198,31 +204,33 @@ def main(argv: List[str]) -> None:
         # blind to a python that disappeared from every supported train. The generator lives in another
         # repository and its axes move independently of what this policy promises to publish.
         built = {(item["python_version"], item["desired_cuda"]) for item in items}
-        # A train that produced no row at all is missing for every python, so reporting it per python
-        # would read as a python problem. Named on its own instead, and first, because the per-pair
-        # report below would otherwise bury it.
-        absent_trains = sorted(
-            set(SUPPORTED_CUDA_VERSIONS) - {cuda for _, cuda in built}
-        )
+        built_trains = {cuda for _, cuda in built}
+        # A train the generator offered nothing for is one PyTorch stopped shipping, not a build
+        # break here. Skip it and publish the rest, so one dropped train cannot take the others
+        # down with it. When PyTorch dropped CUDA 12.6, failing here also blocked cu130 and cu132
+        # from publishing, which is the opposite of what a consumer needs. The train returns on its
+        # own if PyTorch ships it again, with no edit here.
+        absent_trains = sorted(set(SUPPORTED_CUDA_VERSIONS) - built_trains)
         if absent_trains:
             print(
-                f"this policy publishes {SUPPORTED_CUDA_VERSIONS}, but the generator offered no row "
-                f"this filter could keep for {absent_trains}, so a release would publish no wheel for "
-                "that CUDA version at all",
+                f"the generator offered no row for {absent_trains}, so they are skipped this run; "
+                f"publishing {sorted(built_trains)}",
                 file=sys.stderr,
             )
-            sys.exit(1)
+        # A train that IS offered but missing some python versions is a real break, not an upstream
+        # drop: the release would ship an incomplete train, fewer wheels than promised for a version
+        # that is otherwise present. Checked only against the trains actually offered, so a fully
+        # absent train handled above does not also trip this and read as a python problem.
         missing = sorted(
             f"{python}/{cuda}"
             for python in SUPPORTED_PYTHON_VERSIONS
-            for cuda in SUPPORTED_CUDA_VERSIONS
+            for cuda in built_trains
             if (python, cuda) not in built
         )
         if missing:
             print(
-                f"this policy publishes {SUPPORTED_CUDA_VERSIONS} for each of "
-                f"{SUPPORTED_PYTHON_VERSIONS}, but {len(missing)} combination(s) produced no row, so a "
-                f"release would publish no wheel for them: {missing}",
+                f"a published train is missing some of {SUPPORTED_PYTHON_VERSIONS}, so a release "
+                f"would ship an incomplete train: {missing}",
                 file=sys.stderr,
             )
             sys.exit(1)


### PR DESCRIPTION
## Problem

The nightly CUDA wheel build stopped publishing anything after PyTorch removed its CUDA 12.6 nightlies. ExecuTorch still listed `cu126` as a version to publish, and the release check treated a listed-but-absent train as a hard error, so it failed the whole job at the matrix-filter step. That blocked `cu130` and `cu132` from publishing too, even though their builds were fine.

The result: no CUDA nightly wheel at all for several days, while the CPU wheel kept publishing normally.

## Fix

Make the check degrade per train instead of all-or-nothing. A version listed in the policy is published only when the shared matrix generator still offers it. When PyTorch stops shipping a train, its rows simply do not appear, the release skips it with a note, and the other trains publish as usual. If PyTorch ships that train again later, it returns on its own with no code change here.

The release still fails loudly in the two cases that are real problems:
- an empty matrix, which would otherwise read as a green check for a build that never happened
- a train that is offered but comes through missing some Python versions, which would ship that train incomplete

Example, with PyTorch no longer offering cu126:

```
before: filter exits 1, publishes nothing
after:  filter exits 0, publishes cu130 and cu132, skips cu126 with a note
```

## Test plan

Extended the filter unit tests. A fully absent train is now asserted to be skipped while the others publish, plus a case for the exact cu126 drop. The incomplete-train and empty-matrix cases are asserted to still exit nonzero. Full suite: 21 passed, 2 subtests. Also ran the filter against today's real matrix (cu130 and cu132 only) and confirmed it exits 0 and publishes both.
