### PR TITLE
Gate test xfails on dependency versions (#22658)

### DIFF
--- a/backends/arm/test/BUCK
+++ b/backends/arm/test/BUCK
@@ -45,6 +45,8 @@ fbcode_target(_kind = runtime.python_library,
     deps = [
         ":runner_utils",
         "//executorch/backends/arm/tosa:tosa",
+        "//executorch/backends/arm:vgf",
+        "fbsource//third-party/pypi/packaging:packaging",
         "fbsource//third-party/pypi/pytest:pytest",
     ]
 )

--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -4,17 +4,19 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from __future__ import annotations
+
 import os
 import platform
-
+import warnings
+from collections.abc import Mapping
 from datetime import datetime
-
+from importlib import import_module, metadata
 from pathlib import Path
 from typing import Any, Callable, Optional, ParamSpec, TypeVar
 
 import pytest
 from executorch.backends.arm.ethosu import EthosUCompileSpec
-
 from executorch.backends.arm.test.runner_utils import (
     arm_executor_runner_exists,
     corstone300_installed,
@@ -26,6 +28,12 @@ from executorch.backends.arm.test.runner_utils import (
 from executorch.backends.arm.tosa import TosaSpecification
 from executorch.backends.arm.tosa.compile_spec import TosaCompileSpec
 from executorch.backends.arm.vgf import VgfCompileSpec
+from executorch.backends.arm.vgf.model_converter import (
+    get_model_converter_version_text,
+    parse_model_converter_version,
+)
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
 
 
 def is_aarch64_host() -> bool:
@@ -300,7 +308,94 @@ XfailfNoVKMLEmulationLayer = pytest.mark.xfail(
 )
 """Xfails a test if VKML Emulation Layer is not installed."""
 
-xfail_type = str | tuple[str, type[Exception]]
+
+def xfail_if_version(
+    version: str | Version | None,
+    specifier: str,
+    *,
+    reason: str,
+    strict: bool = True,
+    raises: type[Exception] | None = None,
+) -> pytest.MarkDecorator:
+    """Xfail when a dependency version matches a PEP 440 specifier.
+
+    Use as a test decorator or as a value in `parametrize`'s `xfails` map.
+    Missing/unknown versions do not enable the xfail. Unparseable versions
+    produce a warning; missing dependencies need a separate skip marker.
+
+    """
+    versions = SpecifierSet(specifier)
+    try:
+        matches = version is not None and version in versions
+    except InvalidVersion:
+        warnings.warn(
+            f"Unparseable dependency version {version!r}; xfail for "
+            f"{specifier!r} is disabled ({reason}).",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        matches = False
+
+    return pytest.mark.xfail(
+        condition=matches,
+        reason=reason,
+        strict=strict,
+        raises=raises,
+    )
+
+
+def xfail_if_dependency_version(
+    dependency: str,
+    specifier: str,
+    *,
+    reason: str,
+    module: str | None = None,
+    strict: bool = True,
+    raises: type[Exception] | None = None,
+) -> pytest.MarkDecorator:
+    """Xfail for matching versions of an installed Python distribution.
+
+    If distribution metadata is absent, optionally read `module.__version__`.
+    For example, Vela uses dependency="ethos-u-vela", module="ethosu.vela".
+    Missing dependencies do not enable the xfail; use a separate skip marker.
+
+    """
+    try:
+        version = metadata.version(dependency)
+    except metadata.PackageNotFoundError:
+        version = None
+        if module is not None:
+            try:
+                version = getattr(import_module(module), "__version__", None)
+            except ModuleNotFoundError as exc:
+                if exc.name != module and not module.startswith(f"{exc.name}."):
+                    raise
+
+    return xfail_if_version(
+        version, specifier, reason=reason, strict=strict, raises=raises
+    )
+
+
+def xfail_if_model_converter_version(
+    specifier: str,
+    *,
+    reason: str,
+    strict: bool = True,
+    raises: type[Exception] | None = None,
+) -> pytest.MarkDecorator:
+    """Xfail for matching versions of the converter executable used by VGF."""
+    version_text = get_model_converter_version_text()
+    version = (
+        parse_model_converter_version(version_text)
+        if version_text is not None
+        else None
+    )
+    return xfail_if_version(
+        version, specifier, reason=reason, strict=strict, raises=raises
+    )
+
+
+xfail_type = str | tuple[str, type[Exception]] | pytest.MarkDecorator
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
@@ -310,7 +405,7 @@ Decorator = Callable[[Callable[_P, _R]], Callable[_P, _R]]
 def parametrize(
     arg_name: str,
     test_data: dict[str, Any],
-    xfails: dict[str, xfail_type] | None = None,
+    xfails: Mapping[str, xfail_type] | None = None,
     skips: dict[str, str] | None = None,
     strict: bool = True,
     flakies: dict[str, int] | None = None,
@@ -320,16 +415,14 @@ def parametrize(
 
     - test_data is expected as a dict of (id, test_data) pairs
     - alllows to specifiy a dict of (id, failure_reason) pairs to mark specific tests as xfail.
-      Failure_reason can be str, type[Exception], or tuple[str, type[Exception]].
+      Failure_reason can be str, tuple[str, type[Exception]], or an xfail marker.
       Strings set the reason for failure, the exception type sets expected error.
+      Explicit xfail markers retain their own options, including strictness.
 
     """
-    if xfails is None:
-        xfails = {}
-    if skips is None:
-        skips = {}
-    if flakies is None:
-        flakies = {}
+    xfail_cases = xfails or {}
+    skip_cases = skips or {}
+    flaky_cases = flakies or {}
 
     def decorator_func(func: Callable[_P, _R]) -> Callable[_P, _R]:
         """Test data is transformed from a dict of (id, data) pairs to a list of
@@ -337,29 +430,36 @@ def parametrize(
         """
         pytest_testsuite = []
         for id, test_parameters in test_data.items():
-            if id in flakies:
+            if id in flaky_cases:
                 # Mark this parameter as flaky with given reruns
-                marker = (pytest.mark.flaky(reruns=flakies[id]),)
-            elif id in skips:
+                marker = (pytest.mark.flaky(reruns=flaky_cases[id]),)
+            elif id in skip_cases:
                 # fail markers do not work with 'buck' based ci, so use skip instead
-                marker = (pytest.mark.skip(reason=skips[id]),)
-            elif id in xfails:
-                xfail_info = xfails[id]
+                marker = (pytest.mark.skip(reason=skip_cases[id]),)
+            elif id in xfail_cases:
+                xfail_info = xfail_cases[id]
                 reason = ""
                 raises = None
                 if isinstance(xfail_info, str):
                     reason = xfail_info
                 elif isinstance(xfail_info, tuple):
                     reason, raises = xfail_info
+                elif isinstance(xfail_info, pytest.MarkDecorator):
+                    if xfail_info.name != "xfail":
+                        raise ValueError("xfails only accepts xfail markers")
                 else:
                     raise RuntimeError(
-                        "xfail info needs to be str, or tuple[str, type[Exception]]"
+                        "xfail info needs to be str, tuple[str, type[Exception]], "
+                        "or an xfail marker"
                     )
                 # Set up our fail marker
                 marker: tuple[pytest.MarkDecorator, ...]  # type: ignore[no-redef]
-                marker = (
-                    pytest.mark.xfail(reason=reason, raises=raises, strict=strict),
+                xfail_marker = (
+                    xfail_info
+                    if isinstance(xfail_info, pytest.MarkDecorator)
+                    else pytest.mark.xfail(reason=reason, raises=raises, strict=strict)
                 )
+                marker = (xfail_marker,)
             else:
                 marker = ()  # type: ignore[assignment]
 

--- a/backends/arm/test/misc/test_version_xfail.py
+++ b/backends/arm/test/misc/test_version_xfail.py
@@ -1,0 +1,252 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from executorch.backends.arm.test import common
+from packaging.specifiers import InvalidSpecifier
+from packaging.version import Version
+
+pytest_plugins = ["pytester"]
+
+
+@pytest.mark.parametrize(
+    "version,specifier,expected",
+    [
+        ("0.9.0", "==0.10.0", False),
+        ("0.10.0", "==0.10.0", True),
+        ("0.10.1", "==0.10.0", False),
+        ("0.10.1", ">=0.10,<0.11", True),
+        ("0.11.0", ">=0.10,<0.11", False),
+        ("0.10.0rc1", ">=0.10.0rc1,<0.11", True),
+        (Version("0.10.0+local"), "==0.10.0", True),
+        (None, "==0.10.0", False),
+    ],
+)
+def test_version_specifier(version, specifier, expected):
+    marker = common.xfail_if_version(version, specifier, reason="regression")
+
+    assert marker.kwargs["condition"] is expected
+
+
+@pytest.mark.parametrize("version", [None, "4.3.0-29-gd37febc"])
+def test_invalid_specifier_rejected_even_with_unknown_version(version):
+    with pytest.raises(InvalidSpecifier):
+        common.xfail_if_version(version, "not a specifier", reason="regression")
+
+
+@pytest.mark.parametrize("version", ["4.3.0-29-gd37febc", "unknown"])
+def test_unparseable_version_warns_without_xfail(version):
+    with pytest.warns(RuntimeWarning, match="Unparseable dependency version") as caught:
+        marker = common.xfail_if_version(version, ">=4.3", reason="Vela regression")
+
+    assert marker.kwargs["condition"] is False
+    assert version in str(caught[0].message)
+    assert "Vela regression" in str(caught[0].message)
+
+
+@pytest.mark.parametrize("version,expected", [("5.0.0", False), ("5.1.0", True)])
+def test_dependency_distribution_metadata(tmp_path, monkeypatch, version, expected):
+    distribution = tmp_path / f"xfail_test_dependency-{version}.dist-info"
+    distribution.mkdir()
+    (distribution / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: xfail-test-dependency\nVersion: {version}\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    marker = common.xfail_if_dependency_version(
+        "xfail-test-dependency",
+        ">=5.1,<5.2",
+        module="unused_fallback_module",
+        reason="regression",
+        strict=False,
+        raises=ValueError,
+    )
+
+    assert marker.kwargs == {
+        "condition": expected,
+        "reason": "regression",
+        "strict": False,
+        "raises": ValueError,
+    }
+
+
+@pytest.mark.parametrize("module", [None, "missing_xfail_dependency.submodule"])
+def test_missing_dependency_does_not_xfail(module):
+    marker = common.xfail_if_dependency_version(
+        "missing-xfail-dependency", ">=1", module=module, reason="regression"
+    )
+
+    assert marker.kwargs["condition"] is False
+
+
+@pytest.mark.parametrize(
+    "version,expected,warning_count",
+    [
+        ("5.0.0", False, 0),
+        ("5.1.0", True, 0),
+        ("4.3.0-29-gd37febc", False, 1),
+    ],
+)
+def test_vela_module_fallback(monkeypatch, recwarn, version, expected, warning_count):
+    vela = pytest.importorskip("ethosu.vela")
+    monkeypatch.setattr(vela, "__version__", version)
+
+    def missing_metadata(dependency):
+        raise common.metadata.PackageNotFoundError(dependency)
+
+    monkeypatch.setattr(common.metadata, "version", missing_metadata)
+
+    marker = common.xfail_if_dependency_version(
+        "ethos-u-vela",
+        "==5.1.0",
+        module="ethosu.vela",
+        reason="regression",
+    )
+
+    assert marker.kwargs["condition"] is expected
+    assert len(recwarn) == warning_count
+    if warning_count:
+        warning = recwarn.pop(RuntimeWarning)
+        assert "Unparseable dependency version" in str(warning.message)
+        assert version in str(warning.message)
+
+
+def test_suite_collects_without_vela(pytester, monkeypatch):
+    monkeypatch.setitem(sys.modules, "ethosu.vela", None)
+    test_file = pytester.makepyfile(test_without_vela=Path(__file__).read_text())
+
+    result = pytester.runpytest_inprocess(
+        "-q",
+        f"{test_file}::test_version_specifier",
+        f"{test_file}::test_vela_module_fallback",
+    )
+
+    result.assert_outcomes(passed=8, skipped=3)
+
+
+def test_module_fallback_does_not_hide_broken_import(tmp_path, monkeypatch):
+    (tmp_path / "broken_xfail_dependency.py").write_text(
+        "import missing_transitive_xfail_dependency\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    with pytest.raises(
+        ModuleNotFoundError, match="missing_transitive_xfail_dependency"
+    ):
+        common.xfail_if_dependency_version(
+            "missing-xfail-dependency",
+            ">=1",
+            module="broken_xfail_dependency",
+            reason="regression",
+        )
+
+
+@pytest.mark.parametrize(
+    "version_text,expected",
+    [
+        ("model-converter 0.9.0", False),
+        ("model-converter 0.10.0", True),
+        ("model-converter 0.10.1", True),
+        ("model-converter 0.11.0", True),
+        ("model-converter d8c1b8e", False),
+        ("model-converter 19d1d0f", True),
+        ("model-converter unknown-build", False),
+        (None, False),
+    ],
+)
+def test_model_converter_version(monkeypatch, version_text, expected):
+    monkeypatch.setattr(
+        common, "get_model_converter_version_text", lambda: version_text
+    )
+
+    marker = common.xfail_if_model_converter_version(">=0.10.0", reason="regression")
+
+    assert marker.kwargs["condition"] is expected
+
+
+@pytest.mark.parametrize(
+    "version,passes,outcomes",
+    [
+        ("0.9.0", True, {"passed": 1}),
+        ("0.9.0", False, {"failed": 1}),
+        ("0.10.0", False, {"xfailed": 1}),
+        ("0.10.0", True, {"failed": 1}),
+        (None, False, {"failed": 1}),
+        ("4.3.0-29-gd37febc", True, {"passed": 1}),
+        ("4.3.0-29-gd37febc", False, {"failed": 1}),
+    ],
+)
+def test_decorator_outcomes(pytester, version, passes, outcomes):
+    pytester.makepyfile(
+        f"""
+        from executorch.backends.arm.test import common
+
+        @common.xfail_if_version({version!r}, "==0.10.0", reason="regression")
+        def test_dependency():
+            assert {passes!r}
+        """
+    )
+
+    result = pytester.runpytest_inprocess("-q")
+
+    result.assert_outcomes(**outcomes)
+
+
+def test_parametrize_xfails_apply_only_to_selected_cases(pytester):
+    pytester.makepyfile(
+        """
+        from executorch.backends.arm.test import common
+
+        @common.parametrize(
+            "passes",
+            {"affected": False, "unaffected": False, "legacy": False, "tuple": False},
+            xfails={
+                "affected": common.xfail_if_version(
+                    "0.10.0", "==0.10.0", reason="regression"
+                ),
+                "legacy": "known failure",
+                "tuple": ("known assertion", AssertionError),
+            },
+        )
+        def test_cases(passes):
+            assert passes
+        """
+    )
+
+    result = pytester.runpytest_inprocess("-q")
+
+    result.assert_outcomes(xfailed=3, failed=1)
+
+
+def test_parametrize_preserves_explicit_marker_options(pytester):
+    pytester.makepyfile(
+        """
+        from executorch.backends.arm.test import common
+
+        @common.parametrize(
+            "passes",
+            {"unexpected_pass": True, "wrong_exception": False},
+            strict=False,
+            xfails={
+                name: common.xfail_if_version(
+                    "0.10.0", "==0.10.0", reason="regression", raises=ValueError
+                )
+                for name in ("unexpected_pass", "wrong_exception")
+            },
+        )
+        def test_cases(passes):
+            assert passes
+        """
+    )
+
+    result = pytester.runpytest_inprocess("-q")
+
+    result.assert_outcomes(failed=2)

--- a/backends/arm/test/ops/test_avg_pool2d.py
+++ b/backends/arm/test/ops/test_avg_pool2d.py
@@ -288,7 +288,16 @@ def test_avg_pool2d_16a8w_u85_INT(test_module):
     pipeline.run()
 
 
-@common.parametrize("test_module", test_modules | test_modules_bf16 | test_modules_fp16)
+@common.parametrize(
+    "test_module",
+    test_modules | test_modules_bf16 | test_modules_fp16,
+    xfails={
+        "kernel_3x3_stride_1_pad_1_bf16": common.xfail_if_model_converter_version(
+            "<0.10.0",
+            reason="MLCE-1887: Unsupported BF16 PAD constant encoding in emulation layer.",
+        ),
+    },
+)
 @common.SkipIfNoModelConverter
 def test_avg_pool2d_vgf_no_quant(test_module):
     model, input_tensor = test_module()
@@ -364,7 +373,6 @@ reject_modules = {
 
 @common.parametrize("reject_module", reject_modules)
 def test_avg_pool2d_u55_INT_not_delegated(reject_module):
-
     model, test_data = reject_module()
 
     pipeline = OpNotSupportedPipeline[input_t](

--- a/backends/arm/test/ops/test_slice.py
+++ b/backends/arm/test/ops/test_slice.py
@@ -387,9 +387,12 @@ def test_slice_tensor_u85_INT_step(test_data: Tuple):
     "test_data",
     test_data_step_int | test_data_step_fp,
     xfails={
-        "arange_fp32_2d_step4": (
-            "MLCE-1969: Emlayer 0.10 Interval memory planner corrupts "
-            "multi-input CONCAT output"
+        "arange_fp32_2d_step4": common.xfail_if_model_converter_version(
+            ">=0.10.0",
+            reason=(
+                "MLCE-1969: Emlayer 0.10 Interval memory planner corrupts "
+                "multi-input CONCAT output"
+            ),
         ),
     },
 )

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -62,6 +62,7 @@ def define_arm_tests():
 
     # Misc tests
     test_files += [
+        "misc/test_version_xfail.py",
         "misc/test_compile_spec.py",
         "misc/test_external_vela_blocks.py",
         # "misc/test_evaluate_model.py",
@@ -156,7 +157,10 @@ def define_arm_tests():
                 "//executorch/backends/arm:public_api",
             ] if runtime.is_oss else []) + ([
                 "//executorch/backends/arm/scripts/docgen:generate_vgf_op_support",
-            ] if test_file == "misc/test_docgen_op_support.py" else []),
+            ] if test_file == "misc/test_docgen_op_support.py" else []) + ([
+                "fbsource//third-party/pypi/ethos-u-vela:ethos-u-vela",
+                "fbsource//third-party/pypi/packaging:packaging",
+            ] if test_file == "misc/test_version_xfail.py" else []),
         )
 
     runtime.cxx_test(


### PR DESCRIPTION
Summary:

`arange_fp32_2d_step4` passes with internal `model-converter` 0.9.0 and fails with the 0.10.0 release used on GitHub. Internal glibc compatibility prevents upgrading the converter, so gate the slice xfail on `>=0.10.0` to keep the source synchronized while preserving the correct result in each environment. Keep the marker strict so a future converter release that fixes the bug reports an XPASS and prompts an update to the xfail.

Gate `test_avg_pool2d_vgf_no_quant[kernel_3x3_stride_1_pad_1_bf16]` on `<0.10.0` for MLCE-1887 (`Unsupported BF16 PAD constant encoding` in the emulation layer). This reproduces with the internal 0.9.0 toolchain; PR #21809 removed the original unconditional xfail when upgrading to 0.10.0. The new marker remains strict and applies only to this parameter case.

Add `xfail_if_version` for PEP 440 specifiers and `xfail_if_dependency_version` for distribution metadata with an optional module `__version__` fallback, including `ethos-u-vela` in Buck. The converter wrapper reads the executable selected by the existing VGF tooling. Missing versions leave normal test behavior intact; unparseable installed versions warn and disable the xfail, while invalid caller specifiers remain errors. Accept read-only xfail mappings in `common.parametrize` so existing typed dictionaries remain compatible, while preserving each marker's `strict` and `raises` options.

This follows the revert of D117201127 so the slice change replaces the block already present on GitHub. It supersedes PR #22083. Both `xplat` and `fbcode` mirrors are updated.

Authored with Codex.

Differential Revision: D119383772


