### PR TITLE
Pin mypy CI Transformers to the examples version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: |
+            .github/workflows/lint.yml
             requirements-lintrunner.txt
             torch_pin.py
 
@@ -56,7 +57,8 @@ jobs:
           pip install lintrunner==0.12.7 lintrunner-adapters==0.14.1
           pip install -r requirements-lintrunner.txt
           USE_CPP=0 pip install --no-build-isolation third-party/ao
-          pip install pytest numpy parameterized huggingface_hub transformers timm expecttest types-requests
+          # Match requirements-examples.txt for the model APIs checked by mypy.
+          pip install pytest numpy parameterized huggingface_hub "transformers==5.0.0rc1" timm expecttest types-requests
 
       - name: Generate mypy stubs for C++ bindings
         run: |


### PR DESCRIPTION
### Summary
Match the Transformers 5.0.0rc1 pin in requirements-examples.txt and include the workflow in the pip cache key. This prevents upstream API removals from breaking mypy on unchanged model tests.

### Test plan
Validated with lintrunner --all-files --take MYPY.

Authored with OpenAI Codex.