### PR TITLE
[executorch][muse-glimmer] Add CUDA speculative sampling orchestration

### DIFF
--- a/examples/models/muse-glimmer/runtime/engine/sampling_cuda.cu
+++ b/examples/models/muse-glimmer/runtime/engine/sampling_cuda.cu
@@ -329,6 +329,113 @@ __global__ void normalize_residual_rows_kernel(
   }
 }
 
+__global__ void greedy_speculative_sample_kernel(
+    const uint64_t* target_tokens,
+    const uint64_t* candidates,
+    int64_t verify_length,
+    int64_t* accepted_count,
+    uint64_t* correction_token) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+  *accepted_count = verify_length;
+  *correction_token = target_tokens[verify_length - 1];
+  for (int64_t row = 0; row < verify_length - 1; ++row) {
+    if (target_tokens[row] != candidates[row + 1]) {
+      *accepted_count = row + 1;
+      *correction_token = target_tokens[row];
+      return;
+    }
+  }
+}
+
+enum CorrectionMode : int32_t {
+  kTargetDistribution = 0,
+  kResidualDistribution = 1,
+  kExcludeDraftToken = 2,
+};
+
+__global__ void select_speculative_correction_kernel(
+    const float* target_probabilities,
+    const float* draft_probabilities,
+    const uint64_t* candidates,
+    int64_t verify_length,
+    int64_t row_size,
+    bool draft_argmax,
+    DeviceRngState* rng,
+    int32_t* selection,
+    int64_t* accepted_count) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) {
+    return;
+  }
+  *accepted_count = verify_length;
+  selection[0] = static_cast<int32_t>(verify_length - 1);
+  selection[1] = kTargetDistribution;
+  for (int64_t row = 0; row < verify_length - 1; ++row) {
+    const uint64_t token = candidates[row + 1];
+    const float p = target_probabilities[row * row_size + token];
+    const float q = draft_argmax
+        ? 1.0f
+        : draft_probabilities[(row + 1) * row_size + token];
+    const float acceptance = q > 0.0f ? fminf(1.0f, p / q) : 1.0f;
+    curandStatePhilox4_32_10_t local_rng;
+    curand_init(rng->seed, 0, rng->base + row, &local_rng);
+    if (uniform_from_uint32(curand(&local_rng)) >= acceptance) {
+      *accepted_count = row + 1;
+      selection[0] = static_cast<int32_t>(row);
+      selection[1] = draft_argmax ? kExcludeDraftToken : kResidualDistribution;
+      return;
+    }
+  }
+}
+
+__global__ void build_correction_distribution_kernel(
+    const float* target_probabilities,
+    const float* draft_probabilities,
+    const uint64_t* candidates,
+    const int32_t* selection,
+    int64_t row_size,
+    float* correction,
+    double* correction_double) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x) * blockDim.x +
+      threadIdx.x;
+  if (token >= row_size) {
+    return;
+  }
+  const int64_t row = selection[0];
+  const int32_t mode = selection[1];
+  const float p = target_probabilities[row * row_size + token];
+  float value = p;
+  if (mode == kResidualDistribution) {
+    value = fmaxf(0.0f, p - draft_probabilities[(row + 1) * row_size + token]);
+  } else if (mode == kExcludeDraftToken &&
+             token == static_cast<int64_t>(candidates[row + 1])) {
+    value = 0.0f;
+  }
+  correction[token] = value;
+  correction_double[token] = static_cast<double>(value);
+}
+
+__global__ void normalize_correction_distribution_kernel(
+    const float* target_probabilities,
+    const int32_t* selection,
+    const double* cumulative,
+    int64_t row_size,
+    float* correction) {
+  const int64_t token = static_cast<int64_t>(blockIdx.x) * blockDim.x +
+      threadIdx.x;
+  if (token >= row_size) {
+    return;
+  }
+  const float denominator = static_cast<float>(cumulative[row_size - 1]);
+  if (denominator > 0.0f) {
+    correction[token] /= denominator;
+  } else {
+    correction[token] =
+        target_probabilities[static_cast<int64_t>(selection[0]) * row_size + token];
+  }
+}
+
 } // namespace
 
 struct SamplingWorkspace::Impl {
@@ -862,6 +969,123 @@ cudaError_t sample_token(
       sampled_tokens,
       workspace,
       stream);
+}
+
+cudaError_t greedy_speculative_sample(
+    const uint64_t* target_tokens,
+    const uint64_t* candidates,
+    int64_t verify_length,
+    int64_t* accepted_count,
+    uint64_t* correction_token,
+    cudaStream_t stream) {
+  if (target_tokens == nullptr || candidates == nullptr ||
+      accepted_count == nullptr || correction_token == nullptr ||
+      verify_length < 1) {
+    return cudaErrorInvalidValue;
+  }
+  greedy_speculative_sample_kernel<<<1, 1, 0, stream>>>(
+      target_tokens,
+      candidates,
+      verify_length,
+      accepted_count,
+      correction_token);
+  return cudaGetLastError();
+}
+
+cudaError_t stochastic_speculative_sample(
+    const float* target_probabilities,
+    const float* draft_probabilities,
+    const uint64_t* candidates,
+    int64_t verify_length,
+    int64_t row_size,
+    bool draft_argmax,
+    int64_t* accepted_count,
+    uint64_t* correction_token,
+    SamplingWorkspace& workspace,
+    cudaStream_t stream) {
+  if (target_probabilities == nullptr || draft_probabilities == nullptr ||
+      candidates == nullptr || accepted_count == nullptr ||
+      correction_token == nullptr || verify_length < 2 || row_size <= 0) {
+    return cudaErrorInvalidValue;
+  }
+  cudaError_t error = workspace.reserve(verify_length, row_size, stream);
+  if (error != cudaSuccess) {
+    return error;
+  }
+  auto& state = *workspace.impl_;
+  if (verify_length > 1) {
+    advance_rng_kernel<<<1, 1, 0, stream>>>(state.rng, verify_length - 1);
+    error = cudaGetLastError();
+    if (error != cudaSuccess) {
+      return error;
+    }
+  }
+  select_speculative_correction_kernel<<<1, 1, 0, stream>>>(
+      target_probabilities,
+      draft_probabilities,
+      candidates,
+      verify_length,
+      row_size,
+      draft_argmax,
+      state.rng,
+      state.cutoffs,
+      accepted_count);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    return error;
+  }
+
+  const int blocks =
+      static_cast<int>((row_size + kSamplingThreads - 1) / kSamplingThreads);
+  build_correction_distribution_kernel<<<blocks, kSamplingThreads, 0, stream>>>(
+      target_probabilities,
+      draft_probabilities,
+      candidates,
+      state.cutoffs,
+      row_size,
+      state.sort_keys_in,
+      state.weights);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    return error;
+  }
+  error = cub::DeviceScan::InclusiveSum(
+      state.temporary_storage,
+      state.temporary_storage_bytes,
+      state.weights,
+      state.cumulative,
+      static_cast<int>(row_size),
+      stream);
+  if (error != cudaSuccess) {
+    return error;
+  }
+  normalize_correction_distribution_kernel<<<
+      blocks, kSamplingThreads, 0, stream>>>(
+      target_probabilities,
+      state.cutoffs,
+      state.cumulative,
+      row_size,
+      state.sort_keys_in);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) {
+    return error;
+  }
+  probabilities_to_double_kernel<<<blocks, kSamplingThreads, 0, stream>>>(
+      state.sort_keys_in, row_size, state.weights);
+  error = cub::DeviceScan::InclusiveSum(
+      state.temporary_storage,
+      state.temporary_storage_bytes,
+      state.weights,
+      state.cumulative,
+      static_cast<int>(row_size),
+      stream);
+  if (error != cudaSuccess) {
+    return error;
+  }
+  advance_rng_kernel<<<1, 1, 0, stream>>>(state.rng, 1);
+  categorical_sample_kernel<<<1, 1, 0, stream>>>(
+      state.cumulative, 1, row_size, state.rng, correction_token);
+  return cudaGetLastError();
 }
 
 } // namespace muse_glimmer::cuda

--- a/examples/models/muse-glimmer/runtime/engine/sampling_cuda.h
+++ b/examples/models/muse-glimmer/runtime/engine/sampling_cuda.h
@@ -86,6 +86,17 @@ class SamplingWorkspace {
       bool,
       SamplingWorkspace&,
       cudaStream_t);
+  friend cudaError_t stochastic_speculative_sample(
+      const float*,
+      const float*,
+      const uint64_t*,
+      int64_t,
+      int64_t,
+      bool,
+      int64_t*,
+      uint64_t*,
+      SamplingWorkspace&,
+      cudaStream_t);
 };
 
 // Computes one argmax per contiguous row of `values`.
@@ -172,6 +183,28 @@ cudaError_t sample_token(
     float* out_probabilities,
     bool probabilities_only,
     SamplingWorkspace& workspace,
+    cudaStream_t stream);
+
+// Device-side DFlash verification using already normalized target/draft
+// probabilities. Returns the committed candidate count and correction token.
+cudaError_t stochastic_speculative_sample(
+    const float* target_probabilities,
+    const float* draft_probabilities,
+    const uint64_t* candidates,
+    int64_t verify_length,
+    int64_t row_size,
+    bool draft_argmax,
+    int64_t* accepted_count,
+    uint64_t* correction_token,
+    SamplingWorkspace& workspace,
+    cudaStream_t stream);
+
+cudaError_t greedy_speculative_sample(
+    const uint64_t* target_tokens,
+    const uint64_t* candidates,
+    int64_t verify_length,
+    int64_t* accepted_count,
+    uint64_t* correction_token,
     cudaStream_t stream);
 
 } // namespace muse_glimmer::cuda

--- a/examples/models/muse-glimmer/tests/sampling_cuda_test.cpp
+++ b/examples/models/muse-glimmer/tests/sampling_cuda_test.cpp
@@ -555,4 +555,181 @@ TEST(CudaSamplingTest, SampleTokenMatchesHostModes) {
   ASSERT_CUDA_SUCCESS(cudaFree(device_logits));
 }
 
+TEST(CudaSamplingTest, GreedySpeculativeSamplingMatchesHostFlow) {
+  constexpr int64_t kVerifyLength = 4;
+  const std::array<uint64_t, kVerifyLength> target_tokens = {11, 12, 13, 14};
+  const std::array<uint64_t, kVerifyLength> rejected_candidates = {
+      10, 11, 99, 13};
+  const std::array<uint64_t, kVerifyLength> accepted_candidates = {
+      10, 11, 12, 13};
+
+  uint64_t* device_target_tokens = nullptr;
+  uint64_t* device_candidates = nullptr;
+  int64_t* device_accepted_count = nullptr;
+  uint64_t* device_correction_token = nullptr;
+  ASSERT_CUDA_SUCCESS(cudaMalloc(
+      &device_target_tokens, target_tokens.size() * sizeof(uint64_t)));
+  ASSERT_CUDA_SUCCESS(cudaMalloc(
+      &device_candidates, rejected_candidates.size() * sizeof(uint64_t)));
+  ASSERT_CUDA_SUCCESS(cudaMalloc(&device_accepted_count, sizeof(int64_t)));
+  ASSERT_CUDA_SUCCESS(cudaMalloc(&device_correction_token, sizeof(uint64_t)));
+  ASSERT_CUDA_SUCCESS(cudaMemcpy(
+      device_target_tokens,
+      target_tokens.data(),
+      target_tokens.size() * sizeof(uint64_t),
+      cudaMemcpyHostToDevice));
+
+  auto verify = [&](const auto& candidates,
+                    int64_t expected_count,
+                    uint64_t expected_correction) {
+    ASSERT_CUDA_SUCCESS(cudaMemcpy(
+        device_candidates,
+        candidates.data(),
+        candidates.size() * sizeof(uint64_t),
+        cudaMemcpyHostToDevice));
+    ASSERT_CUDA_SUCCESS(muse_glimmer::cuda::greedy_speculative_sample(
+        device_target_tokens,
+        device_candidates,
+        kVerifyLength,
+        device_accepted_count,
+        device_correction_token,
+        nullptr));
+    int64_t accepted_count = 0;
+    uint64_t correction_token = 0;
+    ASSERT_CUDA_SUCCESS(cudaMemcpy(
+        &accepted_count,
+        device_accepted_count,
+        sizeof(int64_t),
+        cudaMemcpyDeviceToHost));
+    ASSERT_CUDA_SUCCESS(cudaMemcpy(
+        &correction_token,
+        device_correction_token,
+        sizeof(uint64_t),
+        cudaMemcpyDeviceToHost));
+    EXPECT_EQ(accepted_count, expected_count);
+    EXPECT_EQ(correction_token, expected_correction);
+  };
+  verify(rejected_candidates, 2, 12);
+  verify(accepted_candidates, 4, 14);
+
+  ASSERT_CUDA_SUCCESS(cudaFree(device_correction_token));
+  ASSERT_CUDA_SUCCESS(cudaFree(device_accepted_count));
+  ASSERT_CUDA_SUCCESS(cudaFree(device_candidates));
+  ASSERT_CUDA_SUCCESS(cudaFree(device_target_tokens));
+}
+
+TEST(CudaSamplingTest, StochasticSpeculativeSamplingHandlesAcceptAndReject) {
+  constexpr int64_t kVerifyLength = 4;
+  constexpr int64_t kRowSize = 4;
+  const std::array<uint64_t, kVerifyLength> candidates = {0, 1, 2, 3};
+  const std::array<float, kVerifyLength * kRowSize> all_accepted_target = {
+      0,
+      1,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      1,
+  };
+  const std::array<float, kVerifyLength * kRowSize> all_accepted_draft = {
+      1,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      0,
+      1,
+      0,
+      0,
+      0,
+      0,
+      1,
+  };
+  auto rejected_target = all_accepted_target;
+  rejected_target[0] = 1.0f;
+  rejected_target[1] = 0.0f;
+
+  float* device_target = nullptr;
+  float* device_draft = nullptr;
+  uint64_t* device_candidates = nullptr;
+  int64_t* device_accepted_count = nullptr;
+  uint64_t* device_correction_token = nullptr;
+  const size_t probabilities_bytes = all_accepted_target.size() * sizeof(float);
+  ASSERT_CUDA_SUCCESS(cudaMalloc(&device_target, probabilities_bytes));
+  ASSERT_CUDA_SUCCESS(cudaMalloc(&device_draft, probabilities_bytes));
+  ASSERT_CUDA_SUCCESS(
+      cudaMalloc(&device_candidates, candidates.size() * sizeof(uint64_t)));
+  ASSERT_CUDA_SUCCESS(cudaMalloc(&device_accepted_count, sizeof(int64_t)));
+  ASSERT_CUDA_SUCCESS(cudaMalloc(&device_correction_token, sizeof(uint64_t)));
+  ASSERT_CUDA_SUCCESS(cudaMemcpy(
+      device_candidates,
+      candidates.data(),
+      candidates.size() * sizeof(uint64_t),
+      cudaMemcpyHostToDevice));
+  ASSERT_CUDA_SUCCESS(cudaMemcpy(
+      device_draft,
+      all_accepted_draft.data(),
+      probabilities_bytes,
+      cudaMemcpyHostToDevice));
+
+  muse_glimmer::cuda::SamplingWorkspace workspace;
+  ASSERT_CUDA_SUCCESS(workspace.reserve(kVerifyLength, kRowSize, nullptr));
+  ASSERT_CUDA_SUCCESS(workspace.set_seed(7890, nullptr));
+  auto verify = [&](const auto& target,
+                    int64_t expected_count,
+                    uint64_t expected_correction) {
+    ASSERT_CUDA_SUCCESS(cudaMemcpy(
+        device_target,
+        target.data(),
+        probabilities_bytes,
+        cudaMemcpyHostToDevice));
+    ASSERT_CUDA_SUCCESS(muse_glimmer::cuda::stochastic_speculative_sample(
+        device_target,
+        device_draft,
+        device_candidates,
+        kVerifyLength,
+        kRowSize,
+        false,
+        device_accepted_count,
+        device_correction_token,
+        workspace,
+        nullptr));
+    int64_t accepted_count = 0;
+    uint64_t correction_token = 0;
+    ASSERT_CUDA_SUCCESS(cudaMemcpy(
+        &accepted_count,
+        device_accepted_count,
+        sizeof(int64_t),
+        cudaMemcpyDeviceToHost));
+    ASSERT_CUDA_SUCCESS(cudaMemcpy(
+        &correction_token,
+        device_correction_token,
+        sizeof(uint64_t),
+        cudaMemcpyDeviceToHost));
+    EXPECT_EQ(accepted_count, expected_count);
+    EXPECT_EQ(correction_token, expected_correction);
+  };
+  verify(all_accepted_target, 4, 3);
+  verify(rejected_target, 1, 0);
+
+  ASSERT_CUDA_SUCCESS(cudaFree(device_correction_token));
+  ASSERT_CUDA_SUCCESS(cudaFree(device_accepted_count));
+  ASSERT_CUDA_SUCCESS(cudaFree(device_candidates));
+  ASSERT_CUDA_SUCCESS(cudaFree(device_draft));
+  ASSERT_CUDA_SUCCESS(cudaFree(device_target));
+}
+
 } // namespace


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22698
* __->__ #22697
* #22696
* #22695
* #22694
* #22693
* #22692
* #22691
* #22690

Add the CUDA counterparts of the DFlash verification step. stochastic_speculative_sample walks the candidate block on device using already normalized target and draft probability rows, applies the host acceptance rule, and falls back to residual or excluded-token correction on the first rejection, while greedy_speculative_sample compares committed argmax tokens without touching probabilities. Both return the committed candidate count and correction token as device-resident scalars so the decode loop never needs the full probability rows on the host.

Differential Revision: [D117826289](https://our.internmc.facebook.com/intern/diff/D117826289/)