### PR TITLE
Arm backend: Support leading full slices in index.Tensor

### DIFF
--- a/backends/arm/_passes/decompose_index_tensor_to_gather_pass.py
+++ b/backends/arm/_passes/decompose_index_tensor_to_gather_pass.py
@@ -30,7 +30,7 @@ from executorch.exir.pass_base import ExportPass
 
 
 def get_index_tensor_decomposition(op):
-    """Return the operator overloads used to lower index.Tensor via TOSA gather.
+    """Return operators used to lower index.Tensor through TOSA gather.
 
     Raises:
         RuntimeError: If the provided operator is not supported by this pass.
@@ -53,12 +53,12 @@ def get_index_tensor_decomposition(op):
 def _broadcast_shape(
     shapes: Sequence[Sequence[int]],
 ) -> list[int]:
-    """Compute the broadcasted shape (PyTorch/Numpy semantics) for a list of
-    shapes.
+    """Compute the broadcasted shape using PyTorch/NumPy semantics.
 
     Requirements:
       - static shape only
-      - shapes are right-aligned; lower-rank shapes are implicitly front-padded with 1s
+      - shapes are right-aligned; lower-rank shapes are implicitly
+        front-padded with 1s
       - per-axis dims must either match exactly or be 1
 
     Raises:
@@ -81,86 +81,121 @@ def _broadcast_shape(
 
 
 class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
-    """Decompose edge.aten.index.Tensor into backend TOSA gather (+ basic
-    arith).
+    """Decompose edge.aten.index.Tensor into a TOSA gather and arithmetic.
 
     Supported subset:
-      y = x.index([i0, i1, ..., i{m-1}])
+      y = x.index([None, ..., None, i0, i1, ..., i{m-1}])
 
-    where each ik is a Tensor index, and m is the number of index tensors.
+    where each ik is a Tensor index, m is the number of index tensors, and the
+    optional leading None entries preserve dimensions before the indexed block.
 
     Constraints:
-      - `indices` list contains only Tensor indices (no None/slice/ellipsis)
+      - `indices` contains an optional leading run of None entries followed by
+        only Tensor indices
       - Each index tensor dtype is int32
-      - Index tensor shapes are broadcastable to a common shape `S` (per index.Tensor semantics)
-      - Only prefix indexing is supported: the `m` tensor indices select elements
-            from the first `m` dimensions of `x`, so `m <= rank(x)`.
+      - Index tensor shapes are broadcastable to a common shape `S` (per
+        index.Tensor semantics)
+      - The `m` tensor indices select one contiguous block of dimensions after
+        the leading preserved dimensions.
       - Static shapes are required
-      - If `x` has more than 2^31 elements, the computed linear index may overflow int32.
+      - If `x` has more than 2^31 elements, the computed linear index may
+        overflow int32.
 
     Lowering strategy (single gather)
     ---------------------------------
     Let:
+      - `p` be the number of leading None entries
       - `S` be the broadcasted index shape
       - `W = prod(S)` (number of indexed positions)
-      - `K = prod(x.shape[:m])` (flattened size of the indexed prefix)
-      - `C = prod(x.shape[m:])` (flattened size of the trailing slice per index)
-      - `trailing = x.shape[m:]`
+      - `P = prod(x.shape[:p])` (flattened size of the leading preserved
+        dimensions)
+      - `K = prod(x.shape[p:p+m])` (flattened size of the indexed block)
+      - `C = prod(x.shape[p+m:])` (flattened size of the trailing slice per
+        index)
+      - `leading = x.shape[:p]` and `trailing = x.shape[p+m:]`
 
     Steps:
     1) Compute parameters needed to lower index.Tensor
-         - `S`, `W`, `K`, `C`, `trailing`
-         - `lin_scales[i] = stride_i // C`, where `stride_i` are the contiguous-style
-           strides derived from `x.shape` (for dim i).
-    2) Reshape x to `[1, K, C]` (`x_1kc`).
-    3) Build linear indices (`lin_1w`) by scaling each flattened index and summing:
-         lin_1w = unsqueeze0( sum_{i=0..m-1} ( idx_flat[i] * lin_scales[i] ) )
-       where:
-         - `m = len(indices)`
-         - `idx_flat[i]` is the i-th index tensor after broadcast to `S` and flatten to `[W]`
-         - `lin_1w` has shape `[1, W]` and is used as the `indices` input to `tosa.GATHER`
-    4) Single gather:
-         `tosa.GATHER(x=x_1kc, indices=lin_1w) -> [1,W,C]`
-    5) Reshape result to `[*S, *trailing]`.
+         - `S`, `W`, `P`, `K`, `C`, `leading`, `trailing`
+         - `lin_scales` as the contiguous strides of the indexed block
+           `x.shape[p:p+m]`.
+    2) Reshape x to `[P, K, C]` (`x_pkc`).
+    3) Build linear indices by scaling and accumulating the flattened index
+       tensors element-wise:
+         For each tensor index, broadcast it to `S`, then flatten it:
 
-    Example
-    -------
+           idx_broadcast[i] = broadcast_to(indices[p + i], S)
+           idx_flat[i] = reshape(idx_broadcast[i], [W])
+
+         For each j in [0, W):
+
+           lin_w[j] =
+               sum_{i=0..m-1} idx_flat[i][j] * lin_scales[i]
+
+         Equivalently, in tensor notation:
+
+           lin_w =
+               sum_{i=0..m-1} idx_flat[i] * lin_scales[i]  # shape [W]
+
+         Then:
+
+           lin_1w = unsqueeze(lin_w, 0)                    # [1, W]
+           lin_pw = lin_1w
+           if P > 1:
+               lin_pw = expand(lin_1w, [P, W])             # [P, W]
+    4) Single gather:
+         `tosa.GATHER(x=x_pkc, indices=lin_pw) -> [P,W,C]`
+    5) Reshape result to `[*leading, *S, *trailing]`.
+
+    Example:
     Consider:
-        x.shape = [2, 3, 4]
-        indices = [i0, i1]   # m = 2
+        x.shape = [2, 3, 4, 5]
+        indices = [None, i0, i1]   # p = 1, m = 2
         i0.shape = [2, 1]
         i1.shape = [1, 2]
+
+    This corresponds to ``x[:, i0, i1, :]``: the first dimension is
+    preserved, the next two dimensions are indexed, and the last dimension is
+    trailing.
 
     1) The index shapes broadcast to:
         S := [2, 2]
         W := prod(S) = 4
 
-    We index the first m=2 dimensions of x, so:
-        K := prod(x.shape[:m]) = 2 * 3 = 6
-        C := prod(x.shape[m:]) = 4
-        trailing := x.shape[m:] = [4]
+    We preserve p=1 leading dimension and index the next m=2 dimensions:
+        leading := x.shape[:p] = [2]
+        trailing := x.shape[p+m:] = [5]
+        P := prod(leading) = 2
+        K := prod(x.shape[p:p+m]) = 3 * 4 = 12
+        C := prod(trailing) = 5
 
-    Contiguous strides of x are [12, 4, 1], so:
-        lin_scales := [stride0 // C, stride1 // C] = [12//4, 4//4] = [3, 1]
+    The indexed block has shape [3, 4], so its contiguous strides are:
+        lin_scales := [4, 1]
 
     2) Values are reshaped to:
-        x_1kc = view(x, [1, K, C]) = [1, 6, 4]
+        x_pkc = view(x, [P, K, C]) = [2, 12, 5]
 
     3) After broadcasting and flattening the indices to length W:
         i0_broadcast, i1_broadcast have shape S=[2,2]
         i0_flat, i1_flat have shape [W]=[4]
 
-    Linear indices are computed as:
-        lin_w
-            = lin_scales * [i0_flat, i1_flat]
-            = 3 * i0_flat + 1 * i1_flat          # shape [W]
-        lin_w is reshaped to [1, W] to match tosa.Gather semantics
+    Linear indices are computed element-wise as:
+        for each j in [0, W):
+
+            lin_w[j] = 4 * i0_flat[j] + i1_flat[j]
+
+        hence:
+
+            lin_w = 4 * i0_flat + i1_flat  # shape [W]
+
+        lin_w is then unsqueezed to [1, W] and expanded so that
+        lin_pw.shape = [P, W] = [2, 4].
 
     4) Single Gather:
-        out_1wc = tosa.GATHER(values=x_1kc, indices=lin_1w)  # [1, 4, 4]
+        out_pwc = tosa.GATHER(values=x_pkc, indices=lin_pw)  # [2, 4, 5]
 
     5) Reshape result:
-        out = view(out_1wc, [*S, *x.shape[m:]])              # [2, 2, 4]
+        out = view(out_pwc, [*leading, *S, *trailing])       # [2, 2, 2, 5]
 
     """
 
@@ -192,69 +227,76 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
         return strides
 
     @staticmethod
-    def _validate_tensor_indices(indices):
+    def _validate_and_split_indices(indices):
         assert (
             isinstance(indices, (list, tuple)) and len(indices) > 0
         ), f"index.Tensor expects non-empty indices list/tuple, got {type(indices)}."
 
-        for i, idx in enumerate(indices):
-            assert (
-                idx is not None
-            ), f"index.Tensor: None indices are not supported at the moment (indices[{i}] is None)."
+        leading_rank = 0
+        while leading_rank < len(indices) and indices[leading_rank] is None:
+            leading_rank += 1
+
+        tensor_indices = indices[leading_rank:]
+        assert tensor_indices, "index.Tensor expects at least one tensor index."
+        for i, idx in enumerate(tensor_indices, start=leading_rank):
+            assert idx is not None, (
+                "index.Tensor supports None entries only before all tensor indices "
+                f"(indices[{i}] is None)."
+            )
             assert (
                 idx.data.dtype == torch.int32
             ), "index.Tensor requires index dtype must be int32"
 
-    def _compute_index_tensor_params(self, x, m, index_shapes):
-        """Compute shape/stride-derived parameters needed to lower
-        edge.aten.index.Tensor.
+        return leading_rank, tensor_indices
 
-        Derives the broadcasted index shape and the scale factors used to flatten and
-        acculumulate multi-dimensional indices into a single gather index, following
-        the S/W/K/C notation described in the class docstring.
+    def _compute_index_tensor_params(self, x, leading_rank, m, index_shapes):
+        """Compute parameters needed to lower edge.aten.index.Tensor.
+
+        Derives the broadcasted index shape and the scale factors used to
+        flatten and accumulate multi-dimensional indices into a single gather
+        index, following the S/W/P/K/C notation described in the class
+        docstring.
 
         Args:
-          x: Values tensor being indexed.
-          m: Number of tensor indices (i.e., len(indices)).
-          index_shapes: Shapes corresponding to each tensor index.
+            x (ProxyValue): Values tensor being indexed.
+            leading_rank (int): Number of leading dimensions preserved by None
+                entries.
+            m (int): Number of tensor indices.
+            index_shapes (Sequence[Sequence[int]]): Shapes corresponding to
+                each tensor index.
 
         Returns:
-          (x_data, S, W, K, C, trailing, lin_scales), where:
-            - x_data is `x.data` (FakeTensor)
-            - trailing is `x.shape[m:]` as a list of ints
-            - lin_scales are per-dimension scale factors for linearization
+            tuple: `(x_data, S, W, P, K, C, leading, trailing, lin_scales)`,
+                where `x_data` is `x.data`, `leading` and `trailing` contain
+                the preserved dimensions, and `lin_scales` contains the
+                indexed-block strides used for linearization.
 
         """
-
         x_data = x.data  # FakeTensor
         x_shape = tuple(x_data.shape)
         x_rank = len(x_shape)
 
         assert x_rank >= 1, f"index.Tensor expects x rank>=1, got {x_shape}."
-        assert (
-            m <= x_rank
-        ), f"index.Tensor has too many indices ({m}) for x rank {x_rank}."
+        assert leading_rank + m <= x_rank, (
+            "index.Tensor has more preserved and indexed dimensions "
+            f"({leading_rank + m}) than the input rank ({x_rank})."
+        )
 
         # Broadcast shape S for indices, and flattened length W
         S = _broadcast_shape(index_shapes)
         W = math.prod(S) if S else 1
 
-        # Compute gather factors K and C for leading-dims indexing
-        leading = list(x_shape[:m])
-        trailing = list(x_shape[m:])
-        K = math.prod(leading) if leading else 1
+        # Compute gather factors for the preserved, indexed, and trailing blocks.
+        leading = list(x_shape[:leading_rank])
+        indexed = list(x_shape[leading_rank : leading_rank + m])
+        trailing = list(x_shape[leading_rank + m :])
+        P = math.prod(leading) if leading else 1
+        K = math.prod(indexed) if indexed else 1
         C = math.prod(trailing) if trailing else 1
 
-        # Strides for linearization (contiguous-style)
-        strides = self._shape_to_stride(x_shape)
+        lin_scales = self._shape_to_stride(indexed)
 
-        # Stride/C divisibility is guaranteed for contiguous strides and C=prod(trailing).
-        lin_scales: list[int] = []
-        for i in range(m):
-            stride = strides[i]
-            lin_scales.append(stride // C)
-
-        return x_data, S, W, K, C, trailing, lin_scales
+        return x_data, S, W, P, K, C, leading, trailing, lin_scales
 
     def _decompose_constant_index(self, x, indices, meta):
         tensor_indices = [
@@ -341,13 +383,21 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
         if constant_result is not None:
             return constant_result
 
-        self._validate_tensor_indices(indices)
+        leading_rank, indices = self._validate_and_split_indices(indices)
         index_shapes = [idx.data.shape for idx in indices]
         m = len(indices)
 
-        x_data, S, W, K, C, trailing, lin_scales = self._compute_index_tensor_params(
-            x, m, index_shapes
-        )
+        (
+            x_data,
+            S,
+            W,
+            P,
+            K,
+            C,
+            leading,
+            trailing,
+            lin_scales,
+        ) = self._compute_index_tensor_params(x, leading_rank, m, index_shapes)
 
         (
             view_op,
@@ -371,16 +421,16 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
                 updated=True,
             )
 
-        # ---- x: [1, K, C] ----
-        x_1kc = super().call_operator(
+        # ---- x: [P, K, C] ----
+        x_pkc = super().call_operator(
             view_op,
-            (x_for_gather, [1, K, C]),
+            (x_for_gather, [P, K, C]),
             {},
             meta,
             updated=True,
         )
 
-        # Build linear index [1, W] from broadcasted indices
+        # Build linear index [W] from broadcasted indices
         lin_w = None
         plain_meta = meta_without_qparams(meta)
         for i, idx in enumerate(indices):
@@ -427,7 +477,7 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
                 updated=True,
             )
 
-            # Accumulate into lin_1w: [1, W]
+            # Accumulate into lin_w: [W]
             if lin_w is None:
                 lin_w = idx_scaled
             else:
@@ -441,10 +491,10 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
 
         if lin_w is None:
             raise RuntimeError(
-                f"[{self.__class__.__name__}] internal error: lin_1w not constructed."
+                f"[{self.__class__.__name__}] internal error: lin_w not constructed."
             )
 
-        # Make indices shape [1, W] for tosa.GATHER
+        # Make indices shape [P, W] for tosa.GATHER.
         lin_1w = super().call_operator(
             unsqueeze_op,
             (lin_w, 0),
@@ -452,22 +502,31 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
             plain_meta,
             updated=True,
         )
+        lin_pw = lin_1w
+        if P > 1:
+            lin_pw = super().call_operator(
+                expand_op,
+                (lin_1w, [P, W]),
+                {},
+                plain_meta,
+                updated=True,
+            )
 
         # ---- backend tosa gather ---
-        # tosa.GATHER(x=[1,K,C], indices=[1,W]) -> [1,W,C]
-        gathered_1wc = super().call_operator(
+        # tosa.GATHER(x=[P,K,C], indices=[P,W]) -> [P,W,C]
+        gathered_pwc = super().call_operator(
             tosa_gather_op,
-            (x_1kc, lin_1w),
+            (x_pkc, lin_pw),
             {},
             meta,
             updated=True,
         )
 
-        # ---- output: [*S, *trailing] ----
-        out_shape = list(S) + list(trailing)
+        # ---- output: [*leading, *S, *trailing] ----
+        out_shape = list(leading) + list(S) + list(trailing)
         out = super().call_operator(
             view_op,
-            (gathered_1wc, out_shape),
+            (gathered_pwc, out_shape),
             {},
             meta,
             updated=True,

--- a/backends/arm/operator_support/index_tensor_support.py
+++ b/backends/arm/operator_support/index_tensor_support.py
@@ -4,12 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 """Provide TOSA support checks for ``aten.index.Tensor``.
 
-Reject unsupported patterns such as front-positioned slice/ellipsis/None
-markers and cases that exceed ``int32`` element limits.
+Reject unsupported indexing layouts, zero-sized tensors, and cases that exceed
+``int32`` element limits.
 
 """
 
 import math
+from typing import cast, Sequence
 
 import torch
 import torch.fx as fx
@@ -23,6 +24,15 @@ from executorch.backends.arm.tosa import TosaSpecification
 from executorch.exir.dialects._ops import ops as exir_ops
 
 
+def _has_leading_full_slices_only(indices) -> bool:
+    found_tensor_index = False
+    for index in indices:
+        if index is None and found_tensor_index:
+            return False
+        found_tensor_index |= index is not None
+    return found_tensor_index
+
+
 @register_tosa_support_check
 class IndexTensorSupported(SupportedTOSAOperatorCheck):
     """Prevent partitioning of unsupported ``index.Tensor`` usages.
@@ -30,10 +40,10 @@ class IndexTensorSupported(SupportedTOSAOperatorCheck):
     This support check is intended to prevent the partitioning of
     currently unsupported usages of the index.Tensor operator.
 
-    1. Usages where slice, ellipsis or None are present before an indexing tensor:
-        t[{start}:{end}, indexTensor] - slicing
-        t[None, indexTensor] - unsqueeze
-        t[..., indexTensor] - ellipsis
+    1. Usages where a slice, ellipsis, or None separates indexing tensors:
+        t[indexTensor, {start}:{end}, indexTensor] - slicing
+        t[indexTensor, None, indexTensor] - unsqueeze
+        t[indexTensor, ..., indexTensor] - ellipsis
 
     2. Usages where the value tensor contains more than int32.max elements
         This is due to int32 TOSA limitation and the fact that we flatten out
@@ -41,25 +51,21 @@ class IndexTensorSupported(SupportedTOSAOperatorCheck):
         As such to avoid overflow we reject lowering of this operator if it is
         possible for indices to go over the int32 limit.
 
-    Extra information regarding #2:
+    3. Usages where the value or an index tensor is zero-sized, because TOSA
+        requires every tensor dimension to be at least one.
+
+    Extra information regarding #1:
         Pytorch decomposes slice and None usages before they reach aten.
         In the case of Slicing and Unsqueeze, Pytorch will add the relevant
         operation just before the index.Tensor op.
         In the case of Ellipsis no extra operation is added.
 
-        In all three cases Pytorch will insert "None"(s) in the index list
-        only if the above operations are done on a dimension BEFORE one being indexed.
-
-        When slicing, unsqueeze and ellipsis are done on dimensions after
-        the ones being indexed, then they do not affect the final output
-        values, only the shape. Thus None is not passed to the index.Tensor op.
-
         The purpose of None is to signify to index.Tensor that a dimension
         should not be indexed.
-        In such cases the logic behaves similar to batching along that dimension.
-        For the sake of simplicity we have not implemented this behavior yet
-        and thus have put this support check in place to prevent the partitioning
-        of index.Tensor ops which include None.
+        A leading run of None entries behaves like batching along those
+        dimensions and is supported. None entries after the first tensor index
+        remain unsupported because they interleave preserved and indexed
+        dimensions.
 
     Examples:
         #1 - Slice -----------------------------------------------------
@@ -87,12 +93,6 @@ class IndexTensorSupported(SupportedTOSAOperatorCheck):
         out = ...edge__ops_aten_index_Tensor(unsqueeze_res, [torch.arange(3)])
 
     NB.
-        With the current implementation of flattening tensors and indices out,
-        supporting None (Unsqueeze) is simply a matter of ignoring the
-        None dimension.
-        This is not the case for Slice and Ellipsis operators, where
-        the size of the new dimension can be > 1.
-
         Note that slice ops interleaved between indexes such as:
             t[1:3, torch.arange(5), 2:3, torch.arange(3).reshape(3,1)]
         are also possible and can result in some unintuitive behaviors
@@ -108,39 +108,47 @@ class IndexTensorSupported(SupportedTOSAOperatorCheck):
         """Return True if ``aten.index.Tensor`` usage fits supported patterns.
 
         Enforces the following constraints:
-        - No ``None`` (unsqueeze), slice, or ellipsis before an indexing tensor,
-          except for the U55 constant-index lowering.
+        - ``None`` entries may only form a leading run before all tensor indices.
+        - At least one tensor index is present.
+        - Value and index tensors must not be zero-sized.
+        - Boolean and byte mask indices are not supported.
         - The value tensor element count fits in ``int32``.
 
         """
-        indices = node.args[1]
-        if not tosa_spec.is_U55_subset and any(
-            index is None for index in indices  # type: ignore[union-attr]
-        ):
+        indices = cast(Sequence[fx.Node | None], node.args[1])
+        if not _has_leading_full_slices_only(indices):
             self.reporter.report_reject(
                 node,
-                (
-                    "None (from slice/unsqueeze/ellipsis) before an indexing tensor"
-                    " is not supported."
-                ),
+                "Only leading None entries followed by tensor indices are supported.",
             )
             return False
 
-        # The U55-specific check limits this to one constant tensor index.
-        for index in (
-            index for index in indices if index is not None  # type: ignore[union-attr]
+        if any(
+            get_first_fake_tensor(ensure_type(fx.Node, index)).dtype
+            in (torch.bool, torch.uint8)
+            for index in indices
+            if index is not None
         ):
-            index_node = ensure_type(torch.fx.Node, index)
-            if get_first_fake_tensor(index_node).dtype in (torch.bool, torch.uint8):
-                self.reporter.report_reject(
-                    node, "Boolean and byte mask indices are not supported."
-                )
-                return False
+            self.reporter.report_reject(
+                node, "Boolean and byte mask indices are not supported."
+            )
+            return False
 
-        # Usage 2 guard
         input_node = ensure_type(torch.fx.Node, node.args[0])
         input_val = get_first_fake_tensor(input_node)
         total_vals = math.prod(input_val.shape)
+        has_zero_sized_index = any(
+            math.prod(get_first_fake_tensor(ensure_type(fx.Node, index)).shape) == 0
+            for index in indices
+            if index is not None
+        )
+        if total_vals == 0 or has_zero_sized_index:
+            self.reporter.report_reject(
+                node,
+                "Zero-sized value or index tensors are not supported by TOSA.",
+            )
+            return False
+
         if total_vals > torch.iinfo(torch.int32).max:
             self.reporter.report_reject(
                 node,

--- a/backends/arm/test/ops/test_index_tensor.py
+++ b/backends/arm/test/ops/test_index_tensor.py
@@ -44,6 +44,18 @@ class IndexTensorInt64Buffer(torch.nn.Module):
         return x[self.index]
 
 
+class IndexTensorLeadingInt64Buffers(torch.nn.Module):
+    """NCHW indexing with leading full slices and int64 index buffers."""
+
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("rows", torch.tensor([[0], [2]], dtype=torch.int64))
+        self.register_buffer("columns", torch.tensor([[1, 3]], dtype=torch.int64))
+
+    def forward(self, x: torch.Tensor):
+        return x[:, :, self.rows, self.columns]
+
+
 class ConstantIndexTensor(torch.nn.Module):
     def __init__(self, indices: list[int]):
         super().__init__()
@@ -100,8 +112,73 @@ def test_index_tensor_tosa_FP_int64_buffer_index():
     pipeline.run()
 
 
+def test_index_tensor_tosa_FP_leading_full_slice_int64_buffer_indices():
+    pipeline = TosaPipelineFP[Tuple[torch.Tensor]](
+        IndexTensorLeadingInt64Buffers(),
+        (torch.rand(1, 2, 4, 5),),
+        IndexTensorTestCommon.aten_op,
+        IndexTensorTestCommon.exir_op,
+        atol=IndexTensorTestCommon.atol,
+        rtol=IndexTensorTestCommon.rtol,
+    )
+    pipeline.count_tosa_ops({"GATHER": 1, "TRANSPOSE": 0})
+    pipeline.run()
+
+
 input_params_slice = Tuple[torch.Tensor, int, int, str, Tuple[torch.Tensor]]
 input_params = Tuple[torch.Tensor, Tuple[torch.Tensor]]
+input_t2 = Tuple[torch.Tensor, torch.Tensor]
+input_t3 = Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+
+
+class IndexTensorLeadingFullSlice(torch.nn.Module):
+    def forward(self, x: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
+        return x[:, index, :]
+
+
+class IndexTensorLeadingFullSlicesNCHW(torch.nn.Module):
+    def forward(
+        self, x: torch.Tensor, rows: torch.Tensor, columns: torch.Tensor
+    ) -> torch.Tensor:
+        return x[:, :, rows, columns]
+
+
+class IndexTensorLeadingFullSliceWithTrailingDim(torch.nn.Module):
+    def forward(
+        self, x: torch.Tensor, rows: torch.Tensor, columns: torch.Tensor
+    ) -> torch.Tensor:
+        return x[:, rows, columns, :]
+
+
+leading_full_slice_test_data = {
+    "nchw_broadcast_indices": lambda: (
+        IndexTensorLeadingFullSlicesNCHW(),
+        (
+            torch.arange(2 * 3 * 4 * 5, dtype=torch.float32).reshape(2, 3, 4, 5),
+            torch.tensor([[0], [2]], dtype=torch.int32),
+            torch.tensor([[1, 3, 4]], dtype=torch.int32),
+        ),
+    ),
+    "leading_and_trailing_dims": lambda: (
+        IndexTensorLeadingFullSliceWithTrailingDim(),
+        (
+            torch.arange(2 * 4 * 5 * 3, dtype=torch.float32).reshape(2, 4, 5, 3),
+            torch.tensor([[0], [2]], dtype=torch.int32),
+            torch.tensor([[1, 3, 4]], dtype=torch.int32),
+        ),
+    ),
+}
+
+zero_sized_test_data = {
+    "zero_sized_leading_dimension": (
+        torch.empty(0, 3, 4),
+        torch.tensor([0, 2], dtype=torch.int32),
+    ),
+    "empty_index_tensor": (
+        torch.rand(2, 3, 4),
+        torch.empty(0, dtype=torch.int32),
+    ),
+}
 
 
 class IndexTensor_Ellipsis(torch.nn.Module):
@@ -158,7 +235,6 @@ class IndexTensor_Ellipsis(torch.nn.Module):
     IndexTensor_Ellipsis.test_data_ellipsis,
     xfails={
         # More info in index_tensor_support.py
-        "test_4d_ellipsis_before": "Ellipsis before index unsupported",
         "test_4d_ellipsis_middle": "Ellipsis before index unsupported",
     },
 )
@@ -182,7 +258,6 @@ def test_index_tensor_tosa_FP_ellipsis(test_data: input_params):
     IndexTensor_Ellipsis.test_data_ellipsis,
     xfails={
         # More info in index_tensor_support.py
-        "test_4d_ellipsis_before": "Ellipsis before index unsupported",
         "test_4d_ellipsis_middle": "Ellipsis before index unsupported",
     },
 )
@@ -270,8 +345,6 @@ class IndexTensor_Slice(torch.nn.Module):
     IndexTensor_Slice.test_data,
     xfails={
         # More info in index_tensor_support.py
-        "test_4d_slice_before_1d_idx": "Slice before index unsupported",
-        "test_3d_slice_before_2d_idx": "Slice before index unsupported",
         "test_4d_slice_middle": "Slice before index unsupported",
     },
 )
@@ -295,8 +368,6 @@ def test_index_tensor_tosa_FP_slice(test_data: input_params_slice):
     IndexTensor_Slice.test_data,
     xfails={
         # More info in index_tensor_support.py
-        "test_4d_slice_before_1d_idx": "Slice before index unsupported",
-        "test_3d_slice_before_2d_idx": "Slice before index unsupported",
         "test_4d_slice_middle": "Slice before index unsupported",
     },
 )
@@ -467,8 +538,7 @@ class IndexTensor(torch.nn.Module):
         ),
     }
 
-    # xfail - None (unsqueeze) unsupported
-    test_data_none: dict[input_params] = {
+    test_data_leading_none: dict[input_params] = {
         "test_3d_3_idx_with_none_before": (
             torch.rand(12, 3, 7),
             (
@@ -484,6 +554,9 @@ class IndexTensor(torch.nn.Module):
                 torch.randint(3, size=(12,), dtype=torch.int32),
             ),
         ),
+    }
+
+    test_data_none: dict[input_params] = test_data_leading_none | {
         "test_3d_3_idx_with_none_around": (
             torch.rand(12, 3, 7),
             (
@@ -573,25 +646,22 @@ def test_index_tensor_tosa_INT(test_data: input_params):
     IndexTensor.test_data_none,
     xfails={
         # More info in index_tensor_support.py
-        "test_3d_3_idx_with_none_before": "None (Unsqueeze) unsupported",
-        "test_3d_3_idx_with_2_none_before": "None (Unsqueeze) unsupported",
-        "test_3d_3_idx_with_none_around": "None (Unsqueeze) unsupported",
         "test_3d_3_idx_with_none_middle": "None (Unsqueeze) unsupported",
     },
 )
 def test_index_tensor_tosa_FP_none(test_data: input_params):
     test_input = test_data
     with torch.no_grad():
-        (
-            TosaPipelineFP[input_params](
-                IndexTensor(),
-                test_input,
-                IndexTensorTestCommon.aten_op,
-                IndexTensorTestCommon.exir_op,
-                atol=IndexTensorTestCommon.atol,
-                rtol=IndexTensorTestCommon.rtol,
-            ).run()
+        pipeline = TosaPipelineFP[input_params](
+            IndexTensor(),
+            test_input,
+            IndexTensorTestCommon.aten_op,
+            IndexTensorTestCommon.exir_op,
+            atol=IndexTensorTestCommon.atol,
+            rtol=IndexTensorTestCommon.rtol,
         )
+        pipeline.count_tosa_ops({"GATHER": 1, "TRANSPOSE": 0})
+        pipeline.run()
 
 
 @common.parametrize(
@@ -599,23 +669,100 @@ def test_index_tensor_tosa_FP_none(test_data: input_params):
     IndexTensor.test_data_none,
     xfails={
         # More info in index_tensor_support.py
-        "test_3d_3_idx_with_none_before": "None (Unsqueeze) unsupported",
-        "test_3d_3_idx_with_2_none_before": "None (Unsqueeze) unsupported",
-        "test_3d_3_idx_with_none_around": "None (Unsqueeze) unsupported",
         "test_3d_3_idx_with_none_middle": "None (Unsqueeze) unsupported",
     },
 )
 def test_index_tensor_tosa_INT_none(test_data: input_params):
     test_input = test_data
     with torch.no_grad():
-        (
-            TosaPipelineINT[input_params](
-                IndexTensor(),
-                test_input,
-                IndexTensorTestCommon.aten_op,
-                IndexTensorTestCommon.exir_op,
-            ).run()
+        pipeline = TosaPipelineINT[input_params](
+            IndexTensor(),
+            test_input,
+            IndexTensorTestCommon.aten_op,
+            IndexTensorTestCommon.exir_op,
         )
+        pipeline.count_tosa_ops({"GATHER": 1, "TRANSPOSE": 0})
+        pipeline.run()
+
+
+@common.parametrize("test_data", leading_full_slice_test_data)
+def test_index_tensor_tosa_FP_leading_full_slices(test_data):
+    model, test_inputs = test_data()
+    pipeline = TosaPipelineFP[input_t3](
+        model,
+        test_inputs,
+        IndexTensorTestCommon.aten_op,
+        IndexTensorTestCommon.exir_op,
+        atol=IndexTensorTestCommon.atol,
+        rtol=IndexTensorTestCommon.rtol,
+    )
+    pipeline.count_tosa_ops({"GATHER": 1, "TRANSPOSE": 0})
+    pipeline.run()
+
+
+@common.parametrize("test_data", leading_full_slice_test_data)
+def test_index_tensor_tosa_INT_leading_full_slices(test_data):
+    model, test_inputs = test_data()
+    pipeline = TosaPipelineINT[input_t3](
+        model,
+        test_inputs,
+        IndexTensorTestCommon.aten_op,
+        IndexTensorTestCommon.exir_op,
+    )
+    pipeline.count_tosa_ops({"GATHER": 1, "TRANSPOSE": 0})
+    pipeline.run()
+
+
+@common.parametrize("test_data", zero_sized_test_data)
+def test_index_tensor_zero_sized_not_delegated_tosa_FP(test_data: input_t2):
+    OpNotSupportedPipeline[input_t2](
+        IndexTensorLeadingFullSlice(),
+        test_data,
+        {IndexTensorTestCommon.exir_op: 1},
+    ).run()
+
+
+@common.parametrize("test_data", IndexTensor.test_data_leading_none)
+@common.SkipIfNoModelConverter
+def test_index_tensor_vgf_leading_full_slices(test_data: input_params):
+    pipeline = VgfPipeline[input_params](
+        IndexTensor(),
+        test_data,
+        IndexTensorTestCommon.aten_op,
+        IndexTensorTestCommon.exir_op,
+        atol=IndexTensorTestCommon.atol,
+        rtol=IndexTensorTestCommon.rtol,
+        quantize=False,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", leading_full_slice_test_data)
+@common.SkipIfNoModelConverter
+def test_index_tensor_leading_full_slice_indexing_vgf_no_quant(test_data):
+    model, test_inputs = test_data()
+    VgfPipeline[input_t3](
+        model,
+        test_inputs,
+        IndexTensorTestCommon.aten_op,
+        IndexTensorTestCommon.exir_op,
+        atol=IndexTensorTestCommon.atol,
+        rtol=IndexTensorTestCommon.rtol,
+        quantize=False,
+    ).run()
+
+
+@common.parametrize("test_data", leading_full_slice_test_data)
+@common.SkipIfNoModelConverter
+def test_index_tensor_leading_full_slice_indexing_vgf_quant(test_data):
+    model, test_inputs = test_data()
+    VgfPipeline[input_t3](
+        model,
+        test_inputs,
+        IndexTensorTestCommon.aten_op,
+        IndexTensorTestCommon.exir_op,
+        quantize=True,
+    ).run()
 
 
 @common.parametrize("test_data", IndexTensor.test_data_int | IndexTensor.test_data_fp)

--- a/docs/source/backends/arm-vgf/VGF_op_support.md
+++ b/docs/source/backends/arm-vgf/VGF_op_support.md
@@ -148,7 +148,7 @@ Total supported PyTorch APIs: **155**.
 | `torch.t` / `torch.Tensor.t` | FP, INT | `FP32`, `INT8` | 8x8 |
 | `torch.tan` | FP, INT | `FP32`, `INT8` | 8x8 |
 | `torch.tanh` / `torch.nn.Tanh` | FP, INT | `FP16`, `BF16`, `INT8` | 8x8 |
-| `torch.Tensor.__getitem__` / `tensor indexing` | FP, INT | `FP16`, `BF16`, `INT8` | 8x8 |
+| `torch.Tensor.__getitem__` / `tensor indexing` | FP, INT | `FP32`, `FP16`, `BF16`, `INT8` | 8x8 |
 | `torch.Tensor.__getitem__` / `tensor slicing` | FP, INT | `FP32`, `FP16`, `BF16`, `INT8` | 8x8 |
 | `torch.Tensor.__setitem__` / `tensor indexing assignment` | FP, INT | `FP32`, `INT8` | 8x8 |
 | `torch.Tensor.copy_` | FP, INT | `FP32`, `INT8` | 8x8 |


### PR DESCRIPTION
Generalize index.Tensor decomposition to treat leading full-slice dimensions as the TOSA GATHER batch dimension. Reshape values to [P, K, C], expand linearized indices to [P, W], and restore the PyTorch output shape without transposing the data tensor.

Update support checks to accept leading None entries while rejecting interleaved indexing, and add tests for TOSA FP, TOSA INT, and VGF.

Change-Id: I657dd1876c7ca2632b951bc517f8960a10242548


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani