### PR TITLE
Arm backend: Silence successful VGF coverage output

### DIFF
--- a/backends/arm/scripts/docgen/generate_vgf_op_support.py
+++ b/backends/arm/scripts/docgen/generate_vgf_op_support.py
@@ -2669,7 +2669,7 @@ def run_check(repo_root: Path, *, strict_ast: bool = False) -> int:  # noqa: C90
             print(f"| `{op}` | {profile} | {classification} | {sat} | {test_cell} |")
         print()
 
-    if unresolved:
+    if strict_ast and unresolved:
         _print_unresolved(unresolved)
     if diagnostics:
         print("AST normalisation diagnostics:")

--- a/backends/arm/scripts/pre-push
+++ b/backends/arm/scripts/pre-push
@@ -74,6 +74,8 @@ run_docgen_check() {
 }
 
 run_vgf_op_support_checks() {
+    local coverage_output
+
     echo -e "${INFO} Generating VGF operator support documentation"
 
     if ! python "$VGF_OP_SUPPORT_SCRIPT"; then
@@ -90,7 +92,8 @@ run_vgf_op_support_checks() {
 
     echo -e "${INFO} Checking VGF operator support coverage"
 
-    if ! python "$VGF_OP_SUPPORT_SCRIPT" --check; then
+    if ! coverage_output=$(python "$VGF_OP_SUPPORT_SCRIPT" --check 2>&1); then
+        echo "$coverage_output" >&2
         echo -e "${ERROR} VGF operator support coverage check failed" >&2
         FAILED=1
     else

--- a/backends/arm/test/misc/test_docgen_op_support.py
+++ b/backends/arm/test/misc/test_docgen_op_support.py
@@ -411,6 +411,7 @@ def test_run_check_reports_missing_profile(
 
 def test_run_check_strict_ast_fails_on_unresolved_attribution(
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     unresolved = [
         docgen.UnresolvedPipelineEvidence(
@@ -431,7 +432,10 @@ def test_run_check_strict_ast_fails_on_unresolved_attribution(
     monkeypatch.setattr(docgen, "_collect_backend_supported_ops", lambda _root: {})
 
     assert docgen.run_check(Path("/repo"), strict_ast=False) == 0
+    assert "Unresolved VgfPipeline attribution" not in capsys.readouterr().out
+
     assert docgen.run_check(Path("/repo"), strict_ast=True) == 1
+    assert "Unresolved VgfPipeline attribution" in capsys.readouterr().out
 
 
 def test_main_writes_requested_markdown_and_html(


### PR DESCRIPTION
Capture VGF coverage checker output during pre-push and print it only when the check fails. Keep strict attribution diagnostics available for direct checker use while making successful pushes concise.


Assisted-by: Codex
Change-Id: I4246d3f4ef07e4ec3dd3ace3292fc9b098a97931


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani