### PR TITLE
[executorch][native] Add the OwnedBytes API

### DIFF
--- a/backends/native/runtime/deserialize/OwnedBytes.cpp
+++ b/backends/native/runtime/deserialize/OwnedBytes.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/deserialize/OwnedBytes.h>
+
+#include <cerrno>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+#include <system_error>
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace ptn {
+namespace {
+
+std::string errno_suffix(int error) {
+  return ": " + std::error_code(error, std::system_category()).message();
+}
+
+} // namespace
+
+void OwnedBytes::Unmap::operator()(void* base) const noexcept {
+#if !defined(_WIN32)
+  // Nothing useful to do if this fails, and it must not throw: unique_ptr calls
+  // this from its destructor.
+  ::munmap(base, size);
+#endif
+}
+
+OwnedBytes OwnedBytes::from_vector(std::vector<uint8_t> bytes) {
+  return OwnedBytes(std::move(bytes));
+}
+
+OwnedBytes OwnedBytes::from_file(const std::string& path, bool use_mmap) {
+  return use_mmap ? map_file(path) : read_file(path);
+}
+
+OwnedBytes OwnedBytes::read_file(const std::string& path) {
+  std::error_code error;
+  const std::filesystem::file_status status =
+      std::filesystem::status(path, error);
+  if (error) {
+    throw std::runtime_error("cannot inspect " + path + ": " + error.message());
+  }
+  if (!std::filesystem::is_regular_file(status)) {
+    throw std::runtime_error("cannot read " + path + ": not a regular file");
+  }
+  const uintmax_t file_size = std::filesystem::file_size(path, error);
+  if (error) {
+    throw std::runtime_error("cannot size " + path + ": " + error.message());
+  }
+  if (file_size > std::numeric_limits<size_t>::max() ||
+      file_size >
+          static_cast<uintmax_t>(std::numeric_limits<std::streamsize>::max())) {
+    throw std::runtime_error("cannot read " + path + ": file is too large");
+  }
+
+  std::ifstream file(path, std::ios::binary);
+  if (!file) {
+    throw std::runtime_error("cannot open " + path);
+  }
+  const size_t size = static_cast<size_t>(file_size);
+  if (size == 0) {
+    return OwnedBytes(std::vector<uint8_t>());
+  }
+  HeapBuffer buffer{std::make_unique_for_overwrite<uint8_t[]>(size), size};
+  if (!file.read(
+          reinterpret_cast<char*>(buffer.data.get()),
+          static_cast<std::streamsize>(size))) {
+    throw std::runtime_error("cannot read " + path);
+  }
+  return OwnedBytes(std::move(buffer));
+}
+
+OwnedBytes OwnedBytes::map_file(const std::string& path) {
+#if defined(_WIN32)
+  // TODO: Implement Windows mappings with CreateFileMapping and MapViewOfFile.
+  throw std::runtime_error("cannot mmap " + path + ": unsupported platform");
+#else
+  const int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd < 0) {
+    const int error = errno;
+    throw std::runtime_error("cannot open " + path + errno_suffix(error));
+  }
+
+  struct stat st = {};
+  if (::fstat(fd, &st) < 0) {
+    const std::string suffix = errno_suffix(errno);
+    ::close(fd);
+    throw std::runtime_error("cannot size " + path + suffix);
+  }
+  if (!S_ISREG(st.st_mode)) {
+    ::close(fd);
+    throw std::runtime_error("cannot mmap " + path + ": not a regular file");
+  }
+  if (st.st_size < 0) {
+    ::close(fd);
+    throw std::runtime_error("cannot mmap " + path + ": invalid file size");
+  }
+  if (static_cast<uintmax_t>(st.st_size) > std::numeric_limits<size_t>::max()) {
+    ::close(fd);
+    throw std::runtime_error("cannot mmap " + path + ": file is too large");
+  }
+  const size_t size = static_cast<size_t>(st.st_size);
+  if (size == 0) {
+    ::close(fd);
+    return OwnedBytes(std::vector<uint8_t>());
+  }
+
+  // The whole file from offset 0, so the base is page-aligned and every span
+  // into it has the same alignment it would have in a heap buffer. MAP_SHARED
+  // lets other processes mapping this file share the same physical pages; the
+  // mapping is read-only either way.
+  void* base = ::mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0);
+  if (base == MAP_FAILED) {
+    const int error = errno;
+    ::close(fd);
+    throw std::runtime_error("cannot mmap " + path + errno_suffix(error));
+  }
+  // The mapping keeps the file alive on its own, so the descriptor is dead
+  // weight past this point.
+  ::close(fd);
+  return OwnedBytes(MappedFile(base, Unmap{size}));
+#endif
+}
+
+ByteSpan OwnedBytes::span() const {
+  if (const HeapBuffer* buffer = std::get_if<HeapBuffer>(&storage_)) {
+    if (buffer->data == nullptr) {
+      return {};
+    }
+    return ByteSpan(buffer->data.get(), buffer->size);
+  }
+  if (const MappedFile* mapped = std::get_if<MappedFile>(&storage_)) {
+    if (mapped->get() == nullptr) {
+      return {};
+    }
+    return ByteSpan(
+        static_cast<const uint8_t*>(mapped->get()), mapped->get_deleter().size);
+  }
+  const std::vector<uint8_t>& bytes = std::get<std::vector<uint8_t>>(storage_);
+  return ByteSpan(bytes.data(), bytes.size());
+}
+
+bool OwnedBytes::is_mapped() const {
+  return std::holds_alternative<MappedFile>(storage_);
+}
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/OwnedBytes.h
+++ b/backends/native/runtime/deserialize/OwnedBytes.h
@@ -1,0 +1,96 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <executorch/backends/native/runtime/deserialize/ByteSpan.h>
+
+namespace ptn {
+
+// Owning, read-only bytes: either a heap buffer or a read-only file mapping.
+//
+// Hands out spans that alias the storage. Each alternative keeps its payload
+// address across a move, so spans taken before a move stay valid for as long as
+// the OwnedBytes lives. Copy is deleted: this holds a whole model.
+//
+// The mapped alternative is the one that matters for large packages: nothing is
+// copied, the pages are demand-paged, and they are shared with any other
+// process mapping the same file.
+class OwnedBytes {
+ private:
+  // Releases a mapping. Carries the length because that is what munmap needs,
+  // which lets a unique_ptr supply the whole move-only lifetime — no
+  // hand-written destructor or move operations.
+  struct Unmap {
+    size_t size = 0;
+
+    void operator()(void* base) const noexcept;
+  };
+
+  struct HeapBuffer {
+    std::unique_ptr<uint8_t[]> data;
+    size_t size = 0;
+  };
+
+  // A read-only mapping of an entire file.
+  using MappedFile = std::unique_ptr<void, Unmap>;
+
+  std::variant<std::vector<uint8_t>, HeapBuffer, MappedFile> storage_;
+
+  explicit OwnedBytes(std::vector<uint8_t> bytes)
+      : storage_(std::move(bytes)) {}
+  explicit OwnedBytes(HeapBuffer buffer) : storage_(std::move(buffer)) {}
+  explicit OwnedBytes(MappedFile mapped_file)
+      : storage_(std::move(mapped_file)) {}
+
+ public:
+  // Empty, owning nothing.
+  OwnedBytes() = default;
+
+  ~OwnedBytes() = default;
+  OwnedBytes(OwnedBytes&&) noexcept = default;
+  OwnedBytes& operator=(OwnedBytes&&) noexcept = default;
+  OwnedBytes(const OwnedBytes&) = delete;
+  OwnedBytes& operator=(const OwnedBytes&) = delete;
+
+  // The whole payload. Valid for this OwnedBytes' lifetime.
+  ByteSpan span() const;
+
+  // True when these bytes are a file mapping rather than a heap buffer.
+  bool is_mapped() const;
+
+  // Take ownership of a buffer the caller already has, without copying it.
+  static OwnedBytes from_vector(std::vector<uint8_t> bytes);
+
+  // Acquire the contents of `path`. Maps it read-only by default: nothing is
+  // copied, pages arrive on demand, and they are shared with any other process
+  // mapping the same file. Pass use_mmap=false to read it into the heap
+  // instead, which is worth it only when the file must outlive edits to it on
+  // disk. A mapping sees concurrent edits, and accessing pages past a
+  // concurrent truncation can terminate the process with SIGBUS.
+  //
+  // `path` must report its complete size through the filesystem. Virtual files
+  // such as procfs entries that report zero bytes but produce data are outside
+  // this API's scope.
+  //
+  // Throws std::runtime_error if the file cannot be read, or cannot be mapped
+  // when mapping was asked for (including on a platform with no mmap). An empty
+  // file yields empty heap bytes either way, since mmap rejects a zero length.
+  static OwnedBytes from_file(const std::string& path, bool use_mmap = true);
+
+ private:
+  static OwnedBytes read_file(const std::string& path);
+  static OwnedBytes map_file(const std::string& path);
+};
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/targets.bzl
+++ b/backends/native/runtime/deserialize/targets.bzl
@@ -10,6 +10,15 @@ def define_common_targets():
         visibility = ["//executorch/backends/native/..."],
     )
 
+    # Owning byte buffer backed by heap storage or a read-only file mapping.
+    runtime.cxx_library(
+        name = "owned_bytes",
+        srcs = ["OwnedBytes.cpp"],
+        exported_headers = ["OwnedBytes.h"],
+        exported_deps = [":byte_span"],
+        visibility = ["//executorch/backends/native/..."],
+    )
+
     # JSON representation used by package metadata readers.
     runtime.cxx_library(
         name = "json",

--- a/backends/native/test/runtime/deserialize/targets.bzl
+++ b/backends/native/test/runtime/deserialize/targets.bzl
@@ -2,6 +2,14 @@ load("@fbsource//xplat/executorch/build:runtime_wrapper.bzl", "runtime")
 
 def define_common_targets():
     runtime.cxx_test(
+        name = "owned_bytes_test",
+        srcs = ["test_owned_bytes.cpp"],
+        deps = [
+            "//executorch/backends/native/runtime/deserialize:owned_bytes",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "safetensors_reader_test",
         srcs = ["test_safetensors_reader.cpp"],
         deps = [

--- a/backends/native/test/runtime/deserialize/test_owned_bytes.cpp
+++ b/backends/native/test/runtime/deserialize/test_owned_bytes.cpp
@@ -1,0 +1,131 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/deserialize/OwnedBytes.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace ptn {
+namespace {
+
+class OwnedBytesTest : public ::testing::Test {
+ private:
+  std::vector<std::filesystem::path> paths_;
+
+ protected:
+  std::string temp_path(std::string_view suffix) {
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    const std::filesystem::path path = std::filesystem::temp_directory_path() /
+        (std::string("owned_bytes_") + info->name() + std::string(suffix));
+    std::error_code error;
+    std::filesystem::remove(path, error);
+    paths_.push_back(path);
+    return path.string();
+  }
+
+  void write_file(const std::string& path, std::string_view contents) {
+    std::ofstream file(path, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(file);
+    file.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+    ASSERT_TRUE(file);
+  }
+
+  void TearDown() override {
+    for (const std::filesystem::path& path : paths_) {
+      std::error_code error;
+      std::filesystem::remove(path, error);
+    }
+  }
+};
+
+static_assert(!std::is_copy_constructible_v<OwnedBytes>);
+static_assert(!std::is_copy_assignable_v<OwnedBytes>);
+static_assert(std::is_nothrow_move_constructible_v<OwnedBytes>);
+static_assert(std::is_nothrow_move_assignable_v<OwnedBytes>);
+
+// cppcheck-suppress-begin syntaxError
+TEST_F(OwnedBytesTest, TakesOwnershipOfVector) {
+  std::vector<uint8_t> source{1, 2, 3};
+  const uint8_t* data = source.data();
+
+  OwnedBytes bytes = OwnedBytes::from_vector(std::move(source));
+  const ByteSpan span = bytes.span();
+  OwnedBytes moved = std::move(bytes);
+
+  EXPECT_FALSE(moved.is_mapped());
+  EXPECT_EQ(span.data(), data);
+  EXPECT_EQ(moved.span().data(), data);
+  EXPECT_EQ(
+      std::vector<uint8_t>(span.begin(), span.end()),
+      (std::vector<uint8_t>{1, 2, 3}));
+}
+
+TEST_F(OwnedBytesTest, ReadsFileIntoHeap) {
+  const std::string path = temp_path("_heap.bin");
+  ASSERT_NO_FATAL_FAILURE(write_file(path, "abc"));
+
+  OwnedBytes bytes = OwnedBytes::from_file(path, false);
+  const ByteSpan span = bytes.span();
+  const OwnedBytes moved = std::move(bytes);
+
+  EXPECT_FALSE(moved.is_mapped());
+  EXPECT_TRUE(bytes.span().empty());
+  EXPECT_EQ(
+      std::vector<uint8_t>(span.begin(), span.end()),
+      (std::vector<uint8_t>{'a', 'b', 'c'}));
+}
+
+TEST_F(OwnedBytesTest, MapsFile) {
+  const std::string path = temp_path("_mapped.bin");
+  ASSERT_NO_FATAL_FAILURE(write_file(path, "abc"));
+
+#if defined(_WIN32)
+  EXPECT_THROW(OwnedBytes::from_file(path), std::runtime_error);
+#else
+  OwnedBytes bytes = OwnedBytes::from_file(path);
+  const ByteSpan span = bytes.span();
+  const OwnedBytes moved = std::move(bytes);
+  EXPECT_TRUE(moved.is_mapped());
+  EXPECT_TRUE(bytes.span().empty());
+  EXPECT_EQ(
+      std::vector<uint8_t>(span.begin(), span.end()),
+      (std::vector<uint8_t>{'a', 'b', 'c'}));
+#endif
+}
+
+TEST_F(OwnedBytesTest, EmptyFileUsesHeapStorage) {
+  const std::string path = temp_path("_empty.bin");
+  ASSERT_NO_FATAL_FAILURE(write_file(path, ""));
+
+  const OwnedBytes bytes = OwnedBytes::from_file(path);
+
+  EXPECT_FALSE(bytes.is_mapped());
+  EXPECT_TRUE(bytes.span().empty());
+}
+
+TEST_F(OwnedBytesTest, RejectsInvalidPaths) {
+  EXPECT_THROW(
+      OwnedBytes::from_file(temp_path("_missing.bin"), false),
+      std::runtime_error);
+  EXPECT_THROW(
+      OwnedBytes::from_file(
+          std::filesystem::temp_directory_path().string(), false),
+      std::runtime_error);
+}
+// cppcheck-suppress-end syntaxError
+
+} // namespace
+} // namespace ptn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22704
* #22703
* #22702
* __->__ #22701
* #22700
* #22699

## Ulterior Motive

Support package-sized data without forcing every caller into one loading
strategy.

## Rationale

**What**: Add move-only byte ownership over vectors, uninitialized heap buffers,
and read-only file mappings.

**Why**: Package readers need stable borrowed spans while avoiding redundant
copies and zero-fill before file reads.

## Details

```text
OwnedBytes
   |
   +-- vector<uint8_t>       caller-owned bytes moved in
   +-- HeapBuffer            direct file read
   +-- mmap + Unmap deleter  demand-paged file
   |
   +-- span()                uniform read-only view
```

- Whole-file validation rejects missing paths, non-regular files, and oversized
  files. Virtual files that do not report their size are explicitly unsupported.
- Empty mappings fall back to empty heap storage because zero-length `mmap` is
  invalid.
- Moved-from heap and mapped instances return an empty span instead of a null
  span with a stale size.
- Mapping errors preserve `errno` before any allocating error construction.
- Tests compare complete payloads and stop at the original file-write failure.

Authored with Codex.

Differential Revision: [D119396096](https://our.internmc.facebook.com/intern/diff/D119396096/)