### PR TITLE
[ET-VK] Tag tensors in list args that mix None entries

### DIFF
--- a/backends/vulkan/_passes/tag_memory_meta_pass.py
+++ b/backends/vulkan/_passes/tag_memory_meta_pass.py
@@ -122,6 +122,10 @@ def set_arg_node_repr_or_transition(
     elif isinstance(arg_node, (list, tuple)):
         ret: bool = False
         for n in arg_node:
+            # `None` entries (e.g. the unspecified indices of `aten.index.Tensor`)
+            # do not reference a tensor; skip them.
+            if n is None:
+                continue
             assert isinstance(n, torch.fx.Node)
             assert utils.is_single_tensor_node(n)
             ret = single_node_impl(n) or ret
@@ -193,9 +197,12 @@ class TagMemoryMetaPass(ExportPass):
             return True
 
         if isinstance(node, (tuple, list)):
-            for n in node:
-                if not isinstance(n, torch.fx.Node):
-                    return False
+            # `None` entries (e.g. the unspecified indices of `aten.index.Tensor`)
+            # do not reference a tensor; skip them.
+            tensor_nodes = utils.tensor_nodes_in_arg(node)
+            if len(tensor_nodes) == 0:
+                return False
+            for n in tensor_nodes:
                 if not self.is_non_constant_tensor_node(n):
                     return False
 
@@ -252,14 +259,14 @@ class TagMemoryMetaPass(ExportPass):
         """
         arg_node = op_node.args[arg_i]
 
+        arg_tensor_nodes = utils.tensor_nodes_in_arg(arg_node)
         # For non-tensor arguments, return ANY_STORAGE_INCL_PACKED_INT8 so that the respset does
         # not appear to be empty.
-        if not utils.is_tensor_arg_node(arg_node):
+        if len(arg_tensor_nodes) == 0:
             return utils.ANY_STORAGE_INCL_PACKED_INT8
 
         # Special case for cat - use the first tensor in the list as representative
-        if isinstance(arg_node, list):
-            arg_node = arg_node[0]
+        arg_node = arg_tensor_nodes[0]
 
         if utils.has_node_repr(arg_node):
             arg_node_repr = utils.get_node_repr(arg_node)
@@ -421,8 +428,12 @@ class TagMemoryMetaPass(ExportPass):
 
         # First, trace downstream users to discover what layout they prefer.
         arg_node = op_repsets.op_node.args[arg_i]
-        if isinstance(arg_node, list):
-            arg_node = arg_node[0]
+        if isinstance(arg_node, (list, tuple)):
+            arg_tensor_nodes = utils.tensor_nodes_in_arg(arg_node)
+            if len(arg_tensor_nodes) == 0:
+                return
+            # Use the first tensor in the list as representative
+            arg_node = arg_tensor_nodes[0]
 
         arg_repset = op_repsets.get_arg_repset(arg_i)
         if not arg_repset.is_constrained():
@@ -456,7 +467,7 @@ class TagMemoryMetaPass(ExportPass):
 
     def constrain_op_repsets(self, op_repsets: utils.OpRepSets) -> None:
         for i in range(len(op_repsets.op_node.args)):
-            if utils.is_tensor_arg_node(op_repsets.op_node.args[i]):
+            if utils.tensor_nodes_in_arg(op_repsets.op_node.args[i]):
                 self.constrain_op_arg_repset(i, op_repsets)
 
         self.constrain_op_out_repset(op_repsets)
@@ -526,7 +537,7 @@ class TagMemoryMetaPass(ExportPass):
                     or transitions_inserted
                 )
             elif isinstance(arg_node, (list, tuple)):
-                for n in arg_node:
+                for n in utils.tensor_nodes_in_arg(arg_node):
                     assert isinstance(n, torch.fx.Node)
                     assert utils.is_single_tensor_node(n)
                     transitions_inserted = (

--- a/backends/vulkan/test/test_vulkan_passes.py
+++ b/backends/vulkan/test/test_vulkan_passes.py
@@ -779,3 +779,58 @@ class TestVulkanPasses(unittest.TestCase):
 
         gm = ep.graph_module
         self.assertEqual(op_node_count(gm, "q8ta_pixel_shuffle.default"), 0)
+
+    def test_tag_memory_meta_pass_tags_tensor_in_mixed_none_list(self):
+        """TagMemoryMetaPass must tag tensor nodes that sit in a list argument
+        alongside None entries. Regression test for
+        https://github.com/pytorch/executorch/issues/22510: `aten.index.Tensor`
+        reaches the edge dialect as `index.Tensor(x, [None, idx])`, and the old
+        list checks only recognized a list when every entry was a tensor node,
+        so `idx` never got a storage/memory-layout representation.
+        """
+        import executorch.backends.vulkan.utils as vk_utils
+        from executorch.backends.vulkan._passes.tag_memory_meta_pass import (
+            TagMemoryMetaPass,
+        )
+        from executorch.exir.passes.spec_prop_pass import SpecPropPass
+
+        class IndexModule(torch.nn.Module):
+            def forward(self, x, idx):
+                return x[:, idx]
+
+        model = IndexModule().eval()
+        program = torch.export.export(
+            model, (torch.randn(2, 4), torch.tensor([0, 2, 1, 3])), strict=True
+        )
+        edge_program = to_edge(
+            program, compile_config=EdgeCompileConfig(_check_ir_validity=False)
+        )
+        gm = edge_program._edge_programs["forward"].graph_module
+
+        # Mirror vulkan_preprocess: SpecPropPass annotates TensorSpecs first.
+        gm = SpecPropPass()(gm).graph_module
+
+        index_node = next(
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and "index" in str(n.target)
+        )
+        index_list_arg = index_node.args[1]
+        self.assertIsInstance(index_list_arg, list)
+        self.assertTrue(any(a is None for a in index_list_arg))
+        idx_node = next(n for n in index_list_arg if isinstance(n, torch.fx.Node))
+
+        # The helper skips None entries but keeps tensor nodes.
+        self.assertEqual(vk_utils.tensor_nodes_in_arg(index_list_arg), [idx_node])
+        self.assertEqual(vk_utils.tensor_nodes_in_arg(idx_node), [idx_node])
+        self.assertEqual(vk_utils.tensor_nodes_in_arg([None, None]), [])
+        self.assertEqual(vk_utils.tensor_nodes_in_arg(5), [])
+
+        self.assertFalse(vk_utils.has_node_repr(idx_node))
+
+        TagMemoryMetaPass(vk_utils.DEFAULT_TEXTURE_LIMITS).call(gm)
+
+        self.assertTrue(
+            vk_utils.has_node_repr(idx_node),
+            "tensor node in a mixed None/tensor list arg was not tagged",
+        )

--- a/backends/vulkan/utils.py
+++ b/backends/vulkan/utils.py
@@ -275,6 +275,20 @@ def is_tensor_arg_node(node: Any) -> bool:
     return False
 
 
+def tensor_nodes_in_arg(arg: Any) -> List[torch.fx.Node]:
+    """
+    The tensor nodes contained in an operator argument, skipping `None` entries
+    (e.g. the unspecified indices of `aten.index.Tensor`). A single node argument
+    yields a single-element list when it is a tensor node, and an empty list
+    otherwise.
+    """
+    if isinstance(arg, torch.fx.Node):
+        return [arg] if is_tensor_node(arg) else []
+    if isinstance(arg, (list, tuple)):
+        return [n for n in arg if is_tensor_node(n)]
+    return []
+
+
 def num_tensor_arg_nodes(node: torch.fx.Node) -> int:
     """
     For a given node, return the number of argument nodes that are associated with


### PR DESCRIPTION
Fixes #22510

## Summary
`TagMemoryMetaPass` skipped any list argument that was not composed entirely of tensor nodes. `aten.index.Tensor` reaches the edge dialect as `index.Tensor(x, [None, idx])`, so the index tensor never received a storage/memory-layout representation, and any op implementation asserting on the layout of that tensor would fail.

## Changes
- `backends/vulkan/utils.py`: added `tensor_nodes_in_arg()`, which returns the tensor nodes of an argument while skipping `None` entries.
- `backends/vulkan/_passes/tag_memory_meta_pass.py`: use the helper everywhere the pass walks a list argument —
  - `set_arg_node_repr_or_transition` skips `None` entries when tagging list args,
  - `is_non_constant_tensor_node` accepts lists whose non-`None` entries are all non-constant tensor nodes,
  - `get_arg_tensor_source_repset` / `constrain_op_arg_repset` use the first tensor node of a list as the representative instead of `arg[0]` (which could be `None`),
  - `constrain_op_repsets` now constrains args that contain at least one tensor node.

  Lists composed entirely of tensors behave exactly as before.

- `backends/vulkan/test/test_vulkan_passes.py`: regression test exporting `x[:, idx]` (with `idx` a graph input) and asserting the pass tags the index tensor node.

## Test evidence
- Reproduced the bug on `main` (897fc8e): after `TagMemoryMetaPass`, the `idx` node in `index.Tensor(x, [None, idx])` had no `node_repr`. With this fix it is tagged (`BUFFER` / `TENSOR_WIDTH_PACKED`, matching the index op's storage requirement for higher-rank `self`).
- `python -m unittest executorch.backends.vulkan.test.test_vulkan_passes`: 12 tests, all pass, including the new `test_tag_memory_meta_pass_tags_tensor_in_mixed_none_list` (verified it fails on unmodified code).
- `black --check` and `flake8 --select=E9,F` clean on all touched files.

---
This PR was authored with AI assistance (Muse).


cc @SS-JIA @manuelcandales @digantdesai @cbilgin