### PR TITLE
Exclude FVP implementation tests from Buck

### DIFF
--- a/backends/cortex_m/test/targets.bzl
+++ b/backends/cortex_m/test/targets.bzl
@@ -72,6 +72,8 @@ def define_common_targets(is_fbcode = False):
             srcs = ["test_explicit_layout_pipeline.py"],
             compile = "with-source",
             typing = False,
+            # Implementation tests require the Cortex-M FVP runner, which Buck does not provide.
+            env = {"PYTEST_ADDOPTS": "-k 'not test_implementation'"},
             deps = [
                 "//caffe2:torch",
                 "//executorch/backends/cortex_m:target_config",


### PR DESCRIPTION
Summary:
D119737033 adds two simulator tests to the explicit-layout test module. The Buck target collects them without providing the Cortex-M FVP runner, so both fail with FileNotFoundError before executing the kernel.

Set PYTEST_ADDOPTS on the Buck target to exclude test_implementation cases. The four graph tests remain enabled, and direct pytest runs in the Cortex-M FVP environment continue to include the implementation tests. Keep the fbcode and xplat build definitions in sync.

Authored with Codex.

Differential Revision: D119808430


