### PR TITLE
Arm backend: Delegate constant tensor index

### DIFF
--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -606,7 +606,7 @@ class ArmPassManager(ExportedProgramPassManager):
                 DecomposeStridedSliceCopyPass(),
                 DecomposeSliceScatterPass(),
                 AccumulateIndexPutPass(),
-                DecomposeIndexTensorToGatherPass(),
+                DecomposeIndexTensorToGatherPass(exported_program),
                 DecomposeAdaptiveAvgPool2dPass(),
                 DecomposeDynamicAdaptiveAvgPool2dPass(),
                 DecomposeAvgPool2dPass(),

--- a/backends/arm/_passes/decompose_index_tensor_to_gather_pass.py
+++ b/backends/arm/_passes/decompose_index_tensor_to_gather_pass.py
@@ -10,7 +10,11 @@ from typing import Sequence, Set, Type
 import torch
 
 from executorch.backends.arm._passes import ArmOpTargetedPass
-from executorch.backends.arm._passes.arm_pass_utils import meta_without_qparams
+from executorch.backends.arm._passes.arm_pass_utils import (
+    get_param_tensor,
+    is_param_node,
+    meta_without_qparams,
+)
 from executorch.backends.arm._passes.convert_expand_copy_to_repeat import (
     ConvertExpandCopyToRepeatPass,
 )
@@ -20,6 +24,7 @@ from executorch.backends.arm._passes.convert_squeezes_to_view import (
 from executorch.backends.arm._passes.replace_scalar_with_tensor_pass import (
     ReplaceScalarWithTensorByProfilePass,
 )
+from executorch.exir import ExportedProgram
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
 
@@ -169,6 +174,12 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
         exir_ops.edge.aten.index.Tensor,
     }
 
+    def __init__(
+        self, exported_program: ExportedProgram | None = None, *args, **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.exported_program = exported_program
+
     @staticmethod
     def _shape_to_stride(
         values_shape: Sequence[int],
@@ -245,6 +256,70 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
 
         return x_data, S, W, K, C, trailing, lin_scales
 
+    def _decompose_constant_index(self, x, indices, meta):
+        tensor_indices = [
+            (dim, index) for dim, index in enumerate(indices) if index is not None
+        ]
+        if (
+            self.exported_program is None
+            or len(tensor_indices) != 1
+            or any(not isinstance(size, int) for size in x.data.shape)
+        ):
+            return None
+
+        indexed_dim, index_tensor = tensor_indices[0]
+        if not is_param_node(self.exported_program, index_tensor.node):
+            return None
+
+        constant_index = get_param_tensor(self.exported_program, index_tensor.node)
+        if (
+            constant_index is None
+            or constant_index.dim() != 1
+            or constant_index.numel() == 0
+        ):
+            return None
+
+        indexed_dim_size = x.data.shape[indexed_dim]
+        index_values = []
+        for value in constant_index.tolist():
+            normalized_value = value if value >= 0 else value + indexed_dim_size
+            if normalized_value < 0 or normalized_value >= indexed_dim_size:
+                raise IndexError(
+                    f"index {value} is out of bounds for dimension {indexed_dim} "
+                    f"with size {indexed_dim_size}"
+                )
+            index_values.append(normalized_value)
+
+        if index_values == list(
+            range(index_values[0], index_values[0] + len(index_values))
+        ):
+            return super().call_operator(
+                exir_ops.edge.aten.slice_copy.Tensor,
+                (x, indexed_dim, index_values[0], index_values[-1] + 1),
+                {},
+                meta,
+                updated=True,
+            )
+
+        slices = []
+        for index_value in index_values:
+            slices.append(
+                super().call_operator(
+                    exir_ops.edge.aten.slice_copy.Tensor,
+                    (x, indexed_dim, index_value, index_value + 1),
+                    {},
+                    meta,
+                    updated=True,
+                )
+            )
+        return super().call_operator(
+            exir_ops.edge.aten.cat.default,
+            (slices, indexed_dim),
+            {},
+            meta,
+            updated=True,
+        )
+
     def call_operator(self, op, args, kwargs, meta):
         if op not in self.target_ops:
             return super().call_operator(op, args, kwargs, meta)
@@ -254,6 +329,17 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
         ), f"[{self.__class__.__name__}] Expected 2 args for {op}, got {len(args)}."
 
         x, indices = args
+
+        tensor_indices = [index for index in indices if index is not None]
+        if len(tensor_indices) == 1 and tensor_indices[0].data.dtype in (
+            torch.bool,
+            torch.uint8,
+        ):
+            return super().call_operator(op, args, kwargs, meta)
+
+        constant_result = self._decompose_constant_index(x, indices, meta)
+        if constant_result is not None:
+            return constant_result
 
         self._validate_tensor_indices(indices)
         index_shapes = [idx.data.shape for idx in indices]

--- a/backends/arm/operator_support/ethos_u55_support.py
+++ b/backends/arm/operator_support/ethos_u55_support.py
@@ -203,7 +203,6 @@ class EthosU55NotSupported(OperatorSupportBase):
         exir_ops.edge.aten.ne.Scalar,
         exir_ops.edge.aten.gather.default,  # GATHER
         exir_ops.edge.aten.grid_sampler_2d,  # GATHER
-        exir_ops.edge.aten.index.Tensor,  # GATHER
         exir_ops.edge.aten.index_put.default,  # SCATTER
         exir_ops.edge.aten.scatter.src,
         exir_ops.edge.aten.scatter.value,
@@ -425,6 +424,53 @@ class EthosU55UnfoldCopyCheck(OperatorSupportBase):
             self.reporter.report_reject(
                 node,
                 f"U55 unfold_copy supports at most {self.max_windows} windows.",
+            )
+            return False
+
+        return True
+
+
+class EthosU55IndexTensorCheck(OperatorSupportBase):
+    """Accept single constant index.Tensor cases that lower to slices."""
+
+    def __init__(
+        self, exported_program: ExportedProgram, reporter: WhyNoPartitionReporter
+    ):
+        self.exported_program = exported_program
+        self.reporter = reporter
+
+    def is_node_supported(
+        self, submodules: typing.Mapping[str, torch.nn.Module], node: fx.Node
+    ) -> bool:
+        del submodules
+        if node.target != exir_ops.edge.aten.index.Tensor:
+            return True
+
+        input_arg, indices_arg = node.args
+        input_node = typing.cast(fx.Node, input_arg)
+        indices = typing.cast(typing.Sequence[fx.Node | None], indices_arg)
+        input_shape = get_first_fake_tensor(input_node).shape
+        tensor_indices = [index for index in indices if index is not None]
+        if len(tensor_indices) != 1:
+            self.reporter.report_reject(
+                node,
+                "U55 index.Tensor only supports indexing along one dimension but got "
+                f"{len(tensor_indices)}.",
+            )
+            return False
+
+        index_node = tensor_indices[0]
+        index_shape = get_first_fake_tensor(index_node).shape
+        if (
+            not is_param_node(self.exported_program, index_node)
+            or len(index_shape) != 1
+            or index_shape[0] == 0
+            or any(not isinstance(size, int) for size in input_shape)
+        ):
+            self.reporter.report_reject(
+                node,
+                "U55 index.Tensor requires static input shape and a nonempty "
+                "constant rank-1 index.",
             )
             return False
 

--- a/backends/arm/operator_support/index_tensor_support.py
+++ b/backends/arm/operator_support/index_tensor_support.py
@@ -108,20 +108,32 @@ class IndexTensorSupported(SupportedTOSAOperatorCheck):
         """Return True if ``aten.index.Tensor`` usage fits supported patterns.
 
         Enforces the following constraints:
-        - No ``None`` (unsqueeze), slice, or ellipsis before an indexing tensor.
+        - No ``None`` (unsqueeze), slice, or ellipsis before an indexing tensor,
+          except for the U55 constant-index lowering.
         - The value tensor element count fits in ``int32``.
 
         """
         indices = node.args[1]
-        for index in indices:  # type: ignore[union-attr]
-            # Usage 1 guard
-            if index is None:
+        if not tosa_spec.is_U55_subset and any(
+            index is None for index in indices  # type: ignore[union-attr]
+        ):
+            self.reporter.report_reject(
+                node,
+                (
+                    "None (from slice/unsqueeze/ellipsis) before an indexing tensor"
+                    " is not supported."
+                ),
+            )
+            return False
+
+        # The U55-specific check limits this to one constant tensor index.
+        for index in (
+            index for index in indices if index is not None  # type: ignore[union-attr]
+        ):
+            index_node = ensure_type(torch.fx.Node, index)
+            if get_first_fake_tensor(index_node).dtype in (torch.bool, torch.uint8):
                 self.reporter.report_reject(
-                    node,
-                    (
-                        "None (from slice/unsqueeze/ellipsis) before an indexing tensor"
-                        " is not supported."
-                    ),
+                    node, "Boolean and byte mask indices are not supported."
                 )
                 return False
 

--- a/backends/arm/operator_support/tosa_supported_operators.py
+++ b/backends/arm/operator_support/tosa_supported_operators.py
@@ -40,6 +40,7 @@ from executorch.backends.arm.operator_support.ethos_u55_support import (
     EthosU55CastCheck,
     EthosU55DtypeSupport,
     EthosU55IndexSelectCheck,
+    EthosU55IndexTensorCheck,
     EthosU55NotSupported,
     EthosU55ResizeCheck,
     EthosU55ReverseCheck,
@@ -414,6 +415,7 @@ def _negative_checks(
         checks.append(EthosU55ResizeCheck(reporter))
         checks.append(EthosU55ReverseCheck(reporter))
         checks.append(EthosU55UnfoldCopyCheck(reporter))
+        checks.append(EthosU55IndexTensorCheck(exported_program, reporter))
         checks.append(EthosU55IndexSelectCheck(exported_program, reporter))
         checks.append(EthosU55DtypeSupport(reporter))
         checks.append(EthosU55CastCheck(reporter))

--- a/backends/arm/test/misc/test_tosa_operator_support.py
+++ b/backends/arm/test/misc/test_tosa_operator_support.py
@@ -5,10 +5,14 @@
 
 import pytest
 import torch
+from executorch.backends.arm.operator_support.index_tensor_support import (
+    IndexTensorSupported,
+)
 from executorch.backends.arm.operator_support.tosa_supported_operators import (
     CheckFPComparisonInputs,
     CheckKnownUnsupportedTOSASemantics,
 )
+from executorch.backends.arm.tosa import TosaSpecification
 from executorch.exir.backend.utils import WhyNoPartitionReporter
 from executorch.exir.dialects._ops import ops as exir_ops
 from torch._subclasses.fake_tensor import FakeTensorMode
@@ -132,3 +136,19 @@ def test_rejects_argmax_with_mixed_int32_cast_and_raw_user() -> None:
     raw_user.meta["val"] = _fake_tensor((3,), torch.int64)
 
     assert not _checker().is_node_supported({}, node)
+
+
+@pytest.mark.parametrize("dtype", (torch.bool, torch.uint8))
+def test_rejects_index_tensor_mask(dtype: torch.dtype) -> None:
+    graph = torch.fx.Graph()
+    x = _placeholder(graph, "x", (5, 2, 3))
+    index = _placeholder(graph, "index", (5,), dtype)
+    node = graph.call_function(exir_ops.edge.aten.index.Tensor, (x, [index]))
+    node.meta["val"] = _fake_tensor((2, 2, 3))
+
+    checker = IndexTensorSupported(
+        TosaSpecification.create_from_string("TOSA-1.0+INT+u55"),
+        WhyNoPartitionReporter(),
+    )
+
+    assert not checker.is_node_supported({}, node)

--- a/backends/arm/test/ops/test_index_tensor.py
+++ b/backends/arm/test/ops/test_index_tensor.py
@@ -8,12 +8,15 @@ from typing import Tuple
 
 import torch
 from executorch.backends.arm.test import common
+from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
     OpNotSupportedPipeline,
     TosaPipelineFP,
     TosaPipelineINT,
     VgfPipeline,
 )
+from executorch.exir.dialects._ops import ops as exir_ops
 
 
 class IndexTensorTestCommon:
@@ -39,6 +42,46 @@ class IndexTensorInt64Buffer(torch.nn.Module):
 
     def forward(self, x: torch.Tensor):
         return x[self.index]
+
+
+class ConstantIndexTensor(torch.nn.Module):
+    def __init__(self, indices: list[int]):
+        super().__init__()
+        self.register_buffer("index", torch.tensor(indices, dtype=torch.int32))
+
+    def forward(self, x: torch.Tensor):
+        return x[self.index]
+
+
+class ConstantIndexTensorDim(torch.nn.Module):
+    def __init__(self, dim: int, indices: list[int]):
+        super().__init__()
+        self.dim = dim
+        self.register_buffer("index", torch.tensor(indices, dtype=torch.int32))
+
+    def forward(self, x: torch.Tensor):
+        indices = [slice(None)] * x.dim()
+        indices[self.dim] = self.index
+        return x[tuple(indices)]
+
+
+class ConstantTensorIndex(torch.nn.Module):
+    def __init__(self, index: torch.Tensor):
+        super().__init__()
+        self.register_buffer("index", index)
+
+    def forward(self, x: torch.Tensor):
+        return x[self.index]
+
+
+class ConstantMultiIndexTensor(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("index_0", torch.tensor([0, 1], dtype=torch.int32))
+        self.register_buffer("index_1", torch.tensor([1, 0], dtype=torch.int32))
+
+    def forward(self, x: torch.Tensor):
+        return x[self.index_0, self.index_1]
 
 
 def test_index_tensor_tosa_FP_int64_buffer_index():
@@ -622,3 +665,116 @@ def test_index_tensor_vgf_quant(test_data: input_params):
         quantize=True,
     )
     pipeline.run()
+
+
+@common.parametrize(
+    "indices",
+    {
+        "contiguous": [1, 2, 3],
+        "noncontiguous": [1, 3],
+        "descending": [3, 1],
+        "duplicate": [1, 1],
+        "negative": [-1, -3],
+    },
+)
+@common.XfailIfNoCorstone300
+def test_index_tensor_u55_INT_constant(indices):
+    pipeline = EthosU55PipelineINT[Tuple[torch.Tensor]](
+        ConstantIndexTensor(indices),
+        (torch.rand(5, 2, 3),),
+        aten_ops=[],
+        exir_ops=[],
+    )
+    pipeline.run()
+
+
+@common.parametrize(
+    "test_data",
+    {
+        "dim1_contiguous": (1, [1, 2, 3]),
+        "dim1_noncontiguous": (1, [1, 3]),
+        "dim2_descending": (2, [3, 1]),
+        "dim2_duplicate": (2, [1, 1]),
+        "dim2_negative": (2, [-1, -3]),
+    },
+)
+@common.XfailIfNoCorstone300
+def test_index_tensor_u55_INT_constant_later_dim(test_data):
+    dim, indices = test_data
+    pipeline = EthosU55PipelineINT[Tuple[torch.Tensor]](
+        ConstantIndexTensorDim(dim, indices),
+        (torch.rand(5, 5, 5),),
+        aten_ops=[],
+        exir_ops=[],
+    )
+    pipeline.run()
+
+
+@common.XfailIfNoCorstone300
+def test_index_tensor_u55_INT_constant_a16w8():
+    pipeline = EthosU55PipelineINT[Tuple[torch.Tensor]](
+        ConstantIndexTensor([1, 2, 3]),
+        (torch.rand(5, 2, 3),),
+        aten_ops=[],
+        exir_ops=[],
+        a16w8_quantization=True,
+    )
+    pipeline.run()
+
+
+def test_index_tensor_u55_INT_constant_empty_not_delegated():
+    pipeline = OpNotSupportedPipeline[Tuple[torch.Tensor]](
+        ConstantIndexTensor([]),
+        (torch.rand(5, 2, 3),),
+        {IndexTensorTestCommon.exir_op: 1},
+        quantize=True,
+        u55_subset=True,
+    )
+    pipeline.run()
+
+
+def test_index_tensor_u55_INT_constant_multi_not_delegated():
+    pipeline = OpNotSupportedPipeline[Tuple[torch.Tensor]](
+        ConstantMultiIndexTensor(),
+        (torch.rand(5, 2, 3),),
+        {IndexTensorTestCommon.exir_op: 1},
+        quantize=True,
+        u55_subset=True,
+    )
+    pipeline.run()
+
+
+@common.parametrize(
+    "index",
+    {
+        "multidimensional": torch.tensor([[0, 1]], dtype=torch.int32),
+        "boolean": torch.tensor([False, True, False, True, False]),
+    },
+)
+def test_index_tensor_u55_INT_constant_shape_or_dtype_not_delegated(index):
+    pipeline = OpNotSupportedPipeline[Tuple[torch.Tensor]](
+        ConstantTensorIndex(index),
+        (torch.rand(5, 2, 3),),
+        {IndexTensorTestCommon.exir_op: 1},
+        quantize=True,
+        u55_subset=True,
+    )
+    pipeline.run()
+
+
+def test_index_tensor_u55_INT_constant_symbolic_dim_not_delegated():
+    indexed_dim = torch.export.Dim("indexed_dim", min=4, max=8)
+    tester = ArmTester(
+        ConstantIndexTensor([1, 2, 3]),
+        (torch.rand(5, 2, 3),),
+        common.get_u55_compile_spec(),
+        dynamic_shapes={"x": {0: indexed_dim}},
+    )
+    tester.quantize().export().to_edge().partition()
+
+    targets = {
+        node.target
+        for node in tester.stages[tester.cur].artifact.exported_program().graph.nodes
+    }
+    assert exir_ops.edge.aten.index.Tensor in targets
+    assert torch.ops.higher_order.executorch_call_delegate not in targets

--- a/backends/arm/test/passes/test_decompose_index_tensor_to_gather_pass.py
+++ b/backends/arm/test/passes/test_decompose_index_tensor_to_gather_pass.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Arm Limited and/or its affiliates.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+from executorch.backends.arm._passes.decompose_index_tensor_to_gather_pass import (
+    DecomposeIndexTensorToGatherPass,
+)
+from executorch.backends.arm.tosa.specification import (
+    TosaLoweringContext,
+    TosaSpecification,
+)
+from executorch.exir import to_edge
+from torch.export import export
+
+
+class ConstantIndexTensor(torch.nn.Module):
+    def __init__(self, dim: int, index: int):
+        super().__init__()
+        self.dim = dim
+        self.index: torch.Tensor
+        self.register_buffer("index", torch.tensor([index], dtype=torch.int32))
+
+    def forward(self, x: torch.Tensor):
+        indices: list[slice | torch.Tensor] = [slice(None)] * x.dim()
+        indices[self.dim] = self.index
+        return x[tuple(indices)]
+
+
+@pytest.mark.parametrize(
+    "dim,index",
+    (
+        (0, 5),
+        (1, -6),
+    ),
+)
+def test_constant_out_of_bounds_index_raises(dim: int, index: int):
+    exported_program = export(
+        ConstantIndexTensor(dim, index),
+        (torch.rand(5, 5, 5),),
+    )
+    edge_program = to_edge(exported_program)
+    edge_exported_program = edge_program.exported_program()
+    decompose_pass = DecomposeIndexTensorToGatherPass(edge_exported_program)
+
+    with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+INT")):
+        with pytest.raises(
+            IndexError,
+            match=rf"index {index} is out of bounds for dimension {dim} with size 5",
+        ):
+            decompose_pass(edge_exported_program.graph_module)


### PR DESCRIPTION
Lower U55 index.Tensor operations with one constant rank-1 integer index to slices and optional concatenation, including indices on non-leading dimensions.

Keep runtime, empty, mask, rank>1, multiple-index, and symbolic-shape cases on the CPU. Reject out-of-range constants during preprocessing.

Authored with Codex.


Change-Id: Ib16e1c800b3517d054c77cfde39639de6f8b9369


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani