### PR TITLE
[executorch][native] Load .ptn constants on demand

### DIFF
--- a/backends/native/runtime/deserialize/Package.cpp
+++ b/backends/native/runtime/deserialize/Package.cpp
@@ -7,7 +7,8 @@
 #include <executorch/backends/native/runtime/deserialize/Package.h>
 
 #include <algorithm>
-#include <fstream>
+#include <array>
+#include <atomic>
 #include <stdexcept>
 #include <string_view>
 
@@ -18,6 +19,7 @@ namespace {
 
 // Reserved by safetensors, so it can never name a constant.
 constexpr std::string_view kMetadataKey = "__metadata__";
+std::atomic<uint64_t> next_package_id{1};
 
 std::unordered_map<std::string, std::string> parse_aliases(
     ByteSpan member,
@@ -76,57 +78,81 @@ bool Package::looks_like_package(ByteSpan bytes) {
   return bytes.size() >= 2 && bytes[0] == 'P' && bytes[1] == 'K';
 }
 
-Package Package::load(std::vector<uint8_t> bytes) {
+Package::Package()
+    : id_(next_package_id.fetch_add(1, std::memory_order_relaxed)) {}
+
+Package Package::load(OwnedBytes bytes) {
   Package out;
-  out.bytes_ = std::move(bytes);
-  const ByteSpan image{out.bytes_.data(), out.bytes_.size()};
+  out.archive_bytes_ = std::move(bytes);
+  out.zip_ = ZipReader::open(out.archive_bytes_.span());
+  out.load_metadata();
+  return out;
+}
 
-  out.zip_ = ZipReader::open(image);
+Package Package::load(const std::string& path) {
+  Package out;
+  out.zip_ = ZipReader::open(path);
+  out.load_metadata();
+  return out;
+}
 
-  if (!out.zip_->member_size(kProgramEntry)) {
+Package& Package::operator=(Package&& other) noexcept {
+  if (this != &other) {
+    zip_.reset();
+    id_ = other.id_;
+    archive_bytes_ = std::move(other.archive_bytes_);
+    zip_ = std::move(other.zip_);
+    program_ = std::move(other.program_);
+    tensors_ = std::move(other.tensors_);
+    tensor_data_offset_ = other.tensor_data_offset_;
+    aliases_ = std::move(other.aliases_);
+  }
+  return *this;
+}
+
+void Package::load_metadata() {
+  if (!zip_->member_size(kProgramEntry)) {
     throw std::runtime_error(
         std::string("package: missing required member ") + kProgramEntry);
   }
-  out.program_ = out.zip_->read(kProgramEntry);
+  program_ = zip_->read(kProgramEntry);
 
   // Absent whenever the program references no constants, which is normal for a
   // graph over user inputs alone.
-  if (out.zip_->member_size(kSafeTensorsEntry)) {
-    out.tensor_bytes_ = out.zip_->read(kSafeTensorsEntry);
-    out.tensors_ = SafeTensorsReader::open(ByteSpan(out.tensor_bytes_));
+  const std::optional<size_t> tensor_size =
+      zip_->member_size(kSafeTensorsEntry);
+  if (tensor_size) {
+    std::array<uint8_t, SafeTensorsReader::kLengthPrefixSize> prefix{};
+    if (*tensor_size < prefix.size()) {
+      throw std::runtime_error(
+          "package: safetensors member is shorter than its length prefix");
+    }
+    zip_->read_into(kSafeTensorsEntry, 0, MutableByteSpan(prefix));
+    const size_t header_size = SafeTensorsReader::header_size(prefix);
+    if (header_size > *tensor_size - prefix.size()) {
+      throw std::runtime_error(
+          "package: safetensors header exceeds its zip member");
+    }
+    std::vector<uint8_t> header(header_size);
+    zip_->read_into(kSafeTensorsEntry, prefix.size(), MutableByteSpan(header));
+    tensor_data_offset_ = prefix.size() + header_size;
+    tensors_ = SafeTensorsReader::open_header(
+        ByteSpan(header), *tensor_size - tensor_data_offset_);
   }
 
-  if (out.zip_->member_size(kAliasesEntry)) {
-    if (!out.tensors_) {
+  if (zip_->member_size(kAliasesEntry)) {
+    if (!tensors_) {
       throw std::runtime_error(
           std::string("package: has ") + kAliasesEntry + " but no " +
           kSafeTensorsEntry);
     }
-    const std::vector<uint8_t> aliases = out.zip_->read(kAliasesEntry);
-    out.aliases_ = parse_aliases(ByteSpan(aliases), *out.tensors_);
+    const std::vector<uint8_t> aliases = zip_->read(kAliasesEntry);
+    aliases_ = parse_aliases(ByteSpan(aliases), *tensors_);
   }
-
-  return out;
 }
 
-Package Package::load_file(const std::string& path) {
-  std::ifstream file(path, std::ios::binary | std::ios::ate);
-  if (!file) {
-    throw std::runtime_error("package: cannot open " + path);
-  }
-  const std::streamsize size = file.tellg();
-  if (size < 0) {
-    throw std::runtime_error("package: cannot size " + path);
-  }
-  file.seekg(0, std::ios::beg);
-  std::vector<uint8_t> bytes(static_cast<size_t>(size));
-  if (size > 0 && !file.read(reinterpret_cast<char*>(bytes.data()), size)) {
-    throw std::runtime_error("package: cannot read " + path);
-  }
-  return load(std::move(bytes));
-}
-
-std::optional<Constant> Package::constant(const std::string& key) const {
+std::optional<ConstantInfo> Package::constant_info(
+    const std::string& key) const {
   if (!tensors_) {
     return std::nullopt;
   }
@@ -138,12 +164,49 @@ std::optional<Constant> Package::constant(const std::string& key) const {
     return std::nullopt;
   }
 
-  Constant out;
+  ConstantInfo out;
+  out.package_id = id_;
   out.dtype = entry->dtype;
   out.sizes = &entry->sizes;
-  out.bytes = tensors_->bytes(*entry);
+  out.nbytes = entry->nbytes;
   out.owner = owner;
   return out;
+}
+
+std::optional<OwnedBytes> Package::acquire_constant(
+    const std::string& key) const {
+  const std::optional<ConstantInfo> info = constant_info(key);
+  if (!info) {
+    return std::nullopt;
+  }
+  std::vector<uint8_t> bytes(info->nbytes);
+  load_constant_into(key, MutableByteSpan(bytes));
+  return OwnedBytes::from_vector(std::move(bytes));
+}
+
+bool Package::load_constant_into(
+    const std::string& key,
+    MutableByteSpan destination) const {
+  const std::optional<ConstantInfo> info = constant_info(key);
+  if (!info) {
+    return false;
+  }
+  if (destination.size() != info->nbytes) {
+    throw std::runtime_error(
+        "package: destination for '" + key + "' has " +
+        std::to_string(destination.size()) + " bytes; expected " +
+        std::to_string(info->nbytes));
+  }
+  const TensorEntry* entry = tensors_->find(info->owner);
+  zip_->read_into(
+      kSafeTensorsEntry, tensor_data_offset_ + entry->offset, destination);
+  return true;
+}
+
+void Package::verify_constants() const {
+  if (tensors_) {
+    zip_->verify(kSafeTensorsEntry);
+  }
 }
 
 std::vector<std::string> Package::keys() const {

--- a/backends/native/runtime/deserialize/Package.h
+++ b/backends/native/runtime/deserialize/Package.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -13,6 +14,7 @@
 #include <vector>
 
 #include <executorch/backends/native/runtime/deserialize/ByteSpan.h>
+#include <executorch/backends/native/runtime/deserialize/OwnedBytes.h>
 #include <executorch/backends/native/runtime/deserialize/SafeTensorsReader.h>
 #include <executorch/backends/native/runtime/deserialize/ZipReader.h>
 #include <executorch/backends/native/runtime/graph/ScalarType.h>
@@ -25,12 +27,13 @@ constexpr const char* kProgramEntry = "program.ptg";
 constexpr const char* kSafeTensorsEntry = "program.safetensors";
 constexpr const char* kAliasesEntry = "aliases.json";
 
-// One constant resolved out of a package. The sizes and bytes are borrowed from
+// Metadata for one constant resolved out of a package. `sizes` is borrowed from
 // the Package and must not outlive it.
-struct Constant {
+struct ConstantInfo {
+  uint64_t package_id = 0;
   ScalarType dtype = kFloat;
   const std::vector<int64_t>* sizes = nullptr;
-  ByteSpan bytes;
+  size_t nbytes = 0;
   // Key that actually owns these bytes. Differs from the requested key when the
   // package deduplicated two byte-identical immutable constants.
   std::string owner;
@@ -39,37 +42,39 @@ struct Constant {
 // A loaded .ptn package: the serialized native Program plus the constants it
 // references.
 //
-// Owns the package image and extracted members. Copy is deleted: a package is
-// model-sized.
+// Opening a file-backed package reads its directory and metadata, but leaves
+// weight payloads on disk until an engine requests them.
 class Package {
  private:
-  std::vector<uint8_t> bytes_;
+  uint64_t id_ = 0;
+  OwnedBytes archive_bytes_;
   std::optional<ZipReader> zip_;
   std::vector<uint8_t> program_;
-  std::vector<uint8_t> tensor_bytes_;
   // Absent when the program references no constants, in which case the package
   // has no safetensors member at all.
   std::optional<SafeTensorsReader> tensors_;
+  size_t tensor_data_offset_ = 0;
   std::unordered_map<std::string, std::string> aliases_;
 
-  Package() = default;
+  Package();
 
  public:
   ~Package() = default;
   Package(Package&&) noexcept = default;
-  Package& operator=(Package&&) noexcept = default;
+  Package& operator=(Package&& other) noexcept;
   Package(const Package&) = delete;
   Package& operator=(const Package&) = delete;
 
-  // Parse a .ptn image. Takes ownership rather than copying, so a
-  // hundred-megabyte package is resident once. Throws std::runtime_error if the
-  // zip, the safetensors index, or the alias map is malformed, or if the
-  // required program member is missing.
-  static Package load(std::vector<uint8_t> bytes);
+  // Open and parse the .ptn at `path` without loading its weight payloads.
+  static Package load(const std::string& path);
 
-  // Read and parse a .ptn from disk. Throws std::runtime_error if the file
-  // cannot be read.
-  static Package load_file(const std::string& path);
+  // Parse a .ptn image already in hand. Takes ownership rather than copying, so
+  // a hundred-megabyte package is resident once. For callers that must inspect
+  // the bytes before deciding this is a package at all; everyone else should
+  // use the path overload. Throws std::runtime_error if the zip, the
+  // safetensors index, or the alias map is malformed, or if the required
+  // program member is missing.
+  static Package load(OwnedBytes bytes);
 
   // The serialized native Program flatbuffer (the program.ptg member).
   ByteSpan program_bytes() const {
@@ -89,9 +94,19 @@ class Package {
     return aliases_;
   }
 
-  // Constant for `key`, resolving an alias to its owner. nullopt when the
-  // package holds no such constant.
-  std::optional<Constant> constant(const std::string& key) const;
+  // Metadata for `key`, resolving an alias to its owner. nullopt when absent.
+  std::optional<ConstantInfo> constant_info(const std::string& key) const;
+
+  // Load one constant into a new owning buffer. nullopt when absent.
+  std::optional<OwnedBytes> acquire_constant(const std::string& key) const;
+
+  // Load one constant directly into an exact-sized destination. Returns false
+  // when absent and throws when the destination has the wrong size.
+  bool load_constant_into(const std::string& key, MutableByteSpan destination)
+      const;
+
+  // Stream all weight bytes once to verify the zip member checksum.
+  void verify_constants() const;
 
   // Every key the package resolves, owners and aliases alike, sorted.
   std::vector<std::string> keys() const;
@@ -102,6 +117,9 @@ class Package {
   // True if `bytes` starts with the zip local-header signature, i.e. looks like
   // a package rather than a bare .ptg flatbuffer. Lets a tool accept either.
   static bool looks_like_package(ByteSpan bytes);
+
+ private:
+  void load_metadata();
 };
 
 } // namespace ptn

--- a/backends/native/runtime/deserialize/SafeTensorsReader.cpp
+++ b/backends/native/runtime/deserialize/SafeTensorsReader.cpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <bit>
 #include <cstring>
+#include <limits>
 #include <numeric>
 #include <stdexcept>
 #include <string_view>
@@ -21,8 +22,6 @@ namespace {
 
 // Reserved header member holding free-form string metadata, not a tensor.
 constexpr std::string_view kMetadataKey = "__metadata__";
-constexpr size_t kHeaderLenSize = 8;
-
 struct DtypeCode {
   std::string_view code;
   ScalarType dtype;
@@ -55,19 +54,6 @@ ScalarType scalar_type_of(std::string_view code) {
         "safetensors: unsupported dtype code: " + std::string(code));
   }
   return it->dtype;
-}
-
-uint64_t read_header_len(ByteSpan blob) {
-  static_assert(
-      std::endian::native == std::endian::little,
-      "the length prefix is little-endian; a big-endian host needs a swap");
-  if (blob.size() < kHeaderLenSize) {
-    throw std::runtime_error(
-        "safetensors: blob is shorter than its length prefix");
-  }
-  uint64_t len = 0;
-  std::memcpy(&len, blob.data(), kHeaderLenSize);
-  return len;
 }
 
 const Json& required_member(
@@ -129,15 +115,39 @@ size_t numel_of(const std::vector<int64_t>& sizes, const std::string& name) {
 
 } // namespace
 
+size_t SafeTensorsReader::header_size(ByteSpan prefix) {
+  static_assert(
+      std::endian::native == std::endian::little,
+      "the length prefix is little-endian; a big-endian host needs a swap");
+  if (prefix.size() < kLengthPrefixSize) {
+    throw std::runtime_error(
+        "safetensors: blob is shorter than its length prefix");
+  }
+  uint64_t size = 0;
+  std::memcpy(&size, prefix.data(), kLengthPrefixSize);
+  if (size > std::numeric_limits<size_t>::max()) {
+    throw std::runtime_error("safetensors: header is too large");
+  }
+  return static_cast<size_t>(size);
+}
+
 SafeTensorsReader SafeTensorsReader::open(ByteSpan blob) {
-  const uint64_t header_len = read_header_len(blob);
-  if (header_len > blob.size() - kHeaderLenSize) {
+  const size_t header_len = header_size(blob);
+  if (header_len > blob.size() - kLengthPrefixSize) {
     throw std::runtime_error("safetensors: header length exceeds the blob");
   }
+  const ByteSpan header =
+      blob.subspan(kLengthPrefixSize, static_cast<size_t>(header_len));
+  return open_header(
+      header,
+      blob.size() - kLengthPrefixSize - static_cast<size_t>(header_len));
+}
 
+SafeTensorsReader SafeTensorsReader::open_header(
+    ByteSpan header_bytes,
+    size_t data_size) {
   const std::string_view header_text(
-      reinterpret_cast<const char*>(blob.data() + kHeaderLenSize),
-      static_cast<size_t>(header_len));
+      reinterpret_cast<const char*>(header_bytes.data()), header_bytes.size());
   Json header;
   try {
     header = Json::parse(header_text);
@@ -150,7 +160,6 @@ SafeTensorsReader SafeTensorsReader::open(ByteSpan blob) {
   }
 
   SafeTensorsReader out;
-  out.data_ = blob.subspan(kHeaderLenSize + static_cast<size_t>(header_len));
 
   for (auto member = header.begin(); member != header.end(); ++member) {
     const std::string& name = member.key();
@@ -188,7 +197,8 @@ SafeTensorsReader SafeTensorsReader::open(ByteSpan blob) {
     }
     const uint64_t begin = range[0].get<uint64_t>();
     const uint64_t end = range[1].get<uint64_t>();
-    if (begin > end || end > out.data_.size()) {
+    if (begin > end || end > data_size ||
+        end > std::numeric_limits<size_t>::max()) {
       throw std::runtime_error(
           "safetensors: entry '" + name +
           "' byte range is outside the data section");
@@ -225,10 +235,6 @@ SafeTensorsReader SafeTensorsReader::open(ByteSpan blob) {
 const TensorEntry* SafeTensorsReader::find(const std::string& name) const {
   const auto it = entries_.find(name);
   return it == entries_.end() ? nullptr : &it->second;
-}
-
-ByteSpan SafeTensorsReader::bytes(const TensorEntry& entry) const {
-  return data_.subspan(entry.offset, entry.nbytes);
 }
 
 size_t SafeTensorsReader::total_bytes() const {

--- a/backends/native/runtime/deserialize/SafeTensorsReader.h
+++ b/backends/native/runtime/deserialize/SafeTensorsReader.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
@@ -34,28 +35,29 @@ struct TensorEntry {
 // reader exposes metadata semantics.
 //
 // Tensor payloads are packed with no per-tensor padding, so an entry's absolute
-// alignment within the file is arbitrary: copy through these spans rather than
-// handing them to an API that requires alignment.
+// alignment within the file is arbitrary. Consumers must copy bytes into any
+// destination that requires stronger alignment.
 class SafeTensorsReader {
  private:
-  // The data section only, i.e. the blob past its header.
-  ByteSpan data_;
   std::unordered_map<std::string, TensorEntry> entries_;
   std::vector<std::string> names_;
 
  public:
+  static constexpr size_t kLengthPrefixSize = 8;
+
   // Parse `blob`'s index. Throws std::runtime_error if the blob is truncated,
   // the header is not a JSON object, a dtype has no ScalarType, or a byte range
   // is inconsistent with its dtype and shape.
-  //
-  // Borrows `blob`, which must outlive both this reader and any span from it.
   static SafeTensorsReader open(ByteSpan blob);
+
+  // Decode the format's little-endian length prefix.
+  static size_t header_size(ByteSpan prefix);
+
+  // Parse a header without loading its data section.
+  static SafeTensorsReader open_header(ByteSpan header, size_t data_size);
 
   // Entry for `name`, or nullptr when absent.
   const TensorEntry* find(const std::string& name) const;
-
-  // Payload of an entry obtained from this reader.
-  ByteSpan bytes(const TensorEntry& entry) const;
 
   // Tensor names, in header order, excluding "__metadata__".
   const std::vector<std::string>& names() const {

--- a/backends/native/runtime/deserialize/ZipReader.cpp
+++ b/backends/native/runtime/deserialize/ZipReader.cpp
@@ -6,6 +6,8 @@
 
 #include <executorch/backends/native/runtime/deserialize/ZipReader.h>
 
+#include <algorithm>
+#include <array>
 #include <cstdio>
 #include <limits>
 #include <stdexcept>
@@ -207,6 +209,44 @@ void ZipReader::read_entry_into(
           "zip: unexpected end of member " + std::string(name));
     }
     written += static_cast<size_t>(count);
+  }
+}
+
+void ZipReader::verify(std::string_view name) const {
+  const Entry* entry = find_entry(name);
+  if (entry == nullptr) {
+    throw std::runtime_error("zip: no member named " + std::string(name));
+  }
+
+  ZipFileHandle file(
+      zip_fopen_index(impl_->archive.get(), entry->index, ZIP_FL_UNCHANGED));
+  if (file == nullptr) {
+    throw_zip(impl_->archive.get(), "cannot open member " + std::string(name));
+  }
+
+  std::array<uint8_t, 64 * 1024> buffer{};
+  size_t read = 0;
+  while (read < entry->size) {
+    const size_t request = std::min(buffer.size(), entry->size - read);
+    const zip_int64_t count = zip_fread(file.get(), buffer.data(), request);
+    if (count < 0) {
+      throw_zip_file(file.get(), "cannot verify member " + std::string(name));
+    }
+    if (count == 0) {
+      throw std::runtime_error(
+          "zip: unexpected end of member " + std::string(name));
+    }
+    read += static_cast<size_t>(count);
+  }
+
+  uint8_t extra = 0;
+  const zip_int64_t count = zip_fread(file.get(), &extra, 1);
+  if (count < 0) {
+    throw_zip_file(file.get(), "cannot verify member " + std::string(name));
+  }
+  if (count != 0) {
+    throw std::runtime_error(
+        "zip: member is larger than its metadata: " + std::string(name));
   }
 }
 

--- a/backends/native/runtime/deserialize/ZipReader.h
+++ b/backends/native/runtime/deserialize/ZipReader.h
@@ -76,6 +76,9 @@ class ZipReader {
       size_t offset,
       MutableByteSpan destination) const;
 
+  // Reads a complete member and verifies its checksum without retaining it.
+  void verify(std::string_view name) const;
+
   const std::vector<std::string>& names() const {
     return names_;
   }

--- a/backends/native/runtime/deserialize/targets.bzl
+++ b/backends/native/runtime/deserialize/targets.bzl
@@ -10,7 +10,7 @@ def define_common_targets():
         visibility = ["//executorch/backends/native/..."],
     )
 
-    # Owning byte buffer backed by heap storage or a read-only file mapping.
+    # Owning byte buffer behind a package: heap read or read-only mmap.
     runtime.cxx_library(
         name = "owned_bytes",
         srcs = ["OwnedBytes.cpp"],
@@ -28,6 +28,8 @@ def define_common_targets():
         visibility = ["//executorch/backends/native/..."],
     )
 
+    # Read-only reader for stored (uncompressed) zip archives, which is what a .ptn
+    # package is.
     runtime.cxx_library(
         name = "zip_reader",
         srcs = ["ZipReader.cpp"],
@@ -49,12 +51,14 @@ def define_common_targets():
         deps = [":json"],
         visibility = ["//executorch/backends/native/..."],
     )
+    # The .ptn package: program flatbuffer plus its constants.
     runtime.cxx_library(
         name = "package",
         srcs = ["Package.cpp"],
         exported_headers = ["Package.h"],
         exported_deps = [
             ":byte_span",
+            ":owned_bytes",
             ":safetensors_reader",
             ":zip_reader",
             "//executorch/backends/native/runtime/graph:scalar_type",

--- a/backends/native/test/runtime/deserialize/targets.bzl
+++ b/backends/native/test/runtime/deserialize/targets.bzl
@@ -10,6 +10,15 @@ def define_common_targets():
     )
 
     runtime.cxx_test(
+        name = "package_test",
+        srcs = ["test_package.cpp"],
+        deps = [
+            "//executorch/backends/native/runtime/deserialize:package",
+            "fbsource//third-party/libzip:zip",
+        ],
+    )
+
+    runtime.cxx_test(
         name = "safetensors_reader_test",
         srcs = ["test_safetensors_reader.cpp"],
         deps = [

--- a/backends/native/test/runtime/deserialize/test_package.cpp
+++ b/backends/native/test/runtime/deserialize/test_package.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <executorch/backends/native/runtime/deserialize/Package.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <zip.h>
+
+namespace ptn {
+namespace {
+
+std::vector<uint8_t> make_safetensors(
+    std::string_view header,
+    std::string_view data) {
+  const uint64_t header_size = header.size();
+  std::vector<uint8_t> bytes(sizeof(header_size) + header.size() + data.size());
+  std::memcpy(bytes.data(), &header_size, sizeof(header_size));
+  std::memcpy(bytes.data() + sizeof(header_size), header.data(), header.size());
+  std::memcpy(
+      bytes.data() + sizeof(header_size) + header.size(),
+      data.data(),
+      data.size());
+  return bytes;
+}
+
+ByteSpan as_bytes(std::string_view value) {
+  return ByteSpan(reinterpret_cast<const uint8_t*>(value.data()), value.size());
+}
+
+struct ZipDiscard {
+  void operator()(zip_t* archive) const noexcept {
+    zip_discard(archive);
+  }
+};
+
+class TempPackage {
+ private:
+  const std::string program_ = "program";
+  const std::string aliases_ = R"({"tied_weight":"weight"})";
+  std::filesystem::path path_;
+
+ public:
+  TempPackage() {
+    path_ = std::filesystem::temp_directory_path() /
+        ("ptn_package_" + std::to_string(reinterpret_cast<uintptr_t>(this)) +
+         ".ptn");
+    int error = 0;
+    std::unique_ptr<zip_t, ZipDiscard> archive(
+        zip_open(path_.string().c_str(), ZIP_CREATE | ZIP_TRUNCATE, &error));
+    if (archive == nullptr) {
+      throw std::runtime_error("failed to create test package");
+    }
+    const std::vector<uint8_t> tensors = make_safetensors(
+        R"({"weight":{"dtype":"U8","shape":[4],"data_offsets":[0,4]},"bias":{"dtype":"I16","shape":[1],"data_offsets":[4,6]}})",
+        "dataxy");
+    add(archive.get(), kProgramEntry, as_bytes(program_));
+    add(archive.get(), kSafeTensorsEntry, ByteSpan(tensors));
+    add(archive.get(), kAliasesEntry, as_bytes(aliases_));
+    if (zip_close(archive.get()) != 0) {
+      throw std::runtime_error("failed to close test package");
+    }
+    archive.release();
+  }
+
+  ~TempPackage() {
+    std::error_code error;
+    std::filesystem::remove(path_, error);
+  }
+
+  std::string path() const {
+    return path_.string();
+  }
+
+ private:
+  static void add(zip_t* archive, const char* name, ByteSpan bytes) {
+    zip_source_t* source =
+        zip_source_buffer(archive, bytes.data(), bytes.size(), 0);
+    if (source == nullptr) {
+      throw std::runtime_error("failed to create test package source");
+    }
+    const zip_int64_t index =
+        zip_file_add(archive, name, source, ZIP_FL_ENC_UTF_8);
+    if (index < 0) {
+      zip_source_free(source);
+      throw std::runtime_error("failed to add test package member");
+    }
+    if (zip_set_file_compression(archive, index, ZIP_CM_STORE, 0) != 0) {
+      throw std::runtime_error("failed to store test package member");
+    }
+  }
+};
+
+// cppcheck-suppress-begin syntaxError
+TEST(PackageTest, LoadsConstantsOnDemand) {
+  const TempPackage file;
+  const Package package = Package::load(file.path());
+
+  EXPECT_EQ(package.owner_keys(), (std::vector<std::string>{"weight", "bias"}));
+  EXPECT_EQ(package.constant_bytes(), 6);
+
+  const std::optional<ConstantInfo> info = package.constant_info("tied_weight");
+  ASSERT_TRUE(info);
+  EXPECT_NE(info->package_id, 0);
+  EXPECT_EQ(info->dtype, kByte);
+  EXPECT_EQ(*info->sizes, (std::vector<int64_t>{4}));
+  EXPECT_EQ(info->nbytes, 4);
+  EXPECT_EQ(info->owner, "weight");
+
+  std::array<uint8_t, 4> destination{};
+  EXPECT_TRUE(package.load_constant_into("weight", destination));
+  EXPECT_EQ(destination, (std::array<uint8_t, 4>{'d', 'a', 't', 'a'}));
+
+  const std::optional<OwnedBytes> acquired =
+      package.acquire_constant("tied_weight");
+  ASSERT_TRUE(acquired);
+  EXPECT_TRUE(std::ranges::equal(acquired->span(), destination));
+  EXPECT_NO_THROW(package.verify_constants());
+}
+
+TEST(PackageTest, ReportsMissingConstantsAndWrongDestinations) {
+  const TempPackage file;
+  const Package package = Package::load(file.path());
+
+  EXPECT_EQ(package.constant_info("missing"), std::nullopt);
+  EXPECT_EQ(package.acquire_constant("missing"), std::nullopt);
+  std::array<uint8_t, 1> destination{};
+  EXPECT_FALSE(package.load_constant_into("missing", destination));
+  EXPECT_THROW(
+      package.load_constant_into("weight", destination), std::runtime_error);
+}
+
+TEST(PackageTest, SupportsCallerOwnedArchiveBytes) {
+  const TempPackage file;
+  Package package = Package::load(file.path());
+  package = Package::load(OwnedBytes::from_file(file.path(), false));
+
+  const std::optional<OwnedBytes> weight = package.acquire_constant("weight");
+  ASSERT_TRUE(weight);
+  EXPECT_TRUE(std::ranges::equal(
+      weight->span(), (std::array<uint8_t, 4>{'d', 'a', 't', 'a'})));
+}
+// cppcheck-suppress-end syntaxError
+
+} // namespace
+} // namespace ptn

--- a/backends/native/test/runtime/deserialize/test_safetensors_reader.cpp
+++ b/backends/native/test/runtime/deserialize/test_safetensors_reader.cpp
@@ -45,7 +45,6 @@ TEST(SafeTensorsReaderTest, ReadsIndexAndPayloadsInHeaderOrder) {
   EXPECT_EQ(reader.find("first")->sizes, (std::vector<int64_t>{1}));
   EXPECT_EQ(reader.find("first")->offset, 0);
   EXPECT_EQ(reader.find("first")->nbytes, 4);
-  EXPECT_EQ(reader.bytes(*reader.find("second"))[0], 'X');
   EXPECT_EQ(reader.total_bytes(), 6);
   EXPECT_EQ(reader.find("missing"), nullptr);
 }
@@ -55,6 +54,17 @@ TEST(SafeTensorsReaderTest, RejectsNonEmptyMetadata) {
       SafeTensorsReader::open(
           make_safetensors(R"({"__metadata__":{"source":"test"}})", "")),
       std::runtime_error);
+}
+
+TEST(SafeTensorsReaderTest, ReadsHeaderWithoutPayload) {
+  const std::string header =
+      R"({"x":{"dtype":"U8","shape":[2],"data_offsets":[0,2]}})";
+  const SafeTensorsReader reader = SafeTensorsReader::open_header(
+      ByteSpan(reinterpret_cast<const uint8_t*>(header.data()), header.size()),
+      2);
+
+  ASSERT_NE(reader.find("x"), nullptr);
+  EXPECT_EQ(reader.find("x")->nbytes, 2);
 }
 
 TEST(SafeTensorsReaderTest, RejectsInvalidMetadata) {

--- a/backends/native/test/runtime/deserialize/test_zip_reader.cpp
+++ b/backends/native/test/runtime/deserialize/test_zip_reader.cpp
@@ -94,6 +94,7 @@ TEST(ZipReaderTest, ReadsStoredMemberRanges) {
   EXPECT_EQ(
       zip.read("program.ptg"),
       (std::vector<uint8_t>{'p', 'r', 'o', 'g', 'r', 'a', 'm'}));
+  EXPECT_NO_THROW(zip.verify("program.safetensors"));
 }
 
 TEST(ZipReaderTest, RejectsInvalidRanges) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #22704
* __->__ #22703
* #22702
* #22701
* #22700
* #22699

## Ulterior Motive

Keep large model weights off heap until a backend chooses their destination and
lifetime.

## Rationale

**What**: Split safetensors metadata parsing from payload access. Add
metadata-only lookup, owned acquisition, direct destination loading, package
identity, and checksum verification.

**Why**: Eager extraction duplicates model-sized weights and prevents direct
placement into backend-managed memory.

## Details

```text
Package::load(path)
   |
   +-- open ZIP directory
   +-- read program.ptg
   +-- read safetensors prefix + JSON only
   |
   +-- constant_info(key)      no payload read
   +-- acquire_constant(key)   new OwnedBytes
   +-- load_constant_into()    caller destination
   +-- verify_constants()      streamed CRC check
```

- Package identity survives moves. Alias lookups return canonical owner keys,
  enabling cross-instance upload accounting.
- Prefix and checksum scratch arrays are value-initialized, satisfying the
  blocking clang-tidy signal.
- `ptn_inspector` uses the path-based `Package::load` API after the eager
  `load_file` API is removed.
- New package-test ZIP handles use RAII on constructor failures.

Authored with Codex.

Differential Revision: [D119396097](https://our.internmc.facebook.com/intern/diff/D119396097/)