### PR TITLE
Arm backend: Increase flow-test semihosting memory

### DIFF
--- a/backends/arm/test/setup_testing.sh
+++ b/backends/arm/test/setup_testing.sh
@@ -10,7 +10,10 @@ script_dir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 et_root_dir=$(realpath "${script_dir}/../../..")
 build_executor_runner=${et_root_dir}/backends/arm/scripts/build_executor_runner.sh
 build_root_test_dir=${et_root_dir}/arm_test/arm_semihosting_executor_runner
-extraflags="-DET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE=83886080"
+extraflags="-DET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE=83886080 -DET_ARM_BAREMETAL_SEMIHOSTING_FILE_ALLOCATOR_POOL_SIZE=134217728"
+# Corstone-320 has 256 MiB of DDR. Its 64 MiB temporary pool leaves 48 MiB
+# for the method pool while keeping 16 MiB free for other DDR sections.
+u85_extraflags="-DET_ARM_BAREMETAL_METHOD_ALLOCATOR_POOL_SIZE=50331648 -DET_ARM_BAREMETAL_SEMIHOSTING_FILE_ALLOCATOR_POOL_SIZE=134217728"
 portable_extraflags="${extraflags} -DHEAP_SIZE=0x00007000"
 
 join_by_comma() {
@@ -31,7 +34,7 @@ ops_list_quantized_decomposed=(
 
 ${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-300" --extra_build_flags="${extraflags}"
 ${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-300-u65" --extra_build_flags="${extraflags}"
-${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-320" --extra_build_flags="${extraflags}"
+${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_quantized_decomposed[@]}")" --output="${build_root_test_dir}_corstone-320" --extra_build_flags="${u85_extraflags}"
 
 # List of portable ops used by testing, this is mainly used to test models in the flow
 # test setup to make sure models that are not fully delegated can still be tested and run OK
@@ -92,7 +95,7 @@ ops_list_u85=(
 
 ${build_executor_runner} --pte=semihosting --target=ethos-u55-128 --system_config=Ethos_U55_High_End_Embedded --memory_mode=Shared_Sram --select_ops_list="$(join_by_comma "${ops_list_u55[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-300" --extra_build_flags="${portable_extraflags}"
 ${build_executor_runner} --pte=semihosting --target=ethos-u65-256 --system_config=Ethos_U65_High_End --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_u65[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-300-u65" --extra_build_flags="${portable_extraflags}"
-${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_u85[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-320" --extra_build_flags="${extraflags}"
+${build_executor_runner} --pte=semihosting --target=ethos-u85-128 --system_config=Ethos_U85_SYS_DRAM_Mid --memory_mode=Dedicated_Sram_384KB --select_ops_list="$(join_by_comma "${ops_list_u85[@]}")" --output="${build_root_test_dir}_portable-ops_corstone-320" --extra_build_flags="${u85_extraflags}"
 
 ethos_u_runtime_ctest_dir="${et_root_dir}/arm_test/ethosu_runtime_tests"
 cmake \


### PR DESCRIPTION
Increase the file allocator pool to support larger models. Rebalance the U85 method pool to keep allocations within the Corstone-320 DDR limit.

### Test plan
Tested by backends/test/suite

cc @digantdesai @freddan80 @per @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani