### PR TITLE
Declare the system frameworks the executorch SwiftPM product needs (template)

### DIFF
--- a/Package.swift.template
+++ b/Package.swift.template
@@ -65,6 +65,13 @@ let products = deliverables([
   "executorch": [
     "sha256": "__SHA256_executorch__",
     "sha256" + debug_suffix: "__SHA256_executorch_debug__",
+    "frameworks": [
+      "Accelerate",
+      "CoreGraphics",
+      "CoreImage",
+      "CoreVideo",
+      "Foundation",
+    ],
     "libraries": [
       "c++",
     ],


### PR DESCRIPTION
Part of #22686. Companion to #22711, which makes the same change to the root
`Package.swift`.

### Why this branch too

The manifest that prebuilt-binary users get is generated from this template, not from
the root `Package.swift` on the main branch. The release job checks this file out of the
`swiftpm` branch and substitutes the version and checksums into it. So #22711 on its own
does not reach anyone who depends on a `swiftpm-<version>` branch, which is the path the
documentation recommends.

### Problem

The `executorch` product declared only the C++ standard library. A package that depends
on it alone and links with `-all_load` fails with 16 missing symbols, 8 from vImage,
which lives in Accelerate, and 8 from Core Image. Both come from the image processor that
ships inside the product.

Accelerate and Core Image are the two that fix the link for most consumers. Core Graphics,
Core Video and Foundation usually arrive as link hints instead, either from the Swift files
in the framework or from the consumer's own code when it is built with modules enabled,
which is the default. An Objective-C consumer built with modules off gets no such hints and
does need those named as well, so all five are declared.

### Note for reviewers

These declarations sit on the `executorch` product because that is the only place the
current packaging allows: `libextension_image.a` is merged into `executorch.xcframework`
along with eight other archives, and a manifest cannot attach a linker setting to one part
of a merged archive. It therefore reads as if the runtime depends on Accelerate and Core
Image, which it does not. #22722 tracks giving the image processor its own product, the way
`executorch_llm` already works, after which these move there and `executorch` goes back to
only `c++`.

This branch has no CI of its own, and a template is not a manifest, so nothing here
evaluates the result before consumers do. I validated it by hand as described below.

### Test plan

- Rendered this template with the version and checksums of a published nightly, then ran
  `swift package describe`, which is the check the release job performs on the substituted
  manifest. It passes, and both the release and debug `executorch` targets carry the five
  frameworks plus libc++.
- Confirmed that check can fail: removing a stub directory makes `describe` exit nonzero.
- Built a package against the rendered manifest and the published frameworks, depending
  only on the `executorch` product with `-all_load`. It links, and the binary runs.
  Removing just the added block brings back the 16 missing symbols.

cc @larryliu0820 @GregoryComer @cbilgin
