### PR TITLE
Core ML: let op_linear_quantizer_config compress gather tables

### DIFF
--- a/backends/apple/coreml/compiler/coreml_preprocess.py
+++ b/backends/apple/coreml/compiler/coreml_preprocess.py
@@ -655,7 +655,9 @@ class CoreMLBackend(BackendDetails):
             # it. It stays off by default: the table is the one weight an embedding model's
             # output quality rests on most directly, so opting in belongs with the caller
             # who can measure the result.
-            if CoreMLBackend.quantize_embedding_tables_from_compile_specs(compile_specs):
+            if CoreMLBackend.quantize_embedding_tables_from_compile_specs(
+                compile_specs
+            ):
                 config = cto.coreml.OptimizationConfig(
                     global_config=op_linear_quantizer_config,
                 )

--- a/backends/apple/coreml/compiler/coreml_preprocess.py
+++ b/backends/apple/coreml/compiler/coreml_preprocess.py
@@ -73,6 +73,7 @@ class COMPILE_SPEC_KEYS(Enum):
     MIN_DEPLOYMENT_TARGET = "min_deployment_target"
     MODEL_COMPUTE_PRECISION = "model_compute_precision"
     OP_LINEAR_QUANTIZER_CONFIG = "op_linear_quantizer_config"
+    QUANTIZE_EMBEDDING_TABLES = "quantize_embedding_tables"
     ENUMERATED_SHAPES = "enumerated_shapes"
     PASS_PIPELINE = "pass_pipeline"
     MULTIMETHOD_WEIGHT_SHARING_STRATEGY = "multimethod_weight_sharing_strategy"
@@ -278,6 +279,32 @@ class CoreMLBackend(BackendDetails):
         return None
 
     @staticmethod
+    def generate_quantize_embedding_tables_compile_spec(
+        quantize_embedding_tables: bool,
+    ) -> CompileSpec:
+        """
+        Returns the compile spec saying whether op_linear_quantizer_config should also
+        compress embedding tables.
+        """
+        return CompileSpec(
+            COMPILE_SPEC_KEYS.QUANTIZE_EMBEDDING_TABLES.value,
+            str(quantize_embedding_tables).encode("utf-8"),
+        )
+
+    @staticmethod
+    def quantize_embedding_tables_from_compile_specs(
+        compile_specs: List[CompileSpec],
+    ) -> bool:
+        """
+        Returns whether embedding tables opt in to op_linear_quantizer_config. Defaults
+        to False, which is the behaviour of every model lowered before this spec existed.
+        """
+        for compile_spec in compile_specs:
+            if compile_spec.key == COMPILE_SPEC_KEYS.QUANTIZE_EMBEDDING_TABLES.value:
+                return compile_spec.value.decode("utf-8") == "True"
+        return False
+
+    @staticmethod
     def generate_pass_pipeline_compile_spec(pass_names: List[str]) -> CompileSpec:
         """
         Creates a compile spec representing the pass pipeline to be used by the CoreML backend
@@ -396,6 +423,7 @@ class CoreMLBackend(BackendDetails):
         compute_precision: ct.precision = ct.precision.FLOAT16,
         model_type: MODEL_TYPE = MODEL_TYPE.MODEL,
         op_linear_quantizer_config: Optional[Dict] = None,
+        quantize_embedding_tables: bool = False,
         pass_names: Optional[List[str]] = None,
     ) -> List[CompileSpec]:
         """
@@ -418,6 +446,12 @@ class CoreMLBackend(BackendDetails):
             compile_specs.append(
                 CoreMLBackend.generate_op_linear_quantizer_config_compile_spec(
                     op_linear_quantizer_config
+                )
+            )
+        if quantize_embedding_tables:
+            compile_specs.append(
+                CoreMLBackend.generate_quantize_embedding_tables_compile_spec(
+                    quantize_embedding_tables
                 )
             )
         if pass_names is not None:
@@ -615,12 +649,23 @@ class CoreMLBackend(BackendDetails):
             # embedding is one constant feeding both a gather and a linear, and coremltools
             # refuses to compress a constant its consumers disagree about, so opting the
             # gather out there does not skip the table, it fails the whole lowering.
-            tied = _gathers_sharing_a_weight(mlmodel)
-            config = cto.coreml.OptimizationConfig(
-                global_config=op_linear_quantizer_config,
-                op_type_configs={"gather": None},
-                op_name_configs={name: op_linear_quantizer_config for name in tied},
-            )
+            #
+            # quantize_embedding_tables drops the opt-out entirely, for models whose table
+            # is most of their weight and which have measured that compressing it is worth
+            # it. It stays off by default: the table is the one weight an embedding model's
+            # output quality rests on most directly, so opting in belongs with the caller
+            # who can measure the result.
+            if CoreMLBackend.quantize_embedding_tables_from_compile_specs(compile_specs):
+                config = cto.coreml.OptimizationConfig(
+                    global_config=op_linear_quantizer_config,
+                )
+            else:
+                tied = _gathers_sharing_a_weight(mlmodel)
+                config = cto.coreml.OptimizationConfig(
+                    global_config=op_linear_quantizer_config,
+                    op_type_configs={"gather": None},
+                    op_name_configs={name: op_linear_quantizer_config for name in tied},
+                )
             mlmodel = cto.coreml.linear_quantize_weights(mlmodel, config=config)
 
         return mlmodel

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -473,6 +473,71 @@ class TestCoreMLPartitioner(unittest.TestCase):
             # raised during lowering, not carried in the result.
             self.assertIsNotNone(delegated.to_executorch())
 
+    def test_quantize_embedding_tables_opt_in(self):
+        """
+        The embedding table is exempt from op_linear_quantizer_config by default and
+        compressed when the caller opts in, so the opt-in model is the smaller one.
+        """
+
+        class Embed(torch.nn.Module):
+            def __init__(self, vocab=4096, dim=128):
+                super().__init__()
+                self.embedding = torch.nn.Embedding(vocab, dim)
+
+            def forward(self, ids):
+                return self.embedding(ids).sum(dim=1)
+
+        ids = torch.zeros(1, 4, dtype=torch.long)
+        exported = torch.export.export(Embed().eval(), (ids,), strict=True)
+
+        sizes = {}
+        for opt_in in (False, True):
+            compile_specs = CoreMLBackend.generate_compile_specs(
+                minimum_deployment_target=ct.target.iOS18,
+                compute_precision=ct.precision(ct.precision.FLOAT16.value),
+                op_linear_quantizer_config={
+                    "mode": "linear_symmetric",
+                    "dtype": "int8",
+                    "granularity": "per_channel",
+                },
+                quantize_embedding_tables=opt_in,
+            )
+            delegated = executorch.exir.to_edge_transform_and_lower(
+                exported,
+                partitioner=[CoreMLPartitioner(compile_specs=compile_specs)],
+            )
+            sizes[opt_in] = len(delegated.to_executorch().buffer)
+
+        self.assertLess(sizes[True], sizes[False])
+
+    def test_quantize_embedding_tables_defaults_to_off(self):
+        """
+        Absent the spec, the table stays exempt. Covers models lowered by callers that
+        predate the option.
+        """
+        self.assertFalse(CoreMLBackend.quantize_embedding_tables_from_compile_specs([]))
+        specs = CoreMLBackend.generate_compile_specs(
+            op_linear_quantizer_config={
+                "mode": "linear_symmetric",
+                "dtype": "int8",
+                "granularity": "per_channel",
+            },
+        )
+        self.assertFalse(
+            CoreMLBackend.quantize_embedding_tables_from_compile_specs(specs)
+        )
+        opted_in = CoreMLBackend.generate_compile_specs(
+            op_linear_quantizer_config={
+                "mode": "linear_symmetric",
+                "dtype": "int8",
+                "granularity": "per_channel",
+            },
+            quantize_embedding_tables=True,
+        )
+        self.assertTrue(
+            CoreMLBackend.quantize_embedding_tables_from_compile_specs(opted_in)
+        )
+
     def test_deprecation_warning_for_to_backend_workflow(self):
         """
         Test that the deprecated to_edge + to_backend workflow shows a deprecation warning.


### PR DESCRIPTION
### Summary

`op_linear_quantizer_config` is applied with `op_type_configs={"gather": None}`, so gather tables are never compressed. For a transformer that is usually right: the body is most of the weight, and the embedding table is the one tensor output quality rests on most directly.

For a sentence embedder it is backwards. The table IS the model.

| model | fp16 | int8, tables exempt | int8, tables included |
|---|---|---|---|
| all-MiniLM-L6-v2 | 45.5 MB | 34.7 MB (-24%) | 22.8 MB (-50%) |
| paraphrase-multilingual-MiniLM-L12-v2 | 235.6 MB | 214.1 MB (-9%) | 118.4 MB (-50%) |

The multilingual model keeps 96 MB of fp16 vocab table it does not need. Its 250k rows are most of the file, so the current exemption leaves almost the whole win on the table.

This adds `quantize_gather_tables` to `generate_compile_specs`, off by default, so the caller who can measure the result decides. Models lowered before this spec existed are unaffected, including the tied-embedding handling from #21969.

### Scope: every float gather table, not only embeddings

The opt-in names every gather whose table is a float constant. Core ML lowers `index_select` and plain constant indexing to `gather` as well, so a float buffer such as a rotary position cache is compressed too. Confirmed on a module with no embedding layer: both caches were picked up.

Narrowing to real embedding lookups is not possible here. By the time the MIL program exists a gather is a gather, with nothing marking which came from `nn.Embedding`, so narrowing would be a shape heuristic that is wrong in a different way. The name, both helper docstrings and the partitioner docs page all say what it actually covers.

Integer tables are skipped by the opt-in, which checks the dtype. Run against the quantizer directly, a two-dimensional integer table raises and takes the conversion down, while a one-dimensional one is skipped by the quantizer itself.

Only single-axis `gather` is covered, by the opt-in and by the default exemption alike. `gather_along_axis` (`torch.gather`) and `gather_nd` (indexing with two index tensors) are compressed either way; widening the exemption would shrink what existing models compress, so it belongs in its own change.

### Does it cost anything at runtime

Measured on an iPhone 16, all-MiniLM-L6-v2, CPU_ONLY, release build, 3 warmup + 20 timed, re-taken after the float-table selection landed; the only change since is the rename.

| variant | pipeline | peak RAM | file |
|---|---|---|---|
| fp16 | 1.26 ms | 125.02 MB | 45.5 MB |
| int8, tables exempt | 1.273 ms | 113.05 MB | 34.7 MB |
| int8, tables included | 1.274 ms | 102.55 MB | 22.8 MB |

Latency is flat across all three, so compressing the tables costs no speed on the CPU compute unit, and peak memory falls 18%.

Cosine against the torch fp32 reference over 8 sentences: including the tables costs 0.00001 on all-MiniLM (0.99889 -> 0.99888) and 0.00002 on paraphrase-L12 (0.99979 -> 0.99977).

### Test plan

Four tests in `test_coreml_partitioner.py`: the compile spec round-trips and defaults to off, a caller passing `pass_names` positionally still binds it there, an embedding-only model lowers smaller with the opt-in, and a model that also indexes a uint8 buffer still lowers and still shrinks, which pins the float-table filter. That buffer is two-dimensional on purpose: a 1-D table is skipped by the quantizer on its own, so it would pass with the filter deleted. Confirmed it reaches MIL as `gather` over a `uint8` (4096, 8) constant, uncast.

cc @kimishpatel @YifanShenSZ @cymbalrush @metascroy @shoumikhin



