### PR TITLE
[executorch][muse-glimmer] Add CUDA categorical sampling

### DIFF
--- a/examples/models/muse-glimmer/runtime/engine/sampling_cuda.cu
+++ b/examples/models/muse-glimmer/runtime/engine/sampling_cuda.cu
@@ -9,6 +9,7 @@
 #include <executorch/examples/models/muse-glimmer/runtime/engine/sampling_cuda.h>
 
 #include <cuda_runtime.h>
+#include <curand_kernel.h>
 #include <math_constants.h>
 #include <cub/device/device_scan.cuh>
 #include <cub/device/device_segmented_radix_sort.cuh>
@@ -29,6 +30,12 @@ constexpr int kSamplingThreads = 256;
 struct ArgmaxCandidate {
   float value;
   uint64_t index;
+};
+
+struct DeviceRngState {
+  uint64_t seed;
+  unsigned long long counter;
+  unsigned long long base;
 };
 
 __device__ ArgmaxCandidate
@@ -180,6 +187,72 @@ __global__ void scatter_probabilities_kernel(
       : 0.0f;
 }
 
+__global__ void initialize_rng_kernel(DeviceRngState* state, uint64_t seed) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    state->seed = seed;
+    state->counter = 0;
+    state->base = 0;
+  }
+}
+
+__global__ void advance_rng_kernel(
+    DeviceRngState* state,
+    unsigned long long count) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    state->base = atomicAdd(&state->counter, count);
+  }
+}
+
+__global__ void probabilities_to_double_kernel(
+    const float* probabilities,
+    int64_t total_size,
+    double* values) {
+  const int64_t offset =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (offset < total_size) {
+    values[offset] = static_cast<double>(probabilities[offset]);
+  }
+}
+
+__device__ float uniform_from_uint32(uint32_t value) {
+  constexpr uint32_t kMantissaMask = (uint32_t{1} << 24) - 1;
+  constexpr float kScale = 1.0f / static_cast<float>(uint32_t{1} << 24);
+  return static_cast<float>(value & kMantissaMask) * kScale;
+}
+
+__global__ void categorical_sample_kernel(
+    const double* cumulative,
+    int64_t row_count,
+    int64_t row_size,
+    DeviceRngState* rng,
+    uint64_t* tokens) {
+  const int64_t row =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (row >= row_count) {
+    return;
+  }
+  curandStatePhilox4_32_10_t local_rng;
+  curand_init(rng->seed, 0, rng->base + row, &local_rng);
+  const double coin =
+      static_cast<double>(uniform_from_uint32(curand(&local_rng)));
+  const int64_t row_start = row * row_size;
+  int64_t low = 0;
+  int64_t high = row_size - 1;
+  if (coin > cumulative[row_start + high]) {
+    tokens[row] = static_cast<uint64_t>(high);
+    return;
+  }
+  while (low < high) {
+    const int64_t middle = low + (high - low) / 2;
+    if (cumulative[row_start + middle] >= coin) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+  tokens[row] = static_cast<uint64_t>(low);
+}
+
 } // namespace
 
 struct SamplingWorkspace::Impl {
@@ -195,10 +268,12 @@ struct SamplingWorkspace::Impl {
   int64_t* offsets{nullptr};
   int32_t* cutoffs{nullptr};
   float* denominators{nullptr};
+  DeviceRngState* rng{nullptr};
   void* temporary_storage{nullptr};
   size_t temporary_storage_bytes{0};
 
   void release() {
+    cudaFree(rng);
     cudaFree(temporary_storage);
     cudaFree(denominators);
     cudaFree(cutoffs);
@@ -259,6 +334,7 @@ cudaError_t SamplingWorkspace::reserve(
   MUSE_GLIMMER_CUDA_ALLOCATE(offsets, row_count + 1);
   MUSE_GLIMMER_CUDA_ALLOCATE(cutoffs, row_count);
   MUSE_GLIMMER_CUDA_ALLOCATE(denominators, row_count);
+  MUSE_GLIMMER_CUDA_ALLOCATE(rng, 1);
 
 #undef MUSE_GLIMMER_CUDA_ALLOCATE
 
@@ -267,6 +343,12 @@ cudaError_t SamplingWorkspace::reserve(
   initialize_offsets_kernel<<<offset_blocks, kSamplingThreads, 0, stream>>>(
       impl_->offsets, row_count, row_size);
   cudaError_t error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    impl_->release();
+    return error;
+  }
+  initialize_rng_kernel<<<1, 1, 0, stream>>>(impl_->rng, 0);
+  error = cudaGetLastError();
   if (error != cudaSuccess) {
     impl_->release();
     return error;
@@ -311,6 +393,14 @@ cudaError_t SamplingWorkspace::reserve(
     impl_->release();
   }
   return error;
+}
+
+cudaError_t SamplingWorkspace::set_seed(uint64_t seed, cudaStream_t stream) {
+  if (impl_->rng == nullptr) {
+    return cudaErrorInvalidValue;
+  }
+  initialize_rng_kernel<<<1, 1, 0, stream>>>(impl_->rng, seed);
+  return cudaGetLastError();
 }
 
 cudaError_t argmax_index(
@@ -441,6 +531,57 @@ cudaError_t fill_sampling_probabilities(
       total_size,
       row_size,
       probabilities);
+  return cudaGetLastError();
+}
+
+cudaError_t categorical_sample(
+    const float* probabilities,
+    int64_t row_count,
+    int64_t row_size,
+    uint64_t* tokens,
+    SamplingWorkspace& workspace,
+    cudaStream_t stream) {
+  if (probabilities == nullptr || tokens == nullptr || row_count <= 0 ||
+      row_size <= 0 || row_count > std::numeric_limits<int>::max() ||
+      row_size > std::numeric_limits<int>::max() / row_count) {
+    return cudaErrorInvalidValue;
+  }
+  cudaError_t error = workspace.reserve(row_count, row_size, stream);
+  if (error != cudaSuccess) {
+    return error;
+  }
+  auto& state = *workspace.impl_;
+  const int64_t total_size = state.total_size;
+  const int item_blocks =
+      static_cast<int>((total_size + kSamplingThreads - 1) / kSamplingThreads);
+  probabilities_to_double_kernel<<<item_blocks, kSamplingThreads, 0, stream>>>(
+      probabilities, total_size, state.weights);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    return error;
+  }
+
+  for (int64_t row = 0; row < row_count; ++row) {
+    error = cub::DeviceScan::InclusiveSum(
+        state.temporary_storage,
+        state.temporary_storage_bytes,
+        state.weights + row * row_size,
+        state.cumulative + row * row_size,
+        static_cast<int>(row_size),
+        stream);
+    if (error != cudaSuccess) {
+      return error;
+    }
+  }
+  advance_rng_kernel<<<1, 1, 0, stream>>>(state.rng, row_count);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    return error;
+  }
+  const int row_blocks =
+      static_cast<int>((row_count + kSamplingThreads - 1) / kSamplingThreads);
+  categorical_sample_kernel<<<row_blocks, kSamplingThreads, 0, stream>>>(
+      state.cumulative, row_count, row_size, state.rng, tokens);
   return cudaGetLastError();
 }
 

--- a/examples/models/muse-glimmer/runtime/engine/sampling_cuda.h
+++ b/examples/models/muse-glimmer/runtime/engine/sampling_cuda.h
@@ -28,6 +28,9 @@ class SamplingWorkspace {
   // before CUDA graph capture; repeated calls for the same shape are no-ops.
   cudaError_t reserve(int64_t row_count, int64_t row_size, cudaStream_t stream);
 
+  // Resets the graph-safe Philox state used by stochastic primitives.
+  cudaError_t set_seed(uint64_t seed, cudaStream_t stream);
+
  private:
   struct Impl;
   Impl* impl_;
@@ -40,6 +43,13 @@ class SamplingWorkspace {
       int32_t,
       double,
       float*,
+      SamplingWorkspace&,
+      cudaStream_t);
+  friend cudaError_t categorical_sample(
+      const float*,
+      int64_t,
+      int64_t,
+      uint64_t*,
       SamplingWorkspace&,
       cudaStream_t);
 };
@@ -68,6 +78,16 @@ cudaError_t fill_sampling_probabilities(
     int32_t top_k,
     double top_p,
     float* probabilities,
+    SamplingWorkspace& workspace,
+    cudaStream_t stream);
+
+// CUDA counterpart of muse_glimmer::categorical_sample for normalized
+// contiguous probability rows. Produces one device-resident token id per row.
+cudaError_t categorical_sample(
+    const float* probabilities,
+    int64_t row_count,
+    int64_t row_size,
+    uint64_t* tokens,
     SamplingWorkspace& workspace,
     cudaStream_t stream);
 

--- a/examples/models/muse-glimmer/tests/sampling_cuda_test.cpp
+++ b/examples/models/muse-glimmer/tests/sampling_cuda_test.cpp
@@ -12,8 +12,10 @@
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstdint>
 #include <memory>
+#include <random>
 #include <tuple>
 #include <vector>
 
@@ -181,6 +183,87 @@ TEST(CudaSamplingTest, SamplingProbabilitiesMatchHost) {
       EXPECT_NEAR(sum, 1.0, 2e-5);
     }
   }
+}
+
+TEST(CudaSamplingTest, CategoricalSampleMatchesHostDistribution) {
+  constexpr int64_t kRows = 20000;
+  constexpr int64_t kRowSize = 4;
+  constexpr std::array<float, kRowSize> kDistribution = {
+      0.15f, 0.5f, 0.05f, 0.3f};
+  std::vector<float> probabilities(kRows * kRowSize);
+  for (int64_t row = 0; row < kRows; ++row) {
+    std::copy(
+        kDistribution.begin(),
+        kDistribution.end(),
+        probabilities.begin() + row * kRowSize);
+  }
+
+  float* device_probabilities = nullptr;
+  uint64_t* device_tokens = nullptr;
+  const size_t probability_bytes = probabilities.size() * sizeof(float);
+  ASSERT_CUDA_SUCCESS(cudaMalloc(&device_probabilities, probability_bytes));
+  ASSERT_CUDA_SUCCESS(cudaMalloc(&device_tokens, kRows * sizeof(uint64_t)));
+  ASSERT_CUDA_SUCCESS(cudaMemcpy(
+      device_probabilities,
+      probabilities.data(),
+      probability_bytes,
+      cudaMemcpyHostToDevice));
+
+  muse_glimmer::cuda::SamplingWorkspace workspace;
+  ASSERT_CUDA_SUCCESS(workspace.reserve(kRows, kRowSize, nullptr));
+  ASSERT_CUDA_SUCCESS(workspace.set_seed(1234, nullptr));
+  ASSERT_CUDA_SUCCESS(muse_glimmer::cuda::categorical_sample(
+      device_probabilities,
+      kRows,
+      kRowSize,
+      device_tokens,
+      workspace,
+      nullptr));
+  std::vector<uint64_t> first(kRows);
+  ASSERT_CUDA_SUCCESS(cudaMemcpy(
+      first.data(),
+      device_tokens,
+      first.size() * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+
+  ASSERT_CUDA_SUCCESS(workspace.set_seed(1234, nullptr));
+  ASSERT_CUDA_SUCCESS(muse_glimmer::cuda::categorical_sample(
+      device_probabilities,
+      kRows,
+      kRowSize,
+      device_tokens,
+      workspace,
+      nullptr));
+  std::vector<uint64_t> repeated(kRows);
+  ASSERT_CUDA_SUCCESS(cudaMemcpy(
+      repeated.data(),
+      device_tokens,
+      repeated.size() * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  EXPECT_EQ(first, repeated);
+
+  std::array<int64_t, kRowSize> cuda_counts{};
+  for (const uint64_t token : first) {
+    ASSERT_LT(token, kRowSize);
+    ++cuda_counts[token];
+  }
+  std::mt19937 host_rng(1234);
+  std::array<int64_t, kRowSize> host_counts{};
+  for (int64_t sample = 0; sample < kRows; ++sample) {
+    ++host_counts[muse_glimmer::categorical_sample(
+        host_rng, kDistribution.data(), kRowSize)];
+  }
+  for (int64_t token = 0; token < kRowSize; ++token) {
+    const double cuda_frequency =
+        static_cast<double>(cuda_counts[token]) / kRows;
+    const double host_frequency =
+        static_cast<double>(host_counts[token]) / kRows;
+    EXPECT_NEAR(cuda_frequency, kDistribution[token], 0.015);
+    EXPECT_NEAR(cuda_frequency, host_frequency, 0.02);
+  }
+
+  ASSERT_CUDA_SUCCESS(cudaFree(device_tokens));
+  ASSERT_CUDA_SUCCESS(cudaFree(device_probabilities));
 }
 
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22698
* #22697
* #22696
* #22695
* #22694
* #22693
* __->__ #22692
* #22691
* #22690

Add a batched CUDA counterpart for muse_glimmer::categorical_sample. Keep Philox seed and counter state in the preallocated CUDA sampling workspace so sampling is reproducible and graph-safe while tokens remain device-resident. Validate CUDA repeatability and distributional parity with the host sampler.

Differential Revision: [D117826284](https://our.internmc.facebook.com/intern/diff/D117826284/)