### PR TITLE
Vulkan: hoist the pointwise conv spatial divides out of the K loop

### DIFF
--- a/backends/vulkan/runtime/graph/ops/glsl/conv2d_pw_tiled.glsl
+++ b/backends/vulkan/runtime/graph/ops/glsl/conv2d_pw_tiled.glsl
@@ -51,35 +51,60 @@ ${layout_declare_spec_const(C, "int", "activation_type", "0")}
 #include "linear_fp_packed_weight_tile_load.glslh"
 #include "linear_fp_output_tile_fp_compute.glslh"
 
-void load_input_tile_with_checks(
-    out FPInputTile tile,
-    const int k4_start,
+// Texel coordinates for the TILE_M spatial positions this invocation covers.
+//
+// Recovering (x, y) from the flattened spatial index costs a division and a
+// modulo by W_out, which is a runtime uniform, so the compiler cannot strength
+// reduce either into a shift. Those coordinates depend only on m, so computing
+// them once per invocation keeps the K loop free of integer division; done
+// per (m, k4) instead, a conv with K4 = 4 issues four times as many divides as
+// the arithmetic they feed.
+struct InCoords {
+  ivec2 pos[TILE_M];
+  ivec2 out_pos[TILE_M];
+  bool valid[TILE_M];
+};
+
+void compute_in_coords(
+    out InCoords coords,
     const int m_start,
-    const int K4,
     const int M,
     const int W_out,
     const int W_in,
     const int H_in) {
   [[unroll]] for (int m = 0; m < TILE_M; ++m) {
+    const int out_spatial = m_start + m;
+    if (out_spatial >= M) {
+      coords.pos[m] = ivec2(0);
+      coords.out_pos[m] = ivec2(0);
+      coords.valid[m] = false;
+      continue;
+    }
+    const int out_x = out_spatial % W_out;
+    const int out_y = out_spatial / W_out;
+    coords.out_pos[m] = ivec2(out_x, out_y);
+    if (stride_1_padding_0 != 0) {
+      coords.pos[m] = ivec2(out_x, out_y);
+      coords.valid[m] = true;
+    } else {
+      const int in_x = out_x * stride_w - padding_w;
+      const int in_y = out_y * stride_h - padding_h;
+      coords.pos[m] = ivec2(in_x, in_y);
+      coords.valid[m] = in_x >= 0 && in_x < W_in && in_y >= 0 && in_y < H_in;
+    }
+  }
+}
+
+void load_input_tile_with_checks(
+    out FPInputTile tile,
+    const InCoords coords,
+    const int k4_start,
+    const int K4) {
+  [[unroll]] for (int m = 0; m < TILE_M; ++m) {
     [[unroll]] for (int k4 = 0; k4 < TILE_K4; ++k4) {
-      if (k4_start + k4 < K4 && m_start + m < M) {
-        if (stride_1_padding_0 != 0) {
-          const int spatial = m_start + m;
-          tile.data[m][k4] =
-              texelFetch(t_in, ivec3(spatial % W_out, spatial / W_out, k4_start + k4), 0);
-        } else {
-          const int out_spatial = m_start + m;
-          const int out_x = out_spatial % W_out;
-          const int out_y = out_spatial / W_out;
-          const int in_x = out_x * stride_w - padding_w;
-          const int in_y = out_y * stride_h - padding_h;
-          if (in_x >= 0 && in_x < W_in && in_y >= 0 && in_y < H_in) {
-            tile.data[m][k4] =
-                texelFetch(t_in, ivec3(in_x, in_y, k4_start + k4), 0);
-          } else {
-            tile.data[m][k4] = VEC4_T(0.0);
-          }
-        }
+      if (k4_start + k4 < K4 && coords.valid[m]) {
+        tile.data[m][k4] =
+            texelFetch(t_in, ivec3(coords.pos[m], k4_start + k4), 0);
       } else {
         tile.data[m][k4] = VEC4_T(0.0);
       }
@@ -89,22 +114,23 @@ void load_input_tile_with_checks(
 
 void store_output_tile_with_checks(
     const FPOutTile out_tile,
+    const InCoords coords,
     const int n4_start,
     const int m_start,
     const int N4,
-    const int M,
-    const int W_out) {
+    const int M) {
+  // Reuse the coordinates computed for this invocation rather than dividing by
+  // W_out again per output texel.
   [[unroll]] for (int m = 0; m < TILE_M; ++m) {
     [[unroll]] for (int n4 = 0; n4 < TILE_N4; ++n4) {
       if (m_start + m < M && n4_start + n4 < N4) {
-        const int spatial = m_start + m;
         VEC4_T texel = out_tile.data[m][n4];
         if (activation_type == 1) {
           texel = max(texel, VEC4_T(0.0));
         } else if (activation_type == 2) {
           texel = clamp(texel, VEC4_T(out_min), VEC4_T(out_max));
         }
-        imageStore(t_out, ivec3(spatial % W_out, spatial / W_out, n4_start + n4), texel);
+        imageStore(t_out, ivec3(coords.out_pos[m], n4_start + n4), texel);
       }
     }
   }
@@ -138,8 +164,11 @@ void main() {
   FPInputTile in_tile;
   FPWeightTile w_tile;
 
+  InCoords in_coords;
+  compute_in_coords(in_coords, m_start, M, W_out, W_in, H_in);
+
   for (int k4 = 0; k4 < K4; k4++) {
-    load_input_tile_with_checks(in_tile, k4, m_start, K4, M, W_out, W_in, H_in);
+    load_input_tile_with_checks(in_tile, in_coords, k4, K4);
     load_packed_weight_tile_with_checks(w_tile, n4_start, k4, 0, N4, K4);
     fp_accumulate_with_fp_weight(out_tile, in_tile, w_tile);
   }
@@ -154,5 +183,5 @@ void main() {
     }
   }
 
-  store_output_tile_with_checks(out_tile, n4_start, m_start, N4, M, W_out);
+  store_output_tile_with_checks(out_tile, in_coords, n4_start, m_start, N4, M);
 }


### PR DESCRIPTION
### Summary

`conv2d_pw_tiled` recovers the `(x, y)` texel coordinate from the flattened spatial index with a divide and a modulo by `W_out`. `W_out` is a runtime uniform, so neither strength reduces to a shift, and both sat inside the loop over `K`: once per `(m, k4)` on the input loads, and again per output texel on the store. The coordinates depend only on `m`, so a conv with `K4 = 4` issued four times as many integer divides as the arithmetic they fed.

This computes them once per invocation and passes them down. No change to the tiling, the dispatch, or the math.

### Measurements

Three models, both GPU vendors. Arms interleaved within one session, per-dispatch GPU timestamps from the query pool, median of 3 rounds. Mali-G76 is a Galaxy S10+, Adreno 840 a Galaxy S26 Ultra.

| model | device | `conv2d_pw` share | `conv2d_pw` | whole graph GPU |
|---|---|---|---|---|
| lraspp-mobilenet-v3-large fp16 @520 | Mali-G76 | 71% | 256.3 -> 72.0 ms (**3.56x**) | 284.1 -> 100.2 ms (2.83x) |
| selfie-segmentation fp16 @256 | Mali-G76 | 66% | 8.02 -> 4.18 ms (**1.92x**) | 12.2 -> 8.3 ms (1.47x) |
| selfie-segmentation fp16 @256 | Adreno 840 | 66% | 0.657 -> 0.519 ms (**1.27x**) | 1.179 -> 1.041 ms (1.13x) |
| PP-OCRv6 fp16 | Adreno 840 | 41% | 32.08 -> 23.64 ms (**1.36x**) | 65.76 -> 57.34 ms (1.15x) |

The gain tracks how much of the graph is pointwise convolution and how deep the K loop is, which is why lraspp gains most: more channels means more K iterations, so more redundant divides per invocation. A transformer with no pointwise convs (CLIP ViT-B/32 vision, 0 such dispatches) is unaffected at 1.000x, as expected.

End to end on lraspp this is 310.3 -> 114.1 ms on Mali. For reference the XNNPACK int8 build of the same model, which is what that backend ships as its Android default, measures 93.0 ms there.

Interleaving matters on the Mali part: the same binary reads 25.2 ms hot and 8.0 ms settled, so arms measured in separate sessions are not comparable. Within a session, round to round spread is under 1%.

### Correctness

Output is bit identical before and after on every model measured, `max |diff| = 0.0`, including on inputs chosen to produce non-degenerate outputs.
