### PR TITLE
[ET-VK][q8ta-conv] Optimize narrow q8ta convolution workgroups

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.cpp
@@ -111,6 +111,7 @@ GlobalWorkGrid pick_q8ta_conv2d_gwg(
   (void)shader;
   (void)resize_args;
 
+  VK_CHECK_COND(graph != nullptr);
   const ValueRef output = args.at(0).refs.at(0);
 
   const uint32_t W = graph->size_at<uint32_t>(-1, output);
@@ -133,6 +134,7 @@ GlobalWorkGrid pick_q8ta_conv2d_gwg(
  * tensor dimensions. Uses experimentation results:
  *   - {4, 2, 8} for medium tensors: +57% improvement on 81x81
  *   - {8, 1, 8} for very large tensors: best baseline performance
+ *   - {2, 1, 32} or {4, 1, 16} for narrow output widths
  *   - {64, 1, 1} for narrow channel dimensions: minimize inactive invocations
  */
 LocalWorkGroup pick_q8ta_conv2d_lwg(
@@ -144,14 +146,13 @@ LocalWorkGroup pick_q8ta_conv2d_lwg(
   (void)shader;
   (void)resize_args;
 
+  VK_CHECK_COND(graph != nullptr);
   const ValueRef output = args.at(0).refs.at(0);
-
-  // Get actual tensor dimensions for adaptive sizing
-  const uint32_t H = graph->size_at<uint32_t>(-2, output);
+  const uint32_t output_height = graph->size_at<uint32_t>(-2, output);
 
   // For very large tensors (H >= 100 and large x/z), use {8, 1, 8}
   // This configuration performed best for 128x128 tensors in experiments
-  if (H >= 100 && gwg[0u] >= 24 && gwg[2u] >= 24) {
+  if (output_height >= 100 && gwg[0u] >= 24 && gwg[2u] >= 24) {
     return LocalWorkGroup(8u, 1u, 8u);
   }
 
@@ -159,6 +160,16 @@ LocalWorkGroup pick_q8ta_conv2d_lwg(
   // This configuration showed +57% improvement on 81x81 tensors
   if (gwg[0u] >= 4 && gwg[1u] >= 2 && gwg[2u] >= 8) {
     return LocalWorkGroup(4u, 2u, 8u);
+  }
+
+  if (gwg[0u] == 2u && gwg[2u] >= 32u) {
+    return LocalWorkGroup(2u, 1u, 32u);
+  }
+
+  // LWG x oversubscribes the 3 global groups here; safe only because the
+  // shader early-returns out-of-bounds invocations.
+  if (gwg[0u] == 3u && gwg[2u] >= 16u) {
+    return LocalWorkGroup(4u, 1u, 16u);
   }
 
   // For tensors with sufficient x and z dimensions, use square configuration

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dDW.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dDW.cpp
@@ -29,6 +29,7 @@ GlobalWorkGrid pick_q8ta_conv2d_dw_gwg(
   (void)shader;
   (void)resize_args;
 
+  VK_CHECK_COND(graph != nullptr);
   const ValueRef output = args.at(0).refs.at(0);
 
   const uint32_t W = graph->size_at<uint32_t>(-1, output);
@@ -46,6 +47,15 @@ GlobalWorkGrid pick_q8ta_conv2d_dw_gwg(
       kTiledWorkGrid);
 }
 
+/**
+ * Picks a local workgroup size for q8ta_conv2d_dw with adaptive sizing based
+ * on tensor dimensions. Uses experimentation results:
+ *   - {2, 1, 32} or {4, 1, 16} for narrow output widths
+ *
+ * Unlike the regular conv picker, there is no medium-tensor branch shadowing
+ * gwg[0] == 4, so the second narrow branch matches 3..4 (the conv picker's
+ * {4, 2, 8} branch claims gwg[0] >= 4 first, leaving only == 3 reachable).
+ */
 LocalWorkGroup pick_q8ta_conv2d_dw_lwg(
     ComputeGraph* graph,
     const vkapi::ShaderInfo& shader,
@@ -56,6 +66,16 @@ LocalWorkGroup pick_q8ta_conv2d_dw_lwg(
   (void)shader;
   (void)args;
   (void)resize_args;
+
+  if (gwg[0u] == 2u && gwg[2u] >= 32u) {
+    return LocalWorkGroup(2u, 1u, 32u);
+  }
+
+  // LWG x oversubscribes when gwg[0] is 3; safe only because the shader
+  // early-returns out-of-bounds invocations.
+  if (gwg[0u] >= 3u && gwg[0u] <= 4u && gwg[2u] >= 16u) {
+    return LocalWorkGroup(4u, 1u, 16u);
+  }
 
   // Some inactive invocations are okay; set 6 as the threshold to use the
   // a square wg size.

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <array>
+#include <functional>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -277,6 +278,40 @@ static TestCase create_test_case_from_config(
   });
 
   return test_case;
+}
+
+static std::vector<TestCase> generate_narrow_workgroup_test_cases() {
+  std::vector<TestCase> test_cases;
+  std::vector<Conv2dConfig> configs = {
+      {OutInChannels(64, 32),
+       InputSize2D(9, 9),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       1},
+      {OutInChannels(128, 32),
+       InputSize2D(7, 7),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       1},
+  };
+
+  for (auto& config : configs) {
+    const bool is_performance = config.channels.out > kRefDimSizeLimit;
+    config.op_name = "conv2d_q8ta_q8csw_q8to";
+    config.test_case_name = make_test_case_name(
+        config, is_performance, utils::kTexture3D, utils::kBuffer);
+    test_cases.push_back(create_test_case_from_config(
+        config,
+        vkapi::kFloat,
+        utils::kTexture3D,
+        utils::kPackedInt8_4C,
+        /*impl_selector=*/"general"));
+  }
+  return test_cases;
 }
 
 // Generate easy test cases for quantized conv2d operation (for debugging)
@@ -626,6 +661,12 @@ static std::vector<TestCase> generate_quantized_conv2d_test_cases() {
       test_cases.push_back(std::move(test_case));
     }
   }
+
+  auto narrow_workgroup_cases = generate_narrow_workgroup_test_cases();
+  test_cases.insert(
+      test_cases.end(),
+      narrow_workgroup_cases.begin(),
+      narrow_workgroup_cases.end());
 
   return test_cases;
 }
@@ -1037,6 +1078,7 @@ int main(int argc, char* argv[]) {
       !can_use_unsigned_pw_dot(adapter, kMaxUnsignedDotAccumulatorBytes + 1));
 
   std::string im2col_impl_selector;
+  bool narrow_workgroups_only = false;
   for (int i = 1; i < argc; ++i) {
     const std::string arg(argv[i]);
     if (arg == "--im2col-path=signed") {
@@ -1045,10 +1087,18 @@ int main(int argc, char* argv[]) {
       im2col_impl_selector = "im2col_unsigned";
     } else if (arg == "--im2col-path=auto") {
       im2col_impl_selector = "im2col_auto";
+    } else if (arg == "--narrow-workgroups-only") {
+      narrow_workgroups_only = true;
     } else {
       std::cerr << "Unknown argument: " << arg << std::endl;
       return 2;
     }
+  }
+  if (narrow_workgroups_only && !im2col_impl_selector.empty()) {
+    std::cerr
+        << "Narrow-workgroup and im2col path selectors are mutually exclusive"
+        << std::endl;
+    return 2;
   }
   set_debugging(false);
   set_print_output(false);
@@ -1067,18 +1117,23 @@ int main(int argc, char* argv[]) {
 
   ReferenceComputeFunc ref_fn = reference_impl;
 
-  // Execute test cases using the new framework with custom FLOP calculator
-  const auto test_case_generator = [im2col_impl_selector]() {
-    return im2col_impl_selector.empty()
-        ? generate_quantized_conv2d_test_cases()
-        : generate_im2col_unsigned_test_cases(im2col_impl_selector);
-  };
-  auto results = execute_test_cases(
 #ifdef DEBUG_MODE
-      generate_quantized_conv2d_easy_cases,
+  std::function<std::vector<TestCase>()> test_case_generator =
+      generate_quantized_conv2d_easy_cases;
 #else
-      test_case_generator,
+  std::function<std::vector<TestCase>()> test_case_generator =
+      [im2col_impl_selector]() {
+        return im2col_impl_selector.empty()
+            ? generate_quantized_conv2d_test_cases()
+            : generate_im2col_unsigned_test_cases(im2col_impl_selector);
+      };
 #endif
+  if (narrow_workgroups_only) {
+    test_case_generator = generate_narrow_workgroup_test_cases;
+  }
+
+  auto results = execute_test_cases(
+      test_case_generator,
       quantized_conv2d_flop_calculator,
       "QuantizedConv2dQ8ToQ8To",
       /*warmup_runs = */ 1,

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d_dw.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d_dw.cpp
@@ -22,6 +22,7 @@ using namespace executorch::vulkan::prototyping;
 using namespace vkcompute;
 
 static constexpr int64_t kRefDimSizeLimit = 100;
+static constexpr int64_t kRefOperationLimit = 2 * 1024 * 1024;
 
 // Utility function to create a test case from a Conv2dConfig for depthwise
 // convolution
@@ -271,6 +272,43 @@ std::vector<TestCase> generate_quantized_conv2d_dw_easy_cases() {
   return test_cases;
 }
 
+std::vector<TestCase> generate_quantized_conv2d_dw_narrow_workgroup_cases() {
+  std::vector<TestCase> test_cases;
+  std::vector<Conv2dConfig> configs = {
+      {OutInChannels(128, 128),
+       InputSize2D(7, 7),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       128},
+      {OutInChannels(64, 64),
+       InputSize2D(9, 9),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       64},
+      {OutInChannels(64, 64),
+       InputSize2D(13, 13),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       64},
+  };
+
+  for (auto& config : configs) {
+    const bool is_performance = config.channels.out > kRefDimSizeLimit;
+    config.op_name = "conv2d_q8ta_q8csw_q8to";
+    config.test_case_name = make_test_case_name(
+        config, is_performance, utils::kTexture3D, utils::kBuffer);
+    test_cases.push_back(create_test_case_from_config(
+        config, vkapi::kFloat, utils::kTexture3D, utils::kPackedInt8_4C));
+  }
+  return test_cases;
+}
+
 // Generate test cases for quantized depthwise conv2d operation
 std::vector<TestCase> generate_quantized_conv2d_dw_test_cases() {
   std::vector<TestCase> test_cases;
@@ -439,6 +477,13 @@ std::vector<TestCase> generate_quantized_conv2d_dw_test_cases() {
     }
   }
 
+  auto narrow_workgroup_cases =
+      generate_quantized_conv2d_dw_narrow_workgroup_cases();
+  test_cases.insert(
+      test_cases.end(),
+      narrow_workgroup_cases.begin(),
+      narrow_workgroup_cases.end());
+
   return test_cases;
 }
 
@@ -498,10 +543,14 @@ void conv2d_q8ta_q8csw_q8to_dw_reference_impl(TestCase& test_case) {
   int64_t dilation_w = dilation_data[1];
   int64_t groups = groups_spec.get_int_value();
 
-  // Skip for large tensors since computation time will be extremely slow
-  if (N > kRefDimSizeLimit || C_in > kRefDimSizeLimit ||
-      H_in > kRefDimSizeLimit || W_in > kRefDimSizeLimit ||
-      C_out > kRefDimSizeLimit) {
+  // Skip large tensors only when the reference would be expensive: each
+  // output element costs K_h * K_w MACs (one input channel per output
+  // channel), so large-dim cases with few total operations still validate.
+  const int64_t reference_operations = N * C_out * H_out * W_out * K_h * K_w;
+  const bool has_large_dimension = N > kRefDimSizeLimit ||
+      C_in > kRefDimSizeLimit || H_in > kRefDimSizeLimit ||
+      W_in > kRefDimSizeLimit || C_out > kRefDimSizeLimit;
+  if (has_large_dimension && reference_operations > kRefOperationLimit) {
     throw std::invalid_argument(
         "One or more dimensions exceed the allowed limit for reference implementation.");
   }
@@ -680,13 +729,27 @@ int main(int argc, char* argv[]) {
 
   ReferenceComputeFunc ref_fn = reference_impl;
 
-  // Execute test cases using the new framework with custom FLOP calculator
-  auto results = execute_test_cases(
+  bool narrow_workgroups_only = false;
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg(argv[i]);
+    if (arg == "--narrow-workgroups-only") {
+      narrow_workgroups_only = true;
+    } else {
+      std::cerr << "Unknown argument: " << arg << std::endl;
+      return 2;
+    }
+  }
 #ifdef DEBUG_MODE
-      generate_quantized_conv2d_dw_easy_cases,
+  auto test_case_generator = generate_quantized_conv2d_dw_easy_cases;
 #else
-      generate_quantized_conv2d_dw_test_cases,
+  auto test_case_generator = generate_quantized_conv2d_dw_test_cases;
 #endif
+  if (narrow_workgroups_only) {
+    test_case_generator = generate_quantized_conv2d_dw_narrow_workgroup_cases;
+  }
+
+  auto results = execute_test_cases(
+      test_case_generator,
       quantized_conv2d_dw_flop_calculator,
       "QuantizedDepthwiseInt8Conv2d",
       /*warmup_runs = */ 1,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22669
* #22668
* __->__ #22667

Use narrow local workgroups for regular and depthwise q8ta convolutions whose
output width underfills existing workgroups. This reduces inactive invocations
in SceneX small-spatial layers. Authored with Codex.

Differential Revision: [D119274189](https://our.internmc.facebook.com/intern/diff/D119274189/)