### PR TITLE
Initialize portable FFT output-size storage

### DIFF
--- a/kernels/portable/cpu/op_fft_r2c.cpp
+++ b/kernels/portable/cpu/op_fft_r2c.cpp
@@ -238,7 +238,7 @@ Tensor& _fft_r2c_out(
         d);
   }
 
-  std::array<Tensor::SizesType, kTensorDimensionLimit> out_sizes_storage;
+  std::array<Tensor::SizesType, kTensorDimensionLimit> out_sizes_storage{};
   executorch::runtime::Span<Tensor::SizesType> out_sizes(
       out_sizes_storage.data(), in_sizes.size());
   std::copy(in_sizes.begin(), in_sizes.end(), out_sizes.begin());


### PR DESCRIPTION
### Summary

Follow-up to #22055. Value-initialize `out_sizes_storage` in the portable `_fft_r2c` kernel to satisfy `cppcoreguidelines-pro-type-member-init`. The active output dimensions are still copied from the input before resizing.

Authored with assistance from OpenAI Codex.

### Test plan

`lintrunner kernels/portable/cpu/op_fft_r2c.cpp` passes.

The kernel translation unit passes a C++17 compile check:

```sh
g++ -std=c++17 -DC10_USING_CUSTOM_GENERATED_MACROS -I.. \
  -Iruntime/core/portable_type/c10 -fsyntax-only \
  kernels/portable/cpu/op_fft_r2c.cpp
```

`git diff --check` passes.
