### PR TITLE
[executorch][native] Add the .ptn package reader

### DIFF
--- a/backends/native/runtime/deserialize/Package.cpp
+++ b/backends/native/runtime/deserialize/Package.cpp
@@ -1,0 +1,170 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/deserialize/Package.h>
+
+#include <algorithm>
+#include <fstream>
+#include <stdexcept>
+#include <string_view>
+
+#include <executorch/backends/native/runtime/deserialize/Json.h>
+
+namespace ptn {
+namespace {
+
+// Reserved by safetensors, so it can never name a constant.
+constexpr std::string_view kMetadataKey = "__metadata__";
+
+std::unordered_map<std::string, std::string> parse_aliases(
+    ByteSpan member,
+    const SafeTensorsReader& tensors) {
+  Json doc;
+  try {
+    doc = Json::parse(std::string_view(
+        reinterpret_cast<const char*>(member.data()), member.size()));
+  } catch (const Json::exception& error) {
+    throw std::runtime_error(
+        "package: invalid aliases.json: " + std::string(error.what()));
+  }
+  if (!doc.is_object()) {
+    throw std::runtime_error("package: aliases.json is not a JSON object");
+  }
+
+  std::unordered_map<std::string, std::string> aliases;
+  for (auto entry = doc.begin(); entry != doc.end(); ++entry) {
+    const std::string& key = entry.key();
+    if (!entry.value().is_string()) {
+      throw std::runtime_error(
+          "package: alias '" + key + "' does not name a string owner");
+    }
+    const std::string& owner = entry.value().get_ref<const std::string&>();
+    if (key == kMetadataKey) {
+      throw std::runtime_error(
+          "package: alias key is reserved by safetensors: " + key);
+    }
+    // An owner is always a real safetensors entry and an alias is never one, so
+    // resolution stays a single lookup. Enforce both rather than trusting it.
+    if (tensors.find(owner) == nullptr) {
+      std::string message = "package: alias '";
+      message += key;
+      message += "' names owner '";
+      message += owner;
+      message += "', which has no safetensors entry";
+      throw std::runtime_error(message);
+    }
+    if (tensors.find(key) != nullptr) {
+      throw std::runtime_error(
+          "package: '" + key + "' is both a safetensors owner and an alias");
+    }
+    if (!aliases.emplace(key, owner).second) {
+      throw std::runtime_error("package: duplicate alias key: " + key);
+    }
+  }
+  return aliases;
+}
+
+} // namespace
+
+bool Package::looks_like_package(ByteSpan bytes) {
+  // Every zip record signature begins "PK"; a bare .ptg starts with a
+  // flatbuffer root offset followed by "NPTG" at offset 4, so this cannot
+  // collide.
+  return bytes.size() >= 2 && bytes[0] == 'P' && bytes[1] == 'K';
+}
+
+Package Package::load(std::vector<uint8_t> bytes) {
+  Package out;
+  out.bytes_ = std::move(bytes);
+  const ByteSpan image{out.bytes_.data(), out.bytes_.size()};
+
+  out.zip_ = ZipReader::open(image);
+
+  if (!out.zip_->member_size(kProgramEntry)) {
+    throw std::runtime_error(
+        std::string("package: missing required member ") + kProgramEntry);
+  }
+  out.program_ = out.zip_->read(kProgramEntry);
+
+  // Absent whenever the program references no constants, which is normal for a
+  // graph over user inputs alone.
+  if (out.zip_->member_size(kSafeTensorsEntry)) {
+    out.tensor_bytes_ = out.zip_->read(kSafeTensorsEntry);
+    out.tensors_ = SafeTensorsReader::open(ByteSpan(out.tensor_bytes_));
+  }
+
+  if (out.zip_->member_size(kAliasesEntry)) {
+    if (!out.tensors_) {
+      throw std::runtime_error(
+          std::string("package: has ") + kAliasesEntry + " but no " +
+          kSafeTensorsEntry);
+    }
+    const std::vector<uint8_t> aliases = out.zip_->read(kAliasesEntry);
+    out.aliases_ = parse_aliases(ByteSpan(aliases), *out.tensors_);
+  }
+
+  return out;
+}
+
+Package Package::load_file(const std::string& path) {
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  if (!file) {
+    throw std::runtime_error("package: cannot open " + path);
+  }
+  const std::streamsize size = file.tellg();
+  if (size < 0) {
+    throw std::runtime_error("package: cannot size " + path);
+  }
+  file.seekg(0, std::ios::beg);
+  std::vector<uint8_t> bytes(static_cast<size_t>(size));
+  if (size > 0 && !file.read(reinterpret_cast<char*>(bytes.data()), size)) {
+    throw std::runtime_error("package: cannot read " + path);
+  }
+  return load(std::move(bytes));
+}
+
+std::optional<Constant> Package::constant(const std::string& key) const {
+  if (!tensors_) {
+    return std::nullopt;
+  }
+  const auto alias = aliases_.find(key);
+  const std::string& owner = alias == aliases_.end() ? key : alias->second;
+
+  const TensorEntry* entry = tensors_->find(owner);
+  if (entry == nullptr) {
+    return std::nullopt;
+  }
+
+  Constant out;
+  out.dtype = entry->dtype;
+  out.sizes = &entry->sizes;
+  out.bytes = tensors_->bytes(*entry);
+  out.owner = owner;
+  return out;
+}
+
+std::vector<std::string> Package::keys() const {
+  std::vector<std::string> out;
+  if (tensors_) {
+    out = tensors_->names();
+  }
+  for (const auto& alias : aliases_) {
+    out.push_back(alias.first);
+  }
+  std::ranges::sort(out);
+  return out;
+}
+
+const std::vector<std::string>& Package::owner_keys() const {
+  static const std::vector<std::string> kNone;
+  return tensors_ ? tensors_->names() : kNone;
+}
+
+size_t Package::constant_bytes() const {
+  return tensors_ ? tensors_->total_bytes() : 0;
+}
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/Package.h
+++ b/backends/native/runtime/deserialize/Package.h
@@ -1,0 +1,107 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <executorch/backends/native/runtime/deserialize/ByteSpan.h>
+#include <executorch/backends/native/runtime/deserialize/SafeTensorsReader.h>
+#include <executorch/backends/native/runtime/deserialize/ZipReader.h>
+#include <executorch/backends/native/runtime/graph/ScalarType.h>
+
+namespace ptn {
+
+// Fixed member names inside a .ptn. The package survives being renamed because
+// nothing depends on the file name.
+constexpr const char* kProgramEntry = "program.ptg";
+constexpr const char* kSafeTensorsEntry = "program.safetensors";
+constexpr const char* kAliasesEntry = "aliases.json";
+
+// One constant resolved out of a package. The sizes and bytes are borrowed from
+// the Package and must not outlive it.
+struct Constant {
+  ScalarType dtype = kFloat;
+  const std::vector<int64_t>* sizes = nullptr;
+  ByteSpan bytes;
+  // Key that actually owns these bytes. Differs from the requested key when the
+  // package deduplicated two byte-identical immutable constants.
+  std::string owner;
+};
+
+// A loaded .ptn package: the serialized native Program plus the constants it
+// references.
+//
+// Owns the package image and extracted members. Copy is deleted: a package is
+// model-sized.
+class Package {
+ private:
+  std::vector<uint8_t> bytes_;
+  std::optional<ZipReader> zip_;
+  std::vector<uint8_t> program_;
+  std::vector<uint8_t> tensor_bytes_;
+  // Absent when the program references no constants, in which case the package
+  // has no safetensors member at all.
+  std::optional<SafeTensorsReader> tensors_;
+  std::unordered_map<std::string, std::string> aliases_;
+
+  Package() = default;
+
+ public:
+  ~Package() = default;
+  Package(Package&&) noexcept = default;
+  Package& operator=(Package&&) noexcept = default;
+  Package(const Package&) = delete;
+  Package& operator=(const Package&) = delete;
+
+  // Parse a .ptn image. Takes ownership rather than copying, so a
+  // hundred-megabyte package is resident once. Throws std::runtime_error if the
+  // zip, the safetensors index, or the alias map is malformed, or if the
+  // required program member is missing.
+  static Package load(std::vector<uint8_t> bytes);
+
+  // Read and parse a .ptn from disk. Throws std::runtime_error if the file
+  // cannot be read.
+  static Package load_file(const std::string& path);
+
+  // The serialized native Program flatbuffer (the program.ptg member).
+  ByteSpan program_bytes() const {
+    return ByteSpan(program_);
+  }
+
+  // Zip member names present, in central-directory order. Diagnostic only.
+  const std::vector<std::string>& member_names() const {
+    return zip_->names();
+  }
+
+  // Keys that own their bytes, in safetensors header order.
+  const std::vector<std::string>& owner_keys() const;
+
+  // Duplicate key -> owner key.
+  const std::unordered_map<std::string, std::string>& aliases() const {
+    return aliases_;
+  }
+
+  // Constant for `key`, resolving an alias to its owner. nullopt when the
+  // package holds no such constant.
+  std::optional<Constant> constant(const std::string& key) const;
+
+  // Every key the package resolves, owners and aliases alike, sorted.
+  std::vector<std::string> keys() const;
+
+  // Total bytes across owner entries, i.e. what the constants actually cost.
+  size_t constant_bytes() const;
+
+  // True if `bytes` starts with the zip local-header signature, i.e. looks like
+  // a package rather than a bare .ptg flatbuffer. Lets a tool accept either.
+  static bool looks_like_package(ByteSpan bytes);
+};
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/ZipReader.cpp
+++ b/backends/native/runtime/deserialize/ZipReader.cpp
@@ -1,0 +1,213 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/deserialize/ZipReader.h>
+
+#include <cstdio>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+#include <zip.h>
+
+namespace ptn {
+namespace {
+
+struct ZipDeleter {
+  void operator()(zip_t* archive) const noexcept {
+    zip_discard(archive);
+  }
+};
+
+struct ZipFileDeleter {
+  void operator()(zip_file_t* file) const noexcept {
+    zip_fclose(file);
+  }
+};
+
+using ZipHandle = std::unique_ptr<zip_t, ZipDeleter>;
+using ZipFileHandle = std::unique_ptr<zip_file_t, ZipFileDeleter>;
+
+[[noreturn]] void throw_zip(zip_t* archive, const std::string& operation) {
+  throw std::runtime_error("zip: " + operation + ": " + zip_strerror(archive));
+}
+
+[[noreturn]] void throw_zip_file(
+    zip_file_t* file,
+    const std::string& operation) {
+  throw std::runtime_error(
+      "zip: " + operation + ": " + zip_file_strerror(file));
+}
+
+ZipHandle open_path(const std::string& path) {
+  int error_code = 0;
+  ZipHandle archive(
+      zip_open(path.c_str(), ZIP_RDONLY | ZIP_CHECKCONS, &error_code));
+  if (archive == nullptr) {
+    zip_error_t error;
+    zip_error_init_with_code(&error, error_code);
+    const std::string message =
+        "zip: cannot open " + path + ": " + zip_error_strerror(&error);
+    zip_error_fini(&error);
+    throw std::runtime_error(message);
+  }
+  return archive;
+}
+
+ZipHandle open_memory(ByteSpan bytes) {
+  zip_error_t error;
+  zip_error_init(&error);
+  zip_source_t* source =
+      zip_source_buffer_create(bytes.data(), bytes.size(), 0, &error);
+  if (source == nullptr) {
+    const std::string message = "zip: cannot create memory source: " +
+        std::string(zip_error_strerror(&error));
+    zip_error_fini(&error);
+    throw std::runtime_error(message);
+  }
+
+  ZipHandle archive(
+      zip_open_from_source(source, ZIP_RDONLY | ZIP_CHECKCONS, &error));
+  if (archive == nullptr) {
+    zip_source_free(source);
+    const std::string message = "zip: cannot open memory source: " +
+        std::string(zip_error_strerror(&error));
+    zip_error_fini(&error);
+    throw std::runtime_error(message);
+  }
+  zip_error_fini(&error);
+  return archive;
+}
+
+} // namespace
+
+struct ZipReader::Impl {
+  explicit Impl(ZipHandle handle) : archive(std::move(handle)) {}
+
+  ZipHandle archive;
+};
+
+ZipReader::ZipReader(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {
+  const zip_int64_t count = zip_get_num_entries(impl_->archive.get(), 0);
+  if (count < 0) {
+    throw_zip(impl_->archive.get(), "cannot enumerate members");
+  }
+
+  names_.reserve(static_cast<size_t>(count));
+  for (zip_uint64_t index = 0; index < static_cast<zip_uint64_t>(count);
+       ++index) {
+    zip_stat_t stat;
+    zip_stat_init(&stat);
+    if (zip_stat_index(impl_->archive.get(), index, ZIP_FL_UNCHANGED, &stat) !=
+        0) {
+      throw_zip(impl_->archive.get(), "cannot stat member");
+    }
+    constexpr zip_uint64_t kRequired = ZIP_STAT_NAME | ZIP_STAT_SIZE |
+        ZIP_STAT_COMP_METHOD | ZIP_STAT_ENCRYPTION_METHOD;
+    if ((stat.valid & kRequired) != kRequired || stat.name == nullptr) {
+      throw std::runtime_error("zip: member metadata is incomplete");
+    }
+    const std::string name(stat.name);
+    if (stat.comp_method != ZIP_CM_STORE) {
+      throw std::runtime_error("zip: member is compressed: " + name);
+    }
+    if (stat.encryption_method != ZIP_EM_NONE) {
+      throw std::runtime_error("zip: member is encrypted: " + name);
+    }
+    if (stat.size > std::numeric_limits<size_t>::max()) {
+      throw std::runtime_error("zip: member is too large: " + name);
+    }
+    if (!entries_.emplace(name, Entry{index, static_cast<size_t>(stat.size)})
+             .second) {
+      throw std::runtime_error("zip: duplicate member name: " + name);
+    }
+    names_.push_back(name);
+  }
+}
+
+ZipReader::~ZipReader() = default;
+ZipReader::ZipReader(ZipReader&&) noexcept = default;
+ZipReader& ZipReader::operator=(ZipReader&&) noexcept = default;
+
+ZipReader ZipReader::open(const std::string& path) {
+  return ZipReader(std::make_unique<Impl>(open_path(path)));
+}
+
+ZipReader ZipReader::open(ByteSpan archive) {
+  return ZipReader(std::make_unique<Impl>(open_memory(archive)));
+}
+
+std::optional<size_t> ZipReader::member_size(std::string_view name) const {
+  const Entry* entry = find_entry(name);
+  return entry == nullptr ? std::nullopt : std::optional<size_t>(entry->size);
+}
+
+std::vector<uint8_t> ZipReader::read(std::string_view name) const {
+  const Entry* entry = find_entry(name);
+  if (entry == nullptr) {
+    throw std::runtime_error("zip: no member named " + std::string(name));
+  }
+  std::vector<uint8_t> bytes(entry->size);
+  read_entry_into(name, *entry, 0, MutableByteSpan(bytes));
+  return bytes;
+}
+
+void ZipReader::read_into(
+    std::string_view name,
+    size_t offset,
+    MutableByteSpan destination) const {
+  const Entry* entry = find_entry(name);
+  if (entry == nullptr) {
+    throw std::runtime_error("zip: no member named " + std::string(name));
+  }
+  read_entry_into(name, *entry, offset, destination);
+}
+
+const ZipReader::Entry* ZipReader::find_entry(std::string_view name) const {
+  const auto entry = entries_.find(name);
+  return entry == entries_.end() ? nullptr : &entry->second;
+}
+
+void ZipReader::read_entry_into(
+    std::string_view name,
+    const Entry& entry,
+    size_t offset,
+    MutableByteSpan destination) const {
+  if (offset > entry.size || destination.size() > entry.size - offset) {
+    throw std::runtime_error(
+        "zip: read range is outside member " + std::string(name));
+  }
+  if (destination.empty()) {
+    return;
+  }
+
+  ZipFileHandle file(
+      zip_fopen_index(impl_->archive.get(), entry.index, ZIP_FL_UNCHANGED));
+  if (file == nullptr) {
+    throw_zip(impl_->archive.get(), "cannot open member " + std::string(name));
+  }
+  if (zip_fseek(file.get(), static_cast<zip_int64_t>(offset), SEEK_SET) != 0) {
+    throw_zip_file(file.get(), "cannot seek member " + std::string(name));
+  }
+
+  size_t written = 0;
+  while (written < destination.size()) {
+    const zip_uint64_t request =
+        static_cast<zip_uint64_t>(destination.size() - written);
+    const zip_int64_t count =
+        zip_fread(file.get(), destination.data() + written, request);
+    if (count < 0) {
+      throw_zip_file(file.get(), "cannot read member " + std::string(name));
+    }
+    if (count == 0) {
+      throw std::runtime_error(
+          "zip: unexpected end of member " + std::string(name));
+    }
+    written += static_cast<size_t>(count);
+  }
+}
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/ZipReader.h
+++ b/backends/native/runtime/deserialize/ZipReader.h
@@ -1,0 +1,84 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <executorch/backends/native/runtime/deserialize/ByteSpan.h>
+
+namespace ptn {
+
+// Read-only access to stored members of a zip archive.
+class ZipReader {
+ private:
+  struct Entry {
+    uint64_t index = 0;
+    size_t size = 0;
+  };
+
+  struct StringHash {
+    using is_transparent = void;
+
+    size_t operator()(std::string_view value) const noexcept {
+      return std::hash<std::string_view>{}(value);
+    }
+  };
+
+  struct Impl;
+
+  std::unique_ptr<Impl> impl_;
+  std::unordered_map<std::string, Entry, StringHash, std::equal_to<>> entries_;
+  std::vector<std::string> names_;
+
+  explicit ZipReader(std::unique_ptr<Impl> impl);
+  const Entry* find_entry(std::string_view name) const;
+  void read_entry_into(
+      std::string_view name,
+      const Entry& entry,
+      size_t offset,
+      MutableByteSpan destination) const;
+
+ public:
+  ~ZipReader();
+  ZipReader(ZipReader&&) noexcept;
+  ZipReader& operator=(ZipReader&&) noexcept;
+  ZipReader(const ZipReader&) = delete;
+  ZipReader& operator=(const ZipReader&) = delete;
+
+  // Opens an archive without loading its member payloads.
+  static ZipReader open(const std::string& path);
+
+  // Opens an archive over caller-owned memory. `archive` must outlive this
+  // reader and every read made through it.
+  static ZipReader open(ByteSpan archive);
+
+  // Member size, or nullopt when the member is absent.
+  std::optional<size_t> member_size(std::string_view name) const;
+
+  // Copies one complete member.
+  std::vector<uint8_t> read(std::string_view name) const;
+
+  // Copies a member range directly into caller-owned storage.
+  void read_into(
+      std::string_view name,
+      size_t offset,
+      MutableByteSpan destination) const;
+
+  const std::vector<std::string>& names() const {
+    return names_;
+  }
+};
+
+} // namespace ptn

--- a/backends/native/runtime/deserialize/targets.bzl
+++ b/backends/native/runtime/deserialize/targets.bzl
@@ -28,6 +28,15 @@ def define_common_targets():
         visibility = ["//executorch/backends/native/..."],
     )
 
+    runtime.cxx_library(
+        name = "zip_reader",
+        srcs = ["ZipReader.cpp"],
+        exported_headers = ["ZipReader.h"],
+        exported_deps = [":byte_span"],
+        deps = ["fbsource//third-party/libzip:zip"],
+        visibility = ["//executorch/backends/native/..."],
+    )
+
     # safetensors index reader.
     runtime.cxx_library(
         name = "safetensors_reader",
@@ -39,4 +48,17 @@ def define_common_targets():
         ],
         deps = [":json"],
         visibility = ["//executorch/backends/native/..."],
+    )
+    runtime.cxx_library(
+        name = "package",
+        srcs = ["Package.cpp"],
+        exported_headers = ["Package.h"],
+        exported_deps = [
+            ":byte_span",
+            ":safetensors_reader",
+            ":zip_reader",
+            "//executorch/backends/native/runtime/graph:scalar_type",
+        ],
+        deps = [":json"],
+        visibility = ["PUBLIC"],
     )

--- a/backends/native/test/runtime/deserialize/targets.bzl
+++ b/backends/native/test/runtime/deserialize/targets.bzl
@@ -16,3 +16,12 @@ def define_common_targets():
             "//executorch/backends/native/runtime/deserialize:safetensors_reader",
         ],
     )
+
+    runtime.cxx_test(
+        name = "zip_reader_test",
+        srcs = ["test_zip_reader.cpp"],
+        deps = [
+            "//executorch/backends/native/runtime/deserialize:zip_reader",
+            "fbsource//third-party/libzip:zip",
+        ],
+    )

--- a/backends/native/test/runtime/deserialize/test_zip_reader.cpp
+++ b/backends/native/test/runtime/deserialize/test_zip_reader.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/deserialize/ZipReader.h>
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <zip.h>
+
+namespace ptn {
+namespace {
+
+struct ZipDiscard {
+  void operator()(zip_t* archive) const noexcept {
+    zip_discard(archive);
+  }
+};
+
+class TempZip {
+ public:
+  TempZip() {
+    path_ = std::filesystem::temp_directory_path() /
+        ("ptn_zip_reader_" + std::to_string(reinterpret_cast<uintptr_t>(this)) +
+         ".zip");
+    int error = 0;
+    std::unique_ptr<zip_t, ZipDiscard> archive(
+        zip_open(path_.string().c_str(), ZIP_CREATE | ZIP_TRUNCATE, &error));
+    if (archive == nullptr) {
+      throw std::runtime_error("failed to create test zip");
+    }
+    add(archive.get(), "program.ptg", "program");
+    add(archive.get(), "program.safetensors", "0123456789");
+    if (zip_close(archive.get()) != 0) {
+      throw std::runtime_error("failed to close test zip");
+    }
+    archive.release();
+  }
+
+  ~TempZip() {
+    std::error_code error;
+    std::filesystem::remove(path_, error);
+  }
+
+  const std::string path() const {
+    return path_.string();
+  }
+
+ private:
+  static void add(zip_t* archive, const char* name, std::string_view bytes) {
+    zip_source_t* source =
+        zip_source_buffer(archive, bytes.data(), bytes.size(), 0);
+    if (source == nullptr) {
+      throw std::runtime_error("failed to create test zip source");
+    }
+    const zip_int64_t index =
+        zip_file_add(archive, name, source, ZIP_FL_ENC_UTF_8);
+    if (index < 0) {
+      zip_source_free(source);
+      throw std::runtime_error("failed to add test zip member");
+    }
+    if (zip_set_file_compression(archive, index, ZIP_CM_STORE, 0) != 0) {
+      throw std::runtime_error("failed to store test zip member");
+    }
+  }
+
+  std::filesystem::path path_;
+};
+
+// cppcheck-suppress-begin syntaxError
+TEST(ZipReaderTest, ReadsStoredMemberRanges) {
+  const TempZip file;
+  ZipReader zip = ZipReader::open(file.path());
+
+  EXPECT_EQ(
+      zip.names(),
+      (std::vector<std::string>{"program.ptg", "program.safetensors"}));
+  EXPECT_EQ(zip.member_size("program.safetensors"), 10);
+  EXPECT_EQ(zip.member_size("missing"), std::nullopt);
+
+  std::array<uint8_t, 4> bytes{};
+  zip.read_into("program.safetensors", 3, MutableByteSpan(bytes));
+  EXPECT_EQ(bytes, (std::array<uint8_t, 4>{'3', '4', '5', '6'}));
+  EXPECT_EQ(
+      zip.read("program.ptg"),
+      (std::vector<uint8_t>{'p', 'r', 'o', 'g', 'r', 'a', 'm'}));
+}
+
+TEST(ZipReaderTest, RejectsInvalidRanges) {
+  const TempZip file;
+  ZipReader zip = ZipReader::open(file.path());
+
+  std::array<uint8_t, 4> bytes{};
+  EXPECT_THROW(
+      zip.read_into("program.safetensors", 8, MutableByteSpan(bytes)),
+      std::runtime_error);
+  EXPECT_THROW(
+      zip.read_into("missing", 0, MutableByteSpan(bytes)), std::runtime_error);
+}
+// cppcheck-suppress-end syntaxError
+
+} // namespace
+} // namespace ptn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22704
* #22703
* __->__ #22702
* #22701
* #22700
* #22699

## Ulterior Motive

Unify native graph and constant loading behind one PTN package abstraction.

## Rationale

**What**: Add a `libzip` wrapper, `Package` facade, alias resolution, and
`ptn_inspector`.

**Why**: Runtime callers should consume one validated package instead of parsing
ZIP and safetensors details themselves.

## Details

```text
model.ptn
  |
  +-- program.ptg ---------> Program
  +-- program.safetensors -> SafeTensorsReader
  +-- aliases.json --------> alias key -> owner key
```

- `ZipReader` accepts stored, unencrypted members only. Transparent lookup and
  shared entry plumbing avoid temporary strings and duplicate map probes.
- `Package` owns the archive image and extracted data. `Constant` views borrow
  metadata and bytes from that package.
- `ptn_inspector` delegates file loading to `Package` and parses the program once
  in its default reporting path.
- Test archives use RAII, including constructor-failure paths.

Authored with Codex.

Differential Revision: [D118480654](https://our.internmc.facebook.com/intern/diff/D118480654/)