### PR TITLE
NXP backend: remove #22179 workaround for QAT channels-last segfault

### DIFF
--- a/backends/nxp/tests/models/test_mlperf_tiny_image_classification.py
+++ b/backends/nxp/tests/models/test_mlperf_tiny_image_classification.py
@@ -80,16 +80,6 @@ def test_mlperf_tiny_classification_mse_cpu_vs_npu(
         else None
     )
 
-    # This model does not work in channels-last format and QAT when running using portable kernels.
-    # See more information below.
-    # Github issue: https://github.com/pytorch/executorch/issues/22179
-    # NXP internal issue ID: EIEX-1065
-    ref_model = (
-        ReferenceModel.QUANTIZED_EDGE_PYTHON
-        if channels_last and use_qat
-        else ReferenceModel.QUANTIZED_EXECUTORCH_CPP
-    )
-
     lower_run_compare(
         model,
         [input_spec],
@@ -97,7 +87,7 @@ def test_mlperf_tiny_classification_mse_cpu_vs_npu(
         request,
         dataset_creator=dataset_creator,
         output_comparator=comparator,
-        reference_model=ref_model,
+        reference_model=ReferenceModel.QUANTIZED_EXECUTORCH_CPP,
         mocker=mocker,
         use_qat=use_qat,
         train_fn=train_fn,


### PR DESCRIPTION
What: test_mlperf_tiny_classification_mse_cpu_vs_npu used the Python edge reference instead of the portable-kernel C++ reference for the QAT plus channels-last variant, because that configuration segfaulted in the portable kernels.

Why: the crash is fixed on current main (issue https://github.com/pytorch/executorch/issues/22179). The reporter's stack predates two out-of-bounds fixes in the portable dequantize path that this model exercises at runtime (16 per-channel dequantize ops): #21517 fixed an out-of-bounds traversal for non-contiguous (channels-last) inputs, and #21773 fixed misreading int32 zero points as int64. The int32 zero points are QAT-only: QAT emits int32 bias zero points while PTQ emits int64, matching the issue's QAT-only signature.

Verification: exported the exact failing configuration (QAT, channels-last, 15-epoch training, dataset calibration, NXP edge passes) and ran it with the portable-kernel executor_runner. It runs cleanly and its outputs bit-match the eager quantized reference. The quantized_kernels_test suite passes 74/74, including the regression tests from both fixes. lintrunner reports no issues on the touched file. The NXP SDK-gated test itself was not run here (no SDK); NXP CI will exercise it.

Fixes https://github.com/pytorch/executorch/issues/22179

Authored with AI assistance (Muse Code).

cc @robert-kalmar @digantdesai @rascani