### PR TITLE
[executorch][muse-glimmer] Add CUDA sampling probabilities

### DIFF
--- a/examples/models/muse-glimmer/runtime/engine/sampling_cuda.cu
+++ b/examples/models/muse-glimmer/runtime/engine/sampling_cuda.cu
@@ -10,8 +10,12 @@
 
 #include <cuda_runtime.h>
 #include <math_constants.h>
+#include <cub/device/device_scan.cuh>
+#include <cub/device/device_segmented_radix_sort.cuh>
 
+#include <algorithm>
 #include <cstdint>
+#include <limits>
 
 namespace muse_glimmer::cuda {
 namespace {
@@ -20,6 +24,7 @@ constexpr int kArgmaxThreads = 256;
 static_assert(
     (kArgmaxThreads & (kArgmaxThreads - 1)) == 0,
     "argmax reduction requires a power-of-two thread count");
+constexpr int kSamplingThreads = 256;
 
 struct ArgmaxCandidate {
   float value;
@@ -74,7 +79,239 @@ __global__ void argmax_index_kernel(
   }
 }
 
+__global__ void initialize_offsets_kernel(
+    int64_t* offsets,
+    int64_t row_count,
+    int64_t row_size) {
+  const int64_t row =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (row <= row_count) {
+    offsets[row] = row * row_size;
+  }
+}
+
+__global__ void initialize_token_indices_kernel(
+    int32_t* indices,
+    int64_t total_size,
+    int64_t row_size) {
+  const int64_t offset =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (offset < total_size) {
+    indices[offset] = static_cast<int32_t>(offset % row_size);
+  }
+}
+
+__global__ void compute_sorted_weights_kernel(
+    const float* sorted_logits,
+    int64_t total_size,
+    int64_t row_size,
+    int32_t retained_count,
+    float inverse_temperature,
+    double* weights) {
+  const int64_t offset =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (offset >= total_size) {
+    return;
+  }
+  const int64_t rank = offset % row_size;
+  if (rank >= retained_count) {
+    weights[offset] = 0.0;
+    return;
+  }
+  const int64_t row_start = offset - rank;
+  const float weight = expf(
+      (sorted_logits[offset] - sorted_logits[row_start]) * inverse_temperature);
+  weights[offset] = static_cast<double>(weight);
+}
+
+__global__ void find_nucleus_kernel(
+    const double* cumulative,
+    int64_t row_count,
+    int64_t row_size,
+    int32_t retained_count,
+    double top_p,
+    int32_t* cutoffs,
+    float* denominators) {
+  const int64_t row =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (row >= row_count) {
+    return;
+  }
+  const int64_t row_start = row * row_size;
+  const int32_t last_retained = retained_count - 1;
+  const double total = cumulative[row_start + last_retained];
+  int32_t cutoff = last_retained;
+  if (top_p > 0.0 && top_p < 1.0) {
+    const double target = top_p * total;
+    int32_t low = 0;
+    int32_t high = last_retained;
+    while (low < high) {
+      const int32_t middle = low + (high - low) / 2;
+      if (cumulative[row_start + middle] >= target) {
+        high = middle;
+      } else {
+        low = middle + 1;
+      }
+    }
+    cutoff = low;
+  }
+  cutoffs[row] = cutoff;
+  denominators[row] = static_cast<float>(cumulative[row_start + cutoff]);
+}
+
+__global__ void scatter_probabilities_kernel(
+    const double* sorted_weights,
+    const int32_t* sorted_indices,
+    const int32_t* cutoffs,
+    const float* denominators,
+    int64_t total_size,
+    int64_t row_size,
+    float* probabilities) {
+  const int64_t offset =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (offset >= total_size) {
+    return;
+  }
+  const int64_t row = offset / row_size;
+  const int64_t rank = offset - row * row_size;
+  const int32_t token = sorted_indices[offset];
+  probabilities[row * row_size + token] = rank <= cutoffs[row]
+      ? static_cast<float>(sorted_weights[offset]) / denominators[row]
+      : 0.0f;
+}
+
 } // namespace
+
+struct SamplingWorkspace::Impl {
+  int64_t row_count{0};
+  int64_t row_size{0};
+  int64_t total_size{0};
+  float* sort_keys_in{nullptr};
+  float* sort_keys_out{nullptr};
+  int32_t* sort_indices_in{nullptr};
+  int32_t* sort_indices_out{nullptr};
+  double* weights{nullptr};
+  double* cumulative{nullptr};
+  int64_t* offsets{nullptr};
+  int32_t* cutoffs{nullptr};
+  float* denominators{nullptr};
+  void* temporary_storage{nullptr};
+  size_t temporary_storage_bytes{0};
+
+  void release() {
+    cudaFree(temporary_storage);
+    cudaFree(denominators);
+    cudaFree(cutoffs);
+    cudaFree(offsets);
+    cudaFree(cumulative);
+    cudaFree(weights);
+    cudaFree(sort_indices_out);
+    cudaFree(sort_indices_in);
+    cudaFree(sort_keys_out);
+    cudaFree(sort_keys_in);
+    *this = Impl{};
+  }
+};
+
+SamplingWorkspace::SamplingWorkspace() : impl_(new Impl()) {}
+
+SamplingWorkspace::~SamplingWorkspace() {
+  impl_->release();
+  delete impl_;
+}
+
+cudaError_t SamplingWorkspace::reserve(
+    int64_t row_count,
+    int64_t row_size,
+    cudaStream_t stream) {
+  if (row_count <= 0 || row_size <= 0 ||
+      row_size > std::numeric_limits<int32_t>::max() ||
+      row_count > std::numeric_limits<int64_t>::max() / row_size) {
+    return cudaErrorInvalidValue;
+  }
+  if (impl_->row_count == row_count && impl_->row_size == row_size) {
+    return cudaSuccess;
+  }
+
+  impl_->release();
+  impl_->row_count = row_count;
+  impl_->row_size = row_size;
+  impl_->total_size = row_count * row_size;
+  const size_t total_size = static_cast<size_t>(impl_->total_size);
+
+#define MUSE_GLIMMER_CUDA_ALLOCATE(member, count)             \
+  do {                                                        \
+    const cudaError_t error = cudaMalloc(                     \
+        reinterpret_cast<void**>(&impl_->member),             \
+        static_cast<size_t>(count) * sizeof(*impl_->member)); \
+    if (error != cudaSuccess) {                               \
+      impl_->release();                                       \
+      return error;                                           \
+    }                                                         \
+  } while (false)
+
+  MUSE_GLIMMER_CUDA_ALLOCATE(sort_keys_in, total_size);
+  MUSE_GLIMMER_CUDA_ALLOCATE(sort_keys_out, total_size);
+  MUSE_GLIMMER_CUDA_ALLOCATE(sort_indices_in, total_size);
+  MUSE_GLIMMER_CUDA_ALLOCATE(sort_indices_out, total_size);
+  MUSE_GLIMMER_CUDA_ALLOCATE(weights, total_size);
+  MUSE_GLIMMER_CUDA_ALLOCATE(cumulative, total_size);
+  MUSE_GLIMMER_CUDA_ALLOCATE(offsets, row_count + 1);
+  MUSE_GLIMMER_CUDA_ALLOCATE(cutoffs, row_count);
+  MUSE_GLIMMER_CUDA_ALLOCATE(denominators, row_count);
+
+#undef MUSE_GLIMMER_CUDA_ALLOCATE
+
+  const int offset_blocks = static_cast<int>(
+      (row_count + 1 + kSamplingThreads - 1) / kSamplingThreads);
+  initialize_offsets_kernel<<<offset_blocks, kSamplingThreads, 0, stream>>>(
+      impl_->offsets, row_count, row_size);
+  cudaError_t error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    impl_->release();
+    return error;
+  }
+
+  size_t sort_bytes = 0;
+  error = cub::DeviceSegmentedRadixSort::SortPairsDescending(
+      nullptr,
+      sort_bytes,
+      impl_->sort_keys_in,
+      impl_->sort_keys_out,
+      impl_->sort_indices_in,
+      impl_->sort_indices_out,
+      static_cast<int>(impl_->total_size),
+      static_cast<int>(row_count),
+      impl_->offsets,
+      impl_->offsets + 1,
+      0,
+      sizeof(float) * 8,
+      stream);
+  if (error != cudaSuccess) {
+    impl_->release();
+    return error;
+  }
+
+  size_t scan_bytes = 0;
+  error = cub::DeviceScan::InclusiveSum(
+      nullptr,
+      scan_bytes,
+      impl_->weights,
+      impl_->cumulative,
+      static_cast<int>(row_size),
+      stream);
+  if (error != cudaSuccess) {
+    impl_->release();
+    return error;
+  }
+
+  impl_->temporary_storage_bytes = std::max(sort_bytes, scan_bytes);
+  error = cudaMalloc(&impl_->temporary_storage, impl_->temporary_storage_bytes);
+  if (error != cudaSuccess) {
+    impl_->release();
+  }
+  return error;
+}
 
 cudaError_t argmax_index(
     const float* values,
@@ -91,6 +328,119 @@ cudaError_t argmax_index(
       kArgmaxThreads,
       0,
       stream>>>(values, row_size, indices);
+  return cudaGetLastError();
+}
+
+cudaError_t fill_sampling_probabilities(
+    const float* logits,
+    int64_t row_count,
+    int64_t row_size,
+    double temperature,
+    int32_t top_k,
+    double top_p,
+    float* probabilities,
+    SamplingWorkspace& workspace,
+    cudaStream_t stream) {
+  if (logits == nullptr || probabilities == nullptr || temperature <= 0.0 ||
+      row_count <= 0 || row_size <= 0 ||
+      row_count > std::numeric_limits<int>::max() ||
+      row_size > std::numeric_limits<int>::max() / row_count) {
+    return cudaErrorInvalidValue;
+  }
+  cudaError_t error = workspace.reserve(row_count, row_size, stream);
+  if (error != cudaSuccess) {
+    return error;
+  }
+  auto& state = *workspace.impl_;
+  const int64_t total_size = state.total_size;
+  const size_t logits_bytes = static_cast<size_t>(total_size) * sizeof(float);
+  error = cudaMemcpyAsync(
+      state.sort_keys_in,
+      logits,
+      logits_bytes,
+      cudaMemcpyDeviceToDevice,
+      stream);
+  if (error != cudaSuccess) {
+    return error;
+  }
+
+  const int item_blocks =
+      static_cast<int>((total_size + kSamplingThreads - 1) / kSamplingThreads);
+  initialize_token_indices_kernel<<<item_blocks, kSamplingThreads, 0, stream>>>(
+      state.sort_indices_in, total_size, row_size);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    return error;
+  }
+
+  error = cub::DeviceSegmentedRadixSort::SortPairsDescending(
+      state.temporary_storage,
+      state.temporary_storage_bytes,
+      state.sort_keys_in,
+      state.sort_keys_out,
+      state.sort_indices_in,
+      state.sort_indices_out,
+      static_cast<int>(total_size),
+      static_cast<int>(row_count),
+      state.offsets,
+      state.offsets + 1,
+      0,
+      sizeof(float) * 8,
+      stream);
+  if (error != cudaSuccess) {
+    return error;
+  }
+
+  const int32_t retained_count =
+      top_k > 0 && top_k < row_size ? top_k : static_cast<int32_t>(row_size);
+  compute_sorted_weights_kernel<<<item_blocks, kSamplingThreads, 0, stream>>>(
+      state.sort_keys_out,
+      total_size,
+      row_size,
+      retained_count,
+      1.0f / static_cast<float>(temperature),
+      state.weights);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    return error;
+  }
+
+  for (int64_t row = 0; row < row_count; ++row) {
+    error = cub::DeviceScan::InclusiveSum(
+        state.temporary_storage,
+        state.temporary_storage_bytes,
+        state.weights + row * row_size,
+        state.cumulative + row * row_size,
+        static_cast<int>(row_size),
+        stream);
+    if (error != cudaSuccess) {
+      return error;
+    }
+  }
+
+  const int row_blocks =
+      static_cast<int>((row_count + kSamplingThreads - 1) / kSamplingThreads);
+  find_nucleus_kernel<<<row_blocks, kSamplingThreads, 0, stream>>>(
+      state.cumulative,
+      row_count,
+      row_size,
+      retained_count,
+      top_p,
+      state.cutoffs,
+      state.denominators);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    return error;
+  }
+
+  scatter_probabilities_kernel<<<item_blocks, kSamplingThreads, 0, stream>>>(
+      state.weights,
+      state.sort_indices_out,
+      state.cutoffs,
+      state.denominators,
+      total_size,
+      row_size,
+      probabilities);
   return cudaGetLastError();
 }
 

--- a/examples/models/muse-glimmer/runtime/engine/sampling_cuda.h
+++ b/examples/models/muse-glimmer/runtime/engine/sampling_cuda.h
@@ -16,6 +16,34 @@
 
 namespace muse_glimmer::cuda {
 
+class SamplingWorkspace {
+ public:
+  SamplingWorkspace();
+  ~SamplingWorkspace();
+
+  SamplingWorkspace(const SamplingWorkspace&) = delete;
+  SamplingWorkspace& operator=(const SamplingWorkspace&) = delete;
+
+  // Allocates all scratch buffers needed for this fixed batch shape. Call
+  // before CUDA graph capture; repeated calls for the same shape are no-ops.
+  cudaError_t reserve(int64_t row_count, int64_t row_size, cudaStream_t stream);
+
+ private:
+  struct Impl;
+  Impl* impl_;
+
+  friend cudaError_t fill_sampling_probabilities(
+      const float*,
+      int64_t,
+      int64_t,
+      double,
+      int32_t,
+      double,
+      float*,
+      SamplingWorkspace&,
+      cudaStream_t);
+};
+
 // Computes one argmax per contiguous row of `values`.
 //
 // `values` and `indices` must point to CUDA memory. Equal maxima select the
@@ -26,6 +54,21 @@ cudaError_t argmax_index(
     int64_t row_count,
     int64_t row_size,
     uint64_t* indices,
+    cudaStream_t stream);
+
+// CUDA counterpart of muse_glimmer::fill_sampling_probabilities for contiguous
+// rows. Applies temperature, then top-k, then top-p, and writes normalized
+// dense probabilities in original token order. All tensor pointers are device
+// pointers and the launch sequence is asynchronous with respect to `stream`.
+cudaError_t fill_sampling_probabilities(
+    const float* logits,
+    int64_t row_count,
+    int64_t row_size,
+    double temperature,
+    int32_t top_k,
+    double top_p,
+    float* probabilities,
+    SamplingWorkspace& workspace,
     cudaStream_t stream);
 
 } // namespace muse_glimmer::cuda

--- a/examples/models/muse-glimmer/tests/sampling_cuda_test.cpp
+++ b/examples/models/muse-glimmer/tests/sampling_cuda_test.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <tuple>
 #include <vector>
 
 namespace {
@@ -33,6 +34,62 @@ struct CudaDeleter {
 
 template <typename T>
 using CudaPtr = std::unique_ptr<T, CudaDeleter>;
+
+bool expect_cuda_success(cudaError_t error) {
+  if (error == cudaSuccess) {
+    return true;
+  }
+  ADD_FAILURE() << cudaGetErrorString(error);
+  return false;
+}
+
+std::vector<float> cuda_sampling_probabilities(
+    const std::vector<float>& logits,
+    int64_t row_count,
+    int64_t row_size,
+    double temperature,
+    int32_t top_k,
+    double top_p,
+    muse_glimmer::cuda::SamplingWorkspace& workspace) {
+  const size_t bytes = logits.size() * sizeof(float);
+
+  float* raw_device_logits = nullptr;
+  if (!expect_cuda_success(cudaMalloc(&raw_device_logits, bytes))) {
+    return {};
+  }
+  CudaPtr<float> device_logits(raw_device_logits);
+
+  float* raw_device_probabilities = nullptr;
+  if (!expect_cuda_success(cudaMalloc(&raw_device_probabilities, bytes))) {
+    return {};
+  }
+  CudaPtr<float> device_probabilities(raw_device_probabilities);
+
+  if (!expect_cuda_success(cudaMemcpy(
+          device_logits.get(), logits.data(), bytes, cudaMemcpyHostToDevice)) ||
+      !expect_cuda_success(muse_glimmer::cuda::fill_sampling_probabilities(
+          device_logits.get(),
+          row_count,
+          row_size,
+          temperature,
+          top_k,
+          top_p,
+          device_probabilities.get(),
+          workspace,
+          nullptr))) {
+    return {};
+  }
+
+  std::vector<float> probabilities(logits.size());
+  if (!expect_cuda_success(cudaMemcpy(
+          probabilities.data(),
+          device_probabilities.get(),
+          bytes,
+          cudaMemcpyDeviceToHost))) {
+    probabilities.clear();
+  }
+  return probabilities;
+}
 
 TEST(CudaSamplingTest, ArgmaxMatchesHostForBatchedRowsAndTies) {
   constexpr int64_t kRows = 3;
@@ -82,6 +139,48 @@ TEST(CudaSamplingTest, ArgmaxRejectsInvalidArguments) {
   EXPECT_EQ(
       muse_glimmer::cuda::argmax_index(nullptr, 1, 1, nullptr, nullptr),
       cudaErrorInvalidValue);
+}
+
+TEST(CudaSamplingTest, SamplingProbabilitiesMatchHost) {
+  constexpr int64_t kRows = 2;
+  constexpr int64_t kRowSize = 257;
+  std::vector<float> logits(kRows * kRowSize);
+  for (int64_t row = 0; row < kRows; ++row) {
+    for (int64_t token = 0; token < kRowSize; ++token) {
+      logits[row * kRowSize + token] =
+          static_cast<float>(((token * 37 + row * 11) % 101) - 50) / 7.0f;
+    }
+    // Exercise stable token-id tie breaks at the filtering boundary.
+    logits[row * kRowSize + 3] = 5.0f;
+    logits[row * kRowSize + 19] = 5.0f;
+  }
+
+  const std::tuple<double, int32_t, double> configurations[] = {
+      {0.5, 0, 1.0},
+      {1.0, 7, 1.0},
+      {0.8, 0, 0.9},
+      {1.7, 31, 0.75},
+      {1.0, 1, 0.1},
+  };
+  muse_glimmer::cuda::SamplingWorkspace workspace;
+  for (const auto& [temperature, top_k, top_p] : configurations) {
+    const auto actual = cuda_sampling_probabilities(
+        logits, kRows, kRowSize, temperature, top_k, top_p, workspace);
+    ASSERT_EQ(actual.size(), logits.size());
+    for (int64_t row = 0; row < kRows; ++row) {
+      const auto expected = muse_glimmer::sampling_probabilities(
+          logits.data() + row * kRowSize, kRowSize, temperature, top_k, top_p);
+      double sum = 0.0;
+      for (int64_t token = 0; token < kRowSize; ++token) {
+        const float probability = actual[row * kRowSize + token];
+        EXPECT_EQ(probability == 0.0f, expected[token] == 0.0f)
+            << "token " << token;
+        EXPECT_NEAR(probability, expected[token], 2e-5f) << "token " << token;
+        sum += probability;
+      }
+      EXPECT_NEAR(sum, 1.0, 2e-5);
+    }
+  }
 }
 
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22698
* #22697
* #22696
* #22695
* #22694
* #22693
* #22692
* __->__ #22691
* #22690

Add a CUDA counterpart for muse_glimmer::fill_sampling_probabilities. Apply temperature, stable top-k filtering, and top-p filtering in the same order as the host sampler, using a preallocated graph-safe CUB workspace. Add batched parity tests covering filtering combinations and token-id tie breaks.

Differential Revision: [D117826283](https://our.internmc.facebook.com/intern/diff/D117826283/)