### PR TITLE
Move the Cadence Xtensa workflows to OSDC

### DIFF
--- a/.github/workflows/_xtensa_build.yml
+++ b/.github/workflows/_xtensa_build.yml
@@ -1,9 +1,8 @@
 # Reusable: cross-compile cadence_executor_runner for one Cadence Xtensa core.
 #
-# A native job (not linux_job_v2) because the GitHub OIDC token must be minted on
-# the runner host: the ACTIONS_ID_TOKEN_REQUEST_* vars do not cross into
-# linux_job_v2's docker exec. So the role is assumed on the host, then the build
-# runs inside the CI image via docker run with the creds passed in. Binding the
+# A native job rather than linux_job_v3, because the build has to assume the
+# Cadence artifacts role rather than the role/arc that linux_job_v3 assumes for
+# itself, and only a native job can run configure-aws-credentials. Binding the
 # environment also gives the OIDC token the environment claim. The licensed
 # toolchain + core configs are fetched at runtime from an auth-gated store;
 # role/region/store come from CI variables and are not committed.
@@ -23,30 +22,49 @@ on:
         default: ""
 
 jobs:
+  # The runner pod pulls the container before any step runs, so the image has to
+  # be a fully qualified reference resolved by a job this one depends on.
+  docker-image:
+    name: Resolve CI docker image
+    uses: ./.github/workflows/_docker-image.yml
+
   build:
     name: ${{ inputs.backend }}
-    runs-on: linux.2xlarge
+    needs: docker-image
+    # Intel, not the x86iavx512 (r7a/AMD) default: the Cadence licence key that
+    # xt-clang computes for a core differs by CPU vendor, and only the Intel one
+    # (XT_XCC_TIE_ED4D1230) is in the bundled licence. On an AMD runner the
+    # vision core resolves to XT_XCC_TIE_ED4DB539 and the checkout fails with
+    # "No such feature exists". hifi4's older RI-2022.10 toolchain does not care.
+    runs-on: mt-l-x86iamx-8-64
+    container:
+      image: ${{ needs.docker-image.outputs.docker-registry }}/ci-image:executorch-ubuntu-22.04-clang12-${{ needs.docker-image.outputs.ci-docker-hash }}
     environment: cadence
     permissions:
       id-token: write
       contents: read
     steps:
+      - name: Fix workspace permissions
+        shell: bash
+        run: |
+          set -euxo pipefail
+          # An OSDC pod is ephemeral, so the workspace starts empty and there is
+          # nothing to clean. What it does need is to be writable: the GH hook
+          # creates it as uid 1001
+          # (https://github.com/actions/runner-images/issues/10936), which the
+          # image's uid 1000 ci-user cannot write to. chmod rather than
+          # recreating the directory keeps the hook able to clean up afterwards.
+          # An image running as root can already write and often ships no sudo,
+          # so a failure here is not fatal.
+          sudo chmod -R 777 "${GITHUB_WORKSPACE}" 2>/dev/null || true
+
       - name: Checkout executorch
         uses: actions/checkout@v4
         with:
           submodules: recursive
           ref: ${{ inputs.ref }}
 
-      - name: Calculate docker image
-        id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
-        with:
-          docker-image-name: ci-image:executorch-ubuntu-22.04-clang12
-
-      - name: Pull docker image
-        run: docker pull "${{ steps.calculate-docker-image.outputs.docker-image }}"
-
-      - name: Assume Cadence artifacts role (host OIDC)
+      - name: Assume Cadence artifacts role
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.CADENCE_CI_AWS_ROLE }}
@@ -54,37 +72,24 @@ jobs:
 
       - name: Cross-compile cadence_executor_runner
         env:
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
           BACKEND: ${{ inputs.backend }}
           XTENSA_S3_BUCKET: ${{ vars.CADENCE_CI_S3_BUCKET }}
         shell: bash
         run: |
-          set -eux
-          # OIDC/role assumption already happened on the host above; pass the
-          # resulting AWS creds and the store/backend into the CI image, where
-          # the toolchain download + cross-compile run.
-          docker run --rm \
-            -e BACKEND -e XTENSA_S3_BUCKET \
-            -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
-            -e AWS_DEFAULT_REGION -e AWS_REGION \
-            -v "${GITHUB_WORKSPACE}:/work/executorch" -w /work/executorch \
-            "${DOCKER_IMAGE}" \
-            bash -c '
-              set -exo pipefail
-              eval "$(/opt/conda/bin/conda shell.bash hook)"
-              conda activate "$(conda env list --json | jq -r ".envs | .[-1]")"
-              ./install_requirements.sh > /dev/null
-              pip install --quiet awscli
-              # hifi4/fusion_g3 optimized kernels need the foss-xtensa nnlib
-              # sources, which are not vendored in executorch; the cadence
-              # installer clones them. vision has no nnlib dependency.
-              if [ "${BACKEND}" != "vision" ]; then
-                backends/cadence/install_requirements.sh
-              fi
-              source .ci/scripts/setup-xtensa-tools.sh "${BACKEND}"
-              .ci/scripts/build-cadence-xtensa.sh --no-run
-              chmod -R a+rX cmake-out
-            '
+          set -exo pipefail
+          eval "$(/opt/conda/bin/conda shell.bash hook)"
+          conda activate "$(conda env list --json | jq -r ".envs | .[-1]")"
+          ./install_requirements.sh > /dev/null
+          pip install --quiet awscli
+          # hifi4/fusion_g3 optimized kernels need the foss-xtensa nnlib
+          # sources, which are not vendored in executorch; the cadence
+          # installer clones them. vision has no nnlib dependency.
+          if [ "${BACKEND}" != "vision" ]; then
+            backends/cadence/install_requirements.sh
+          fi
+          source .ci/scripts/setup-xtensa-tools.sh "${BACKEND}"
+          .ci/scripts/build-cadence-xtensa.sh --no-run
+          chmod -R a+rX cmake-out
 
       - name: Upload runner
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_xtensa_test.yml
+++ b/.github/workflows/_xtensa_test.yml
@@ -1,6 +1,6 @@
 # Reusable: build + run the Cadence Xtensa op-level gtest tests for one core on
 # the Instruction Set Simulator (xt-run). Mirrors _xtensa_build.yml's native
-# OIDC + docker-run skeleton (running xt-run needs the same licensed toolchain),
+# OIDC skeleton (running xt-run needs the same licensed toolchain),
 # then builds the gtest op-test ELF and runs it on the simulator. The runner
 # cross-compile and these op tests are separate build configs (the tests need
 # exceptions/RTTI that the runner build disables), so this is a self-contained
@@ -21,30 +21,49 @@ on:
         default: ""
 
 jobs:
+  # The runner pod pulls the container before any step runs, so the image has to
+  # be a fully qualified reference resolved by a job this one depends on.
+  docker-image:
+    name: Resolve CI docker image
+    uses: ./.github/workflows/_docker-image.yml
+
   test:
     name: ${{ inputs.backend }}
-    runs-on: linux.2xlarge
+    needs: docker-image
+    # Intel, not the x86iavx512 (r7a/AMD) default: the Cadence licence key that
+    # xt-clang computes for a core differs by CPU vendor, and only the Intel one
+    # (XT_XCC_TIE_ED4D1230) is in the bundled licence. On an AMD runner the
+    # vision core resolves to XT_XCC_TIE_ED4DB539 and the checkout fails with
+    # "No such feature exists". hifi4's older RI-2022.10 toolchain does not care.
+    runs-on: mt-l-x86iamx-8-64
+    container:
+      image: ${{ needs.docker-image.outputs.docker-registry }}/ci-image:executorch-ubuntu-22.04-clang12-${{ needs.docker-image.outputs.ci-docker-hash }}
     environment: cadence
     permissions:
       id-token: write
       contents: read
     steps:
+      - name: Fix workspace permissions
+        shell: bash
+        run: |
+          set -euxo pipefail
+          # An OSDC pod is ephemeral, so the workspace starts empty and there is
+          # nothing to clean. What it does need is to be writable: the GH hook
+          # creates it as uid 1001
+          # (https://github.com/actions/runner-images/issues/10936), which the
+          # image's uid 1000 ci-user cannot write to. chmod rather than
+          # recreating the directory keeps the hook able to clean up afterwards.
+          # An image running as root can already write and often ships no sudo,
+          # so a failure here is not fatal.
+          sudo chmod -R 777 "${GITHUB_WORKSPACE}" 2>/dev/null || true
+
       - name: Checkout executorch
         uses: actions/checkout@v4
         with:
           submodules: recursive
           ref: ${{ inputs.ref }}
 
-      - name: Calculate docker image
-        id: calculate-docker-image
-        uses: pytorch/test-infra/.github/actions/calculate-docker-image@main
-        with:
-          docker-image-name: ci-image:executorch-ubuntu-22.04-clang12
-
-      - name: Pull docker image
-        run: docker pull "${{ steps.calculate-docker-image.outputs.docker-image }}"
-
-      - name: Assume Cadence artifacts role (host OIDC)
+      - name: Assume Cadence artifacts role
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.CADENCE_CI_AWS_ROLE }}
@@ -52,33 +71,20 @@ jobs:
 
       - name: Build and run op tests on xt-run
         env:
-          DOCKER_IMAGE: ${{ steps.calculate-docker-image.outputs.docker-image }}
           BACKEND: ${{ inputs.backend }}
           XTENSA_S3_BUCKET: ${{ vars.CADENCE_CI_S3_BUCKET }}
         shell: bash
         run: |
-          set -eux
-          # OIDC/role assumption already happened on the host above; pass the
-          # resulting AWS creds and the store/backend into the CI image, where
-          # the toolchain download + op-test build + xt-run happen.
-          docker run --rm \
-            -e BACKEND -e XTENSA_S3_BUCKET \
-            -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
-            -e AWS_DEFAULT_REGION -e AWS_REGION \
-            -v "${GITHUB_WORKSPACE}:/work/executorch" -w /work/executorch \
-            "${DOCKER_IMAGE}" \
-            bash -c '
-              set -exo pipefail
-              eval "$(/opt/conda/bin/conda shell.bash hook)"
-              conda activate "$(conda env list --json | jq -r ".envs | .[-1]")"
-              ./install_requirements.sh > /dev/null
-              pip install --quiet awscli
-              # hifi4/fusion_g3 optimized kernels need the foss-xtensa nnlib
-              # sources, which are not vendored in executorch; the cadence
-              # installer clones them. vision has no nnlib dependency.
-              if [ "${BACKEND}" != "vision" ]; then
-                backends/cadence/install_requirements.sh
-              fi
-              source .ci/scripts/setup-xtensa-tools.sh "${BACKEND}"
-              .ci/scripts/test-cadence-xtensa.sh
-            '
+          set -exo pipefail
+          eval "$(/opt/conda/bin/conda shell.bash hook)"
+          conda activate "$(conda env list --json | jq -r ".envs | .[-1]")"
+          ./install_requirements.sh > /dev/null
+          pip install --quiet awscli
+          # hifi4/fusion_g3 optimized kernels need the foss-xtensa nnlib
+          # sources, which are not vendored in executorch; the cadence
+          # installer clones them. vision has no nnlib dependency.
+          if [ "${BACKEND}" != "vision" ]; then
+            backends/cadence/install_requirements.sh
+          fi
+          source .ci/scripts/setup-xtensa-tools.sh "${BACKEND}"
+          .ci/scripts/test-cadence-xtensa.sh


### PR DESCRIPTION
Split out of #22108, where the vision build was failing.

Both workflows were native rather than `linux_job` callers because the OIDC token had to be minted on the runner host — `ACTIONS_ID_TOKEN_REQUEST_*` did not cross into the docker exec, so the job assumed the Cadence role outside the container and passed credentials into `docker run`. OSDC has no host docker daemon and the job already runs inside its container, so that wrapper collapses into plain steps. They stay native only because they assume the Cadence artifacts role rather than `role/arc`.

They run on `mt-l-x86iamx-8-64` (r7i, **Intel**) rather than the usual `mt-l-x86iavx512-8-64` (r7a, AMD). The Xtensa core key `xt-clang` derives for the FlexNet checkout depends on the CPU vendor, and only the Intel one is in the bundled licence:

```
Intel  asks XT_XCC_TIE_ED4D1230  -> Checkout succeeded (no server used)
AMD    asks XT_XCC_TIE_ED4DB539  -> -5 No such feature exists
```

The `XTENSA_XCC_TIE` in the surface error is the last of four fallback names tried after the real one misses, which makes it look like a missing feature rather than a key mismatch. Everything else is identical between the two runners: same `xt-clang` binary, same 5676 files of core config, same params before and after the registry rewrite, same licence files (verified by md5). hifi4 is unaffected because its older RI-2022.10 toolchain does not check out a TIE feature, but both workflows use the Intel label so a future vision op test does not reintroduce the trap.

Same class of issue as `test-qnn-delegate-linux`, which also had to move to an Intel OSDC label.

Authored with Claude Code.