### PR TITLE
Arm backend: Bound U55 constant tensor index

### DIFF
--- a/backends/arm/_passes/arm_pass_manager.py
+++ b/backends/arm/_passes/arm_pass_manager.py
@@ -609,7 +609,10 @@ class ArmPassManager(ExportedProgramPassManager):
                 DecomposeStridedSliceCopyPass(),
                 DecomposeSliceScatterPass(),
                 AccumulateIndexPutPass(),
-                DecomposeIndexTensorToGatherPass(exported_program),
+                DecomposeIndexTensorToGatherPass(
+                    exported_program,
+                    decompose_constant_indices=self.tosa_spec.is_U55_subset,
+                ),
                 DecomposeAdaptiveAvgPool2dPass(),
                 DecomposeDynamicAdaptiveAvgPool2dPass(),
                 DecomposeAvgPool2dPass(),

--- a/backends/arm/_passes/decompose_index_tensor_to_gather_pass.py
+++ b/backends/arm/_passes/decompose_index_tensor_to_gather_pass.py
@@ -24,6 +24,7 @@ from executorch.backends.arm._passes.convert_squeezes_to_view import (
 from executorch.backends.arm._passes.replace_scalar_with_tensor_pass import (
     ReplaceScalarWithTensorByProfilePass,
 )
+from executorch.backends.arm.constants import MAX_U55_INDEX_TENSOR_ELEMENTS
 from executorch.exir import ExportedProgram
 from executorch.exir.dialects._ops import ops as exir_ops
 from executorch.exir.pass_base import ExportPass
@@ -210,10 +211,15 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
     }
 
     def __init__(
-        self, exported_program: ExportedProgram | None = None, *args, **kwargs
+        self,
+        exported_program: ExportedProgram | None = None,
+        decompose_constant_indices: bool = False,
+        *args,
+        **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.exported_program = exported_program
+        self.decompose_constant_indices = decompose_constant_indices
 
     @staticmethod
     def _shape_to_stride(
@@ -303,7 +309,8 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
             (dim, index) for dim, index in enumerate(indices) if index is not None
         ]
         if (
-            self.exported_program is None
+            not self.decompose_constant_indices
+            or self.exported_program is None
             or len(tensor_indices) != 1
             or any(not isinstance(size, int) for size in x.data.shape)
         ):
@@ -318,6 +325,7 @@ class DecomposeIndexTensorToGatherPass(ArmOpTargetedPass):
             constant_index is None
             or constant_index.dim() != 1
             or constant_index.numel() == 0
+            or constant_index.numel() > MAX_U55_INDEX_TENSOR_ELEMENTS
         ):
             return None
 

--- a/backends/arm/constants.py
+++ b/backends/arm/constants.py
@@ -48,5 +48,6 @@ ODHWI_INVERSE_ORDER: Final = (0, 4, 1, 2, 3)
 HWCM_ORDER: Final = (2, 3, 0, 1)
 
 MAX_RANK: Final = 6
+MAX_U55_INDEX_TENSOR_ELEMENTS: Final = 64
 
 DISALLOW_TFA_META_KEY: Final = "_arm_disallow_tfa"

--- a/backends/arm/operator_support/ethos_u55_support.py
+++ b/backends/arm/operator_support/ethos_u55_support.py
@@ -19,6 +19,7 @@ from executorch.backends.arm._passes.arm_pass_utils import (
     is_param_node,
 )
 from executorch.backends.arm._passes.insert_table_ops import TableOps
+from executorch.backends.arm.constants import MAX_U55_INDEX_TENSOR_ELEMENTS
 from executorch.exir import ExportedProgram
 from executorch.exir.backend.utils import WhyNoPartitionReporter
 from executorch.exir.dialects._ops import ops as exir_ops
@@ -465,12 +466,13 @@ class EthosU55IndexTensorCheck(OperatorSupportBase):
             not is_param_node(self.exported_program, index_node)
             or len(index_shape) != 1
             or index_shape[0] == 0
+            or index_shape[0] > MAX_U55_INDEX_TENSOR_ELEMENTS
             or any(not isinstance(size, int) for size in input_shape)
         ):
             self.reporter.report_reject(
                 node,
-                "U55 index.Tensor requires static input shape and a nonempty "
-                "constant rank-1 index.",
+                "U55 index.Tensor requires static input shape and a constant "
+                f"rank-1 index with at most {MAX_U55_INDEX_TENSOR_ELEMENTS} elements.",
             )
             return False
 

--- a/backends/arm/test/ops/test_index_tensor.py
+++ b/backends/arm/test/ops/test_index_tensor.py
@@ -109,6 +109,7 @@ def test_index_tensor_tosa_FP_int64_buffer_index():
         atol=IndexTensorTestCommon.atol,
         rtol=IndexTensorTestCommon.rtol,
     )
+    pipeline.count_tosa_ops({"GATHER": 1})
     pipeline.run()
 
 
@@ -896,9 +897,12 @@ def test_index_tensor_u55_INT_constant_multi_not_delegated():
     {
         "multidimensional": torch.tensor([[0, 1]], dtype=torch.int32),
         "boolean": torch.tensor([False, True, False, True, False]),
+        "too_many_elements": torch.tensor(
+            [value for _ in range(33) for value in (0, 2)], dtype=torch.int32
+        ),
     },
 )
-def test_index_tensor_u55_INT_constant_shape_or_dtype_not_delegated(index):
+def test_index_tensor_u55_INT_constant_unsupported_not_delegated(index):
     pipeline = OpNotSupportedPipeline[Tuple[torch.Tensor]](
         ConstantTensorIndex(index),
         (torch.rand(5, 2, 3),),

--- a/backends/arm/test/passes/test_decompose_index_tensor_to_gather_pass.py
+++ b/backends/arm/test/passes/test_decompose_index_tensor_to_gather_pass.py
@@ -43,7 +43,9 @@ def test_constant_out_of_bounds_index_raises(dim: int, index: int):
     )
     edge_program = to_edge(exported_program)
     edge_exported_program = edge_program.exported_program()
-    decompose_pass = DecomposeIndexTensorToGatherPass(edge_exported_program)
+    decompose_pass = DecomposeIndexTensorToGatherPass(
+        edge_exported_program, decompose_constant_indices=True
+    )
 
     with TosaLoweringContext(TosaSpecification.create_from_string("TOSA-1.0+INT")):
         with pytest.raises(


### PR DESCRIPTION
Run constant index.Tensor slice expansion only for the U55 subset and reject constant index buffers with more than 64 elements. Other TOSA targets continue through the GATHER lowering, preventing Swin V2 Tiny relative-position buffers from expanding into tens of thousands of graph operations.

Authored with Codex.


Change-Id: I0555f1f044bda7859a5a868a11686a65335fc8c8


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani