### PR TITLE
[executorch][native] Add deserializer bridge (Program -> Method)

### DIFF
--- a/backends/native/runtime/Deserialize.cpp
+++ b/backends/native/runtime/Deserialize.cpp
@@ -1,0 +1,617 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+// The deserializer bridge: native_backend::Program (FlatBuffer) -> ptn
+// in-memory IR (Method / Graph / Node / Argument / Value). In-graph references
+// (SSA names) are resolved to list ValueIds; per-graph namespaces are
+// resolved independently (each HOP subgraph rebuilds its own name -> id map).
+//
+// Everything here runs on a buffer Program::load() has already put through
+// flatbuffers::Verifier, so accessors return non-null wherever the schema
+// declares the field required and wherever a union discriminator matches; the
+// walkers below dereference those results directly. Fields the schema leaves
+// optional are still checked, because verification says nothing about whether
+// they are present. Vector<Offset<T>>::Get() computes an address rather than a
+// nullable pointer, and verification bounds-checks every referenced object.
+
+#include <executorch/backends/native/runtime/Program.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <flatbuffers/flatbuffers.h>
+
+#include <executorch/backends/native/runtime/native_graph_generated.h>
+
+namespace ptn {
+namespace {
+
+std::string str_of(const flatbuffers::String* s) {
+  return s != nullptr ? s->str() : std::string();
+}
+
+bool nonempty(const flatbuffers::String* s) {
+  return s != nullptr && s->size() > 0;
+}
+
+ScalarType map_scalar_type(fbs::ScalarType t) {
+  // ptn::ScalarType ids are pinned to the schema's, so the byte maps straight.
+  return static_cast<ScalarType>(static_cast<int8_t>(t));
+}
+
+OpKind map_op_kind(fbs::OpKind k) {
+  switch (k) {
+    case fbs::OpKind::CALL_FUNCTION:
+      return OpKind::CallFunction;
+    case fbs::OpKind::PLACEHOLDER:
+      return OpKind::Placeholder;
+    case fbs::OpKind::OUTPUT:
+      return OpKind::Output;
+    default:
+      throw std::runtime_error(
+          "build_graph: unsupported OpKind value " +
+          std::to_string(static_cast<int>(k)));
+  }
+}
+
+OutputValueKind map_output_value_kind(fbs::OutputValueKind k) {
+  switch (k) {
+    case fbs::OutputValueKind::TENSOR:
+      return OutputValueKind::Tensor;
+    case fbs::OutputValueKind::TENSOR_LIST:
+      return OutputValueKind::TensorList;
+    case fbs::OutputValueKind::INT:
+      return OutputValueKind::Int;
+    case fbs::OutputValueKind::BOOL:
+      return OutputValueKind::Bool;
+    case fbs::OutputValueKind::FLOAT:
+      return OutputValueKind::Float;
+    default:
+      throw std::runtime_error(
+          "build_graph: unsupported OutputValueKind value " +
+          std::to_string(static_cast<int>(k)));
+  }
+}
+
+ValueRole map_input_kind(fbs::InputKind k) {
+  switch (k) {
+    case fbs::InputKind::USER_INPUT:
+      return ValueRole::UserInput;
+    case fbs::InputKind::PARAMETER:
+      return ValueRole::Parameter;
+    case fbs::InputKind::BUFFER:
+      return ValueRole::Buffer;
+    case fbs::InputKind::CONSTANT_TENSOR:
+      return ValueRole::ConstantTensor;
+    default:
+      throw std::runtime_error(
+          "build_method: unsupported InputKind value " +
+          std::to_string(static_cast<int>(k)));
+  }
+}
+
+OutputKind map_output_kind(fbs::OutputKind k) {
+  switch (k) {
+    case fbs::OutputKind::USER_OUTPUT:
+      return OutputKind::UserOutput;
+    case fbs::OutputKind::BUFFER_MUTATION:
+      return OutputKind::BufferMutation;
+    case fbs::OutputKind::USER_INPUT_MUTATION:
+      return OutputKind::UserInputMutation;
+    default:
+      throw std::runtime_error(
+          "build_method: unsupported OutputKind value " +
+          std::to_string(static_cast<int>(k)));
+  }
+}
+
+// The wire describes a dim as a min..max range, while the IR holds a concrete
+// extent. Collapsing a range to its upper bound would run the graph at that
+// bound and compute over elements the caller never supplied, so a dim that is
+// not a single non-negative extent is refused where it enters the IR.
+int64_t static_extent(
+    const fbs::Dim* d,
+    const std::string& value_name,
+    flatbuffers::uoffset_t i) {
+  if (d->min() == d->max() && d->min() >= 0) {
+    return d->min();
+  }
+  throw std::runtime_error(
+      "build_tensor_meta: " + value_name + " dim " + std::to_string(i) +
+      " is not a static extent (" + std::to_string(d->min()) + ".." +
+      (d->max() < 0 ? std::string("inf") : std::to_string(d->max())) +
+      "); this runtime requires static shapes");
+}
+
+TensorMeta build_tensor_meta(
+    const fbs::TensorMeta* m,
+    const std::string& name) {
+  TensorMeta out;
+  if (m == nullptr) {
+    return out;
+  }
+  out.dtype = map_scalar_type(m->dtype());
+  if (const auto* sizes = m->sizes()) {
+    out.sizes.reserve(sizes->size());
+    for (flatbuffers::uoffset_t i = 0; i < sizes->size(); ++i) {
+      out.sizes.push_back(static_extent(sizes->Get(i), name, i));
+    }
+  }
+  if (const auto* dord = m->dim_order()) {
+    out.dim_order_hint.reserve(dord->size());
+    for (flatbuffers::uoffset_t i = 0; i < dord->size(); ++i) {
+      out.dim_order_hint.push_back(static_cast<int32_t>(dord->Get(i)));
+    }
+  }
+  return out;
+}
+
+// value name -> tensor metadata.
+using MetaTable = std::unordered_map<std::string, const fbs::TensorMeta*>;
+
+// One graph body plus the SSA-name -> value-id map used to build it.
+//
+// The wire format addresses values two ways: a graph body is positional, and
+// the value list keeps that (a ValueId is an index), while the method-level
+// side tables -- constants, mutable_buffers, output_specs -- name their targets
+// by SSA string, since the serializer writes them independently of the body.
+// Only the builder knows how one maps to the other, so it hands the map back
+// for build_method to resolve those names against.
+//
+// Build-time scaffolding: nothing outside build_method sees it, and neither
+// Method nor Graph stores it. Once the bindings are resolved to ids it is
+// discarded, and the graph is index-addressed from then on.
+struct BuiltGraph {
+  Graph graph;
+  std::unordered_map<std::string, ValueId> name_to_id;
+};
+
+// `extra_meta` supplies metadata for values the graph's own tensor_values side
+// table omits: a constant placeholder's meta rides on the Method's
+// NamedTensorRef binding instead, so build_method passes it in to type those
+// values on creation. Subgraphs have no such bindings.
+BuiltGraph build_graph(const fbs::Graph* g, const MetaTable& extra_meta = {});
+
+// Builds one Graph body. The graph under construction, its SSA-name -> id map,
+// and the name -> metadata table are shared by every step of the build, so they
+// are members rather than threaded through each call. One builder per body: a
+// subgraph gets a fresh one, which is what gives each body its own independent
+// SSA namespace.
+class GraphBuilder {
+ public:
+  BuiltGraph run(const fbs::Graph* g, const MetaTable& extra_meta);
+
+ private:
+  // Resolve a name to its ValueId, creating the Value on first mention.
+  // A name in the meta side table becomes a Tensor value; otherwise a None
+  // value (scalar / symbolic outputs, refined once the loader models them).
+  ValueId id_of(const std::string& name);
+
+  Argument convert_arg(const fbs::Argument* a);
+
+  Graph graph_;
+  std::unordered_map<std::string, ValueId> n2i_;
+  MetaTable tm_;
+};
+
+ValueId GraphBuilder::id_of(const std::string& name) {
+  if (name.empty()) {
+    return kInvalid;
+  }
+  const auto it = n2i_.find(name);
+  if (it != n2i_.end()) {
+    return it->second;
+  }
+  const ValueId id = static_cast<ValueId>(graph_.values.size());
+  const auto mit = tm_.find(name);
+  if (mit != tm_.end() && mit->second != nullptr) {
+    graph_.values.emplace_back(name, build_tensor_meta(mit->second, name));
+  } else {
+    graph_.values.emplace_back(name);
+  }
+  n2i_[name] = id;
+  return id;
+}
+
+Argument GraphBuilder::convert_arg(const fbs::Argument* a) {
+  using AV = fbs::ArgumentValue;
+  switch (a->value_type()) {
+    case AV::NONE:
+    case AV::NoneArg:
+      return NoneArg{};
+    case AV::TensorArg: {
+      TensorArg t;
+      t.id = id_of(str_of(a->value_as_TensorArg()->name()));
+      return t;
+    }
+    case AV::IntArg: {
+      const auto* x = a->value_as_IntArg();
+      IntArg r;
+      r.value = x->value();
+      r.id = nonempty(x->ref()) ? id_of(x->ref()->str()) : kInvalid;
+      return r;
+    }
+    case AV::FloatArg: {
+      const auto* x = a->value_as_FloatArg();
+      FloatArg r;
+      r.value = x->value();
+      r.id = nonempty(x->ref()) ? id_of(x->ref()->str()) : kInvalid;
+      return r;
+    }
+    case AV::BoolArg: {
+      const auto* x = a->value_as_BoolArg();
+      BoolArg r;
+      r.value = x->value();
+      r.id = nonempty(x->ref()) ? id_of(x->ref()->str()) : kInvalid;
+      return r;
+    }
+    case AV::StringArg: {
+      StringArg r;
+      r.value = str_of(a->value_as_StringArg()->value());
+      return r;
+    }
+    case AV::ScalarTypeArg: {
+      ScalarTypeArg r;
+      r.value = map_scalar_type(a->value_as_ScalarTypeArg()->value());
+      return r;
+    }
+    case AV::IntListArg: {
+      const auto* x = a->value_as_IntListArg();
+      IntListArg r;
+      if (const auto* vals = x->values()) {
+        for (flatbuffers::uoffset_t i = 0; i < vals->size(); ++i) {
+          r.values.push_back(vals->Get(i));
+        }
+      }
+      if (const auto* refs = x->refs()) {
+        for (flatbuffers::uoffset_t i = 0; i < refs->size(); ++i) {
+          r.ids.push_back(
+              nonempty(refs->Get(i)) ? id_of(refs->Get(i)->str()) : kInvalid);
+        }
+      }
+      return r;
+    }
+    case AV::FloatListArg: {
+      FloatListArg r;
+      if (const auto* vals = a->value_as_FloatListArg()->values()) {
+        for (flatbuffers::uoffset_t i = 0; i < vals->size(); ++i) {
+          r.values.push_back(vals->Get(i));
+        }
+      }
+      return r;
+    }
+    case AV::BoolListArg: {
+      BoolListArg r;
+      if (const auto* vals = a->value_as_BoolListArg()->values()) {
+        for (flatbuffers::uoffset_t i = 0; i < vals->size(); ++i) {
+          r.values.push_back(vals->Get(i));
+        }
+      }
+      return r;
+    }
+    case AV::TensorListArg: {
+      TensorListArg r;
+      if (const auto* nm = a->value_as_TensorListArg()->names()) {
+        for (flatbuffers::uoffset_t i = 0; i < nm->size(); ++i) {
+          r.ids.push_back(id_of(nm->Get(i)->str()));
+        }
+      }
+      return r;
+    }
+    case AV::OptionalTensorListArg: {
+      const auto* oa = a->value_as_OptionalTensorListArg();
+      const auto* nm = oa->names();
+      const auto* hv = oa->has_value();
+      OptionalTensorListArg r;
+      if (nm != nullptr) {
+        for (flatbuffers::uoffset_t i = 0; i < nm->size(); ++i) {
+          const bool present = hv != nullptr && i < hv->size() && hv->Get(i);
+          r.ids.push_back(present ? id_of(nm->Get(i)->str()) : kInvalid);
+        }
+      }
+      return r;
+    }
+    case AV::GraphArg: {
+      const fbs::GraphArg* ga = a->value_as_GraphArg();
+      GraphArg r;
+      r.name = str_of(ga->name());
+      r.subgraph_id = static_cast<GraphId>(graph_.subgraphs.size());
+      graph_.subgraphs.push_back(build_graph(ga->graph()).graph);
+      return r;
+    }
+    default:
+      throw std::runtime_error(
+          "build_graph: unsupported ArgumentValue value " +
+          std::to_string(static_cast<int>(a->value_type())));
+  }
+}
+
+BuiltGraph GraphBuilder::run(const fbs::Graph* g, const MetaTable& extra_meta) {
+  if (g == nullptr) {
+    return {};
+  }
+
+  if (const auto* tvs = g->tensor_values()) {
+    for (flatbuffers::uoffset_t i = 0; i < tvs->size(); ++i) {
+      const fbs::TensorValue* tv = tvs->Get(i);
+      tm_[str_of(tv->name())] = tv->meta();
+    }
+  }
+  for (const auto& entry : extra_meta) {
+    const fbs::TensorMeta*& slot = tm_[entry.first];
+    if (slot == nullptr) {
+      slot = entry.second;
+    }
+  }
+
+  // Pre-create meta-carrying values in a deterministic order (nicer ids).
+  if (const auto* tvs = g->tensor_values()) {
+    for (flatbuffers::uoffset_t i = 0; i < tvs->size(); ++i) {
+      id_of(str_of(tvs->Get(i)->name()));
+    }
+  }
+
+  if (const auto* nodes = g->nodes()) {
+    for (flatbuffers::uoffset_t i = 0; i < nodes->size(); ++i) {
+      const fbs::Node* nd = nodes->Get(i);
+      Node node;
+      node.name = str_of(nd->name());
+      node.op_kind = map_op_kind(nd->op_kind());
+      node.target = str_of(nd->target());
+
+      if (const auto* ins = nd->inputs()) {
+        for (flatbuffers::uoffset_t j = 0; j < ins->size(); ++j) {
+          const fbs::NamedArgument* na = ins->Get(j);
+          NamedArgument narg;
+          narg.name = str_of(na->name());
+          narg.mutated = na->mutated();
+          narg.arg = convert_arg(na->arg());
+          node.inputs.push_back(std::move(narg));
+        }
+      }
+
+      if (const auto* outs = nd->outputs()) {
+        for (flatbuffers::uoffset_t j = 0; j < outs->size(); ++j) {
+          const fbs::Output* o = outs->Get(j);
+          Output out;
+          out.kind = map_output_value_kind(o->kind());
+          if (o->kind() == fbs::OutputValueKind::TENSOR_LIST) {
+            if (const auto* nm = o->names()) {
+              for (flatbuffers::uoffset_t k = 0; k < nm->size(); ++k) {
+                out.elem_ids.push_back(id_of(nm->Get(k)->str()));
+              }
+            }
+          } else {
+            out.value_id = id_of(str_of(o->name()));
+            if (nonempty(o->alias_of()) && valid(out.value_id)) {
+              const ValueId alias_id = id_of(o->alias_of()->str());
+              if (alias_id == out.value_id) {
+                throw std::runtime_error(
+                    "build_graph: output '" + str_of(o->name()) +
+                    "' cannot alias itself");
+              }
+              graph_.values.at(static_cast<size_t>(out.value_id)).alias_id =
+                  alias_id;
+            }
+          }
+          node.outputs.push_back(std::move(out));
+        }
+      }
+
+      // A placeholder with no explicit Output still produces its named value;
+      // synthesize one so def-use wiring records the placeholder as producer.
+      if (node.op_kind == OpKind::Placeholder && node.outputs.empty() &&
+          !node.name.empty()) {
+        Output out;
+        out.value_id = id_of(node.name);
+        node.outputs.push_back(out);
+      }
+
+      graph_.nodes.push_back(std::move(node));
+    }
+  }
+
+  if (const auto* gi = g->inputs()) {
+    for (flatbuffers::uoffset_t i = 0; i < gi->size(); ++i) {
+      graph_.input_ids.push_back(id_of(gi->Get(i)->str()));
+    }
+  }
+  if (const auto* go = g->outputs()) {
+    for (flatbuffers::uoffset_t i = 0; i < go->size(); ++i) {
+      graph_.output_ids.push_back(id_of(go->Get(i)->str()));
+    }
+  }
+
+  graph_.initialize_schedule();
+  graph_.rebuild_def_use();
+  return BuiltGraph{std::move(graph_), std::move(n2i_)};
+}
+
+BuiltGraph build_graph(const fbs::Graph* g, const MetaTable& extra_meta) {
+  return GraphBuilder().run(g, extra_meta);
+}
+
+// Resolve a method-level binding name (namespace 2) against the top-level
+// graph's SSA names, or kInvalid if the graph holds no such value.
+ValueId id_of_name(
+    const std::unordered_map<std::string, ValueId>& n2i,
+    const std::string& name) {
+  const auto it = n2i.find(name);
+  return it != n2i.end() ? it->second : kInvalid;
+}
+
+ValueId require_binding_value(
+    const std::unordered_map<std::string, ValueId>& n2i,
+    const std::string& name) {
+  const ValueId id = id_of_name(n2i, name);
+  if (!valid(id)) {
+    throw std::runtime_error(
+        "build_method: data binding '" + name +
+        "' does not name a graph value");
+  }
+  return id;
+}
+
+void stamp_role(Graph& graph, ValueId id, ValueRole role) {
+  if (in_bounds(id, graph.values.size())) {
+    graph.values.at(static_cast<size_t>(id)).role = role;
+  }
+}
+
+} // namespace
+
+Method Program::build_method(size_t index) const {
+  if (program_fb_ == nullptr) {
+    throw std::runtime_error("build_method: program is not loaded");
+  }
+  const auto* methods = program_fb_->methods();
+  if (methods == nullptr || index >= methods->size()) {
+    throw std::runtime_error("build_method: method index out of range");
+  }
+  const fbs::Method* m =
+      methods->Get(static_cast<flatbuffers::uoffset_t>(index));
+
+  Method method;
+  method.name = str_of(m->name());
+
+  MetaTable constant_meta;
+  if (const auto* cs = m->constants()) {
+    for (flatbuffers::uoffset_t i = 0; i < cs->size(); ++i) {
+      const fbs::NamedTensorRef* c = cs->Get(i);
+      constant_meta[str_of(c->name())] = c->meta();
+    }
+  }
+
+  BuiltGraph built = build_graph(m->graph(), constant_meta);
+  const std::unordered_map<std::string, ValueId>& n2i = built.name_to_id;
+  method.graph = std::move(built.graph);
+  Graph& graph = method.graph;
+
+  // external-constant / buffer identity (key) -> value, for BufferMutation
+  // output targets (a namespace-3 fqn, not an SSA name).
+  std::unordered_map<std::string, ValueId> key_to_id;
+  std::unordered_set<ValueId> bound_ids;
+
+  if (const auto* cs = m->constants()) {
+    for (flatbuffers::uoffset_t i = 0; i < cs->size(); ++i) {
+      const fbs::NamedTensorRef* c = cs->Get(i);
+      DataBinding b;
+      const std::string name = str_of(c->name());
+      b.value_id = require_binding_value(n2i, name);
+      if (!bound_ids.insert(b.value_id).second) {
+        throw std::runtime_error(
+            "build_method: graph value '" + name +
+            "' has multiple data bindings");
+      }
+      b.role = map_input_kind(c->kind());
+      b.key = str_of(c->data_key());
+      b.has_data = true;
+      b.mutated = c->mutated();
+      stamp_role(graph, b.value_id, b.role);
+      if (!b.key.empty()) {
+        key_to_id[b.key] = b.value_id;
+      }
+      method.data_bindings.push_back(std::move(b));
+    }
+  }
+
+  if (const auto* mbs = m->mutable_buffers()) {
+    for (flatbuffers::uoffset_t i = 0; i < mbs->size(); ++i) {
+      const fbs::MutableBufferSpec* mb = mbs->Get(i);
+      DataBinding b;
+      const std::string name = str_of(mb->name());
+      b.value_id = require_binding_value(n2i, name);
+      if (!bound_ids.insert(b.value_id).second) {
+        throw std::runtime_error(
+            "build_method: graph value '" + name +
+            "' has multiple data bindings");
+      }
+      b.role = ValueRole::Buffer;
+      b.key = str_of(mb->fqn());
+      b.has_data = false;
+      b.mutated = true;
+      stamp_role(graph, b.value_id, ValueRole::Buffer);
+      if (!b.key.empty()) {
+        key_to_id[b.key] = b.value_id;
+      }
+      method.data_bindings.push_back(std::move(b));
+    }
+  }
+
+  // Top-level graph inputs not otherwise bound are user inputs.
+  for (const ValueId id : graph.input_ids) {
+    if (in_bounds(id, graph.values.size()) &&
+        graph.values[id].role == ValueRole::Intermediate) {
+      graph.values[id].role = ValueRole::UserInput;
+    }
+  }
+
+  // output_specs are parallel to graph.outputs (same order); each classifies
+  // graph.output_ids[i]. The mutation target resolves to a placeholder value:
+  // an fqn (BufferMutation) via key_to_id, else an SSA name
+  // (UserInputMutation).
+  if (const auto* os = m->output_specs()) {
+    if (os->size() != graph.output_ids.size()) {
+      throw std::runtime_error(
+          "build_method: output_specs count does not match graph outputs");
+    }
+    for (flatbuffers::uoffset_t i = 0; i < os->size(); ++i) {
+      const fbs::OutputSpec* o = os->Get(i);
+      OutputSpec spec;
+      spec.kind = map_output_kind(o->kind());
+      const std::string target = str_of(o->target());
+      if (spec.kind != OutputKind::UserOutput) {
+        if (spec.kind == OutputKind::BufferMutation) {
+          const auto it = key_to_id.find(target);
+          spec.target_id = it != key_to_id.end() ? it->second : kInvalid;
+        } else {
+          spec.target_id = id_of_name(n2i, target);
+        }
+        if (!valid(spec.target_id)) {
+          throw std::runtime_error(
+              "build_method: mutation target '" + target +
+              "' does not name a bound value");
+        }
+      }
+      method.output_specs.push_back(spec);
+    }
+  }
+
+  return method;
+}
+
+// Defined here (rather than in Program.cpp) so it sits next to build_method and
+// the deserializer helpers it drives: get_method is the public lazy entry
+// point, build_method the private materializer it calls on a cache miss.
+const Method& Program::get_method(const std::string& name) const {
+  const auto it = method_cache_.find(name);
+  if (it != method_cache_.end()) {
+    return it->second;
+  }
+  if (program_fb_ != nullptr) {
+    if (const auto* methods = program_fb_->methods()) {
+      for (flatbuffers::uoffset_t i = 0; i < methods->size(); ++i) {
+        const flatbuffers::String* method_name = methods->Get(i)->name();
+        if (method_name != nullptr &&
+            std::string_view(method_name->c_str(), method_name->size()) ==
+                name) {
+          auto res = method_cache_.emplace(name, build_method(i));
+          return res.first->second;
+        }
+      }
+    }
+  }
+  throw std::runtime_error(
+      "Program::get_method: no method named '" + name + "'");
+}
+
+} // namespace ptn

--- a/backends/native/runtime/Program.cpp
+++ b/backends/native/runtime/Program.cpp
@@ -8,6 +8,8 @@
 
 #include <cstdint>
 #include <stdexcept>
+#include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -42,12 +44,38 @@ Program Program::load(const void* data, size_t size) {
   }
 
   const fbs::Program* program_fb = fbs::GetProgram(bytes.data());
+  // Both accessors below are schema-required, so successful verification
+  // guarantees that they are non-null.
+  std::unordered_set<std::string> method_names;
+  for (const fbs::Method* method : *program_fb->methods()) {
+    const std::string name = method->name()->str();
+    if (name.empty()) {
+      throw std::runtime_error("native program: method name is empty");
+    }
+    if (!method_names.insert(name).second) {
+      throw std::runtime_error(
+          "native program: duplicate method name '" + name + "'");
+    }
+  }
   return Program(std::move(bytes), program_fb);
 }
 
 size_t Program::num_methods() const {
   const auto* methods = program_fb_->methods();
   return methods == nullptr ? 0 : methods->size();
+}
+
+std::vector<std::string> Program::method_names() const {
+  std::vector<std::string> names;
+  const auto* methods = program_fb_->methods();
+  if (methods != nullptr) {
+    names.reserve(methods->size());
+    for (flatbuffers::uoffset_t i = 0; i < methods->size(); ++i) {
+      const auto* nm = methods->Get(i)->name();
+      names.push_back(nm != nullptr ? nm->str() : std::string());
+    }
+  }
+  return names;
 }
 
 } // namespace ptn

--- a/backends/native/runtime/Program.h
+++ b/backends/native/runtime/Program.h
@@ -8,7 +8,11 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <unordered_map>
 #include <vector>
+
+#include <executorch/backends/native/runtime/Method.h>
 
 // Forward-declaration of the generated FlatBuffer root type, included only from
 // .cpp files so flatbuffers stays an implementation detail of the reader.
@@ -29,6 +33,10 @@ class Program {
   // rather than return a null root, so accessors dereference it unchecked.
   std::vector<uint8_t> bytes_;
   const fbs::Program* program_fb_ = nullptr;
+  // Lazily materialized methods, keyed by name, populated on get_method(). The
+  // cache is mutable so lookups work on a const Program; unordered_map keeps
+  // returned references stable across later insertions. Not thread-safe.
+  mutable std::unordered_map<std::string, Method> method_cache_;
 
   Program(std::vector<uint8_t> bytes, const fbs::Program* program_fb)
       : bytes_(std::move(bytes)), program_fb_(program_fb) {}
@@ -41,7 +49,8 @@ class Program {
   Program& operator=(const Program&) = delete;
 
   // Parse and verify serialized native-graph bytes (a *.ptg buffer). Throws
-  // std::runtime_error on failure.
+  // std::runtime_error on failure. Methods are materialized lazily (see
+  // get_method), not here.
   static Program load(const void* data, size_t size);
 
   const fbs::Program* flatbuffer() const {
@@ -49,6 +58,20 @@ class Program {
   }
 
   size_t num_methods() const;
+
+  // Names of the program's methods, in serialized order.
+  std::vector<std::string> method_names() const;
+
+  // Materialize (or return the cached) method by name. Builds the in-memory IR
+  // on first request and caches it; later calls return the same instance.
+  // Throws std::runtime_error if no method has that name. Impl in
+  // Deserialize.cpp.
+  const Method& get_method(const std::string& name) const;
+
+ private:
+  // Deserialize the fb method at `index` into the in-memory IR (Graph +
+  // bindings). Impl in Deserialize.cpp.
+  Method build_method(size_t index) const;
 };
 
 } // namespace ptn

--- a/backends/native/runtime/targets.bzl
+++ b/backends/native/runtime/targets.bzl
@@ -46,10 +46,15 @@ def define_common_targets():
     runtime.cxx_library(
         name = "runtime",
         srcs = [
+            "Deserialize.cpp",
             "Program.cpp",
         ],
         exported_headers = [
             "Program.h",
+        ],
+        exported_deps = [
+            # Program.h publicly exposes Method (build_method), so the IR is exported.
+            ":method",
         ],
         deps = [
             ":native_graph_schema",

--- a/backends/native/test/runtime/BUCK
+++ b/backends/native/test/runtime/BUCK
@@ -1,0 +1,8 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+non_fbcode_target(_kind = define_common_targets)
+
+fbcode_target(_kind = define_common_targets)

--- a/backends/native/test/runtime/targets.bzl
+++ b/backends/native/test/runtime/targets.bzl
@@ -1,0 +1,11 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    runtime.cxx_test(
+        name = "program_test",
+        srcs = ["test_program_deserialize.cpp"],
+        deps = [
+            "//executorch/backends/native/runtime:native_graph_schema",
+            "//executorch/backends/native/runtime:runtime",
+        ],
+    )

--- a/backends/native/test/runtime/test_program_deserialize.cpp
+++ b/backends/native/test/runtime/test_program_deserialize.cpp
@@ -1,0 +1,299 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/Program.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <flatbuffers/flatbuffers.h>
+#include <gtest/gtest.h>
+
+#include <executorch/backends/native/runtime/native_graph_generated.h>
+
+namespace ptn {
+namespace {
+
+namespace fbs = ::native_backend;
+
+flatbuffers::Offset<
+    flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
+create_strings(
+    flatbuffers::FlatBufferBuilder& builder,
+    const std::vector<std::string>& values) {
+  std::vector<flatbuffers::Offset<flatbuffers::String>> strings;
+  strings.reserve(values.size());
+  for (const std::string& value : values) {
+    strings.push_back(builder.CreateString(value));
+  }
+  return builder.CreateVector(strings);
+}
+
+flatbuffers::Offset<fbs::Graph> create_graph(
+    flatbuffers::FlatBufferBuilder& builder,
+    const std::vector<flatbuffers::Offset<fbs::Node>>& nodes = {},
+    const std::vector<std::string>& inputs = {},
+    const std::vector<std::string>& outputs = {},
+    const std::vector<flatbuffers::Offset<fbs::TensorValue>>& tensor_values =
+        {}) {
+  return fbs::CreateGraph(
+      builder,
+      builder.CreateVector(nodes),
+      inputs.empty() ? 0 : create_strings(builder, inputs),
+      outputs.empty() ? 0 : create_strings(builder, outputs),
+      tensor_values.empty() ? 0 : builder.CreateVector(tensor_values));
+}
+
+flatbuffers::Offset<fbs::Method> create_method(
+    flatbuffers::FlatBufferBuilder& builder,
+    const std::string& name,
+    flatbuffers::Offset<fbs::Graph> graph,
+    const std::vector<flatbuffers::Offset<fbs::OutputSpec>>& output_specs = {},
+    const std::vector<flatbuffers::Offset<fbs::NamedTensorRef>>& constants = {},
+    const std::vector<flatbuffers::Offset<fbs::MutableBufferSpec>>&
+        mutable_buffers = {}) {
+  return fbs::CreateMethod(
+      builder,
+      builder.CreateString(name),
+      graph,
+      constants.empty() ? 0 : builder.CreateVector(constants),
+      output_specs.empty() ? 0 : builder.CreateVector(output_specs),
+      mutable_buffers.empty() ? 0 : builder.CreateVector(mutable_buffers));
+}
+
+std::vector<uint8_t> finish_program(
+    flatbuffers::FlatBufferBuilder& builder,
+    const std::vector<flatbuffers::Offset<fbs::Method>>& methods) {
+  const auto program = fbs::CreateProgram(
+      builder, builder.CreateString("1"), builder.CreateVector(methods));
+  fbs::FinishProgramBuffer(builder, program);
+  return {
+      builder.GetBufferPointer(),
+      builder.GetBufferPointer() + builder.GetSize()};
+}
+
+Program load_program(const std::vector<uint8_t>& bytes) {
+  return Program::load(bytes.data(), bytes.size());
+}
+
+// cppcheck-suppress-begin syntaxError
+TEST(ProgramTest, LoadRejectsEmptyMethodName) {
+  flatbuffers::FlatBufferBuilder builder;
+  const auto graph = create_graph(builder);
+  const auto bytes =
+      finish_program(builder, {create_method(builder, "", graph)});
+
+  EXPECT_THROW(load_program(bytes), std::runtime_error);
+}
+
+TEST(ProgramTest, LoadRejectsDuplicateMethodNames) {
+  flatbuffers::FlatBufferBuilder builder;
+  const auto graph = create_graph(builder);
+  const auto first = create_method(builder, "forward", graph);
+  const auto second = create_method(builder, "forward", graph);
+  const auto bytes = finish_program(builder, {first, second});
+
+  EXPECT_THROW(load_program(bytes), std::runtime_error);
+}
+
+TEST(ProgramTest, GetMethodRejectsMismatchedOutputSpecs) {
+  flatbuffers::FlatBufferBuilder builder;
+  const auto graph = create_graph(builder, {}, {}, {"output"});
+  const auto first = fbs::CreateOutputSpecDirect(builder, "output");
+  const auto second = fbs::CreateOutputSpecDirect(builder, "extra");
+  const auto method = create_method(builder, "forward", graph, {first, second});
+  const auto bytes = finish_program(builder, {method});
+  const Program program = load_program(bytes);
+
+  EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+}
+
+TEST(ProgramTest, GetMethodPreservesAliasWhenTargetIsCreatedOnDemand) {
+  flatbuffers::FlatBufferBuilder builder;
+  const auto output = fbs::CreateOutputDirect(builder, "view", "input");
+  const std::vector<flatbuffers::Offset<fbs::Output>> outputs = {output};
+  const auto node = fbs::CreateNodeDirect(
+      builder,
+      "view",
+      fbs::OpKind::CALL_FUNCTION,
+      "aten.view",
+      nullptr,
+      &outputs);
+  const auto graph = create_graph(builder, {node}, {"input"}, {"view"});
+  const auto bytes =
+      finish_program(builder, {create_method(builder, "forward", graph)});
+  const Program program = load_program(bytes);
+
+  const Graph& loaded = program.get_method("forward").graph;
+  ASSERT_EQ(loaded.input_ids.size(), 1);
+  ASSERT_EQ(loaded.output_ids.size(), 1);
+  EXPECT_EQ(loaded.value(loaded.output_ids[0]).alias_id, loaded.input_ids[0]);
+}
+
+TEST(ProgramTest, GetMethodRejectsSelfAlias) {
+  flatbuffers::FlatBufferBuilder builder;
+  const auto output = fbs::CreateOutputDirect(builder, "view", "view");
+  const std::vector<flatbuffers::Offset<fbs::Output>> outputs = {output};
+  const auto node = fbs::CreateNodeDirect(
+      builder,
+      "view",
+      fbs::OpKind::CALL_FUNCTION,
+      "aten.view",
+      nullptr,
+      &outputs);
+  const auto graph = create_graph(builder, {node}, {}, {"view"});
+  const auto bytes =
+      finish_program(builder, {create_method(builder, "forward", graph)});
+  const Program program = load_program(bytes);
+
+  EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+}
+
+TEST(ProgramTest, GetMethodRejectsDynamicTensorExtent) {
+  flatbuffers::FlatBufferBuilder builder;
+  const std::vector<flatbuffers::Offset<fbs::Dim>> sizes = {
+      fbs::CreateDim(builder, 2, 16)};
+  const auto meta =
+      fbs::CreateTensorMetaDirect(builder, fbs::ScalarType::FLOAT, &sizes);
+  const auto tensor = fbs::CreateTensorValueDirect(builder, "input", meta);
+  const auto graph = create_graph(builder, {}, {"input"}, {}, {tensor});
+  const auto bytes =
+      finish_program(builder, {create_method(builder, "forward", graph)});
+  const Program program = load_program(bytes);
+
+  EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+}
+
+TEST(ProgramTest, GetMethodRejectsUnknownEnumValues) {
+  {
+    flatbuffers::FlatBufferBuilder builder;
+    const auto node = fbs::CreateNodeDirect(
+        builder, "node", static_cast<fbs::OpKind>(127), "unknown");
+    const auto graph = create_graph(builder, {node});
+    const auto bytes =
+        finish_program(builder, {create_method(builder, "forward", graph)});
+    const Program program = load_program(bytes);
+    EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+  }
+  {
+    flatbuffers::FlatBufferBuilder builder;
+    const auto output = fbs::CreateOutput(
+        builder,
+        builder.CreateString("output"),
+        0,
+        static_cast<fbs::OutputValueKind>(127));
+    const std::vector<flatbuffers::Offset<fbs::Output>> outputs = {output};
+    const auto node = fbs::CreateNodeDirect(
+        builder,
+        "node",
+        fbs::OpKind::CALL_FUNCTION,
+        "unknown",
+        nullptr,
+        &outputs);
+    const auto graph = create_graph(builder, {node}, {}, {"output"});
+    const auto bytes =
+        finish_program(builder, {create_method(builder, "forward", graph)});
+    const Program program = load_program(bytes);
+    EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+  }
+  {
+    flatbuffers::FlatBufferBuilder builder;
+    const auto meta = fbs::CreateTensorMeta(builder);
+    const auto constant = fbs::CreateNamedTensorRefDirect(
+        builder, "input", "weight", meta, static_cast<fbs::InputKind>(127));
+    const auto graph = create_graph(builder, {}, {"input"});
+    const auto method =
+        create_method(builder, "forward", graph, {}, {constant});
+    const auto bytes = finish_program(builder, {method});
+    const Program program = load_program(bytes);
+    EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+  }
+  {
+    flatbuffers::FlatBufferBuilder builder;
+    const auto argument =
+        fbs::CreateArgument(builder, static_cast<fbs::ArgumentValue>(127), 0);
+    const auto named_argument =
+        fbs::CreateNamedArgumentDirect(builder, "input", argument);
+    const std::vector<flatbuffers::Offset<fbs::NamedArgument>> inputs = {
+        named_argument};
+    const auto node = fbs::CreateNodeDirect(
+        builder, "node", fbs::OpKind::CALL_FUNCTION, "unknown", &inputs);
+    const auto graph = create_graph(builder, {node});
+    const auto bytes =
+        finish_program(builder, {create_method(builder, "forward", graph)});
+    const Program program = load_program(bytes);
+    EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+  }
+  {
+    flatbuffers::FlatBufferBuilder builder;
+    const auto output_spec = fbs::CreateOutputSpec(
+        builder,
+        builder.CreateString("output"),
+        static_cast<fbs::OutputKind>(127));
+    const auto graph = create_graph(builder, {}, {}, {"output"});
+    const auto method = create_method(builder, "forward", graph, {output_spec});
+    const auto bytes = finish_program(builder, {method});
+    const Program program = load_program(bytes);
+    EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+  }
+}
+
+TEST(ProgramTest, GetMethodRejectsUnresolvedDataBinding) {
+  flatbuffers::FlatBufferBuilder builder;
+  const auto meta = fbs::CreateTensorMeta(builder);
+  const auto constant = fbs::CreateNamedTensorRefDirect(
+      builder, "missing", "weight", meta, fbs::InputKind::PARAMETER);
+  const auto graph = create_graph(builder);
+  const auto method = create_method(builder, "forward", graph, {}, {constant});
+  const auto bytes = finish_program(builder, {method});
+  const Program program = load_program(bytes);
+
+  EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+}
+
+TEST(ProgramTest, GetMethodRejectsUnresolvedMutationTarget) {
+  {
+    flatbuffers::FlatBufferBuilder builder;
+    const auto output_spec = fbs::CreateOutputSpecDirect(
+        builder, "output", fbs::OutputKind::BUFFER_MUTATION, "missing");
+    const auto graph = create_graph(builder, {}, {}, {"output"});
+    const auto method = create_method(builder, "forward", graph, {output_spec});
+    const auto bytes = finish_program(builder, {method});
+    const Program program = load_program(bytes);
+    EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+  }
+  {
+    flatbuffers::FlatBufferBuilder builder;
+    const auto output_spec = fbs::CreateOutputSpecDirect(
+        builder, "output", fbs::OutputKind::USER_INPUT_MUTATION, "missing");
+    const auto graph = create_graph(builder, {}, {}, {"output"});
+    const auto method = create_method(builder, "forward", graph, {output_spec});
+    const auto bytes = finish_program(builder, {method});
+    const Program program = load_program(bytes);
+    EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+  }
+}
+
+TEST(ProgramTest, GetMethodRejectsDuplicateDataBinding) {
+  flatbuffers::FlatBufferBuilder builder;
+  const auto meta = fbs::CreateTensorMeta(builder);
+  const auto constant = fbs::CreateNamedTensorRefDirect(
+      builder, "state", "state", meta, fbs::InputKind::BUFFER);
+  const auto mutable_buffer =
+      fbs::CreateMutableBufferSpecDirect(builder, "state", "state");
+  const auto graph = create_graph(builder, {}, {"state"});
+  const auto method = create_method(
+      builder, "forward", graph, {}, {constant}, {mutable_buffer});
+  const auto bytes = finish_program(builder, {method});
+  const Program program = load_program(bytes);
+
+  EXPECT_THROW(program.get_method("forward"), std::runtime_error);
+}
+// cppcheck-suppress-end syntaxError
+
+} // namespace
+} // namespace ptn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22704
* #22703
* #22702
* #22701
* #22700
* __->__ #22699

## Ulterior Motive

Turn serialized native graphs into executable in-memory IR. This is stack
foundation: package loading and backend execution both depend on `Method` and
`Graph` objects.

## Rationale

**What**: Add lazy `Program`-to-`Method` deserialization, graph-local SSA
resolution, method bindings, mutation metadata, nested subgraphs, and strict
wire-data validation.

**Why**: `Program::load` previously verified bytes but could not materialize
runtime IR.

## Details

```text
verified PTG
    |
    v
Program::get_method(name)
    |
    +-- cache hit --> existing Method
    |
    +-- cache miss --> build_method()
                       |
                       +-- GraphBuilder per graph namespace
                       +-- resolve names to stable ValueIds
                       +-- attach bindings and output specs
                       +-- rebuild def-use
```

- Dynamic extents are rejected instead of silently fixed at an upper bound.
- Constants contribute tensor metadata missing from graph-local tables.
- Tensor-list outputs, aliases, scalar references, and `GraphArg` subgraphs are
  resolved.
- Unknown argument tags, unresolved mutation targets, and self-aliases fail
  during deserialization. Valid alias chains remain supported.
- Method-name lookup compares FlatBuffer bytes in place without allocating a
  temporary string for every candidate.

Authored with Codex.

Differential Revision: [D114426391](https://our.internmc.facebook.com/intern/diff/D114426391/)