### PR TITLE
[executorch][native] Add a safetensors index reader

### DIFF
--- a/backends/native/runtime/deserialize/BUCK
+++ b/backends/native/runtime/deserialize/BUCK
@@ -1,0 +1,11 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+# Any targets that should be shared between fbcode and xplat must be defined in
+# targets.bzl. This file can contain cell-only targets.
+
+non_fbcode_target(_kind = define_common_targets)
+
+fbcode_target(_kind = define_common_targets)

--- a/backends/native/runtime/deserialize/ByteSpan.h
+++ b/backends/native/runtime/deserialize/ByteSpan.h
@@ -1,0 +1,18 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+namespace ptn {
+
+// Borrowed byte-range views. The producer defines their lifetime.
+using ByteSpan = std::span<const uint8_t>;
+using MutableByteSpan = std::span<uint8_t>;
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/Json.h
+++ b/backends/native/runtime/deserialize/Json.h
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+namespace ptn {
+
+using Json = nlohmann::ordered_json;
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/SafeTensorsReader.cpp
+++ b/backends/native/runtime/deserialize/SafeTensorsReader.cpp
@@ -1,0 +1,244 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/deserialize/SafeTensorsReader.h>
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstring>
+#include <numeric>
+#include <stdexcept>
+#include <string_view>
+
+#include <executorch/backends/native/runtime/deserialize/Json.h>
+
+namespace ptn {
+namespace {
+
+// Reserved header member holding free-form string metadata, not a tensor.
+constexpr std::string_view kMetadataKey = "__metadata__";
+constexpr size_t kHeaderLenSize = 8;
+
+struct DtypeCode {
+  std::string_view code;
+  ScalarType dtype;
+};
+
+// safetensors dtype codes, as written by safetensors.torch. Codes with no
+// ScalarType counterpart (complex, 4-bit and 8-bit float variants) are absent
+// and rejected by name, so an unsupported constant fails at load rather than
+// being misread as another width.
+constexpr std::array<DtypeCode, 13> kDtypeCodes{{
+    {"F64", kDouble},
+    {"F32", kFloat},
+    {"F16", kHalf},
+    {"BF16", kBFloat16},
+    {"I64", kLong},
+    {"I32", kInt},
+    {"I16", kShort},
+    {"I8", kChar},
+    {"U8", kByte},
+    {"BOOL", kBool},
+    {"U16", kUInt16},
+    {"U32", kUInt32},
+    {"U64", kUInt64},
+}};
+
+ScalarType scalar_type_of(std::string_view code) {
+  const auto it = std::ranges::find(kDtypeCodes, code, &DtypeCode::code);
+  if (it == kDtypeCodes.end()) {
+    throw std::runtime_error(
+        "safetensors: unsupported dtype code: " + std::string(code));
+  }
+  return it->dtype;
+}
+
+uint64_t read_header_len(ByteSpan blob) {
+  static_assert(
+      std::endian::native == std::endian::little,
+      "the length prefix is little-endian; a big-endian host needs a swap");
+  if (blob.size() < kHeaderLenSize) {
+    throw std::runtime_error(
+        "safetensors: blob is shorter than its length prefix");
+  }
+  uint64_t len = 0;
+  std::memcpy(&len, blob.data(), kHeaderLenSize);
+  return len;
+}
+
+const Json& required_member(
+    const Json& entry,
+    std::string_view key,
+    const std::string& name) {
+  const auto value = entry.find(key);
+  if (value == entry.end()) {
+    std::string message = "safetensors: entry '";
+    message += name;
+    message += "' has no '";
+    message += key;
+    message += "'";
+    throw std::runtime_error(message);
+  }
+  return value.value();
+}
+
+std::vector<int64_t> read_sizes(const Json& shape, const std::string& name) {
+  if (!shape.is_array()) {
+    throw std::runtime_error(
+        "safetensors: entry '" + name + "' shape is not an array");
+  }
+  std::vector<int64_t> sizes;
+  for (const Json& dim : shape) {
+    if (!dim.is_number_unsigned()) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name +
+          "' has a non-negative integer dimension");
+    }
+    const uint64_t value = dim.get<uint64_t>();
+    if (value > static_cast<uint64_t>(INT64_MAX)) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name + "' has an out-of-range dimension");
+    }
+    sizes.push_back(static_cast<int64_t>(value));
+  }
+  return sizes;
+}
+
+// Element count of `sizes`, rejecting an overflowing product. A rank-0 shape is
+// a scalar, whose element count is 1.
+size_t numel_of(const std::vector<int64_t>& sizes, const std::string& name) {
+  size_t numel = 1;
+  for (const int64_t dim : sizes) {
+    if (dim < 0) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name + "' has a negative dimension");
+    }
+    const size_t d = static_cast<size_t>(dim);
+    if (d != 0 && numel > SIZE_MAX / d) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name + "' element count overflows");
+    }
+    numel *= d;
+  }
+  return numel;
+}
+
+} // namespace
+
+SafeTensorsReader SafeTensorsReader::open(ByteSpan blob) {
+  const uint64_t header_len = read_header_len(blob);
+  if (header_len > blob.size() - kHeaderLenSize) {
+    throw std::runtime_error("safetensors: header length exceeds the blob");
+  }
+
+  const std::string_view header_text(
+      reinterpret_cast<const char*>(blob.data() + kHeaderLenSize),
+      static_cast<size_t>(header_len));
+  Json header;
+  try {
+    header = Json::parse(header_text);
+  } catch (const Json::exception& error) {
+    throw std::runtime_error(
+        "safetensors: invalid JSON header: " + std::string(error.what()));
+  }
+  if (!header.is_object()) {
+    throw std::runtime_error("safetensors: header is not a JSON object");
+  }
+
+  SafeTensorsReader out;
+  out.data_ = blob.subspan(kHeaderLenSize + static_cast<size_t>(header_len));
+
+  for (auto member = header.begin(); member != header.end(); ++member) {
+    const std::string& name = member.key();
+    if (name == kMetadataKey) {
+      if (!member.value().is_object() || !member.value().empty()) {
+        throw std::runtime_error(
+            "safetensors: __metadata__ must be an empty object");
+      }
+      continue;
+    }
+    const Json& entry = member.value();
+    if (!entry.is_object()) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name + "' is not an object");
+    }
+
+    TensorEntry parsed;
+    const Json& dtype = required_member(entry, "dtype", name);
+    if (!dtype.is_string()) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name + "' dtype is not a string");
+    }
+    parsed.dtype = scalar_type_of(dtype.get_ref<const std::string&>());
+    parsed.sizes = read_sizes(required_member(entry, "shape", name), name);
+
+    const Json& range = required_member(entry, "data_offsets", name);
+    if (!range.is_array() || range.size() != 2) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name + "' data_offsets is not a pair");
+    }
+    if (!range[0].is_number_unsigned() || !range[1].is_number_unsigned()) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name +
+          "' data_offsets contains a non-negative integer");
+    }
+    const uint64_t begin = range[0].get<uint64_t>();
+    const uint64_t end = range[1].get<uint64_t>();
+    if (begin > end || end > out.data_.size()) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name +
+          "' byte range is outside the data section");
+    }
+    parsed.offset = static_cast<size_t>(begin);
+    parsed.nbytes = static_cast<size_t>(end - begin);
+
+    // The payload must be exactly as large as its dtype and shape imply.
+    // Without this, a short entry becomes an out-of-bounds read in whatever
+    // consumes it, sized from the metadata rather than the bytes.
+    const size_t numel = numel_of(parsed.sizes, name);
+    const size_t element_bytes = element_size(parsed.dtype);
+    if (element_bytes != 0 && numel > SIZE_MAX / element_bytes) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name + "' byte size overflows");
+    }
+    const size_t expected = numel * element_bytes;
+    if (parsed.nbytes != expected) {
+      throw std::runtime_error(
+          "safetensors: entry '" + name + "' holds " +
+          std::to_string(parsed.nbytes) +
+          " bytes but its dtype and shape need " + std::to_string(expected));
+    }
+
+    if (!out.entries_.emplace(name, std::move(parsed)).second) {
+      throw std::runtime_error("safetensors: duplicate entry: " + name);
+    }
+    out.names_.push_back(name);
+  }
+
+  return out;
+}
+
+const TensorEntry* SafeTensorsReader::find(const std::string& name) const {
+  const auto it = entries_.find(name);
+  return it == entries_.end() ? nullptr : &it->second;
+}
+
+ByteSpan SafeTensorsReader::bytes(const TensorEntry& entry) const {
+  return data_.subspan(entry.offset, entry.nbytes);
+}
+
+size_t SafeTensorsReader::total_bytes() const {
+  return std::accumulate(
+      entries_.begin(),
+      entries_.end(),
+      size_t{0},
+      [](size_t total, const auto& entry) {
+        return total + entry.second.nbytes;
+      });
+}
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/SafeTensorsReader.h
+++ b/backends/native/runtime/deserialize/SafeTensorsReader.h
@@ -1,0 +1,69 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <executorch/backends/native/runtime/deserialize/ByteSpan.h>
+#include <executorch/backends/native/runtime/graph/ScalarType.h>
+
+namespace ptn {
+
+// One tensor's entry in a safetensors index.
+struct TensorEntry {
+  ScalarType dtype = kFloat;
+  std::vector<int64_t> sizes;
+  // Byte range within the blob's data section, not the whole blob.
+  size_t offset = 0;
+  size_t nbytes = 0;
+};
+
+// Reader for the safetensors format:
+//
+//     [u64 header_len][JSON header][data section]
+//
+// The header maps a tensor name to its dtype, shape, and byte range within the
+// data section. The reserved "__metadata__" member must be empty until the
+// reader exposes metadata semantics.
+//
+// Tensor payloads are packed with no per-tensor padding, so an entry's absolute
+// alignment within the file is arbitrary: copy through these spans rather than
+// handing them to an API that requires alignment.
+class SafeTensorsReader {
+ private:
+  // The data section only, i.e. the blob past its header.
+  ByteSpan data_;
+  std::unordered_map<std::string, TensorEntry> entries_;
+  std::vector<std::string> names_;
+
+ public:
+  // Parse `blob`'s index. Throws std::runtime_error if the blob is truncated,
+  // the header is not a JSON object, a dtype has no ScalarType, or a byte range
+  // is inconsistent with its dtype and shape.
+  //
+  // Borrows `blob`, which must outlive both this reader and any span from it.
+  static SafeTensorsReader open(ByteSpan blob);
+
+  // Entry for `name`, or nullptr when absent.
+  const TensorEntry* find(const std::string& name) const;
+
+  // Payload of an entry obtained from this reader.
+  ByteSpan bytes(const TensorEntry& entry) const;
+
+  // Tensor names, in header order, excluding "__metadata__".
+  const std::vector<std::string>& names() const {
+    return names_;
+  }
+
+  // Total payload bytes across all entries.
+  size_t total_bytes() const;
+};
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/targets.bzl
+++ b/backends/native/runtime/deserialize/targets.bzl
@@ -1,0 +1,33 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    # Borrowed byte-range view shared by the package readers (a std::span alias,
+    # named so the borrow contract has somewhere to live).
+    runtime.cxx_library(
+        name = "byte_span",
+        srcs = [],
+        exported_headers = ["ByteSpan.h"],
+        visibility = ["//executorch/backends/native/..."],
+    )
+
+    # JSON representation used by package metadata readers.
+    runtime.cxx_library(
+        name = "json",
+        srcs = [],
+        exported_headers = ["Json.h"],
+        exported_external_deps = ["nlohmann_json"],
+        visibility = ["//executorch/backends/native/..."],
+    )
+
+    # safetensors index reader.
+    runtime.cxx_library(
+        name = "safetensors_reader",
+        srcs = ["SafeTensorsReader.cpp"],
+        exported_headers = ["SafeTensorsReader.h"],
+        exported_deps = [
+            ":byte_span",
+            "//executorch/backends/native/runtime/graph:scalar_type",
+        ],
+        deps = [":json"],
+        visibility = ["//executorch/backends/native/..."],
+    )

--- a/backends/native/test/runtime/deserialize/BUCK
+++ b/backends/native/test/runtime/deserialize/BUCK
@@ -1,0 +1,8 @@
+load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target", "non_fbcode_target")
+load(":targets.bzl", "define_common_targets")
+
+oncall("executorch")
+
+non_fbcode_target(_kind = define_common_targets)
+
+fbcode_target(_kind = define_common_targets)

--- a/backends/native/test/runtime/deserialize/targets.bzl
+++ b/backends/native/test/runtime/deserialize/targets.bzl
@@ -1,0 +1,10 @@
+load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
+
+def define_common_targets():
+    runtime.cxx_test(
+        name = "safetensors_reader_test",
+        srcs = ["test_safetensors_reader.cpp"],
+        deps = [
+            "//executorch/backends/native/runtime/deserialize:safetensors_reader",
+        ],
+    )

--- a/backends/native/test/runtime/deserialize/test_safetensors_reader.cpp
+++ b/backends/native/test/runtime/deserialize/test_safetensors_reader.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/deserialize/SafeTensorsReader.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace ptn {
+namespace {
+
+std::vector<uint8_t> make_safetensors(
+    std::string_view header,
+    std::string_view data) {
+  const uint64_t header_size = header.size();
+  std::vector<uint8_t> bytes(sizeof(header_size) + header.size() + data.size());
+  std::memcpy(bytes.data(), &header_size, sizeof(header_size));
+  std::memcpy(bytes.data() + sizeof(header_size), header.data(), header.size());
+  std::memcpy(
+      bytes.data() + sizeof(header_size) + header.size(),
+      data.data(),
+      data.size());
+  return bytes;
+}
+
+// cppcheck-suppress-begin syntaxError
+TEST(SafeTensorsReaderTest, ReadsIndexAndPayloadsInHeaderOrder) {
+  const std::vector<uint8_t> bytes = make_safetensors(
+      R"({"second":{"dtype":"U8","shape":[2],"data_offsets":[4,6]},"__metadata__":{},"first":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}})",
+      "abcdXY");
+
+  const SafeTensorsReader reader = SafeTensorsReader::open(bytes);
+
+  EXPECT_EQ(reader.names(), (std::vector<std::string>{"second", "first"}));
+  ASSERT_NE(reader.find("first"), nullptr);
+  EXPECT_EQ(reader.find("first")->dtype, kFloat);
+  EXPECT_EQ(reader.find("first")->sizes, (std::vector<int64_t>{1}));
+  EXPECT_EQ(reader.find("first")->offset, 0);
+  EXPECT_EQ(reader.find("first")->nbytes, 4);
+  EXPECT_EQ(reader.bytes(*reader.find("second"))[0], 'X');
+  EXPECT_EQ(reader.total_bytes(), 6);
+  EXPECT_EQ(reader.find("missing"), nullptr);
+}
+
+TEST(SafeTensorsReaderTest, RejectsNonEmptyMetadata) {
+  EXPECT_THROW(
+      SafeTensorsReader::open(
+          make_safetensors(R"({"__metadata__":{"source":"test"}})", "")),
+      std::runtime_error);
+}
+
+TEST(SafeTensorsReaderTest, RejectsInvalidMetadata) {
+  EXPECT_THROW(
+      SafeTensorsReader::open(make_safetensors("[]", "")), std::runtime_error);
+  EXPECT_THROW(
+      SafeTensorsReader::open(make_safetensors(
+          R"({"x":{"dtype":"U8","shape":[1.0],"data_offsets":[0,1]}})", "x")),
+      std::runtime_error);
+  EXPECT_THROW(
+      SafeTensorsReader::open(make_safetensors(
+          R"({"x":{"dtype":"U8","shape":[1],"data_offsets":[0,2]}})", "x")),
+      std::runtime_error);
+}
+
+TEST(SafeTensorsReaderTest, RejectsByteSizeOverflow) {
+  EXPECT_THROW(
+      SafeTensorsReader::open(make_safetensors(
+          R"({"x":{"dtype":"F64","shape":[2305843009213693952],"data_offsets":[0,0]}})",
+          "")),
+      std::runtime_error);
+}
+// cppcheck-suppress-end syntaxError
+
+} // namespace
+} // namespace ptn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22704
* #22703
* #22702
* #22701
* __->__ #22700
* #22699

## Ulterior Motive

Give PTN package loading a validated constant index before archive integration.

## Rationale

**What**: Add borrowed `ByteSpan` views and a `SafeTensorsReader` that preserves
entry order and validates dtype, shape, byte ranges, and payload size.

**Why**: Engines need trustworthy tensor metadata and byte locations before
uploading weights.

## Details

```text
[u64 header length][ordered JSON][tensor payload]
         |              |
         v              v
  bounds checks    TensorEntry map
                        |
                        +-- dtype
                        +-- shape
                        +-- offset + byte count
```

`SafeTensorsReader` owns parsed metadata but borrows source bytes. Unsupported
dtype codes, malformed JSON, overflow, inconsistent sizes, out-of-range offsets,
and non-empty metadata are rejected.

Authored with Codex.

Differential Revision: [D118480653](https://our.internmc.facebook.com/intern/diff/D118480653/)