### PR TITLE
[ET-VK][q8ta-conv] Route profitable batched Mali q8ta convolutions to im2col

### DIFF
--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h>
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dRoute.h>
 
 #include <executorch/backends/vulkan/runtime/graph/ops/OperatorRegistry.h>
 
@@ -41,52 +42,6 @@ bool q8ta_conv2d_check_4w4c_packed_dim_info(const api::PackedDimInfo& info) {
       info.outer_packed_dim == WHCN::kWidthDim &&
       info.outer_packed_dim_block_size == 4;
 }
-
-namespace {
-
-uint64_t q8ta_conv2d_im2col_scratch_limit(ComputeGraph& graph) {
-  constexpr uint64_t kMaxBatchedIm2ColScratchBytes = 32ULL * 1024ULL * 1024ULL;
-  const uint64_t device_scratch_limit =
-      graph.context()->adapter_ptr()->max_buffer_numel();
-  return device_scratch_limit < kMaxBatchedIm2ColScratchBytes
-      ? device_scratch_limit
-      : kMaxBatchedIm2ColScratchBytes;
-}
-
-bool should_use_q8ta_conv2d_im2col(
-    ComputeGraph& graph,
-    const int64_t batch,
-    const int64_t groups,
-    const int64_t in_channels_per_group,
-    const int64_t flattened_kernel_size,
-    const int64_t out_height,
-    const int64_t out_width) {
-  const bool im2col_eligible = in_channels_per_group % 4 == 0;
-  if (!im2col_eligible) {
-    return false;
-  }
-
-  const int64_t spatial_out = out_height * out_width;
-  if (batch > 1) {
-    constexpr int64_t kMinFlattenedKernelSize = 1024;
-    constexpr int64_t kMaxSpatialOutput = 64;
-    const uint64_t scratch_bytes = static_cast<uint64_t>(batch) *
-        static_cast<uint64_t>(flattened_kernel_size) *
-        static_cast<uint64_t>(out_height) *
-        static_cast<uint64_t>(utils::align_up_4(out_width));
-    return groups == 1 && flattened_kernel_size >= kMinFlattenedKernelSize &&
-        spatial_out <= kMaxSpatialOutput &&
-        scratch_bytes <= q8ta_conv2d_im2col_scratch_limit(graph);
-  }
-
-  if (graph.device_is_mali()) {
-    return true;
-  }
-
-  return groups == 1 && (in_channels_per_group >= 32 || spatial_out <= 4096);
-}
-
-} // namespace
 
 //
 // Workgroup size selection functions
@@ -531,27 +486,38 @@ void q8ta_conv2d(ComputeGraph& graph, const std::vector<ValueRef>& args) {
   const ValueRef output = args.at(15);
 
   const int64_t groups = graph.extract_scalar<int64_t>(groups_ref);
+  // Valid models always carry groups >= 1; fail fast on corrupt input
+  // instead of dividing channel counts by zero downstream (both this
+  // dispatcher and q8ta_conv2d_general divide by groups).
+  VK_CHECK_COND(groups > 0, "q8ta_conv2d requires groups >= 1");
   const int64_t in_channels = graph.size_at<int64_t>(-3, input);
   const int64_t in_channels_per_group = in_channels / groups;
   const int64_t batch = graph.size_at<int64_t>(-4, input);
 
   const int64_t H_out = graph.size_at<int64_t>(-2, output);
   const int64_t W_out = graph.size_at<int64_t>(-1, output);
-  int64_t flattened_kernel_size;
+  const int64_t out_channels = graph.size_at<int64_t>(-3, output);
+  int64_t kernel_height;
+  int64_t kernel_width;
   {
     const auto kernel_size = graph.get_int_list(kernel_size_ref);
-    flattened_kernel_size = utils::align_up_4(
-        in_channels_per_group * kernel_size->at(0) * kernel_size->at(1));
+    kernel_height = kernel_size->at(0);
+    kernel_width = kernel_size->at(1);
   }
 
-  const bool use_im2col = should_use_q8ta_conv2d_im2col(
-      graph,
+  const bool use_im2col = should_use_q8ta_conv2d_im2col({
+      graph.device_is_mali(),
+      graph.can_use_int8_dot_product(),
+      static_cast<uint64_t>(graph.max_buffer_numel()),
       batch,
       groups,
       in_channels_per_group,
-      flattened_kernel_size,
+      out_channels,
+      kernel_height,
+      kernel_width,
       H_out,
-      W_out);
+      W_out,
+  });
 
   if (use_im2col) {
     q8ta_conv2d_im2col(graph, args);

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dRoute.cpp
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dRoute.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dRoute.h>
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2d.h>
+#include <executorch/backends/vulkan/runtime/utils/VecUtils.h>
+
+#include <limits>
+
+namespace vkcompute {
+
+namespace {
+
+// Computes the per-group im2col kernel columns (in-channels x kernel height
+// x kernel width, aligned up to 4) for the stream-plan sizing. Returns false
+// (leaving the output untouched) when any dimension is non-positive or an
+// intermediate product would overflow int64; callers fail closed to the
+// direct path.
+bool calculate_aligned_kernel_size(
+    const Q8taConv2dRouteParams& params,
+    int64_t& aligned_kernel_size) {
+  if (params.in_channels_per_group <= 0 || params.kernel_height <= 0 ||
+      params.kernel_width <= 0 ||
+      params.in_channels_per_group >
+          std::numeric_limits<int64_t>::max() / params.kernel_height) {
+    return false;
+  }
+  const int64_t channel_kernel_height =
+      params.in_channels_per_group * params.kernel_height;
+  if (channel_kernel_height >
+      std::numeric_limits<int64_t>::max() / params.kernel_width) {
+    return false;
+  }
+  const int64_t unaligned_kernel_size =
+      channel_kernel_height * params.kernel_width;
+  if (unaligned_kernel_size > std::numeric_limits<int64_t>::max() - 3) {
+    return false;
+  }
+  aligned_kernel_size = utils::align_up_4(unaligned_kernel_size);
+  return true;
+}
+
+} // namespace
+
+bool should_use_q8ta_conv2d_im2col(const Q8taConv2dRouteParams& params) {
+  if (params.batch <= 0 || params.groups <= 0 ||
+      params.in_channels_per_group <= 0 || params.out_channels <= 0 ||
+      params.kernel_height <= 0 || params.kernel_width <= 0 ||
+      params.out_height <= 0 || params.out_width <= 0 ||
+      params.out_height >
+          std::numeric_limits<int64_t>::max() / params.out_width) {
+    return false;
+  }
+  int64_t flattened_kernel_size;
+  if (!calculate_aligned_kernel_size(params, flattened_kernel_size)) {
+    return false;
+  }
+  const bool im2col_eligible = params.in_channels_per_group % 4 == 0;
+  if (!im2col_eligible) {
+    return false;
+  }
+  // Grouped im2col partitions output blocks per group in the PW GEMM
+  // (group_idx = oc_block / OC4_per_group), so each group must own whole
+  // packed-4 output blocks; otherwise one block straddles two groups and
+  // reads the wrong group's weights.
+  if (params.groups > 1 &&
+      (params.out_channels % params.groups != 0 ||
+       params.out_channels / params.groups % 4 != 0)) {
+    return false;
+  }
+
+  const int64_t spatial_out = params.out_height * params.out_width;
+  if (params.batch > 1) {
+    constexpr int64_t kMinFlattenedKernelSize = 1024;
+    constexpr int64_t kMaxSpatialOutput = 64;
+    // Size the probe plan with the same budget the consumer uses, so
+    // num_tiles == 1 here means a single tile at execution too.
+    const Q8taConv2dStreamPlan full_plan =
+        make_q8ta_conv2d_stream_plan_for_device(
+            params.batch,
+            flattened_kernel_size,
+            params.out_height,
+            params.out_width,
+            params.max_buffer_bytes);
+    // Device-independent fast path: a large kernel over a tiny output makes
+    // the im2col materialization negligible next to the GEMM, and a single
+    // scratch tile means no streaming overhead, so this wins on every
+    // device without needing vendor-specific tuning.
+    const bool use_single_tile_batched_im2col = params.groups == 1 &&
+        flattened_kernel_size >= kMinFlattenedKernelSize &&
+        spatial_out <= kMaxSpatialOutput && full_plan.feasible &&
+        full_plan.num_tiles == 1;
+    if (use_single_tile_batched_im2col) {
+      return true;
+    }
+
+    if (!params.is_mali) {
+      return false;
+    }
+
+    // Mali: route all eligible batched convolutions through bounded
+    // streaming im2col. The remaining guards are correctness bounds, not
+    // perf cliffs.
+    if (!params.supports_int8_dot_product ||
+        // Conservative superset of the dispatch-time unsigned-path check
+        // (which compares the unaligned weight K): reject the aligned
+        // per-group K above the accumulator bound on every int8-dot path,
+        // failing closed for signed-path shapes near the bound as well.
+        flattened_kernel_size > kMaxUnsignedDotAccumulatorBytes) {
+      return false;
+    }
+    int64_t plan_kernel_size = flattened_kernel_size;
+    if (params.groups > 1) {
+      if (plan_kernel_size >
+          std::numeric_limits<int64_t>::max() / params.groups) {
+        return false;
+      }
+      plan_kernel_size *= params.groups;
+    }
+    const Q8taConv2dStreamPlan device_plan =
+        make_q8ta_conv2d_stream_plan_for_device(
+            params.batch,
+            plan_kernel_size,
+            params.out_height,
+            params.out_width,
+            params.max_buffer_bytes);
+    return device_plan.feasible;
+  }
+
+  if (params.is_mali) {
+    return true;
+  }
+
+  // Single-batch heuristic: im2col pays off when wide channels
+  // amortize the materialization over GEMM work, or when a small output
+  // keeps the materialized buffer cheap. Anything else stays direct.
+  return params.groups == 1 &&
+      (params.in_channels_per_group >= 32 || spatial_out <= 4096);
+}
+
+} // namespace vkcompute

--- a/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dRoute.h
+++ b/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dRoute.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace vkcompute {
+
+struct Q8taConv2dRouteParams final {
+  bool is_mali;
+  bool supports_int8_dot_product;
+  // Adapter::max_buffer_numel(), which returns maxStorageBufferRange in bytes
+  // (not elements).
+  uint64_t max_buffer_bytes;
+  int64_t batch;
+  int64_t groups;
+  int64_t in_channels_per_group;
+  int64_t out_channels;
+  int64_t kernel_height;
+  int64_t kernel_width;
+  int64_t out_height;
+  int64_t out_width;
+};
+
+bool should_use_q8ta_conv2d_im2col(const Q8taConv2dRouteParams& params);
+
+} // namespace vkcompute

--- a/backends/vulkan/test/custom_ops/impl/TestQ8taConv2d.cpp
+++ b/backends/vulkan/test/custom_ops/impl/TestQ8taConv2d.cpp
@@ -252,28 +252,34 @@ void test_q8ta_conv2d(ComputeGraph& graph, const std::vector<ValueRef>& args) {
   const ValueRef dilation = args.at(idx++);
   const ValueRef groups = args.at(idx++);
   const ValueRef activation = args.at(idx++);
-  const ValueRef layout_int = args.at(idx++);
+  const ValueRef input_layout_int = args.at(idx++);
+  const ValueRef output_layout_int = args.at(idx++);
   const ValueRef impl_selector_str = args.at(idx++);
   const ValueRef fp_output = args.at(idx++);
 
   // Extract the layout parameter and cast to GPUMemoryLayout
-  int32_t layout_value = graph.extract_scalar<int32_t>(layout_int);
-  utils::GPUMemoryLayout layout =
-      static_cast<utils::GPUMemoryLayout>(layout_value);
+  const auto input_layout = static_cast<utils::GPUMemoryLayout>(
+      graph.extract_scalar<int32_t>(input_layout_int));
+  const auto output_layout = static_cast<utils::GPUMemoryLayout>(
+      graph.extract_scalar<int32_t>(output_layout_int));
 
   // Extract the impl_selector string
   std::string impl_selector = graph.extract_string(impl_selector_str);
 
   // Create temporary packed int8 tensors for input and output
   TmpTensor packed_int8_input(
-      &graph, graph.sizes_of(fp_input), vkapi::kInt8x4, utils::kBuffer, layout);
+      &graph,
+      graph.sizes_of(fp_input),
+      vkapi::kInt8x4,
+      utils::kBuffer,
+      input_layout);
 
   TmpTensor packed_int8_output(
       &graph,
       graph.sizes_of(fp_output),
       vkapi::kInt8x4,
       utils::kBuffer,
-      layout);
+      output_layout);
 
   // Quantize floating point input to packed int8
   add_q8ta_quantize_node(

--- a/backends/vulkan/test/custom_ops/q8ta_conv2d_route_test.cpp
+++ b/backends/vulkan/test/custom_ops/q8ta_conv2d_route_test.cpp
@@ -1,0 +1,473 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/vulkan/runtime/graph/ops/impl/Q8taConv2dRoute.h>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+namespace vkcompute {
+namespace {
+
+constexpr uint64_t kLargeDeviceBuffer = 1ULL << 32;
+
+Q8taConv2dRouteParams make_mali_grouped_params() {
+  return {
+      /*is_mali=*/true,
+      /*supports_int8_dot_product=*/true,
+      kLargeDeviceBuffer,
+      /*batch=*/60,
+      /*groups=*/2,
+      /*in_channels_per_group=*/32,
+      /*out_channels=*/64,
+      /*kernel_height=*/3,
+      /*kernel_width=*/3,
+      /*out_height=*/128,
+      /*out_width=*/128,
+  };
+}
+
+TEST(Q8taConv2dRouteTest, RoutesBatchedRegularMaliConvolutionToIm2Col) {
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col({
+      /*is_mali=*/true,
+      /*supports_int8_dot_product=*/true,
+      kLargeDeviceBuffer,
+      /*batch=*/60,
+      /*groups=*/1,
+      /*in_channels_per_group=*/64,
+      /*out_channels=*/128,
+      /*kernel_height=*/3,
+      /*kernel_width=*/3,
+      /*out_height=*/20,
+      /*out_width=*/26,
+  }));
+
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col({
+      /*is_mali=*/true,
+      /*supports_int8_dot_product=*/true,
+      kLargeDeviceBuffer,
+      /*batch=*/60,
+      /*groups=*/1,
+      /*in_channels_per_group=*/128,
+      /*out_channels=*/256,
+      /*kernel_height=*/3,
+      /*kernel_width=*/3,
+      /*out_height=*/10,
+      /*out_width=*/13,
+  }));
+}
+
+TEST(Q8taConv2dRouteTest, RoutesMeasuredSceneXGroupedConvolutionsToIm2Col) {
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(make_mali_grouped_params()));
+
+  Q8taConv2dRouteParams params = make_mali_grouped_params();
+  params.groups = 4;
+  params.in_channels_per_group = 32;
+  params.out_channels = 128;
+  params.kernel_height = 5;
+  params.kernel_width = 5;
+  params.out_height = 64;
+  params.out_width = 64;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+
+  params = make_mali_grouped_params();
+  params.out_height = 64;
+  params.out_width = 64;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+
+  params = make_mali_grouped_params();
+  params.groups = 3;
+  params.in_channels_per_group = 32;
+  params.out_channels = 96;
+  params.kernel_height = 4;
+  params.kernel_width = 4;
+  params.out_height = 64;
+  params.out_width = 64;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, RoutesPreviouslyOutOfEnvelopeShapesToIm2Col) {
+  Q8taConv2dRouteParams params = make_mali_grouped_params();
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+
+  params.is_mali = false;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.is_mali = true;
+  params.supports_int8_dot_product = false;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.supports_int8_dot_product = true;
+
+  // No group-count gate: regular and wide grouped shapes route alike, as
+  // long as each group owns whole packed-4 output blocks.
+  params.groups = 1;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.groups = 5;
+  params.out_channels = 80;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.groups = 2;
+  params.out_channels = 64;
+
+  // No kernel squareness/size gate.
+  params.kernel_width = 5;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.kernel_height = 2;
+  params.kernel_width = 2;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.kernel_height = 6;
+  params.kernel_width = 6;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.kernel_height = 3;
+  params.kernel_width = 3;
+
+  // Packing alignment is still required.
+  params.in_channels_per_group = 31;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.in_channels_per_group = 34;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.in_channels_per_group = 32;
+
+  // Output channels indivisible by groups fail closed.
+  params.out_channels = 63;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.out_channels = 64;
+  // No spatial window gates.
+  params.out_height = 63;
+  params.out_width = 64;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.out_height = 128;
+  params.out_width = 129;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, RejectsMisalignedGroupedOutputChannels) {
+  // The PW GEMM derives group_idx = oc_block / OC4_per_group, so a group
+  // with a non-multiple-of-4 channel count would straddle packed blocks.
+  Q8taConv2dRouteParams params = make_mali_grouped_params();
+  params.groups = 3;
+  params.out_channels = 66;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.groups = 5;
+  params.out_channels = 65;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.out_channels = 80;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, RejectsMisalignedGroupedSingleBatchMali) {
+  // The single-batch Mali branch dispatches the same grouped PW shader, so
+  // the packed-4 output-block requirement binds there too.
+  Q8taConv2dRouteParams params = make_mali_grouped_params();
+  params.batch = 1;
+  params.groups = 2;
+  params.out_channels = 66;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.out_channels = 64;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, RoutesSingleTileScratchToIm2ColOffTileToDirect) {
+  // The legacy full-scratch envelope (up to 32MiB) narrowed to a single
+  // 16MiB streaming tile. With K=1152 and 8x8 output, batch 227 needs
+  // 15.96MiB in one tile (routes im2col) while batch 228 needs 16.03MiB in
+  // two tiles (stays direct on non-Mali, though both fit the old budget).
+  auto make_params = [](int64_t batch) {
+    return Q8taConv2dRouteParams{
+        /*is_mali=*/false,
+        /*supports_int8_dot_product=*/true,
+        kLargeDeviceBuffer,
+        batch,
+        /*groups=*/1,
+        /*in_channels_per_group=*/128,
+        /*out_channels=*/128,
+        /*kernel_height=*/3,
+        /*kernel_width=*/3,
+        /*out_height=*/8,
+        /*out_width=*/8,
+    };
+  };
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(make_params(227)));
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(make_params(228)));
+}
+
+TEST(Q8taConv2dRouteTest, RespectsMaliDeviceBufferLimitForGroupedShapes) {
+  Q8taConv2dRouteParams params = make_mali_grouped_params();
+  params.groups = 4;
+  params.out_channels = 128;
+  params.kernel_height = 5;
+  params.kernel_width = 5;
+  params.out_height = 64;
+  params.out_width = 64;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+
+  // One im2col row is 3200 kernel columns x 64 aligned width bytes.
+  constexpr uint64_t kBytesPerRow = 3200 * 64;
+  params.max_buffer_bytes = kBytesPerRow;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.max_buffer_bytes = kBytesPerRow - 1;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, RejectsOverflowingMaliGroupedGeometry) {
+  Q8taConv2dRouteParams params = make_mali_grouped_params();
+  params.groups = 4;
+  params.out_channels = 128;
+  // max()/36 + 2 is 0 (mod 4), so it passes the alignment gate and reaches
+  // the grouped overflow guard: align(C*3*3) > max()/4 with groups == 4.
+  params.in_channels_per_group = std::numeric_limits<int64_t>::max() / 36 + 2;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+
+  params = make_mali_grouped_params();
+  params.out_height = std::numeric_limits<int64_t>::max();
+  params.out_width = 2;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, RejectsIneligibleBatchedMaliConvolutions) {
+  Q8taConv2dRouteParams params = {
+      /*is_mali=*/true,
+      /*supports_int8_dot_product=*/true,
+      kLargeDeviceBuffer,
+      /*batch=*/60,
+      /*groups=*/1,
+      /*in_channels_per_group=*/64,
+      /*out_channels=*/128,
+      /*kernel_height=*/3,
+      /*kernel_width=*/3,
+      /*out_height=*/20,
+      /*out_width=*/26,
+  };
+
+  // Grouped and pointwise batched shapes route alike on Mali.
+  params.groups = 2;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.groups = 1;
+  params.kernel_height = 1;
+  params.kernel_width = 1;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.kernel_height = 3;
+  params.kernel_width = 3;
+
+  // Packing alignment is still required.
+  params.in_channels_per_group = 62;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.in_channels_per_group = 64;
+
+  // Kernels past the unsigned-dot accumulator bound stay direct.
+  params.in_channels_per_group = 4096;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, RoutesSmallAndLargeBatchedShapesToIm2Col) {
+  Q8taConv2dRouteParams params = {
+      /*is_mali=*/true,
+      /*supports_int8_dot_product=*/true,
+      kLargeDeviceBuffer,
+      /*batch=*/60,
+      /*groups=*/1,
+      /*in_channels_per_group=*/32,
+      /*out_channels=*/64,
+      /*kernel_height=*/3,
+      /*kernel_width=*/3,
+      /*out_height=*/20,
+      /*out_width=*/26,
+  };
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+
+  // No kernel-size gate.
+  params.in_channels_per_group = 64;
+  params.kernel_height = 2;
+  params.kernel_width = 2;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.in_channels_per_group = 32;
+  params.kernel_height = 3;
+  params.kernel_width = 3;
+
+  params.supports_int8_dot_product = false;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.supports_int8_dot_product = true;
+  params.in_channels_per_group = 30;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.in_channels_per_group = 32;
+
+  // No output-channel or spatial window gates.
+  params.out_channels = 63;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.out_channels = 64;
+  params.out_height = 8;
+  params.out_width = 16;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.out_height = 8;
+  params.out_width = 15;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.out_height = 32;
+  params.out_width = 32;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.out_height = 1;
+  params.out_width = 521;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.out_height = 20;
+  params.out_width = 26;
+
+  // No pointwise exclusion.
+  params.in_channels_per_group = 256;
+  params.kernel_height = 1;
+  params.kernel_width = 1;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, RespectsMaliDeviceBufferLimit) {
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col({
+      /*is_mali=*/true,
+      /*supports_int8_dot_product=*/true,
+      /*max_buffer_bytes=*/15 * 1024,
+      /*batch=*/60,
+      /*groups=*/1,
+      /*in_channels_per_group=*/64,
+      /*out_channels=*/128,
+      /*kernel_height=*/3,
+      /*kernel_width=*/3,
+      /*out_height=*/20,
+      /*out_width=*/26,
+  }));
+
+  // One im2col row is 576 kernel columns x 28 aligned width bytes; the
+  // device plan is feasible down to exactly that budget.
+  constexpr uint64_t kBytesPerRow = 576 * 28;
+  Q8taConv2dRouteParams params = {
+      /*is_mali=*/true,
+      /*supports_int8_dot_product=*/true,
+      /*max_buffer_bytes=*/kBytesPerRow,
+      /*batch=*/60,
+      /*groups=*/1,
+      /*in_channels_per_group=*/64,
+      /*out_channels=*/128,
+      /*kernel_height=*/3,
+      /*kernel_width=*/3,
+      /*out_height=*/20,
+      /*out_width=*/26,
+  };
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+  params.max_buffer_bytes = kBytesPerRow - 1;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, PreservesNonMaliBatchedHeuristic) {
+  Q8taConv2dRouteParams params = {
+      /*is_mali=*/false,
+      /*supports_int8_dot_product=*/true,
+      kLargeDeviceBuffer,
+      /*batch=*/60,
+      /*groups=*/1,
+      /*in_channels_per_group=*/128,
+      /*out_channels=*/256,
+      /*kernel_height=*/3,
+      /*kernel_width=*/3,
+      /*out_height=*/10,
+      /*out_width=*/13,
+  };
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+
+  params.out_height = 8;
+  params.out_width = 8;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+
+  params.is_mali = true;
+  params.supports_int8_dot_product = false;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+
+  params.is_mali = false;
+  params.max_buffer_bytes = 1024;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, LegacyBatchedRoutePrecedesMaliExtensionGates) {
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col({
+      /*is_mali=*/true,
+      /*supports_int8_dot_product=*/false,
+      kLargeDeviceBuffer,
+      /*batch=*/2,
+      /*groups=*/1,
+      /*in_channels_per_group=*/1024,
+      /*out_channels=*/32,
+      /*kernel_height=*/1,
+      /*kernel_width=*/1,
+      /*out_height=*/8,
+      /*out_width=*/8,
+  }));
+}
+
+TEST(Q8taConv2dRouteTest, PreservesSingleBatchPolicy) {
+  Q8taConv2dRouteParams params = {
+      /*is_mali=*/true,
+      /*supports_int8_dot_product=*/true,
+      kLargeDeviceBuffer,
+      /*batch=*/1,
+      /*groups=*/4,
+      /*in_channels_per_group=*/8,
+      /*out_channels=*/32,
+      /*kernel_height=*/3,
+      /*kernel_width=*/3,
+      /*out_height=*/128,
+      /*out_width=*/128,
+  };
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+
+  params.is_mali = false;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.groups = 1;
+  params.in_channels_per_group = 32;
+  EXPECT_TRUE(should_use_q8ta_conv2d_im2col(params));
+}
+
+TEST(Q8taConv2dRouteTest, RejectsInvalidAndOverflowingGeometry) {
+  Q8taConv2dRouteParams params = {
+      /*is_mali=*/true,
+      /*supports_int8_dot_product=*/true,
+      kLargeDeviceBuffer,
+      /*batch=*/60,
+      /*groups=*/1,
+      /*in_channels_per_group=*/64,
+      /*out_channels=*/128,
+      /*kernel_height=*/3,
+      /*kernel_width=*/3,
+      /*out_height=*/20,
+      /*out_width=*/26,
+  };
+
+  params.groups = 0;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.groups = 1;
+  params.batch = 0;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.batch = 60;
+  params.out_channels = 0;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+  params.out_channels = 128;
+  params.out_height = std::numeric_limits<int64_t>::max();
+  params.out_width = 2;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+
+  params.out_height = 20;
+  params.out_width = 26;
+  params.in_channels_per_group = std::numeric_limits<int64_t>::max();
+  params.kernel_height = 2;
+  params.kernel_width = 1;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+
+  params.in_channels_per_group = 4;
+  params.kernel_height = std::numeric_limits<int64_t>::max() / 4;
+  params.kernel_width = 2;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+
+  params.in_channels_per_group = std::numeric_limits<int64_t>::max() - 2;
+  params.kernel_height = 1;
+  params.kernel_width = 1;
+  EXPECT_FALSE(should_use_q8ta_conv2d_im2col(params));
+}
+
+} // namespace
+} // namespace vkcompute

--- a/backends/vulkan/test/custom_ops/targets.bzl
+++ b/backends/vulkan/test/custom_ops/targets.bzl
@@ -108,6 +108,16 @@ def define_common_targets(is_fbcode = False):
         ],
     )
 
+    runtime.cxx_test(
+        name = "q8ta_conv2d_route_test",
+        srcs = ["q8ta_conv2d_route_test.cpp"],
+        platforms = get_platforms(),
+        deps = [
+            "//third-party/googletest:gtest_main",
+            "//executorch/backends/vulkan:vulkan_graph_runtime",
+        ],
+    )
+
     define_custom_op_test_binary("test_add")
     define_custom_op_test_binary("test_q8csw_linear")
     define_custom_op_test_binary("test_q8csw_conv2d")

--- a/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
+++ b/backends/vulkan/test/custom_ops/test_q8ta_conv2d.cpp
@@ -40,11 +40,12 @@ struct Im2colUnsignedTestOptions {
 };
 
 // Utility function to create a test case from a Conv2dConfig
-static TestCase create_test_case_from_config(
+static TestCase create_test_case_from_config_with_layouts(
     const Conv2dConfig& config,
     vkapi::ScalarType input_dtype,
     utils::StorageType fp_storage_type,
-    utils::GPUMemoryLayout int8_memory_layout,
+    utils::GPUMemoryLayout input_int8_memory_layout,
+    utils::GPUMemoryLayout output_int8_memory_layout,
     const std::string& impl_selector = "",
     const Im2colUnsignedTestOptions* im2col_options = nullptr,
     const float input_scale_val = 0.008123f,
@@ -81,7 +82,10 @@ static TestCase create_test_case_from_config(
       std::to_string(config.stride.h) + " p" +
       std::to_string(config.padding.h) + " d" +
       std::to_string(config.dilation.h) + " g" + std::to_string(config.groups);
-  std::string storage_str = repr_str(utils::kBuffer, int8_memory_layout);
+  std::string storage_str = repr_str(utils::kBuffer, input_int8_memory_layout);
+  if (input_int8_memory_layout != output_int8_memory_layout) {
+    storage_str += "->" + repr_str(utils::kBuffer, output_int8_memory_layout);
+  }
   std::string suffix = impl_selector.empty() ? "" : "[" + impl_selector + "]";
   std::string test_name = make_test_label(
       prefix, dtype_str, dtype_str, shape_str, storage_str, suffix);
@@ -252,8 +256,11 @@ static TestCase create_test_case_from_config(
   test_case.add_input_spec(activation);
 
   // Add memory layout parameter for the quantized tensors
-  ValueSpec layout_int(static_cast<int32_t>(int8_memory_layout));
-  test_case.add_input_spec(layout_int);
+  ValueSpec input_layout_int(static_cast<int32_t>(input_int8_memory_layout));
+  test_case.add_input_spec(input_layout_int);
+
+  ValueSpec output_layout_int(static_cast<int32_t>(output_int8_memory_layout));
+  test_case.add_input_spec(output_layout_int);
 
   // Add impl_selector string
   ValueSpec impl_selector_spec = ValueSpec::make_string(impl_selector);
@@ -274,6 +281,27 @@ static TestCase create_test_case_from_config(
   });
 
   return test_case;
+}
+
+static TestCase create_test_case_from_config(
+    const Conv2dConfig& config,
+    vkapi::ScalarType input_dtype,
+    utils::StorageType fp_storage_type,
+    utils::GPUMemoryLayout int8_memory_layout,
+    const std::string& impl_selector = "",
+    const Im2colUnsignedTestOptions* im2col_options = nullptr,
+    const float input_scale_val = 0.008123f,
+    const DataGenType input_data_gen = DataGenType::RANDOM) {
+  return create_test_case_from_config_with_layouts(
+      config,
+      input_dtype,
+      fp_storage_type,
+      int8_memory_layout,
+      int8_memory_layout,
+      impl_selector,
+      im2col_options,
+      input_scale_val,
+      input_data_gen);
 }
 
 static std::vector<TestCase> generate_narrow_workgroup_test_cases() {
@@ -485,6 +513,94 @@ static std::vector<TestCase> generate_streaming_im2col_test_cases() {
       /*input_scale_val=*/1.0f,
       /*input_data_gen=*/DataGenType::RANDINT));
   return test_cases;
+}
+
+// SceneX route tests. The kPackedInt8_4C input + kPackedInt8_4W4C output
+// layout combination is only exercised here (default generators never pair
+// them); run via --scenex-regular <auto|direct|im2col> <case>. Zero
+// tolerances are exact by construction: both pipelines accumulate in int32
+// with identical requantize, so any mismatch is a real regression, not noise.
+static TestCase create_scenex_test_case(
+    const Conv2dConfig& source_config,
+    const std::string& route) {
+  Conv2dConfig config = source_config;
+  config.op_name = "conv2d_q8ta_q8csw_q8to";
+  config.test_case_name =
+      make_test_case_name(config, false, utils::kTexture3D, utils::kBuffer);
+
+  const std::string impl_selector = route == "auto" ? ""
+      : route == "direct"                           ? "general"
+                                                    : "im2col";
+  TestCase test_case = create_test_case_from_config_with_layouts(
+      config,
+      vkapi::kFloat,
+      utils::kTexture3D,
+      utils::kPackedInt8_4C,
+      utils::kPackedInt8_4W4C,
+      impl_selector,
+      /*im2col_options=*/nullptr,
+      /*input_scale_val=*/1.0f,
+      /*input_data_gen=*/DataGenType::RANDINT);
+  test_case.set_abs_tolerance(0.0f);
+  test_case.set_rel_tolerance(0.0f);
+  return test_case;
+}
+
+static TestCase generate_scenex_regular_test_case(
+    const std::string& route,
+    const int case_index) {
+  const std::vector<Conv2dConfig> configs = {
+      {OutInChannels(128, 64),
+       InputSize2D(40, 51),
+       KernelSize(3, 3),
+       Stride(2, 2),
+       Padding(1, 1),
+       Dilation(1, 1),
+       1,
+       60},
+      {OutInChannels(256, 128),
+       InputSize2D(20, 26),
+       KernelSize(3, 3),
+       Stride(2, 2),
+       Padding(1, 1),
+       Dilation(1, 1),
+       1,
+       60},
+  };
+  return create_scenex_test_case(configs.at(case_index), route);
+}
+
+static TestCase generate_scenex_grouped_test_case(
+    const std::string& route,
+    const int case_index) {
+  const std::vector<Conv2dConfig> configs = {
+      {OutInChannels(64, 64),
+       InputSize2D(128, 128),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       2,
+       60},
+      {OutInChannels(128, 128),
+       InputSize2D(128, 128),
+       KernelSize(5, 5),
+       Stride(2, 2),
+       Padding(2, 2),
+       Dilation(1, 1),
+       4,
+       60},
+      {OutInChannels(64, 64),
+       InputSize2D(64, 64),
+       KernelSize(3, 3),
+       Stride(1, 1),
+       Padding(1, 1),
+       Dilation(1, 1),
+       2,
+       60},
+  };
+
+  return create_scenex_test_case(configs.at(case_index), route);
 }
 
 // Generate test cases for quantized conv2d operation
@@ -966,6 +1082,8 @@ static void conv2d_q8ta_q8csw_q8to_reference_impl(TestCase& test_case) {
   const ValueSpec& activation_spec = test_case.inputs()[idx++];
   const ValueSpec& layout_spec = test_case.inputs()[idx++];
   (void)layout_spec; // Not used in reference implementation
+  const ValueSpec& output_layout_spec = test_case.inputs()[idx++];
+  (void)output_layout_spec; // Not used in reference implementation
   const ValueSpec& impl_selector_spec = test_case.inputs()[idx++];
   (void)impl_selector_spec; // Not used in reference implementation
 
@@ -1153,6 +1271,41 @@ static void reference_impl(TestCase& test_case) {
   conv2d_q8ta_q8csw_q8to_reference_impl(test_case);
 }
 
+// The impl selector holds one of "", "general", or "im2col"; activation and
+// other string inputs use disjoint values. Overwrite it by value so a
+// reordered input list fails loudly instead of mutating the wrong spec.
+// Note: for route == "direct" the measured run already forces "general", so
+// this reference re-executes the identical implementation and only checks
+// determinism; genuine cross-implementation correctness comes from the
+// auto/im2col legs.
+static void scenex_direct_reference(TestCase& test_case) {
+  TestCase direct_case = test_case;
+  bool found_selector = false;
+  for (auto it = direct_case.inputs().rbegin();
+       it != direct_case.inputs().rend();
+       ++it) {
+    if (it->is_string() &&
+        (it->get_string_value().empty() ||
+         it->get_string_value() == "general" ||
+         it->get_string_value() == "im2col")) {
+      it->string_data = "general";
+      found_selector = true;
+      break;
+    }
+  }
+  if (!found_selector) {
+    throw std::runtime_error("scenex reference: impl selector input not found");
+  }
+  execute_test_case(
+      direct_case,
+      /*warmup_runs=*/1,
+      /*benchmark_runs=*/1,
+      /*chained_dispatches=*/1,
+      /*write_outputs=*/true);
+  test_case.outputs().at(0).get_ref_float_data() =
+      direct_case.outputs().at(0).get_float_data();
+}
+
 // Custom FLOP calculator for quantized conv2d operation
 static int64_t quantized_conv2d_flop_calculator(const TestCase& test_case) {
   int kernel_idx = 9; // kernel_size is at index 9 for q8ta_q8csw_q8to
@@ -1276,6 +1429,14 @@ static void execute_streaming_dynamic_shrink_test() {
   std::cout << "Streaming im2col dynamic shrink PASSED" << std::endl;
 }
 
+// Single usage string for the scenex route-test modes; argument errors
+// return 2 like the other CLI errors in main.
+static int print_scenex_usage(const char* mode, const char* cases) {
+  std::cerr << "Usage: " << mode << " <auto|direct|im2col> <" << cases << ">"
+            << std::endl;
+  return 2;
+}
+
 int main(int argc, char* argv[]) {
   const vkapi::Adapter& adapter = *vkcompute::api::context()->adapter_ptr();
   const bool prefers_unsigned_dot =
@@ -1291,29 +1452,44 @@ int main(int argc, char* argv[]) {
   bool narrow_workgroups_only = false;
   bool streaming_im2col_only = false;
   bool streaming_dynamic_shrink_only = false;
-  for (int i = 1; i < argc; ++i) {
-    const std::string arg(argv[i]);
-    if (arg == "--im2col-path=signed") {
-      im2col_impl_selector = "im2col";
-    } else if (arg == "--im2col-path=unsigned") {
-      im2col_impl_selector = "im2col_unsigned";
-    } else if (arg == "--im2col-path=auto") {
-      im2col_impl_selector = "im2col_auto";
-    } else if (arg == "--narrow-workgroups-only") {
-      narrow_workgroups_only = true;
-    } else if (arg == "--streaming-im2col-only") {
-      streaming_im2col_only = true;
-    } else if (arg == "--streaming-dynamic-shrink-only") {
-      streaming_dynamic_shrink_only = true;
-    } else {
-      std::cerr << "Unknown argument: " << arg << std::endl;
-      return 2;
+  const bool scenex_regular =
+      argc == 4 && std::string(argv[1]) == "--scenex-regular";
+  const bool scenex_grouped =
+      argc == 4 && std::string(argv[1]) == "--scenex-grouped";
+  if (argc >= 2 && std::string(argv[1]) == "--scenex-regular" &&
+      !scenex_regular) {
+    return print_scenex_usage("--scenex-regular", "0|1");
+  }
+  if (argc >= 2 && std::string(argv[1]) == "--scenex-grouped" &&
+      !scenex_grouped) {
+    return print_scenex_usage("--scenex-grouped", "0|1|2");
+  }
+  if (!scenex_regular && !scenex_grouped) {
+    for (int i = 1; i < argc; ++i) {
+      const std::string arg(argv[i]);
+      if (arg == "--im2col-path=signed") {
+        im2col_impl_selector = "im2col";
+      } else if (arg == "--im2col-path=unsigned") {
+        im2col_impl_selector = "im2col_unsigned";
+      } else if (arg == "--im2col-path=auto") {
+        im2col_impl_selector = "im2col_auto";
+      } else if (arg == "--narrow-workgroups-only") {
+        narrow_workgroups_only = true;
+      } else if (arg == "--streaming-im2col-only") {
+        streaming_im2col_only = true;
+      } else if (arg == "--streaming-dynamic-shrink-only") {
+        streaming_dynamic_shrink_only = true;
+      } else {
+        std::cerr << "Unknown argument: " << arg << std::endl;
+        return 2;
+      }
     }
   }
   const int selected_modes = static_cast<int>(!im2col_impl_selector.empty()) +
       static_cast<int>(narrow_workgroups_only) +
       static_cast<int>(streaming_im2col_only) +
-      static_cast<int>(streaming_dynamic_shrink_only);
+      static_cast<int>(streaming_dynamic_shrink_only) +
+      static_cast<int>(scenex_regular) + static_cast<int>(scenex_grouped);
   if (selected_modes > 1) {
     std::cerr << "Test mode selectors are mutually exclusive" << std::endl;
     return 2;
@@ -1334,6 +1510,8 @@ int main(int argc, char* argv[]) {
   print_separator();
 
   ReferenceComputeFunc ref_fn = reference_impl;
+  int warmup_runs = 1;
+  int benchmark_runs = 1;
 
   if (streaming_dynamic_shrink_only) {
     execute_streaming_dynamic_shrink_test();
@@ -1365,14 +1543,44 @@ int main(int argc, char* argv[]) {
       return cases;
     };
 #endif
+  } else if (scenex_regular) {
+    const std::string route = argv[2];
+    const std::string case_arg = argv[3];
+    if ((route != "auto" && route != "direct" && route != "im2col") ||
+        (case_arg != "0" && case_arg != "1")) {
+      return print_scenex_usage("--scenex-regular", "0|1");
+    }
+    const int case_index = case_arg == "0" ? 0 : 1;
+    test_case_generator = [route, case_index]() {
+      return std::vector<TestCase>{
+          generate_scenex_regular_test_case(route, case_index)};
+    };
+    ref_fn = scenex_direct_reference;
+    warmup_runs = 3;
+    benchmark_runs = 10;
+  } else if (scenex_grouped) {
+    const std::string route = argv[2];
+    const std::string case_arg = argv[3];
+    if ((route != "auto" && route != "direct" && route != "im2col") ||
+        (case_arg != "0" && case_arg != "1" && case_arg != "2")) {
+      return print_scenex_usage("--scenex-grouped", "0|1|2");
+    }
+    const int case_index = case_arg == "0" ? 0 : case_arg == "1" ? 1 : 2;
+    test_case_generator = [route, case_index]() {
+      return std::vector<TestCase>{
+          generate_scenex_grouped_test_case(route, case_index)};
+    };
+    ref_fn = scenex_direct_reference;
+    warmup_runs = 3;
+    benchmark_runs = 10;
   }
 
   auto results = execute_test_cases(
       test_case_generator,
       quantized_conv2d_flop_calculator,
       "QuantizedConv2dQ8ToQ8To",
-      /*warmup_runs = */ 1,
-      /*benchmark_runs = */ 1,
+      warmup_runs,
+      benchmark_runs,
       ref_fn);
 
 #ifndef DEBUG_MODE


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #22669
* #22668
* #22667

Batched regular q8ta convolutions default to direct convolution, leaving Mali
integer-dot-product throughput unused. Route the measured profitable envelope
through bounded im2col while preserving existing single-batch, legacy batched,
and non-Mali decisions.

The policy uses device capability, convolution geometry, scratch feasibility,
and tile count instead of model-specific shape allowlists.

Large batched grouped q8ta convolutions remain expensive on Mali after regular
convolutions move to im2col. Route the measured profitable grouped envelope
through bounded streaming im2col. Keep Adreno, PowerVR, legacy, and
single-batch behavior unchanged.

Require four-channel alignment within each group so packed output blocks never
cross group boundaries.

Authored with Codex.

Differential Revision: [D119408978](https://our.internmc.facebook.com/intern/diff/D119408978/)