### PR TITLE
Fix Muse Glimmer CUDA build after metadata constants update

### DIFF
--- a/examples/models/muse-glimmer/runtime/engine/muse_glimmer_engine.cpp
+++ b/examples/models/muse-glimmer/runtime/engine/muse_glimmer_engine.cpp
@@ -117,7 +117,6 @@ constexpr const char* kDFlashMinDraftPrefillChunk =
     "get_min_draft_prefill_chunk";
 constexpr const char* kDFlashMaxDraftPrefillChunk =
     "get_max_draft_prefill_chunk";
-constexpr const char* kActivationDtype = "get_activation_dtype";
 constexpr const char* kVisionHiddenSize = "get_vision_hidden_size";
 constexpr const char* kMaxVisionPatches = "get_max_vision_patches";
 constexpr int64_t kVisionDownsampleArea = 4;


### PR DESCRIPTION
Summary:
- remove the duplicate Muse-local kActivationDtype constant
- use the shared LLM runtime metadata key introduced in constants.h

This fixes all four Muse Glimmer CUDA jobs failing with an ambiguous kActivationDtype reference.

Test plan:
- Reproduced the ambiguity on main with the CI-equivalent compile flags on a 2x RTX 5090 server
- Re-ran the same translation-unit compile with this patch; it passes
- Failure example: https://github.com/pytorch/executorch/actions/runs/34620399764/job/103332852551