### PR TITLE
Arm backend: Fix generate_vgf_op_support to work with custom ops.

### DIFF
--- a/backends/arm/scripts/docgen/generate_vgf_op_support.py
+++ b/backends/arm/scripts/docgen/generate_vgf_op_support.py
@@ -54,6 +54,10 @@ BACKEND_NAME = "VGF"
 BACKEND_PIPELINE_CLASS_NAMES = frozenset({"VgfPipeline"})
 BACKEND_PIPELINE_LABEL = "VgfPipeline"
 BACKEND_TOSA_SPEC = "TOSA-1.0+FP+INT+int4+int16"
+BACKEND_PROFILE_TOSA_SPECS = {
+    "FP": "TOSA-1.0+FP",
+    "INT": "TOSA-1.0+INT",
+}
 
 GENERATOR_PATH = Path("backends/arm/scripts/docgen/generate_vgf_op_support.py")
 GENERATOR_COMMAND = f"python {GENERATOR_PATH}"
@@ -2197,6 +2201,37 @@ def _profiles_for_checker(
     return profiles
 
 
+def _collect_backend_custom_partition_ops(
+    backend_tosa_spec: TosaSpecificationLike,
+) -> dict[str, set[object]]:
+    """Collect VGF custom partition ops for each enabled support profile.
+
+    Instantiate the partitioner with a single-profile compile spec so custom
+    registrations that are conditional on the compile spec are attributed only
+    to the profiles for which they are actually registered.
+
+    """
+    from executorch.backends.arm.vgf import VgfCompileSpec, VgfPartitioner
+
+    enabled_profiles = {
+        "FP": backend_tosa_spec.support_float(),
+        "INT": backend_tosa_spec.support_integer(),
+    }
+    custom_ops_by_profile: dict[str, set[object]] = {}
+
+    for profile, enabled in enabled_profiles.items():
+        if not enabled:
+            continue
+        partitioner = VgfPartitioner(
+            VgfCompileSpec(BACKEND_PROFILE_TOSA_SPECS[profile])
+        )
+        custom_ops_by_profile[profile] = set(
+            getattr(partitioner, "_custom_partition_ops", ())
+        )
+
+    return custom_ops_by_profile
+
+
 def _collect_backend_supported_ops(  # noqa: C901
     repo_root: Path,
 ) -> dict[str, SupportedOperatorEvidence]:
@@ -2247,6 +2282,10 @@ def _collect_backend_supported_ops(  # noqa: C901
         for target in getattr(checker, "targets", ()):  # type: ignore[attr-defined]
             for profile in _profiles_for_checker(checker, tosa_spec):
                 add(target, profile, checker_evidence)
+
+    for profile, targets in _collect_backend_custom_partition_ops(tosa_spec).items():
+        for target in targets:
+            add(target, profile, "VgfPartitioner.register_custom_partition_op")
 
     # Lowering visitors are not the source of partitioner support, but they are
     # useful evidence when the exported op name matches a registered visitor

--- a/backends/arm/test/misc/test_docgen_op_support.py
+++ b/backends/arm/test/misc/test_docgen_op_support.py
@@ -364,6 +364,33 @@ def test_matching_evidence_accepts_stage_equivalent_alias() -> None:
     assert records[0].asserted_op == alias
 
 
+def test_collect_backend_custom_partition_ops_discovers_fp_and_int_profiles() -> None:
+    from executorch.backends.arm.tosa import TosaSpecification
+
+    tosa_spec = TosaSpecification.create_from_string(docgen.BACKEND_TOSA_SPEC)
+    custom_ops = docgen._collect_backend_custom_partition_ops(tosa_spec)
+    canonical_by_profile = {
+        profile: {
+            docgen._canonical_pytorch_op_from_target(target) for target in targets
+        }
+        for profile, targets in custom_ops.items()
+    }
+
+    expected = "torch.ops.aten.grid_sampler_2d.default"
+    assert expected in canonical_by_profile["FP"]
+    assert expected in canonical_by_profile["INT"]
+
+
+def test_collect_backend_supported_ops_includes_vgf_custom_partition_ops() -> None:
+    repo_root = Path(__file__).resolve().parents[4]
+
+    expected = docgen._collect_backend_supported_ops(repo_root)
+    row = expected["torch.ops.aten.grid_sampler_2d.default"]
+
+    assert row.support_profiles == {"FP", "INT"}
+    assert "VgfPartitioner.register_custom_partition_op" in row.evidence
+
+
 def test_run_check_reports_missing_profile(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
In automatic generation of supported ops we don't take into account registry of custom ops. This PR fixes this.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani