### PR TITLE
NXP backend: Update Buck sources after test reorganization

### DIFF
--- a/backends/nxp/tests/BUCK
+++ b/backends/nxp/tests/BUCK
@@ -7,7 +7,7 @@ oncall("executorch")
 fbcode_target(_kind = runtime.python_library,
     name = "models",
     srcs = [
-        "models.py",
+        "simple_models.py",
     ],
     deps = [
         "//caffe2:torch",
@@ -115,7 +115,7 @@ fbcode_target(_kind = python_pytest,
 fbcode_target(_kind = python_pytest,
     name = "test_fold_redundant_qdq",
     srcs = [
-        "test_fold_redundant_qdq.py",
+        "generic_tests/test_fold_redundant_qdq.py",
     ],
     deps = [
         "//caffe2:torch",
@@ -128,7 +128,7 @@ fbcode_target(_kind = python_pytest,
 fbcode_target(_kind = python_pytest,
     name = "test_convert_1d_conv_to_2d",
     srcs = [
-        "test_convert_1d_conv_to_2d.py",
+        "generic_tests/test_convert_1d_conv_to_2d.py",
     ],
     env = {
         "PYTEST_ADDOPTS": "--ignore-glob=*full_pipeline*  -k 'not full_pipeline'",


### PR DESCRIPTION
### Summary

Follow-up to #22361. Update the NXP test Buck sources after the test reorganization: `models.py` became `simple_models.py`, and the redundant-QDQ and 1D-convolution tests moved under `generic_tests/`. The stale paths prevent affected test targets from building.

Keep the existing target names and dependencies so consumers continue to resolve the same libraries and tests.

Authored with assistance from OpenAI Codex.

### Test plan

Parsed every explicit `srcs` and `resources` entry in `backends/nxp/tests/BUCK` and checked it against the checkout. Before the change, exactly the three updated paths were missing; afterward, all 15 entries resolve to files.

`lintrunner backends/nxp/tests/BUCK` and `git diff --check` pass. The internal Buck builds and test targets were not run locally.
