### PR TITLE
Don't upload golden artifacts to GitHub Actions storage

### DIFF
--- a/.ci/scripts/test_backend.sh
+++ b/.ci/scripts/test_backend.sh
@@ -154,9 +154,6 @@ if [[ "$FLOW" == *nxp* ]]; then
     export NXP_RUNNER_PATH="$(pwd)/examples/nxp/executor_runner/build/nxp_executor_runner"
 fi
 
-GOLDEN_DIR="${ARTIFACT_DIR}/golden-artifacts"
-export GOLDEN_ARTIFACTS_DIR="${GOLDEN_DIR}"
-
 EXIT_CODE=0
 # An Ethos-U failure captures a few hundred thousand lines of Vela operator
 # listings, and the runner agent throws System.OutOfMemoryException processing

--- a/.github/workflows/_test_backend.yml
+++ b/.github/workflows/_test_backend.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: string
         default: ci-image:executorch-ubuntu-22.04-clang12
+      save-goldens:
+        description: 'Write golden .pte/.bin files in the models suite and package them; only for regenerating the Android test fixture'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   docker-image:
@@ -77,10 +82,13 @@ jobs:
       script: |
         set -eux
 
+        if [[ "${{ inputs.save-goldens }}" == "true" && "${{ matrix.suite }}" == "models" ]]; then
+          export GOLDEN_ARTIFACTS_DIR="${RUNNER_ARTIFACT_DIR}/golden-artifacts"
+        fi
         source .ci/scripts/test_backend.sh "${{ matrix.suite }}" "${{ matrix.flow }}" "${RUNNER_ARTIFACT_DIR}"
 
   package-golden-artifacts:
-    if: ${{ inputs.run-linux }}
+    if: ${{ inputs.run-linux && inputs.save-goldens }}
     needs: test-backend-linux
     runs-on: linux.2xlarge
     steps:
@@ -115,13 +123,6 @@ jobs:
           else
             echo "No golden artifacts found."
           fi
-
-      - name: Upload combined golden artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: golden-artifacts-${{ inputs.backend }}
-          path: golden_artifacts_*.zip
-          if-no-files-found: ignore
 
       - name: Upload golden artifacts to S3
         uses: seemethere/upload-artifact-s3@v5

--- a/.github/workflows/test-backend-xnnpack.yml
+++ b/.github/workflows/test-backend-xnnpack.yml
@@ -11,6 +11,11 @@ on:
       - ciflow/nightly/*
   pull_request:
   workflow_dispatch:
+    inputs:
+      save-goldens:
+        description: 'Write and package the models-suite goldens (Android test fixture)'
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-${{ github.ref_type == 'branch' && github.sha }}-${{ github.event_name == 'workflow_dispatch' }}-${{ github.event_name == 'schedule' }}
@@ -31,3 +36,7 @@ jobs:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       timeout: 120
       run-linux: true
+      # The nightly keeps writing goldens: they are what the Android instrumentation
+      # test pins (android_test_setup.sh), and a fresh key must exist before the pin
+      # ages out of S3. Every other run skips them.
+      save-goldens: ${{ inputs.save-goldens == true || github.event_name == 'schedule' }}


### PR DESCRIPTION
### Summary

Addresses step 4:
https://docs.google.com/document/d/1CnGfiP5SU0PG0IdJWn9Ca43LS8bGlEMi3l2gjgC7k48/edit

* We upload the golden artifacts to GitHub Actions storage _and_ S3. Nothing uses the GHA copy; the Android test uses the S3 one https://github.com/pytorch/executorch/blob/5b7718754e2ab4d634dc8e7ad837209345307983/extension/android/executorch_android/android_test_setup.sh#L34 So keep only the S3 upload.
* `test_backend.sh` always set `GOLDEN_ARTIFACTS_DIR`, so every PR and push to main wrote goldens into the test reports of every backend, about 2 TB/day. Now only the xnnpack nightly writes them (that's where the Android pin comes from), plus a manual `save-goldens` dispatch when we need a fresh one.

### Test plan

CI. On this PR `package-golden-artifacts` is skipped and the models test reports are a few MB instead of ~1.7 GB.

_Authored with Claude Code._