### PR TITLE
Add node filter to propagate slice (#22705)

### DIFF
--- a/backends/cadence/aot/reorder_ops.py
+++ b/backends/cadence/aot/reorder_ops.py
@@ -1176,6 +1176,7 @@ class PropagateSlice(RemoveOrReplacePassInterface):
         - add.Tensor: binary with broadcast — slices non-broadcasting inputs
         - mul.Tensor: binary with broadcast — slices non-broadcasting inputs
 
+    Callers can provide per-target filters for additional legality constraints.
     Handles any slice dim and any step size.
     """
 
@@ -1183,6 +1184,9 @@ class PropagateSlice(RemoveOrReplacePassInterface):
         self,
         additional_unary_targets: Optional[list[EdgeOpOverload]] = None,
         additional_binary_targets: Optional[list[EdgeOpOverload]] = None,
+        target_filters: Optional[
+            dict[EdgeOpOverload, Callable[[torch.fx.Node], bool]]
+        ] = None,
     ) -> None:
         super().__init__()
         unary_targets = [
@@ -1204,6 +1208,7 @@ class PropagateSlice(RemoveOrReplacePassInterface):
                 Callable[[torch.fx.Node, torch.fx.Node], bool],
             ],
         ] = {}
+        self._target_filters = target_filters or {}
         for t in unary_targets:
             self._dispatch[t] = (
                 self._should_swap_elementwise,
@@ -1353,6 +1358,9 @@ class PropagateSlice(RemoveOrReplacePassInterface):
 
         entry = self._dispatch.get(parent.target)
         if entry is None:
+            return False
+        target_filter = self._target_filters.get(parent.target)
+        if target_filter is not None and not target_filter(parent):
             return False
 
         should_swap, do_swap = entry

--- a/backends/cadence/aot/tests/test_reorder_ops_passes.py
+++ b/backends/cadence/aot/tests/test_reorder_ops_passes.py
@@ -1425,6 +1425,35 @@ class TestPropagateSlice(unittest.TestCase):
         self.assertIs(sub_nodes[0].args[1], slice_nodes[0])
         self.assertEqual(list(sub_nodes[0].meta["val"].shape), [2, 60, 1, 1])
 
+    def test_additional_binary_target_filter_prevents_swap(self) -> None:
+        lhs_data = torch.randn(1, 60, 1, 1)
+        rhs_data = torch.randn(4, 60, 1, 1)
+        builder = GraphBuilder()
+        lhs = builder.placeholder("lhs", lhs_data)
+        rhs = builder.placeholder("rhs", rhs_data)
+        sub = builder.call_operator(
+            exir_ops.edge.aten.sub.Tensor,
+            args=(lhs, rhs),
+        )
+        sliced = builder.call_operator(
+            exir_ops.edge.aten.slice_copy.Tensor,
+            args=(sub, 0, 0, 4, 2),
+        )
+        builder.output([sliced])
+        gm = builder.get_graph_module()
+
+        result = PropagateSlice(
+            additional_binary_targets=[exir_ops.edge.aten.sub.Tensor],
+            target_filters={exir_ops.edge.aten.sub.Tensor: lambda _: False},
+        ).call(gm)
+
+        self.assertFalse(result.modified)
+        slice_nodes = gm.graph.find_nodes(
+            op="call_function", target=exir_ops.edge.aten.slice_copy.Tensor
+        )
+        self.assertEqual(len(slice_nodes), 1)
+        self.assertIs(slice_nodes[0].args[0], sub.node)
+
     def test_swap_additional_binary_target_with_mismatched_ranks(self) -> None:
         lhs_data = torch.randn(2, 3, 4)
         rhs_data = torch.randn(3, 4)


### PR DESCRIPTION
Summary:

Currently, the pass only accepts additional lists of ops, but we may want to block for certain nodes conditionally.

Reviewed By: aliafzal

Differential Revision: D119543813


