### PR TITLE
Arm backend: Remove deprecated pytest options

### DIFF
--- a/backends/arm/test/conftest.py
+++ b/backends/arm/test/conftest.py
@@ -130,8 +130,6 @@ def pytest_addoption(parser):
         except Exception:  # nosec B110 - pytest redefines options, safe to ignore
             pass
 
-    try_addoption("--arm_quantize_io", action="store_true", help="Deprecated.")
-    try_addoption("--arm_run_corstoneFVP", action="store_true", help="Deprecated.")
     try_addoption(
         "--llama_inputs",
         nargs="+",


### PR DESCRIPTION
Remove --arm_quantize_io and --arm_run_corstoneFVP, deprecated in ExecuTorch 0.6. These options no longer affect test execution.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @robell @rascani