### PR TITLE
Add ReplaceCopyWithAliasPass (#22762)

### DIFF
--- a/backends/native/BUCK
+++ b/backends/native/BUCK
@@ -18,6 +18,7 @@ fbcode_target(
         "partitioner.py",
         "passes/__init__.py",
         "passes/reinplace.py",
+        "passes/replace_copy_with_alias.py",
         "preprocess.py",
         "serialization/__init__.py",
         "serialization/graph_serialize.py",

--- a/backends/native/passes/__init__.py
+++ b/backends/native/passes/__init__.py
@@ -34,6 +34,9 @@ from executorch.backends.native.passes.reinplace import (
     BACKEND_INPLACE_OPS,
     NativeReinplacePass,
 )
+from executorch.backends.native.passes.replace_copy_with_alias import (
+    ReplaceCopyWithAliasPass,
+)
 
 from executorch.backends.transforms.collapse_view_copy import CollapseViewCopyPass
 
@@ -46,6 +49,7 @@ __all__ = [
     "CollapseViewCopyPass",
     "get_default_passes",
     "NativeReinplacePass",
+    "ReplaceCopyWithAliasPass",
 ]
 
 

--- a/backends/native/passes/replace_copy_with_alias.py
+++ b/backends/native/passes/replace_copy_with_alias.py
@@ -1,0 +1,181 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Rewrite functional ``*_copy`` view ops into aliasing view ops."""
+
+import torch
+
+from executorch.exir.pass_base import ExportPass, PassResult
+from torch.fx import GraphModule, Node
+
+_COPY_SUFFIX = "_copy"
+
+
+def _alias_op_for_copy(
+    copy_op: torch._ops.OpOverload,
+) -> torch._ops.OpOverload | None:
+    """Return the aliasing view op for a functional ``*_copy`` view op, or None.
+
+    ExecuTorch functionalizes aliasing view ops into functional ``_copy`` forms
+    (``view -> view_copy``, ``permute -> permute_copy``, ...). This inverts that
+    for the native delegate: ``aten::<base>_copy.<overload>`` maps to
+    ``aten::<base>.<overload>`` (same overload name), but only when the candidate
+    is a genuine view op — i.e. its first arg is a read-only alias
+    (``Tensor(a) self``). That check rejects non-view ``_copy`` ops such as
+    ``_to_copy`` (a dtype/device cast, not a view).
+    """
+    name = copy_op._schema.name  # e.g. "aten::slice_copy"
+    if "::" not in name:
+        return None
+    namespace, base = name.split("::", 1)
+    if namespace != "aten" or not base.endswith(_COPY_SUFFIX):
+        return None
+
+    alias_base = base[: -len(_COPY_SUFFIX)]
+    packet = getattr(torch.ops.aten, alias_base, None)
+    if packet is None:
+        return None
+    overload_name = copy_op._schema.overload_name or "default"
+    alias_op = getattr(packet, overload_name, None)
+    if alias_op is None:
+        return None
+
+    args = alias_op._schema.arguments
+    if not args:
+        return None
+    first = args[0]
+    # A view op reads-aliases its first arg (Tensor(a)); a mutating op would set
+    # is_write, and a copy/cast has no alias_info at all.
+    if first.alias_info is None or first.alias_info.is_write:
+        return None
+    return alias_op
+
+
+# View-family ops whose size argument may contain an inferred -1 and/or symbolic
+# dims. Their base names (no namespace); used to substitute the known output shape
+# when re-running under fake mode.
+_VIEW_SIZE_OPS: frozenset = frozenset({"view", "reshape", "_unsafe_view", "expand"})
+
+
+def _recompute_view_val(
+    alias_op: torch._ops.OpOverload, node: Node
+) -> torch.Tensor | None:
+    """Re-run ``alias_op`` on fake inputs to get the view's true shape/strides.
+
+    The ``_copy`` op's ``meta["val"]`` has contiguous strides (it materialized a
+    copy); the aliasing op generally does not (e.g. ``permute``/``slice`` produce
+    non-contiguous views). Recomputing keeps the serialized stride metadata
+    honest (the native runtime treats it as authoritative). Returns None if the
+    value cannot be produced (caller then leaves the node as a copy).
+
+    Two things make a naive re-run fail on dynamic shapes: symbolic dims arrive as
+    references to in-graph sym_size nodes (resolved here to their SymInt values),
+    and a size arg may hold an inferred ``-1`` that the meta kernel cannot resolve
+    against symbolic dims. For size-taking view ops the output shape is already
+    known, so it is used directly as the size (dropping the ``-1``).
+    """
+    from torch._guards import detect_fake_mode
+
+    def resolve(a: object) -> object:
+        if isinstance(a, Node):
+            return a.meta.get("val")
+        if isinstance(a, (list, tuple)):
+            return type(a)(resolve(x) for x in a)
+        return a
+
+    out_val = node.meta.get("val")
+    fake_args = [resolve(a) for a in node.args]
+    fake_kwargs = {k: resolve(v) for k, v in node.kwargs.items()}
+
+    base = alias_op._schema.name.split("::", 1)[-1]
+    if base in _VIEW_SIZE_OPS and isinstance(out_val, torch.Tensor):
+        fake_args = [
+            list(out_val.shape) if isinstance(a, (list, tuple)) else a
+            for a in fake_args
+        ]
+
+    fake_mode = detect_fake_mode(fake_args)
+    # A meta kernel can legitimately refuse this input: RuntimeError covers both
+    # plain shape/stride errors and the fake-tensor family (UnsupportedOperator,
+    # DataDependentOutput, DynamicOutputShape, UnsupportedFakeTensor, and
+    # NotImplementedError, which all subclass it); the rest catch a malformed
+    # arg list. Anything else is a bug in this pass and should surface.
+    try:
+        if fake_mode is not None:
+            with fake_mode:
+                result = alias_op(*fake_args, **fake_kwargs)
+        else:
+            result = alias_op(*fake_args, **fake_kwargs)
+    except (RuntimeError, IndexError, TypeError, ValueError):
+        return None
+    return result if isinstance(result, torch.Tensor) else None
+
+
+class ReplaceCopyWithAliasPass(ExportPass):
+    """Rewrite functional ``*_copy`` view ops into aliasing view ops.
+
+    ExecuTorch functionalizes aliasing view ops (``view``, ``permute``,
+    ``slice``, ``transpose``, ``squeeze``, ...) into their ``_copy`` forms so the
+    core runtime never aliases. The native runtime can execute true zero-copy
+    views, so inside the delegate we invert that: each ``<op>_copy`` that is a
+    genuine view (see ``_alias_op_for_copy``) is rewritten to the aliasing
+    ``<op>``, and its fake-value metadata is recomputed so the serialized strides
+    describe the alias rather than a contiguous copy.
+
+    Runs in ``NativeBackend.preprocess`` (never as a pre-partition transform),
+    since aliasing aten ops are not core-tagged and must stay inside the delegate.
+    At runtime each view's base buffer must outlive the view. Views whose result
+    is a delegate output are skipped: the output buffer may be reassigned by the
+    caller, so aliasing into it is unsafe.
+
+    Multi-output views (``split``/``unbind``) are left as copies for now — their
+    getitem consumers need handling this pass does not yet do.
+
+    A view is also left as a copy when its aliased layout is not dim-order
+    expressible (e.g. a gapped last-dim slice): the serialized TensorMeta records
+    only dim_order, not strides, so such a layout cannot be represented and must
+    stay a materialized (contiguous) copy.
+    """
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        from executorch.backends.native.serialization.graph_serialize import _dim_order
+
+        graph = graph_module.graph
+        modified = False
+
+        for node in graph.nodes:
+            if node.op != "call_function":
+                continue
+            op = getattr(node.target, "_op", node.target)
+            if not isinstance(op, torch._ops.OpOverload):
+                continue
+            alias_op = _alias_op_for_copy(op)
+            if alias_op is None:
+                continue
+            if any(user.op == "output" for user in node.users):
+                continue
+            if not isinstance(node.meta.get("val"), torch.Tensor):
+                continue
+
+            new_val = _recompute_view_val(alias_op, node)
+            if new_val is None:
+                continue
+            # TensorMeta serializes only dim_order, not strides, so an aliased view
+            # whose layout is not dim-order expressible (e.g. a gapped last-dim
+            # slice) cannot be represented; leave it as a materialized copy.
+            try:
+                _dim_order(new_val)
+            except ValueError:
+                continue
+
+            node.target = alias_op
+            node.meta["val"] = new_val
+            modified = True
+
+        if modified:
+            graph.lint()
+
+        return PassResult(graph_module, modified)

--- a/backends/native/preprocess.py
+++ b/backends/native/preprocess.py
@@ -23,7 +23,10 @@ yields a program whose constants are simply absent -- see to_native.
 
 Graph cleanup (CSE, reinplace, view_copy collapsing) is expected to run before
 lowering via the ``transform_passes`` argument of
-``to_edge_transform_and_lower`` (see ``passes.get_default_passes``).
+``to_edge_transform_and_lower`` (see ``passes.get_default_passes``). Preprocess is
+otherwise a serialization step, except for ``ReplaceCopyWithAliasPass``, which
+must run here so aliasing view ops stay inside the delegate rather than leaking
+into the core graph.
 """
 
 from dataclasses import dataclass, field
@@ -36,6 +39,7 @@ from executorch.backends.native.partitioner import (
     PTN_SERIALIZATION_KEY,
 )
 
+from executorch.backends.native.passes import ReplaceCopyWithAliasPass
 from executorch.backends.native.serialization import serialize_graph
 
 from executorch.exir._serialize._named_data_store import NamedDataStore
@@ -46,6 +50,8 @@ from executorch.exir.backend.backend_details import (
     ExportedProgram,
     PreprocessResult,
 )
+
+from pyre_extensions import none_throws
 
 from torch._subclasses.fake_tensor import FakeTensor
 
@@ -107,8 +113,12 @@ class NativeBackend(BackendDetails):
         edge_program: ExportedProgram,
         module_compile_spec: List[CompileSpec],
     ) -> PreprocessResult:
+        graph_module = none_throws(
+            ReplaceCopyWithAliasPass()(edge_program.graph_module)
+        ).graph_module
+
         flatbuffer_bytes, constant_data = serialize_graph(
-            edge_program.graph_module,
+            graph_module,
             edge_program.graph_signature,
             edge_program.state_dict,
             edge_program.constants,

--- a/backends/native/test/test_passes.py
+++ b/backends/native/test/test_passes.py
@@ -9,8 +9,18 @@ import unittest
 import torch
 import torch.nn as nn
 
+from executorch.backends.native import get_default_compile_config
+from executorch.backends.native.partitioner import NativePartitioner
+from executorch.backends.native.passes import get_default_passes
 from executorch.backends.native.passes.reinplace import NativeReinplacePass
-from executorch.backends.native.test.utils import _transformed
+from executorch.backends.native.serialization import deserialize_graph
+from executorch.backends.native.test.utils import (
+    _call_function_targets,
+    _get_delegate_blob,
+    _lower,
+    _transformed,
+)
+from executorch.exir import to_edge_transform_and_lower
 from executorch.exir.passes.cse_pass import CSEPass
 
 
@@ -49,3 +59,54 @@ class NativeReinplacePassTest(unittest.TestCase):
             any("relu_" in t for t in targets),
             f"expected in-place relu_, got {targets}",
         )
+
+
+class ReplaceCopyWithAliasPassTest(unittest.TestCase):
+    def test_alias_ops_serialize_valid_targets(self):
+        # ReplaceCopyWithAliasPass rewrites *_copy view ops to plain aten
+        # OpOverloads (e.g. transpose_copy -> transpose). Those must serialize to
+        # real op names, not the bare "torch._ops.aten." from over-unwrapping.
+        class ViewModel(nn.Module):
+            def forward(self, x):
+                return x.transpose(0, 1).reshape(-1) + 1.0
+
+        blob = _get_delegate_blob(_lower(ViewModel(), (torch.randn(3, 4),)))
+        graph = deserialize_graph(blob)
+        targets = [t for t in _call_function_targets(graph) if t]
+        # The pass rewrites at least one *_copy view op to its aliasing form.
+        alias_names = ("transpose", "permute", "view", "slice", "unsqueeze", "expand")
+        self.assertTrue(
+            any(
+                any(f"aten.{a}." in t for a in alias_names) and "_copy." not in t
+                for t in targets
+            ),
+            f"expected an aliasing view op, got {targets}",
+        )
+        for t in targets:
+            self.assertFalse(
+                t.startswith("torch._ops.") or t.endswith("."),
+                f"malformed serialized target: {t!r}",
+            )
+
+    def test_dynamic_view_converts_to_alias(self):
+        # A view with a symbolic size (dynamic dim) on a contiguous input must be
+        # rewritten to a true aten.view, not conservatively left as view_copy.
+        class DynView(nn.Module):
+            def forward(self, x):
+                return x.reshape(x.shape[0], -1) + 1.0
+
+        ep = torch.export.export(
+            DynView(),
+            (torch.randn(4, 2, 3),),
+            dynamic_shapes={"x": {0: torch.export.Dim("b", max=1024)}},
+        )
+        edge = to_edge_transform_and_lower(
+            ep,
+            transform_passes=get_default_passes(),
+            partitioner=[NativePartitioner()],
+            compile_config=get_default_compile_config(),
+        )
+        graph = deserialize_graph(_get_delegate_blob(edge))
+        targets = _call_function_targets(graph)
+        self.assertIn("torch.ops.aten.view.default", targets)
+        self.assertNotIn("torch.ops.aten.view_copy.default", targets)

--- a/backends/native/test/test_preprocess.py
+++ b/backends/native/test/test_preprocess.py
@@ -89,7 +89,7 @@ class PtnConstantHandoffTest(unittest.TestCase):
         base = torch.arange(6).view(2, 3)
         view = base.t()
         edge_program = SimpleNamespace(
-            graph_module=object(),
+            graph_module=torch.fx.GraphModule(nn.Module(), torch.fx.Graph()),
             graph_signature=object(),
             state_dict={},
             constants={},

--- a/backends/native/test/utils.py
+++ b/backends/native/test/utils.py
@@ -9,7 +9,10 @@
 import torch
 
 from executorch.backends.native import get_default_compile_config
-from executorch.exir import to_edge
+from executorch.backends.native.partitioner import NativePartitioner
+from executorch.backends.native.passes import get_default_passes
+from executorch.backends.native.serialization.schema import OpKind
+from executorch.exir import to_edge, to_edge_transform_and_lower
 
 
 def _transformed(model, example_inputs, passes):
@@ -18,3 +21,24 @@ def _transformed(model, example_inputs, passes):
         compile_config=get_default_compile_config(),
     )
     return edge.transform(passes).exported_program()
+
+
+def _lower(model, example_inputs):
+    ep = torch.export.export(model, example_inputs)
+    return to_edge_transform_and_lower(
+        ep,
+        transform_passes=get_default_passes(),
+        partitioner=[NativePartitioner()],
+        compile_config=get_default_compile_config(),
+    )
+
+
+def _get_delegate_blob(edge):
+    et = edge.to_executorch()
+    delegates = et.executorch_program.backend_delegate_data
+    assert len(delegates) == 1, f"Expected 1 delegate blob, got {len(delegates)}"
+    return bytes(delegates[0].data)
+
+
+def _call_function_targets(graph):
+    return [n.target for n in graph.nodes if n.op_kind == OpKind.CALL_FUNCTION]


### PR DESCRIPTION
Summary:

Rewrite functional *_copy view ops (view_copy, permute_copy, slice_copy, ...)
into their aliasing forms inside the delegate, so the native runtime executes
true zero-copy views. Runs in preprocess (aliasing aten ops are not core-tagged
and must stay in the delegate). Recomputes fake-value strides, including for
symbolic/dynamic shapes; views that feed outputs or can't be recomputed stay as
copies.

Reviewed By: SS-JIA

Differential Revision: D111753301


