### PR TITLE
Fix version xfail warnings with newer packaging

### DIFF
--- a/backends/arm/test/common.py
+++ b/backends/arm/test/common.py
@@ -326,6 +326,8 @@ def xfail_if_version(
     """
     versions = SpecifierSet(specifier)
     try:
+        if isinstance(version, str):
+            version = Version(version)
         matches = version is not None and version in versions
     except InvalidVersion:
         warnings.warn(


### PR DESCRIPTION
### Summary
Parse dependency version strings explicitly before checking specifier membership so malformed versions consistently emit the expected warning. Newer packaging releases return False instead of raising InvalidVersion during membership checks.

### Test plan
Validated all 38 version-marker tests with packaging 24.2 and 26.3, plus formatting and lint checks.

Authored with Codex.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell