### PR TITLE
Change title to 'OpenVINO Backend'

### DIFF
--- a/docs/source/build-run-openvino.md
+++ b/docs/source/build-run-openvino.md
@@ -1,4 +1,4 @@
-# Building and Running ExecuTorch with OpenVINO Backend
+# OpenVINO Backend
 
 In this tutorial we will walk you through the process of setting up the prerequisites, building OpenVINO backend library, exporting `.pte` models with OpenVINO optimizations, and executing the exported models on Intel hardware.
 


### PR DESCRIPTION
Updated the title of the OpenVINO backend documentation. Keeping it uniform with other backend section titles.

Fixes #20745

cc @mergennachin