### PR TITLE
Arm backend: Add missing test for U55.

### DIFF
--- a/backends/arm/test/ops/test_arange.py
+++ b/backends/arm/test/ops/test_arange.py
@@ -272,6 +272,18 @@ def test_linspace_tosa_INT(test_data: test_data_t):
 
 
 @common.parametrize("test_data", LinspaceAdd.test_data)
+@common.XfailIfNoCorstone300
+def test_linspace_u55_INT(test_data: test_data_t):
+    input_data, init_data = test_data
+    pipeline = EthosU55PipelineINT[input_t](
+        LinspaceAdd(*init_data),
+        input_data(),
+        LinspaceAdd.aten_op,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", LinspaceAdd.test_data)
 @common.SkipIfNoModelConverter
 def test_linspace_vgf_no_quant(test_data: test_data_t):
     input_data, init_data = test_data

--- a/backends/arm/test/ops/test_as_strided_copy.py
+++ b/backends/arm/test/ops/test_as_strided_copy.py
@@ -10,6 +10,7 @@ from executorch.backends.arm.common.as_strided_utils import contiguous_strides
 
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
     OpNotSupportedPipeline,
     TosaPipelineFP,
     TosaPipelineINT,
@@ -88,6 +89,19 @@ def test_as_strided_tosa_INT(test_data):
     tensor, size, stride = test_data()
     module = AsStridedCopyModule(size, stride)
     pipeline = TosaPipelineINT[input_t](
+        module,
+        (tensor,),
+        aten_op,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", delegated_cases)
+@common.XfailIfNoCorstone300
+def test_as_strided_u55_INT(test_data):
+    tensor, size, stride = test_data()
+    module = AsStridedCopyModule(size, stride)
+    pipeline = EthosU55PipelineINT[input_t](
         module,
         (tensor,),
         aten_op,

--- a/backends/arm/test/ops/test_constant_pad_nd.py
+++ b/backends/arm/test/ops/test_constant_pad_nd.py
@@ -18,6 +18,7 @@ from executorch.backends.arm.quantizer.arm_quantizer import (
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.arm_tester import ArmTester
 from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
     TosaPipelineFP,
     TosaPipelineINT,
     VgfPipeline,
@@ -340,6 +341,17 @@ def test_constant_pad_nd_tosa_INT_a16w8(test_data: Tuple):
         aten_op,
         exir_op,
         tosa_extensions=["int16"],
+    )
+    pipeline.run()
+
+
+@common.XfailIfNoCorstone300
+def test_constant_pad_nd_u55_INT():
+    inp, padding, value, mode = test_data_suite["4dim_last2dim"]()
+    pipeline = EthosU55PipelineINT[input_t1](
+        ConstantPadND(padding, value, mode),
+        (inp,),
+        aten_op,
     )
     pipeline.run()
 

--- a/backends/arm/test/ops/test_log1p.py
+++ b/backends/arm/test/ops/test_log1p.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Arm Limited and/or its affiliates.
+# Copyright 2025-2026 Arm Limited and/or its affiliates.
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
@@ -8,6 +8,7 @@ from typing import Tuple
 import torch
 from executorch.backends.arm.test import common
 from executorch.backends.arm.test.tester.test_pipeline import (
+    EthosU55PipelineINT,
     TosaPipelineFP,
     TosaPipelineINT,
     VgfPipeline,
@@ -48,6 +49,17 @@ def test_log1p_tosa_INT(test_data: input_t1):
         test_data(),
         aten_op,
         exir_op,
+    )
+    pipeline.run()
+
+
+@common.parametrize("test_data", test_data_suite)
+@common.XfailIfNoCorstone300
+def test_log1p_u55_INT(test_data: input_t1):
+    pipeline = EthosU55PipelineINT[input_t1](
+        Log1p(),
+        test_data(),
+        aten_op,
     )
     pipeline.run()
 


### PR DESCRIPTION
Added tests for U55 to get full coverage for the script to produce a list of supported ops, Ethos U55.

cc @digantdesai @freddan80 @per @zingo @oscarandersson8218 @mansnils @Sebastian-Larsson @robell @rascani