### PR TITLE
Declare the system frameworks the executorch SwiftPM product needs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,13 @@ let products = deliverables([
     ],
   ],
   "executorch": [
+    "frameworks": [
+      "Accelerate",
+      "CoreGraphics",
+      "CoreImage",
+      "CoreVideo",
+      "Foundation",
+    ],
     "libraries": [
       "c++",
     ],


### PR DESCRIPTION
Part of #22686

### Problem

The `executorch` SwiftPM product declared only the C++ standard library. The image
processor inside it calls into Accelerate and Core Image, so a package that depends on
`executorch` alone and links with `-all_load` fails to link. I reproduced it against
the published prebuilt frameworks: 16 missing symbols, 8 from vImage, which lives in
Accelerate, and 8 from Core Image.

On iOS the Core Image half is usually hidden, because an app that imports UIKit,
SwiftUI or AVFoundation already pulls Core Image in. On macOS, and on an iOS app that
imports only Foundation, both halves fail. Until now each app had to name these
frameworks itself, which is a detail the package should own.

### Change

Declare Accelerate, Core Graphics, Core Image, Core Video and Foundation on the
`executorch` product.

All five are used by the image processor. For most consumers Accelerate and Core Image are
the two that fix the link, because Core Graphics, Core Video and Foundation already arrive
as link hints, either from the Swift files in the framework or from the consumer's own code
when it is built with modules enabled, which is the default. Turn modules off in an
Objective-C consumer and those hints disappear, and then Core Graphics and Core Video are
needed explicitly too. Declaring all five covers that case as well and lets the product
state what it actually uses.

### Note for reviewers

The manifest that prebuilt-binary users get is generated from `Package.swift.template`
on the `swiftpm` branch, not from this file, and it carries the same `executorch` entry
with only `c++`. This change alone therefore does not reach anyone using the prebuilt
frameworks. I will send the matching change against that branch as a follow up.

That is why this says "Part of" rather than "Fixes": the issue should stay open
until the template change lands too.

### Test plan

- `swift package --disable-sandbox dump-package` parses, and both the release and debug
  `executorch` targets carry the five frameworks plus libc++.
- Built a package that depends only on the `executorch` product with `-all_load` against
  the prebuilt frameworks. It links and runs with this change. Removing just the added
  block brings back the 16 missing symbols, so the check fails without the fix.
- The Apple builds on this PR pass. The demo app jobs do not run here, because they need
  secrets a fork pull request cannot use, so nothing in CI currently links a real app against
  this product. A test that would catch this needs a consumer that links `executorch` and
  nothing else.

