### PR TITLE
Only fuse an RMS norm whose weight can be prepacked

### DIFF
--- a/backends/vulkan/patterns/rms_norm.py
+++ b/backends/vulkan/patterns/rms_norm.py
@@ -6,6 +6,8 @@
 
 from typing import Optional
 
+import executorch.backends.vulkan.utils as utils
+
 import torch
 
 from executorch.backends.vulkan.patterns.pattern_registry import (
@@ -68,6 +70,19 @@ class RmsNormMatch(PatternMatch):
             final_mul_node
         )
         if norm_mul_node is None:
+            return
+
+        # et_vk.rms_norm prepacks its weight, so the multiplier has to be a
+        # constant that the prepacker can see. A multiplier that is computed in
+        # the graph - an adaptive norm whose scale comes from a conditioning
+        # signal, or Gemma's `1.0 + weight` - is not prepackable, and folding it
+        # in anyway makes the delegate abort at the first inference with
+        # "prepack_standard ... (graph.val_is_tref(tensor_data)) is false".
+        # Leaving the multiply unfused is correct and costs one dispatch.
+        if (
+            not isinstance(self.weight_node, torch.fx.Node)
+            or self.weight_node.op != "placeholder"
+        ):
             return
 
         self.all_nodes.append(norm_mul_node)
@@ -263,6 +278,13 @@ def replace_rms_norm_with_fused_op(
     graph_module: torch.fx.GraphModule,
     match: RmsNormMatch,
 ):
+    # The detector only sees the graph, which cannot distinguish a constant
+    # placeholder from a user input; both look the same there. Only a constant
+    # is actually prepackable, so make the final check here, where the exported
+    # program is available.
+    if not utils.is_param_node(ep, match.weight_node):
+        return
+
     eps_val = _extract_eps_value(match.eps_node)
 
     with graph_module.graph.inserting_before(match.anchor_node):

--- a/backends/vulkan/test/test_vulkan_passes.py
+++ b/backends/vulkan/test/test_vulkan_passes.py
@@ -779,3 +779,74 @@ class TestVulkanPasses(unittest.TestCase):
 
         gm = ep.graph_module
         self.assertEqual(op_node_count(gm, "q8ta_pixel_shuffle.default"), 0)
+
+    def test_rms_norm_fuses_only_prepackable_weight(self):
+        """et_vk.rms_norm prepacks its weight, so the fusion must only fold in a
+        multiplier that is an actual constant.
+
+        Folding in a computed multiplier - an adaptive norm whose scale comes
+        from a conditioning signal, or Gemma's `1.0 + weight` - produced an op
+        the runtime aborted on:
+
+          prepack_standard ... (graph.val_is_tref(tensor_data)) is false!
+
+        Leaving those unfused is correct; the norm and the multiply are both
+        supported on their own.
+        """
+        eps = 1e-6
+        dim = 64
+
+        def norm(x):
+            return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+
+        class TimesParameter(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = torch.nn.Parameter(torch.rand(dim) + 0.5)
+
+            def forward(self, x):
+                return norm(x) * self.w
+
+        class TimesComputedConstant(torch.nn.Module):
+            """Gemma's RMSNorm: constant valued, but an intermediate node."""
+
+            def __init__(self):
+                super().__init__()
+                self.w = torch.nn.Parameter(torch.rand(dim) * 0.1)
+
+            def forward(self, x):
+                return norm(x) * (1.0 + self.w)
+
+        class TimesGraphInput(torch.nn.Module):
+            """Adaptive norm: the scale is a runtime value."""
+
+            def forward(self, x, scale):
+                return norm(x) * scale
+
+        x = torch.randn(1, 8, dim)
+
+        for model, inputs, expected, why in [
+            (TimesParameter(), (x,), 1, "a leaf parameter is prepackable"),
+            (TimesComputedConstant(), (x,), 0, "1.0 + w is an intermediate node"),
+            (
+                TimesGraphInput(),
+                (x, torch.rand(1, 1, dim)),
+                0,
+                "a graph input is not a constant",
+            ),
+        ]:
+            with self.subTest(model=type(model).__name__):
+                edge_program = to_edge(
+                    torch.export.export(model.eval(), inputs, strict=True),
+                    compile_config=EdgeCompileConfig(_check_ir_validity=False),
+                )
+                ep = edge_program._edge_programs["forward"]
+                fuse_pass = FusePatternsPass()
+                fuse_pass._exported_program = ep
+                fuse_pass.call(ep.graph_module)
+
+                self.assertEqual(
+                    op_node_count(ep.graph_module, "rms_norm.default"),
+                    expected,
+                    f"expected {expected} fused rms_norm: {why}",
+                )


### PR DESCRIPTION
Fixes #22773

### Summary

`et_vk.rms_norm` prepacks its weight, so the multiply that the fusion folds in has to be a constant the prepacker can see. `RmsNormMatch` folded in whatever multiply followed the norm, without checking, so a multiplier computed in the graph produced an op the runtime aborts on at the first inference:

```
prepack_standard at backends/vulkan/runtime/graph/ops/impl/Staging.cpp:229:
  (graph.val_is_tref(tensor_data)) is false!
```

Two common shapes hit this:

- **Adaptive normalization** — a norm whose scale is produced at inference from a conditioning signal. This is AdaLN / AdaLN-Zero, so it covers DiT and most diffusion transformers, and π₀.₅, where the scale comes from the flow-matching timestep.
- **Gemma's ordinary RMSNorm**, written `norm(x) * (1.0 + weight)`. The multiplier is constant *valued*, but it is an intermediate node, not a leaf, so it is equally unprepackable.

So the deciding property is not "constant vs. computed" — it is whether the multiplier is something the prepacker can resolve to a constant tensor.

### The change

Reject a non-prepackable weight. This is done in two places because the two callers see different things:

- The **detector** (`RmsNormMatch.__init__`) is handed only a node — `get_all_fusable_subgraphs` has no `ExportedProgram` — so it requires the weight to be a placeholder. That covers every computed multiplier, including both cases above.
- The **replacement** is handed the exported program, so the remaining distinction — a constant placeholder vs. a user input, which are indistinguishable in the graph alone — is made there with `utils.is_param_node`.

Refusing the match is safe: the norm and the multiply are ordinary supported ops, so the pattern stays unfused and costs one extra dispatch. Note the weight is not part of `match.all_nodes`, so declining the match does not leave the partitioner holding nodes nothing will replace.

### Test plan

```
python -m unittest backends.vulkan.test.test_vulkan_passes -v
```

12 tests pass. The new test, `test_rms_norm_fuses_only_prepackable_weight`, fails without the source change, in both of its negative subtests:

```
AssertionError: 1 != 0 : expected 0 fused rms_norm: 1.0 + w is an intermediate node
AssertionError: 1 != 0 : expected 0 fused rms_norm: a graph input is not a constant
```

Also verified end to end on an AMD Radeon 8060S (RADV GFX1151, RDNA 3.5), lowering each module and comparing the delegate's output against eager:

| multiplier | before | after |
|---|---|---|
| leaf parameter | fused, ok | fused, ok (unchanged) |
| leaf buffer | fused, ok | fused, ok (unchanged) |
| parameter through a dtype cast | prepack abort | unfused, ok |
| `1.0 + parameter` (Gemma) | prepack abort | unfused, ok |
| graph input (adaptive norm) | prepack abort | unfused, ok |
| computed by a layer (AdaLN) | prepack abort | unfused, ok |

The dtype-cast row is worth calling out: the pattern's own docstring describes the Llama-style graph where the weight reaches the multiply through a `to_copy`, and that form aborts today whenever the cast is not constant-folded before the pass. Requiring the weight node itself to be a placeholder covers it, at the cost of not fusing that form — which is what already happens, except now it runs instead of aborting. If fusing through a weight cast is wanted, that seems better as a separate change that prepacks the underlying constant deliberately.

`backends.vulkan.test.test_vulkan_delegate` produces an identical set of results before and after (its failures in my environment are pre-existing and unrelated).

Found while lowering openpi's π₀.₅ to the Vulkan delegate.


cc @SS-JIA @manuelcandales @digantdesai @cbilgin