### PR TITLE
Qualcomm AI Engine Direct - Adding LPAI Custom Op Support and Example

### DIFF
--- a/.claude/skills/qualcomm/SKILL.md
+++ b/.claude/skills/qualcomm/SKILL.md
@@ -22,6 +22,7 @@ When the user's request falls into one of these areas, read the corresponding fi
 |---|---|---|
 | Export / lowering / quantization options / pass pipelines | `lowering_export.md` | User asks about exporting, lowering, quantization config, QuantDtype, QuantRecipe, pass pipelines |
 | New op development | `new_op_development.md` | User asks to add/implement a new op or op builder |
+| Custom op enablement via QNN op packages | `custom_op_enablement.md` | User asks to add a custom PyTorch op with their own kernel, mentions op packages / `qnn-op-package-generator` / `QnnCustomOpPackageBuilder`, or needs an op QNN has no equivalent for and that cannot be composed from existing QNN ops. Covers HTP and LPAI/eNPU. |
 | Model enablement | `model_enablement.md` | User asks to enable a new model end-to-end |
 | Buck vs CMake parity (pre-PR or fix red CI) | `buck_parity.md` | User changed BUCK / TARGETS / `targets.bzl` or `CMakeLists.txt` under `backends/qualcomm/`, added new `.cpp` / `.h` / `#include` there, is preparing to push a PR that touches QNN, **or** the `test-qnn-buck-build-linux` CI check on their PR is red and they want to fix it locally. Direct trigger: `/qualcomm buck-fix`. |
 | Profiling & debugging | `profiling.md` | User asks about profiling, optrace, QHAS, QAIRT Visualizer *(file TBD)* |
@@ -37,12 +38,16 @@ Use `backends/qualcomm/scripts/build.sh`. Linux only (macOS not supported).
 
 **Build targets:**
 
-| Target | Default | Build dir |
-|---|---|---|
-| x86_64 (Python interface + host tools) | enabled | `build-x86/` |
-| Android arm64-v8a (device runner) | enabled | `build-android/` |
-| Direct mode (LPAI ADSP or Hexagon CDSP) | disabled | `build-direct/` |
-| OE Linux embedded | disabled | `build-oe-linux/` |
+| Target | Default | Build dir | Flag |
+|---|---|---|---|
+| x86_64 (Python interface + host tools) | enabled | `build-x86/` | (on by default; `--skip_x86_64` to disable) |
+| Android arm64-v8a (device runner) | enabled | `build-android/` | (on by default; `--skip_linux_android` to disable) |
+| Direct mode (LPAI ADSP or Hexagon CDSP) | disabled | `build-direct/` | `--build_direct_mode <0\|3> --soc_model <model>` |
+| OE Linux embedded | disabled | `build-oe-linux/` | `--enable_linux_embedded` |
+
+Direct mode takes the DSP type as its argument: **`0` = ADSP/LPAI**, **`3` = CDSP/HTP**.
+`--soc_model` is required with it. When the DSP type is `0`, the build also signs
+the runtime libraries by calling `sign_library.sh --direct_mode`.
 
 **Common build commands:**
 
@@ -59,8 +64,11 @@ Use `backends/qualcomm/scripts/build.sh`. Linux only (macOS not supported).
 # Incremental build (skip clean)
 ./backends/qualcomm/scripts/build.sh --no_clean
 
-# Enable Hexagon DSP direct mode (requires HEXAGON_SDK_ROOT, HEXAGON_TOOLS_ROOT, DSP_VERSION)
-./backends/qualcomm/scripts/build.sh --enable_hexagon
+# Direct mode on the ADSP/LPAI (requires HEXAGON_SDK_ROOT, HEXAGON_TOOLS_ROOT)
+./backends/qualcomm/scripts/build.sh --build_direct_mode 0 --soc_model SM8850
+
+# Direct mode on the CDSP/HTP
+./backends/qualcomm/scripts/build.sh --build_direct_mode 3 --soc_model SM8750
 
 # OE Linux embedded target (requires TOOLCHAIN_ROOT_HOST, TOOLCHAIN_ROOT_TARGET)
 ./backends/qualcomm/scripts/build.sh --enable_linux_embedded
@@ -88,7 +96,17 @@ python backends/qualcomm/tests/test_qnn_delegate.py \
 
 > **Note (build from source):** Set `PYTHONPATH` to the parent directory of the executorch repo root. Required because `executorch.examples.qualcomm` lives in the source tree and is not installed into site-packages.
 
-Required flags: `--soc_model` (SoC model), `--build_folder` (Android build dir). Optional: `--device` (device serial), `--host` (host), `-a` (artifact dir), `--compile_only`, `--enable_x86_64`.
+Required: `--soc_model`, `--build_folder` (Android build dir). Optional: `--device`
+(serial), `--host`, `--artifact_dir` / `-a`, `--compile_only`, `--enable_x86_64`,
+`--backend <htp|gpu|lpai>`, `--direct_build_folder <dir>` (direct mode; required
+for LPAI op package tests).
+
+> Most flags are **long-form only** — they come from
+> `setup_common_args_and_variables()` in `backends/qualcomm/export_utils.py`,
+> which defines no short aliases. Only the test file's own arguments have them
+> (`-r`/`--executorch_root`, `-a`/`--artifact_dir`, `-i`/`--image_dataset`,
+> `-p`/`--pretrained_weight`, `-n`/`--model_name`, `-e`/`--error_only`,
+> `-d`/`--op_package_dir`).
 
 **Test classes:**
 

--- a/.claude/skills/qualcomm/custom_op_enablement.md
+++ b/.claude/skills/qualcomm/custom_op_enablement.md
@@ -1,0 +1,294 @@
+---
+name: custom_op_enablement
+description: Enable a user-defined PyTorch operator on QNN via a QNN Op Package (custom kernel). Use when the op has no QNN equivalent and cannot be composed from existing QNN ops, or when overriding a built-in QNN op with your own kernel. Covers HTP and LPAI/eNPU.
+---
+
+# Custom Op Enablement — QNN Op Packages
+
+An **op package** is a shared library holding your own kernel, registered with the
+QNN backend at context-creation time. Use it when the delegate cannot express the
+op with QNN primitives.
+
+## Decision Tree
+
+1. QNN has a native op → **native builder**, see `new_op_development.md`
+2. No native op, composable from several QNN ops → **decompose pass**, see `new_op_development.md`
+3. No native op, needs your own kernel → **op package** (this file)
+4. Built-in QNN op exists but you want to replace its implementation → **op package**
+
+Prefer 1 and 2. An op package means owning C/C++ kernel code, a per-target
+build, and (on LPAI) code signing.
+
+> Reference examples: `examples/qualcomm/custom_op/` — `custom_ops_1.py` (HTP,
+> single output), `custom_ops_2.py` (HTP, multi output), `custom_ops_lpai.py`
+> (LPAI/eNPU, direct mode). Tutorial prose lives in that folder's `README.md`;
+> this file carries the decisions and traps.
+
+## HTP vs LPAI
+
+The programming models differ substantially. Pick the column before writing code.
+
+| | HTP | LPAI (eNPU) |
+|---|---|---|
+| Interface | `QnnOpPackage_Interface_t` v1, `DEF_PACKAGE_OP` macros | OpPackage **v1.4**: `init`/`terminate`/`getInfo`/`validateOpConfig` |
+| Files per op | `{Op}.cpp` | `{Op}_inference.c` **and** `{Op}_compiler.cpp` |
+| Kernel entry | registered impl via macro | `executeOp` on `QnnLpaiOpPackage_OperationInfo_t` |
+| Tensor access | `TensorType&` wrappers | `QnnLpaiOpPackage_GlobalInfrastructure_t` accessors |
+| Make targets | `htp_x86 htp_aarch64 htp_v<arch>` | `lpai_x86`, `lpai_hexagon_v79` |
+| Build output | `build/` | `libs/` |
+| On-device transport | FastRPC (normal runner) | **direct mode only** |
+| Code signing | not required | **required** |
+| Arch lookup | `_soc_info_table[chipset].htp_info.htp_arch` | `get_soc_to_lpai_hw_ver_map()[soc_model]` |
+| SDK floor | 2.37 verified | **2.49** (2.48 first ships the headers; 2.49 needed for direct mode) |
+
+LPAI has no FastRPC path: the LPAI team does not support registering an op
+package over FastRPC, so on-device execution requires direct mode, where the
+delegate is compiled for Hexagon and calls `registerOpPackage()` inside the DSP
+process.
+
+## Workflow
+
+1. **Define the PyTorch op** with `torch.library`, including the `.out` variant
+   (ExecuTorch export requires it). See README Step 1.
+2. **Write the XML OpDef.** `PackageName` determines the library name
+   (`libQnn<PackageName>.so`).
+3. **Generate the skeleton:**
+   ```bash
+   qnn-op-package-generator -p path/to/config.xml -o <output_dir>
+   ```
+4. **Fill in the `TODO` blocks.** On LPAI that is the kernel in
+   `{Op}_inference.c` and `validateOp` in `{Op}_compiler.cpp`.
+5. **Build**, **register**, **quantize** (below).
+
+> `QNN_SDK_ROOT` must be exported *before* sourcing `envsetup.sh`, or the script
+> picks whichever SDK it finds first and the package is generated against the
+> wrong headers.
+
+### LPAI: one source set, two builds
+
+`LPAI_INFERENCE_ONLY` selects which half is compiled:
+
+* **unset** → x86_64 host library, containing the compiler-side callbacks
+  (`validateOp`, `getTempBufferSize`, `getLayoutSupportFlag`) **and** the
+  inference implementation. Enough to compile a model and to run the x86 simulator.
+* **set** → inference-only DSP skel, plus the island image.
+
+The `lpai_hexagon_v79` target emits **two** objects that both carry the kernel:
+`libQnn<Pkg>.so` and `libLpaiOpPackageIsland.so`. Rebuild, sign, and deploy them
+together — updating one leaves the DSP running the older kernel.
+
+> `HEXAGON_TOOLS_VERSION` (bare version, e.g. `8.8.06`, resolved under
+> `$HEXAGON_SDK_ROOT/tools/HEXAGON_Tools/`) selects the op package compiler.
+> `HEXAGON_TOOLS_ROOT` (full path, must be **19.0**) is for the direct-mode
+> runtime. Different variables; setting one does not satisfy the other.
+
+> The QNN LPAI headers `#include <cstdint>`, so the C++ compiler must ship the
+> C++ standard library headers. Pass `CC=gcc CXX=g++` if your default `clang`
+> lacks libstdc++ headers.
+
+## Registration
+
+```python
+from executorch.backends.qualcomm.custom_op.interface import QnnCustomOpPackageBuilder
+from executorch.backends.qualcomm.serialization.qc_schema import (
+    QnnExecuTorchOpPackagePlatform,  # UNKNOWN, X86_64, AARCH64_ANDROID, HEXAGON
+    QnnExecuTorchOpPackageTarget,    # UNKNOWN, CPU, HTP, LPAI
+)
+
+op_package_config = QnnCustomOpPackageBuilder(
+    xml_path=f"{op_package_dir}/config/my_package.xml",
+    torch_op_name_map={"ExampleCustomOp": torch.ops.my_ops.mul3.default},
+)
+op_package_config.register_implementation(target=..., platform=..., op_package_path=...)
+op_package_options = op_package_config.get_op_package_options()
+```
+
+`torch_op_name_map` maps the XML `<Name>` to the PyTorch target; a key missing
+from the parsed package raises `ValueError`. Pass `op_package_options` to
+`build_executorch_binary`.
+
+Which combinations to register, and what `op_package_path` means:
+
+| Backend | target / platform | `op_package_path` |
+|---|---|---|
+| HTP | `HTP` / `AARCH64_ANDROID` | on-device path to `libQnn<Pkg>_HTP.so` |
+| HTP | `CPU` / `AARCH64_ANDROID` | on-device path to `libQnn<Pkg>.so` |
+| HTP | `CPU` / `X86_64` | host path to the x86 build |
+| LPAI | `LPAI` / `X86_64` | host path — used for graph compilation (preprocess) |
+| LPAI | `LPAI` / `HEXAGON` | **bare file name**, e.g. `libQnn<Pkg>.so` |
+
+Two traps here:
+
+* **HTP needs the hexagon object copied to a distinct name.** The HTP and CPU
+  registrations must not share a path, so `custom_ops_1.py` copies
+  `build/hexagon-v<arch>/libQnn<Pkg>.so` → `..._HTP.so` after building.
+* **LPAI/HEXAGON takes a base name, not a path.** In direct mode there is no
+  64-bit AP process; the object is resolved through `ADSP_LIBRARY_PATH`.
+
+### Quantization
+
+Op-package ops are quantized like any other, via `CustomOpsQuantAnnotator` +
+`IOQuantConfig` (`input_quant_specs` / `output_quant_specs`, indexed per
+input/output). Indices you omit stay unquantized — that is how integer index
+outputs of a multi-output op are handled. See README Step 4.
+
+## Partitioning of op-package ops needs no bypass
+
+Op-package ops go through the ordinary `is_node_supported` path in
+`partition/qnn_partitioner.py`: `CustomOp.define_node` builds the op wrapper and
+`QnnBackend.validateOpConfig` accepts it. Look for `my_ops.mul3.default | True`
+in the log (not `| Forced Passed`).
+
+This works because the op package is registered *before* partitioning, not at
+preprocess time. `to_edge_transform_and_lower_to_qnn` opens a
+`QnnManagerContext` around the whole flow, and `InitBackend` →
+`GetOrCreateBackendBundle` → `QnnBackend::Configure` →
+`BackendRegisterOpPackage` runs the registration from the
+`op_package_options` carried in the compiler spec. `QnnOperatorSupport` obtains
+its manager from that same context via `get_current_qnn_manager`, so it
+validates against a backend that already has the package.
+
+An earlier revision force-passed these nodes on the (incorrect) assumption that
+registration happened later; that has been removed. If a custom op ever does get
+rejected here, find out why rather than re-adding a bypass — a silent
+force-pass hides genuine validation failures, and the cached-per-backend-type
+bundle in `QnnManagerRegistry` is a plausible culprit (a bundle created earlier
+without `op_package_options` would be reused).
+
+`LpaiPartitionFallbackSupport` needs no separate check — it calls the same
+`is_node_supported`.
+
+## LPAI direct mode
+
+Build the runtime (this also signs the runtime libraries when DSP type is 0):
+
+```bash
+backends/qualcomm/scripts/build.sh --build_direct_mode 0 --soc_model SM8850
+```
+
+Five things that are easy to get wrong:
+
+* **`platform=HEXAGON` is mandatory.** In direct mode the delegate is neither
+  `__x86_64__` nor `__ANDROID__`; before `__hexagon__` was handled,
+  `current_platform` stayed `UNKNOWN` and every registration was silently
+  skipped — no error, just an op that never ran.
+* **`--domain_id 0`** selects the ADSP. The default `3` is the CDSP, where LPAI
+  is absent. `SimpleADB` passes this automatically when `direct_build_folder` is
+  set; a hand-written invocation must not omit it.
+* **`registerOpPackage`'s 4th argument is backend specific.** CPU/HTP take a
+  processor target name (`"CPU"`, `"HTP"`); LPAI takes an *optional target memory
+  pool*. The runtime passes `nullptr` for LPAI so the backend picks its default.
+* **Island mode and op packages are currently mutually exclusive.**
+  `LpaiContextCustomConfig` sets `QNN_LPAI_CONTEXT_SET_CFG_ENABLE_ISLAND` under
+  `#ifndef __hexagon__`, with a pre-existing `TODO: support graph based execution
+  in island mode`. Direct mode *is* `__hexagon__`, so island is compiled out
+  there — and direct mode is the only way to reach an op package. The island
+  image is built, signed and deployed, but the kernel does not execute from it.
+  Everything below was validated in non-island mode.
+* **The loader searches `<workspace>/adsp/` before `<workspace>/`.** If you
+  populate both, keep them identical or you will run a stale kernel.
+
+Everything the drivers need follows from `direct_build_folder` in `QnnConfig`:
+`SimpleADB` selects `qnn_executor_direct_runner`, appends `--domain_id`, and
+`get_lpai_target_env()` returns `kAdsp`. Forgetting to forward that one field
+produces a non-direct `.pte` run by the FastRPC runner — which fails on the DSP,
+not at compile time.
+
+### Signing
+
+Everything the aDSP loads must be signed.
+
+| What | Who signs it |
+|---|---|
+| Direct-mode runtime libs | `build.sh --build_direct_mode 0` (calls `sign_library.sh --direct_mode`) |
+| Op package DSP objects | `custom_ops_lpai.py` after `make lpai_hexagon_v79` |
+| Either, without rebuilding | `sign_library.sh` by hand |
+
+```bash
+# op package only
+backends/qualcomm/scripts/sign_library.sh --lpai_arch v6 \
+  --op_package_dir path/to/MyOpPackage
+```
+
+Signed output lands in `$QNN_SDK_ROOT/lib/lpai-v<hw_ver>/signed`, and that is
+what gets deployed. `--skip_sign_op_package` deploys the raw build outputs
+instead — only loadable on a device that does not enforce signing.
+
+> `elfsigner.py` imports `imp`, removed in Python 3.12, so it needs an older
+> interpreter. The driver prepends its own interpreter's directory to `PATH` for
+> the subprocess. Never suppress `elfsigner` output — a silent failure here looks
+> like a stale-kernel bug later.
+
+## eNPU quantization conventions
+
+The values an LPAI kernel receives do **not** follow the
+`value = scale * (q - zero_point)` rule the surrounding Q/DQ nodes use. For 8a8w
+on SM8850:
+
+* **`offset = -128` while the graph's zero point is `0`.** The offset biases the
+  values *as stored*: `code = stored - offset` on the way in,
+  `stored = code + offset` on the way out, `value = scale * code`. Doing only one
+  of the two shifts the tensor by 128 codes.
+* **Saturate the code, not the stored byte.** For `1.0` with `scale = 1/255` the
+  code is 255 and the stored byte 127, so a clamp on the byte never fires — yet
+  code 256 is stored as the innocuous byte 128 and read back as `256-256 = 0`.
+  Clamping the wrong quantity yielded `1.494` (`= 3/255 * 127`) instead of `3.0`.
+* **The reported dtype's sign is unusable.** The package declares
+  `UFIXED_POINT_8` and the tensors are unsigned, but `getTensorDataType()`
+  reports `INT_8`. Take only the element *width*; treating storage as signed
+  reads `0x80` as `-128` and collapses the tensor to the zero point.
+* **Scale can arrive as `scale / 2^shift` with `shift > 31`** (e.g. `scale =
+  538976320, shift = 37` for `1/255`). `1u << shift` is UB for `shift >= 32` and
+  evaluates to 0 here, so the division yields `+inf` and every value becomes
+  `NaN`. Use `ldexpf(scale, -shift)`.
+
+Element addressing uses `layoutOrder` / `layoutStride`, so input and output may
+use different memory layouts. Do not assume they match.
+
+## Debugging on the DSP
+
+Host logs say nothing about the kernel. Enable FARF and read `logcat`:
+
+```bash
+adb shell "echo 0x1f > $W/qnn_executor_direct_runner.farf"
+adb logcat -d -v time | grep 'ADSP:\[DS\]'
+```
+
+* **DSP `printf` garbles long argument lists** — a dozen args prints plausible
+  but nonsensical filler. Use several small `printf`s of one to three args.
+* **Transient `EAI_ERR: Failed to reset global enpu clock level`** (often with
+  `FTQ driver invoke method (273) failed`) means the kernel never ran and the
+  output buffer is untouched. Retry; do not read the zeros as a measurement.
+* **Stale-library trap.** Verify md5 local → remote → every on-device path, and
+  grep the built `.so` for a marker string, before trusting any on-device result.
+* `QnnContextCustomProtocol expected magic number ... but get: ...` is
+  **informational** — a format probe that falls through to the Dlc path. Not an
+  error, and unrelated to op packages.
+
+## Verification
+
+```bash
+# LPAI, x86 simulator
+python examples/qualcomm/custom_op/custom_ops_lpai.py \
+  --build_folder build-x86 --backend lpai --soc_model SM8850 \
+  --op_package_dir examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage \
+  --build_op_package --enable_x86_64
+
+# LPAI, on device (direct mode); builds + signs + deploys + compares
+python backends/qualcomm/tests/test_qnn_delegate.py \
+  TestUtilsScript.test_custom_op_lpai \
+  --executorch_root . --artifact_dir ./custom_op_lpai \
+  --build_folder build-android --direct_build_folder build-direct \
+  --backend lpai --soc_model SM8850 --device <serial> [--host <host>]
+```
+
+A healthy on-device run shows `my_ops.mul3.default | True` (validated against the
+backend) for your op, `_dom=adsp` in the runner's domain URI, and a non-trivial
+`qnn_executorch_execute_all` duration.
+
+HTP equivalents are `TestUtilsScript.test_custom_op_1` / `test_custom_op_2` with
+`--op_package_dir`; see README "Running the Examples".
+
+> Confidence: the LPAI path above is verified end-to-end on SM8850. The HTP
+> material is derived from the committed examples and has not been re-run as part
+> of that work.

--- a/.claude/skills/qualcomm/new_op_development.md
+++ b/.claude/skills/qualcomm/new_op_development.md
@@ -4,6 +4,7 @@
 
 1. **QNN has a native op?** → Native builder approach (Steps 1–8)
 2. **No native op, needs multiple QNN ops?** → Decompose pass approach
+3. **No native op, needs your own kernel?** → QNN op package, see `custom_op_enablement.md`
 
 ---
 
@@ -159,11 +160,12 @@ self.lower_module_and_test_output(qdq_module, sample_input)
 **Run on-device:**
 ```bash
 python backends/qualcomm/tests/test_qnn_delegate.py \
-  -k TestQNNFloatingPointOperator.test_qnn_backend_my_op \
-  --model SM8750 --host <HOST> --device <DEVICE_ID> --build_folder build-android
+  TestQNNFloatingPointOperator.test_qnn_backend_my_op \
+  --soc_model SM8750 --host <HOST> --device <DEVICE_ID> --build_folder build-android
 ```
 
-Always ask user for `--model`, `--host`, `--device`, `--build_folder` values.
+Always ask user for `--soc_model`, `--host`, `--device`, `--build_folder` values.
+See `SKILL.md` → Testing for the full flag list (long-form only).
 
 ## Step 8b: Add Rework Framework Tests (Emulator-Based)
 

--- a/backends/qualcomm/export_utils.py
+++ b/backends/qualcomm/export_utils.py
@@ -212,6 +212,37 @@ class QnnConfig:
         return skip_node_id_set, skip_node_op_set
 
 
+def get_lpai_device_lib_dir(qnn_sdk: str, lpai_hw_ver) -> str:
+    """
+    Resolve the directory holding the LPAI device (aDSP) libraries in the QNN SDK.
+
+    LPAI only loads code-signed libraries, which live under
+    ``lib/lpai-v<hw_ver>/signed``. That directory is not shipped by the SDK, it
+    is produced by ``backends/qualcomm/scripts/sign_library.sh``. A missing
+    setup step is therefore reported here, rather than surfacing later as an
+    opaque library load failure from the QNN API.
+
+    Args:
+        qnn_sdk: Path to QNN_SDK_ROOT.
+        lpai_hw_ver: LPAI hardware version of the target SoC.
+
+    Returns:
+        Path of the directory containing the signed LPAI device libraries.
+    """
+    signed_dir = f"{qnn_sdk}/lib/lpai-v{lpai_hw_ver}/signed"
+    if not os.path.isdir(signed_dir):
+        raise RuntimeError(
+            f"{signed_dir} not found. LPAI libraries must be code-signed before "
+            "they can be loaded, please run\n"
+            "  backends/qualcomm/scripts/sign_library.sh "
+            f"--lpai_arch v{lpai_hw_ver}\n"
+            "(for direct mode, run it as "
+            f"'--direct_mode --htp_arch v<htp_arch> --lpai_arch v{lpai_hw_ver}') "
+            "and try again."
+        )
+    return signed_dir
+
+
 class SimpleADB:
     """
     A wrapper class for communicating with Android device
@@ -286,6 +317,23 @@ class SimpleADB:
         self.extra_cmds = ""
         self.skip_push = qnn_config.skip_push
         self.backend_library_paths = {}
+        # Resolved on first use through the lpai_lib_dir property, see there.
+        self._lpai_lib_dir = None
+        # Names of the LPAI device libraries that live in the *signed* directory.
+        # They are kept as bare names and joined with lpai_lib_dir only when an
+        # LPAI deployment actually asks for them, see _library_paths_for().
+        self._signed_lpai_lib_names = (
+            [
+                "libqnn_executorch_backend.so",
+                "libqnn_executorch_skel.so",
+                "libQnnLpai.so",
+                "libQnnSystem.so",
+                "libc++abi.so.1",
+                "libc++.so.1",
+            ]
+            if self.direct_build_folder
+            else ["libQnnLpaiSkel.so"]
+        )
 
         if self.direct_build_folder and self.dump_intermediate_outputs:
             raise ValueError(
@@ -305,14 +353,9 @@ class SimpleADB:
                         f"{self.hexagon_tools_root}/Tools/target/hexagon/lib/v{self.htp_arch}/G0/pic/libc++abi.so.1",
                         f"{self.hexagon_tools_root}/Tools/target/hexagon/lib/v{self.htp_arch}/G0/pic/libc++.so.1",
                     ],
-                    QnnExecuTorchBackendType.kLpaiBackend: [
-                        f"{self.qnn_sdk}/lib/lpai-v{self.lpai_hw_ver}/signed/libqnn_executorch_backend.so",
-                        f"{self.qnn_sdk}/lib/lpai-v{self.lpai_hw_ver}/signed/libqnn_executorch_skel.so",
-                        f"{self.qnn_sdk}/lib/lpai-v{self.lpai_hw_ver}/signed/libQnnLpai.so",
-                        f"{self.qnn_sdk}/lib/lpai-v{self.lpai_hw_ver}/signed/libQnnSystem.so",
-                        f"{self.qnn_sdk}/lib/lpai-v{self.lpai_hw_ver}/signed/libc++abi.so.1",
-                        f"{self.qnn_sdk}/lib/lpai-v{self.lpai_hw_ver}/signed/libc++.so.1",
-                    ],
+                    # every LPAI library in direct mode has to be code-signed,
+                    # so they are all added by _library_paths_for()
+                    QnnExecuTorchBackendType.kLpaiBackend: [],
                 }
             )
             for _, library_paths in self.backend_library_paths.items():
@@ -339,19 +382,39 @@ class SimpleADB:
                     QnnExecuTorchBackendType.kGpuBackend: [
                         f"{self.qnn_sdk}/lib/{self.target}/libQnnGpu.so",
                     ],
-                    # please note that users need to sign LPAI related libs manually
+                    # the LPAI skel additionally has to be code-signed, it is
+                    # added by _library_paths_for()
                     QnnExecuTorchBackendType.kLpaiBackend: [
                         f"{self.qnn_sdk}/lib/{self.target}/libQnnLpai.so",
-                        (
-                            f"{self.qnn_sdk}/lib/lpai-v{self.lpai_hw_ver}/"
-                            f"signed/libQnnLpaiSkel.so"
-                        ),
                         f"{self.qnn_sdk}/lib/{self.target}/libQnnLpaiStub.so",
                     ],
                 }
             )
             for _, library_paths in self.backend_library_paths.items():
                 library_paths.extend(traditional_general_artifacts)
+
+    @property
+    def lpai_lib_dir(self) -> str:
+        """
+        Directory holding the signed LPAI device libraries.
+
+        Resolved on first access rather than in __init__ on purpose: the
+        directory only exists once the libraries have been code-signed, so
+        resolving it raises. Deploying a different backend on an LPAI capable
+        SoC never loads these libraries and must not fail because of them.
+        """
+        if self._lpai_lib_dir is None:
+            self._lpai_lib_dir = get_lpai_device_lib_dir(self.qnn_sdk, self.lpai_hw_ver)
+        return self._lpai_lib_dir
+
+    def _library_paths_for(self, backend: QnnExecuTorchBackendType) -> List[str]:
+        """Backend libraries to deploy, including the signed LPAI ones."""
+        paths = list(self.backend_library_paths[backend])
+        if backend == QnnExecuTorchBackendType.kLpaiBackend:
+            paths.extend(
+                f"{self.lpai_lib_dir}/{name}" for name in self._signed_lpai_lib_names
+            )
+        return paths
 
     def _adb(self, cmd, output_callback: Optional[Callable[[str], None]] = None):
         if not self.host_id:
@@ -393,7 +456,7 @@ class SimpleADB:
 
             # backend libraries
             for backend in backends:
-                artifacts.extend(self.backend_library_paths[backend])
+                artifacts.extend(self._library_paths_for(backend))
 
             # Ensure that all necessary library artifacts exists.
             missing = [path for path in artifacts if not os.path.exists(path)]

--- a/backends/qualcomm/runtime/backends/QnnBackendCommon.cpp
+++ b/backends/qualcomm/runtime/backends/QnnBackendCommon.cpp
@@ -40,22 +40,33 @@ void QnnBackend::BackendRegisterOpPackage(
       QnnExecuTorchOpPackagePlatform::UNKNOWN;
 #if defined(__x86_64__)
   current_platform = QnnExecuTorchOpPackagePlatform::X86_64;
+#elif defined(__hexagon__)
+  current_platform = QnnExecuTorchOpPackagePlatform::HEXAGON;
 #elif defined(__ANDROID__)
   current_platform = QnnExecuTorchOpPackagePlatform::AARCH64_ANDROID;
 #endif
   if (current_platform == QnnExecuTorchOpPackagePlatform::UNKNOWN)
     QNN_EXECUTORCH_LOG_ERROR(
-        "Failed to detect the platform. Only support x86_64 or android.");
+        "Failed to detect the platform. Only support x86_64, hexagon, or android.");
   for (const auto op_package_info : *op_packages_infos) {
     if (current_platform != op_package_info->platform() ||
         op_package_manager_.Has(op_package_info->op_package_path()->c_str()))
       continue;
 
+    // The 4th argument of registerOpPackage is backend specific. For CPU / HTP
+    // it is the processor target name (e.g. "CPU", "HTP"). For LPAI it is an
+    // optional target memory pool string instead, so pass nullptr to let the
+    // backend pick its default pool.
+    const char* op_package_target =
+        op_package_info->target() == QnnExecuTorchOpPackageTarget::LPAI
+        ? nullptr
+        : EnumNameQnnExecuTorchOpPackageTarget(op_package_info->target());
+
     error = qnn_interface.qnn_backend_register_op_package(
         handle_,
         op_package_info->op_package_path()->c_str(),
         op_package_info->interface_provider()->c_str(),
-        EnumNameQnnExecuTorchOpPackageTarget(op_package_info->target()));
+        op_package_target);
     if (error != QNN_SUCCESS) {
       QNN_EXECUTORCH_LOG_ERROR(
           "Failed to register op package: "

--- a/backends/qualcomm/runtime/backends/direct_mode/QnnExecuTorchIdlWrapper.cpp
+++ b/backends/qualcomm/runtime/backends/direct_mode/QnnExecuTorchIdlWrapper.cpp
@@ -141,6 +141,7 @@ QnnExecuTorchIdlWrapper::QnnExecuTorchIdlWrapper(
   }
 
   output_tensors_.resize(method_->outputs_size());
+  output_is_preallocated_.assign(method_->outputs_size(), false);
   for (int i = 0; i < output_tensors_.size(); ++i) {
     Result<TensorInfo> tensor_info = method_meta_->output_tensor_meta(i);
     output_tensors_[i].resize(
@@ -148,8 +149,16 @@ QnnExecuTorchIdlWrapper::QnnExecuTorchIdlWrapper(
     Error ret = method_->set_output_data_ptr(
         align_ptr(output_tensors_[i].data()), tensor_info->nbytes(), i);
     if (ret != Error::Ok) {
-      FARF(RUNTIME_ERROR, "Failed to set output tensor: %d", (int)ret);
-      return;
+      // This fails when the output is memory planned or is a constant, in which
+      // case the data pointer cannot be overridden. That is not an error: the
+      // method already owns a buffer for this output, so remember to read the
+      // result back from the method instead of from output_tensors_[i].
+      FARF(
+          RUNTIME_HIGH,
+          "Output %d is pre-allocated, reading it back from the method: 0x%x",
+          i,
+          (int)ret);
+      output_is_preallocated_[i] = true;
     }
   }
 }
@@ -162,6 +171,16 @@ Error QnnExecuTorchIdlWrapper::execute_all(
     double& total_read_file_interval,
     double& total_save_file_interval) {
   Error status = Error::Ok;
+  // The constructor bails out early on any failure, which leaves method_ unset.
+  // Dereferencing it here would fault on the DSP and mask the original error,
+  // so report the bad state instead.
+  if (method_ == nullptr) {
+    FARF(
+        RUNTIME_ERROR,
+        "Model was not loaded successfully, unable to execute. "
+        "Please check the earlier errors reported during load.");
+    return Error::InvalidState;
+  }
   TimePoint execute_start, execute_end, read_start, read_end, save_start,
       save_end;
   std::ifstream input_list(input_list_path);
@@ -246,8 +265,20 @@ Error QnnExecuTorchIdlWrapper::execute_all(
         }
 
         size_t expected_bytes = method_meta_->output_tensor_meta(i)->nbytes();
-        ssize_t bytes =
-            write(fd, align_ptr(output_tensors_[i].data()), expected_bytes);
+        // Outputs whose data pointer could not be overridden live in the
+        // method's own memory, so read those back through get_output().
+        const void* output_data = align_ptr(output_tensors_[i].data());
+        if (output_is_preallocated_[i]) {
+          const auto& evalue = method_->get_output(i);
+          if (!evalue.isTensor()) {
+            FARF(RUNTIME_ERROR, "Output %zu is not a tensor.", i);
+            close(fd);
+            status = Error::Internal;
+            return status;
+          }
+          output_data = evalue.toTensor().const_data_ptr();
+        }
+        ssize_t bytes = write(fd, output_data, expected_bytes);
         if (bytes < 0) {
           FARF(RUNTIME_ERROR, "Failed to write data to output file.");
           close(fd);

--- a/backends/qualcomm/runtime/backends/direct_mode/QnnExecuTorchIdlWrapper.h
+++ b/backends/qualcomm/runtime/backends/direct_mode/QnnExecuTorchIdlWrapper.h
@@ -60,6 +60,9 @@ class QnnExecuTorchIdlWrapper {
   std::vector<executorch::runtime::Span<uint8_t>> planned_spans_;
   std::vector<std::vector<uint8_t>> input_tensors_;
   std::vector<std::vector<uint8_t>> output_tensors_;
+  // Tracks the outputs whose data pointer could not be overridden because they
+  // are memory planned or constant. Those are read back from the method itself.
+  std::vector<bool> output_is_preallocated_;
   std::vector<executorch::aten::TensorImpl> input_tensor_impls_;
 };
 

--- a/backends/qualcomm/scripts/sign_library.sh
+++ b/backends/qualcomm/scripts/sign_library.sh
@@ -18,22 +18,42 @@ usage() {
     echo ""
     echo "Direct mode, e.g.:"
     echo "  executorch$ $0 --direct_mode --htp_arch v81 --lpai_arch v6"
+    echo ""
+    echo "Additionally sign a custom op package, e.g.:"
+    echo "  executorch$ $0 --direct_mode --htp_arch v81 --lpai_arch v6 \\"
+    echo "      --op_package_dir examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage"
+    echo ""
+    echo "The DSP target the op package was built for defaults to"
+    echo "$default_op_package_arch and can be overridden with --op_package_arch."
     exit 1;
 }
 
-short=l:,c:,d,h
-long=lpai_arch:,htp_arch:,direct_mode,help
+short=l:,c:,d,p:,a:,h
+long=lpai_arch:,htp_arch:,direct_mode,op_package_dir:,op_package_arch:,help
 args=$(getopt -a -o $short -l $long -n $0 -- $@)
 eval set -- $args
 
 lpai_arch=""
 htp_arch=""
 direct_mode=false
+op_package_dir=""
+# Hexagon target the op package was compiled for. This is *not* $htp_arch and
+# not $lpai_arch either: on SM8850 the HTP is V81 and the LPAI hardware version
+# is V6, while the op package builds for hexagon-v79. The three version numbers
+# are independent, and v79 is currently the only usable value because the QNN
+# SDK ships a single LPAI op package makefile,
+# share/QNN/OpPackageGenerator/makefiles/LPAI/Makefile.hexagon-v79, which
+# hardcodes QNN_TARGET, -mv79 and the computev79 QuRT headers. The option exists
+# so that this script does not have to change once the SDK ships more of them.
+default_op_package_arch=v79
+op_package_arch=$default_op_package_arch
 while true; do
   case $1 in
     -l | --lpai_arch) lpai_arch=$2; shift 2;;
     -c | --htp_arch) htp_arch=$2; shift 2;;
     -d | --direct_mode) direct_mode=true; shift;;
+    -p | --op_package_dir) op_package_dir=$2; shift 2;;
+    -a | --op_package_arch) op_package_arch=$2; shift 2;;
     -h | --help) usage;;
     --) shift; break;;
     *) echo "unknown keyword: $1"; usage;;
@@ -59,13 +79,67 @@ signed_folder=$QNN_SDK_ROOT/lib/lpai-$lpai_arch/signed
 signer=$HEXAGON_SDK_ROOT/tools/elfsigner/elfsigner.py
 mkdir -p $signed_folder
 
+# Sign one library, failing loudly if the signer did not.
+#
+# The exit status has to be checked explicitly: without it a failing signer (a
+# missing input, an expired certificate, or an interpreter too new for
+# elfsigner.py, which imports the `imp` module removed in Python 3.12) leaves
+# this script exiting 0 while the signed library is missing or stale. The
+# failure then only shows up on device as an opaque library load error.
+#
+# `yes` feeds the signer's interactive confirmation prompt and is expected to
+# die with SIGPIPE once the signer exits, so PIPESTATUS[1] rather than $? is the
+# status of interest here.
+sign_library() {
+  local lib=$1
+  if [[ ! -f $lib ]]; then
+    echo "no such library: $lib"
+    exit 1
+  fi
+  yes 2>/dev/null | python $signer -i $lib -o $signed_folder
+  local signer_status=${PIPESTATUS[1]}
+  if [[ $signer_status -ne 0 ]]; then
+    echo "failed to sign $lib (elfsigner.py exited $signer_status)"
+    echo "note that elfsigner.py imports 'imp' and needs python < 3.12"
+    exit 1
+  fi
+}
+
 if [ "$direct_mode" = true ]; then
-  yes 2>/dev/null | python $signer -i $QNN_SDK_ROOT/lib/lpai-$lpai_arch/unsigned/libQnnLpai.so -o $signed_folder
-  yes 2>/dev/null | python $signer -i $QNN_SDK_ROOT/lib/hexagon-$htp_arch/unsigned/libQnnSystem.so -o $signed_folder
-  yes 2>/dev/null | python $signer -i $HEXAGON_TOOLS_ROOT/Tools/target/hexagon/lib/$htp_arch/G0/pic/libc++abi.so.1 -o $signed_folder
-  yes 2>/dev/null | python $signer -i $HEXAGON_TOOLS_ROOT/Tools/target/hexagon/lib/$htp_arch/G0/pic/libc++.so.1 -o $signed_folder
-  yes 2>/dev/null | python $signer -i $PRJ_ROOT/build-direct/backends/qualcomm/qnn_executorch/direct_mode/libqnn_executorch_skel.so -o $signed_folder
-  yes 2>/dev/null | python $signer -i $PRJ_ROOT/build-direct/backends/qualcomm/libqnn_executorch_backend.so -o $signed_folder
+  sign_library $QNN_SDK_ROOT/lib/lpai-$lpai_arch/unsigned/libQnnLpai.so
+  sign_library $QNN_SDK_ROOT/lib/hexagon-$htp_arch/unsigned/libQnnSystem.so
+  sign_library $HEXAGON_TOOLS_ROOT/Tools/target/hexagon/lib/$htp_arch/G0/pic/libc++abi.so.1
+  sign_library $HEXAGON_TOOLS_ROOT/Tools/target/hexagon/lib/$htp_arch/G0/pic/libc++.so.1
+  sign_library $PRJ_ROOT/build-direct/backends/qualcomm/qnn_executorch/direct_mode/libqnn_executorch_skel.so
+  sign_library $PRJ_ROOT/build-direct/backends/qualcomm/libqnn_executorch_backend.so
 else
-  yes 2>/dev/null | python $signer -i $QNN_SDK_ROOT/lib/lpai-$lpai_arch/unsigned/libQnnLpaiSkel.so -o $signed_folder
+  sign_library $QNN_SDK_ROOT/lib/lpai-$lpai_arch/unsigned/libQnnLpaiSkel.so
+fi
+
+# A custom op package brings its own DSP code, which must be signed just like
+# the runtime libraries above or the DSP refuses to load it. Both objects built
+# by the hexagon target carry the kernel and both have to be signed: the op
+# package itself and libLpaiOpPackageIsland.so, which is linked for
+# always-resident (island) memory. Which one the runtime resolves depends on
+# island mode, so sign both rather than guessing.
+if [[ -n $op_package_dir ]]; then
+  hexagon_libs=$op_package_dir/libs/hexagon-$op_package_arch
+  if [[ ! -d $hexagon_libs ]]; then
+    echo "no such directory: $hexagon_libs"
+    echo "build the op package first, e.g. 'make lpai_hexagon_$op_package_arch' in $op_package_dir"
+    exit 1
+  fi
+  # A glob that matches nothing expands to itself, which would hand the signer
+  # the literal "*.so"; guard with -e so an unbuilt directory is reported here.
+  signed_any=false
+  for lib in $hexagon_libs/*.so; do
+    [[ -e $lib ]] || continue
+    sign_library $lib
+    signed_any=true
+  done
+  if [ "$signed_any" = false ]; then
+    echo "no .so found in $hexagon_libs"
+    echo "build the op package first, e.g. 'make lpai_hexagon_$op_package_arch' in $op_package_dir"
+    exit 1
+  fi
 fi

--- a/backends/qualcomm/serialization/qc_compiler_spec.fbs
+++ b/backends/qualcomm/serialization/qc_compiler_spec.fbs
@@ -276,6 +276,7 @@ enum QnnExecuTorchOpPackageTarget: int {
   UNKNOWN = 0,
   CPU,
   HTP,
+  LPAI,
 }
 
 /// The platform of the op package library.
@@ -283,6 +284,7 @@ enum QnnExecuTorchOpPackagePlatform: int {
   UNKNOWN = 0,
   X86_64,
   AARCH64_ANDROID,
+  HEXAGON,
 }
 
 table QnnExecuTorchOpPackageInfo {

--- a/backends/qualcomm/serialization/qc_schema.py
+++ b/backends/qualcomm/serialization/qc_schema.py
@@ -267,6 +267,7 @@ class QnnExecuTorchOpPackageTarget(IntEnum):
     UNKNOWN = 0
     CPU = 1
     HTP = 2
+    LPAI = 3
 
 
 @unique
@@ -274,6 +275,7 @@ class QnnExecuTorchOpPackagePlatform(IntEnum):
     UNKNOWN = 0
     X86_64 = 1
     AARCH64_ANDROID = 2
+    HEXAGON = 3
 
 
 @dataclass

--- a/backends/qualcomm/tests/test_qnn_delegate.py
+++ b/backends/qualcomm/tests/test_qnn_delegate.py
@@ -77,7 +77,7 @@ from executorch.backends.qualcomm.tests.models import *  # noqa: F403
 import os
 import random
 
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from typing import List
 
 from executorch.backends.qualcomm._passes import FoldQDQ, TagQuantIO
@@ -11596,6 +11596,130 @@ class TestUtilsScript(TestQNN):
             conn = listener.accept()
             p.communicate()
             msg = json.loads(conn.recv())
+            self.assertTrue(msg["is_close"])
+
+    # Building an LPAI op package needs the LPAI op package headers and
+    # makefiles, which are only shipped by Qualcomm AI Engine Direct SDK >= 2.48.
+    @unittest.skipIf(
+        is_qnn_sdk_version_less_than("2.48"),
+        "LPAI op package support requires QNN SDK >= 2.48",
+    )
+    def test_custom_op_lpai(self):
+        # Running the kernel on the DSP additionally requires direct mode, which
+        # in turn requires SDK >= 2.49. Registering an op package over FastRPC is
+        # not supported, so there is no non-direct on-device path to fall back to.
+        if not self.enable_x86_64:
+            if is_qnn_sdk_version_less_than("2.49"):
+                self.skipTest(
+                    "Running an LPAI op package on device requires QNN SDK >= 2.49"
+                )
+            if not self.direct_build_folder:
+                self.skipTest(
+                    "Running an LPAI op package on device requires direct mode; "
+                    "please provide --direct_build_folder"
+                )
+
+        self._run_custom_op_lpai()
+
+    @unittest.skipIf(
+        is_qnn_sdk_version_less_than("2.48"),
+        "LPAI op package support requires QNN SDK >= 2.48",
+    )
+    def test_custom_op_lpai_requant_edge_cases(self):
+        # The kernel's requantization has two paths that the default run cannot
+        # reach, because it calibrates and infers with the same tensor and so
+        # always lands at the top of the calibrated range:
+        #   * a small input, whose code is biased into the upper half of the
+        #     stored byte and has to be un-biased modulo the storage width;
+        #   * an input above the calibrated range, which has to saturate.
+        # The arithmetic is identical in the x86 and the DSP build, so exercise
+        # it on the simulator rather than paying for a DSP rebuild and re-sign.
+        if not self.enable_x86_64:
+            self.skipTest(
+                "The requantization edge cases are checked on the x86 simulator; "
+                "please provide --enable_x86_64"
+            )
+
+        # expected=EXPECT_EAGER compares against the eager result, which is the
+        # right reference as long as the input is inside the calibrated range.
+        EXPECT_EAGER = None
+        RequantCase = namedtuple("RequantCase", "calibration inference expected")
+        cases = [
+            # code 64, stored as the byte 192 once biased by offset -128. A
+            # kernel that un-biases without wrapping reads this as code 320,
+            # saturates, and returns 3.0.
+            RequantCase(calibration=1.0, inference=0.25, expected=EXPECT_EAGER),
+            # Above the calibrated range: the graph's quantize node clamps the
+            # input to 1.0, so the correct answer is 3.0 rather than 6.0.
+            RequantCase(calibration=1.0, inference=2.0, expected=3.0),
+        ]
+        for index, case in enumerate(cases):
+            with self.subTest(calibration=case.calibration, inference=case.inference):
+                extra_args = [
+                    "--calibration_value",
+                    str(case.calibration),
+                    "--inference_value",
+                    str(case.inference),
+                ]
+                if case.expected is not EXPECT_EAGER:
+                    extra_args.extend(["--expected_value", str(case.expected)])
+                # The op package only has to be built once: the cases differ
+                # only in the values passed to the already built kernel, and a
+                # rebuild costs about as much as the run itself.
+                self._run_custom_op_lpai(
+                    extra_args=extra_args, build_op_package=index == 0
+                )
+
+    def _run_custom_op_lpai(self, extra_args=None, build_op_package=True):
+        op_package_dir = (
+            f"{self.executorch_root}/examples/qualcomm/custom_op/"
+            "example_op_package_lpai/ExampleLpaiOpPackage"
+        )
+        cmds = [
+            "python",
+            f"{self.executorch_root}/examples/qualcomm/custom_op/custom_ops_lpai.py",
+            "--artifact",
+            self.artifact_dir,
+            "--build_folder",
+            self.build_folder,
+            "--soc_model",
+            self.soc_model,
+            "--backend",
+            "lpai",
+            "--ip",
+            self.ip,
+            "--port",
+            str(self.port),
+            "--op_package_dir",
+            op_package_dir,
+        ]
+        if build_op_package:
+            cmds.append("--build_op_package")
+        cmds.extend(extra_args or [])
+        # A device serial is only meaningful for an on-device run; the x86
+        # simulator is driven without one.
+        if self.device:
+            cmds.extend(["--device", self.device])
+        if self.host:
+            cmds.extend(["--host", self.host])
+        if self.enable_x86_64:
+            cmds.extend(["--enable_x86_64"])
+        else:
+            # On device the op package is only reachable through direct mode,
+            # which also selects the direct runner and passes --domain_id.
+            cmds.extend(["--direct_build_folder", self.direct_build_folder])
+
+        p = subprocess.Popen(cmds, stdout=subprocess.DEVNULL)
+        with Listener((self.ip, self.port)) as listener:
+            conn = listener.accept()
+            p.communicate()
+            msg = json.loads(conn.recv())
+            if "Error" in msg:
+                self.fail(msg["Error"])
+            # Checked separately from the output: the eager fallback computes
+            # the same values, so a matching output does not by itself prove
+            # that the op package ran.
+            self.assertTrue(msg["is_delegated"])
             self.assertTrue(msg["is_close"])
 
     def test_debugger_generate_optrace(self):

--- a/examples/qualcomm/custom_op/README.md
+++ b/examples/qualcomm/custom_op/README.md
@@ -255,7 +255,7 @@ quantizer = make_quantizer(
     quant_dtype=QuantDtype.use_8a8w,
     custom_annotations=(annotate_fn,),
     backend=get_backend_type(args.backend),
-    soc_model=args.model,
+    soc_model=args.soc_model,
 )
 ```
 
@@ -333,3 +333,305 @@ python3 examples/qualcomm/custom_op/custom_ops_2.py \
   --build_op_package \
   --enable_x86_64
 ```
+
+### Example 3: LPAI (eNPU) custom op (`custom_ops_lpai.py`)
+
+Registers the same `torch.ops.my_ops.mul3.default` operator, but delegates it to
+the **LPAI** backend via `ExampleLpaiOpPackage`.
+
+> **Requires Qualcomm AI Engine Direct SDK >= 2.49.** SDK 2.48 is the first
+> release that ships `include/QNN/LPAI/QnnLpaiOpPackage.h`,
+> `include/QNN/LPAI/QnnLpaiOpPackageInfrastructure.h` and
+> `share/QNN/OpPackageGenerator/makefiles/LPAI/`; on older SDKs (e.g. 2.47) the
+> LPAI Mako templates are present but the headers and makefiles they depend on
+> are not, so `qnn-op-package-generator` fails and the generated sources cannot
+> be compiled. 2.49 is required for the on-device flow, which needs the direct
+> mode runtime.
+>
+> `QNN_SDK_ROOT` must be exported *before* sourcing `envsetup.sh`, otherwise the
+> script silently selects whichever SDK it finds first, and the op package is
+> then generated against the wrong headers.
+
+> **On-device execution requires direct mode.** The LPAI team does not support
+> registering an op package over FastRPC, so the DSP-side kernel is only reachable
+> when the delegate itself is compiled for Hexagon and runs inside the DSP
+> process. See [Running on device](#running-on-device-direct-mode) below.
+
+#### How the LPAI op package differs from HTP
+
+| | HTP | LPAI |
+| --- | --- | --- |
+| Interface version | `QnnOpPackage_Interface_t` v1 (`DEF_PACKAGE_OP` macros) | QNN OpPackage **v1.4** (`init` / `terminate` / `getInfo` / `validateOpConfig`) |
+| Files per op | `{OpName}.cpp` | `{OpName}_inference.c` **and** `{OpName}_compiler.cpp` |
+| Kernel entry point | `DEF_PACKAGE_OP(...)` registered impl | `executeOp` callback on `QnnLpaiOpPackage_OperationInfo_t` |
+| Tensor access | `TensorType&` wrappers | `QnnLpaiOpPackage_GlobalInfrastructure_t` accessors (`getInputTensor`, `getTensorData`, `getTensorLayout`, ...) |
+| Build outputs | one lib per hexagon arch + x86 + aarch64 | x86 host lib (compiler **and** inference side) + `hexagon-v79` inference-only skel and island image |
+
+The same sources are compiled twice, selected by the `LPAI_INFERENCE_ONLY` define:
+
+* **without** the define -> host / compiler side library
+  (`libs/x86_64-linux-clang/libQnnExampleLpaiOpPackage.so`). This library
+  contains the compiler-side callbacks (`validateOp`, `getTempBufferSize`,
+  `getLayoutSupportFlag`) **and** the inference implementation, so it is all that
+  is needed to compile a model and to run it through the LPAI x86_64 simulator.
+* **with** the define -> inference-only skel for the DSP
+  (`libs/hexagon-v79/libQnnExampleLpaiOpPackage.so`, plus the island image
+  `libs/hexagon-v79/libLpaiOpPackageIsland.so`). Building this target
+  additionally requires `HEXAGON_SDK_ROOT` and `HEXAGON_TOOLS_VERSION`.
+
+> **`HEXAGON_TOOLS_VERSION` and `HEXAGON_TOOLS_ROOT` are different variables.**
+> The op package Makefile selects the compiler with `HEXAGON_TOOLS_VERSION` (a
+> bare version number such as `8.8.06`, resolved under
+> `$HEXAGON_SDK_ROOT/tools/HEXAGON_Tools/`), while the direct mode runtime build
+> uses `HEXAGON_TOOLS_ROOT` (a full path, and it must point at **19.0**, the only
+> version that ships v81). Both are needed for the on-device flow and setting one
+> does not satisfy the other.
+
+Note that the `hexagon-v79` target produces **two** objects and both contain the
+kernel: the op package itself and `libLpaiOpPackageIsland.so`, which is linked
+with the uImage linker script the SDK ships in
+`share/QNN/OpPackageGenerator/makefiles/LPAI/island` for always-resident
+(island) memory. Both must be rebuilt, signed and deployed together; updating
+only one of them leaves the DSP running the older kernel.
+
+> **Island mode is not exercised by this example.** The island image is built,
+> signed and deployed, but the kernel is not executed from it. LPAI enables
+> island only outside of direct mode — `LpaiContextCustomConfig` sets
+> `QNN_LPAI_CONTEXT_SET_CFG_ENABLE_ISLAND` under `#ifndef __hexagon__`, and it
+> carries a pre-existing `TODO: support graph based execution in island mode`.
+> Since an op package is only reachable in direct mode (where `__hexagon__` *is*
+> defined), the two are currently mutually exclusive, and the flow below was
+> validated in non-island mode.
+
+#### Generating the op package skeleton
+
+The committed sources under `example_op_package_lpai/` were produced with:
+
+```bash
+qnn-op-package-generator \
+  -p examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/config/example_op_package_lpai.xml \
+  -o <output_dir>
+```
+
+and then the two `TODO` blocks were filled in:
+* `ExampleCustomOp_inference.c` - the `mul3` kernel. Because LPAI is a fixed
+  point accelerator, the kernel reads the per-tensor quantization parameters and
+  requantizes. Element addressing uses `layoutOrder` / `layoutStride`, so the
+  input and output are free to use different memory layouts. See
+  [Quantization conventions](#quantization-conventions-on-the-enpu) for the
+  arithmetic, which has several non-obvious pitfalls.
+* `ExampleCustomOp_compiler.cpp` - `validateOp`, which checks that the input and
+  output share a data type and are rank 4 with matching dimensions.
+
+#### Quantization conventions on the eNPU
+
+The values an LPAI kernel is handed do not follow the plain
+`value = scale * (q - zero_point)` rule that the surrounding ExecuTorch
+quantize / dequantize nodes use, and the differences are easy to get wrong.
+
+The numbers below were measured with the committed example (8a8w, `mul3`,
+`--calibration_value 1.0`) by printing the values `getPerTensorQuantParams()` and
+`getTensorDataType()` return, plus the first stored byte, from inside the kernel:
+
+```
+in  offset=-128  dataType=3 (INT_8)  scale.type=1 (INT)  scale=538976320  shift=37
+out offset=-128  dataType=3 (INT_8)  scale.type=1 (INT)  scale=808464448  shift=36
+stored_in[0]=127
+```
+
+`538976320 / 2^37 = 1/255` and `808464448 / 2^36 = 3/255`, as expected for input
+range `[0, 1]` and output range `[0, 3]`.
+
+* **`getPerTensorQuantParams()` reports `offset = -128`** (for input *and*
+  output), while the Q/DQ nodes in the ExecuTorch graph use a zero point of `0`.
+  The offset biases the values *as they sit in memory*:
+
+  ```
+  code   = stored - offset          // remove the bias to get the graph's code
+  stored = code   + offset          // re-apply it before writing
+  value  = scale * code
+  ```
+
+  The measurement above confirms this: the graph's code for `1.0` is `255`, and
+  the byte the kernel actually reads is `255 + (-128) = 127`. The kernel must
+  therefore un-bias on the way in **and** re-bias on the way out; doing only one
+  of the two shifts the whole tensor by 128 codes.
+
+* **Un-biasing must wrap modulo the storage width.** With `offset = -128` the
+  codes `0..127` are stored as the bytes `128..255`, so `stored - offset`
+  produces `256..383` rather than `0..127`, and the value then saturates. Mask
+  the result (`& 0xFF`, or `& 0xFFFF` for 16 bit) before scaling. The output
+  direction gets this for free from the narrowing store, which is why the bug
+  only affects the input path — and why it only shows up for *small* values:
+  calibrating on `1.0` and running on `1.0` always yields the stored byte `127`,
+  which takes the correct branch. Running on `0.25` yields the stored byte `192`
+  and returns `3.0` instead of `0.75`. Both cases are covered by
+  `--calibration_value` / `--inference_value`.
+
+* **Saturate the code, not the stored byte.** For input `1.0` with
+  `scale = 1/255` the code is `255` and the stored byte is `127`, so a clamp
+  applied to the byte never triggers — yet a code of `256` (one past the maximum)
+  is stored as the innocent looking byte `128` and read back by the consumer as
+  code `256 - 256 = 0`. Overflow has to be caught while the value is still a
+  code. Note that this particular op cannot overflow: its output range is exactly
+  three times its input range, so `requantScale` is `1`. A kernel whose ranges
+  are not related that way can, hence the clamp.
+
+* **The reported data type's *sign* is unusable.** The op package declares
+  `QNN_DATATYPE_UFIXED_POINT_8` and the tensors really are unsigned, but
+  `getTensorDataType()` reports `LPAI_CUSTOM_OP_DATATYPE_INT_8` (enum value `3`,
+  see the measurement above). Take only the element *width* from the reported
+  type; treating the storage as signed reads `0x80` as `-128` instead of `128`
+  and collapses the tensor to the zero point.
+
+* **The scale arrives as `scale / 2^shift` with `shift > 31`** — `shift` is `37`
+  and `36` above. Computing `1u << shift` is undefined behaviour for
+  `shift >= 32` and evaluates to `0` on this DSP, so the division silently yields
+  `+inf` and every requantized value becomes `NaN`. Use `ldexpf(scale, -shift)`.
+
+> These conventions are not documented in the QNN/LPAI SDK documentation as far
+> as we can tell, which is why they are spelled out (and measured) here.
+
+> **Note:** the QNN LPAI headers `#include <cstdint>`, so the C++ compiler must
+> provide the C++ standard library headers. Pass `CC=gcc CXX=g++` (as the example
+> script does) if your default `clang` install does not ship libstdc++ headers.
+
+**x86 emulator:**
+```bash
+python3 examples/qualcomm/custom_op/custom_ops_lpai.py \
+  --build_folder build-x86 \
+  --backend lpai \
+  --soc_model SM8850 \
+  --op_package_dir examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage \
+  --build_op_package \
+  --enable_x86_64
+```
+
+##### Exercising the requantization edge cases
+
+The calibration input and the inference input are separate
+(`--calibration_value` / `--inference_value`). This matters: when both are the
+same tensor, the input always sits at the top of the calibrated range (code
+`255`, stored byte `127`), and the quantization pitfalls listed above are never
+reached. Two extra runs cover them, and neither needs a device:
+
+```bash
+# Low codes: calibrate on 1.0, run on 0.25 -> code 64, stored byte 192.
+# A kernel that un-biases without wrapping returns 3.0 instead of 0.75.
+python3 examples/qualcomm/custom_op/custom_ops_lpai.py \
+  --build_folder build-x86 --backend lpai --soc_model SM8850 \
+  --op_package_dir examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage \
+  --enable_x86_64 --calibration_value 1.0 --inference_value 0.25
+
+# Above the calibrated range: run on 2.0. The graph's quantize node clamps to
+# the calibrated maximum, so the expected result is the saturated 3.0 rather
+# than 6.0, which has to be stated explicitly.
+python3 examples/qualcomm/custom_op/custom_ops_lpai.py \
+  --build_folder build-x86 --backend lpai --soc_model SM8850 \
+  --op_package_dir examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage \
+  --enable_x86_64 --calibration_value 1.0 --inference_value 2.0 --expected_value 3.0
+```
+
+#### Running on device (direct mode)
+
+On-device execution goes through **direct mode**: the delegate is compiled for
+Hexagon and runs inside the DSP process, so it registers the op package locally
+instead of forwarding the registration over FastRPC. Build the runtime with:
+
+```bash
+backends/qualcomm/scripts/build.sh --build_direct_mode 0 --soc_model SM8850
+```
+
+Everything that runs on the DSP must be **signed**, including the op package.
+This is handled for you in two places:
+
+* the build command above ends by calling
+  `sign_library.sh --direct_mode`, which signs the direct mode **runtime**
+  libraries;
+* `custom_ops_lpai.py` calls `sign_library.sh --op_package_dir` whenever it
+  builds the `hexagon-v79` target (i.e. with `--build_op_package` and without
+  `--enable_x86_64`), which signs every `.so` the **op package** produces. The
+  signed objects are then deployed from
+  `$QNN_SDK_ROOT/lib/lpai-v<hw_ver>/signed`. Pass `--skip_sign_op_package` to
+  deploy the raw build outputs instead, which only load on a device that does
+  not enforce code signing.
+
+To re-sign without rebuilding, invoke the script directly:
+
+```bash
+# runtime libraries and op package together
+backends/qualcomm/scripts/sign_library.sh \
+  --direct_mode --htp_arch v81 --lpai_arch v6 \
+  --op_package_dir examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage
+```
+
+Note that `elfsigner.py` uses the `imp` module, which was removed in Python 3.12,
+so it has to run under an older interpreter. The example script takes care of
+this by putting its own interpreter first on `PATH`.
+
+Generate the `.pte` and push the artifacts:
+
+```bash
+python3 examples/qualcomm/custom_op/custom_ops_lpai.py \
+  --build_folder build-android \
+  --backend lpai \
+  --device <device_serial> \
+  --host <host> \
+  --soc_model SM8850 \
+  --op_package_dir examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage \
+  --build_op_package
+```
+
+On device, the DSP libraries must be present in **both** the workspace root and
+its `adsp/` subdirectory, because the loader searches `<path>/adsp/` first and
+then `<path>/`. The runner also needs `--domain_id 0` to select the ADSP; the
+default of `3` selects the CDSP, where LPAI is not present:
+
+```bash
+W=/data/local/tmp/executorch/custom_qnn_lpai
+ADSP_LIBRARY_PATH=$W LD_LIBRARY_PATH=$W ./qnn_executor_direct_runner \
+  --model_path $W/custom_qnn_lpai.pte \
+  --input_list_path $W/input_list.txt \
+  --output_folder_path $W \
+  --domain_id 0
+```
+
+Supported LPAI SoCs are those with an `LpaiInfo` entry in
+`backends/qualcomm/serialization/qc_schema.py` (e.g. `SM8850`, `SAR2230P`).
+
+#### Debugging on the DSP
+
+Host-side logs say nothing about what happens inside the kernel. Enable FARF
+logging and read the DSP output from `logcat`:
+
+```bash
+adb shell "echo 0x1f > $W/qnn_executor_direct_runner.farf"
+adb logcat -d -v time | grep 'ADSP:\[DS\]'
+```
+
+Two things worth knowing when reading that output:
+
+* **`printf` on the DSP garbles long argument lists.** A single call with a dozen
+  arguments prints repeating ASCII filler that looks like real but nonsensical
+  data. Use several small `printf`s with one to three arguments each.
+* A transient `EAI_ERR: Failed to reset global enpu clock level` (usually with
+  `FTQ driver invoke method (273) failed`) means the kernel never ran and the
+  output buffer was left untouched. It clears on a retry a few seconds later; do
+  not read the all-zero buffer as a measurement.
+
+#### Registering the op package for LPAI
+
+Registration is identical to HTP apart from the target enum:
+
+```python
+op_package_config.register_implementation(
+    target=QnnExecuTorchOpPackageTarget.LPAI,
+    platform=QnnExecuTorchOpPackagePlatform.X86_64,
+    op_package_path=x86_op_package_path,
+)
+```
+
+Note that the fourth argument of QNN's `registerOpPackage` is backend specific:
+for CPU / HTP it is the processor target name (`"CPU"`, `"HTP"`), whereas for
+LPAI it is an *optional target memory pool* string. The ExecuTorch runtime
+therefore passes `nullptr` for LPAI so that the backend selects its default pool.

--- a/examples/qualcomm/custom_op/custom_ops_lpai.py
+++ b/examples/qualcomm/custom_op/custom_ops_lpai.py
@@ -1,0 +1,511 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Example of registering a custom operator for the LPAI (eNPU) backend.
+
+The LPAI op package programming model differs from HTP:
+  * the op package implements the QNN OpPackage v1.4 interface
+  * the same sources are built twice, selected by ``LPAI_INFERENCE_ONLY``:
+      - without the define -> host/compiler side library (x86_64), which also
+        contains the inference implementation
+      - with the define    -> inference only skel for the DSP
+        (hexagon-``LPAI_OP_PACKAGE_ARCH``)
+  * kernels access tensors through ``QnnLpaiOpPackage_GlobalInfrastructure_t``
+
+Requires Qualcomm AI Engine Direct SDK >= 2.48, which is the first release that
+ships ``QnnLpaiOpPackage.h`` and ``share/QNN/OpPackageGenerator/makefiles/LPAI``.
+The on-device path needs >= 2.49, because it additionally requires direct mode.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from multiprocessing.connection import Client
+
+import numpy as np
+import torch
+
+from executorch.backends.qualcomm.custom_op.annotator import (
+    CustomOpsQuantAnnotator,
+    IOQuantConfig,
+)
+from executorch.backends.qualcomm.custom_op.interface import QnnCustomOpPackageBuilder
+from executorch.backends.qualcomm.export_utils import (
+    build_executorch_binary,
+    generate_inputs,
+    get_backend_type,
+    make_quantizer,
+    QnnConfig,
+    setup_common_args_and_variables,
+    SimpleADB,
+)
+from executorch.backends.qualcomm.quantizer.qconfig import (
+    get_ptq_per_channel_quant_config,
+)
+from executorch.backends.qualcomm.quantizer.quantizer import QuantDtype
+from executorch.backends.qualcomm.serialization.qc_schema import (
+    QnnExecuTorchOpPackagePlatform,
+    QnnExecuTorchOpPackageTarget,
+)
+from executorch.backends.qualcomm.utils.utils import get_soc_to_lpai_hw_ver_map
+from executorch.examples.qualcomm.utils import make_output_dir
+from executorch.exir._serialize._program import deserialize_pte_binary
+from torch.library import impl, Library
+
+my_op_lib = Library("my_ops", "DEF")
+
+# registering an operator that multiplies input tensor by 3 and returns it.
+my_op_lib.define("mul3(Tensor input) -> Tensor")
+
+
+@impl(my_op_lib, "mul3", dispatch_key="CompositeExplicitAutograd")
+def mul3_impl(a: torch.Tensor) -> torch.Tensor:
+    return a * 3
+
+
+# registering the out variant.
+my_op_lib.define("mul3.out(Tensor input, *, Tensor(a!) output) -> Tensor(a!)")
+
+
+@impl(my_op_lib, "mul3.out", dispatch_key="CompositeExplicitAutograd")
+def mul3_out_impl(a: torch.Tensor, *, out: torch.Tensor) -> torch.Tensor:
+    out.copy_(a)
+    out.mul_(3)
+    return out
+
+
+# Hexagon target the DSP side of the op package is built for.
+#
+# This is neither the HTP architecture of the SoC nor its LPAI hardware version:
+# on SM8850 the HTP is V81 and the LPAI hardware version is V6, while the op
+# package is compiled for hexagon-v79. The three version numbers are
+# independent, so this one cannot be derived from --soc_model. v79 is currently
+# the only usable value because the QNN SDK ships a single LPAI op package
+# makefile, share/QNN/OpPackageGenerator/makefiles/LPAI/Makefile.hexagon-v79,
+# which hardcodes QNN_TARGET, -mv79 and the computev79 QuRT headers.
+# Keep in sync with default_op_package_arch in
+# backends/qualcomm/scripts/sign_library.sh, which only applies when that script
+# is invoked by hand; this driver always passes --op_package_arch explicitly.
+LPAI_OP_PACKAGE_ARCH = "v79"
+
+
+# example model
+class Model(torch.nn.Module):
+    def forward(self, a):
+        return torch.ops.my_ops.mul3.default(a)
+
+
+def _assert_custom_op_delegated(pte_path: str, op_prefix: str):
+    """
+    Check that the custom op really was lowered into the QNN delegate.
+
+    Comparing the output alone does not prove anything here: an op that is not
+    delegated falls back to the CPU implementation registered above, which
+    computes the same values, so the numbers would still match while the op
+    package was never exercised. The lowered program makes the distinction
+    explicit - a delegated op leaves no operator entry behind, while an op that
+    fell back appears in the execution plan's operator list.
+
+    Args:
+        pte_path: Path of the serialized program to inspect.
+        op_prefix: Operator name to look for, without the overload suffix
+            ("my_ops::mul3"). Matched as a prefix because the name a fallback
+            leaves behind depends on which overload was selected.
+
+    Raises:
+        RuntimeError: If the graph has no QNN delegate, or if the custom op is
+            still being executed by a CPU kernel.
+    """
+    with open(pte_path, "rb") as pte_file:
+        program = deserialize_pte_binary(pte_file.read()).program
+
+    for plan in program.execution_plan:
+        operators = [operator.name for operator in plan.operators]
+        fell_back = [name for name in operators if name.startswith(op_prefix)]
+        if fell_back:
+            raise RuntimeError(
+                f"{fell_back} was not delegated, it is executed by a CPU kernel "
+                f"in method '{plan.name}'. The op package was not exercised "
+                f"even if the output happens to match. Operators: {operators}"
+            )
+        if not plan.delegates:
+            raise RuntimeError(
+                f"method '{plan.name}' contains no delegate, the whole graph "
+                f"fell back to CPU. Operators: {operators}"
+            )
+
+
+def _run(cmd, cwd=None, env=None):
+    subprocess.run(cmd, stdout=sys.stdout, cwd=cwd, env=env, check=True)
+
+
+def _sign_op_package(op_package_dir: str, lpai_arch: str, op_package_arch: str) -> str:
+    """
+    Code-sign the DSP objects produced by the op package's hexagon target.
+
+    Everything the aDSP loads must be signed, the op package included, so the
+    libraries that get pushed to the device are the signed ones rather than the
+    build outputs under ``libs/hexagon-<op_package_arch>``.
+
+    Returns:
+        ``$QNN_SDK_ROOT/lib/lpai-<lpai_arch>/signed``, where sign_library.sh
+        places the signed libraries.
+    """
+    executorch_root = os.path.dirname(  # <root>
+        os.path.dirname(  # examples
+            os.path.dirname(  # qualcomm
+                os.path.dirname(os.path.abspath(__file__))  # custom_op
+            )
+        )
+    )
+    # sign_library.sh calls elfsigner.py through `python`, and elfsigner.py
+    # imports `imp`, which was removed in Python 3.12. Put the interpreter
+    # running this script first on PATH so that whatever version is known to
+    # work here is used instead of the system default.
+    env = dict(os.environ)
+    env["PATH"] = os.pathsep.join(
+        [os.path.dirname(sys.executable), env.get("PATH", "")]
+    )
+    _run(
+        [
+            "bash",
+            f"{executorch_root}/backends/qualcomm/scripts/sign_library.sh",
+            "--lpai_arch",
+            lpai_arch,
+            "--op_package_dir",
+            os.path.abspath(op_package_dir),
+            "--op_package_arch",
+            op_package_arch,
+        ],
+        env=env,
+    )
+    return f"{os.getenv('QNN_SDK_ROOT')}/lib/lpai-{lpai_arch}/signed"
+
+
+def main(args):
+    qnn_config = QnnConfig.load_config(args.config_file if args.config_file else args)
+
+    if args.backend != "lpai":
+        raise RuntimeError(
+            f"This example targets the LPAI backend, got --backend {args.backend}"
+        )
+
+    # ensure the working directory exist.
+    os.makedirs(args.artifact, exist_ok=True)
+
+    instance = Model()
+    pte_filename = "custom_qnn_lpai"
+    shape = (1, 32, 28, 28)
+    # Calibration and inference inputs are separate tensors on purpose. With a
+    # single tensor for both, the input always lands at the top of the
+    # calibration range (code 255, stored 127 for 8a8w), which leaves the
+    # kernel's low-code and saturation paths unreachable. See --inference_value.
+    calibration_input = (torch.full(shape, args.calibration_value),)
+    sample_input = (torch.full(shape, args.inference_value),)
+    workspace = f"/data/local/tmp/executorch/{pte_filename}"
+
+    xml_path = f"{args.op_package_dir}/config/example_op_package_lpai.xml"
+    op_package_config = QnnCustomOpPackageBuilder(
+        xml_path=xml_path,
+        torch_op_name_map={"ExampleCustomOp": torch.ops.my_ops.mul3.default},
+    )
+    lib_name = f"libQnn{op_package_config.op_package_name}"
+    # Both DSP objects carry the kernel and both have to be deployed: the op
+    # package itself and libLpaiOpPackageIsland.so, which is the same kernel
+    # linked for always-resident (island) memory. Which one the runtime resolves
+    # depends on island mode, so deploy both rather than guessing.
+    dsp_lib_names = [f"{lib_name}.so", "libLpaiOpPackageIsland.so"]
+    # Unless the libraries get signed below, the ones straight out of the build
+    # are used, which only load on a device that does not enforce code signing.
+    dsp_lib_dir = f"{args.op_package_dir}/libs/hexagon-{LPAI_OP_PACKAGE_ARCH}"
+
+    if args.build_op_package:
+        # The x86_64 library contains both the compiler side and the inference
+        # side implementation, so it is all that is needed to compile and to run
+        # the model through the LPAI x86_64 simulator.
+        build_device_targets = not args.enable_x86_64
+        if build_device_targets and "HEXAGON_SDK_ROOT" not in os.environ:
+            raise RuntimeError(
+                "Environment variable HEXAGON_SDK_ROOT must be set to build "
+                f"the DSP (hexagon-{LPAI_OP_PACKAGE_ARCH}) inference skel"
+            )
+
+        _run(["make", "clean"], cwd=args.op_package_dir)
+        # Each target is built with its own invocation because the toolchain
+        # overrides are per target and must not leak into the others.
+        #
+        # lpai_x86 needs CC/CXX forced to gcc/g++: the QNN LPAI headers include
+        # <cstdint>, so the C++ compiler must provide the C++ standard library
+        # headers, and a bare clang install may not ship libstdc++ headers.
+        _run(["make", "lpai_x86", "CC=gcc", "CXX=g++"], cwd=args.op_package_dir)
+        if build_device_targets:
+            # The hexagon target uses hexagon-clang from $HEXAGON_SDK_ROOT, so
+            # it must not have CC/CXX overridden.
+            _run(
+                ["make", f"lpai_hexagon_{LPAI_OP_PACKAGE_ARCH}"],
+                cwd=args.op_package_dir,
+            )
+            if not args.skip_sign_op_package:
+                # A freshly built op package carries unsigned DSP code, which
+                # the aDSP refuses to load, so sign it before deploying. The
+                # SoC has already been checked against the supported list by
+                # QnnConfig above, so this lookup cannot fail here.
+                lpai_arch = f"v{get_soc_to_lpai_hw_ver_map()[args.soc_model]}"
+                dsp_lib_dir = _sign_op_package(
+                    args.op_package_dir, lpai_arch, LPAI_OP_PACKAGE_ARCH
+                )
+
+    op_package_paths = []
+    # The x86_64 library is always registered: it is what the LPAI simulator
+    # runs, and it is also what compiles the graph on the host (preprocess) for
+    # an on-device run.
+    op_package_config.register_implementation(
+        target=QnnExecuTorchOpPackageTarget.LPAI,
+        platform=QnnExecuTorchOpPackagePlatform.X86_64,
+        op_package_path=os.path.abspath(
+            f"{args.op_package_dir}/libs/x86_64-linux-clang/{lib_name}.so"
+        ),
+    )
+    if not args.enable_x86_64:
+        # Register the hexagon build for on-device execution, which runs in
+        # direct mode: the delegate itself is compiled for Hexagon and runs
+        # inside the DSP process, so it calls registerOpPackage() locally rather
+        # than forwarding the registration over FastRPC. There is no 64 bit AP
+        # process in that path, so the DSP object is registered directly and is
+        # resolved by *base name* through ADSP_LIBRARY_PATH, which is why a bare
+        # file name is registered here instead of a path.
+        op_package_config.register_implementation(
+            target=QnnExecuTorchOpPackageTarget.LPAI,
+            platform=QnnExecuTorchOpPackagePlatform.HEXAGON,
+            op_package_path=f"{lib_name}.so",
+        )
+        op_package_paths = [f"{dsp_lib_dir}/{name}" for name in dsp_lib_names]
+    op_package_options = op_package_config.get_op_package_options()
+
+    # Quantization. The LPAI backend is a fixed point accelerator and the op
+    # package declares support for QNN_DATATYPE_UFIXED_POINT_8, so the custom op
+    # is annotated with 8 bit activations. 16 bit activations are not supported
+    # end to end yet, see the data type comment in
+    # example_op_package_lpai/ExampleLpaiOpPackage/src/ops/ExampleCustomOp_compiler.cpp.
+    quant_dtype = QuantDtype.use_8a8w
+    quant_cfg = get_ptq_per_channel_quant_config()
+    custom_quant_annotator = CustomOpsQuantAnnotator()
+    custom_quant_annotator.register_annotation(
+        torch.ops.my_ops.mul3.default,
+        IOQuantConfig(
+            input_quant_specs={0: quant_cfg.input_activation},
+            output_quant_specs={0: quant_cfg.output_activation},
+        ),
+    )
+    annotate_fn = custom_quant_annotator.build_annotation_fn()
+    quantizer = make_quantizer(
+        quant_dtype=quant_dtype,
+        custom_annotations=(annotate_fn,),
+        backend=get_backend_type(args.backend),
+        soc_model=args.soc_model,
+    )
+
+    build_executorch_binary(
+        model=instance,
+        qnn_config=qnn_config,
+        file_name=f"{args.artifact}/{pte_filename}",
+        dataset=[calibration_input],
+        op_package_options=op_package_options,
+        quant_dtype=quant_dtype,
+        custom_quantizer=quantizer,
+    )
+
+    # The output comparison further down cannot tell a delegated op from one
+    # that fell back to the CPU implementation registered above, so check the
+    # lowered graph explicitly before running it.
+    _assert_custom_op_delegated(f"{args.artifact}/{pte_filename}.pte", "my_ops::mul3")
+
+    # collect output data
+    output_data_folder = f"{args.artifact}/outputs"
+    make_output_dir(output_data_folder)
+
+    if args.enable_x86_64:
+        input_list_filename = "input_list.txt"
+        generate_inputs(args.artifact, input_list_filename, sample_input)
+        qnn_sdk = os.getenv("QNN_SDK_ROOT")
+        assert qnn_sdk, "QNN_SDK_ROOT was not found in environment variable"
+        target = "x86_64-linux-clang"
+        build_folder = os.path.abspath(args.build_folder)
+        artifact = os.path.abspath(args.artifact)
+
+        runner_cmd = " ".join(
+            [
+                f"export LD_LIBRARY_PATH={qnn_sdk}/lib/{target}/:{build_folder}/lib &&",
+                f"{build_folder}/examples/qualcomm/executor_runner/qnn_executor_runner",
+                f"--model_path {artifact}/{pte_filename}.pte",
+                f"--input_list_path {artifact}/{input_list_filename}",
+                f"--output_folder_path {artifact}/outputs",
+            ]
+        )
+        # check=True so that a runner failure is reported as such: without it
+        # the only symptom is the missing output file read further down, which
+        # says nothing about what actually went wrong.
+        subprocess.run(
+            runner_cmd,
+            shell=True,
+            executable="/bin/bash",
+            cwd=artifact,
+            check=True,
+        )
+    else:
+        adb = SimpleADB(
+            qnn_config=qnn_config,
+            pte_path=f"{args.artifact}/{pte_filename}.pte",
+            workspace=workspace,
+        )
+        adb.push(inputs=sample_input, files=op_package_paths)
+        if args.debug:
+            adb.execute(custom_runner_cmd="logcat -c")
+            # FARF configuration is looked up as <runner base name>.farf, and in
+            # direct mode the runner is qnn_executor_direct_runner rather than
+            # qnn_executor_runner, so derive the name instead of hardcoding it.
+            runner_name = os.path.basename(adb.runner)
+            adb.execute(custom_runner_cmd=f"echo 0x1f > {workspace}/{runner_name}.farf")
+
+        adb.execute()
+        if args.debug:
+            adb.execute(
+                custom_runner_cmd=f"logcat -d -v time >{workspace}/outputs/debug_logs.txt"
+            )
+        adb.pull(host_output_path=args.artifact)
+
+    # By default the eager result is the reference. When the inference input
+    # exceeds the calibrated range the quantized graph must saturate instead,
+    # so --expected_value states that clamped result explicitly.
+    x86_golden = (
+        instance(*sample_input)
+        if args.expected_value is None
+        else torch.full(shape, args.expected_value)
+    )
+    device_output = torch.from_numpy(
+        np.fromfile(
+            os.path.join(output_data_folder, "output_0_0.raw"), dtype=np.float32
+        )
+    ).reshape(x86_golden.size())
+    # The op package requantizes into 8 bit, so compare with a tolerance that
+    # accounts for a few quantization steps (3/255 wide each by default).
+    result = torch.all(
+        torch.isclose(x86_golden, device_output, atol=args.atol)
+    ).tolist()
+
+    if args.ip and args.port != -1:
+        with Client((args.ip, args.port)) as conn:
+            conn.send(
+                json.dumps(
+                    {
+                        "is_close": result,
+                        # Reaching this point means the op package was really
+                        # used, see _assert_custom_op_delegated().
+                        "is_delegated": True,
+                    }
+                )
+            )
+    else:
+        print(f"is_close? {result}")
+        if not result:
+            print(f"x86_golden {x86_golden}")
+            print(f"device_out {device_output}")
+
+
+if __name__ == "__main__":
+    parser = setup_common_args_and_variables()
+
+    parser.add_argument(
+        "-a",
+        "--artifact",
+        help="path for storing generated artifacts by this example. "
+        "Default ./custom_op_lpai",
+        default="./custom_op_lpai",
+        type=str,
+    )
+
+    parser.add_argument(
+        "-d",
+        "--op_package_dir",
+        help="Path to operator package generated from QNN.",
+        type=str,
+        required=True,
+    )
+
+    parser.add_argument(
+        "--build_op_package",
+        help="Build op package based on op_package_dir. Building the DSP skel "
+        "additionally requires `HEXAGON_SDK_ROOT` to be set. Please refer to "
+        "Qualcomm AI Engine Direct SDK document to get more details",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--skip_sign_op_package",
+        help="Do not code-sign the DSP libraries built by --build_op_package. "
+        "The unsigned libraries only load on a device which does not enforce "
+        "code signing.",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--atol",
+        help="Absolute tolerance used when comparing against the eager result. "
+        "The default leaves room for a few output quantization steps, which are "
+        "3/255 wide for the default calibration range in 8 bit.",
+        default=0.05,
+        type=float,
+    )
+
+    parser.add_argument(
+        "--calibration_value",
+        help="Value of the constant tensor the quantizer is calibrated with. "
+        "It fixes the quantization range, so with the default 1.0 the input "
+        "scale is 1/255 and the output scale 3/255.",
+        default=1.0,
+        type=float,
+    )
+
+    parser.add_argument(
+        "--inference_value",
+        help="Value of the constant tensor the model is run with. Keep it below "
+        "--calibration_value to exercise the kernel's low code path (e.g. 0.25 "
+        "gives code 64, stored as the byte 192 once biased), or above it to "
+        "exercise saturation (e.g. 2.0 requantizes to code 510, which must be "
+        "clamped to 255).",
+        default=1.0,
+        type=float,
+    )
+
+    parser.add_argument(
+        "--expected_value",
+        help="Compare the output against this constant instead of the eager "
+        "result. Needed when --inference_value is outside the calibrated range, "
+        "where the correct answer is the saturated one rather than 3x the input.",
+        default=None,
+        type=float,
+    )
+
+    parser.add_argument(
+        "--debug",
+        help="Enable device logging",
+        action="store_true",
+        default=False,
+    )
+
+    args = parser.parse_args()
+
+    try:
+        main(args)
+    except Exception as e:
+        if args.ip and args.port != -1:
+            with Client((args.ip, args.port)) as conn:
+                conn.send(json.dumps({"Error": str(e)}))
+        else:
+            raise

--- a/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/.gitignore
+++ b/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/.gitignore
@@ -1,0 +1,3 @@
+# Build artifacts produced by the Makefiles in makefiles/.
+obj/
+libs/

--- a/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/Makefile
+++ b/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/Makefile
@@ -1,0 +1,107 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# ==============================================================================
+# Makefile for ExampleLpaiOpPackage
+# Builds libQnnExampleLpaiOpPackage.so for multiple targets:
+#   - x86_64-linux-clang  (compiler-side, host)
+#   - hexagon-v79         (inference-side, DSP)
+#
+# NOTE: the library is named libQnn<PackageName>.so to match the naming
+# convention used by the other ExecuTorch op package examples.
+# ==============================================================================
+
+# define default
+default: all
+
+# define package name
+export PACKAGE_NAME := ExampleLpaiOpPackage
+
+# define source directories
+export SRC_DIR     := src
+export SRC_DIR_OPS := src/ops
+export INCLUDE_DIR := include
+
+make_dir := makefiles
+
+# define library name
+export LIBRARY_NAME := libQnn$(PACKAGE_NAME).so
+
+# ==============================================================================
+# Environment checks
+# ==============================================================================
+
+.PHONY: check_qnn_sdk
+check_qnn_sdk:
+ifndef QNN_SDK_ROOT
+	$(error ERROR: QNN_SDK_ROOT is not set. Please set it to the QNN SDK root path.)
+endif
+
+.PHONY: check_hexagon_sdk
+check_hexagon_sdk:
+ifndef HEXAGON_SDK_ROOT
+	$(error ERROR: HEXAGON_SDK_ROOT is not set. Please set it to the Hexagon SDK root path.)
+endif
+ifndef HEXAGON_TOOLS_VERSION
+	$(error ERROR: HEXAGON_TOOLS_VERSION is not set. Please set it to the Hexagon Tools version.)
+endif
+
+# ==============================================================================
+# Build targets
+# ==============================================================================
+
+.PHONY: all
+all: lpai_x86 lpai_hexagon_v79
+
+# x86_64 target (compiler-side, used by QNN compiler/tools on host)
+.PHONY: lpai_x86
+lpai_x86: check_qnn_sdk
+	$(MAKE) -f $(make_dir)/Makefile.linux-x86_64
+
+# hexagon-v79 target (inference-side, runs on DSP)
+.PHONY: lpai_hexagon_v79
+lpai_hexagon_v79: check_qnn_sdk check_hexagon_sdk
+	$(MAKE) -f $(make_dir)/Makefile.hexagon-v79
+
+# ==============================================================================
+# Clean targets
+# ==============================================================================
+
+.PHONY: clean
+clean: clean_x86 clean_hexagon
+
+.PHONY: clean_x86
+clean_x86:
+	@rm -rf libs/x86_64-linux-clang obj/x86_64-linux-clang
+
+.PHONY: clean_hexagon
+clean_hexagon:
+	@rm -rf libs/hexagon-v79 obj/hexagon-v79
+
+
+# ==============================================================================
+# Help
+# ==============================================================================
+
+.PHONY: help
+help:
+	@echo "Makefile for $(PACKAGE_NAME)"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all              - Build for x86_64 and hexagon-v79 (default)"
+	@echo "  lpai_x86         - Build for x86_64-linux-clang (compiler-side, host)"
+	@echo "  lpai_hexagon_v79 - Build for hexagon-v79 (inference-side, DSP)"
+	@echo "  clean            - Remove all build artifacts"
+	@echo ""
+	@echo "Required environment variables:"
+	@echo "  QNN_SDK_ROOT          - Path to QNN SDK"
+	@echo "  HEXAGON_SDK_ROOT      - Path to Hexagon SDK (for the hexagon target)"
+	@echo "  HEXAGON_TOOLS_VERSION - Hexagon tools version (for the hexagon target)"
+	@echo ""
+	@echo "Output:"
+	@echo "  libs/x86_64-linux-clang/$(LIBRARY_NAME)"
+	@echo "  libs/hexagon-v79/$(LIBRARY_NAME)"
+	@echo "  libs/hexagon-v79/libLpaiOpPackageIsland.so"

--- a/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/config/example_op_package_lpai.xml
+++ b/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/config/example_op_package_lpai.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) Qualcomm Innovation Center, Inc.
+All rights reserved
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+-->
+<OpDefCollection
+        PackageName="ExampleLpaiOpPackage"
+        Domain="aisw"
+        Version="1.0"
+>
+    <OpDefList>
+        <OpDef>
+            <Name>ExampleCustomOp</Name>
+            <Description>
+                <Content>
+                    ExampleCustomOp for testing LPAI OP package registration
+                    functionality. Multiplies the input activation by 3.
+                </Content>
+            </Description>
+
+            <Input>
+                <Name>input</Name>
+                <Description>
+                    <Content>input activation</Content>
+                </Description>
+                <Mandatory>true</Mandatory>
+                <!--
+                    QNN_DATATYPE_UINT_8 is listed in addition to the fixed point
+                    type because the LPAI lowering validates op configs twice:
+                    once from LpaiPartitionFallbackSupport, while the graph still
+                    carries explicit quantize / dequantize nodes and the tensors
+                    are plain integers, and once after FoldQDQ has folded the
+                    quantization parameters into the tensors.
+
+                    Only 8 bit activations are declared: 16 bit ones do not work
+                    end to end on this backend yet, see the comment on
+                    g_ExampleCustomOpInput_0_DataTypes in
+                    src/ops/ExampleCustomOp_compiler.cpp.
+                -->
+                <Datatype>QNN_DATATYPE_UFIXED_POINT_8</Datatype>
+                <Datatype>QNN_DATATYPE_UINT_8</Datatype>
+                <Shape>
+                    <Rank>4D</Rank>
+                    <Layout>NHWC</Layout>
+                    <Text>a tensor of 4 dimension</Text>
+                </Shape>
+            </Input>
+
+            <Output>
+                <Name>output</Name>
+                <Description>
+                    <Content>output activation</Content>
+                </Description>
+                <Mandatory>true</Mandatory>
+                <Datatype>QNN_DATATYPE_UFIXED_POINT_8</Datatype>
+                <Datatype>QNN_DATATYPE_UINT_8</Datatype>
+                <Shape>
+                    <Rank>4D</Rank>
+                    <Layout>NHWC</Layout>
+                    <Text>a tensor of 4 dimension</Text>
+                </Shape>
+            </Output>
+
+            <!--This Op is implemented on these Backends-->
+            <SupportedBackend>LPAI</SupportedBackend>
+        </OpDef>
+
+    </OpDefList>
+
+</OpDefCollection>

--- a/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/makefiles/Makefile.hexagon-v79
+++ b/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/makefiles/Makefile.hexagon-v79
@@ -1,0 +1,222 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# ==============================================================================
+# Makefile.hexagon-v79
+# Builds libLpaiOpPackage.so for hexagon-v79 (inference-side / DSP)
+#
+# This target is used by the LPAI eAI runtime on the Hexagon DSP.
+# It compiles the inference-side op implementations using the Hexagon toolchain.
+#
+# Required:
+#   QNN_SDK_ROOT      - Path to QNN SDK
+#   HEXAGON_SDK_ROOT  - Path to Hexagon SDK (hexagon-sdk-6.0.0 for v79)
+#
+# Island build (make island):
+#   The uImage linker script and version note source come from the QNN SDK, so
+#   QNN_SDK_ROOT is required here as well. All inference sources are compiled
+#   into the island library.
+# ==============================================================================
+
+# define target
+QNN_TARGET := hexagon-v79
+
+# define source directories
+SRC_DIR     ?= src
+SRC_DIR_OPS ?= src/ops
+INCLUDE_DIR ?= include
+
+# define output directories
+LIB_DIR     := libs/$(QNN_TARGET)
+OBJ_DIR     := obj/$(QNN_TARGET)
+OBJ_DIR_OPS := obj/$(QNN_TARGET)/ops
+
+# define library name
+LIBRARY_NAME ?= libLpaiOpPackage.so
+LIBRARY      := $(LIB_DIR)/$(LIBRARY_NAME)
+
+# ==============================================================================
+# Hexagon SDK and toolchain setup
+# ==============================================================================
+
+ifndef HEXAGON_SDK_ROOT
+$(error ERROR: HEXAGON_SDK_ROOT is not set. Please set it to the Hexagon SDK root path.)
+endif
+
+ifndef HEXAGON_TOOLS_VERSION
+$(error ERROR: HEXAGON_TOOLS_VERSION is not set. Please set it to the correct Tools version.)
+endif
+
+# Hexagon SDK version for v79: hexagon-sdk-6.0.0
+HEXAGON_TOOLS_DIR     := $(HEXAGON_SDK_ROOT)/tools/HEXAGON_Tools/$(HEXAGON_TOOLS_VERSION)/Tools
+
+ifeq ($(wildcard $(HEXAGON_TOOLS_DIR)/.),)
+$(error ERROR: Cannot find Hexagon tools at $(HEXAGON_TOOLS_DIR). \
+        Please verify HEXAGON_SDK_ROOT and HEXAGON_TOOLS_VERSION is set correctly.)
+endif
+
+CC  := $(HEXAGON_TOOLS_DIR)/bin/hexagon-clang
+
+# ==============================================================================
+# Include paths
+# ==============================================================================
+
+ifdef QNN_SDK_ROOT
+INCLUDES += -I$(QNN_SDK_ROOT)/include/QNN
+INCLUDES += -I$(QNN_SDK_ROOT)/include/QNN/LPAI
+else
+$(error ERROR: QNN_SDK_ROOT is not set.)
+endif
+
+INCLUDES += -I$(INCLUDE_DIR)
+INCLUDES += -I$(HEXAGON_SDK_ROOT)/rtos/qurt/computev79/include/qurt
+INCLUDES += -I$(HEXAGON_SDK_ROOT)/rtos/qurt/computev79/include/posix
+INCLUDES += -I$(HEXAGON_SDK_ROOT)/incs
+INCLUDES += -I$(HEXAGON_SDK_ROOT)/incs/stddef
+
+# ==============================================================================
+# Compiler and linker flags
+# ==============================================================================
+
+COMMON_CFLAGS := -std=c11 -fPIC $(INCLUDES)
+COMMON_CFLAGS += -mv79
+COMMON_CFLAGS += -mhvx -mhvx-length=128B
+COMMON_CFLAGS += -DUSE_OS_QURT
+COMMON_CFLAGS += -DLPAI_INFERENCE_ONLY
+COMMON_CFLAGS += -DQNN_API="__attribute__((visibility(\"default\")))"
+COMMON_CFLAGS += -D__QAIC_HEADER_EXPORT="__attribute__((visibility(\"default\")))"
+
+ifdef QNN_DEBUG_ENABLE
+CFLAGS   := $(COMMON_CFLAGS) -O0 -g
+else
+CFLAGS   := $(COMMON_CFLAGS) -O2
+endif
+
+LDFLAGS := -shared -fPIC
+
+# ==============================================================================
+# Sources and objects
+#
+# Hexagon (inference-side):
+#   src/          - all .c including CustomOpLpaiInterface.c;
+#                   LPAI_INFERENCE_ONLY macro controls which branch is compiled
+#   src/ops/      - only *_inference.c, exclude *_compiler.cpp
+# ==============================================================================
+
+SOURCES         := $(wildcard $(SRC_DIR)/*.c)
+SOURCES_OPS_ALL := $(wildcard $(SRC_DIR_OPS)/*.c)
+SOURCES_OPS     := $(filter %_inference.c, $(SOURCES_OPS_ALL))
+
+OBJECTS     := $(patsubst $(SRC_DIR)/%.c,    $(OBJ_DIR)/%.o,     $(SOURCES))
+OBJECTS_OPS := $(patsubst $(SRC_DIR_OPS)/%.c,$(OBJ_DIR_OPS)/%.o, $(SOURCES_OPS))
+
+ALL_OBJECTS := $(OBJECTS) $(OBJECTS_OPS)
+
+LINKER := $(CC)
+
+# ==============================================================================
+# Build rules
+# ==============================================================================
+
+.PHONY: all
+all: library island
+
+.PHONY: library
+library: $(LIBRARY)
+
+$(LIBRARY): $(ALL_OBJECTS) | $(LIB_DIR)
+	@echo "Linking $(LIBRARY)..."
+	$(LINKER) $(LDFLAGS) -o $@ $^
+	@echo "Build complete: $@"
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
+	@echo "Compiling $<..."
+	$(CC) $(CFLAGS) -MMD -c $< -o $@
+
+$(OBJ_DIR_OPS)/%.o: $(SRC_DIR_OPS)/%.c | $(OBJ_DIR_OPS)
+	@echo "Compiling $<..."
+	$(CC) $(CFLAGS) -MMD -c $< -o $@
+
+# ==============================================================================
+# Directory creation
+# ==============================================================================
+
+$(LIB_DIR) $(OBJ_DIR) $(OBJ_DIR_OPS):
+	@mkdir -p $@
+
+# ==============================================================================
+# Dependency files
+# ==============================================================================
+
+-include $(OBJECTS:.o=.d)
+-include $(OBJECTS_OPS:.o=.d)
+
+# ==============================================================================
+# Island build
+#
+# Produces libLpaiOpPackageIsland.so: a size-constrained shared library loaded
+# into always-resident (island) memory on the Hexagon DSP via the uImage loader.
+#
+# Uses the same inference sources as the regular library target. Objects are
+# compiled into a separate directory to avoid colliding with the regular build.
+#
+# The uImage linker script and version note source are taken from the QNN SDK
+# rather than copied here: they are Qualcomm Technologies proprietary files, and
+# the SDK ships them alongside the LPAI op package makefiles from 2.48 onwards,
+# which is already the minimum version required to build an LPAI op package.
+# ==============================================================================
+
+ISLAND_ASSETS_DIR := $(QNN_SDK_ROOT)/share/QNN/OpPackageGenerator/makefiles/LPAI/island
+LINKER_SCRIPT     := $(ISLAND_ASSETS_DIR)/uimage_v2.lcs
+UIMG_SRC          := $(ISLAND_ASSETS_DIR)/uimg_dl_v2.c
+
+ISLAND_LIBRARY_NAME := libLpaiOpPackageIsland.so
+ISLAND_LIBRARY      := $(LIB_DIR)/$(ISLAND_LIBRARY_NAME)
+
+OBJ_DIR_ISLAND     := obj/$(QNN_TARGET)/island
+OBJ_DIR_OPS_ISLAND := obj/$(QNN_TARGET)/island/ops
+UIMG_OBJ           := $(OBJ_DIR_ISLAND)/uimg_dl_v2.o
+
+OBJECTS_ISLAND     := $(patsubst $(SRC_DIR)/%.c,    $(OBJ_DIR_ISLAND)/%.o,     $(SOURCES))
+OBJECTS_OPS_ISLAND := $(patsubst $(SRC_DIR_OPS)/%.c,$(OBJ_DIR_OPS_ISLAND)/%.o, $(SOURCES_OPS))
+
+ISLAND_LDFLAGS := -shared -fPIC -T$(LINKER_SCRIPT)
+
+.PHONY: island
+island: $(ISLAND_LIBRARY)
+
+$(ISLAND_LIBRARY): $(OBJECTS_ISLAND) $(OBJECTS_OPS_ISLAND) $(UIMG_OBJ) | $(LIB_DIR)
+	@echo "Linking $(ISLAND_LIBRARY)..."
+	$(LINKER) $(ISLAND_LDFLAGS) -o $@ $^
+	@echo "Island build complete: $@"
+
+$(OBJ_DIR_ISLAND)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR_ISLAND)
+	@echo "Compiling (island) $<..."
+	$(CC) $(CFLAGS) -MMD -c $< -o $@
+
+$(OBJ_DIR_OPS_ISLAND)/%.o: $(SRC_DIR_OPS)/%.c | $(OBJ_DIR_OPS_ISLAND)
+	@echo "Compiling (island) $<..."
+	$(CC) $(CFLAGS) -MMD -c $< -o $@
+
+$(UIMG_OBJ): $(UIMG_SRC) | $(OBJ_DIR_ISLAND)
+	@echo "Compiling uImage version note..."
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(OBJ_DIR_ISLAND) $(OBJ_DIR_OPS_ISLAND):
+	@mkdir -p $@
+
+-include $(OBJECTS_ISLAND:.o=.d)
+-include $(OBJECTS_OPS_ISLAND:.o=.d)
+
+# ==============================================================================
+# Clean
+# ==============================================================================
+
+.PHONY: clean
+clean:
+	@echo "Cleaning hexagon-v79 build artifacts..."
+	@rm -rf $(OBJ_DIR) $(LIB_DIR)
+	@echo "Clean complete"

--- a/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/makefiles/Makefile.linux-x86_64
+++ b/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/makefiles/Makefile.linux-x86_64
@@ -1,0 +1,150 @@
+# Copyright (c) Qualcomm Innovation Center, Inc.
+# All rights reserved
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# ==============================================================================
+# Makefile.linux-x86_64
+# Builds libLpaiOpPackage.so for x86_64-linux-clang (compiler-side / host)
+#
+# This target is used by the QNN compiler/tools on the host machine.
+# It includes both compiler-side and inference-side op implementations.
+#
+# Required:
+#   QNN_SDK_ROOT  - Path to QNN SDK
+# ==============================================================================
+
+# define target
+QNN_TARGET := x86_64-linux-clang
+
+# define source directories
+SRC_DIR     ?= src
+SRC_DIR_OPS ?= src/ops
+INCLUDE_DIR ?= include
+
+# define output directories
+LIB_DIR     := libs/$(QNN_TARGET)
+OBJ_DIR     := obj/$(QNN_TARGET)
+OBJ_DIR_OPS := obj/$(QNN_TARGET)/ops
+
+# define library name
+LIBRARY_NAME ?= libLpaiOpPackage.so
+LIBRARY      := $(LIB_DIR)/$(LIBRARY_NAME)
+
+# ==============================================================================
+# Compiler setup
+# ==============================================================================
+
+# Prefer clang-9, fall back to clang
+CC ?= clang-9
+ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang version"), 0)
+  CC := clang
+endif
+
+CXX ?= clang++-9
+ifeq ($(shell $(CXX) -v 2>&1 | grep -c "clang version"), 0)
+  CXX := clang++
+endif
+
+# ==============================================================================
+# Include paths
+# ==============================================================================
+
+ifdef QNN_SDK_ROOT
+INCLUDES += -I$(QNN_SDK_ROOT)/include/QNN
+INCLUDES += -I$(QNN_SDK_ROOT)/include/QNN/LPAI
+else
+$(error ERROR: QNN_SDK_ROOT is not set.)
+endif
+
+INCLUDES += -I$(INCLUDE_DIR)
+
+# ==============================================================================
+# Compiler and linker flags
+# ==============================================================================
+
+COMMON_CFLAGS := -std=c11 -fPIC $(INCLUDES)
+COMMON_CFLAGS += -DQNN_API="__attribute__((visibility(\"default\")))"
+COMMON_CFLAGS += -D__QAIC_HEADER_EXPORT="__attribute__((visibility(\"default\")))"
+COMMON_CFLAGS += -march=x86-64
+
+COMMON_CXXFLAGS := -std=c++11 -fPIC $(INCLUDES)
+COMMON_CXXFLAGS += -DQNN_API="__attribute__((visibility(\"default\")))"
+COMMON_CXXFLAGS += -D__QAIC_HEADER_EXPORT="__attribute__((visibility(\"default\")))"
+COMMON_CXXFLAGS += -march=x86-64
+
+ifdef QNN_DEBUG_ENABLE
+CFLAGS   := $(COMMON_CFLAGS) -O0 -g
+CXXFLAGS := $(COMMON_CXXFLAGS) -O0 -g
+else
+CFLAGS   := $(COMMON_CFLAGS) -O2
+CXXFLAGS := $(COMMON_CXXFLAGS) -O2
+endif
+
+LDFLAGS := -shared -fPIC
+
+# ==============================================================================
+# Sources and objects
+# ==============================================================================
+
+SOURCES     := $(wildcard $(SRC_DIR)/*.c)
+SOURCES_OPS_C   := $(wildcard $(SRC_DIR_OPS)/*.c)
+SOURCES_OPS_CXX := $(wildcard $(SRC_DIR_OPS)/*.cpp)
+SOURCES_OPS     := $(SOURCES_OPS_C) $(SOURCES_OPS_CXX)
+
+OBJECTS     := $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SOURCES))
+OBJECTS_OPS_C   := $(patsubst $(SRC_DIR_OPS)/%.c,$(OBJ_DIR_OPS)/%.o,$(SOURCES_OPS_C))
+OBJECTS_OPS_CXX := $(patsubst $(SRC_DIR_OPS)/%.cpp,$(OBJ_DIR_OPS)/%.o,$(SOURCES_OPS_CXX))
+OBJECTS_OPS     := $(OBJECTS_OPS_C) $(OBJECTS_OPS_CXX)
+
+ALL_OBJECTS := $(OBJECTS) $(OBJECTS_OPS)
+
+# ==============================================================================
+# Build rules
+# ==============================================================================
+
+.PHONY: library
+library: $(LIBRARY)
+
+$(LIBRARY): $(ALL_OBJECTS) | $(LIB_DIR)
+	@echo "Linking $(LIBRARY)..."
+	$(CXX) $(LDFLAGS) -o $@ $^
+	@echo "Build complete: $@"
+
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
+	@echo "Compiling $<..."
+	$(CC) $(CFLAGS) -MMD -c $< -o $@
+
+$(OBJ_DIR_OPS)/%.o: $(SRC_DIR_OPS)/%.c | $(OBJ_DIR_OPS)
+	@echo "Compiling $<..."
+	$(CC) $(CFLAGS) -MMD -c $< -o $@
+
+$(OBJ_DIR_OPS)/%.o: $(SRC_DIR_OPS)/%.cpp | $(OBJ_DIR_OPS)
+	@echo "Compiling $<..."
+	$(CXX) $(CXXFLAGS) -MMD -c $< -o $@
+
+# ==============================================================================
+# Directory creation
+# ==============================================================================
+
+$(LIB_DIR) $(OBJ_DIR) $(OBJ_DIR_OPS):
+	@mkdir -p $@
+
+# ==============================================================================
+# Dependency files
+# ==============================================================================
+
+-include $(OBJECTS:.o=.d)
+-include $(OBJECTS_OPS_C:.o=.d)
+-include $(OBJECTS_OPS_CXX:.o=.d)
+
+# ==============================================================================
+# Clean
+# ==============================================================================
+
+.PHONY: clean
+clean:
+	@echo "Cleaning x86_64-linux-clang build artifacts..."
+	@rm -rf $(OBJ_DIR) $(LIB_DIR)
+	@echo "Clean complete"

--- a/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/src/ExampleLpaiOpPackageInterface.c
+++ b/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/src/ExampleLpaiOpPackageInterface.c
@@ -1,0 +1,270 @@
+//==============================================================================
+// Auto Generated Code for ExampleLpaiOpPackage
+//==============================================================================
+
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#include "QnnOpPackage.h"
+#include "QnnLpaiOpPackage.h"
+#include "QnnLpaiOpPackageInfrastructure.h"
+
+extern QnnOpPackage_OperationInfo_t get_ExampleCustomOp_opInfo_Inference();
+extern QnnOpPackage_OperationInfo_t get_ExampleCustomOp_opInfo_Compiler();
+
+// ---------------------------------------------------------------------------
+// Op Package Info (derived from Opdef XML)
+// ---------------------------------------------------------------------------
+
+#define CUSTOM_OP_COUNT 1
+
+static char sg_packageName[] = "ExampleLpaiOpPackage";
+static const char* sg_opNames[CUSTOM_OP_COUNT] = {"ExampleCustomOp"};
+static QnnOpPackage_OperationInfo_t sg_opInfos[CUSTOM_OP_COUNT];
+static QnnOpPackage_Info_t sg_packageInfo = QNN_OP_PACKAGE_INFO_INIT;
+
+// Global data
+// NOTE: sg_globalInfra is intentionally non-static so that per-op inference
+QnnLpaiOpPackage_GlobalInfrastructure_t sg_globalInfra = QNN_LPAI_OP_PACKAGE_GLOBAL_INFRASTRUCTURE_INIT;
+bool sg_packageInitialized = false;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+static QnnOpPackage_OperationInfo_t getOpInfo(const char* opName) {
+    for (size_t i = 0; i < CUSTOM_OP_COUNT; i++) {
+        if (strcmp(opName, sg_opInfos[i]->opType) == 0) {
+            return sg_opInfos[i];
+        }
+    }
+    return NULL;
+}
+
+// ---------------------------------------------------------------------------
+// QNN OpPackage APIs
+// ---------------------------------------------------------------------------
+
+/**
+ * @note Things to do here for LPAI backend:
+ *   1. Store the global infrastructure so inference ops can use it
+ *   2. Register each op's info (inference or compiler mode)
+ */
+Qnn_ErrorHandle_t ExampleLpaiOpPackageInit(QnnOpPackage_GlobalInfrastructure_t infrastructure) {
+    if (sg_packageInitialized) {
+        return QNN_OP_PACKAGE_ERROR_LIBRARY_ALREADY_INITIALIZED;
+    }
+
+    // QnnOpPackage_GlobalInfrastructure_t is a pointer type and the backend is
+    // allowed to hand over something the package must reject, hence the
+    // QNN_OP_PACKAGE_ERROR_INVALID_INFRASTRUCTURE error code. The compiler side
+    // of an LPAI op package does not use the infrastructure accessors, so keep
+    // the zero initialized default instead of dereferencing a null pointer.
+    if (infrastructure != NULL) {
+        sg_globalInfra = *infrastructure;
+    }
+
+#if defined(LPAI_INFERENCE_ONLY)
+    sg_opInfos[0] = get_ExampleCustomOp_opInfo_Inference();
+#else
+    sg_opInfos[0] = get_ExampleCustomOp_opInfo_Compiler();
+#endif
+
+    sg_packageInitialized = true;
+    return QNN_OP_PACKAGE_NO_ERROR;
+}
+
+/**
+ * @note Things to do here for LPAI backend:
+ *   1. Release all allocated memory of opPackage
+ *   2. Destroy globalInfrastructure
+ */
+Qnn_ErrorHandle_t ExampleLpaiOpPackageTerminate(void) {
+    if (!sg_packageInitialized) {
+        return QNN_OP_PACKAGE_ERROR_LIBRARY_NOT_INITIALIZED;
+    }
+
+    // NOTE: QnnOpPackage_OperationInfo_t is a *pointer* typedef, and each entry
+    // points at a statically allocated struct owned by the per-op source file.
+    // Only the pointers are cleared here; memset'ing sizeof(the struct) into
+    // &sg_opInfos[i] would write past the end of this array.
+    for (size_t i = 0; i < CUSTOM_OP_COUNT; i++) {
+        sg_opInfos[i] = NULL;
+    }
+
+    sg_packageInitialized = false;
+    return QNN_OP_PACKAGE_NO_ERROR;
+}
+
+/**
+ * @note Things to do here for LPAI backend:
+ *   1. Return opPackage_Info (packageName, op type names, count, opInfos).
+ *      This information is passed to lower-level modules.
+ */
+Qnn_ErrorHandle_t ExampleLpaiOpPackageGetInfo(const QnnOpPackage_Info_t** info) {
+    if (!sg_packageInitialized) {
+        return QNN_OP_PACKAGE_ERROR_LIBRARY_NOT_INITIALIZED;
+    }
+    if (!info) {
+        return QNN_OP_PACKAGE_ERROR_INVALID_ARGUMENT;
+    }
+
+    sg_packageInfo.packageName    = sg_packageName;
+    sg_packageInfo.operationInfo  = sg_opInfos;
+    sg_packageInfo.numOperations  = CUSTOM_OP_COUNT;
+    sg_packageInfo.operationNames = sg_opNames;
+
+    *info = &sg_packageInfo;
+    return QNN_OP_PACKAGE_NO_ERROR;
+}
+
+#ifndef LPAI_INFERENCE_ONLY
+/**
+ * @note Things to do here for LPAI backend:
+ *   1. Validate opConfig against the package opdef (counts match)
+ *   2. Delegate to op-specific validateOp callback for deeper checks
+ */
+Qnn_ErrorHandle_t ExampleLpaiOpPackageValidateOpConfig(Qnn_OpConfig_t opConfig) {
+    if (!sg_packageInitialized) {
+        return QNN_OP_PACKAGE_ERROR_LIBRARY_NOT_INITIALIZED;
+    }
+
+    // A validation failure otherwise surfaces to the user only as a generic
+    // "not supported" from the partitioner, so the reason is reported here.
+
+    // Validate package name
+    if (!opConfig.v1.packageName || strcmp(opConfig.v1.packageName, sg_packageName) != 0) {
+        fprintf(stderr, "ExampleCustomOp: unexpected package name %s\n",
+                opConfig.v1.packageName ? opConfig.v1.packageName : "(null)");
+        return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+    }
+
+    // Validate operation type exists
+    const char* operationType = opConfig.v1.typeName;
+    if (!operationType) {
+        fprintf(stderr, "ExampleCustomOp: null operation type name\n");
+        return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+    }
+
+    QnnOpPackage_OperationInfo_t opInfo = getOpInfo(operationType);
+    if (!opInfo) {
+        fprintf(stderr, "ExampleCustomOp: unknown operation type %s\n", operationType);
+        return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+    }
+
+    // Validate tensor and parameter counts
+    if (opConfig.v1.numOfInputs != opInfo->numOfInputs) {
+        fprintf(stderr, "%s: expected %u inputs, got %u\n",
+                operationType, opInfo->numOfInputs, opConfig.v1.numOfInputs);
+        return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+    }
+    if (opConfig.v1.numOfOutputs != opInfo->numOfOutputs) {
+        fprintf(stderr, "%s: expected %u outputs, got %u\n",
+                operationType, opInfo->numOfOutputs, opConfig.v1.numOfOutputs);
+        return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+    }
+    if (opConfig.v1.numOfParams != opInfo->numOfParams) {
+        fprintf(stderr, "%s: expected %u params, got %u\n",
+                operationType, opInfo->numOfParams, opConfig.v1.numOfParams);
+        return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+    }
+
+    // Validate input datatypes: each input is checked against its own supported type list
+    if (opInfo->inputDatatypes) {
+        for (uint32_t i = 0; i < opConfig.v1.numOfInputs; i++) {
+            Qnn_DataType_t dtype = opConfig.v1.inputTensors[i].v1.dataType;
+            bool found = false;
+            for (uint32_t j = 0; j < opInfo->inputDatatypes[i].numOfTypes; j++) {
+                if (dtype == opInfo->inputDatatypes[i].DataTypes[j]) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                fprintf(stderr, "%s: unsupported input[%u] data type 0x%x\n",
+                        operationType, i, (unsigned)dtype);
+                return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+            }
+        }
+    }
+
+    // Validate output datatypes: each output is checked against its own supported type list
+    if (opInfo->outputDatatypes) {
+        for (uint32_t i = 0; i < opConfig.v1.numOfOutputs; i++) {
+            Qnn_DataType_t dtype = opConfig.v1.outputTensors[i].v1.dataType;
+            bool found = false;
+            for (uint32_t j = 0; j < opInfo->outputDatatypes[i].numOfTypes; j++) {
+                if (dtype == opInfo->outputDatatypes[i].DataTypes[j]) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                fprintf(stderr, "%s: unsupported output[%u] data type 0x%x\n",
+                        operationType, i, (unsigned)dtype);
+                return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+            }
+        }
+    }
+
+    // Delegate to op-specific validation if provided
+    if (opInfo->validateOp) {
+        Qnn_ErrorHandle_t ret = opInfo->validateOp(opConfig);
+        if (ret != QNN_OP_PACKAGE_NO_ERROR) {
+            return ret;
+        }
+    }
+
+    return QNN_OP_PACKAGE_NO_ERROR;
+}
+#endif  // LPAI_INFERENCE_ONLY
+
+// ---------------------------------------------------------------------------
+// Logging stubs (extend as needed)
+// ---------------------------------------------------------------------------
+
+// These accept the backend's logging callback and deliberately discard it: the
+// diagnostics in this package go to stderr through fprintf instead, which keeps
+// them visible on the host without depending on the caller's log level. A
+// production op package would keep the callback and route its messages through
+// it so that they land in the QNN log alongside everything else.
+
+/** @brief Set callback for logging and configure log level. */
+Qnn_ErrorHandle_t ExampleLpaiOpPackageLogInitialize(QnnLog_Callback_t callback, QnnLog_Level_t maxLogLevel) {
+    return QNN_OP_PACKAGE_NO_ERROR;
+}
+
+/** @brief Change the active log level. */
+Qnn_ErrorHandle_t ExampleLpaiOpPackageLogSetLevel(QnnLog_Level_t maxLogLevel) {
+    return QNN_OP_PACKAGE_NO_ERROR;
+}
+
+/** @brief Clear the logging callback and reset log level. */
+Qnn_ErrorHandle_t ExampleLpaiOpPackageLogTerminate(void) {
+    return QNN_OP_PACKAGE_NO_ERROR;
+}
+
+// ---------------------------------------------------------------------------
+// Interface Provider (QNN OpPackage v1.4)
+// ---------------------------------------------------------------------------
+
+
+Qnn_ErrorHandle_t ExampleLpaiOpPackageInterfaceProvider(QnnOpPackage_Interface_t* interface) {
+    if (!interface) return QNN_OP_PACKAGE_ERROR_INVALID_ARGUMENT;
+    interface->interfaceVersion      = (Qnn_Version_t)QNN_OP_PACKAGE_API_VERSION_1_4_0;
+    interface->v1_4.init             = ExampleLpaiOpPackageInit;
+    interface->v1_4.terminate        = ExampleLpaiOpPackageTerminate;
+    interface->v1_4.getInfo          = ExampleLpaiOpPackageGetInfo;
+#ifndef LPAI_INFERENCE_ONLY
+    interface->v1_4.validateOpConfig = ExampleLpaiOpPackageValidateOpConfig;
+#else
+    interface->v1_4.validateOpConfig = NULL;
+#endif
+    interface->v1_4.createOpImpl     = NULL;
+    interface->v1_4.freeOpImpl       = NULL;
+    interface->v1_4.logInitialize    = ExampleLpaiOpPackageLogInitialize;
+    interface->v1_4.logSetLevel      = ExampleLpaiOpPackageLogSetLevel;
+    interface->v1_4.logTerminate     = ExampleLpaiOpPackageLogTerminate;
+    return QNN_OP_PACKAGE_NO_ERROR;
+}

--- a/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/src/ops/ExampleCustomOp_compiler.cpp
+++ b/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/src/ops/ExampleCustomOp_compiler.cpp
@@ -1,0 +1,225 @@
+//==============================================================================
+// Auto Generated Code for ExampleLpaiOpPackage
+//==============================================================================
+
+// Use the C stdio header rather than <iostream> so that this file can be built
+// with toolchains that do not ship the C++ standard library headers (e.g. bare
+// cross compilers targeting the DSP).
+#include <stdio.h>
+
+#include "QnnLpaiOpPackage.h"
+#include "QnnTypes.h"
+
+extern "C" QnnOpPackage_OperationInfo_t get_ExampleCustomOp_opInfo_Inference();
+// ---------------------------------------------------------------------------
+// Op metadata (counts)
+// ---------------------------------------------------------------------------
+
+uint32_t g_ExampleCustomOpStaticParamsNum = 0;
+uint32_t g_ExampleCustomOpInputsNum = 1;
+uint32_t g_ExampleCustomOpOutputsNum = 1;
+
+// ---------------------------------------------------------------------------
+// Layout support
+// ---------------------------------------------------------------------------
+
+static Qnn_ErrorHandle_t ExampleCustomOp_getLayoutSupportFlag(
+    uint32_t* layoutFlag) {
+  if (layoutFlag == nullptr) {
+    return QNN_OP_PACKAGE_ERROR_INVALID_ARGUMENT;
+  }
+  *layoutFlag = QNN_LPAI_OP_LAYOUT_DEFAULT;
+  return QNN_SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
+// Supported data types (per input / per output)
+// ---------------------------------------------------------------------------
+
+// The LPAI lowering validates an op config twice: once from the
+// LpaiPartitionFallbackSupport edge pass, while the graph still carries
+// explicit quantize / dequantize nodes and the activations are therefore plain
+// integer tensors, and once after FoldQDQ has folded the quantization
+// parameters into the tensors. Both the integer and the fixed point spellings
+// of the activation type are accepted so that the op passes validation at
+// either stage.
+//
+// Only 8 bit activations are declared. The kernel itself is written for 8 and
+// 16 bit, but 16 bit activations do not currently work end to end on the LPAI
+// backend, so declaring them here would advertise a broken configuration:
+//
+//   * a 16 bit activation is a torch.int32 tensor holding the uint16 range
+//     before folding (see get_16a16w_qnn_ptq_config), so it arrives as
+//     QNN_DATATYPE_INT_32 rather than QNN_DATATYPE_UINT_16 - the UINT_16 that
+//     used to be listed here was therefore never matched anyway;
+//   * declaring INT_32 does get a 16a16w graph past validation and the kernel
+//     runs, but only the first half of the output tensor comes back correct.
+//     That reproduces with an identity requantization (calibration value equal
+//     to the inference value, so the scale ratio is exactly 1 and the kernel is
+//     a plain copy), which rules out the requantization arithmetic and points
+//     at how the backend hands 16 bit custom op tensors over.
+//
+// Keeping the declaration to 8 bit means an unsupported graph is rejected at
+// compile time and falls back cleanly instead of silently returning half a
+// result. See examples/qualcomm/custom_op/README.md.
+static Qnn_DataType_t g_ExampleCustomOpInput_0_DataTypes[] = {
+    QNN_DATATYPE_UFIXED_POINT_8,
+    QNN_DATATYPE_UINT_8,
+};
+
+QnnLpaiOpPackage_DataTypeInfo_t g_ExampleCustomOpInputDatatypes[] = {
+    {sizeof(g_ExampleCustomOpInput_0_DataTypes) /
+         sizeof(g_ExampleCustomOpInput_0_DataTypes[0]),
+     g_ExampleCustomOpInput_0_DataTypes},
+};
+
+static Qnn_DataType_t g_ExampleCustomOpOutput_0_DataTypes[] = {
+    QNN_DATATYPE_UFIXED_POINT_8,
+    QNN_DATATYPE_UINT_8,
+};
+
+QnnLpaiOpPackage_DataTypeInfo_t g_ExampleCustomOpOutputDatatypes[] = {
+    {sizeof(g_ExampleCustomOpOutput_0_DataTypes) /
+         sizeof(g_ExampleCustomOpOutput_0_DataTypes[0]),
+     g_ExampleCustomOpOutput_0_DataTypes},
+};
+
+// ---------------------------------------------------------------------------
+// Compile-time validation
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Number of bits held by a QNN data type.
+ *
+ * The lower byte of Qnn_DataType_t encodes the bit width in BCD, so
+ * QNN_DATATYPE_UFIXED_POINT_8 and QNN_DATATYPE_UINT_8 share the same width.
+ */
+static uint32_t dataTypeBitWidth(Qnn_DataType_t dataType) {
+  const uint32_t lowerByte = (uint32_t)dataType & 0xFF;
+  return ((lowerByte >> 4) * 10) + (lowerByte & 0xF);
+}
+
+/**
+ * @brief Validate op configuration at compilation time.
+ *
+ * Called by the host compiler to verify that the Qnn_OpConfig_t provided by
+ * the user matches what this op package supports (tensor ranks, data types,
+ * parameter values, etc.).
+ *
+ * @return QNN_SUCCESS on success, error code otherwise.
+ */
+Qnn_ErrorHandle_t ExampleCustomOp_validateOp(Qnn_OpConfig_t opConfig) {
+  // The package-level ValidateOpConfig already checked the tensor/param
+  // counts and that each data type is in the supported set declared above.
+  // Here we add the op specific constraints:
+  //   1. input and output must use the same element width
+  //   2. input and output must be rank 4 with identical dimensions
+  const Qnn_Tensor_t& input = opConfig.v1.inputTensors[0];
+  const Qnn_Tensor_t& output = opConfig.v1.outputTensors[0];
+
+  // Compare element widths rather than the data types themselves. The op is
+  // validated both before and after the quantization parameters are folded
+  // into the tensors, so the very same graph is presented once as
+  // QNN_DATATYPE_UINT_8 and once as QNN_DATATYPE_UFIXED_POINT_8.
+  if (dataTypeBitWidth(input.v1.dataType) !=
+      dataTypeBitWidth(output.v1.dataType)) {
+    fprintf(
+        stderr,
+        "ExampleCustomOp: input/output data type mismatch (0x%x vs 0x%x)\n",
+        (unsigned)input.v1.dataType,
+        (unsigned)output.v1.dataType);
+    return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+  }
+
+  constexpr uint32_t kExpectedRank = 4;
+  if (input.v1.rank != kExpectedRank || output.v1.rank != kExpectedRank) {
+    fprintf(
+        stderr,
+        "ExampleCustomOp: expected rank 4 input/output, got %u/%u\n",
+        input.v1.rank,
+        output.v1.rank);
+    return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+  }
+
+  for (uint32_t i = 0; i < kExpectedRank; i++) {
+    if (input.v1.dimensions[i] != output.v1.dimensions[i]) {
+      fprintf(
+          stderr,
+          "ExampleCustomOp: input/output dimension mismatch at %u (%u != %u)\n",
+          i,
+          input.v1.dimensions[i],
+          output.v1.dimensions[i]);
+      return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+    }
+  }
+
+  return QNN_SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
+// Buffer size calculation
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Compute the required temp buffer size for this op.
+ *
+ * The buffer is sized to hold the first input tensor, which is what the
+ * generated skeleton suggests and is enough for an elementwise op.
+ *
+ * @param[out] bufferSize  Receives the required temp buffer size in bytes.
+ * @return QNN_SUCCESS on success, error code otherwise.
+ */
+Qnn_ErrorHandle_t ExampleCustomOp_getTempBufferSize(
+    Qnn_OpConfig_t opConfig,
+    size_t* bufferSize) {
+  if (!bufferSize) {
+    return QNN_OP_PACKAGE_ERROR_INVALID_ARGUMENT;
+  }
+
+  const Qnn_Tensor_t* inputTensor0 = &opConfig.v1.inputTensors[0];
+  const uint32_t rank = inputTensor0->v1.rank;
+  const uint32_t* dims = inputTensor0->v1.dimensions;
+  const uint32_t dataTypeSize = dataTypeBitWidth(inputTensor0->v1.dataType) / 8;
+
+  // size = dataTypeSize * dim[0] * dim[1] * ... * dim[rank-1]
+  size_t size = dataTypeSize;
+  for (uint32_t i = 0; i < rank; i++) {
+    size *= dims[i];
+  }
+  *bufferSize = size;
+
+  return QNN_SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
+// Op info registration (compiler mode)
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Return the op info struct populated with both inference and
+ *        compiler-specific fields.
+ *
+ * Calls get_ExampleCustomOp_opInfo_Inference() to obtain the base struct
+ * (opType + executeOp), then layers the compiler-only fields on top.
+ */
+extern "C" QnnOpPackage_OperationInfo_t get_ExampleCustomOp_opInfo_Compiler() {
+  QnnOpPackage_OperationInfo_t ExampleCustomOp_opInfo =
+      get_ExampleCustomOp_opInfo_Inference();
+
+  // Metadata counts
+  ExampleCustomOp_opInfo->numOfParams = g_ExampleCustomOpStaticParamsNum;
+  ExampleCustomOp_opInfo->numOfInputs = g_ExampleCustomOpInputsNum;
+  ExampleCustomOp_opInfo->numOfOutputs = g_ExampleCustomOpOutputsNum;
+
+  // Compiler-side callbacks
+  ExampleCustomOp_opInfo->validateOp = ExampleCustomOp_validateOp;
+  ExampleCustomOp_opInfo->getTempBufferSize = ExampleCustomOp_getTempBufferSize;
+  ExampleCustomOp_opInfo->getLayoutSupportFlag =
+      ExampleCustomOp_getLayoutSupportFlag;
+
+  // Supported data types
+  ExampleCustomOp_opInfo->inputDatatypes = g_ExampleCustomOpInputDatatypes;
+  ExampleCustomOp_opInfo->outputDatatypes = g_ExampleCustomOpOutputDatatypes;
+
+  return ExampleCustomOp_opInfo;
+}

--- a/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/src/ops/ExampleCustomOp_inference.c
+++ b/examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage/src/ops/ExampleCustomOp_inference.c
@@ -1,0 +1,451 @@
+//==============================================================================
+// Auto Generated Code for ExampleLpaiOpPackage
+//==============================================================================
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+
+#include "QnnLpaiOpPackage.h"
+#include "QnnLpaiOpPackageInfrastructure.h"
+
+extern QnnLpaiOpPackage_GlobalInfrastructure_t sg_globalInfra;
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+// Every rejection below returns one of a handful of error codes, which on their
+// own do not say *which* check tripped. Tracing is compiled out by default
+// because this code also runs on the DSP, where printf is expensive and garbles
+// long argument lists (read diagnostics back with FARF + logcat instead, see
+// examples/qualcomm/custom_op/README.md). Build with
+// -DEXAMPLE_CUSTOM_OP_TRACE=1 to switch it on while developing a kernel.
+#if defined(EXAMPLE_CUSTOM_OP_TRACE) && EXAMPLE_CUSTOM_OP_TRACE
+#define TRACE(msg) printf("ExampleCustomOp: " msg "\n")
+#else
+#define TRACE(msg) ((void)0)
+#endif
+
+// Report why the node was rejected and return the matching error code.
+#define FAIL(code, msg)  \
+    do {                 \
+        TRACE(msg);      \
+        return (code);   \
+    } while (0)
+
+// ---------------------------------------------------------------------------
+// Op metadata
+// ---------------------------------------------------------------------------
+
+QnnLpaiOpPackage_OperationInfo_t g_ExampleCustomOp_opInfo;
+char g_ExampleCustomOpOpType[] = "ExampleCustomOp";
+
+// --- helpers ------------------------------------------------------------------
+
+typedef struct {
+    uint32_t                  shapeRank;
+    uint32_t                  layoutRank;
+    uint32_t                  dimSizes[QNN_LPAI_CUSTOM_OP_MAX_LAYOUT_RANK];
+    QnnLpaiCustomOp_Layout_t  layout;
+} TensorIterInfo;
+
+// Populate TensorIterInfo for the given tensor.
+static QnnLpaiCustomOp_Error_t getTensorIterInfo(QnnLpai_CustomOpTensor_t tensor,
+                                                 TensorIterInfo*       info) {
+    if (sg_globalInfra.getTensorShapeRank(tensor,  &info->shapeRank)  != LPAI_CUSTOM_OP_SUCCESS ||
+        sg_globalInfra.getTensorLayoutRank(tensor, &info->layoutRank) != LPAI_CUSTOM_OP_SUCCESS ||
+        sg_globalInfra.getTensorLayout(tensor,     &info->layout)     != LPAI_CUSTOM_OP_SUCCESS) {
+        return LPAI_CUSTOM_OP_FAIL;
+    }
+    // dimSizes[] (and the coords[] array indexed by the same ranks below) hold
+    // QNN_LPAI_CUSTOM_OP_MAX_LAYOUT_RANK entries, so refuse anything deeper
+    // rather than writing past the end of them.
+    if (info->shapeRank  > QNN_LPAI_CUSTOM_OP_MAX_LAYOUT_RANK ||
+        info->layoutRank > QNN_LPAI_CUSTOM_OP_MAX_LAYOUT_RANK) {
+        return LPAI_CUSTOM_OP_FAIL;
+    }
+    for (uint32_t i = 0; i < info->shapeRank; i++) {
+        if (sg_globalInfra.getTensorShapeDimSize(tensor, i, &info->dimSizes[i]) != LPAI_CUSTOM_OP_SUCCESS) {
+            return LPAI_CUSTOM_OP_FAIL;
+        }
+    }
+    return LPAI_CUSTOM_OP_SUCCESS;
+}
+
+// Compute the byte offset of the element at coords[] using the tensor's layout.
+// offset = sum_i( coords[layoutOrder[i]] * layoutStride[i] )
+static uint32_t computeByteOffset(const uint32_t*                 coords,
+                                  const QnnLpaiCustomOp_Layout_t* layout,
+                                  uint32_t                        layoutRank) {
+    uint32_t offset = 0;
+    for (uint32_t i = 0; i < layoutRank; i++) {
+        offset += coords[layout->layoutOrder[i]] * layout->layoutStride[i];
+    }
+    return offset;
+}
+
+// Advance coords[] by one step in memory order (fastest dimension first).
+// Returns after the last element (all coords wrap back to 0).
+//
+// layoutOrder is walked back to front on purpose: QnnLpaiOpPackageInfrastructure.h
+// defines index 0 as the *slowest* moving (least contiguous) dimension and the
+// last valid index as the fastest moving one, so the innermost digit of this
+// odometer is layoutOrder[layoutRank - 1]. Iterating the other way round also
+// visits every element, but in the least cache friendly order possible, and it
+// silently breaks any kernel that is not a pure elementwise map.
+static void advanceCoords(uint32_t*       coords,
+                          const uint32_t* dimSizes,
+                          const uint8_t*  layoutOrder,
+                          uint32_t        layoutRank) {
+    for (uint32_t i = layoutRank; i-- > 0;) {
+        const uint8_t dim = layoutOrder[i];
+        if (++coords[dim] < dimSizes[dim]) return;
+        coords[dim] = 0;
+    }
+}
+
+// Convert a QnnLpaiCustomOp_QuantScale_t into a float scale.
+//
+// The scale may be stored either as a float or as an integer approximation
+// where: scale_float = scale_int / (2 ^ shift)
+//
+// ldexpf() is used rather than (1u << shift) on purpose: shift is routinely
+// larger than 31 (the eNPU reports e.g. scale=538976320, shift=37 for 1/255),
+// and shifting a 32 bit value by >= 32 is undefined behaviour. On the DSP that
+// evaluates to 0, so the division silently produced +inf and every subsequent
+// requantization became NaN.
+//
+// The scale type is matched exhaustively rather than treating "not float" as
+// "integer": the enum also has an UNDEFINED value, and reading that as an
+// integer scale would silently interpret uninitialized union bytes as a
+// scale/shift pair.
+static QnnLpaiCustomOp_Error_t getFloatScale(
+    const QnnLpaiCustomOp_QuantScale_t* scale, float* out) {
+    switch (scale->type) {
+        case QNN_LPAI_CUSTOM_OP_QUANT_SCALE_TYPE_FLOAT:
+            *out = scale->fScale;
+            return LPAI_CUSTOM_OP_SUCCESS;
+        case QNN_LPAI_CUSTOM_OP_QUANT_SCALE_TYPE_INT:
+            *out = ldexpf((float)scale->iScale.scale, -scale->iScale.shift);
+            return LPAI_CUSTOM_OP_SUCCESS;
+        default:
+            return LPAI_CUSTOM_OP_FAIL;
+    }
+}
+
+// Round value to the nearest integer and clamp it into [minValue, maxValue].
+//
+// The comparisons are done in floating point, before the conversion to
+// int32_t, because converting a float that is NaN or outside the range of the
+// target integer type is undefined behaviour, and the clamp cannot undo that
+// afterwards. Written so that a NaN input fails the first comparison and
+// returns minValue rather than propagating.
+static int32_t saturateCast(float value, int32_t minValue, int32_t maxValue) {
+    if (!(value > (float)minValue)) {
+        return minValue;
+    }
+    if (value >= (float)maxValue) {
+        return maxValue;
+    }
+    return (int32_t)(value + 0.5f);
+}
+
+// Number of bytes an element of the given data type occupies. Returns 0 for
+// types this kernel does not handle.
+//
+// Both the signed and the unsigned 8/16 bit types are accepted here. The op
+// package declares QNN_DATATYPE_UFIXED_POINT_8 in its config, and the tensors
+// really are unsigned on device, but the eNPU reports the 8 bit type back as
+// LPAI_CUSTOM_OP_DATATYPE_INT_8 through getTensorDataType(). Only the element
+// width is taken from the reported type; see the comment in
+// ExampleCustomOp_executeOp() for why the reported sign is ignored.
+//
+// The 16 bit cases are deliberately kept, because the arithmetic below is
+// written to be width agnostic and that is the interesting part to copy into a
+// new kernel. Note though that they are currently *unreachable and untested*:
+// the op package only declares 8 bit activations, since a 16 bit graph returns
+// a half correct output tensor for reasons that sit below this kernel (it also
+// reproduces when the requantization is an identity copy). See the data type
+// comment in ExampleCustomOp_compiler.cpp.
+static uint32_t elementSize(QnnLpaiCustomOp_DataType_t type) {
+    switch (type) {
+        case LPAI_CUSTOM_OP_DATATYPE_INT_8:
+        case LPAI_CUSTOM_OP_DATATYPE_UINT_8:
+            return 1u;
+        case LPAI_CUSTOM_OP_DATATYPE_INT_16:
+        case LPAI_CUSTOM_OP_DATATYPE_UINT_16:
+            return 2u;
+        default:
+            return 0u;
+    }
+}
+
+// --- op implementation --------------------------------------------------------
+
+/**
+ * @brief Execute the ExampleCustomOp operation on the given node.
+ *
+ * Uses the package-level sg_globalInfra (declared extern at the top of this
+ * file, defined in ExampleLpaiOpPackageInterface.c) to access tensors.
+ */
+int32_t ExampleCustomOp_executeOp(QnnLpai_CustomOpNode_t lpaiNode) {
+
+    // Retrieve input tensors
+    QnnLpai_CustomOpTensor_t input0       = sg_globalInfra.getInputTensor(lpaiNode, 0);
+
+    // Retrieve output tensors
+    QnnLpai_CustomOpTensor_t output0      = sg_globalInfra.getOutputTensor(lpaiNode, 0);
+
+    // Retrieve parameter tensors
+
+    // Validate that all required tensors were obtained
+    if (!input0)  FAIL(LPAI_CUSTOM_OP_FAIL, "no input tensor 0");
+    if (!output0) FAIL(LPAI_CUSTOM_OP_FAIL, "no output tensor 0");
+
+    // Query data types via out-pointer API
+    QnnLpaiCustomOp_DataType_t inType0  = (QnnLpaiCustomOp_DataType_t)0;
+    QnnLpaiCustomOp_DataType_t outType0 = (QnnLpaiCustomOp_DataType_t)0;
+    if (sg_globalInfra.getTensorDataType(input0,  &inType0)  != LPAI_CUSTOM_OP_SUCCESS) {
+        FAIL(LPAI_CUSTOM_OP_FAIL, "getTensorDataType(input) failed");
+    }
+    if (sg_globalInfra.getTensorDataType(output0, &outType0) != LPAI_CUSTOM_OP_SUCCESS) {
+        FAIL(LPAI_CUSTOM_OP_FAIL, "getTensorDataType(output) failed");
+    }
+    // This op supports 8-bit and 16-bit fixed point and requires the input and
+    // output to use the same data type.
+    const uint32_t bytesPerElement = elementSize(inType0);
+    if (inType0 != outType0 || bytesPerElement == 0u) {
+        FAIL(LPAI_CUSTOM_OP_NOT_SUPPORTED, "unsupported or mismatched data type");
+    }
+
+    // Retrieve raw data pointers
+    void* inData0  = sg_globalInfra.getTensorData(input0);
+    void* outData0 = sg_globalInfra.getTensorData(output0);
+    if (!inData0)  FAIL(LPAI_CUSTOM_OP_FAIL, "no input data pointer");
+    if (!outData0) FAIL(LPAI_CUSTOM_OP_FAIL, "no output data pointer");
+
+    // Retrieve layout and shape info needed for strided iteration
+    TensorIterInfo inInfo0  = {0};
+    TensorIterInfo outInfo0 = {0};
+    if (getTensorIterInfo(input0,  &inInfo0)  != LPAI_CUSTOM_OP_SUCCESS) {
+        FAIL(LPAI_CUSTOM_OP_FAIL, "cannot describe input tensor");
+    }
+    if (getTensorIterInfo(output0, &outInfo0) != LPAI_CUSTOM_OP_SUCCESS) {
+        FAIL(LPAI_CUSTOM_OP_FAIL, "cannot describe output tensor");
+    }
+
+    // Input and output must describe the same logical tensor shape, and the
+    // iteration below relies on both of them being consistent:
+    //   * dimSizes[] is only filled in up to shapeRank, so a layoutRank beyond
+    //     that would make advanceCoords() read a zero extent and never finish
+    //     the odometer;
+    //   * layoutOrder[] indexes coords[], so entries must stay inside the
+    //     logical rank. The header documents the entries past the rank as
+    //     invalid, so they are not to be trusted blindly.
+    if (inInfo0.shapeRank != outInfo0.shapeRank ||
+        inInfo0.layoutRank != inInfo0.shapeRank ||
+        outInfo0.layoutRank != outInfo0.shapeRank) {
+        FAIL(LPAI_CUSTOM_OP_NOT_SUPPORTED, "rank mismatch between shape/layout");
+    }
+    for (uint32_t i = 0; i < inInfo0.shapeRank; i++) {
+        if (inInfo0.dimSizes[i] != outInfo0.dimSizes[i]) {
+            FAIL(LPAI_CUSTOM_OP_NOT_SUPPORTED, "input/output dimension mismatch");
+        }
+        if (inInfo0.layout.layoutOrder[i] >= inInfo0.shapeRank ||
+            outInfo0.layout.layoutOrder[i] >= outInfo0.shapeRank) {
+            FAIL(LPAI_CUSTOM_OP_FAIL, "layoutOrder entry outside the tensor rank");
+        }
+    }
+    // Only the flat layout form is understood by computeByteOffset().
+    if (inInfo0.layout.layoutForm != QNN_LPAI_CUSTOM_OP_LAYOUT_FORM_FLAT ||
+        outInfo0.layout.layoutForm != QNN_LPAI_CUSTOM_OP_LAYOUT_FORM_FLAT) {
+        FAIL(LPAI_CUSTOM_OP_NOT_SUPPORTED, "unsupported layout form");
+    }
+
+    // A zero sized dimension yields no elements, which the loop below handles
+    // by simply not running. Keep the count 64-bit so a large tensor does not
+    // silently wrap while accumulating its dimensions.
+    uint64_t totalElements = 1;
+    for (uint32_t i = 0; i < inInfo0.shapeRank; i++) {
+        totalElements *= inInfo0.dimSizes[i];
+    }
+
+    // Retrieve the per-tensor quantization parameters so the multiply can be
+    // performed in real (dequantized) space and requantized on the way out.
+    QnnLpaiCustomOp_PerTensorQuantInfo_t inQuant  = {0};
+    QnnLpaiCustomOp_PerTensorQuantInfo_t outQuant = {0};
+    if (sg_globalInfra.getPerTensorQuantParams(input0, &inQuant) != LPAI_CUSTOM_OP_SUCCESS) {
+        FAIL(LPAI_CUSTOM_OP_FAIL, "no input quantization parameters");
+    }
+    if (sg_globalInfra.getPerTensorQuantParams(output0, &outQuant) != LPAI_CUSTOM_OP_SUCCESS) {
+        FAIL(LPAI_CUSTOM_OP_FAIL, "no output quantization parameters");
+    }
+
+    float inScale  = 0.0f;
+    float outScale = 0.0f;
+    if (getFloatScale(&inQuant.scale, &inScale) != LPAI_CUSTOM_OP_SUCCESS ||
+        getFloatScale(&outQuant.scale, &outScale) != LPAI_CUSTOM_OP_SUCCESS) {
+        FAIL(LPAI_CUSTOM_OP_FAIL, "unsupported quantization scale type");
+    }
+    // Both scales are checked: a zero output scale would divide by zero, and a
+    // zero input scale would silently map the whole tensor to code 0, which is
+    // a bad quantization parameter rather than a legitimate result.
+    if (inScale == 0.0f || outScale == 0.0f) {
+        FAIL(LPAI_CUSTOM_OP_FAIL, "quantization scale is zero");
+    }
+
+    // ExampleCustomOp computes: output = input * 3
+    //
+    // Quantization convention on the eNPU
+    // -----------------------------------
+    // getPerTensorQuantParams() reports an *offset* that biases the values as
+    // they sit in memory. The relation between a byte in the buffer and the
+    // quantized code that the rest of the graph works with is
+    //
+    //     code = stored - offset          (offset is -128 on the 8a8w graphs
+    //     stored = code + offset           produced here, so stored = code-128)
+    //
+    // and the real value is  v = scale * code.  Note that this is *not* the
+    // usual v = scale * (q - zero_point) with q taken straight from memory: the
+    // surrounding quantize/dequantize nodes in the ExecuTorch graph use a zero
+    // point of 0, so the codes they produce arrive here already biased by the
+    // offset, and the kernel is responsible for removing that bias on the way
+    // in and re-applying it on the way out. Both directions are needed; doing
+    // only one of them shifts the whole tensor by 128 codes. Measured on
+    // SM8850: input code 255 is handed to the kernel as the stored byte 127.
+    //
+    // Both directions have to wrap modulo the storage width. With offset -128
+    // the codes 0..127 are stored as the bytes 128..255, so reading the byte
+    // back and subtracting the offset without wrapping yields 256..383 instead
+    // of 0..127 - i.e. small values would decode as large ones and then
+    // saturate. On the way out the narrowing store already wraps, on the way in
+    // the mask below does it explicitly.
+    //
+    // Putting it together, the multiply becomes a pure operation on codes:
+    //
+    //     code_in  = (stored_in - in_offset) & code_mask
+    //     code_out = round(3 * in_scale / out_scale * code_in)
+    //     stored_out = code_out + out_offset
+    const float kMultiplier = 3.0f;
+    const float requantScale = kMultiplier * inScale / outScale;
+    // The scales come from the runtime, so the ratio is not guaranteed to be a
+    // usable number. Checking it once here keeps the inner loop free of
+    // non-finite values, which saturateCast() would otherwise have to absorb
+    // for every element.
+    if (!isfinite(requantScale)) {
+        FAIL(LPAI_CUSTOM_OP_FAIL, "requantization scale is not finite");
+    }
+
+    // Saturation bounds for a *code*, not for the biased byte that is written to
+    // memory. Clamping the biased byte instead looks harmless but is wrong: for
+    // input 1.0 the code is 255 and the byte is 127, so a clamp on the byte
+    // never triggers, yet a code of 256 (one past the maximum) would be stored
+    // as the perfectly innocent looking byte 128 and read back by the consumer
+    // as code 256-256 = 0. Overflow has to be caught while the value is still a
+    // code.
+    //
+    // For this particular op the clamp cannot actually fire: the output range
+    // observed during calibration is exactly three times the input range, so
+    // requantScale is 1 and code_out == code_in. It is kept because a kernel
+    // whose output range is not a multiple of its input range does overflow
+    // here, and because clamping the wrong quantity is a silent error.
+    // Derived from the storage width so that the two stay in step: for an
+    // n bit code the largest value and the wraparound mask are both 2^n - 1.
+    const uint32_t codeBits = bytesPerElement * 8u;
+    const int32_t codeMin = 0;
+    const int32_t codeMax = (int32_t)((1u << codeBits) - 1u);
+    // Wraps the un-biased input back into the code range, see above.
+    const int32_t codeMask = codeMax;
+
+    uint32_t coords[QNN_LPAI_CUSTOM_OP_MAX_LAYOUT_RANK] = {0};
+    for (uint64_t i = 0; i < totalElements; i++) {
+        // Byte offsets are derived from the same logical coordinates, so the
+        // input and output are free to use different memory layouts.
+        const uint32_t inOffset =
+            computeByteOffset(coords, &inInfo0.layout, inInfo0.layoutRank);
+        const uint32_t outOffset =
+            computeByteOffset(coords, &outInfo0.layout, outInfo0.layoutRank);
+
+        // Read the stored value, widening to int32_t so the same arithmetic
+        // covers both supported widths. The 16 bit access goes through memcpy
+        // because nothing guarantees that a stride, and therefore the byte
+        // offset computed from it, is even; an unaligned uint16_t load is
+        // undefined behaviour and traps on some Hexagon configurations.
+        const uint8_t* inPtr = (const uint8_t*)inData0 + inOffset;
+        int32_t storedIn;
+        if (bytesPerElement == 1u) {
+            storedIn = (int32_t)*inPtr;
+        } else {
+            uint16_t raw;
+            memcpy(&raw, inPtr, sizeof(raw));
+            storedIn = (int32_t)raw;
+        }
+
+        // Remove the input bias to get a code, wrapping modulo the storage
+        // width so that a biased byte >= 128 maps back to a small code instead
+        // of running past codeMax, then scale and saturate in the code domain.
+        const int32_t codeIn = (storedIn - (int32_t)inQuant.offset) & codeMask;
+        const int32_t code =
+            saturateCast(requantScale * (float)codeIn, codeMin, codeMax);
+
+        // Re-apply the output bias. The narrowing cast below wraps modulo the
+        // storage width, mirroring the mask applied on the way in, and is
+        // precisely the inverse of the consumer's (stored - offset), so the
+        // round trip is exact.
+        const int32_t storedOut = code + (int32_t)outQuant.offset;
+
+        uint8_t* outPtr = (uint8_t*)outData0 + outOffset;
+        if (bytesPerElement == 1u) {
+            *outPtr = (uint8_t)storedOut;
+        } else {
+            const uint16_t raw = (uint16_t)storedOut;
+            memcpy(outPtr, &raw, sizeof(raw));
+        }
+
+        advanceCoords(
+            coords, inInfo0.dimSizes, inInfo0.layout.layoutOrder, inInfo0.layoutRank);
+    }
+
+    return LPAI_CUSTOM_OP_SUCCESS;
+}
+
+// ---------------------------------------------------------------------------
+// Op info registration (inference mode)
+// ---------------------------------------------------------------------------
+
+// Report the memory layouts this kernel can consume. The kernel walks tensors
+// through layoutOrder/layoutStride, so the default layout is what it expects.
+//
+// This lives on the inference side on purpose: the eAI runtime on the DSP
+// queries the layout support flag while setting up a custom op node, so the
+// callback must be populated in the inference build too, not only in the
+// compiler build. Leaving it NULL makes the on-device query fail with
+// AEE_EBADSTATE (0x8000040D), surfacing on the host as
+// "Failed to register custom op package through platform".
+static Qnn_ErrorHandle_t ExampleCustomOp_getLayoutSupportFlagInference(
+    uint32_t* layoutFlag) {
+    if (layoutFlag == NULL) {
+        return QNN_OP_PACKAGE_ERROR_INVALID_ARGUMENT;
+    }
+    *layoutFlag = QNN_LPAI_OP_LAYOUT_DEFAULT;
+    return QNN_SUCCESS;
+}
+
+extern QnnOpPackage_OperationInfo_t get_ExampleCustomOp_opInfo_Inference() {
+    memset(&g_ExampleCustomOp_opInfo, 0, sizeof(QnnLpaiOpPackage_OperationInfo_t));
+    g_ExampleCustomOp_opInfo.opType    = g_ExampleCustomOpOpType;
+    g_ExampleCustomOp_opInfo.executeOp = ExampleCustomOp_executeOp;
+
+    // The tensor counts and the layout support callback are needed by the
+    // runtime as well as by the compiler, so populate them here. The compiler
+    // build layers its own callbacks on top of this struct.
+    g_ExampleCustomOp_opInfo.numOfInputs  = 1;
+    g_ExampleCustomOp_opInfo.numOfOutputs = 1;
+    g_ExampleCustomOp_opInfo.numOfParams  = 0;
+    g_ExampleCustomOp_opInfo.getLayoutSupportFlag =
+        ExampleCustomOp_getLayoutSupportFlagInference;
+
+    return &g_ExampleCustomOp_opInfo;
+}


### PR DESCRIPTION
### Summary

Adding an end-to-end example of a custom PyTorch operator delegated to the LPAI backend running on the aDSP in direct mode.
**Note**: Custom ops are currently _only_ supported in Direct Mode, not FastRPC Mode.

Changes required to enable custom ops:

- `platform=HEXAGON` - In direct mode the delegate is not `__x86_64__` or `__ANDROID__`, so `current_platform` stayed `UNKNOWN` and every op package registration was silently skipped. Added a `HEXAGON` platform and an `LPAI` target to the compiler spec schema, and set `current_platform` from `__hexagon__`.
- `registerOpPackage()` - The 4th argument is backend specific. CPU/HTP take a processor target name; LPAI takes an optional target memory pool. The runtime now passes `nullptr` there and lets the backend pick its default.
- Deployment of the signed op package - the example signs the op package libraries via `sign_library.sh` and pushes them with SimpleADB's existing `files=` parameter. `sign_library.sh` gained an `--op_package_dir` option to sign them. On device an LPAI op package requires direct mode (registration over FastRPC is not supported), and both `libQnnExampleLpaiOpPackage.so` and `libLpaiOpPackageIsland.so` carry the kernel, so they must be rebuilt, signed and deployed together.

No partitioner change is needed: op package registration happens when the `QnnManager` for the compiler spec is created (`InitBackend` → `BackendRegisterOpPackage`), i.e. before partitioning, so `validateOpConfig()` already accepts an op package-backed node and it is validated like any other node.

Note: if the op were rejected it would fall back to the CPU implementation that the example registers for eager mode, which computes the same values, so the values would still match, and the test would pass even while the op package was never exercised. The example therefore inspects the lowered program and fails if the custom op is still present as a CPU operator, or if the graph contains no delegate at all. Both tests assert on that in addition to comparing the output.

This pr also fixes 2 existing bugs found, not specific to custom ops:

- `QnnExecuTorchIdlWrapper`'s constructor could return early leaving `method_ == nullptr`, which `execute_all()` then dereferenced. The resulting DSP fault destroyed the real error message. It now reports `Error::InvalidState`.
- `set_output_data_ptr()` returning `InvalidState` for memory-planned outputs was treated as fatal even though it is documented as benign. Such outputs are now tracked and read back via `method_->get_output()`.

LPAI op package conventions that are not currently documented in the SDK, and that the example kernel encodes with comments so the next author does not have to rediscover them:

- Scale may arrive as `scale / 2^shift` with `shift > 31` (the eNPU reports `shift=37`). `1u << shift` is undefined behavior for shifts >= 32 and evaluated to `0` here, turning the scale into `+inf` and every requantized value into `NaN`. The kernel uses `ldexpf()`.
- `getPerTensorQuantParams()` reports biased storage: `code = stored - offset`, `stored = code + offset`, `value = scale * code`, with `offset = -128` for 8-bit. Both directions must wrap modulo the storage width.
- `getTensorDataType()`'s signedness is unusable (it reports `INT_8` for unsigned tensors); only the width can be trusted.
- Strides from `getTensorLayout()` are in **bytes**, and `layoutOrder[0]` is the **slowest** moving dimension (the last valid index is the fastest).
- `getLayoutSupportFlag` must be populated in the inference build as well, or on-device registration fails with `AEE_EBADSTATE (0x8000040D)`.

Some more changes included in this pr:

- Added documentation for the flow in `examples/qualcomm/custom_op/README.md`.
- Added a `custom_op_enablement.md` agent skill covering op packages for both HTP and LPAI.
- Also corrected some stale flags in the QNN skill docs found along the way.
- `sign_library.sh` now checks the signer's exit status. Previously every invocation was `yes | python $signer ...` with no status check, so a failing `elfsigner.py` left the script exiting 0 and deployed stale or missing libraries.
- The DSP target the op package is built for is a separate `--op_package_arch` (default `v79`) rather than being derived from `--htp_arch` or `--lpai_arch`: on SM8850 the HTP is V81 and the LPAI hardware version is V6, while the op package builds for hexagon-V79. 

Constraints:

- Qualcomm AI Engine Direct SDK >= 2.48 to build an op package at all (first release shipping `QnnLpaiOpPackage.h` and the LPAI op package makefiles), and >= 2.49 for the on-device path, which additionally requires direct mode.
- Only non-island mode is supported.
- The example op package declares 8-bit activations only (`QNN_DATATYPE_UFIXED_POINT_8` / `QNN_DATATYPE_UINT_8`). A 16-bit activation arrives as `QNN_DATATYPE_INT_32`, and declaring INT_32 does pass validation and run, but only the first half of the output tensor comes back correct, reproducible with an identity requantization, which rules out the kernel's arithmetic and points at the backend's 16-bit tensor handover. That's an existing backend bug, unrelated to these changes.

### Test plan

Two new tests in `backends/qualcomm/tests/test_qnn_delegate.py`:

- `TestUtilsScript.test_custom_op_lpai` builds the op package, signs it, deploys it, runs on device, and compares against the eager result.
- `TestUtilsScript.test_custom_op_lpai_requant_edge_cases` covers the two requantization paths the default run cannot reach, on the x86_64 simulator (the arithmetic is identical in both builds, so this avoids a DSP rebuild and re-sign): a small input whose code is biased into the upper half of the stored byte and has to be un-biased modulo the storage width, and an input above the calibrated range that has to saturate.

Verified on device:

```
python backends/qualcomm/tests/test_qnn_delegate.py \
  TestUtilsScript.test_custom_op_lpai \
  --executorch_root . --artifact_dir ./custom_op_lpai \
  --build_folder build-android --direct_build_folder build-direct \
  --backend lpai --soc_model SM8850 \
  --device 296753f6 \
  --host aisw-vm12-labsd
```

Passes: `my_ops.mul3.default | True` from the partitioner, `_dom=adsp` in the runner's domain URI, `unique: [3.]` with `max abs err: 0.0`, and `13.533 ms` in `qnn_executorch_execute_all`.

Verified the requantization edge cases on the LPAI x86_64 simulator:

```
python backends/qualcomm/tests/test_qnn_delegate.py \
  TestUtilsScript.test_custom_op_lpai_requant_edge_cases \
  --executorch_root . --artifact_dir ./custom_op_lpai \
  --build_folder build-x86 --backend lpai --soc_model SM8850 \
  --enable_x86_64
```

Both subtests pass, each delegating the op: `calibration=1.0, inference=0.25` matches eager, and `calibration=1.0, inference=2.0` saturates to `3.0` (the graph's quantize node clamps the input to `1.0`, so `3.0` is the correct answer rather than `6.0`).

Also exercised the host-only path directly through the simulator:

```
python examples/qualcomm/custom_op/custom_ops_lpai.py \
  --build_folder build-x86 --backend lpai --soc_model SM8850 \
  --op_package_dir examples/qualcomm/custom_op/example_op_package_lpai/ExampleLpaiOpPackage \
  --build_op_package --enable_x86_64
```

Checked that the delegation assertion actually fails when the op is not delegated, by forcing a fallback with `--skip_delegate_node_ops my_ops.mul3.default`:

```
RuntimeError: ['my_ops::mul3'] was not delegated, it is executed by a CPU kernel in
method 'forward'. The op package was not exercised even if the output happens to match.
```