### PR TITLE
Arm backend: Count serialized operators in constant-pool tests

### DIFF
--- a/backends/arm/test/misc/test_tosa_constant_pool.py
+++ b/backends/arm/test/misc/test_tosa_constant_pool.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 import tosa_serializer as ts
 from executorch.backends.arm.tosa.constant_pool import TosaSerializerWithConstantPool
+from tosa.TosaGraph import TosaGraph  # type: ignore[import-not-found, import-untyped]
 
 
 def _serializer(path_prefix=""):
@@ -20,6 +21,11 @@ def _serializer(path_prefix=""):
         targetPatch=0,
         targetDraft=False,
     )
+
+
+def _serialized_operator_count(serializer):
+    graph = TosaGraph.GetRootAs(serializer.serialize(), 0)
+    return graph.Regions(0).Blocks(0).OperatorsLength()
 
 
 @pytest.mark.parametrize("dtype", [ts.DType.INT8, ts.DType.SHAPE])
@@ -33,7 +39,7 @@ def test_identical_constants_are_reused(dtype):
     assert second is first
     assert first.name == "first"
     block = serializer.currRegion.currBasicBlock
-    assert len(block.operators) == 1
+    assert _serialized_operator_count(serializer) == 1
     constants = block.shapes if dtype == ts.DType.SHAPE else block.tensors
     assert list(constants.keys()) == ["first"]
 
@@ -59,7 +65,7 @@ def test_unpooled_constants_are_not_reused():
     second = serializer.addUnpooledConst([1], ts.DType.INT8, [0], name="second")
 
     assert second is not first
-    assert len(serializer.currRegion.currBasicBlock.operators) == 2
+    assert _serialized_operator_count(serializer) == 2
     assert list(serializer.currRegion.currBasicBlock.tensors.keys()) == [
         "first",
         "second",
@@ -89,7 +95,7 @@ def test_constants_with_different_keys_remain_separate(first, second):
     second_const = serializer.addConst(*second, name="second")
 
     assert second_const is not first_const
-    assert len(serializer.currRegion.currBasicBlock.operators) == 2
+    assert _serialized_operator_count(serializer) == 2
 
 
 def test_float_constants_use_exact_serialized_values():
@@ -110,7 +116,7 @@ def test_float_constants_use_exact_serialized_values():
 
     assert negative_zero is not positive_zero
     assert repeated_negative_zero is negative_zero
-    assert len(serializer.currRegion.currBasicBlock.operators) == 2
+    assert _serialized_operator_count(serializer) == 2
 
 
 def test_constants_are_scoped_to_basic_blocks():

--- a/backends/arm/test/misc/test_tosa_constant_pool.py
+++ b/backends/arm/test/misc/test_tosa_constant_pool.py
@@ -25,7 +25,10 @@ def _serializer(path_prefix=""):
 
 def _serialized_operator_count(serializer):
     graph = TosaGraph.GetRootAs(serializer.serialize(), 0)
-    return graph.Regions(0).Blocks(0).OperatorsLength()
+    assert graph.RegionsLength() == 1
+    region = graph.Regions(0)
+    assert region.BlocksLength() == 1
+    return region.Blocks(0).OperatorsLength()
 
 
 @pytest.mark.parametrize("dtype", [ts.DType.INT8, ts.DType.SHAPE])

--- a/backends/arm/test/targets.bzl
+++ b/backends/arm/test/targets.bzl
@@ -151,6 +151,7 @@ def define_arm_tests():
                 "fbsource//third-party/pypi/pytest:pytest",
                 "fbsource//third-party/pypi/parameterized:parameterized",
                 "fbsource//third-party/tosa_tools:serializer",
+                "fbsource//third-party/tosa_tools:tosa",
                 "fbsource//third-party/tosa_tools:tosa_reference_model",
             ] + ([
                 # Needed only by the OSS-only public API manifest tests above.


### PR DESCRIPTION
### Summary

Follow-up to #22638. Seven constant-pool test cases fail when reading `block.operators` with serializer bindings that apply `keep_alive` to the returned Python list: `TypeError: cannot create weak reference to 'list' object`.

Count operators in the serialized TOSA graph instead, preserving the expected counts and the existing constant identity, name, and lifetime checks. Add the direct Buck dependency for the generated TOSA graph API.

Authored with assistance from OpenAI Codex.

### Test plan

All 13 constant-pool cases pass with TOSA Tools 2026.5.0:

```sh
PYTHONPATH=src python -m pytest -c /dev/null \
  backends/arm/test/misc/test_tosa_constant_pool.py -q
```

`lintrunner backends/arm/test/misc/test_tosa_constant_pool.py backends/arm/test/targets.bzl` and `git diff --check` pass. The internal Buck test target was not run locally.


cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell