### PR TITLE
[executorch][muse-glimmer] Add unified CUDA sample_token entry point

### DIFF
--- a/examples/models/muse-glimmer/runtime/engine/sampling_cuda.cu
+++ b/examples/models/muse-glimmer/runtime/engine/sampling_cuda.cu
@@ -814,4 +814,54 @@ cudaError_t sample_from_residual_in_place(
       stream);
 }
 
+cudaError_t sample_token(
+    const float* logits,
+    int64_t row_count,
+    int64_t row_size,
+    double temperature,
+    int32_t top_k,
+    double top_p,
+    uint64_t* sampled_tokens,
+    float* out_probabilities,
+    bool probabilities_only,
+    SamplingWorkspace& workspace,
+    cudaStream_t stream) {
+  if (logits == nullptr || sampled_tokens == nullptr || row_count <= 0 ||
+      row_size <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  if (temperature <= 0.0) {
+    return argmax_index(
+        logits, row_count, row_size, sampled_tokens, stream);
+  }
+  cudaError_t error = workspace.reserve(row_count, row_size, stream);
+  if (error != cudaSuccess) {
+    return error;
+  }
+  float* probabilities = out_probabilities != nullptr
+      ? out_probabilities
+      : workspace.impl_->sort_keys_in;
+  error = fill_sampling_probabilities(
+      logits,
+      row_count,
+      row_size,
+      temperature,
+      top_k,
+      top_p,
+      probabilities,
+      workspace,
+      stream);
+  if (error != cudaSuccess ||
+      (out_probabilities != nullptr && probabilities_only)) {
+    return error;
+  }
+  return categorical_sample(
+      probabilities,
+      row_count,
+      row_size,
+      sampled_tokens,
+      workspace,
+      stream);
+}
+
 } // namespace muse_glimmer::cuda

--- a/examples/models/muse-glimmer/runtime/engine/sampling_cuda.h
+++ b/examples/models/muse-glimmer/runtime/engine/sampling_cuda.h
@@ -74,6 +74,18 @@ class SamplingWorkspace {
       uint64_t*,
       SamplingWorkspace&,
       cudaStream_t);
+  friend cudaError_t sample_token(
+      const float*,
+      int64_t,
+      int64_t,
+      double,
+      int32_t,
+      double,
+      uint64_t*,
+      float*,
+      bool,
+      SamplingWorkspace&,
+      cudaStream_t);
 };
 
 // Computes one argmax per contiguous row of `values`.
@@ -143,6 +155,22 @@ cudaError_t sample_from_residual_in_place(
     int64_t row_count,
     int64_t row_size,
     uint64_t* sampled_tokens,
+    SamplingWorkspace& workspace,
+    cudaStream_t stream);
+
+// CUDA counterpart of muse_glimmer::sample_token for contiguous logits rows.
+// `out_probabilities` may be null. When it is non-null and `probabilities_only`
+// is true, normalized probabilities are produced without consuming RNG state.
+cudaError_t sample_token(
+    const float* logits,
+    int64_t row_count,
+    int64_t row_size,
+    double temperature,
+    int32_t top_k,
+    double top_p,
+    uint64_t* sampled_tokens,
+    float* out_probabilities,
+    bool probabilities_only,
     SamplingWorkspace& workspace,
     cudaStream_t stream);
 

--- a/examples/models/muse-glimmer/tests/sampling_cuda_test.cpp
+++ b/examples/models/muse-glimmer/tests/sampling_cuda_test.cpp
@@ -468,4 +468,91 @@ TEST(CudaSamplingTest, ResidualCorrectionMatchesHostSemantics) {
   ASSERT_CUDA_SUCCESS(cudaFree(device_target));
 }
 
+TEST(CudaSamplingTest, SampleTokenMatchesHostModes) {
+  constexpr int64_t kRows = 2;
+  constexpr int64_t kRowSize = 5;
+  const std::vector<float> logits = {
+      -2.0f,
+      4.0f,
+      1.0f,
+      4.0f,
+      0.0f,
+      3.0f,
+      -1.0f,
+      2.0f,
+      0.5f,
+      -4.0f,
+  };
+  float* device_logits = nullptr;
+  float* device_probabilities = nullptr;
+  uint64_t* device_tokens = nullptr;
+  ASSERT_CUDA_SUCCESS(
+      cudaMalloc(&device_logits, logits.size() * sizeof(float)));
+  ASSERT_CUDA_SUCCESS(
+      cudaMalloc(&device_probabilities, logits.size() * sizeof(float)));
+  ASSERT_CUDA_SUCCESS(cudaMalloc(&device_tokens, kRows * sizeof(uint64_t)));
+  ASSERT_CUDA_SUCCESS(cudaMemcpy(
+      device_logits,
+      logits.data(),
+      logits.size() * sizeof(float),
+      cudaMemcpyHostToDevice));
+
+  muse_glimmer::cuda::SamplingWorkspace workspace;
+  ASSERT_CUDA_SUCCESS(workspace.reserve(kRows, kRowSize, nullptr));
+  ASSERT_CUDA_SUCCESS(muse_glimmer::cuda::sample_token(
+      device_logits,
+      kRows,
+      kRowSize,
+      0.0,
+      0,
+      1.0,
+      device_tokens,
+      nullptr,
+      false,
+      workspace,
+      nullptr));
+  std::vector<uint64_t> tokens(kRows);
+  ASSERT_CUDA_SUCCESS(cudaMemcpy(
+      tokens.data(),
+      device_tokens,
+      tokens.size() * sizeof(uint64_t),
+      cudaMemcpyDeviceToHost));
+  for (int64_t row = 0; row < kRows; ++row) {
+    EXPECT_EQ(
+        tokens[row],
+        muse_glimmer::argmax_index(logits.data() + row * kRowSize, kRowSize));
+  }
+
+  ASSERT_CUDA_SUCCESS(muse_glimmer::cuda::sample_token(
+      device_logits,
+      kRows,
+      kRowSize,
+      0.8,
+      3,
+      0.7,
+      device_tokens,
+      device_probabilities,
+      true,
+      workspace,
+      nullptr));
+  std::vector<float> probabilities(logits.size());
+  ASSERT_CUDA_SUCCESS(cudaMemcpy(
+      probabilities.data(),
+      device_probabilities,
+      probabilities.size() * sizeof(float),
+      cudaMemcpyDeviceToHost));
+  for (int64_t row = 0; row < kRows; ++row) {
+    const auto expected = muse_glimmer::sampling_probabilities(
+        logits.data() + row * kRowSize, kRowSize, 0.8, 3, 0.7);
+    for (int64_t token = 0; token < kRowSize; ++token) {
+      EXPECT_NEAR(
+          probabilities[row * kRowSize + token], expected[token], 2e-5f);
+    }
+  }
+
+  ASSERT_CUDA_SUCCESS(cudaFree(device_tokens));
+  ASSERT_CUDA_SUCCESS(cudaFree(device_probabilities));
+  ASSERT_CUDA_SUCCESS(cudaFree(device_logits));
+}
+
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22698
* #22697
* __->__ #22696
* #22695
* #22694
* #22693
* #22692
* #22691
* #22690

Add the CUDA counterpart of muse_glimmer::sample_token. Preserve greedy argmax, temperature/top-k/top-p probability construction, optional probabilities-only output, and stochastic categorical sampling behind one device-resident interface.

Differential Revision: [D117826288](https://our.internmc.facebook.com/intern/diff/D117826288/)