### PR TITLE
[ET-VK][q8ta-conv] Bound q8ta im2col scratch memory

### DIFF
--- a/backends/vulkan/runtime/graph/ComputeGraph.cpp
+++ b/backends/vulkan/runtime/graph/ComputeGraph.cpp
@@ -123,16 +123,16 @@ TmpTensor::~TmpTensor() {
 }
 
 int64_t TmpTensor::get_sobj_idx() {
-  int64_t sobj_idx;
+  int64_t idx;
   // If no available temporary shared objects, request a new one to be created
   if (graph_p->tmp_shared_object_idxs_.empty()) {
-    sobj_idx = graph_p->shared_objects_.size();
+    idx = graph_p->shared_objects_.size();
   } else {
     // Get the first available shared object idx
-    sobj_idx = graph_p->tmp_shared_object_idxs_.top();
+    idx = graph_p->tmp_shared_object_idxs_.top();
     graph_p->tmp_shared_object_idxs_.pop();
   }
-  return sobj_idx;
+  return idx;
 }
 
 //
@@ -1212,9 +1212,9 @@ void ComputeGraph::prepack() {
     shared_object.bind_users(this);
   }
   // Make sure all remaining tensors have allocations
-  for (int i = 0; i < values_.size(); i++) {
-    if (values_.at(i).isTensor()) {
-      create_dedicated_allocation_for(i);
+  for (int value_idx = 0; value_idx < values_.size(); value_idx++) {
+    if (values_.at(value_idx).isTensor()) {
+      create_dedicated_allocation_for(value_idx);
     }
   }
 }

--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_conv2d_pw.glsl
@@ -63,6 +63,7 @@ layout(push_constant) uniform restrict Block {
   int output_zp;
   int K4_per_group;
   int OC4_per_group;
+  int stream_row_offset;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -73,6 +74,9 @@ ${layout_declare_spec_const(C, "int", "activation_type", "0")}
 // Layout specialization constants
 ${layout_declare_spec_const(C, "int", "outp_layout", "CONTIG_LAYOUT_INT")}
 ${layout_declare_spec_const(C, "int", "inp_layout", "CONTIG_LAYOUT_INT")}
+// Row-tile input (im2col scratch) vs batched activation input. Uniform per
+// dispatch; declared last so existing constant ids are unchanged.
+${layout_declare_spec_const(C, "int", "use_flat_tile", "0")}
 
 int compute_outp_buffer_idx(
     const int w_block_idx,
@@ -107,9 +111,29 @@ void main() {
   const int W4 = div_up_4(int(outp.sizes[0][0]));
   const int H = int(outp.sizes[0][1]);
   const int OC4 = div_up_4(int(outp.sizes[0][2]));
-  const int hn = int(gl_GlobalInvocationID.z);
-  const int n = hn / H;
-  const int oh = hn % H;
+  const int local_row_idx = int(gl_GlobalInvocationID.z);
+  int n;
+  int oh;
+  int input_n;
+  int input_h;
+  if (use_flat_tile == 1) {
+    if (local_row_idx >= int(inp.sizes[0][1])) {
+      return;
+    }
+    const int global_row_idx = stream_row_offset + local_row_idx;
+    if (global_row_idx >= int(outp.sizes[0][3]) * H) {
+      return;
+    }
+    n = global_row_idx / H;
+    oh = global_row_idx % H;
+    input_n = 0;
+    input_h = local_row_idx;
+  } else {
+    n = local_row_idx / H;
+    oh = local_row_idx % H;
+    input_n = n;
+    input_h = oh;
+  }
 
   // Bounds check in block space
   if (ow_block_idx >= W4 ||
@@ -152,8 +176,8 @@ void main() {
   // Compute initial input tile index with group offset
   // For grouped im2col, each group's K range starts at group_idx * K4_per_group
   // For non-grouped (groups=1), group_idx is always 0 so offset is 0
-  int input_idx = n * inp_n_stride
-                + oh * inp_h_stride
+  int input_idx = input_n * inp_n_stride
+                + input_h * inp_h_stride
                 + ow_block_idx * inp_w_stride
                 + group_idx * K4_per_group;
 

--- a/backends/vulkan/runtime/graph/ops/glsl/q8ta_im2col.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/q8ta_im2col.glsl
@@ -33,6 +33,7 @@ ${layout_declare_spec_const(C, "int", "inp_layout", "CONTIG_LAYOUT_INT")}
 
 layout(push_constant) uniform restrict Block {
   int zp;
+  int stream_row_offset;
 };
 
 layout(local_size_x_id = 0, local_size_y_id = 1, local_size_z_id = 2) in;
@@ -79,24 +80,31 @@ void main() {
   const int im2col_W4 = div_up_4(im2col_sizes.x);
   const int im2col_H = im2col_sizes.y;
   const int im2col_Z4 = div_up_4(im2col_sizes.z);
-  const int im2col_N = im2col_sizes.w;
 
-  // im2col block index from linear output buffer index
+  // im2col block index from linear output buffer index. The scratch holds one
+  // row tile, so local rows are rebased onto the global batch*height rows.
   const int c4_idx = out_buf_idx % im2col_Z4;
   const int row = out_buf_idx / im2col_Z4;
   const int w4_idx = row % im2col_W4;
   const int hn_idx = row / im2col_W4;
+  const int local_row_idx = hn_idx;
   const int h_idx = hn_idx % im2col_H;
-  const int n_idx = hn_idx / im2col_H;
+  const int output_H =
+      (input_sizes.y + 2 * conv2d_params.padding.y -
+       conv2d_params.dilation.y * (conv2d_params.kernel_size.y - 1) - 1) /
+          conv2d_params.stride.y +
+      1;
+  const int global_row_idx = stream_row_offset + local_row_idx;
+  const int n_idx = global_row_idx / output_H;
 
   // out of bounds check
-  if (w4_idx >= im2col_W4 || h_idx >= im2col_H ||
-      c4_idx >= im2col_Z4 || n_idx >= im2col_N) {
+  if (w4_idx >= im2col_W4 || local_row_idx >= im2col_H ||
+      c4_idx >= im2col_Z4 || n_idx >= input_sizes.w) {
     return;
   }
 
   const int im2col_w = mul_4(w4_idx);
-  const int im2col_h = h_idx;
+  const int im2col_h = global_row_idx % output_H;
   const int im2col_k = mul_4(c4_idx);
 
   const int group_idx = im2col_k / conv2d_params.K_per_group;
@@ -167,9 +175,9 @@ void main() {
           input_Z4,
           zp_packed));
 
-  // store_packed_int8_output_tile (with TILE_M4=1, TILE_N4=1)
-  const int buffer_idx = n_idx * int(im2col_outp.strides[0][3])
-                         + h_idx * int(im2col_outp.strides[0][1])
+  // store_packed_int8_output_tile (with TILE_M4=1, TILE_N4=1). The scratch
+  // has a single batch, so every tile writes from row 0 of the same buffer.
+  const int buffer_idx = h_idx * int(im2col_outp.strides[0][1])
                          + w4_idx * int(im2col_outp.strides[0][0])
                          + c4_idx;
 

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h
@@ -14,6 +14,34 @@
 
 namespace vkcompute {
 
+inline constexpr int64_t kQ8taConv2dIm2ColScratchBudgetBytes = 16 * 1024 * 1024;
+inline constexpr int64_t kQ8taConv2dMaxRowsPerTile = 65535;
+
+struct Q8taConv2dStreamPlan final {
+  int64_t aligned_out_width;
+  int64_t rows_per_tile;
+  int64_t num_tiles;
+  int64_t scratch_bytes;
+  bool feasible;
+};
+
+Q8taConv2dStreamPlan make_q8ta_conv2d_stream_plan(
+    int64_t batch,
+    int64_t flattened_kernel_size,
+    int64_t out_height,
+    int64_t out_width,
+    int64_t scratch_budget_bytes);
+
+// max_buffer_bytes is Adapter::max_buffer_numel(), which returns
+// maxStorageBufferRange in bytes (not elements) — directly comparable with
+// the byte-denominated scratch budget.
+Q8taConv2dStreamPlan make_q8ta_conv2d_stream_plan_for_device(
+    int64_t batch,
+    int64_t flattened_kernel_size,
+    int64_t out_height,
+    int64_t out_width,
+    uint64_t max_buffer_bytes);
+
 enum class ActivationType : uint32_t {
   kNone = 0,
   kRelu = 1,
@@ -129,7 +157,10 @@ void add_q8ta_conv2d_pw_node(
     const ValueRef kernel_size = kDummyValueRef,
     const ValueRef stride = kDummyValueRef,
     const ValueRef padding = kDummyValueRef,
-    const ValueRef dilation = kDummyValueRef);
+    const ValueRef dilation = kDummyValueRef,
+    const bool is_im2col = false,
+    const ValueRef stream_row_offset_ref = kDummyValueRef,
+    const ValueRef max_im2col_rows_ref = kDummyValueRef);
 
 constexpr int64_t kMaxUnsignedDotAccumulatorBytes = 33025;
 
@@ -161,13 +192,19 @@ void add_q8ta_im2col_node(
     const ValueRef groups,
     const ValueRef packed_int8_output,
     const ValueRef packed_int8_im2col,
-    const int32_t zp);
+    const int32_t zp,
+    const ValueRef stream_row_offset_ref,
+    const ValueRef max_im2col_rows_ref = kDummyValueRef);
 
 void q8ta_conv2d_im2col(ComputeGraph& graph, const std::vector<ValueRef>& args);
 
 void q8ta_conv2d_im2col_impl(
     ComputeGraph& graph,
     bool use_unsigned_dot,
+    const std::vector<ValueRef>& args);
+
+void q8ta_conv2d_general(
+    ComputeGraph& graph,
     const std::vector<ValueRef>& args);
 
 // Transposed convolution

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dIm2Col.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dIm2Col.cpp
@@ -16,7 +16,67 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
+#include <algorithm>
+#include <limits>
+
 namespace vkcompute {
+
+Q8taConv2dStreamPlan make_q8ta_conv2d_stream_plan(
+    const int64_t batch,
+    const int64_t flattened_kernel_size,
+    const int64_t out_height,
+    const int64_t out_width,
+    const int64_t scratch_budget_bytes) {
+  Q8taConv2dStreamPlan plan{};
+  if (batch <= 0 || flattened_kernel_size <= 0 || out_height <= 0 ||
+      out_width <= 0 || scratch_budget_bytes <= 0) {
+    return plan;
+  }
+
+  constexpr int64_t kAlignment = 4;
+  if (out_width > std::numeric_limits<int64_t>::max() - (kAlignment - 1)) {
+    return plan;
+  }
+  plan.aligned_out_width =
+      (out_width + kAlignment - 1) / kAlignment * kAlignment;
+  if (flattened_kernel_size >
+      std::numeric_limits<int64_t>::max() / plan.aligned_out_width) {
+    return plan;
+  }
+  const int64_t bytes_per_row = flattened_kernel_size * plan.aligned_out_width;
+  if (bytes_per_row > scratch_budget_bytes ||
+      batch > std::numeric_limits<int64_t>::max() / out_height) {
+    return plan;
+  }
+
+  const int64_t total_rows = batch * out_height;
+  if (total_rows > std::numeric_limits<int32_t>::max()) {
+    return plan;
+  }
+  const int64_t max_rows_per_tile = std::min(
+      {total_rows,
+       scratch_budget_bytes / bytes_per_row,
+       kQ8taConv2dMaxRowsPerTile});
+  plan.num_tiles = total_rows / max_rows_per_tile +
+      static_cast<int64_t>(total_rows % max_rows_per_tile != 0);
+  plan.rows_per_tile = total_rows / plan.num_tiles +
+      static_cast<int64_t>(total_rows % plan.num_tiles != 0);
+  plan.scratch_bytes = plan.rows_per_tile * bytes_per_row;
+  plan.feasible = true;
+  return plan;
+}
+
+Q8taConv2dStreamPlan make_q8ta_conv2d_stream_plan_for_device(
+    const int64_t batch,
+    const int64_t flattened_kernel_size,
+    const int64_t out_height,
+    const int64_t out_width,
+    const uint64_t max_buffer_bytes) {
+  const int64_t scratch_budget = static_cast<int64_t>(std::min<uint64_t>(
+      kQ8taConv2dIm2ColScratchBudgetBytes, max_buffer_bytes));
+  return make_q8ta_conv2d_stream_plan(
+      batch, flattened_kernel_size, out_height, out_width, scratch_budget);
+}
 
 //
 // Shader dispatch utilities
@@ -28,21 +88,41 @@ GlobalWorkGrid pick_q8ta_im2col_gwg(
     const std::vector<ArgGroup>& args,
     const std::vector<ValueRef>& resize_args) {
   (void)shader;
-  (void)resize_args;
-
+  VK_CHECK_COND(graph != nullptr);
   const ValueRef im2col_output = args.at(0).refs.at(0);
-
-  const uint32_t N = graph->size_at<uint32_t>(-4, im2col_output);
   const uint32_t K = graph->size_at<uint32_t>(-3, im2col_output);
-  const uint32_t H = graph->size_at<uint32_t>(-2, im2col_output);
+  const uint32_t rows_per_tile = graph->size_at<uint32_t>(-2, im2col_output);
   const uint32_t W = graph->size_at<uint32_t>(-1, im2col_output);
+
+  const ValueRef input = resize_args.at(0);
+  const ValueRef kernel_size = resize_args.at(1);
+  const ValueRef stride = resize_args.at(2);
+  const ValueRef padding = resize_args.at(3);
+  const ValueRef dilation = resize_args.at(4);
+  const int64_t row_offset = graph->extract_scalar<int64_t>(resize_args.at(6));
+
+  const std::vector<int64_t> input_sizes = graph->sizes_of(input);
+  const int64_t batch = utils::val_at(-4, input_sizes);
+  const std::vector<int64_t> out_hw = calc_out_sizes_hw(
+      *graph,
+      input_sizes,
+      kernel_size,
+      /*kernel_size_only=*/true,
+      {stride, padding, dilation, dilation},
+      /*transposed=*/false);
+  const int64_t total_rows = batch * out_hw.at(0);
+  if (row_offset >= total_rows) {
+    return graph->create_linear_gwg(0u);
+  }
+  const uint32_t live_rows = utils::safe_downcast<uint32_t>(
+      std::min<int64_t>(rows_per_tile, total_rows - row_offset));
 
   const uint32_t K4 = utils::div_up_4(K);
   const uint32_t W4 = utils::div_up_4(W);
 
   // Each thread handles one 4x4 block in the output
-  return graph->create_linear_gwg(
-      utils::safe_downcast<uint32_t>(static_cast<uint64_t>(K4) * W4 * H * N));
+  return graph->create_linear_gwg(utils::safe_downcast<uint32_t>(
+      static_cast<uint64_t>(K4) * W4 * live_rows));
 }
 
 LocalWorkGroup pick_q8ta_im2col_lwg(
@@ -102,19 +182,18 @@ std::vector<int64_t> calculate_q8ta_im2col_sizes(
 // Resize
 //
 
-// resize_args = { input, kernel_size, stride, padding, dilation, groups }
+// resize_args = { input, kernel_size, stride, padding, dilation, groups,
+//                 row_offset, max_im2col_rows }
 //
-// The im2col scratch tensor is [N, K, H_out, align_up_4(W_out)] where K (the
-// flattened conv window, channel/kernel-derived) is shape-independent and
-// H_out/W_out are the conv output spatial dims. The downstream PW GEMM that
-// consumes this scratch is resized separately (it preserves H/W). Without this,
-// the scratch freezes at the build-time upper bound and feeds garbage rows into
-// the GEMM. Recompute H_out/W_out from the CURRENT input (NOT the conv output
-// tensor, which may itself still be frozen at this point in the resize order).
+// The scratch tensor is [1, K, rows_per_tile, align_up_4(W_out)]. K and
+// rows_per_tile are fixed; only W_out tracks the current input shape.
+// Batch/height growth past max im2col rows has no dispatches,
+// so fail fast instead of leaving outputs stale.
 void resize_q8ta_im2col_node(
     ComputeGraph* graph,
     const std::vector<ArgGroup>& args,
     const std::vector<ValueRef>& resize_args) {
+  VK_CHECK_COND(graph != nullptr);
   const ValueRef im2col_out = args.at(0).refs.at(0);
   const ValueRef in = resize_args.at(0);
   const ValueRef kernel_size = resize_args.at(1);
@@ -122,11 +201,11 @@ void resize_q8ta_im2col_node(
   const ValueRef padding = resize_args.at(3);
   const ValueRef dilation = resize_args.at(4);
   const ValueRef groups = resize_args.at(5);
+  const int64_t max_im2col_rows =
+      graph->extract_scalar<int64_t>(resize_args.at(7));
 
   const std::vector<int64_t> in_sizes = graph->sizes_of(in);
-  const int64_t batch = utils::val_at(-4, in_sizes);
-
-  // Conv output H/W from the current input.
+  // Conv output width from the current input.
   const std::vector<int64_t> out_hw = calc_out_sizes_hw(
       *graph,
       in_sizes,
@@ -134,7 +213,6 @@ void resize_q8ta_im2col_node(
       /*kernel_size_only=*/true,
       {stride, padding, dilation, dilation},
       /*transposed=*/false);
-  const int64_t out_height = out_hw.at(0);
   const int64_t out_width = out_hw.at(1);
 
   // K (flattened conv window) is shape-independent — recompute from channels +
@@ -149,7 +227,15 @@ void resize_q8ta_im2col_node(
   const int64_t K = flattened_kernel_len * groups_val;
   const int64_t W = utils::align_up_4(out_width);
 
-  graph->virtual_resize(im2col_out, {batch, K, out_height, W});
+  const int64_t rows_per_tile = graph->size_at<int64_t>(-2, im2col_out);
+
+  const int64_t batch = utils::val_at(-4, in_sizes);
+  const int64_t out_height = out_hw.at(0);
+  VK_CHECK_COND(
+      batch * out_height <= max_im2col_rows,
+      "q8ta im2col resize grew past max im2col rows");
+
+  graph->virtual_resize(im2col_out, {1, K, rows_per_tile, W});
 }
 
 //
@@ -166,7 +252,9 @@ void add_q8ta_im2col_node(
     const ValueRef groups,
     const ValueRef packed_int8_output,
     const ValueRef packed_int8_im2col,
-    const int32_t zp) {
+    const int32_t zp,
+    const ValueRef stream_row_offset_ref,
+    const ValueRef max_im2col_rows_ref) {
   // Validate packed dim info for input and output tensors
   VK_CHECK_COND(q8ta_conv2d_check_packed_dim_info(
       graph.packed_dim_info_of(packed_int8_input)));
@@ -195,8 +283,14 @@ void add_q8ta_im2col_node(
       graph.buffer_meta_ubo(packed_int8_input),
       graph.create_params_buffer(conv_params)};
 
+  VK_CHECK_COND(stream_row_offset_ref != kDummyValueRef);
+  VK_CHECK_COND(max_im2col_rows_ref != kDummyValueRef);
+  const int32_t stream_row_offset = utils::safe_downcast<int32_t>(
+      graph.extract_scalar<int64_t>(stream_row_offset_ref));
+
   std::vector<PushConstantDataInfo> push_constants = {
       PushConstantDataInfo(&zp, sizeof(zp)),
+      PushConstantDataInfo(&stream_row_offset, sizeof(stream_row_offset)),
   };
 
   // Build spec constants: apply_bias + layout constants (for generic shader)
@@ -212,6 +306,19 @@ void add_q8ta_im2col_node(
   //   spec_constants.append(graph.hashed_layout_of(packed_int8_im2col));
   // }
 
+  // resize_args = { input, kernel_size, stride, padding, dilation, groups,
+  //                 row_offset, max_im2col_rows }. The grid picker reads the
+  // row offset at index 6; append-only.
+  std::vector<ValueRef> resize_args = {
+      packed_int8_input,
+      kernel_size,
+      stride,
+      padding,
+      dilation,
+      groups,
+      stream_row_offset_ref,
+      max_im2col_rows_ref};
+
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
       VK_KERNEL_FROM_STR(kernel_name),
@@ -225,10 +332,7 @@ void add_q8ta_im2col_node(
       push_constants,
       // Specialization Constants
       spec_constants,
-      // Resize args: { input, kernel_size, stride, padding, dilation, groups }
-      {packed_int8_input, kernel_size, stride, padding, dilation, groups},
-      // Resizing Logic: recompute the im2col scratch dims from the current
-      // input
+      resize_args,
       resize_q8ta_im2col_node));
 }
 
@@ -257,6 +361,25 @@ void q8ta_conv2d_im2col_impl(
   const ValueRef groups = args.at(idx++);
   const ValueRef activation = args.at(idx++);
   const ValueRef packed_int8_output = args.at(idx++);
+
+  const std::vector<int64_t> full_im2col_sizes = calculate_q8ta_im2col_sizes(
+      &graph, packed_int8_input, packed_int8_output, kernel_size, groups);
+  const Q8taConv2dStreamPlan stream_plan =
+      make_q8ta_conv2d_stream_plan_for_device(
+          full_im2col_sizes.at(0),
+          full_im2col_sizes.at(1),
+          full_im2col_sizes.at(2),
+          full_im2col_sizes.at(3),
+          graph.max_buffer_numel());
+  if (!stream_plan.feasible) {
+    q8ta_conv2d_general(graph, args);
+    return;
+  }
+  VK_CHECK_COND(
+      !use_unsigned_dot ||
+          graph.size_at<int64_t>(-1, weight_data) <=
+              kMaxUnsignedDotAccumulatorBytes,
+      "Unsigned q8ta im2col convolution exceeds the accumulator bound");
 
   QuantizationConfig weight_quant_config(8, kPerChannel, {});
 
@@ -287,11 +410,15 @@ void q8ta_conv2d_im2col_impl(
   uint32_t activation_type_val = static_cast<uint32_t>(
       activation_type_from_string(graph.extract_string(activation)));
 
-  // Calculate im2col output sizes
-  std::vector<int64_t> im2col_sizes = calculate_q8ta_im2col_sizes(
-      &graph, packed_int8_input, packed_int8_output, kernel_size, groups);
+  // One fixed-size scratch buffer is reused across all row tiles; the full
+  // fit is a single tile. Interleaved write/read dispatches insert the
+  // barrier before the next tile overwrites it.
+  const std::vector<int64_t> im2col_sizes = {
+      1,
+      full_im2col_sizes.at(1),
+      stream_plan.rows_per_tile,
+      stream_plan.aligned_out_width};
 
-  // Create temporary tensor for im2col output (4W4C layout)
   TmpTensor packed_int8_im2col(
       &graph,
       im2col_sizes,
@@ -300,51 +427,59 @@ void q8ta_conv2d_im2col_impl(
       utils::kPackedInt8_4W4C);
 
   int32_t zp = graph.extract_scalar<int32_t>(input_zp);
-
-  // Step 1: Perform im2col transformation
-  add_q8ta_im2col_node(
-      graph,
-      packed_int8_input,
-      kernel_size,
-      stride,
-      padding,
-      dilation,
-      groups,
-      packed_int8_output,
-      packed_int8_im2col,
-      zp);
-
-  // Step 2: Perform pointwise convolution on the im2col result
   const int32_t groups_val = graph.extract_scalar<int32_t>(groups);
-  VK_CHECK_COND(
-      !use_unsigned_dot ||
-          graph.size_at<int64_t>(-1, weight_data) <=
-              kMaxUnsignedDotAccumulatorBytes,
-      "Unsigned q8ta im2col convolution exceeds the accumulator bound");
 
-  add_q8ta_conv2d_pw_node(
-      graph,
-      use_unsigned_dot,
-      packed_int8_im2col,
-      input_scale,
-      input_zp,
-      packed_weight,
-      packed_weight_sums,
-      packed_weight_scales,
-      output_scale,
-      output_zp,
-      bias_data,
-      packed_bias,
-      activation_type_val,
-      packed_int8_output,
-      groups_val,
-      // Original activation + conv geometry so the PW output H/W is recomputed
-      // from the true conv result, not the width-padded im2col scratch.
-      packed_int8_input,
-      kernel_size,
-      stride,
-      padding,
-      dilation);
+  // Row tiles are fixed at build time: dynamic growth past max im2col rows
+  // has no dispatches, so each resize fails fast below instead of leaving
+  // outputs stale. Shrinkage only ever lowers the total below this bound.
+  const ValueRef max_im2col_rows_ref = graph.add_scalar<int64_t>(
+      stream_plan.num_tiles * stream_plan.rows_per_tile);
+
+  for (int64_t tile = 0; tile < stream_plan.num_tiles; ++tile) {
+    const int64_t row_offset = tile * stream_plan.rows_per_tile;
+    // One row-offset scalar per tile feeds both nodes' push constants (via
+    // re-extraction) and resize args.
+    const ValueRef row_offset_ref = graph.add_scalar<int64_t>(row_offset);
+
+    add_q8ta_im2col_node(
+        graph,
+        packed_int8_input,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        groups,
+        packed_int8_output,
+        packed_int8_im2col,
+        zp,
+        row_offset_ref,
+        max_im2col_rows_ref);
+
+    add_q8ta_conv2d_pw_node(
+        graph,
+        use_unsigned_dot,
+        packed_int8_im2col,
+        input_scale,
+        input_zp,
+        packed_weight,
+        packed_weight_sums,
+        packed_weight_scales,
+        output_scale,
+        output_zp,
+        bias_data,
+        packed_bias,
+        activation_type_val,
+        packed_int8_output,
+        groups_val,
+        packed_int8_input,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        /*is_im2col=*/true,
+        row_offset_ref,
+        max_im2col_rows_ref);
+  }
 }
 
 void q8ta_conv2d_im2col(

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dPW.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dPW.cpp
@@ -14,19 +14,20 @@
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/utils/KernelUtils.h>
 #include <executorch/backends/vulkan/runtime/graph/ops/utils/ShaderNameUtils.h>
 
+#include <algorithm>
+
 namespace vkcompute {
 
 //
 // Shader dispatch utilities
 //
 
-GlobalWorkGrid pick_q8ta_conv2d_pw_gwg(
+GlobalWorkGrid pick_q8ta_conv2d_pw_gwg_impl(
     ComputeGraph* graph,
-    const vkapi::ShaderInfo& shader,
     const std::vector<ArgGroup>& args,
-    const std::vector<ValueRef>& resize_args) {
-  (void)shader;
-  (void)resize_args;
+    const std::vector<ValueRef>& resize_args,
+    const bool is_im2col_tile) {
+  VK_CHECK_COND(graph != nullptr);
 
   const ValueRef output = args.at(0).refs.at(0);
 
@@ -35,23 +36,50 @@ GlobalWorkGrid pick_q8ta_conv2d_pw_gwg(
   const uint32_t C = graph->size_at<uint32_t>(-3, output);
   const uint32_t N = graph->size_at<uint32_t>(-4, output);
 
-  // Each thread covers a 4-width x 4-channel output block.
-  // Tile constants must match TILE_M4 / TILE_N4 in q8ta_conv2d_pw.glsl.
-  constexpr uint32_t TILE_N4 = 1;
-  constexpr uint32_t TILE_M4 = 1;
-
+  // Each thread covers a 4-width x 4-channel output block, matching TILE_M4 /
+  // TILE_N4 (= 1) in q8ta_conv2d_pw.glsl.
   const uint32_t C4 = utils::div_up_4(C);
   const uint32_t W4 = utils::div_up_4(W);
 
-  // Global workgroup size:
-  // x = output channels / (TILE_N4 * 4) = C4 / TILE_N4 = C4
-  // y = width / (TILE_M4 * 4) = W4 / TILE_M4 = W4
-  // z = height * batch
-  return GlobalWorkGrid(
-      {utils::div_up(C4, TILE_N4),
-       utils::div_up(W4, TILE_M4),
-       utils::safe_downcast<uint32_t>(static_cast<uint64_t>(H) * N)},
-      kTiledWorkGrid);
+  uint32_t z;
+  if (is_im2col_tile) {
+    // The bound input is one [1, K, rows, W] scratch tile; the grid covers
+    // the live tile rows after the tile offset.
+    const ValueRef input = args.at(1).refs.at(0);
+    const uint32_t rows_per_tile = graph->size_at<uint32_t>(-2, input);
+    const int64_t row_offset =
+        graph->extract_scalar<int64_t>(resize_args.at(5));
+    const int64_t total_rows = static_cast<int64_t>(N) * H;
+    if (row_offset >= total_rows) {
+      return GlobalWorkGrid({0u, 0u, 0u}, kTiledWorkGrid);
+    }
+    z = utils::safe_downcast<uint32_t>(
+        std::min<int64_t>(rows_per_tile, total_rows - row_offset));
+  } else {
+    // The bound input is the batched activation; the grid covers every
+    // output row.
+    z = utils::safe_downcast<uint32_t>(static_cast<uint64_t>(H) * N);
+  }
+  return GlobalWorkGrid({C4, W4, z}, kTiledWorkGrid);
+}
+
+GlobalWorkGrid pick_q8ta_conv2d_pw_gwg(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)shader;
+  (void)resize_args;
+  return pick_q8ta_conv2d_pw_gwg_impl(graph, args, resize_args, false);
+}
+
+GlobalWorkGrid pick_q8ta_conv2d_pw_streaming_gwg(
+    ComputeGraph* graph,
+    const vkapi::ShaderInfo& shader,
+    const std::vector<ArgGroup>& args,
+    const std::vector<ValueRef>& resize_args) {
+  (void)shader;
+  return pick_q8ta_conv2d_pw_gwg_impl(graph, args, resize_args, true);
 }
 
 LocalWorkGroup pick_q8ta_conv2d_pw_lwg(
@@ -218,14 +246,16 @@ void resize_q8ta_conv2d_pw_node(
   graph->virtual_resize(out, new_sizes);
 }
 
-// resize_args = { conv_input, kernel_size, stride, padding, dilation }
+// resize_args = { conv_input, kernel_size, stride, padding, dilation,
+//                 row_offset, max_im2col_rows }. The grid picker reads the row
+// offset at index 5; append-only.
 //
 // im2col-path PW conv. Here the PW node's bound input is the im2col scratch
-// tensor sized {K, H_out, align_up_4(W_out)} — its width is rounded up to a
-// multiple of 4 for texel alignment, so it must NOT be used to size the output.
-// Recompute the TRUE conv H_out/W_out from the ORIGINAL activation + conv
-// geometry, exactly as resize_q8ta_conv2d_node does. N/C are shape-independent
-// and stay as currently allocated.
+// tensor sized {1, K, rows, align_up_4(W)} (one row tile) — its width is
+// rounded up to a multiple of 4 for texel alignment, so it must NOT be used
+// to size the output.
+// Recompute the true conv N/H_out/W_out from the original activation + conv
+// geometry, exactly as resize_q8ta_conv2d_node does. C is shape-independent.
 void resize_q8ta_conv2d_pw_im2col_node(
     ComputeGraph* graph,
     const std::vector<ArgGroup>& args,
@@ -236,8 +266,13 @@ void resize_q8ta_conv2d_pw_im2col_node(
   const ValueRef stride = resize_args.at(2);
   const ValueRef padding = resize_args.at(3);
   const ValueRef dilation = resize_args.at(4);
+  // Row tiles are fixed at build time: fail fast on growth past max im2col
+  // rows instead of leaving outputs stale.
+  const int64_t max_im2col_rows =
+      graph->extract_scalar<int64_t>(resize_args.at(6));
 
   const std::vector<int64_t> in_sizes = graph->sizes_of(conv_input);
+  const int64_t batch = utils::val_at(-4, in_sizes);
 
   const std::vector<int64_t> out_hw = calc_out_sizes_hw(
       *graph,
@@ -247,8 +282,13 @@ void resize_q8ta_conv2d_pw_im2col_node(
       {stride, padding, dilation, dilation},
       /*transposed=*/false);
 
+  VK_CHECK_COND(
+      batch * out_hw.at(0) <= max_im2col_rows,
+      "q8ta im2col resize grew past max im2col rows");
+
   std::vector<int64_t> new_sizes = graph->sizes_of(out);
   const size_t ndim = new_sizes.size();
+  new_sizes.at(ndim - 4) = utils::val_at(-4, in_sizes);
   new_sizes.at(ndim - 2) = out_hw.at(0);
   new_sizes.at(ndim - 1) = out_hw.at(1);
   graph->virtual_resize(out, new_sizes);
@@ -278,7 +318,10 @@ void add_q8ta_conv2d_pw_node(
     const ValueRef kernel_size,
     const ValueRef stride,
     const ValueRef padding,
-    const ValueRef dilation) {
+    const ValueRef dilation,
+    const bool is_im2col,
+    const ValueRef stream_row_offset_ref,
+    const ValueRef max_im2col_rows_ref) {
   VK_CHECK_COND(q8ta_conv2d_check_4w4c_packed_dim_info(
       graph.packed_dim_info_of(packed_int8_input)));
   VK_CHECK_COND(q8ta_conv2d_check_packed_dim_info(
@@ -304,6 +347,16 @@ void add_q8ta_conv2d_pw_node(
   int32_t output_zp_val = graph.extract_scalar<int32_t>(output_zp);
 
   uint32_t apply_bias = graph.val_is_none(bias_data) ? 0u : 1u;
+  // The tile offset lives in the graph scalar; re-extract it here so the
+  // shader push constant and the grid picker read one value. Standalone
+  // dispatches have no tile and push 0.
+  int32_t stream_row_offset = 0;
+  if (is_im2col) {
+    VK_CHECK_COND(stream_row_offset_ref != kDummyValueRef);
+    VK_CHECK_COND(max_im2col_rows_ref != kDummyValueRef);
+    stream_row_offset = utils::safe_downcast<int32_t>(
+        graph.extract_scalar<int64_t>(stream_row_offset_ref));
+  }
   std::vector<PushConstantDataInfo> push_constants = {
       PushConstantDataInfo(&input_scale_val, sizeof(input_scale_val)),
       PushConstantDataInfo(&input_zp_val, sizeof(input_zp_val)),
@@ -311,7 +364,13 @@ void add_q8ta_conv2d_pw_node(
       PushConstantDataInfo(&output_zp_val, sizeof(output_zp_val)),
       PushConstantDataInfo(&K4_per_group, sizeof(K4_per_group)),
       PushConstantDataInfo(&OC4_per_group, sizeof(OC4_per_group)),
+      PushConstantDataInfo(&stream_row_offset, sizeof(stream_row_offset)),
   };
+
+  // The im2col path consumes one flat scratch tile per dispatch; the
+  // standalone 1x1 path reads its batched activation input directly. The
+  // addressing is selected by spec constant, so both share one shader.
+  const uint32_t use_flat_tile = is_im2col ? 1u : 0u;
 
   const bool use_hw_dot =
       graph.context()->adapter_ptr()->supports_int8_dot_product();
@@ -327,6 +386,13 @@ void add_q8ta_conv2d_pw_node(
   } else {
     kernel_name = use_hw_dot ? "q8ta_conv2d_pw" : "q8ta_conv2d_pw_fallback";
   }
+  if (!use_unsigned_dot) {
+    // Signed PW kernels are only codegen'd for texture weights; a buffer
+    // weight here would fail kernel lookup at dispatch, so fail fast.
+    VK_CHECK_COND(
+        graph.storage_type_of(packed_weight) != utils::kBuffer,
+        "Signed q8ta pointwise convolution requires texture weights");
+  }
   add_dtype_suffix(kernel_name, graph.dtype_of(packed_weight_scales));
 
   vkapi::ParamsBindList param_buffers = {
@@ -338,6 +404,8 @@ void add_q8ta_conv2d_pw_node(
       activation_type,
       graph.hashed_layout_of(packed_int8_output),
       graph.hashed_layout_of(packed_int8_input),
+      // Appended last to match the use_flat_tile declaration order.
+      use_flat_tile,
   };
 
   // The im2col path passes the original activation + conv geometry so the
@@ -347,18 +415,28 @@ void add_q8ta_conv2d_pw_node(
   // output matches directly.
   std::vector<ValueRef> resize_args;
   ExecuteNode::ResizeFunction resize_fn;
-  if (conv_input == kDummyValueRef) {
+  if (!is_im2col) {
     resize_args = {packed_int8_input};
     resize_fn = resize_q8ta_conv2d_pw_node;
   } else {
-    resize_args = {conv_input, kernel_size, stride, padding, dilation};
+    resize_args = {
+        conv_input,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        stream_row_offset_ref,
+        max_im2col_rows_ref};
     resize_fn = resize_q8ta_conv2d_pw_im2col_node;
   }
+
+  const auto pick_gwg =
+      is_im2col ? pick_q8ta_conv2d_pw_streaming_gwg : pick_q8ta_conv2d_pw_gwg;
 
   graph.execute_nodes().emplace_back(new DynamicDispatchNode(
       graph,
       VK_KERNEL_FROM_STR(kernel_name),
-      pick_q8ta_conv2d_pw_gwg,
+      pick_gwg,
       pick_q8ta_conv2d_pw_lwg,
       {{packed_int8_output, vkapi::kWrite},
        {{packed_int8_input,

--- a/backends/vulkan/runtime/vk_api/Adapter.cpp
+++ b/backends/vulkan/runtime/vk_api/Adapter.cpp
@@ -350,6 +350,17 @@ Adapter::~Adapter() {
   }
 }
 
+ScopedAdapterCapabilityOverride::ScopedAdapterCapabilityOverride(
+    Adapter* adapter,
+    AdapterCapabilityOverrides overrides)
+    : adapter_(adapter), previous_(adapter->capability_overrides_) {
+  adapter_->capability_overrides_ = overrides;
+}
+
+ScopedAdapterCapabilityOverride::~ScopedAdapterCapabilityOverride() {
+  adapter_->capability_overrides_ = previous_;
+}
+
 Adapter::Queue Adapter::request_queue() {
   // Lock the mutex as multiple threads can request a queue at the same time
   std::lock_guard<std::mutex> lock(queue_usage_mutex_);

--- a/backends/vulkan/runtime/vk_api/Adapter.h
+++ b/backends/vulkan/runtime/vk_api/Adapter.h
@@ -17,6 +17,8 @@
 
 #include <executorch/backends/vulkan/runtime/vk_api/memory/Allocator.h>
 
+#include <executorch/backends/vulkan/runtime/vk_api/AdapterCapabilityOverrides.h>
+
 #include <array>
 
 namespace vkcompute {
@@ -78,6 +80,8 @@ class Adapter final {
     VkQueue handle;
   };
 
+  friend class ScopedAdapterCapabilityOverride;
+
  private:
   // Use a mutex to manage queue usage info since
   // it can be accessed from multiple threads
@@ -102,6 +106,9 @@ class Adapter final {
   // Miscellaneous
   bool linear_tiling_3d_enabled_;
   bool owns_device_;
+  // Test-only capability overrides; empty unless a ScopedCapabilityOverride
+  // is live.
+  AdapterCapabilityOverrides capability_overrides_;
 
  public:
   // Physical Device metadata
@@ -232,6 +239,9 @@ class Adapter final {
   }
 
   inline bool supports_int8_dot_product() const {
+    if (capability_overrides_.int8_dot_product.has_value()) {
+      return *capability_overrides_.int8_dot_product;
+    }
 #ifdef ETVK_FORCE_NO_EXTENSIONS
     return false;
 #endif
@@ -244,6 +254,9 @@ class Adapter final {
   }
 
   inline bool accelerates_signed_packed4x8_dot() const {
+    if (capability_overrides_.signed_packed4x8_dot.has_value()) {
+      return *capability_overrides_.signed_packed4x8_dot;
+    }
 #ifdef ETVK_FORCE_NO_EXTENSIONS
     return false;
 #endif
@@ -258,6 +271,9 @@ class Adapter final {
   }
 
   inline bool accelerates_unsigned_packed4x8_dot() const {
+    if (capability_overrides_.unsigned_packed4x8_dot.has_value()) {
+      return *capability_overrides_.unsigned_packed4x8_dot;
+    }
 #ifdef ETVK_FORCE_NO_EXTENSIONS
     return false;
 #endif

--- a/backends/vulkan/runtime/vk_api/AdapterCapabilityOverrides.h
+++ b/backends/vulkan/runtime/vk_api/AdapterCapabilityOverrides.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+
+namespace vkcompute {
+namespace vkapi {
+
+class Adapter;
+
+// Test-only device capability overrides. Each set field replaces the
+// corresponding Adapter query, simulating a weaker device so fallback paths
+// can be covered on capable hardware. Forcing a capability the device
+// lacks is undefined behavior and typically fails at pipeline creation.
+// Overrides apply to every graph built against the Adapter while set;
+// hold a ScopedAdapterCapabilityOverride to bound the scope to one test.
+// Not thread-safe: while set, every query on the Adapter observes the
+// override, so hold it only around single-test build plus execute with no
+// concurrent adapter use.
+struct AdapterCapabilityOverrides {
+  std::optional<bool> int8_dot_product;
+  std::optional<bool> signed_packed4x8_dot;
+  std::optional<bool> unsigned_packed4x8_dot;
+
+  static AdapterCapabilityOverrides without_dot_product_support() {
+    AdapterCapabilityOverrides overrides;
+    overrides.int8_dot_product = false;
+    overrides.signed_packed4x8_dot = false;
+    overrides.unsigned_packed4x8_dot = false;
+    return overrides;
+  }
+};
+
+class ScopedAdapterCapabilityOverride final {
+ public:
+  ScopedAdapterCapabilityOverride(
+      Adapter* adapter,
+      AdapterCapabilityOverrides overrides);
+  ~ScopedAdapterCapabilityOverride();
+  ScopedAdapterCapabilityOverride(const ScopedAdapterCapabilityOverride&) =
+      delete;
+  ScopedAdapterCapabilityOverride& operator=(
+      const ScopedAdapterCapabilityOverride&) = delete;
+  ScopedAdapterCapabilityOverride(ScopedAdapterCapabilityOverride&&) = delete;
+  ScopedAdapterCapabilityOverride& operator=(
+      ScopedAdapterCapabilityOverride&&) = delete;
+
+ private:
+  Adapter* adapter_;
+  AdapterCapabilityOverrides previous_;
+};
+
+} // namespace vkapi
+} // namespace vkcompute

--- a/backends/vulkan/test/custom_ops/impl/TestQ8taConv2d.cpp
+++ b/backends/vulkan/test/custom_ops/impl/TestQ8taConv2d.cpp
@@ -20,7 +20,8 @@ namespace {
 void assert_im2col_kernel_selection(
     ComputeGraph& graph,
     const bool expect_unsigned,
-    const bool expect_buffer_weights) {
+    const bool expect_buffer_weights,
+    const bool expect_fallback_kernel = false) {
   const vkapi::Adapter* const adapter = graph.context()->adapter_ptr();
   std::string expected_execute;
   std::string expected_prepack;
@@ -33,9 +34,13 @@ void assert_im2col_kernel_selection(
         : "pack_q8_linear_weight_unsigned_texture2d";
   } else {
     VK_CHECK_COND(!expect_buffer_weights);
-    expected_execute = adapter->supports_int8_dot_product()
-        ? "q8ta_conv2d_pw_float"
-        : "q8ta_conv2d_pw_fallback_float";
+    if (expect_fallback_kernel) {
+      expected_execute = "q8ta_conv2d_pw_fallback_float";
+    } else {
+      expected_execute = adapter->supports_int8_dot_product()
+          ? "q8ta_conv2d_pw_float"
+          : "q8ta_conv2d_pw_fallback_float";
+    }
     expected_prepack = "pack_q8_linear_weight_texture2d";
   }
 
@@ -311,7 +316,20 @@ void test_q8ta_conv2d(ComputeGraph& graph, const std::vector<ValueRef>& args) {
         groups,
         activation,
         packed_int8_output};
-    if (impl_selector == "im2col" || impl_selector == "im2col_unsigned" ||
+    if (impl_selector == "im2col_fallback") {
+      // Simulate a device without dot-product support so the fallback
+      // kernel is selected on any hardware.
+      vkapi::ScopedAdapterCapabilityOverride no_dot_support(
+          graph.context()->adapter_ptr(),
+          vkapi::AdapterCapabilityOverrides::without_dot_product_support());
+      q8ta_conv2d_im2col_impl(graph, /*use_unsigned_dot=*/false, conv_args);
+      assert_im2col_kernel_selection(
+          graph,
+          /*expect_unsigned=*/false,
+          /*expect_buffer_weights=*/false,
+          /*expect_fallback_kernel=*/true);
+    } else if (
+        impl_selector == "im2col" || impl_selector == "im2col_unsigned" ||
         impl_selector == "im2col_auto") {
       const vkapi::Adapter* const adapter = graph.context()->adapter_ptr();
       bool expect_unsigned = impl_selector == "im2col_unsigned";

--- a/backends/vulkan/test/custom_ops/q8ta_conv2d_stream_plan_test.cpp
+++ b/backends/vulkan/test/custom_ops/q8ta_conv2d_stream_plan_test.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+namespace vkcompute {
+namespace {
+
+constexpr int64_t kEightMiB = 8 * 1024 * 1024;
+constexpr int64_t kSixteenMiB = 16 * 1024 * 1024;
+
+TEST(Q8taConv2dStreamPlanTest, SplitsFirstSceneXConvolution) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/60,
+      /*flattened_kernel_size=*/576,
+      /*out_height=*/20,
+      /*out_width=*/26,
+      kEightMiB);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.aligned_out_width, 28);
+  EXPECT_EQ(plan.rows_per_tile, 400);
+  EXPECT_EQ(plan.num_tiles, 3);
+  EXPECT_EQ(plan.scratch_bytes, 6451200);
+}
+
+TEST(Q8taConv2dStreamPlanTest, SplitsSecondSceneXConvolution) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/60,
+      /*flattened_kernel_size=*/1152,
+      /*out_height=*/10,
+      /*out_width=*/13,
+      kEightMiB);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.aligned_out_width, 16);
+  EXPECT_EQ(plan.rows_per_tile, 300);
+  EXPECT_EQ(plan.num_tiles, 2);
+  EXPECT_EQ(plan.scratch_bytes, 5529600);
+}
+
+TEST(Q8taConv2dStreamPlanTest, UsesOneTileWhenFullScratchFits) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/2,
+      /*flattened_kernel_size=*/288,
+      /*out_height=*/7,
+      /*out_width=*/7,
+      kEightMiB);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.rows_per_tile, 14);
+  EXPECT_EQ(plan.num_tiles, 1);
+  EXPECT_EQ(plan.scratch_bytes, 32256);
+}
+
+TEST(Q8taConv2dStreamPlanTest, SelectsFullFitBelowProductionBudget) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/10,
+      /*flattened_kernel_size=*/288,
+      /*out_height=*/30,
+      /*out_width=*/99,
+      kSixteenMiB);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.rows_per_tile, 300);
+  EXPECT_EQ(plan.num_tiles, 1);
+  EXPECT_EQ(plan.scratch_bytes, 8640000);
+}
+
+TEST(Q8taConv2dStreamPlanTest, SelectsStreamingAboveProductionBudget) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/10,
+      /*flattened_kernel_size=*/576,
+      /*out_height=*/30,
+      /*out_width=*/99,
+      kSixteenMiB);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.rows_per_tile, 150);
+  EXPECT_EQ(plan.num_tiles, 2);
+  EXPECT_EQ(plan.scratch_bytes, 8640000);
+}
+
+TEST(Q8taConv2dStreamPlanTest, RejectsOneRowLargerThanBudget) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/1,
+      /*flattened_kernel_size=*/16384,
+      /*out_height=*/1,
+      /*out_width=*/513,
+      kEightMiB);
+
+  EXPECT_FALSE(plan.feasible);
+  EXPECT_EQ(plan.rows_per_tile, 0);
+  EXPECT_EQ(plan.num_tiles, 0);
+  EXPECT_EQ(plan.scratch_bytes, 0);
+}
+
+TEST(Q8taConv2dStreamPlanTest, RejectsOutputWidthAlignmentOverflow) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/1,
+      /*flattened_kernel_size=*/1,
+      /*out_height=*/1,
+      /*out_width=*/std::numeric_limits<int64_t>::max(),
+      std::numeric_limits<int64_t>::max());
+
+  EXPECT_FALSE(plan.feasible);
+}
+
+TEST(Q8taConv2dStreamPlanTest, HandlesTileCountCeilDivisionAtShaderLimit) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/std::numeric_limits<int32_t>::max(),
+      /*flattened_kernel_size=*/1,
+      /*out_height=*/1,
+      /*out_width=*/1,
+      /*scratch_budget_bytes=*/8);
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.rows_per_tile, 2);
+  EXPECT_EQ(plan.num_tiles, 1073741824);
+  EXPECT_EQ(plan.scratch_bytes, 8);
+}
+
+TEST(Q8taConv2dStreamPlanTest, RejectsRowOffsetBeyondShaderIndexRange) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/std::numeric_limits<int64_t>::max(),
+      /*flattened_kernel_size=*/1,
+      /*out_height=*/1,
+      /*out_width=*/1,
+      std::numeric_limits<int64_t>::max());
+
+  EXPECT_FALSE(plan.feasible);
+}
+
+TEST(Q8taConv2dStreamPlanTest, CapsRowsAtGuaranteedWorkgroupCountZ) {
+  const auto plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/100000,
+      /*flattened_kernel_size=*/1,
+      /*out_height=*/1,
+      /*out_width=*/1,
+      std::numeric_limits<int64_t>::max());
+
+  EXPECT_TRUE(plan.feasible);
+  EXPECT_EQ(plan.num_tiles, 2);
+  EXPECT_EQ(plan.rows_per_tile, 50000);
+  EXPECT_EQ(plan.scratch_bytes, 200000);
+}
+
+TEST(Q8taConv2dStreamPlanTest, DeviceBufferLimitMatchesActualPlan) {
+  constexpr int64_t kBytesPerRow = 576 * 28;
+  const auto rejected = make_q8ta_conv2d_stream_plan_for_device(
+      /*batch=*/60,
+      /*flattened_kernel_size=*/576,
+      /*out_height=*/20,
+      /*out_width=*/26,
+      /*max_buffer_bytes=*/kBytesPerRow - 1);
+  EXPECT_FALSE(rejected.feasible);
+
+  const auto accepted = make_q8ta_conv2d_stream_plan_for_device(
+      /*batch=*/60,
+      /*flattened_kernel_size=*/576,
+      /*out_height=*/20,
+      /*out_width=*/26,
+      /*max_buffer_bytes=*/kBytesPerRow);
+  EXPECT_TRUE(accepted.feasible);
+  EXPECT_EQ(accepted.rows_per_tile, 1);
+  EXPECT_EQ(accepted.num_tiles, 1200);
+  EXPECT_EQ(accepted.scratch_bytes, kBytesPerRow);
+}
+
+} // namespace
+} // namespace vkcompute

--- a/backends/vulkan/test/custom_ops/targets.bzl
+++ b/backends/vulkan/test/custom_ops/targets.bzl
@@ -98,6 +98,16 @@ def define_common_targets(is_fbcode = False):
         ],
     )
 
+    runtime.cxx_test(
+        name = "q8ta_conv2d_stream_plan_test",
+        srcs = ["q8ta_conv2d_stream_plan_test.cpp"],
+        platforms = get_platforms(),
+        deps = [
+            "//third-party/googletest:gtest_main",
+            "//executorch/backends/vulkan:vulkan_graph_runtime",
+        ],
+    )
+
     define_custom_op_test_binary("test_add")
     define_custom_op_test_binary("test_q8csw_linear")
     define_custom_op_test_binary("test_q8csw_conv2d")

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
@@ -46,7 +46,9 @@ static TestCase create_test_case_from_config(
     utils::StorageType fp_storage_type,
     utils::GPUMemoryLayout int8_memory_layout,
     const std::string& impl_selector = "",
-    const Im2colUnsignedTestOptions* im2col_options = nullptr) {
+    const Im2colUnsignedTestOptions* im2col_options = nullptr,
+    const float input_scale_val = 0.008123f,
+    const DataGenType input_data_gen = DataGenType::RANDOM) {
   TestCase test_case;
 
   // Calculate output dimensions
@@ -94,18 +96,12 @@ static TestCase create_test_case_from_config(
       input_dtype,
       fp_storage_type,
       fp_memory_layout,
-#ifdef DEBUG_MODE
-      DataGenType::RANDOM
-#else
-      DataGenType::RANDOM
-#endif
-  );
+      input_data_gen);
 
   if (debugging()) {
     print_valuespec_data(input_tensor, "input_tensor");
   }
 
-  float input_scale_val = 0.008123;
   ValueSpec input_scale(input_scale_val);
 
   const int32_t input_zero_point_val =
@@ -373,6 +369,123 @@ std::vector<TestCase> generate_quantized_conv2d_easy_cases() {
 
 static std::vector<TestCase> generate_im2col_unsigned_test_cases(
     const std::string& impl_selector);
+
+static std::vector<TestCase> generate_streaming_im2col_test_cases() {
+  std::vector<TestCase> test_cases;
+
+  Conv2dConfig full_fit_config = {
+      OutInChannels(4, 32),
+      InputSize2D(30, 99),
+      KernelSize(3, 3),
+      Stride(1, 1),
+      Padding(1, 1),
+      Dilation(1, 1),
+      1,
+      10};
+  full_fit_config.op_name = "conv2d_q8ta_q8csw_q8to";
+  full_fit_config.test_case_name = make_test_case_name(
+      full_fit_config, false, utils::kTexture3D, utils::kBuffer);
+
+  Conv2dConfig streaming_fallback_config = full_fit_config;
+  streaming_fallback_config.channels.in = 64;
+  streaming_fallback_config.test_case_name = make_test_case_name(
+      streaming_fallback_config, false, utils::kTexture3D, utils::kBuffer);
+
+  // Forced-fallback cases need no int8 dot-product support, so they run on
+  // all devices; the kAuto cases below stay gated.
+  test_cases.push_back(create_test_case_from_config(
+      full_fit_config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4W4C,
+      /*impl_selector=*/"im2col_fallback",
+      /*im2col_options=*/nullptr,
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT));
+  test_cases.push_back(create_test_case_from_config(
+      streaming_fallback_config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4W4C,
+      /*impl_selector=*/"im2col_fallback",
+      /*im2col_options=*/nullptr,
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT));
+
+  if (!vkcompute::api::context()->adapter_ptr()->supports_int8_dot_product()) {
+    return test_cases;
+  }
+
+  for (const utils::GPUMemoryLayout layout :
+       {utils::kPackedInt8_4C1W, utils::kPackedInt8_4W4C}) {
+    test_cases.push_back(create_test_case_from_config(
+        full_fit_config,
+        vkapi::kFloat,
+        utils::kTexture3D,
+        layout,
+        /*impl_selector=*/"im2col_auto",
+        /*im2col_options=*/nullptr,
+        /*input_scale_val=*/1.0f,
+        /*input_data_gen=*/DataGenType::RANDINT));
+  }
+  Conv2dConfig streaming_config = full_fit_config;
+  streaming_config.channels.in = 64;
+  streaming_config.test_case_name = make_test_case_name(
+      streaming_config, false, utils::kTexture3D, utils::kBuffer);
+  test_cases.push_back(create_test_case_from_config(
+      streaming_config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4C1W,
+      /*impl_selector=*/"im2col_auto",
+      /*im2col_options=*/nullptr,
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT));
+  Conv2dConfig grouped_config = {
+      OutInChannels(16, 32),
+      InputSize2D(30, 99),
+      KernelSize(3, 3),
+      Stride(1, 1),
+      Padding(1, 1),
+      Dilation(1, 1),
+      2,
+      20};
+  grouped_config.op_name = "conv2d_q8ta_q8csw_q8to";
+  grouped_config.test_case_name = make_test_case_name(
+      grouped_config, false, utils::kTexture3D, utils::kBuffer);
+  test_cases.push_back(create_test_case_from_config(
+      grouped_config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4W4C,
+      /*impl_selector=*/"im2col_auto",
+      /*im2col_options=*/nullptr,
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT));
+
+  Conv2dConfig output_channel_tail_config = {
+      OutInChannels(10, 32),
+      InputSize2D(30, 99),
+      KernelSize(3, 3),
+      Stride(1, 1),
+      Padding(1, 1),
+      Dilation(1, 1),
+      1,
+      20};
+  output_channel_tail_config.op_name = "conv2d_q8ta_q8csw_q8to";
+  output_channel_tail_config.test_case_name = make_test_case_name(
+      output_channel_tail_config, false, utils::kTexture3D, utils::kBuffer);
+  test_cases.push_back(create_test_case_from_config(
+      output_channel_tail_config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4W4C,
+      /*impl_selector=*/"im2col_auto",
+      /*im2col_options=*/nullptr,
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT));
+  return test_cases;
+}
 
 // Generate test cases for quantized conv2d operation
 static std::vector<TestCase> generate_quantized_conv2d_test_cases() {
@@ -667,6 +780,10 @@ static std::vector<TestCase> generate_quantized_conv2d_test_cases() {
       test_cases.end(),
       narrow_workgroup_cases.begin(),
       narrow_workgroup_cases.end());
+
+  auto streaming_cases = generate_streaming_im2col_test_cases();
+  test_cases.insert(
+      test_cases.end(), streaming_cases.begin(), streaming_cases.end());
 
   return test_cases;
 }
@@ -1066,6 +1183,99 @@ static int64_t quantized_conv2d_flop_calculator(const TestCase& test_case) {
   return flop;
 }
 
+static void execute_streaming_dynamic_shrink_test() {
+  Conv2dConfig config = {
+      OutInChannels(4, 64),
+      InputSize2D(30, 99),
+      KernelSize(3, 3),
+      Stride(1, 1),
+      Padding(1, 1),
+      Dilation(1, 1),
+      1,
+      10};
+  config.op_name = "conv2d_q8ta_q8csw_q8to";
+  config.test_case_name =
+      make_test_case_name(config, false, utils::kTexture3D, utils::kBuffer);
+  TestCase test_case = create_test_case_from_config(
+      config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4W4C,
+      /*impl_selector=*/"im2col_auto",
+      /*im2col_options=*/nullptr,
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT);
+  for (ValueSpec& input : test_case.inputs()) {
+    input.ensure_data_generated(/*seed=*/0);
+  }
+
+  BenchmarkGraph benchmark_graph = setup_compute_graph(
+      test_case, test_case.operator_name(), /*op_invocations_per_execute=*/1);
+  ComputeGraph& graph = *benchmark_graph.graph;
+  graph.prepare();
+  graph.prepack();
+
+  const std::vector<int64_t> upper_input_sizes = test_case.inputs().at(0).sizes;
+  const std::vector<int64_t> shrunk_input_sizes = {1, 64, 20, 51};
+  const std::vector<int64_t> shrunk_output_sizes = {1, 4, 20, 51};
+  TestCase shrunk_case = test_case;
+  shrunk_case.inputs().at(0).sizes = shrunk_input_sizes;
+  shrunk_case.inputs().at(0).resize_data(1 * 64 * 20 * 51);
+  shrunk_case.outputs().at(0).sizes = shrunk_output_sizes;
+  shrunk_case.outputs().at(0).resize_data(1 * 4 * 20 * 51);
+  reference_impl(shrunk_case);
+
+  constexpr int kRepetitions = 4;
+  for (int repetition = 0; repetition < kRepetitions; ++repetition) {
+    graph.resize_input(0, upper_input_sizes);
+    graph.propagate_resize();
+    graph.maybe_cast_and_copy_into_staging(
+        graph.inputs().at(0).staging,
+        test_case.inputs().at(0).get_data_ptr(),
+        test_case.inputs().at(0).numel(),
+        vkapi::kFloat);
+    graph.execute();
+
+    graph.resize_input(0, shrunk_input_sizes);
+    graph.propagate_resize();
+    if (graph.sizes_of(graph.outputs().at(0).value) != shrunk_output_sizes) {
+      throw std::runtime_error("streaming im2col output did not shrink");
+    }
+    graph.maybe_cast_and_copy_into_staging(
+        graph.inputs().at(0).staging,
+        shrunk_case.inputs().at(0).get_data_ptr(),
+        shrunk_case.inputs().at(0).numel(),
+        vkapi::kFloat);
+    graph.execute();
+    graph.maybe_cast_and_copy_from_staging(
+        graph.outputs().at(0).staging,
+        shrunk_case.outputs().at(0).get_mutable_data_ptr(),
+        shrunk_case.outputs().at(0).numel(),
+        vkapi::kFloat);
+    if (!shrunk_case.outputs().at(0).validate_against_reference(
+            shrunk_case.get_abs_tolerance(), shrunk_case.get_rel_tolerance())) {
+      throw std::runtime_error("streaming im2col shrink output was stale");
+    }
+  }
+
+  const Q8taConv2dStreamPlan upper_plan = make_q8ta_conv2d_stream_plan(
+      /*batch=*/10,
+      /*flattened_kernel_size=*/576,
+      /*out_height=*/30,
+      /*out_width=*/99,
+      kQ8taConv2dIm2ColScratchBudgetBytes);
+  if (!upper_plan.feasible || upper_plan.num_tiles != 2 ||
+      upper_plan.rows_per_tile <= 20) {
+    throw std::runtime_error("dynamic shrink test did not create dead tiles");
+  }
+  const int64_t resized_scratch_bytes =
+      576 * upper_plan.rows_per_tile * utils::align_up_4(51);
+  if (resized_scratch_bytes > kQ8taConv2dIm2ColScratchBudgetBytes) {
+    throw std::runtime_error("streaming im2col scratch exceeded its cap");
+  }
+  std::cout << "Streaming im2col dynamic shrink PASSED" << std::endl;
+}
+
 int main(int argc, char* argv[]) {
   const vkapi::Adapter& adapter = *vkcompute::api::context()->adapter_ptr();
   const bool prefers_unsigned_dot =
@@ -1079,6 +1289,8 @@ int main(int argc, char* argv[]) {
 
   std::string im2col_impl_selector;
   bool narrow_workgroups_only = false;
+  bool streaming_im2col_only = false;
+  bool streaming_dynamic_shrink_only = false;
   for (int i = 1; i < argc; ++i) {
     const std::string arg(argv[i]);
     if (arg == "--im2col-path=signed") {
@@ -1089,15 +1301,21 @@ int main(int argc, char* argv[]) {
       im2col_impl_selector = "im2col_auto";
     } else if (arg == "--narrow-workgroups-only") {
       narrow_workgroups_only = true;
+    } else if (arg == "--streaming-im2col-only") {
+      streaming_im2col_only = true;
+    } else if (arg == "--streaming-dynamic-shrink-only") {
+      streaming_dynamic_shrink_only = true;
     } else {
       std::cerr << "Unknown argument: " << arg << std::endl;
       return 2;
     }
   }
-  if (narrow_workgroups_only && !im2col_impl_selector.empty()) {
-    std::cerr
-        << "Narrow-workgroup and im2col path selectors are mutually exclusive"
-        << std::endl;
+  const int selected_modes = static_cast<int>(!im2col_impl_selector.empty()) +
+      static_cast<int>(narrow_workgroups_only) +
+      static_cast<int>(streaming_im2col_only) +
+      static_cast<int>(streaming_dynamic_shrink_only);
+  if (selected_modes > 1) {
+    std::cerr << "Test mode selectors are mutually exclusive" << std::endl;
     return 2;
   }
   set_debugging(false);
@@ -1117,6 +1335,10 @@ int main(int argc, char* argv[]) {
 
   ReferenceComputeFunc ref_fn = reference_impl;
 
+  if (streaming_dynamic_shrink_only) {
+    execute_streaming_dynamic_shrink_test();
+    return 0;
+  }
 #ifdef DEBUG_MODE
   std::function<std::vector<TestCase>()> test_case_generator =
       generate_quantized_conv2d_easy_cases;
@@ -1130,6 +1352,19 @@ int main(int argc, char* argv[]) {
 #endif
   if (narrow_workgroups_only) {
     test_case_generator = generate_narrow_workgroup_test_cases;
+  } else if (streaming_im2col_only) {
+    test_case_generator = generate_streaming_im2col_test_cases;
+#ifndef DEBUG_MODE
+  } else if (selected_modes == 0) {
+    // The default run also covers the unified tile path: multi-tile
+    // dispatches, grouped/streaming shapes, and the fallback kernel.
+    test_case_generator = [base_generator = test_case_generator]() {
+      auto cases = base_generator();
+      const auto streaming_cases = generate_streaming_im2col_test_cases();
+      cases.insert(cases.end(), streaming_cases.begin(), streaming_cases.end());
+      return cases;
+    };
+#endif
   }
 
   auto results = execute_test_cases(
@@ -1139,6 +1374,12 @@ int main(int argc, char* argv[]) {
       /*warmup_runs = */ 1,
       /*benchmark_runs = */ 1,
       ref_fn);
+
+#ifndef DEBUG_MODE
+  if (selected_modes == 0) {
+    execute_streaming_dynamic_shrink_test();
+  }
+#endif
 
   return 0;
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22669
* __->__ #22668
* #22667

Large or batched q8ta convolutions materialize the complete im2col tensor,
which can require hundreds of MiB. Stream flattened batch/output-height rows
through one reusable 16 MiB scratch buffer. Preserve the original one-dispatch
path when full scratch fits, and fall back to direct convolution when one row
cannot fit.

The cap was selected from 4/8/16/32 MiB device sweeps. 16 MiB is the smallest
cap without extra tiling for the representative 8.6 MiB operator and cuts
Edits Saliency uint8 VMA allocation by at least 129 MiB.

Consolidation (same commit): the full-fit case is the single-tile instance of
the streaming path, not a separate path. The scratch is always
`[1, K, rows_per_tile, align_up_4(W)]`, the full/streaming dispatch fork and
`Q8taIm2ColMode` are gone, and the pointwise shader selects flat-tile vs
batched-activation addressing with a `use_flat_tile` specialization constant
instead of a codegen variant (8 -> 4 PW variants). The standalone 1x1
pointwise path is unchanged.

Review hardening (same commit): row tiles are fixed at build time, so
dynamic batch/height growth past the tiled rows has no dispatches. Each
im2col/PW resize now fail-fasts against a build-time `max_im2col_rows`
bound (`num_tiles * rows_per_tile`) instead of leaving outputs stale;
shrinkage only ever lowers the total below the bound. Also fixes
`-Wshadow` errors in `ComputeGraph.cpp` exposed by the new test target
on Apple builds, and documents `ScopedAdapterCapabilityOverride` as not
thread-safe with deleted move operations.

Authored with Codex.

Differential Revision: [D119274190](https://our.internmc.facebook.com/intern/diff/D119274190/)