### PR TITLE
Declare pyre-extensions for native backend imports

### DIFF
--- a/backends/native/BUCK
+++ b/backends/native/BUCK
@@ -30,6 +30,7 @@ fbcode_target(
     visibility = ["PUBLIC"],
     deps = [
         "fbsource//third-party/pypi/flatbuffers:flatbuffers",
+        "fbsource//third-party/pypi/pyre-extensions:pyre-extensions",
         "//caffe2:torch",
         "//executorch/backends/transforms:collapse_view_copy",
         "//executorch/exir:lib",

--- a/setup.py
+++ b/setup.py
@@ -1138,6 +1138,7 @@ def _base_dependencies() -> List[str]:
         # scope. Neither is needed merely to import the backend.
         "py-cpuinfo",
         "requests",
+        "pyre-extensions",
         "pytorch-tokenizers",
         # Shipped code imports torchao at module scope in many places, so a plain install cannot
         # lower a model without it. Among others: the XNNPACK utilities the partitioner uses


### PR DESCRIPTION
### Summary

PR #22762 added a `pyre_extensions.none_throws` import to the native backend without declaring the dependency. Regular and editable Linux/macOS unit-test jobs now fail with `ModuleNotFoundError`, including [this main CI run](https://github.com/pytorch/executorch/actions/runs/34682233712/job/103522900653).

Declare `pyre-extensions` in the full Python package dependencies and the native backend's internal Buck target so both installation paths provide the import.

Authored with OpenAI Codex.

### Test plan

Verified that setuptools metadata generated from `_base_dependencies()` contains `Requires-Dist: pyre-extensions` and that the minimal dependency list remains unchanged. An isolated environment successfully imported `none_throws` and checked its handling of a value and `None`.

`uv pip compile - --python-version 3.10 --index-url https://pypi.org/simple` with `pyre-extensions` on stdin resolved successfully to 0.0.32. `git diff --check origin/main...HEAD` passed.

Full unit tests and internal Buck builds were not run locally. The commit hook skipped lint because lintrunner is unavailable.
