### PR TITLE
Extract shared test helpers into test/utils.py (#22721)

### DIFF
--- a/backends/native/test/BUCK
+++ b/backends/native/test/BUCK
@@ -32,6 +32,18 @@ fbcode_target(
     deps = [
         "//caffe2:torch",
         "//executorch/backends/native:lib",
+        "//executorch/backends/native/test:utils",
+        "//executorch/exir:lib",
+    ],
+)
+
+fbcode_target(
+    _kind = runtime.python_library,
+    name = "utils",
+    srcs = ["utils.py"],
+    deps = [
+        "//caffe2:torch",
+        "//executorch/backends/native:lib",
         "//executorch/exir:lib",
     ],
 )

--- a/backends/native/test/test_passes.py
+++ b/backends/native/test/test_passes.py
@@ -8,19 +8,10 @@ import unittest
 
 import torch
 import torch.nn as nn
-from executorch.backends.native import get_default_compile_config
 
 from executorch.backends.native.passes.reinplace import NativeReinplacePass
-from executorch.exir import to_edge
+from executorch.backends.native.test.utils import _transformed
 from executorch.exir.passes.cse_pass import CSEPass
-
-
-def _transformed(model, example_inputs, passes):
-    edge = to_edge(
-        torch.export.export(model, example_inputs),
-        compile_config=get_default_compile_config(),
-    )
-    return edge.transform(passes).exported_program()
 
 
 class CSEPassTest(unittest.TestCase):

--- a/backends/native/test/utils.py
+++ b/backends/native/test/utils.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared helpers for the native backend tests."""
+
+import torch
+
+from executorch.backends.native import get_default_compile_config
+from executorch.exir import to_edge
+
+
+def _transformed(model, example_inputs, passes):
+    edge = to_edge(
+        torch.export.export(model, example_inputs),
+        compile_config=get_default_compile_config(),
+    )
+    return edge.transform(passes).exported_program()


### PR DESCRIPTION
Summary:

Move the lowering helper that the native backend tests share out of
test_passes.py and into a test/utils.py library target, so later test modules
can consume it without importing from another test module.

Only _transformed moves here. Subsequent diffs in the stack add their helpers
directly to utils.py rather than accumulating them in test_passes.py and
relocating them later.

Reviewed By: SS-JIA

Differential Revision: D117906918


